### PR TITLE
MINOR: fix comments on deleteTopics method

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -230,7 +230,7 @@ public interface Admin extends AutoCloseable {
      * This is a convenience method for {@link #deleteTopics(TopicCollection, DeleteTopicsOptions)}
      * with default options. See the overload for more details.
      * <p>
-     * When using topic IDs, this operation is supported by brokers with version 3.0.0 or higher.
+     * When using topic IDs, this operation is supported by brokers with inter-broker protocol 2.8 or higher.
      * When using topic names, this operation is supported by brokers with version 0.10.1.0 or higher.
      *
      * @param topics The topics to delete.
@@ -254,7 +254,7 @@ public interface Admin extends AutoCloseable {
      * the topics for deletion, but not actually delete them. The futures will
      * return successfully in this case.
      * <p>
-     * When using topic IDs, this operation is supported by brokers with version 3.0.0 or higher.
+     * When using topic IDs, this operation is supported by brokers with inter-broker protocol 2.8 or higher.
      * When using topic names, this operation is supported by brokers with version 0.10.1.0 or higher.
      *
      * @param topics  The topics to delete.


### PR DESCRIPTION
The deleteTopics call with topic IDs is actually able to be handled by brokers 2.8 or higher. Of course, the call will only be successful if topic IDs are present which requires IBP 2.8 or higher. I've adjusted the comment to reflect this.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
