### PR TITLE
KAFKA-12234: Implement request/response for offsetFetch batching (KIP-709)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -85,7 +85,7 @@
             files="clients[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <suppress checks="NPathComplexity"
-            files="MessageTest.java"/>
+            files="MessageTest.java|OffsetFetchRequest.java"/>
 
     <!-- Clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
@@ -92,11 +92,9 @@ public class ListConsumerGroupOffsetsHandler implements AdminApiHandler<Coordina
             handleError(groupId, responseError, failed, unmapped);
         } else {
             final Map<TopicPartition, OffsetAndMetadata> groupOffsetsListing = new HashMap<>();
-            // if entry for group level response data is null, we are getting back an older version
-            // of the response
-            Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData =
-                response.responseData(groupId.idValue);
-            for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : responseData.entrySet()) {
+            Map<TopicPartition, OffsetFetchResponse.PartitionData> partitionDataMap =
+                response.partitionDataMap(groupId.idValue);
+            for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : partitionDataMap.entrySet()) {
                 final TopicPartition topicPartition = entry.getKey();
                 OffsetFetchResponse.PartitionData partitionData = entry.getValue();
                 final Errors error = partitionData.error;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
@@ -73,10 +73,7 @@ public class ListConsumerGroupOffsetsHandler implements AdminApiHandler<Coordina
     public OffsetFetchRequest.Builder buildRequest(int coordinatorId, Set<CoordinatorKey> keys) {
         // Set the flag to false as for admin client request,
         // we don't need to wait for any pending offset state to clear.
-        return new OffsetFetchRequest.Builder(
-            Collections.singletonMap(groupId.idValue, partitions),
-            false,
-            false);
+        return new OffsetFetchRequest.Builder(groupId.idValue, false, partitions, false);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
@@ -90,16 +90,7 @@ public class ListConsumerGroupOffsetsHandler implements AdminApiHandler<Coordina
         Map<CoordinatorKey, Throwable> failed = new HashMap<>();
         List<CoordinatorKey> unmapped = new ArrayList<>();
 
-        Errors responseError = response.error();
-        // check if error is null, if it is we are dealing with v8 response
-        if (responseError == null) {
-            if (response.groupHasError(groupId.idValue)) {
-                responseError = response.groupLevelError(groupId.idValue);
-            } else {
-                responseError = Errors.NONE;
-            }
-        }
-
+        Errors responseError = response.groupLevelError(groupId.idValue);
         if (responseError != Errors.NONE) {
             handleError(groupId, responseError, failed, unmapped);
         } else {
@@ -107,8 +98,7 @@ public class ListConsumerGroupOffsetsHandler implements AdminApiHandler<Coordina
             // if entry for group level response data is null, we are getting back an older version
             // of the response
             Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData =
-                response.responseData(groupId.idValue) == null ? response.oldResponseData() :
-                    response.responseData(groupId.idValue);
+                response.responseData(groupId.idValue);
             for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : responseData.entrySet()) {
                 final TopicPartition topicPartition = entry.getKey();
                 OffsetFetchResponse.PartitionData partitionData = entry.getValue();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1308,15 +1308,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
         @Override
         public void handle(OffsetFetchResponse response, RequestFuture<Map<TopicPartition, OffsetAndMetadata>> future) {
-            Errors responseError = response.error();
-            // check if error is null, if it is we are dealing with v8 response
-            if (responseError == null) {
-                if (response.groupHasError(rebalanceConfig.groupId)) {
-                    responseError = response.groupLevelError(rebalanceConfig.groupId);
-                } else {
-                    responseError = Errors.NONE;
-                }
-            }
+            Errors responseError = response.groupLevelError(rebalanceConfig.groupId);
             if (responseError != Errors.NONE) {
                 log.debug("Offset fetch failed: {}", responseError.message());
 
@@ -1336,10 +1328,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             }
 
             Set<String> unauthorizedTopics = null;
-            // if map entry is null, we know we are handling a response less than V8
-            boolean useV8 = response.responseData(rebalanceConfig.groupId) != null;
-            Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData = useV8 ?
-                response.responseData(rebalanceConfig.groupId) : response.oldResponseData();
+            Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData =
+                response.responseData(rebalanceConfig.groupId);
             Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>(responseData.size());
             Set<TopicPartition> unstableTxnOffsetTopicPartitions = new HashSet<>();
             for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : responseData.entrySet()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1308,29 +1308,41 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
         @Override
         public void handle(OffsetFetchResponse response, RequestFuture<Map<TopicPartition, OffsetAndMetadata>> future) {
-            if (response.hasError()) {
-                Errors error = response.error();
-                log.debug("Offset fetch failed: {}", error.message());
+            Errors responseError = response.error();
+            // check if error is null, if it is we are dealing with v8 response
+            if (responseError == null) {
+                if (response.groupHasError(rebalanceConfig.groupId)) {
+                    responseError = response.groupLevelError(rebalanceConfig.groupId);
+                } else {
+                    responseError = Errors.NONE;
+                }
+            }
+            if (responseError != Errors.NONE) {
+                log.debug("Offset fetch failed: {}", responseError.message());
 
-                if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
+                if (responseError == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
                     // just retry
-                    future.raise(error);
-                } else if (error == Errors.NOT_COORDINATOR) {
+                    future.raise(responseError);
+                } else if (responseError == Errors.NOT_COORDINATOR) {
                     // re-discover the coordinator and retry
-                    markCoordinatorUnknown(error);
-                    future.raise(error);
-                } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
+                    markCoordinatorUnknown(responseError);
+                    future.raise(responseError);
+                } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
                     future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));
                 } else {
-                    future.raise(new KafkaException("Unexpected error in fetch offset response: " + error.message()));
+                    future.raise(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
                 }
                 return;
             }
 
             Set<String> unauthorizedTopics = null;
-            Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>(response.responseData().size());
+            // if map entry is null, we know we are handling a response less than V8
+            boolean useV8 = response.responseData(rebalanceConfig.groupId) != null;
+            Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData = useV8 ?
+                response.responseData(rebalanceConfig.groupId) : response.oldResponseData();
+            Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>(responseData.size());
             Set<TopicPartition> unstableTxnOffsetTopicPartitions = new HashSet<>();
-            for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : response.responseData().entrySet()) {
+            for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : responseData.entrySet()) {
                 TopicPartition tp = entry.getKey();
                 OffsetFetchResponse.PartitionData partitionData = entry.getValue();
                 if (partitionData.hasError()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1329,7 +1329,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
             Set<String> unauthorizedTopics = null;
             Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData =
-                response.responseData(rebalanceConfig.groupId);
+                response.partitionDataMap(rebalanceConfig.groupId);
             Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>(responseData.size());
             Set<TopicPartition> unstableTxnOffsetTopicPartitions = new HashSet<>();
             for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry : responseData.entrySet()) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -113,7 +113,7 @@ public class OffsetFetchRequest extends AbstractRequest {
                     .setTopics(topics));
             }
             this.data = new OffsetFetchRequestData()
-                .setGroupIds(groups)
+                .setGroups(groups)
                 .setRequireStable(requireStable);
             this.throwOnFetchStableOffsetsUnsupported = throwOnFetchStableOffsetsUnsupported;
         }
@@ -124,7 +124,7 @@ public class OffsetFetchRequest extends AbstractRequest {
                 throw new UnsupportedVersionException("The broker only supports OffsetFetchRequest " +
                     "v" + version + ", but we need v2 or newer to request all topic partitions.");
             }
-            if (data.groupIds().size() > 1 && version < 8) {
+            if (data.groups().size() > 1 && version < 8) {
                 throw new NoBatchedOffsetFetchRequestException("Broker does not support"
                     + " batching groups for fetch offset request on version " + version);
             }
@@ -142,8 +142,8 @@ public class OffsetFetchRequest extends AbstractRequest {
             // convert data to use the appropriate version since version 8 uses different format
             if (version < 8) {
                 OffsetFetchRequestData oldDataFormat = null;
-                if (!data.groupIds().isEmpty()) {
-                    OffsetFetchRequestGroup group = data.groupIds().get(0);
+                if (!data.groups().isEmpty()) {
+                    OffsetFetchRequestGroup group = data.groups().get(0);
                     String groupName = group.groupId();
                     List<OffsetFetchRequestTopics> topics = group.topics();
                     List<OffsetFetchRequestTopic> oldFormatTopics = null;
@@ -163,7 +163,7 @@ public class OffsetFetchRequest extends AbstractRequest {
                 }
                 return new OffsetFetchRequest(oldDataFormat == null ? data : oldDataFormat, version);
             } else {
-                if (data.groupIds().isEmpty()) {
+                if (data.groups().isEmpty()) {
                     String groupName = data.groupId();
                     List<OffsetFetchRequestTopic> oldFormatTopics = data.topics();
                     List<OffsetFetchRequestTopics> topics = null;
@@ -177,7 +177,7 @@ public class OffsetFetchRequest extends AbstractRequest {
                     }
                     OffsetFetchRequestData convertedDataFormat =
                         new OffsetFetchRequestData()
-                            .setGroupIds(Collections.singletonList(
+                            .setGroups(Collections.singletonList(
                                 new OffsetFetchRequestGroup()
                                     .setGroupId(groupName)
                                     .setTopics(topics)))
@@ -229,7 +229,7 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     public Map<String, List<TopicPartition>> groupIdsToPartitions() {
         Map<String, List<TopicPartition>> groupIdsToPartitions = new HashMap<>();
-        for (OffsetFetchRequestGroup group : data.groupIds()) {
+        for (OffsetFetchRequestGroup group : data.groups()) {
             List<TopicPartition> tpList = null;
             if (group.topics() != ALL_TOPIC_PARTITIONS_BATCH) {
                 tpList = new ArrayList<>();
@@ -246,13 +246,13 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     public Map<String, List<OffsetFetchRequestTopics>> groupIdsToTopics() {
         Map<String, List<OffsetFetchRequestTopics>> groupIdsToTopics =
-            new HashMap<>(data.groupIds().size());
-        data.groupIds().forEach(g -> groupIdsToTopics.put(g.groupId(), g.topics()));
+            new HashMap<>(data.groups().size());
+        data.groups().forEach(g -> groupIdsToTopics.put(g.groupId(), g.topics()));
         return groupIdsToTopics;
     }
 
     public List<String> groupIds() {
-        return data.groupIds()
+        return data.groups()
             .stream()
             .map(OffsetFetchRequestGroup::groupId)
             .collect(Collectors.toList());
@@ -316,7 +316,7 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     public boolean isAllPartitionsForGroup(String groupId) {
         OffsetFetchRequestGroup group = data
-            .groupIds()
+            .groups()
             .stream()
             .filter(g -> g.groupId().equals(groupId))
             .collect(Collectors.toList())

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -16,10 +16,15 @@
  */
 package org.apache.kafka.common.requests;
 
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestGroup;
 import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopic;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
@@ -38,6 +43,7 @@ public class OffsetFetchRequest extends AbstractRequest {
     private static final Logger log = LoggerFactory.getLogger(OffsetFetchRequest.class);
 
     private static final List<OffsetFetchRequestTopic> ALL_TOPIC_PARTITIONS = null;
+    private static final List<OffsetFetchRequestTopics> ALL_TOPIC_PARTITIONS_BATCH = null;
     private final OffsetFetchRequestData data;
 
     public static class Builder extends AbstractRequest.Builder<OffsetFetchRequest> {
@@ -46,9 +52,9 @@ public class OffsetFetchRequest extends AbstractRequest {
         private final boolean throwOnFetchStableOffsetsUnsupported;
 
         public Builder(String groupId,
-                       boolean requireStable,
-                       List<TopicPartition> partitions,
-                       boolean throwOnFetchStableOffsetsUnsupported) {
+            boolean requireStable,
+            List<TopicPartition> partitions,
+            boolean throwOnFetchStableOffsetsUnsupported) {
             super(ApiKeys.OFFSET_FETCH);
 
             final List<OffsetFetchRequestTopic> topics;
@@ -68,9 +74,9 @@ public class OffsetFetchRequest extends AbstractRequest {
             }
 
             this.data = new OffsetFetchRequestData()
-                            .setGroupId(groupId)
-                            .setRequireStable(requireStable)
-                            .setTopics(topics);
+                .setGroupId(groupId)
+                .setRequireStable(requireStable)
+                .setTopics(topics);
             this.throwOnFetchStableOffsetsUnsupported = throwOnFetchStableOffsetsUnsupported;
         }
 
@@ -78,32 +84,125 @@ public class OffsetFetchRequest extends AbstractRequest {
             return this.data.topics() == ALL_TOPIC_PARTITIONS;
         }
 
+        public Builder(Map<String, List<TopicPartition>> groupIdToTopicPartitionMap,
+            boolean requireStable,
+            boolean throwOnFetchStableOffsetsUnsupported) {
+            super(ApiKeys.OFFSET_FETCH);
+
+            List<OffsetFetchRequestGroup> groups = new ArrayList<>();
+            for (Entry<String, List<TopicPartition>> entry : groupIdToTopicPartitionMap.entrySet()) {
+                final List<OffsetFetchRequestTopics> topics;
+                if (groupIdToTopicPartitionMap.get(entry.getKey()) != null) {
+                    Map<String, OffsetFetchRequestTopics> offsetFetchRequestTopicMap =
+                        new HashMap<>();
+                    for (TopicPartition topicPartition : groupIdToTopicPartitionMap.get(entry.getKey())) {
+                        String topicName = topicPartition.topic();
+                        OffsetFetchRequestTopics topic = offsetFetchRequestTopicMap.getOrDefault(
+                            topicName, new OffsetFetchRequestTopics().setName(topicName));
+                        topic.partitionIndexes().add(topicPartition.partition());
+                        offsetFetchRequestTopicMap.put(topicName, topic);
+                    }
+                    topics = new ArrayList<>(offsetFetchRequestTopicMap.values());
+                } else {
+                    topics = ALL_TOPIC_PARTITIONS_BATCH;
+                }
+                groups.add(new OffsetFetchRequestGroup()
+                    .setGroupId(entry.getKey())
+                    .setTopics(topics));
+            }
+            this.data = new OffsetFetchRequestData()
+                .setGroupIds(groups)
+                .setRequireStable(requireStable);
+            this.throwOnFetchStableOffsetsUnsupported = throwOnFetchStableOffsetsUnsupported;
+        }
+
         @Override
         public OffsetFetchRequest build(short version) {
-            if (isAllTopicPartitions() && version < 2) {
-                throw new UnsupportedVersionException("The broker only supports OffsetFetchRequest " +
-                    "v" + version + ", but we need v2 or newer to request all topic partitions.");
-            }
-
-            if (data.requireStable() && version < 7) {
-                if (throwOnFetchStableOffsetsUnsupported) {
-                    throw new UnsupportedVersionException("Broker unexpectedly " +
-                        "doesn't support requireStable flag on version " + version);
-                } else {
-                    log.trace("Fallback the requireStable flag to false as broker " +
-                                  "only supports OffsetFetchRequest version {}. Need " +
-                                  "v7 or newer to enable this feature", version);
-
-                    return new OffsetFetchRequest(data.setRequireStable(false), version);
+            if (version < 8) {
+                if (data.groupIds().size() > 1) {
+                    throw new NoBatchedOffsetFetchRequestException("Broker does not support"
+                        + " batching groups for fetch offset request on version " + version);
                 }
-            }
+                OffsetFetchRequestData oldDataFormat = null;
+                if (!data.groupIds().isEmpty()) {
+                    OffsetFetchRequestGroup group = data.groupIds().get(0);
+                    String groupName = group.groupId();
+                    List<OffsetFetchRequestTopics> topics = group.topics();
+                    List<OffsetFetchRequestTopic> oldFormatTopics = null;
+                    if (topics != null) {
+                        oldFormatTopics = topics
+                            .stream()
+                            .map(t ->
+                                new OffsetFetchRequestTopic()
+                                    .setName(t.name())
+                                    .setPartitionIndexes(t.partitionIndexes()))
+                            .collect(Collectors.toList());
+                    }
+                    oldDataFormat = new OffsetFetchRequestData()
+                        .setGroupId(groupName)
+                        .setTopics(oldFormatTopics)
+                        .setRequireStable(data.requireStable());
+                }
+                if (isAllTopicPartitions() && version < 2) {
+                    throw new UnsupportedVersionException("The broker only supports OffsetFetchRequest " +
+                        "v" + version + ", but we need v2 or newer to request all topic partitions.");
+                }
+                if (data.requireStable() && version < 7) {
+                    if (throwOnFetchStableOffsetsUnsupported) {
+                        throw new UnsupportedVersionException("Broker unexpectedly " +
+                            "doesn't support requireStable flag on version " + version);
+                    } else {
+                        log.trace("Fallback the requireStable flag to false as broker " +
+                            "only supports OffsetFetchRequest version {}. Need " +
+                            "v7 or newer to enable this feature", version);
 
+                        return new OffsetFetchRequest(oldDataFormat == null ?
+                            data.setRequireStable(false) : oldDataFormat.setRequireStable(false),
+                            version);
+                    }
+                }
+                return new OffsetFetchRequest(oldDataFormat == null ? data : oldDataFormat, version);
+            }
+            // version 8 but have used old format of request, convert to version 8 of request
+            if (data.groupIds().isEmpty()) {
+                String groupName = data.groupId();
+                List<OffsetFetchRequestTopic> oldFormatTopics = data.topics();
+                List<OffsetFetchRequestTopics> topics = null;
+                if (oldFormatTopics != null) {
+                    topics = oldFormatTopics
+                        .stream()
+                        .map(t -> new OffsetFetchRequestTopics()
+                            .setName(t.name())
+                            .setPartitionIndexes(t.partitionIndexes()))
+                        .collect(Collectors.toList());
+                }
+                OffsetFetchRequestData convertedDataFormat =
+                    new OffsetFetchRequestData()
+                        .setGroupIds(Collections.singletonList(
+                            new OffsetFetchRequestGroup()
+                                .setGroupId(groupName)
+                                .setTopics(topics)))
+                        .setRequireStable(data.requireStable());
+                return new OffsetFetchRequest(convertedDataFormat, version);
+            }
             return new OffsetFetchRequest(data, version);
         }
 
         @Override
         public String toString() {
             return data.toString();
+        }
+    }
+
+    /**
+     * Indicates that it is not possible to fetch consumer groups in batches with FetchOffset.
+     * Instead consumer groups' offsets must be fetched one by one.
+     */
+    public static class NoBatchedOffsetFetchRequestException extends UnsupportedVersionException {
+        private static final long serialVersionUID = 1L;
+
+        public NoBatchedOffsetFetchRequestException(String message) {
+            super(message);
         }
     }
 
@@ -126,6 +225,38 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     public boolean requireStable() {
         return data.requireStable();
+    }
+
+    public Map<String, List<TopicPartition>> groupIdsToPartitions() {
+        Map<String, List<TopicPartition>> groupIdsToPartitions = new HashMap<>();
+        for (OffsetFetchRequestGroup group : data.groupIds()) {
+            List<TopicPartition> tpList = null;
+            if (group.topics() != ALL_TOPIC_PARTITIONS_BATCH) {
+                tpList = new ArrayList<>();
+                for (OffsetFetchRequestTopics topic : group.topics()) {
+                    for (Integer partitionIndex : topic.partitionIndexes()) {
+                        tpList.add(new TopicPartition(topic.name(), partitionIndex));
+                    }
+                }
+            }
+            groupIdsToPartitions.put(group.groupId(), tpList);
+        }
+        return groupIdsToPartitions;
+    }
+
+    public Map<String, List<OffsetFetchRequestTopics>> groupIdsToTopics() {
+        Map<String, List<OffsetFetchRequestTopics>> groupIdsToTopics = new HashMap<>();
+        for (OffsetFetchRequestGroup group : data.groupIds()) {
+            groupIdsToTopics.put(group.groupId(), group.topics());
+        }
+        return groupIdsToTopics;
+    }
+
+    public List<String> groupIds() {
+        return data.groupIds()
+            .stream()
+            .map(OffsetFetchRequestGroup::groupId)
+            .collect(Collectors.toList());
     }
 
     private OffsetFetchRequest(OffsetFetchRequestData data, short version) {
@@ -152,13 +283,27 @@ public class OffsetFetchRequest extends AbstractRequest {
                         new TopicPartition(topic.name(), partitionIndex), partitionError);
                 }
             }
-        }
-
-        if (version() >= 3) {
-            return new OffsetFetchResponse(throttleTimeMs, error, responsePartitions);
-        } else {
             return new OffsetFetchResponse(error, responsePartitions);
         }
+        if (version() == 2) {
+            return new OffsetFetchResponse(error, responsePartitions);
+        }
+        if (version() >= 3 && version() < 8) {
+            return new OffsetFetchResponse(throttleTimeMs, error, responsePartitions);
+        }
+        List<String> groupIds =
+            data.groupIds()
+                .stream()
+                .map(OffsetFetchRequestGroup::groupId)
+                .collect(Collectors.toList());
+        Map<String, Errors> errorsMap = new HashMap<>(groupIds.size());
+        Map<String, Map<TopicPartition, OffsetFetchResponse.PartitionData>> partitionMap =
+            new HashMap<>(groupIds.size());
+        for (String g : groupIds) {
+            errorsMap.put(g, error);
+            partitionMap.put(g, responsePartitions);
+        }
+        return new OffsetFetchResponse(throttleTimeMs, errorsMap, partitionMap);
     }
 
     @Override
@@ -172,6 +317,10 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     public boolean isAllPartitions() {
         return data.topics() == ALL_TOPIC_PARTITIONS;
+    }
+
+    public List<OffsetFetchRequestTopics> isAllPartitionsForGroup() {
+        return ALL_TOPIC_PARTITIONS_BATCH;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -168,15 +168,6 @@ public class OffsetFetchResponse extends AbstractResponse {
     }
 
     /**
-     * Constructor without throttle time for version 8 and above.
-     * @param errors Error code on a per group level basis
-     * @param responseData Fetched offset information grouped group id
-     */
-    public OffsetFetchResponse(Map<String, Errors> errors, Map<String, Map<TopicPartition, PartitionData>> responseData) {
-        this(DEFAULT_THROTTLE_TIME, errors, responseData);
-    }
-
-    /**
      * Constructor with throttle time for version 8 and above.
      * @param throttleTimeMs The time in milliseconds that this response was throttled
      * @param errors Potential coordinator or group level error code

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -203,7 +203,7 @@ public class OffsetFetchResponse extends AbstractResponse {
             groupLevelErrors.put(groupName, errors.get(groupName));
         }
         this.data = new OffsetFetchResponseData()
-            .setGroupIds(groupList)
+            .setGroups(groupList)
             .setThrottleTimeMs(throttleTimeMs);
         this.error = null;
     }
@@ -221,7 +221,7 @@ public class OffsetFetchResponse extends AbstractResponse {
         if (version < 8) {
             this.error = version >= 2 ? Errors.forCode(data.errorCode()) : topLevelError(data);
         } else {
-            for (OffsetFetchResponseGroup group : data.groupIds()) {
+            for (OffsetFetchResponseGroup group : data.groups()) {
                 this.groupLevelErrors.put(group.groupId(), Errors.forCode(group.errorCode()));
             }
             this.error = null;
@@ -272,7 +272,7 @@ public class OffsetFetchResponse extends AbstractResponse {
             for (Map.Entry<String, Errors> entry : groupLevelErrors.entrySet()) {
                 updateErrorCounts(counts, entry.getValue());
             }
-            for (OffsetFetchResponseGroup group : data.groupIds()) {
+            for (OffsetFetchResponseGroup group : data.groups()) {
                 group.topics().forEach(topic ->
                     topic.partitions().forEach(partition ->
                         updateErrorCounts(counts, Errors.forCode(partition.errorCode()))));
@@ -306,7 +306,7 @@ public class OffsetFetchResponse extends AbstractResponse {
     private Map<TopicPartition, PartitionData> buildResponseData(String groupId) {
         Map<TopicPartition, PartitionData> responseData = new HashMap<>();
         OffsetFetchResponseGroup group = data
-            .groupIds()
+            .groups()
             .stream()
             .filter(g -> g.groupId().equals(groupId))
             .collect(Collectors.toList())

--- a/clients/src/main/resources/common/message/OffsetFetchRequest.json
+++ b/clients/src/main/resources/common/message/OffsetFetchRequest.json
@@ -45,7 +45,7 @@
       { "name": "PartitionIndexes", "type": "[]int32", "versions": "0-7",
         "about": "The partition indexes we would like to fetch offsets for." }
     ]},
-    { "name": "GroupIds", "type": "[]OffsetFetchRequestGroup", "versions": "8+",
+    { "name": "Groups", "type": "[]OffsetFetchRequestGroup", "versions": "8+",
       "about": "Each group we would like to fetch offsets for", "fields": [
       { "name": "groupId", "type": "string", "versions": "8+", "entityType": "groupId",
         "about": "The group ID."},

--- a/clients/src/main/resources/common/message/OffsetFetchRequest.json
+++ b/clients/src/main/resources/common/message/OffsetFetchRequest.json
@@ -31,19 +31,33 @@
   // Version 6 is the first flexible version.
   //
   // Version 7 is adding the require stable flag.
-  "validVersions": "0-7",
+  //
+  // Version 8 is adding support for fetching offsets for multiple groups at a time
+  "validVersions": "0-8",
   "flexibleVersions": "6+",
   "fields": [
-    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
+    { "name": "GroupId", "type": "string", "versions": "0-7", "entityType": "groupId",
       "about": "The group to fetch offsets for." },
-    { "name": "Topics", "type": "[]OffsetFetchRequestTopic", "versions": "0+", "nullableVersions": "2+",
+    { "name": "Topics", "type": "[]OffsetFetchRequestTopic", "versions": "0-7", "nullableVersions": "2-7",
       "about": "Each topic we would like to fetch offsets for, or null to fetch offsets for all topics.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Name", "type": "string", "versions": "0-7", "entityType": "topicName",
         "about": "The topic name."},
-      { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
+      { "name": "PartitionIndexes", "type": "[]int32", "versions": "0-7",
         "about": "The partition indexes we would like to fetch offsets for." }
     ]},
+    { "name": "GroupIds", "type": "[]OffsetFetchRequestGroup", "versions": "8+",
+      "about": "Each group we would like to fetch offsets for", "fields": [
+      { "name": "groupId", "type": "string", "versions": "8+", "entityType": "groupId",
+        "about": "The group ID."},
+      { "name": "Topics", "type": "[]OffsetFetchRequestTopics", "versions": "8+", "nullableVersions": "8+",
+        "about": "Each topic we would like to fetch offsets for, or null to fetch offsets for all topics.", "fields": [
+        { "name": "Name", "type": "string", "versions": "8+", "entityType": "topicName",
+          "about": "The topic name."},
+        { "name": "PartitionIndexes", "type": "[]int32", "versions": "8+",
+          "about": "The partition indexes we would like to fetch offsets for." }
+      ]}
+    ]},
     {"name": "RequireStable", "type": "bool", "versions": "7+", "default": "false",
-     "about": "Whether broker should hold on returning unstable offsets but set a retriable error code for the partition."}
+      "about": "Whether broker should hold on returning unstable offsets but set a retriable error code for the partitions."}
   ]
 }

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -79,7 +79,7 @@
             "about": "The partition-level error code, or 0 if there was no error." }
         ]}
       ]},
-      { "name": "ErrorCode", "type": "int16", "versions": "8+", "default": "0", "ignorable": true,
+      { "name": "ErrorCode", "type": "int16", "versions": "8+", "default": "0",
         "about": "The group-level error code, or 0 if there was no error." }
     ]}
   ]

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -30,30 +30,57 @@
   // Version 6 is the first flexible version.
   //
   // Version 7 adds pending offset commit as new error response on partition level.
-  "validVersions": "0-7",
+  //
+  // Version 8 is adding support for fetching offsets for multiple groups
+  "validVersions": "0-8",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "Topics", "type": "[]OffsetFetchResponseTopic", "versions": "0+", 
+    { "name": "Topics", "type": "[]OffsetFetchResponseTopic", "versions": "0-7",
       "about": "The responses per topic.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Name", "type": "string", "versions": "0-7", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]OffsetFetchResponsePartition", "versions": "0+",
+      { "name": "Partitions", "type": "[]OffsetFetchResponsePartition", "versions": "0-7",
         "about": "The responses per partition", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "PartitionIndex", "type": "int32", "versions": "0-7",
           "about": "The partition index." },
-        { "name": "CommittedOffset", "type": "int64", "versions": "0+",
+        { "name": "CommittedOffset", "type": "int64", "versions": "0-7",
           "about": "The committed message offset." },
-        { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "5+", "default": "-1",
+        { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "5-7", "default": "-1",
           "ignorable": true, "about": "The leader epoch." },
-        { "name": "Metadata", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        { "name": "Metadata", "type": "string", "versions": "0-7", "nullableVersions": "0-7",
           "about": "The partition metadata." },
-        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        { "name": "ErrorCode", "type": "int16", "versions": "0-7",
           "about": "The error code, or 0 if there was no error." }
       ]}
     ]},
-    { "name": "ErrorCode", "type": "int16", "versions": "2+", "default": "0", "ignorable": true,
-      "about": "The top-level error code, or 0 if there was no error." }
+    { "name": "ErrorCode", "type": "int16", "versions": "2-7", "default": "0", "ignorable": true,
+      "about": "The top-level error code, or 0 if there was no error." },
+    {"name": "GroupIds", "type": "[]OffsetFetchResponseGroup", "versions": "8+",
+      "about": "The responses per group id.", "fields": [
+      { "name": "groupId", "type": "string", "versions": "8+", "entityType": "groupId",
+        "about": "The group ID." },
+      { "name": "Topics", "type": "[]OffsetFetchResponseTopics", "versions": "8+",
+        "about": "The responses per topic.", "fields": [
+        { "name": "Name", "type": "string", "versions": "8+", "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]OffsetFetchResponsePartitions", "versions": "8+",
+          "about": "The responses per partition", "fields": [
+          { "name": "PartitionIndex", "type": "int32", "versions": "8+",
+            "about": "The partition index." },
+          { "name": "CommittedOffset", "type": "int64", "versions": "8+",
+            "about": "The committed message offset." },
+          { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "8+", "default": "-1",
+            "ignorable": true, "about": "The leader epoch." },
+          { "name": "Metadata", "type": "string", "versions": "8+", "nullableVersions": "0+",
+            "about": "The partition metadata." },
+          { "name": "ErrorCode", "type": "int16", "versions": "8+",
+            "about": "The partition-level error code, or 0 if there was no error." }
+        ]}
+      ]},
+      { "name": "ErrorCode", "type": "int16", "versions": "8+", "default": "0", "ignorable": true,
+        "about": "The group-level error code, or 0 if there was no error." }
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -57,7 +57,7 @@
     ]},
     { "name": "ErrorCode", "type": "int16", "versions": "2-7", "default": "0", "ignorable": true,
       "about": "The top-level error code, or 0 if there was no error." },
-    {"name": "GroupIds", "type": "[]OffsetFetchResponseGroup", "versions": "8+",
+    {"name": "Groups", "type": "[]OffsetFetchResponseGroup", "versions": "8+",
       "about": "The responses per group id.", "fields": [
       { "name": "groupId", "type": "string", "versions": "8+", "entityType": "groupId",
         "about": "The group ID." },

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -73,7 +73,7 @@
             "about": "The committed message offset." },
           { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "8+", "default": "-1",
             "ignorable": true, "about": "The leader epoch." },
-          { "name": "Metadata", "type": "string", "versions": "8+", "nullableVersions": "0+",
+          { "name": "Metadata", "type": "string", "versions": "8+", "nullableVersions": "8+",
             "about": "The partition metadata." },
           { "name": "ErrorCode", "type": "int16", "versions": "8+",
             "about": "The partition-level error code, or 0 if there was no error." }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -55,10 +55,10 @@ public class ListConsumerGroupOffsetsHandlerTest {
     public void testBuildRequest() {
         ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupId, tps, logContext);
         OffsetFetchRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
-        assertEquals(groupId, request.data().groupIds().get(0).groupId());
-        assertEquals(2, request.data().groupIds().get(0).topics().size());
-        assertEquals(2, request.data().groupIds().get(0).topics().get(0).partitionIndexes().size());
-        assertEquals(2, request.data().groupIds().get(0).topics().get(1).partitionIndexes().size());
+        assertEquals(groupId, request.data().groups().get(0).groupId());
+        assertEquals(2, request.data().groups().get(0).topics().size());
+        assertEquals(2, request.data().groups().get(0).topics().get(0).partitionIndexes().size());
+        assertEquals(2, request.data().groups().get(0).topics().get(1).partitionIndexes().size());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -55,10 +55,10 @@ public class ListConsumerGroupOffsetsHandlerTest {
     public void testBuildRequest() {
         ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupId, tps, logContext);
         OffsetFetchRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
-        assertEquals(groupId, request.data().groupId());
-        assertEquals(2, request.data().topics().size());
-        assertEquals(2, request.data().topics().get(0).partitionIndexes().size());
-        assertEquals(2, request.data().topics().get(1).partitionIndexes().size());
+        assertEquals(groupId, request.data().groupIds().get(0).groupId());
+        assertEquals(2, request.data().groupIds().get(0).topics().size());
+        assertEquals(2, request.data().groupIds().get(0).topics().get(0).partitionIndexes().size());
+        assertEquals(2, request.data().groupIds().get(0).topics().get(1).partitionIndexes().size());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -38,9 +38,14 @@ import org.apache.kafka.common.message.OffsetCommitRequestData.OffsetCommitReque
 import org.apache.kafka.common.message.OffsetCommitRequestData.OffsetCommitRequestTopic;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponsePartition;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponseTopic;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestGroup;
 import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopic;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseGroup;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartition;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartitions;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopics;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData.TxnOffsetCommitRequestPartition;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData.TxnOffsetCommitRequestTopic;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData.TxnOffsetCommitResponsePartition;
@@ -607,7 +612,7 @@ public final class MessageTest {
     }
 
     @Test
-    public void testOffsetFetchVersions() throws Exception {
+    public void testOffsetFetchV0ToV7() throws Exception {
         String groupId = "groupId";
         String topicName = "topic";
 
@@ -615,11 +620,11 @@ public final class MessageTest {
             new OffsetFetchRequestTopic()
                 .setName(topicName)
                 .setPartitionIndexes(Collections.singletonList(5)));
-        testAllMessageRoundTrips(new OffsetFetchRequestData()
+        testAllMessageRoundTripsOffsetFetchV0ToV7(new OffsetFetchRequestData()
                                      .setTopics(new ArrayList<>())
                                      .setGroupId(groupId));
 
-        testAllMessageRoundTrips(new OffsetFetchRequestData()
+        testAllMessageRoundTripsOffsetFetchV0ToV7(new OffsetFetchRequestData()
                                      .setGroupId(groupId)
                                      .setTopics(topics));
 
@@ -633,17 +638,19 @@ public final class MessageTest {
                                                        .setRequireStable(true);
 
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            final short finalVersion = version;
-            if (version < 2) {
-                assertThrows(NullPointerException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, allPartitionData));
-            } else {
-                testAllMessageRoundTripsFromVersion(version, allPartitionData);
-            }
+            if (version < 8) {
+                final short finalVersion = version;
+                if (version < 2) {
+                    assertThrows(NullPointerException.class, () -> testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(finalVersion, allPartitionData));
+                } else {
+                    testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(version, allPartitionData);
+                }
 
-            if (version < 7) {
-                assertThrows(UnsupportedVersionException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, requireStableData));
-            } else {
-                testAllMessageRoundTripsFromVersion(finalVersion, requireStableData);
+                if (version < 7) {
+                    assertThrows(UnsupportedVersionException.class, () -> testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(finalVersion, requireStableData));
+                } else {
+                    testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(finalVersion, requireStableData);
+                }
             }
         }
 
@@ -662,20 +669,179 @@ public final class MessageTest {
                       .setErrorCode(Errors.NOT_COORDINATOR.code())
                       .setThrottleTimeMs(10);
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            OffsetFetchResponseData responseData = response.get();
-            if (version <= 1) {
-                responseData.setErrorCode(Errors.NONE.code());
-            }
+            if (version < 8) {
+                OffsetFetchResponseData responseData = response.get();
+                if (version <= 1) {
+                    responseData.setErrorCode(Errors.NONE.code());
+                }
 
-            if (version <= 2) {
-                responseData.setThrottleTimeMs(0);
-            }
+                if (version <= 2) {
+                    responseData.setThrottleTimeMs(0);
+                }
 
-            if (version <= 4) {
-                responseData.topics().get(0).partitions().get(0).setCommittedLeaderEpoch(-1);
-            }
+                if (version <= 4) {
+                    responseData.topics().get(0).partitions().get(0).setCommittedLeaderEpoch(-1);
+                }
 
-            testAllMessageRoundTripsFromVersion(version, responseData);
+                testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(version, responseData);
+            }
+        }
+    }
+
+    private void testAllMessageRoundTripsOffsetFetchV0ToV7(Message message) throws Exception {
+        testDuplication(message);
+        testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(message.lowestSupportedVersion(), message);
+    }
+
+    private void testAllMessageRoundTripsOffsetFetchFromVersionV0ToV7(short fromVersion,
+        Message message) throws Exception {
+        for (short version = fromVersion; version <= 7; version++) {
+            testEquivalentMessageRoundTrip(version, message);
+        }
+    }
+
+    @Test
+    public void testOffsetFetchV8AndAbove() throws Exception {
+        String groupOne = "group1";
+        String groupTwo = "group2";
+        String groupThree = "group3";
+        String groupFour = "group4";
+        String groupFive = "group5";
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String topic3 = "topic3";
+
+        OffsetFetchRequestTopics topicOne = new OffsetFetchRequestTopics()
+            .setName(topic1)
+            .setPartitionIndexes(Collections.singletonList(5));
+        OffsetFetchRequestTopics topicTwo = new OffsetFetchRequestTopics()
+            .setName(topic2)
+            .setPartitionIndexes(Collections.singletonList(10));
+        OffsetFetchRequestTopics topicThree = new OffsetFetchRequestTopics()
+            .setName(topic3)
+            .setPartitionIndexes(Collections.singletonList(15));
+
+        List<OffsetFetchRequestTopics> groupOneTopics = singletonList(topicOne);
+        OffsetFetchRequestGroup group1 =
+            new OffsetFetchRequestGroup()
+                .setGroupId(groupOne)
+                .setTopics(groupOneTopics);
+
+        List<OffsetFetchRequestTopics> groupTwoTopics = Arrays.asList(topicOne, topicTwo);
+        OffsetFetchRequestGroup group2 =
+            new OffsetFetchRequestGroup()
+                .setGroupId(groupTwo)
+                .setTopics(groupTwoTopics);
+
+        List<OffsetFetchRequestTopics> groupThreeTopics = Arrays.asList(topicOne, topicTwo, topicThree);
+        OffsetFetchRequestGroup group3 =
+            new OffsetFetchRequestGroup()
+                .setGroupId(groupThree)
+                .setTopics(groupThreeTopics);
+
+        OffsetFetchRequestGroup group4 =
+            new OffsetFetchRequestGroup()
+                .setGroupId(groupFour)
+                .setTopics(null);
+
+        OffsetFetchRequestGroup group5 =
+            new OffsetFetchRequestGroup()
+                .setGroupId(groupFive)
+                .setTopics(null);
+
+        OffsetFetchRequestData requestData = new OffsetFetchRequestData()
+            .setGroupIds(Arrays.asList(group1, group2, group3, group4, group5))
+            .setRequireStable(true);
+
+        testAllMessageRoundTripsOffsetFetchV8AndAbove(requestData);
+
+        testAllMessageRoundTripsOffsetFetchV8AndAbove(requestData.setRequireStable(false));
+
+
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version >= 8) {
+                testAllMessageRoundTripsOffsetFetchFromVersionV8AndAbove(version, requestData);
+            }
+        }
+
+        OffsetFetchResponseTopics responseTopic1 =
+            new OffsetFetchResponseTopics()
+                .setName(topic1)
+                .setPartitions(Collections.singletonList(
+                    new OffsetFetchResponsePartitions()
+                        .setPartitionIndex(5)
+                        .setMetadata(null)
+                        .setCommittedOffset(100)
+                        .setCommittedLeaderEpoch(3)
+                        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())));
+        OffsetFetchResponseTopics responseTopic2 =
+            new OffsetFetchResponseTopics()
+                .setName(topic2)
+                .setPartitions(Collections.singletonList(
+                    new OffsetFetchResponsePartitions()
+                        .setPartitionIndex(10)
+                        .setMetadata("foo")
+                        .setCommittedOffset(200)
+                        .setCommittedLeaderEpoch(2)
+                        .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code())));
+        OffsetFetchResponseTopics responseTopic3 =
+            new OffsetFetchResponseTopics()
+                .setName(topic3)
+                .setPartitions(Collections.singletonList(
+                    new OffsetFetchResponsePartitions()
+                        .setPartitionIndex(15)
+                        .setMetadata("bar")
+                        .setCommittedOffset(300)
+                        .setCommittedLeaderEpoch(1)
+                        .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())));
+
+        OffsetFetchResponseGroup responseGroup1 =
+            new OffsetFetchResponseGroup()
+                .setGroupId(groupOne)
+                .setTopics(Collections.singletonList(responseTopic1))
+                .setErrorCode(Errors.NOT_COORDINATOR.code());
+        OffsetFetchResponseGroup responseGroup2 =
+            new OffsetFetchResponseGroup()
+                .setGroupId(groupTwo)
+                .setTopics(Arrays.asList(responseTopic1, responseTopic2))
+                .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code());
+        OffsetFetchResponseGroup responseGroup3 =
+            new OffsetFetchResponseGroup()
+                .setGroupId(groupThree)
+                .setTopics(Arrays.asList(responseTopic1, responseTopic2, responseTopic3))
+                .setErrorCode(Errors.NONE.code());
+        OffsetFetchResponseGroup responseGroup4 =
+            new OffsetFetchResponseGroup()
+                .setGroupId(groupFour)
+                .setTopics(Arrays.asList(responseTopic1, responseTopic2, responseTopic3))
+                .setErrorCode(Errors.NONE.code());
+        OffsetFetchResponseGroup responseGroup5 =
+            new OffsetFetchResponseGroup()
+                .setGroupId(groupFive)
+                .setTopics(Arrays.asList(responseTopic1, responseTopic2, responseTopic3))
+                .setErrorCode(Errors.NONE.code());
+
+        Supplier<OffsetFetchResponseData> response =
+            () -> new OffsetFetchResponseData()
+                .setGroupIds(Arrays.asList(responseGroup1, responseGroup2, responseGroup3,
+                    responseGroup4, responseGroup5))
+                .setThrottleTimeMs(10);
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version >= 8) {
+                OffsetFetchResponseData responseData = response.get();
+                testAllMessageRoundTripsOffsetFetchFromVersionV8AndAbove(version, responseData);
+            }
+        }
+    }
+
+    private void testAllMessageRoundTripsOffsetFetchV8AndAbove(Message message) throws Exception {
+        testDuplication(message);
+        testAllMessageRoundTripsOffsetFetchFromVersionV8AndAbove((short) 8, message);
+    }
+
+    private void testAllMessageRoundTripsOffsetFetchFromVersionV8AndAbove(short fromVersion, Message message) throws Exception {
+        for (short version = fromVersion; version <= message.highestSupportedVersion(); version++) {
+            testEquivalentMessageRoundTrip(version, message);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -708,13 +708,13 @@ public final class MessageTest {
                 .setPartitionIndexes(Collections.singletonList(5)));
 
         OffsetFetchRequestData allPartitionData = new OffsetFetchRequestData()
-            .setGroupIds(Collections.singletonList(
+            .setGroups(Collections.singletonList(
                 new OffsetFetchRequestGroup()
                     .setGroupId(groupId)
                     .setTopics(null)));
 
         OffsetFetchRequestData specifiedPartitionData = new OffsetFetchRequestData()
-            .setGroupIds(Collections.singletonList(
+            .setGroups(Collections.singletonList(
                 new OffsetFetchRequestGroup()
                     .setGroupId(groupId)
                     .setTopics(topic)))
@@ -732,7 +732,7 @@ public final class MessageTest {
 
         Supplier<OffsetFetchResponseData> response =
             () -> new OffsetFetchResponseData()
-                .setGroupIds(Collections.singletonList(
+                .setGroups(Collections.singletonList(
                     new OffsetFetchResponseGroup()
                         .setGroupId(groupId)
                         .setTopics(Collections.singletonList(
@@ -804,7 +804,7 @@ public final class MessageTest {
                 .setTopics(null);
 
         OffsetFetchRequestData requestData = new OffsetFetchRequestData()
-            .setGroupIds(Arrays.asList(group1, group2, group3, group4, group5))
+            .setGroups(Arrays.asList(group1, group2, group3, group4, group5))
             .setRequireStable(true);
 
         testAllMessageRoundTripsOffsetFetchV8AndAbove(requestData);
@@ -877,7 +877,7 @@ public final class MessageTest {
 
         Supplier<OffsetFetchResponseData> response =
             () -> new OffsetFetchResponseData()
-                .setGroupIds(Arrays.asList(responseGroup1, responseGroup2, responseGroup3,
+                .setGroups(Arrays.asList(responseGroup1, responseGroup2, responseGroup3,
                     responseGroup4, responseGroup5))
                 .setThrottleTimeMs(10);
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
@@ -18,10 +18,12 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.OffsetFetchRequest.Builder;
+import org.apache.kafka.common.requests.OffsetFetchRequest.NoBatchedOffsetFetchRequestException;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -34,7 +36,9 @@ import java.util.Optional;
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,25 +48,20 @@ public class OffsetFetchRequestTest {
     private final int partitionOne = 1;
     private final String topicTwo = "topic2";
     private final int partitionTwo = 2;
-    private final String groupId = "groupId";
+    private final String topicThree = "topic3";
+    private final String group1 = "group1";
+    private final String group2 = "group2";
+    private final String group3 = "group3";
+    private final String group4 = "group4";
+    private final String group5 = "group5";
 
     private OffsetFetchRequest.Builder builder;
-    private List<TopicPartition> partitions;
-
-    @BeforeEach
-    public void setUp() {
-        partitions = Arrays.asList(new TopicPartition(topicOne, partitionOne),
-                                   new TopicPartition(topicTwo, partitionTwo));
-        builder = new OffsetFetchRequest.Builder(
-            groupId,
-            false,
-            partitions,
-            false);
-    }
 
     @Test
     public void testConstructor() {
-        assertFalse(builder.isAllTopicPartitions());
+        List<TopicPartition> partitions = Arrays.asList(
+            new TopicPartition(topicOne, partitionOne),
+            new TopicPartition(topicTwo, partitionTwo));
         int throttleTimeMs = 10;
 
         Map<TopicPartition, PartitionData> expectedData = new HashMap<>();
@@ -76,25 +75,116 @@ public class OffsetFetchRequestTest {
         }
 
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            OffsetFetchRequest request = builder.build(version);
-            assertFalse(request.isAllPartitions());
-            assertEquals(groupId, request.groupId());
-            assertEquals(partitions, request.partitions());
+            if (version < 8) {
+                builder = new OffsetFetchRequest.Builder(
+                    group1,
+                    false,
+                    partitions,
+                    false);
+                assertFalse(builder.isAllTopicPartitions());
+                OffsetFetchRequest request = builder.build(version);
+                assertFalse(request.isAllPartitions());
+                assertEquals(group1, request.groupId());
+                assertEquals(partitions, request.partitions());
 
-            OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
-            assertEquals(Errors.NONE, response.error());
-            assertFalse(response.hasError());
-            assertEquals(Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(),
-                "Incorrect error count for version " + version);
+                OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
+                assertEquals(Errors.NONE, response.error());
+                assertFalse(response.hasError());
+                assertEquals(Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(),
+                    "Incorrect error count for version " + version);
 
-            if (version <= 1) {
-                assertEquals(expectedData, response.responseData());
-            }
+                if (version <= 1) {
+                    assertEquals(expectedData, response.oldResponseData());
+                }
 
-            if (version >= 3) {
-                assertEquals(throttleTimeMs, response.throttleTimeMs());
+                if (version >= 3) {
+                    assertEquals(throttleTimeMs, response.throttleTimeMs());
+                } else {
+                    assertEquals(DEFAULT_THROTTLE_TIME, response.throttleTimeMs());
+                }
             } else {
-                assertEquals(DEFAULT_THROTTLE_TIME, response.throttleTimeMs());
+                builder = new Builder(Collections.singletonMap(group1, partitions), false, false);
+                OffsetFetchRequest request = builder.build(version);
+                Map<String, List<TopicPartition>> groupToPartitionMap =
+                    request.groupIdsToPartitions();
+                Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
+                    request.groupIdsToTopics();
+                assertNotSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertTrue(groupToPartitionMap.containsKey(group1) && groupToTopicMap.containsKey(
+                    group1));
+                assertEquals(partitions, groupToPartitionMap.get(group1));
+                OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
+                assertEquals(Errors.NONE, response.groupLevelError(group1));
+                assertFalse(response.groupHasError(group1));
+                assertEquals(Collections.singletonMap(Errors.NONE, 1), response.errorCounts(),
+                    "Incorrect error count for version " + version);
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+            }
+        }
+    }
+
+    @Test
+    public void testConstructorWithMultipleGroups() {
+        List<TopicPartition> topic1Partitions = Arrays.asList(
+            new TopicPartition(topicOne, partitionOne),
+            new TopicPartition(topicOne, partitionTwo));
+        List<TopicPartition> topic2Partitions = Arrays.asList(
+            new TopicPartition(topicTwo, partitionOne),
+            new TopicPartition(topicTwo, partitionTwo));
+        List<TopicPartition> topic3Partitions = Arrays.asList(
+            new TopicPartition(topicThree, partitionOne),
+            new TopicPartition(topicThree, partitionTwo));
+        Map<String, List<TopicPartition>> groupToTp = new HashMap<>();
+        groupToTp.put(group1, topic1Partitions);
+        groupToTp.put(group2, topic2Partitions);
+        groupToTp.put(group3, topic3Partitions);
+        groupToTp.put(group4, null);
+        groupToTp.put(group5, null);
+        int throttleTimeMs = 10;
+
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version >= 8) {
+                builder = new Builder(groupToTp, false, false);
+                OffsetFetchRequest request = builder.build(version);
+                Map<String, List<TopicPartition>> groupToPartitionMap =
+                    request.groupIdsToPartitions();
+                Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
+                    request.groupIdsToTopics();
+                assertEquals(groupToTp.keySet(), groupToTopicMap.keySet());
+                assertEquals(groupToTp.keySet(), groupToPartitionMap.keySet());
+                assertNotSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertNotSame(groupToTopicMap.get(group2), request.isAllPartitionsForGroup());
+                assertNotSame(groupToTopicMap.get(group3), request.isAllPartitionsForGroup());
+                assertSame(groupToTopicMap.get(group4), request.isAllPartitionsForGroup());
+                assertSame(groupToTopicMap.get(group5), request.isAllPartitionsForGroup());
+                OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
+                assertEquals(Errors.NONE, response.groupLevelError(group1));
+                assertEquals(Errors.NONE, response.groupLevelError(group2));
+                assertEquals(Errors.NONE, response.groupLevelError(group3));
+                assertEquals(Errors.NONE, response.groupLevelError(group4));
+                assertEquals(Errors.NONE, response.groupLevelError(group5));
+                assertFalse(response.groupHasError(group1));
+                assertFalse(response.groupHasError(group2));
+                assertFalse(response.groupHasError(group3));
+                assertFalse(response.groupHasError(group4));
+                assertFalse(response.groupHasError(group5));
+                assertEquals(Collections.singletonMap(Errors.NONE, 5), response.errorCounts(),
+                    "Incorrect error count for version " + version);
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+            }
+        }
+    }
+
+    @Test
+    public void testBuildThrowForUnsupportedBatchRequest() {
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version < 8) {
+                Map<String, List<TopicPartition>> groupPartitionMap = new HashMap<>();
+                groupPartitionMap.put(group1, null);
+                groupPartitionMap.put(group2, null);
+                builder = new Builder(groupPartitionMap, true, false);
+                final short finalVersion = version;
+                assertThrows(NoBatchedOffsetFetchRequestException.class, () -> builder.build(finalVersion));
             }
         }
     }
@@ -102,21 +192,35 @@ public class OffsetFetchRequestTest {
     @Test
     public void testConstructorFailForUnsupportedRequireStable() {
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            // The builder needs to be initialized every cycle as the internal data `requireStable` flag is flipped.
-            builder = new OffsetFetchRequest.Builder(groupId, true, null, false);
-            final short finalVersion = version;
-            if (version < 2) {
-                assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
-            } else {
-                OffsetFetchRequest request = builder.build(finalVersion);
-                assertEquals(groupId, request.groupId());
-                assertNull(request.partitions());
-                assertTrue(request.isAllPartitions());
-                if (version < 7) {
-                    assertFalse(request.requireStable());
+            if (version < 8) {
+                // The builder needs to be initialized every cycle as the internal data `requireStable` flag is flipped.
+                builder = new OffsetFetchRequest.Builder(group1, true, null, false);
+                final short finalVersion = version;
+                if (version < 2) {
+                    assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
                 } else {
-                    assertTrue(request.requireStable());
+                    OffsetFetchRequest request = builder.build(finalVersion);
+                    assertEquals(group1, request.groupId());
+                    assertNull(request.partitions());
+                    assertTrue(request.isAllPartitions());
+                    if (version < 7) {
+                        assertFalse(request.requireStable());
+                    } else {
+                        assertTrue(request.requireStable());
+                    }
                 }
+            } else {
+                builder = new Builder(Collections.singletonMap(group1, null), true, false);
+                OffsetFetchRequest request = builder.build(version);
+                Map<String, List<TopicPartition>> groupToPartitionMap =
+                    request.groupIdsToPartitions();
+                Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
+                    request.groupIdsToTopics();
+                assertTrue(groupToPartitionMap.containsKey(group1) && groupToTopicMap.containsKey(
+                    group1));
+                assertNull(groupToPartitionMap.get(group1));
+                assertSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertTrue(request.requireStable());
             }
         }
     }
@@ -124,13 +228,15 @@ public class OffsetFetchRequestTest {
     @Test
     public void testBuildThrowForUnsupportedRequireStable() {
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            builder = new OffsetFetchRequest.Builder(groupId, true, null, true);
-            if (version < 7) {
-                final short finalVersion = version;
-                assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
-            } else {
-                OffsetFetchRequest request = builder.build(version);
-                assertTrue(request.requireStable());
+            if (version < 8) {
+                builder = new OffsetFetchRequest.Builder(group1, true, null, true);
+                if (version < 7) {
+                    final short finalVersion = version;
+                    assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
+                } else {
+                    OffsetFetchRequest request = builder.build(version);
+                    assertTrue(request.requireStable());
+                }
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
@@ -36,9 +36,7 @@ import java.util.Optional;
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -94,7 +92,7 @@ public class OffsetFetchRequestTest {
                     "Incorrect error count for version " + version);
 
                 if (version <= 1) {
-                    assertEquals(expectedData, response.oldResponseData());
+                    assertEquals(expectedData, response.responseDataV0ToV7());
                 }
 
                 if (version >= 3) {
@@ -109,7 +107,7 @@ public class OffsetFetchRequestTest {
                     request.groupIdsToPartitions();
                 Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
                     request.groupIdsToTopics();
-                assertNotSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertFalse(request.isAllPartitionsForGroup(group1));
                 assertTrue(groupToPartitionMap.containsKey(group1) && groupToTopicMap.containsKey(
                     group1));
                 assertEquals(partitions, groupToPartitionMap.get(group1));
@@ -152,11 +150,11 @@ public class OffsetFetchRequestTest {
                     request.groupIdsToTopics();
                 assertEquals(groupToTp.keySet(), groupToTopicMap.keySet());
                 assertEquals(groupToTp.keySet(), groupToPartitionMap.keySet());
-                assertNotSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
-                assertNotSame(groupToTopicMap.get(group2), request.isAllPartitionsForGroup());
-                assertNotSame(groupToTopicMap.get(group3), request.isAllPartitionsForGroup());
-                assertSame(groupToTopicMap.get(group4), request.isAllPartitionsForGroup());
-                assertSame(groupToTopicMap.get(group5), request.isAllPartitionsForGroup());
+                assertFalse(request.isAllPartitionsForGroup(group1));
+                assertFalse(request.isAllPartitionsForGroup(group2));
+                assertFalse(request.isAllPartitionsForGroup(group3));
+                assertTrue(request.isAllPartitionsForGroup(group4));
+                assertTrue(request.isAllPartitionsForGroup(group5));
                 OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
                 assertEquals(Errors.NONE, response.groupLevelError(group1));
                 assertEquals(Errors.NONE, response.groupLevelError(group2));
@@ -219,7 +217,7 @@ public class OffsetFetchRequestTest {
                 assertTrue(groupToPartitionMap.containsKey(group1) && groupToTopicMap.containsKey(
                     group1));
                 assertNull(groupToPartitionMap.get(group1));
-                assertSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertTrue(request.isAllPartitionsForGroup(group1));
                 assertTrue(request.requireStable());
             }
         }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -253,7 +253,7 @@ public class OffsetFetchResponseTest {
                 OffsetFetchResponseData data = new OffsetFetchResponseData(
                     new ByteBufferAccessor(latestResponse.serialize(version)), version);
                 OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
-                assertEquals(Errors.NONE.code(), data.groupIds().get(0).errorCode());
+                assertEquals(Errors.NONE.code(), data.groups().get(0).errorCode());
 
                 assertEquals(Errors.NONE, oldResponse.groupLevelError(groupOne));
                 assertEquals(Utils.mkMap(
@@ -352,7 +352,7 @@ public class OffsetFetchResponseTest {
             Collections.singletonMap(groupOne, partitionDataMap));
         OffsetFetchResponseData expectedData =
             new OffsetFetchResponseData()
-                .setGroupIds(Collections.singletonList(
+                .setGroups(Collections.singletonList(
                     new OffsetFetchResponseGroup()
                         .setGroupId(groupOne)
                         .setTopics(Collections.singletonList(
@@ -421,7 +421,7 @@ public class OffsetFetchResponseTest {
             Collections.singletonMap(groupOne, partitionDataMap));
         OffsetFetchResponseData expectedData =
             new OffsetFetchResponseData()
-                .setGroupIds(Collections.singletonList(
+                .setGroups(Collections.singletonList(
                     new OffsetFetchResponseGroup()
                         .setGroupId(groupOne)
                         .setTopics(Collections.singletonList(

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -94,7 +94,7 @@ public class OffsetFetchResponseTest {
 
                 assertEquals(throttleTimeMs, response.throttleTimeMs());
 
-                Map<TopicPartition, PartitionData> responseData = response.oldResponseData();
+                Map<TopicPartition, PartitionData> responseData = response.responseDataV0ToV7();
                 assertEquals(partitionDataMap, responseData);
                 responseData.forEach((tp, data) -> assertTrue(data.hasError()));
             } else {
@@ -236,7 +236,7 @@ public class OffsetFetchResponseTest {
                     ));
                 }
 
-                Map<TopicPartition, PartitionData> responseData = oldResponse.oldResponseData();
+                Map<TopicPartition, PartitionData> responseData = oldResponse.responseDataV0ToV7();
                 assertEquals(expectedDataMap, responseData);
 
                 responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -18,8 +18,11 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseGroup;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartition;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartitions;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
@@ -44,12 +47,19 @@ public class OffsetFetchResponseTest {
     private final int offset = 100;
     private final String metadata = "metadata";
 
+    private final String groupOne = "group1";
+    private final String groupTwo = "group2";
+    private final String groupThree = "group3";
     private final String topicOne = "topic1";
     private final int partitionOne = 1;
     private final Optional<Integer> leaderEpochOne = Optional.of(1);
     private final String topicTwo = "topic2";
     private final int partitionTwo = 2;
     private final Optional<Integer> leaderEpochTwo = Optional.of(2);
+    private final String topicThree = "topic3";
+    private final int partitionThree = 3;
+    private final Optional<Integer> leaderEpochThree = Optional.of(3);
+
 
     private Map<TopicPartition, PartitionData> partitionDataMap;
 
@@ -72,21 +82,102 @@ public class OffsetFetchResponseTest {
 
     @Test
     public void testConstructor() {
-        OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NOT_COORDINATOR, partitionDataMap);
-        assertEquals(Errors.NOT_COORDINATOR, response.error());
-        assertEquals(3, response.errorCounts().size());
-        assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
-                Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
-                Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
-                response.errorCounts());
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version < 8) {
+                OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NOT_COORDINATOR, partitionDataMap);
+                assertEquals(Errors.NOT_COORDINATOR, response.error());
+                assertEquals(3, response.errorCounts().size());
+                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
+                    response.errorCounts());
 
-        assertEquals(throttleTimeMs, response.throttleTimeMs());
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
 
-        Map<TopicPartition, PartitionData> responseData = response.responseData();
-        assertEquals(partitionDataMap, responseData);
-        responseData.forEach(
-            (tp, data) -> assertTrue(data.hasError())
-        );
+                Map<TopicPartition, PartitionData> responseData = response.oldResponseData();
+                assertEquals(partitionDataMap, responseData);
+                responseData.forEach((tp, data) -> assertTrue(data.hasError()));
+            } else {
+                OffsetFetchResponse response = new OffsetFetchResponse(
+                    throttleTimeMs,
+                    Collections.singletonMap(groupOne, Errors.NOT_COORDINATOR),
+                    Collections.singletonMap(groupOne, partitionDataMap));
+                assertEquals(Errors.NOT_COORDINATOR, response.groupLevelError(groupOne));
+                assertEquals(3, response.errorCounts().size());
+                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
+                    response.errorCounts());
+
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+
+                Map<TopicPartition, PartitionData> responseData = response.responseData(groupOne);
+                assertEquals(partitionDataMap, responseData);
+                responseData.forEach((tp, data) -> assertTrue(data.hasError()));
+            }
+        }
+    }
+
+    @Test
+    public void testConstructorWithMultipleGroups() {
+        Map<String, Map<TopicPartition, PartitionData>> responseData = new HashMap<>();
+        Map<String, Errors> errorMap = new HashMap<>();
+        Map<TopicPartition, PartitionData> pd1 = new HashMap<>();
+        Map<TopicPartition, PartitionData> pd2 = new HashMap<>();
+        Map<TopicPartition, PartitionData> pd3 = new HashMap<>();
+        pd1.put(new TopicPartition(topicOne, partitionOne), new PartitionData(
+            offset,
+            leaderEpochOne,
+            metadata,
+            Errors.TOPIC_AUTHORIZATION_FAILED));
+        pd2.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
+            offset,
+            leaderEpochTwo,
+            metadata,
+            Errors.UNKNOWN_TOPIC_OR_PARTITION));
+        pd3.put(new TopicPartition(topicThree, partitionThree), new PartitionData(
+            offset,
+            leaderEpochThree,
+            metadata,
+            Errors.NONE));
+        responseData.put(groupOne, pd1);
+        responseData.put(groupTwo, pd2);
+        responseData.put(groupThree, pd3);
+        errorMap.put(groupOne, Errors.NOT_COORDINATOR);
+        errorMap.put(groupTwo, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        errorMap.put(groupThree, Errors.NONE);
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version >= 8) {
+                OffsetFetchResponse response = new OffsetFetchResponse(
+                    throttleTimeMs, errorMap, responseData);
+
+                assertEquals(Errors.NOT_COORDINATOR, response.groupLevelError(groupOne));
+                assertEquals(Errors.COORDINATOR_LOAD_IN_PROGRESS, response.groupLevelError(groupTwo));
+                assertEquals(Errors.NONE, response.groupLevelError(groupThree));
+                assertTrue(response.groupHasError(groupOne));
+                assertTrue(response.groupHasError(groupTwo));
+                assertFalse(response.groupHasError(groupThree));
+                assertEquals(5, response.errorCounts().size());
+                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1),
+                    Utils.mkEntry(Errors.COORDINATOR_LOAD_IN_PROGRESS, 1),
+                    Utils.mkEntry(Errors.NONE, 2)),
+                    response.errorCounts());
+
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+
+                Map<TopicPartition, PartitionData> responseData1 = response.responseData(groupOne);
+                assertEquals(pd1, responseData1);
+                responseData1.forEach((tp, data) -> assertTrue(data.hasError()));
+                Map<TopicPartition, PartitionData> responseData2 = response.responseData(groupTwo);
+                assertEquals(pd2, responseData2);
+                responseData2.forEach((tp, data) -> assertTrue(data.hasError()));
+                Map<TopicPartition, PartitionData> responseData3 = response.responseData(groupThree);
+                assertEquals(pd3, responseData3);
+                responseData3.forEach((tp, data) -> assertFalse(data.hasError()));
+            }
+        }
     }
 
     /**
@@ -94,77 +185,125 @@ public class OffsetFetchResponseTest {
      */
     @Test
     public void testStructBuild() {
-        partitionDataMap.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
-            offset,
-            leaderEpochTwo,
-            metadata,
-            Errors.GROUP_AUTHORIZATION_FAILED
-        ));
-
-        OffsetFetchResponse latestResponse = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
-
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            OffsetFetchResponseData data = new OffsetFetchResponseData(
-                new ByteBufferAccessor(latestResponse.serialize(version)), version);
+            if (version < 8) {
+                partitionDataMap.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
+                    offset,
+                    leaderEpochTwo,
+                    metadata,
+                    Errors.GROUP_AUTHORIZATION_FAILED
+                ));
 
-            OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
+                OffsetFetchResponse latestResponse = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
+                OffsetFetchResponseData data = new OffsetFetchResponseData(
+                    new ByteBufferAccessor(latestResponse.serialize(version)), version);
 
-            if (version <= 1) {
-                assertEquals(Errors.NONE.code(), data.errorCode());
+                OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
 
-                // Partition level error populated in older versions.
-                assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, oldResponse.error());
-                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 2),
-                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)), oldResponse.errorCounts());
+                if (version <= 1) {
+                    assertEquals(Errors.NONE.code(), data.errorCode());
 
-            } else {
-                assertEquals(Errors.NONE.code(), data.errorCode());
+                    // Partition level error populated in older versions.
+                    assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, oldResponse.error());
+                    assertEquals(Utils.mkMap(Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 2),
+                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                        oldResponse.errorCounts());
+                } else {
+                    assertEquals(Errors.NONE.code(), data.errorCode());
 
-                assertEquals(Errors.NONE, oldResponse.error());
-                assertEquals(Utils.mkMap(
+                    assertEquals(Errors.NONE, oldResponse.error());
+                    assertEquals(Utils.mkMap(
                         Utils.mkEntry(Errors.NONE, 1),
                         Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
-                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)), oldResponse.errorCounts());
-            }
+                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                        oldResponse.errorCounts());
+                }
 
-            if (version <= 2) {
-                assertEquals(DEFAULT_THROTTLE_TIME, oldResponse.throttleTimeMs());
+                if (version <= 2) {
+                    assertEquals(DEFAULT_THROTTLE_TIME, oldResponse.throttleTimeMs());
+                } else {
+                    assertEquals(throttleTimeMs, oldResponse.throttleTimeMs());
+                }
+
+                Map<TopicPartition, PartitionData> expectedDataMap = new HashMap<>();
+                for (Map.Entry<TopicPartition, PartitionData> entry : partitionDataMap.entrySet()) {
+                    PartitionData partitionData = entry.getValue();
+                    expectedDataMap.put(entry.getKey(), new PartitionData(
+                        partitionData.offset,
+                        version <= 4 ? Optional.empty() : partitionData.leaderEpoch,
+                        partitionData.metadata,
+                        partitionData.error
+                    ));
+                }
+
+                Map<TopicPartition, PartitionData> responseData = oldResponse.oldResponseData();
+                assertEquals(expectedDataMap, responseData);
+
+                responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
             } else {
+                partitionDataMap.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
+                    offset,
+                    leaderEpochTwo,
+                    metadata,
+                    Errors.GROUP_AUTHORIZATION_FAILED));
+                OffsetFetchResponse latestResponse = new OffsetFetchResponse(
+                    throttleTimeMs,
+                    Collections.singletonMap(groupOne, Errors.NONE),
+                    Collections.singletonMap(groupOne, partitionDataMap));
+                OffsetFetchResponseData data = new OffsetFetchResponseData(
+                    new ByteBufferAccessor(latestResponse.serialize(version)), version);
+                OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
+                assertEquals(Errors.NONE.code(), data.groupIds().get(0).errorCode());
+
+                assertEquals(Errors.NONE, oldResponse.groupLevelError(groupOne));
+                assertEquals(Utils.mkMap(
+                    Utils.mkEntry(Errors.NONE, 1),
+                    Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                    oldResponse.errorCounts());
                 assertEquals(throttleTimeMs, oldResponse.throttleTimeMs());
+
+                Map<TopicPartition, PartitionData> expectedDataMap = new HashMap<>();
+                for (Map.Entry<TopicPartition, PartitionData> entry : partitionDataMap.entrySet()) {
+                    PartitionData partitionData = entry.getValue();
+                    expectedDataMap.put(entry.getKey(), new PartitionData(
+                        partitionData.offset,
+                        partitionData.leaderEpoch,
+                        partitionData.metadata,
+                        partitionData.error
+                    ));
+                }
+
+                Map<TopicPartition, PartitionData> responseData = oldResponse.responseData(groupOne);
+                assertEquals(expectedDataMap, responseData);
+
+                responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
             }
-
-            Map<TopicPartition, PartitionData> expectedDataMap = new HashMap<>();
-            for (Map.Entry<TopicPartition, PartitionData> entry : partitionDataMap.entrySet()) {
-                PartitionData partitionData = entry.getValue();
-                expectedDataMap.put(entry.getKey(), new PartitionData(
-                    partitionData.offset,
-                    version <= 4 ? Optional.empty() : partitionData.leaderEpoch,
-                    partitionData.metadata,
-                    partitionData.error
-                ));
-            }
-
-            Map<TopicPartition, PartitionData> responseData = oldResponse.responseData();
-            assertEquals(expectedDataMap, responseData);
-
-            responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
         }
     }
 
     @Test
     public void testShouldThrottle() {
-        OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            if (version >= 4) {
-                assertTrue(response.shouldClientThrottle(version));
+            if (version < 8) {
+                OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
+                if (version >= 4) {
+                    assertTrue(response.shouldClientThrottle(version));
+                } else {
+                    assertFalse(response.shouldClientThrottle(version));
+                }
             } else {
-                assertFalse(response.shouldClientThrottle(version));
+                OffsetFetchResponse response = new OffsetFetchResponse(
+                    throttleTimeMs,
+                    Collections.singletonMap(groupOne, Errors.NOT_COORDINATOR),
+                    Collections.singletonMap(groupOne, partitionDataMap));
+                assertTrue(response.shouldClientThrottle(version));
             }
         }
     }
 
     @Test
-    public void testNullableMetadata() {
+    public void testNullableMetadataV0ToV7() {
         PartitionData pd = new PartitionData(
             offset,
             leaderEpochOne,
@@ -196,7 +335,43 @@ public class OffsetFetchResponseTest {
     }
 
     @Test
-    public void testUseDefaultLeaderEpoch() {
+    public void testNullableMetadataV8AndAbove() {
+        PartitionData pd = new PartitionData(
+            offset,
+            leaderEpochOne,
+            null,
+            Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        // test PartitionData.equals with null metadata
+        assertEquals(pd, pd);
+        partitionDataMap.clear();
+        partitionDataMap.put(new TopicPartition(topicOne, partitionOne), pd);
+
+        OffsetFetchResponse response = new OffsetFetchResponse(
+            throttleTimeMs,
+            Collections.singletonMap(groupOne, Errors.GROUP_AUTHORIZATION_FAILED),
+            Collections.singletonMap(groupOne, partitionDataMap));
+        OffsetFetchResponseData expectedData =
+            new OffsetFetchResponseData()
+                .setGroupIds(Collections.singletonList(
+                    new OffsetFetchResponseGroup()
+                        .setGroupId(groupOne)
+                        .setTopics(Collections.singletonList(
+                            new OffsetFetchResponseTopics()
+                                .setName(topicOne)
+                                .setPartitions(Collections.singletonList(
+                                    new OffsetFetchResponsePartitions()
+                                        .setPartitionIndex(partitionOne)
+                                        .setCommittedOffset(offset)
+                                        .setCommittedLeaderEpoch(leaderEpochOne.orElse(-1))
+                                        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+                                        .setMetadata(null)))))
+                        .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())))
+                .setThrottleTimeMs(throttleTimeMs);
+        assertEquals(expectedData, response.data());
+    }
+
+    @Test
+    public void testUseDefaultLeaderEpochV0ToV7() {
         final Optional<Integer> emptyLeaderEpoch = Optional.empty();
         partitionDataMap.clear();
 
@@ -225,6 +400,42 @@ public class OffsetFetchResponseTest {
                             .setMetadata(metadata))
                     ))
                 );
+        assertEquals(expectedData, response.data());
+    }
+
+    @Test
+    public void testUseDefaultLeaderEpochV8() {
+        final Optional<Integer> emptyLeaderEpoch = Optional.empty();
+        partitionDataMap.clear();
+
+        partitionDataMap.put(new TopicPartition(topicOne, partitionOne),
+            new PartitionData(
+                offset,
+                emptyLeaderEpoch,
+                metadata,
+                Errors.UNKNOWN_TOPIC_OR_PARTITION)
+        );
+        OffsetFetchResponse response = new OffsetFetchResponse(
+            throttleTimeMs,
+            Collections.singletonMap(groupOne, Errors.NOT_COORDINATOR),
+            Collections.singletonMap(groupOne, partitionDataMap));
+        OffsetFetchResponseData expectedData =
+            new OffsetFetchResponseData()
+                .setGroupIds(Collections.singletonList(
+                    new OffsetFetchResponseGroup()
+                        .setGroupId(groupOne)
+                        .setTopics(Collections.singletonList(
+                            new OffsetFetchResponseTopics()
+                                .setName(topicOne)
+                                .setPartitions(Collections.singletonList(
+                                    new OffsetFetchResponsePartitions()
+                                        .setPartitionIndex(partitionOne)
+                                        .setCommittedOffset(offset)
+                                        .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
+                                        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+                                        .setMetadata(metadata)))))
+                        .setErrorCode(Errors.NOT_COORDINATOR.code())))
+                .setThrottleTimeMs(throttleTimeMs);
         assertEquals(expectedData, response.data());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -111,7 +111,7 @@ public class OffsetFetchResponseTest {
 
                 assertEquals(throttleTimeMs, response.throttleTimeMs());
 
-                Map<TopicPartition, PartitionData> responseData = response.responseData(groupOne);
+                Map<TopicPartition, PartitionData> responseData = response.partitionDataMap(groupOne);
                 assertEquals(partitionDataMap, responseData);
                 responseData.forEach((tp, data) -> assertTrue(data.hasError()));
             }
@@ -167,13 +167,13 @@ public class OffsetFetchResponseTest {
 
                 assertEquals(throttleTimeMs, response.throttleTimeMs());
 
-                Map<TopicPartition, PartitionData> responseData1 = response.responseData(groupOne);
+                Map<TopicPartition, PartitionData> responseData1 = response.partitionDataMap(groupOne);
                 assertEquals(pd1, responseData1);
                 responseData1.forEach((tp, data) -> assertTrue(data.hasError()));
-                Map<TopicPartition, PartitionData> responseData2 = response.responseData(groupTwo);
+                Map<TopicPartition, PartitionData> responseData2 = response.partitionDataMap(groupTwo);
                 assertEquals(pd2, responseData2);
                 responseData2.forEach((tp, data) -> assertTrue(data.hasError()));
-                Map<TopicPartition, PartitionData> responseData3 = response.responseData(groupThree);
+                Map<TopicPartition, PartitionData> responseData3 = response.partitionDataMap(groupThree);
                 assertEquals(pd3, responseData3);
                 responseData3.forEach((tp, data) -> assertFalse(data.hasError()));
             }
@@ -274,7 +274,7 @@ public class OffsetFetchResponseTest {
                     ));
                 }
 
-                Map<TopicPartition, PartitionData> responseData = oldResponse.responseData(groupOne);
+                Map<TopicPartition, PartitionData> responseData = oldResponse.partitionDataMap(groupOne);
                 assertEquals(expectedDataMap, responseData);
 
                 responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1720,7 +1720,8 @@ public class RequestResponseTest {
         if (version < 8) {
             return new OffsetFetchResponse(Errors.NONE, responseData);
         }
-        return new OffsetFetchResponse(Collections.singletonMap("group1", Errors.NONE),
+        int throttleMs = 10;
+        return new OffsetFetchResponse(throttleMs, Collections.singletonMap("group1", Errors.NONE),
             Collections.singletonMap("group1", responseData));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -233,6 +233,7 @@ import static org.apache.kafka.common.protocol.ApiKeys.JOIN_GROUP;
 import static org.apache.kafka.common.protocol.ApiKeys.LEADER_AND_ISR;
 import static org.apache.kafka.common.protocol.ApiKeys.LIST_GROUPS;
 import static org.apache.kafka.common.protocol.ApiKeys.LIST_OFFSETS;
+import static org.apache.kafka.common.protocol.ApiKeys.OFFSET_FETCH;
 import static org.apache.kafka.common.protocol.ApiKeys.STOP_REPLICA;
 import static org.apache.kafka.common.protocol.ApiKeys.SYNC_GROUP;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
@@ -311,21 +312,30 @@ public class RequestResponseTest {
         checkErrorResponse(createMetadataRequest(3, Collections.singletonList("topic1")), unknownServerException, true);
         checkResponse(createMetadataResponse(), 4, true);
         checkErrorResponse(createMetadataRequest(4, Collections.singletonList("topic1")), unknownServerException, true);
-        checkRequest(createOffsetFetchRequestForAllPartition("group1", false), true);
-        checkRequest(createOffsetFetchRequestForAllPartition("group1", true), true);
-        checkErrorResponse(createOffsetFetchRequestForAllPartition("group1", false), new NotCoordinatorException("Not Coordinator"), true);
-        checkErrorResponse(createOffsetFetchRequestForAllPartition("group1", true), new NotCoordinatorException("Not Coordinator"), true);
         checkRequest(createOffsetFetchRequest(0, false), true);
         checkRequest(createOffsetFetchRequest(1, false), true);
         checkRequest(createOffsetFetchRequest(2, false), true);
         checkRequest(createOffsetFetchRequest(7, true), true);
-        checkRequest(createOffsetFetchRequestForAllPartition("group1", false), true);
-        checkRequest(createOffsetFetchRequestForAllPartition("group1", true), true);
+        checkRequest(createOffsetFetchRequest(8, true), true);
+        checkRequest(createOffsetFetchRequestWithMultipleGroups(8, true), true);
+        checkRequest(createOffsetFetchRequestWithMultipleGroups(8, false), true);
+        checkRequest(createOffsetFetchRequestForAllPartition(7, true), true);
+        checkRequest(createOffsetFetchRequestForAllPartition(8, true), true);
         checkErrorResponse(createOffsetFetchRequest(0, false), unknownServerException, true);
         checkErrorResponse(createOffsetFetchRequest(1, false), unknownServerException, true);
         checkErrorResponse(createOffsetFetchRequest(2, false), unknownServerException, true);
         checkErrorResponse(createOffsetFetchRequest(7, true), unknownServerException, true);
-        checkResponse(createOffsetFetchResponse(), 0, true);
+        checkErrorResponse(createOffsetFetchRequest(8, true), unknownServerException, true);
+        checkErrorResponse(createOffsetFetchRequestWithMultipleGroups(8, true), unknownServerException, true);
+        checkErrorResponse(createOffsetFetchRequestForAllPartition(7, true),
+            new NotCoordinatorException("Not Coordinator"), true);
+        checkErrorResponse(createOffsetFetchRequestForAllPartition(8, true),
+            new NotCoordinatorException("Not Coordinator"), true);
+        checkErrorResponse(createOffsetFetchRequestWithMultipleGroups(8, true),
+            new NotCoordinatorException("Not Coordinator"), true);
+        checkResponse(createOffsetFetchResponse(0), 0, true);
+        checkResponse(createOffsetFetchResponse(7), 7, true);
+        checkResponse(createOffsetFetchResponse(8), 8, true);
         checkRequest(createProduceRequest(2), true);
         checkErrorResponse(createProduceRequest(2), unknownServerException, true);
         checkRequest(createProduceRequest(3), true);
@@ -1051,18 +1061,51 @@ public class RequestResponseTest {
     }
 
     @Test
-    public void testOffsetFetchRequestBuilderToString() {
+    public void testOffsetFetchRequestBuilderToStringV0ToV7() {
         List<Boolean> stableFlags = Arrays.asList(true, false);
         for (Boolean requireStable : stableFlags) {
-            String allTopicPartitionsString = new OffsetFetchRequest.Builder("someGroup", requireStable, null, false).toString();
+            String allTopicPartitionsString = new OffsetFetchRequest.Builder("someGroup",
+                requireStable,
+                null,
+                false)
+                .toString();
 
-            assertTrue(allTopicPartitionsString.contains("groupId='someGroup', topics=null, requireStable="
-                                                             + requireStable.toString()));
+            assertTrue(allTopicPartitionsString.contains("groupId='someGroup', topics=null,"
+                + " groupIds=[], requireStable=" + requireStable));
             String string = new OffsetFetchRequest.Builder("group1",
-                requireStable, Collections.singletonList(new TopicPartition("test11", 1)), false).toString();
+                requireStable,
+                Collections.singletonList(
+                    new TopicPartition("test11", 1)),
+                false)
+                .toString();
             assertTrue(string.contains("test11"));
             assertTrue(string.contains("group1"));
-            assertTrue(string.contains("requireStable=" + requireStable.toString()));
+            assertTrue(string.contains("requireStable=" + requireStable));
+        }
+    }
+
+    @Test
+    public void testOffsetFetchRequestBuilderToStringV8AndAbove() {
+        List<Boolean> stableFlags = Arrays.asList(true, false);
+        for (Boolean requireStable : stableFlags) {
+            String allTopicPartitionsString = new OffsetFetchRequest.Builder(
+                Collections.singletonMap("someGroup", null),
+                requireStable,
+                false)
+                .toString();
+            assertTrue(allTopicPartitionsString.contains("groupIds=[OffsetFetchRequestGroup"
+                + "(groupId='someGroup', topics=null)], requireStable=" + requireStable));
+
+            String subsetTopicPartitionsString = new OffsetFetchRequest.Builder(
+                Collections.singletonMap(
+                    "group1",
+                    Collections.singletonList(new TopicPartition("test11", 1))),
+                requireStable,
+                false)
+                .toString();
+            assertTrue(subsetTopicPartitionsString.contains("test11"));
+            assertTrue(subsetTopicPartitionsString.contains("group1"));
+            assertTrue(subsetTopicPartitionsString.contains("requireStable=" + requireStable));
         }
     }
 
@@ -1603,21 +1646,82 @@ public class RequestResponseTest {
     }
 
     private OffsetFetchRequest createOffsetFetchRequest(int version, boolean requireStable) {
-        return new OffsetFetchRequest.Builder("group1", requireStable, Collections.singletonList(new TopicPartition("test11", 1)), false)
+        if (version < 8) {
+            return new OffsetFetchRequest.Builder(
+                "group1",
+                requireStable,
+                Collections.singletonList(
+                    new TopicPartition("test11", 1)),
+                false)
                 .build((short) version);
+        }
+        return new OffsetFetchRequest.Builder(
+            Collections.singletonMap(
+                "group1",
+                Collections.singletonList(
+                    new TopicPartition("test11", 1))),
+            requireStable,
+            false)
+            .build((short) version);
     }
 
-    private OffsetFetchRequest createOffsetFetchRequestForAllPartition(String groupId, boolean requireStable) {
-        return new OffsetFetchRequest.Builder(groupId, requireStable, null, false).build();
+    private OffsetFetchRequest createOffsetFetchRequestWithMultipleGroups(int version,
+        boolean requireStable) {
+        Map<String, List<TopicPartition>> groupToPartitionMap = new HashMap<>();
+        List<TopicPartition> topic1 = singletonList(
+            new TopicPartition("topic1", 0));
+        List<TopicPartition> topic2 = Arrays.asList(
+            new TopicPartition("topic1", 0),
+            new TopicPartition("topic2", 0),
+            new TopicPartition("topic2", 1));
+        List<TopicPartition> topic3 = Arrays.asList(
+            new TopicPartition("topic1", 0),
+            new TopicPartition("topic2", 0),
+            new TopicPartition("topic2", 1),
+            new TopicPartition("topic3", 0),
+            new TopicPartition("topic3", 1),
+            new TopicPartition("topic3", 2));
+        groupToPartitionMap.put("group1", topic1);
+        groupToPartitionMap.put("group2", topic2);
+        groupToPartitionMap.put("group3", topic3);
+        groupToPartitionMap.put("group4", null);
+        groupToPartitionMap.put("group5", null);
+
+        return new OffsetFetchRequest.Builder(
+            groupToPartitionMap,
+            requireStable,
+            false
+        ).build((short) version);
     }
 
-    private OffsetFetchResponse createOffsetFetchResponse() {
+    private OffsetFetchRequest createOffsetFetchRequestForAllPartition(int version, boolean requireStable) {
+        if (version < 8) {
+            return new OffsetFetchRequest.Builder(
+                "group1",
+                requireStable,
+                null,
+                false)
+                .build((short) version);
+        }
+        return new OffsetFetchRequest.Builder(
+            Collections.singletonMap(
+                "group1", null),
+            requireStable,
+            false)
+            .build((short) version);
+    }
+
+    private OffsetFetchResponse createOffsetFetchResponse(int version) {
         Map<TopicPartition, OffsetFetchResponse.PartitionData> responseData = new HashMap<>();
         responseData.put(new TopicPartition("test", 0), new OffsetFetchResponse.PartitionData(
-                100L, Optional.empty(), "", Errors.NONE));
+            100L, Optional.empty(), "", Errors.NONE));
         responseData.put(new TopicPartition("test", 1), new OffsetFetchResponse.PartitionData(
-                100L, Optional.of(10), null, Errors.NONE));
-        return new OffsetFetchResponse(Errors.NONE, responseData);
+            100L, Optional.of(10), null, Errors.NONE));
+        if (version < 8) {
+            return new OffsetFetchResponse(Errors.NONE, responseData);
+        }
+        return new OffsetFetchResponse(Collections.singletonMap("group1", Errors.NONE),
+            Collections.singletonMap("group1", responseData));
     }
 
     @SuppressWarnings("deprecation")
@@ -2864,7 +2968,7 @@ public class RequestResponseTest {
         assertEquals(Integer.valueOf(3), createMetadataResponse().errorCounts().get(Errors.NONE));
         assertEquals(Integer.valueOf(1), createOffsetCommitResponse().errorCounts().get(Errors.NONE));
         assertEquals(Integer.valueOf(2), createOffsetDeleteResponse().errorCounts().get(Errors.NONE));
-        assertEquals(Integer.valueOf(3), createOffsetFetchResponse().errorCounts().get(Errors.NONE));
+        assertEquals(Integer.valueOf(3), createOffsetFetchResponse(OFFSET_FETCH.latestVersion()).errorCounts().get(Errors.NONE));
         assertEquals(Integer.valueOf(1), createProduceResponse().errorCounts().get(Errors.NONE));
         assertEquals(Integer.valueOf(1), createRenewTokenResponse().errorCounts().get(Errors.NONE));
         assertEquals(Integer.valueOf(1), createSaslAuthenticateResponse().errorCounts().get(Errors.NONE));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1650,16 +1650,14 @@ public class RequestResponseTest {
             return new OffsetFetchRequest.Builder(
                 "group1",
                 requireStable,
-                Collections.singletonList(
-                    new TopicPartition("test11", 1)),
+                Collections.singletonList(new TopicPartition("test11", 1)),
                 false)
                 .build((short) version);
         }
         return new OffsetFetchRequest.Builder(
             Collections.singletonMap(
                 "group1",
-                Collections.singletonList(
-                    new TopicPartition("test11", 1))),
+                Collections.singletonList(new TopicPartition("test11", 1))),
             requireStable,
             false)
             .build((short) version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1071,7 +1071,7 @@ public class RequestResponseTest {
                 .toString();
 
             assertTrue(allTopicPartitionsString.contains("groupId='someGroup', topics=null,"
-                + " groupIds=[], requireStable=" + requireStable));
+                + " groups=[], requireStable=" + requireStable));
             String string = new OffsetFetchRequest.Builder("group1",
                 requireStable,
                 Collections.singletonList(
@@ -1093,7 +1093,7 @@ public class RequestResponseTest {
                 requireStable,
                 false)
                 .toString();
-            assertTrue(allTopicPartitionsString.contains("groupIds=[OffsetFetchRequestGroup"
+            assertTrue(allTopicPartitionsString.contains("groups=[OffsetFetchRequestGroup"
                 + "(groupId='someGroup', topics=null)], requireStable=" + requireStable));
 
             String subsetTopicPartitionsString = new OffsetFetchRequest.Builder(

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -416,7 +416,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         new OffsetCommitResponse(requestThrottleMs, combinedCommitStatus.asJava))
     }
 
-    // reject the request if not authorized to the group
+      // reject the request if not authorized to the group
     if (!authHelper.authorize(request.context, READ, GROUP, offsetCommitRequest.data.groupId)) {
       val error = Errors.GROUP_AUTHORIZATION_FAILED
       val responseTopicList = OffsetCommitRequest.getErrorResponseTopics(

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1338,11 +1338,10 @@ class KafkaApis(val requestChannel: RequestChannel,
     val groupIds = offsetFetchRequest.groupIds().asScala
     val groupToErrorMap =  mutable.Map.empty[String, Errors]
     val groupToPartitionData =  mutable.Map.empty[String, util.Map[TopicPartition, PartitionData]]
-    val groupToTopics = offsetFetchRequest.groupIdsToTopics()
     val groupToTopicPartitions = offsetFetchRequest.groupIdsToPartitions()
     groupIds.foreach(g => {
       val (error, partitionData) = fetchOffsets(g,
-        groupToTopics.get(g) == offsetFetchRequest.isAllPartitionsForGroup,
+        offsetFetchRequest.isAllPartitionsForGroup(g),
         offsetFetchRequest.requireStable(),
         groupToTopicPartitions.get(g), request.context)
       groupToErrorMap += (g -> error)
@@ -1383,11 +1382,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           (error, authorizedPartitionData)
         } else {
           val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
-          if (unauthorizedPartitionData.nonEmpty) {
-            (OffsetFetchResponse.UNAUTHORIZED_PARTITION.error, authorizedPartitionData ++ unauthorizedPartitionData)
-          } else {
-            (Errors.NONE, authorizedPartitionData ++ unauthorizedPartitionData)
-          }
+          (Errors.NONE, authorizedPartitionData ++ unauthorizedPartitionData)
         }
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -61,6 +61,7 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType
+import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
@@ -1254,80 +1255,147 @@ class KafkaApis(val requestChannel: RequestChannel,
    * Handle an offset fetch request
    */
   def handleOffsetFetchRequest(request: RequestChannel.Request): Unit = {
+    val version = request.header.apiVersion
+    if (version == 0) {
+      // reading offsets from ZK
+      handleOffsetFetchRequestV0(request)
+    } else if (version >= 1 && version <= 7) {
+      // reading offsets from Kafka
+      handleOffsetFetchRequestBetweenV1AndV7(request)
+    } else {
+      // batching offset reads for multiple groups starts with version 8 and greater
+      handleOffsetFetchRequestV8AndAbove(request)
+    }
+  }
+
+  private def handleOffsetFetchRequestV0(request: RequestChannel.Request): Unit = {
     val header = request.header
     val offsetFetchRequest = request.body[OffsetFetchRequest]
 
-    def partitionByAuthorized(seq: Seq[TopicPartition]): (Seq[TopicPartition], Seq[TopicPartition]) =
-      authHelper.partitionSeqByAuthorized(request.context, DESCRIBE, TOPIC, seq)(_.topic)
-
     def createResponse(requestThrottleMs: Int): AbstractResponse = {
       val offsetFetchResponse =
-        // reject the request if not authorized to the group
+      // reject the request if not authorized to the group
         if (!authHelper.authorize(request.context, DESCRIBE, GROUP, offsetFetchRequest.groupId))
           offsetFetchRequest.getErrorResponse(requestThrottleMs, Errors.GROUP_AUTHORIZATION_FAILED)
         else {
-          if (header.apiVersion == 0) {
-            val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.unsupported("Version 0 offset fetch requests"))
-            val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
-              offsetFetchRequest.partitions.asScala)
+          val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.unsupported("Version 0 offset fetch requests"))
+          val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
+            offsetFetchRequest.partitions.asScala, request.context)
 
-            // version 0 reads offsets from ZK
-            val authorizedPartitionData = authorizedPartitions.map { topicPartition =>
-              try {
-                if (!metadataCache.contains(topicPartition))
-                  (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
-                else {
-                  val payloadOpt = zkSupport.zkClient.getConsumerOffset(offsetFetchRequest.groupId, topicPartition)
-                  payloadOpt match {
-                    case Some(payload) =>
-                      (topicPartition, new OffsetFetchResponse.PartitionData(payload.toLong,
-                        Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.NONE))
-                    case None =>
-                      (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
-                  }
+          // version 0 reads offsets from ZK
+          val authorizedPartitionData = authorizedPartitions.map { topicPartition =>
+            try {
+              if (!metadataCache.contains(topicPartition))
+                (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
+              else {
+                val payloadOpt = zkSupport.zkClient.getConsumerOffset(offsetFetchRequest.groupId, topicPartition)
+                payloadOpt match {
+                  case Some(payload) =>
+                    (topicPartition, new OffsetFetchResponse.PartitionData(payload.toLong,
+                      Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.NONE))
+                  case None =>
+                    (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
                 }
-              } catch {
-                case e: Throwable =>
-                  (topicPartition, new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
-                    Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.forException(e)))
               }
-            }.toMap
-
-            val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
-            new OffsetFetchResponse(requestThrottleMs, Errors.NONE, (authorizedPartitionData ++ unauthorizedPartitionData).asJava)
-          } else {
-            // versions 1 and above read offsets from Kafka
-            if (offsetFetchRequest.isAllPartitions) {
-              val (error, allPartitionData) = groupCoordinator.handleFetchOffsets(offsetFetchRequest.groupId, offsetFetchRequest.requireStable)
-              if (error != Errors.NONE)
-                offsetFetchRequest.getErrorResponse(requestThrottleMs, error)
-              else {
-                // clients are not allowed to see offsets for topics that are not authorized for Describe
-                val (authorizedPartitionData, _) = authHelper.partitionMapByAuthorized(request.context,
-                  DESCRIBE, TOPIC, allPartitionData)(_.topic)
-                new OffsetFetchResponse(requestThrottleMs, Errors.NONE, authorizedPartitionData.asJava)
-              }
-            } else {
-              val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
-                offsetFetchRequest.partitions.asScala)
-              val (error, authorizedPartitionData) = groupCoordinator.handleFetchOffsets(offsetFetchRequest.groupId,
-                offsetFetchRequest.requireStable, Some(authorizedPartitions))
-              if (error != Errors.NONE)
-                offsetFetchRequest.getErrorResponse(requestThrottleMs, error)
-              else {
-                val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
-                new OffsetFetchResponse(requestThrottleMs, Errors.NONE, (authorizedPartitionData ++ unauthorizedPartitionData).asJava)
-              }
+            } catch {
+              case e: Throwable =>
+                (topicPartition, new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
+                  Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.forException(e)))
             }
-          }
-        }
+          }.toMap
 
+          val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
+          new OffsetFetchResponse(requestThrottleMs, Errors.NONE, (authorizedPartitionData ++ unauthorizedPartitionData).asJava)
+        }
+      trace(s"Sending offset fetch response $offsetFetchResponse for correlation id ${header.correlationId} to client ${header.clientId}.")
+      offsetFetchResponse
+    }
+    requestHelper.sendResponseMaybeThrottle(request, createResponse)
+  }
+
+  private def handleOffsetFetchRequestBetweenV1AndV7(request: RequestChannel.Request): Unit = {
+    val header = request.header
+    val offsetFetchRequest = request.body[OffsetFetchRequest]
+    val groupId = offsetFetchRequest.groupId()
+    val (error, partitionData) = fetchOffsets(groupId, offsetFetchRequest.isAllPartitions,
+      offsetFetchRequest.requireStable, offsetFetchRequest.partitions, request.context)
+    def createResponse(requestThrottleMs: Int): AbstractResponse = {
+      val offsetFetchResponse =
+        if (error != Errors.NONE) {
+          offsetFetchRequest.getErrorResponse(requestThrottleMs, error)
+        } else {
+          new OffsetFetchResponse(requestThrottleMs, Errors.NONE, partitionData.asJava)
+        }
+      trace(s"Sending offset fetch response $offsetFetchResponse for correlation id ${header.correlationId} to client ${header.clientId}.")
+      offsetFetchResponse
+    }
+    requestHelper.sendResponseMaybeThrottle(request, createResponse)
+  }
+
+  private def handleOffsetFetchRequestV8AndAbove(request: RequestChannel.Request): Unit = {
+    val header = request.header
+    val offsetFetchRequest = request.body[OffsetFetchRequest]
+    val groupIds = offsetFetchRequest.groupIds().asScala
+    val groupToErrorMap =  mutable.Map.empty[String, Errors]
+    val groupToPartitionData =  mutable.Map.empty[String, util.Map[TopicPartition, PartitionData]]
+    val groupToTopics = offsetFetchRequest.groupIdsToTopics()
+    val groupToTopicPartitions = offsetFetchRequest.groupIdsToPartitions()
+    groupIds.foreach(g => {
+      val (error, partitionData) = fetchOffsets(g,
+        groupToTopics.get(g) == offsetFetchRequest.isAllPartitionsForGroup,
+        offsetFetchRequest.requireStable(),
+        groupToTopicPartitions.get(g), request.context)
+      groupToErrorMap += (g -> error)
+      groupToPartitionData += (g -> partitionData.asJava)
+    })
+
+    def createResponse(requestThrottleMs: Int): AbstractResponse = {
+      val offsetFetchResponse = new OffsetFetchResponse(requestThrottleMs,
+        groupToErrorMap.asJava, groupToPartitionData.asJava)
       trace(s"Sending offset fetch response $offsetFetchResponse for correlation id ${header.correlationId} to client ${header.clientId}.")
       offsetFetchResponse
     }
 
     requestHelper.sendResponseMaybeThrottle(request, createResponse)
   }
+
+  private def fetchOffsets(groupId: String, isAllPartitions: Boolean, requireStable: Boolean,
+                           partitions: util.List[TopicPartition], context: RequestContext): (Errors, Map[TopicPartition, OffsetFetchResponse.PartitionData]) = {
+    if (!authHelper.authorize(context, DESCRIBE, GROUP, groupId)) {
+      (Errors.GROUP_AUTHORIZATION_FAILED, Map.empty)
+    } else {
+      if (isAllPartitions) {
+        val (error, allPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable)
+        if (error != Errors.NONE) {
+          (error, allPartitionData)
+        } else {
+          // clients are not allowed to see offsets for topics that are not authorized for Describe
+          val (authorizedPartitionData, _) = authHelper.partitionMapByAuthorized(context,
+            DESCRIBE, TOPIC, allPartitionData)(_.topic)
+          (Errors.NONE, authorizedPartitionData)
+        }
+      } else {
+        val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
+          partitions.asScala, context)
+        val (error, authorizedPartitionData) = groupCoordinator.handleFetchOffsets(groupId,
+          requireStable, Some(authorizedPartitions))
+        if (error != Errors.NONE) {
+          (error, authorizedPartitionData)
+        } else {
+          val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
+          if (unauthorizedPartitionData.nonEmpty) {
+            (OffsetFetchResponse.UNAUTHORIZED_PARTITION.error, authorizedPartitionData ++ unauthorizedPartitionData)
+          } else {
+            (Errors.NONE, authorizedPartitionData ++ unauthorizedPartitionData)
+          }
+        }
+      }
+    }
+  }
+
+  private def partitionByAuthorized(seq: Seq[TopicPartition], context: RequestContext):
+  (Seq[TopicPartition], Seq[TopicPartition]) =
+    authHelper.partitionSeqByAuthorized(context, DESCRIBE, TOPIC, seq)(_.topic)
 
   def handleFindCoordinatorRequest(request: RequestChannel.Request): Unit = {
     val version = request.header.apiVersion

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -49,6 +49,7 @@ import org.apache.kafka.common.message.{AddOffsetsToTxnRequestData, AlterPartiti
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, RecordBatch, SimpleRecord}
+import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.apache.kafka.common.resource.ResourceType._
@@ -1382,41 +1383,40 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
 
   @Test
   def testOffsetFetchMultipleGroupsAuthorization(): Unit = {
-    val groups = (0 until 5).map(i => s"group$i")
+    val groups: Seq[String] = (1 to 5).map(i => s"group$i")
     val groupResources = groups.map(group => new ResourcePattern(GROUP, group, LITERAL))
+    val topics: Seq[String] = (1 to 3).map(i => s"topic$i")
+    val topicResources = topics.map(topic => new ResourcePattern(TOPIC, topic, LITERAL))
 
-    val topic1 = "topic1"
-    val topic1List = singletonList(new TopicPartition(topic1, 0))
-    val topicOneResource = new ResourcePattern(TOPIC, topic1, LITERAL)
-    val topic2 = "topic2"
+    val topic1List = singletonList(new TopicPartition(topics(0), 0))
     val topic1And2List = util.Arrays.asList(
-      new TopicPartition(topic1, 0),
-      new TopicPartition(topic2, 0),
-      new TopicPartition(topic2, 1))
-    val topicTwoResource = new ResourcePattern(TOPIC, topic2, LITERAL)
-    val topic3 = "topic3"
+      new TopicPartition(topics(0), 0),
+      new TopicPartition(topics(1), 0),
+      new TopicPartition(topics(1), 1))
     val allTopicsList = util.Arrays.asList(
-      new TopicPartition(topic1, 0),
-      new TopicPartition(topic2, 0),
-      new TopicPartition(topic2, 1),
-      new TopicPartition(topic3, 0),
-      new TopicPartition(topic3, 1),
-      new TopicPartition(topic3, 2))
-    val topicThreeResource = new ResourcePattern(TOPIC, topic3, LITERAL)
+      new TopicPartition(topics(0), 0),
+      new TopicPartition(topics(1), 0),
+      new TopicPartition(topics(1), 1),
+      new TopicPartition(topics(2), 0),
+      new TopicPartition(topics(2), 1),
+      new TopicPartition(topics(2), 2))
 
     // create group to partition map to build batched offsetFetch request
     val groupToPartitionMap = new util.HashMap[String, util.List[TopicPartition]]()
-    groupToPartitionMap.put(groups(1), topic1List)
-    groupToPartitionMap.put(groups(2), topic1And2List)
-    groupToPartitionMap.put(groups(3), allTopicsList)
+    groupToPartitionMap.put(groups(0), topic1List)
+    groupToPartitionMap.put(groups(1), topic1And2List)
+    groupToPartitionMap.put(groups(2), allTopicsList)
+    groupToPartitionMap.put(groups(3), null)
     groupToPartitionMap.put(groups(4), null)
-    groupToPartitionMap.put(groups(5), null)
 
-    createTopic(topic1)
-    createTopic(topic2, numPartitions = 2)
-    createTopic(topic3, numPartitions = 3)
+    createTopic(topics(0))
+    createTopic(topics(1), numPartitions = 2)
+    createTopic(topics(2), numPartitions = 3)
     groupResources.foreach(r => {
       addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), r)
+    })
+    topicResources.foreach(t => {
+      addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), t)
     })
 
     val offset = 15L
@@ -1442,19 +1442,19 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       consumer.close()
     }
 
-    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(1))
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(0))
     commitOffsets(topic1List, topicOneOffsets)
 
-    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(2))
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(1))
     commitOffsets(topic1And2List, topicOneAndTwoOffsets)
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(2))
+    commitOffsets(allTopicsList, allTopicOffsets)
 
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(3))
     commitOffsets(allTopicsList, allTopicOffsets)
 
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(4))
-    commitOffsets(allTopicsList, allTopicOffsets)
-
-    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groups(5))
     commitOffsets(allTopicsList, allTopicOffsets)
 
     removeAllClientAcls()
@@ -1466,23 +1466,30 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       assertEquals(leaderEpoch.get(), partitionData.leaderEpoch.get())
     }
 
+    def verifyResponse(groupLevelResponse: Errors,
+                       partitionData: util.Map[TopicPartition, PartitionData],
+                       topicList: util.List[TopicPartition]): Unit = {
+      assertEquals(Errors.NONE, groupLevelResponse)
+      assertTrue(partitionData.size() == topicList.size())
+      topicList.forEach(t => verifyPartitionData(partitionData.get(t)))
+    }
+
     // test handling partial errors, where one group is fully authorized, some groups don't have
     // the right topic authorizations, and some groups have no authorization
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(0))
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(1))
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(2))
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(4))
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicOneResource)
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(3))
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicResources(0))
     val offsetFetchRequest = createOffsetFetchRequest(groupToPartitionMap)
     var offsetFetchResponse = connectAndReceive[OffsetFetchResponse](offsetFetchRequest)
     offsetFetchResponse.data().groups().forEach(g =>
       g.groupId() match {
         case "group1" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(1)))
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(1)).size() == 1)
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(1)).containsKey(topic1List.get(0)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(0)), offsetFetchResponse
+            .partitionDataMap(groups(0)), topic1List)
         case "group2" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(2)))
-          val group2Response = offsetFetchResponse.partitionDataMap(groups(2))
+          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(1)))
+          val group2Response = offsetFetchResponse.partitionDataMap(groups(1))
           assertTrue(group2Response.size() == 3)
           assertTrue(group2Response.keySet().containsAll(topic1And2List))
           verifyPartitionData(group2Response.get(topic1And2List.get(0)))
@@ -1491,40 +1498,33 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
           assertEquals(OffsetFetchResponse.UNAUTHORIZED_PARTITION, group2Response.get(topic1And2List.get(1)))
           assertEquals(OffsetFetchResponse.UNAUTHORIZED_PARTITION, group2Response.get(topic1And2List.get(2)))
         case "group3" =>
-          assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, offsetFetchResponse.groupLevelError(groups(3)))
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(3)).size() == 0)
+          assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, offsetFetchResponse.groupLevelError(groups(2)))
+          assertTrue(offsetFetchResponse.partitionDataMap(groups(2)).size() == 0)
         case "group4" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(4)))
-          val group4Response = offsetFetchResponse.partitionDataMap(groups(4))
-          assertTrue(group4Response.size() == 1)
-          assertTrue(group4Response.containsKey(allTopicsList.get(0)))
-          verifyPartitionData(group4Response.get(allTopicsList.get(0)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(3)), offsetFetchResponse
+            .partitionDataMap(groups(3)), topic1List)
         case "group5" =>
-          assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, offsetFetchResponse.groupLevelError(groups(5)))
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(5)).size() == 0)
+          assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, offsetFetchResponse.groupLevelError(groups(4)))
+          assertTrue(offsetFetchResponse.partitionDataMap(groups(4)).size() == 0)
       })
 
     // test that after adding some of the ACLs, we get no group level authorization errors, but
     // still get topic level authorization errors for topics we don't have ACLs for
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(3))
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(5))
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicTwoResource)
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(2))
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResources(4))
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicResources(1))
     offsetFetchResponse = connectAndReceive[OffsetFetchResponse](offsetFetchRequest)
     offsetFetchResponse.data().groups().forEach(g =>
       g.groupId() match {
         case "group1" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(1)))
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(1)).size() == 1)
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(1)).containsKey(topic1List.get(0)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(0)), offsetFetchResponse
+            .partitionDataMap(groups(0)), topic1List)
         case "group2" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(2)))
-          val group2Response = offsetFetchResponse.partitionDataMap(groups(2))
-          assertTrue(group2Response.size() == 3)
-          assertTrue(group2Response.keySet().containsAll(topic1And2List))
-          topic1And2List.forEach(t => verifyPartitionData(group2Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(1)), offsetFetchResponse
+            .partitionDataMap(groups(1)), topic1And2List)
         case "group3" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(3)))
-          val group3Response = offsetFetchResponse.partitionDataMap(groups(3))
+          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(2)))
+          val group3Response = offsetFetchResponse.partitionDataMap(groups(2))
           assertTrue(group3Response.size() == 6)
           assertTrue(group3Response.keySet().containsAll(allTopicsList))
           verifyPartitionData(group3Response.get(allTopicsList.get(0)))
@@ -1537,51 +1537,34 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
           assertEquals(OffsetFetchResponse.UNAUTHORIZED_PARTITION, group3Response.get(allTopicsList.get(4)))
           assertEquals(OffsetFetchResponse.UNAUTHORIZED_PARTITION, group3Response.get(allTopicsList.get(5)))
         case "group4" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(4)))
-          val group4Response = offsetFetchResponse.partitionDataMap(groups(4))
-          assertTrue(group4Response.size() == 3)
-          topic1And2List.forEach(t => verifyPartitionData(group4Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(3)), offsetFetchResponse
+            .partitionDataMap(groups(3)), topic1And2List)
         case "group5" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(5)))
-          val group5Response = offsetFetchResponse.partitionDataMap(groups(5))
-          assertTrue(group5Response.size() == 3)
-          topic1And2List.forEach(t => verifyPartitionData(group5Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(4)), offsetFetchResponse
+            .partitionDataMap(groups(4)), topic1And2List)
       })
 
     // test that after adding all necessary ACLs, we get no partition level or group level errors
     // from the offsetFetch response
-    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicThreeResource)
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicResources(2))
     offsetFetchResponse = connectAndReceive[OffsetFetchResponse](offsetFetchRequest)
     offsetFetchResponse.data().groups().forEach(g =>
       g.groupId() match {
         case "group1" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(1)))
-          val group1Response = offsetFetchResponse.partitionDataMap(groups(1))
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(1)).size() == 1)
-          assertTrue(offsetFetchResponse.partitionDataMap(groups(1)).containsKey(topic1List.get(0)))
-          topic1List.forEach(t => verifyPartitionData(group1Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(0)), offsetFetchResponse
+            .partitionDataMap(groups(0)), topic1List)
         case "group2" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(2)))
-          val group2Response = offsetFetchResponse.partitionDataMap(groups(2))
-          assertTrue(group2Response.size() == 3)
-          assertTrue(group2Response.keySet().containsAll(topic1And2List))
-          topic1And2List.forEach(t => verifyPartitionData(group2Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(1)), offsetFetchResponse
+            .partitionDataMap(groups(1)), topic1And2List)
         case "group3" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(3)))
-          val group3Response = offsetFetchResponse.partitionDataMap(groups(3))
-          assertTrue(group3Response.size() == 6)
-          assertTrue(group3Response.keySet().containsAll(allTopicsList))
-          allTopicsList.forEach(t => verifyPartitionData(group3Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(2)), offsetFetchResponse
+            .partitionDataMap(groups(2)), allTopicsList)
         case "group4" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(4)))
-          val group4Response = offsetFetchResponse.partitionDataMap(groups(4))
-          assertTrue(group4Response.size() == 6)
-          allTopicsList.forEach(t => verifyPartitionData(group4Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(3)), offsetFetchResponse
+            .partitionDataMap(groups(3)), allTopicsList)
         case "group5" =>
-          assertEquals(Errors.NONE, offsetFetchResponse.groupLevelError(groups(5)))
-          val group5Response = offsetFetchResponse.partitionDataMap(groups(5))
-          assertTrue(group5Response.size() == 6)
-          allTopicsList.forEach(t => verifyPartitionData(group5Response.get(t)))
+          verifyResponse(offsetFetchResponse.groupLevelError(groups(4)), offsetFetchResponse
+            .partitionDataMap(groups(4)), allTopicsList)
       })
   }
 

--- a/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
@@ -1,0 +1,227 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{AbstractResponse, OffsetFetchRequest, OffsetFetchResponse}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+import java.util
+import java.util.Collections.singletonList
+import scala.jdk.CollectionConverters._
+import java.util.{Optional, Properties}
+
+class OffsetFetchRequestTest extends BaseRequestTest{
+
+  override def brokerCount: Int = 1
+
+  val brokerId: Integer = 0
+  val offset = 15L
+  val leaderEpoch: Optional[Integer] = Optional.of(3)
+  val metadata = "metadata"
+
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.put(KafkaConfig.BrokerIdProp, brokerId.toString)
+    properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
+    properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
+    properties.put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
+    properties.put(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
+    properties.put(KafkaConfig.TransactionsTopicMinISRProp, "1")
+  }
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    doSetup(createOffsetsTopic = false)
+
+    TestUtils.createOffsetsTopic(zkClient, servers)
+  }
+
+  @Test
+  def testOffsetFetchRequestLessThanV8(): Unit = {
+    val topic = "topic"
+    createTopic(topic)
+
+    val groupId = "groupId"
+    val tpList = singletonList(new TopicPartition(topic, 0))
+    val topicOffsets = tpList.asScala.map{
+      tp => (tp, new OffsetAndMetadata(offset, leaderEpoch, metadata))
+    }.toMap.asJava
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+    val consumer = createConsumer()
+    consumer.assign(tpList)
+    consumer.commitSync(topicOffsets)
+    consumer.close()
+    // testing from version 1 onward since version 0 read offsets from ZK
+    for (version <- 1 to ApiKeys.OFFSET_FETCH.latestVersion()) {
+      if (version < 8) {
+        val request =
+          if (version < 7) {
+            new OffsetFetchRequest.Builder(
+              groupId, false, tpList, false)
+              .build(version.asInstanceOf[Short])
+          } else {
+            new OffsetFetchRequest.Builder(
+              groupId, false, tpList, true)
+              .build(version.asInstanceOf[Short])
+          }
+        val response = connectAndReceive[OffsetFetchResponse](request)
+        val topicData = response.data().topics().get(0)
+        val partitionData = topicData.partitions().get(0)
+        if (version < 3) {
+          assertEquals(AbstractResponse.DEFAULT_THROTTLE_TIME, response.throttleTimeMs())
+        }
+        assertEquals(Errors.NONE, response.error())
+        assertEquals(topic, topicData.name())
+        assertEquals(0, partitionData.partitionIndex())
+        assertEquals(offset, partitionData.committedOffset())
+        if (version >= 5) {
+          // committed leader epoch introduced with V5
+          assertEquals(leaderEpoch.get(), partitionData.committedLeaderEpoch())
+        }
+        assertEquals(metadata, partitionData.metadata())
+        assertEquals(Errors.NONE.code(), partitionData.errorCode())
+      }
+    }
+  }
+
+  @Test
+  def testOffsetFetchRequestV8AndAbove(): Unit = {
+    val groupOne = "group1"
+    val groupTwo = "group2"
+    val groupThree = "group3"
+    val groupFour = "group4"
+    val groupFive = "group5"
+
+    val topic1 = "topic1"
+    val topic1List = singletonList(new TopicPartition(topic1, 0))
+    val topic2 = "topic2"
+    val topic1And2List = util.Arrays.asList(
+      new TopicPartition(topic1, 0),
+      new TopicPartition(topic2, 0),
+      new TopicPartition(topic2, 1))
+    val topic3 = "topic3"
+    val allTopicsList = util.Arrays.asList(
+      new TopicPartition(topic1, 0),
+      new TopicPartition(topic2, 0),
+      new TopicPartition(topic2, 1),
+      new TopicPartition(topic3, 0),
+      new TopicPartition(topic3, 1),
+      new TopicPartition(topic3, 2))
+
+    // create group to partition map to build batched offsetFetch request
+    val groupToPartitionMap: util.Map[String, util.List[TopicPartition]] = new util.HashMap[String, util
+    .List[TopicPartition]]()
+    groupToPartitionMap.put(groupOne, topic1List)
+    groupToPartitionMap.put(groupTwo, topic1And2List)
+    groupToPartitionMap.put(groupThree, allTopicsList)
+    groupToPartitionMap.put(groupFour, null)
+    groupToPartitionMap.put(groupFive, null)
+
+    createTopic(topic1)
+    createTopic(topic2, numPartitions = 2)
+    createTopic(topic3, numPartitions = 3)
+
+    val topicOneOffsets = topic1List.asScala.map{
+      tp => (tp, new OffsetAndMetadata(offset, leaderEpoch, metadata))
+    }.toMap.asJava
+    val topicOneAndTwoOffsets = topic1And2List.asScala.map{
+      tp => (tp, new OffsetAndMetadata(offset, leaderEpoch, metadata))
+    }.toMap.asJava
+    val allTopicOffsets = allTopicsList.asScala.map{
+      tp => (tp, new OffsetAndMetadata(offset, leaderEpoch, metadata))
+    }.toMap.asJava
+
+    // create 5 consumers to commit offsets so we can fetch them later
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupOne)
+    var consumer = createConsumer()
+    consumer.assign(topic1List)
+    consumer.commitSync(topicOneOffsets)
+    consumer.close()
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupTwo)
+    consumer = createConsumer()
+    consumer.assign(topic1And2List)
+    consumer.commitSync(topicOneAndTwoOffsets)
+    consumer.close()
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupThree)
+    consumer = createConsumer()
+    consumer.assign(allTopicsList)
+    consumer.commitSync(allTopicOffsets)
+    consumer.close()
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupFour)
+    consumer = createConsumer()
+    consumer.assign(allTopicsList)
+    consumer.commitSync(allTopicOffsets)
+    consumer.close()
+
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupFive)
+    consumer = createConsumer()
+    consumer.assign(allTopicsList)
+    consumer.commitSync(allTopicOffsets)
+    consumer.close()
+    for (version <- 8 to ApiKeys.OFFSET_FETCH.latestVersion()) {
+      val request =  new OffsetFetchRequest.Builder(groupToPartitionMap, false, false)
+        .build(version.asInstanceOf[Short])
+      val response = connectAndReceive[OffsetFetchResponse](request)
+      response.data().groupIds().forEach(g =>
+        g.groupId() match {
+          case "group1" =>
+            assertEquals(Errors.NONE, response.groupLevelError(groupOne))
+            assertTrue(response.responseData(groupOne).size() == 1)
+            assertTrue(response.responseData(groupOne).containsKey(topic1List.get(0)))
+          case "group2" =>
+            assertEquals(Errors.NONE, response.groupLevelError(groupTwo))
+            val group2Response = response.responseData(groupTwo)
+            assertTrue(group2Response.size() == 3)
+            assertTrue(group2Response.keySet().containsAll(topic1And2List))
+            topic1And2List.forEach(t => verifyPartitionData(group2Response.get(t)))
+          case "group3" =>
+            assertEquals(Errors.NONE, response.groupLevelError(groupThree))
+            val group3Response = response.responseData(groupThree)
+            assertTrue(group3Response.size() == 6)
+            assertTrue(group3Response.keySet().containsAll(allTopicsList))
+            allTopicsList.forEach(t => verifyPartitionData(group3Response.get(t)))
+          case "group4" =>
+            assertEquals(Errors.NONE, response.groupLevelError(groupFour))
+            val group4Response = response.responseData(groupFour)
+            assertTrue(group4Response.size() == 6)
+            allTopicsList.forEach(t => verifyPartitionData(group4Response.get(t)))
+          case "group5" =>
+            assertEquals(Errors.NONE, response.groupLevelError(groupFive))
+            val group5Response = response.responseData(groupFive)
+            assertTrue(group5Response.size() == 6)
+            allTopicsList.forEach(t => verifyPartitionData(group5Response.get(t)))
+        })
+    }
+  }
+
+  private def verifyPartitionData(partitionData: OffsetFetchResponse.PartitionData): Unit = {
+    assertTrue(!partitionData.hasError)
+    assertEquals(offset, partitionData.offset)
+    assertEquals(metadata, partitionData.metadata)
+    assertEquals(leaderEpoch.get(), partitionData.leaderEpoch.get())
+  }
+}


### PR DESCRIPTION
This implements the request and response portion of KIP-709: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173084258. The Admin APIs will be implemented in https://github.com/apache/kafka/pull/10964.

It updates the OffsetFetch request and response to support fetching offsets for multiple consumer groups at a time. If the broker does not support the new OffsetFetch version, clients can revert to the previous behaviour and use a request for each coordinator.

We are trying to get this change into the 3.0 release. We believe this change will be safe to check in as we are changing the request protocol, and not the underlying Admin APIs. As a result, we are not changing any major client side code, just updating the protocol for the brokers to support multiple groups for a `offsetFetch` request. We have also added substantial request/response testing to ensure we are having backward compatibility.