### PR TITLE
remove useless code that assign null value to instance field  during …

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -46,7 +46,6 @@ public class NetworkReceive implements Receive {
     public NetworkReceive(String source, ByteBuffer buffer) {
         this.source = source;
         this.buffer = buffer;
-        this.size = null;
         this.maxSize = UNLIMITED;
         this.memoryPool = MemoryPool.NONE;
     }
@@ -54,7 +53,6 @@ public class NetworkReceive implements Receive {
     public NetworkReceive(String source) {
         this.source = source;
         this.size = ByteBuffer.allocate(4);
-        this.buffer = null;
         this.maxSize = UNLIMITED;
         this.memoryPool = MemoryPool.NONE;
     }
@@ -62,7 +60,6 @@ public class NetworkReceive implements Receive {
     public NetworkReceive(int maxSize, String source) {
         this.source = source;
         this.size = ByteBuffer.allocate(4);
-        this.buffer = null;
         this.maxSize = maxSize;
         this.memoryPool = MemoryPool.NONE;
     }


### PR DESCRIPTION
remove useless code that assign null value to instance field in construting NetworkReceive instance, becase the default value of instance field is null, there is no need to assign null value again