### PR TITLE
MINOR: Update dropwizard metrics to 4.1.12.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ versions += [
   bcpkix: "1.66",
   checkstyle: "8.36.2",
   commonsCli: "1.4",
-  dropwizardMetrics: "3.2.5",
+  dropwizardMetrics: "4.1.12.1",
   gradle: "7.1.1",
   grgit: "4.1.0",
   httpclient: "4.5.13",


### PR DESCRIPTION
ZooKeeper was updated to v3.6.3 via https://github.com/apache/kafka/pull/10918.  However, it was noted in that PR discussion (https://github.com/apache/kafka/pull/10918#discussion_r663412933) that the dropwizard metrics-core library has since been updated from v3.2.5 to v4.1.12.1 for 3.7.x releases (via https://github.com/apache/zookeeper/commit/13fe0d0ffb9fd2c379b9b430aaaf9ee75acfceba).  Since there were no code changes associated with this library version bump in ZooKeeper, and since we wish to avoid potential CVEs if possible, we can consider updating to this newer version now assuming that system tests pass. I will attach system test results when they complete.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
