### PR TITLE
KAFKA-12770: CheckStyle team needs this feature (in order to include Kafka into their regression suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ You can run checkstyle using:
 
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
+For experiments (or regression testing purposes) add `-PcheckstyleVersion=X.y.z` switch (to override project-defined checkstyle version).
 
 #### Spotless ####
 The import order is a part of static check. please call `spotlessApply` to optimize the imports of Java codes before filing pull request.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ versions += [
   // when updating checkstyle, check whether the exclusion of
   // CVE-2023-2976 and CVE-2020-8908 can be dropped from
   // gradle/resources/dependencycheck-suppressions.xml
-  checkstyle: "8.36.2",
+  checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "8.36.2",
   commonsCli: "1.4",
   commonsIo: "2.14.0", // ZooKeeper dependency. Do not use, this is going away.
   commonsValidator: "1.9.0",


### PR DESCRIPTION
@ijuma please review.

**_Rationale /related comment:_** https://github.com/apache/kafka/pull/10656#issuecomment-836074067 
![image](https://user-images.githubusercontent.com/19467899/124363918-84db9c00-dc3e-11eb-95cb-493173007a0e.png)

**_Description:_** `checkstyleVersion` build option is introduced (for overriding CheckStyle project-defined dependency version).

**_Note:_** previous PR #10698 (that contains identical commit) is closed: it somehow slipped through the cracks, so I opted to open a new one.
