### PR TITLE
KAFKA-13030 FindCoordinators batching causes slow poll when requestin…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.MemberIdRequiredException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.HeartbeatRequestData;
@@ -887,8 +888,8 @@ public abstract class AbstractCoordinator implements Closeable {
 
             if (e instanceof NoBatchedFindCoordinatorsException) {
                 batchFindCoordinator = false;
-                clearFindCoordinatorFuture();
-                lookupCoordinator();
+                // make a fast failure to send next request without batching
+                super.onFailure(new TimeoutException(e), future);
                 return;
             } 
             if (!(e instanceof RetriableException)) {


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-13030

related: https://github.com/apache/kafka/pull/10743

https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java#L888

```java
            if (e instanceof NoBatchedFindCoordinatorsException) {
                batchFindCoordinator = false;
                clearFindCoordinatorFuture();
                lookupCoordinator();
                return;
            } 
```

The current request future is NOT updated so it can't be completed until timeout. It causes a slow poll when user poll data from older broker the first time.

### Broken Behavior

```java
  var consumer = new KafkaConsumer<>();
  var records = consumer.poll(Duration.ofSeconds(30));
  // there are producers which are pushing data to topic.
  // [BEFORE PR-10743] the return data from fist poll could NOT be empty
  // [AFTER PR-10743] the return data from first poll is always empty. To make matters worst, it returns only if duration is expired (if users set a large duration ...)
  assert records.count() > 0;
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
