### PR TITLE
KAFKA-13029; Set appropriate fields for FindCoordinatorRequest based on version

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
@@ -98,7 +98,7 @@ public class CoordinatorStrategy implements AdminApiLookupStrategy<CoordinatorKe
                 key.idValue + "' cannot be represented in a request."));
         }
         FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
-        if (batch) {
+        if (!response.data().coordinators().isEmpty()) {
             for (Coordinator coordinator : response.data().coordinators()) {
                 CoordinatorKey key = (type == CoordinatorType.GROUP)
                         ? CoordinatorKey.byGroupId(coordinator.key())

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
@@ -97,23 +97,21 @@ public class CoordinatorStrategy implements AdminApiLookupStrategy<CoordinatorKe
             failedKeys.put(key, new InvalidGroupIdException("The given group id '" +
                 key.idValue + "' cannot be represented in a request."));
         }
-        FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
-        // Handle response based on whether batched version is used by checking `coordinators()` in the response data
-        if (!response.data().coordinators().isEmpty()) {
-            for (Coordinator coordinator : response.data().coordinators()) {
-                CoordinatorKey key = (type == CoordinatorType.GROUP)
+
+        for (Coordinator coordinator : ((FindCoordinatorResponse) abstractResponse).coordinators()) {
+            CoordinatorKey key;
+            if (coordinator.key() == null) // old version without batching
+                key = requireSingletonAndType(keys);
+            else {
+                key = (type == CoordinatorType.GROUP)
                         ? CoordinatorKey.byGroupId(coordinator.key())
                         : CoordinatorKey.byTransactionalId(coordinator.key());
-                handleError(Errors.forCode(coordinator.errorCode()),
-                            key,
-                            coordinator.nodeId(),
-                            mappedKeys,
-                            failedKeys);
             }
-        } else {
-            CoordinatorKey key = requireSingletonAndType(keys);
-            Errors error = response.error();
-            handleError(error, key, response.node().id(), mappedKeys, failedKeys);
+            handleError(Errors.forCode(coordinator.errorCode()),
+                        key,
+                        coordinator.nodeId(),
+                        mappedKeys,
+                        failedKeys);
         }
         return new LookupResult<>(failedKeys, mappedKeys);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
@@ -98,6 +98,7 @@ public class CoordinatorStrategy implements AdminApiLookupStrategy<CoordinatorKe
                 key.idValue + "' cannot be represented in a request."));
         }
         FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
+        // Handle response based on whether batched version is used by checking `coordinators()` in the response data
         if (!response.data().coordinators().isEmpty()) {
             for (Coordinator coordinator : response.data().coordinators()) {
                 CoordinatorKey key = (type == CoordinatorType.GROUP)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1317,6 +1317,9 @@ public class TransactionManager {
 
         abstract AbstractRequest.Builder<?> requestBuilder();
 
+        // Propagate requestVersion for parsing response since some responses use
+        // different fields depending on the API version. For example, FindCoordinator
+        // uses different format for versions that support batching.
         abstract void handleResponse(AbstractResponse responseBody, short requestVersion);
 
         abstract Priority priority();

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
@@ -50,7 +50,7 @@ public class FindCoordinatorRequest extends AbstractRequest {
             if (version < MIN_BATCHED_VERSION) {
                 if (batchedKeys > 1)
                     throw new NoBatchedFindCoordinatorsException("Cannot create a v" + version + " FindCoordinator request " +
-                        "because we require features supported only in 4 or later.");
+                        "because we require features supported only in " + MIN_BATCHED_VERSION + " or later.");
                 if (batchedKeys == 1) {
                     data.setKey(data.coordinatorKeys().get(0));
                     data.setCoordinatorKeys(Collections.emptyList());

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
@@ -26,8 +26,11 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 
 public class FindCoordinatorRequest extends AbstractRequest {
+
+    public static final short MIN_BATCHED_VERSION = 4;
 
     public static class Builder extends AbstractRequest.Builder<FindCoordinatorRequest> {
         private final FindCoordinatorRequestData data;
@@ -43,9 +46,18 @@ public class FindCoordinatorRequest extends AbstractRequest {
                 throw new UnsupportedVersionException("Cannot create a v" + version + " FindCoordinator request " +
                         "because we require features supported only in 2 or later.");
             }
-            if (version < 4 && !data.coordinatorKeys().isEmpty()) {
-                throw new NoBatchedFindCoordinatorsException("Cannot create a v" + version + " FindCoordinator request " +
+            int batchedKeys = data.coordinatorKeys().size();
+            if (version < MIN_BATCHED_VERSION) {
+                if (batchedKeys > 1)
+                    throw new NoBatchedFindCoordinatorsException("Cannot create a v" + version + " FindCoordinator request " +
                         "because we require features supported only in 4 or later.");
+                if (batchedKeys == 1) {
+                    data.setKey(data.coordinatorKeys().get(0));
+                    data.setCoordinatorKeys(Collections.emptyList());
+                }
+            } else if (batchedKeys == 0 && data.key() != null) {
+                data.setCoordinatorKeys(Collections.singletonList(data.key()));
+                data.setKey(""); // default value
             }
             return new FindCoordinatorRequest(data, version);
         }
@@ -90,7 +102,7 @@ public class FindCoordinatorRequest extends AbstractRequest {
             response.setThrottleTimeMs(throttleTimeMs);
         }
         Errors error = Errors.forException(e);
-        if (version() < 4) {
+        if (version() < MIN_BATCHED_VERSION) {
             return FindCoordinatorResponse.prepareOldResponse(error, Node.noNode());
         } else {
             return FindCoordinatorResponse.prepareErrorResponse(error, data.coordinatorKeys());

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.message.FindCoordinatorResponseData.Coordinator;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
@@ -87,6 +88,21 @@ public class FindCoordinatorResponse extends AbstractResponse {
     @Override
     public boolean shouldClientThrottle(short version) {
         return version >= 2;
+    }
+
+    public List<FindCoordinatorResponseData.Coordinator> coordinators() {
+        if (!data.coordinators().isEmpty())
+            return data.coordinators();
+        else {
+            FindCoordinatorResponseData.Coordinator coordinator = new Coordinator()
+                    .setErrorCode(data.errorCode())
+                    .setErrorMessage(data.errorMessage())
+                    .setKey(null)
+                    .setNodeId(data.nodeId())
+                    .setHost(data.host())
+                    .setPort(data.port());
+            return Collections.singletonList(coordinator);
+        }
     }
 
     public static FindCoordinatorResponse prepareOldResponse(Errors error, Node node) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -3246,9 +3246,9 @@ public class KafkaAdminClientTest {
             env.kafkaClient().setNodeApiVersions(
                     NodeApiVersions.create(Arrays.asList(findCoordinatorV3, describeGroups)));
 
-            // dummy response for MockClient to handle the UnsupportedVersionException correctly to switch from batched to un-batched
+            // Dummy response for MockClient to handle the UnsupportedVersionException correctly to switch from batched to un-batched
             env.kafkaClient().prepareResponse(null);
-            //Retriable FindCoordinatorResponse errors should be retried
+            // Retriable FindCoordinatorResponse errors should be retried
             for (int i = 0; i < groupIds.size(); i++) {
                 env.kafkaClient().prepareResponse(
                         prepareOldFindCoordinatorResponse(Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode()));


### PR DESCRIPTION
KIP-699 added support for batching in FindCoordinatorRequest using a new protocol that changes the wire format for both batched and unbatched requests. Clients were updated to try the new format first and switch irreversibly to the old format if the new format is not supported on one broker. During rolling upgrade (or a downgrade), it is possible that a broker doesn't support new format at some point while other brokers do at a later point. Clients end up in a bad state until restarted since use new version with old format. This PR changes FindCoordinatorRequest to set data based on actual version when a single group is used. This is always the case for consumer coordinator and transaction coordinator. For admin API, we still switch to unbatched mode on failure, but the data is set based on actual version, so we never fail even if brokers are upgraded/downgraded.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
