### PR TITLE
KAFKA-12984: make AbstractStickyAssignor resilient to invalid input, utilize generation in cooperative, and fix assignment bug

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -42,7 +42,7 @@
               files="AbstractResponse.java"/>
 
     <suppress checks="MethodLength"
-              files="KerberosLogin.java|RequestResponseTest.java|ConnectMetricsRegistry.java|KafkaConsumer.java"/>
+              files="(KerberosLogin|RequestResponseTest|ConnectMetricsRegistry|KafkaConsumer|AbstractStickyAssignor).java"/>
 
     <suppress checks="ParameterNumber"
               files="(NetworkClient|FieldSpec|KafkaRaftClient).java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
@@ -17,9 +17,7 @@
 package org.apache.kafka.clients.consumer;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -32,7 +30,6 @@ import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.protocol.types.Type;
-import org.apache.kafka.common.utils.CollectionUtils;
 
 /**
  * A cooperative version of the {@link AbstractStickyAssignor AbstractStickyAssignor}. This follows the same (sticky)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
@@ -76,10 +76,9 @@ public class CooperativeStickyAssignor extends AbstractStickyAssignor {
     @Override
     protected MemberData memberData(Subscription subscription) {
         ByteBuffer buffer = subscription.userData();
-        buffer.rewind();
 
         Optional<Integer> encodedGeneration;
-        if (buffer.hasRemaining()) {
+        if (buffer != null && buffer.rewind().hasRemaining()) {
             encodedGeneration = Optional.of(buffer.getInt());
         } else {
             encodedGeneration = Optional.empty();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.clients.consumer;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +28,11 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.utils.CollectionUtils;
 
 /**
  * A cooperative version of the {@link AbstractStickyAssignor AbstractStickyAssignor}. This follows the same (sticky)
@@ -43,6 +50,11 @@ import org.apache.kafka.common.TopicPartition;
  * cooperative rebalancing. See the <a href="https://kafka.apache.org/documentation/#upgrade_240_notable">upgrade guide</a> for details.
  */
 public class CooperativeStickyAssignor extends AbstractStickyAssignor {
+
+    // these schemas are used for preserving useful metadata for the assignment, such as the last stable generation
+    private static final String GENERATION_KEY_NAME = "generation";
+    private static final Schema COOPERATIVE_STICKY_ASSIGNOR_USER_DATA_V0 = new Schema(
+        new Field(GENERATION_KEY_NAME, Type.INT32));
 
     private int generation = DEFAULT_GENERATION; // consumer group generation
 
@@ -63,25 +75,28 @@ public class CooperativeStickyAssignor extends AbstractStickyAssignor {
 
     @Override
     public ByteBuffer subscriptionUserData(Set<String> topics) {
-        if (generation == DEFAULT_GENERATION) {
-            return ByteBuffer.allocate(0);
-        } else {
-            ByteBuffer buffer = ByteBuffer.allocate(4);
-            buffer.putInt(generation);
-            buffer.flip();
-            return buffer;
-        }
+        Struct struct = new Struct(COOPERATIVE_STICKY_ASSIGNOR_USER_DATA_V0);
+
+        struct.set(GENERATION_KEY_NAME, generation);
+        ByteBuffer buffer = ByteBuffer.allocate(COOPERATIVE_STICKY_ASSIGNOR_USER_DATA_V0.sizeOf(struct));
+        COOPERATIVE_STICKY_ASSIGNOR_USER_DATA_V0.write(buffer, struct);
+        buffer.flip();
+        return buffer;
     }
 
     @Override
     protected MemberData memberData(Subscription subscription) {
         ByteBuffer buffer = subscription.userData();
-
         Optional<Integer> encodedGeneration;
-        if (buffer != null && buffer.rewind().hasRemaining()) {
-            encodedGeneration = Optional.of(buffer.getInt());
-        } else {
+        if (buffer == null) {
             encodedGeneration = Optional.empty();
+        } else {
+            try {
+                Struct struct = COOPERATIVE_STICKY_ASSIGNOR_USER_DATA_V0.read(buffer);
+                encodedGeneration = Optional.of(struct.getInt(GENERATION_KEY_NAME));
+            } catch (Exception e) {
+                encodedGeneration = Optional.of(DEFAULT_GENERATION);
+            }
         }
         return new MemberData(subscription.ownedPartitions(), encodedGeneration);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -192,7 +191,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
         // the consumers which may still be assigned one or more partitions to reach expected capacity
         List<String> unfilledMembersWithUnderMinQuotaPartitions = new LinkedList<>();
-        Queue<String> unfilledMembersWithExactlyMinQuotaPartitions = new LinkedList<>();
+        LinkedList<String> unfilledMembersWithExactlyMinQuotaPartitions = new LinkedList<>();
 
         int numberOfConsumers = consumerToOwnedPartitions.size();
         int totalPartitionsCount = partitionsPerTopic.values().stream().reduce(0, Integer::sum);
@@ -268,6 +267,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         }
 
         Collections.sort(unfilledMembersWithUnderMinQuotaPartitions);
+        Collections.sort(unfilledMembersWithExactlyMinQuotaPartitions);
 
         Iterator<String> unfilledConsumerIter = unfilledMembersWithUnderMinQuotaPartitions.iterator();
         // Round-Robin filling remaining members up to the expected numbers of maxQuota, otherwise, to minQuota

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -178,13 +178,13 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
      * @param consumerToOwnedPartitions            Each consumer's previously owned and still-subscribed partitions
      * @param partitionsWithMultiplePreviousOwners The partitions being claimed in the previous assignment of multiple consumers
      *
-     * @return                            Map from each member to the list of partitions assigned to them.
+     * @return                                     Map from each member to the list of partitions assigned to them.
      */
     private Map<String, List<TopicPartition>> constrainedAssign(Map<String, Integer> partitionsPerTopic,
                                                                 Map<String, List<TopicPartition>> consumerToOwnedPartitions,
                                                                 Set<TopicPartition> partitionsWithMultiplePreviousOwners) {
         if (log.isDebugEnabled()) {
-            log.debug("performing constrained assign. partitionsPerTopic: {}, consumerToOwnedPartitions: {}",
+            log.debug("Performing constrained assign with partitionsPerTopic: {}, consumerToOwnedPartitions: {}.",
                 partitionsPerTopic, consumerToOwnedPartitions);
         }
 
@@ -344,9 +344,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             }
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Final assignment of partitions to consumers: \n{}", assignment);
-        }
+        log.info("Final assignment of partitions to consumers: \n{}", assignment);
 
         return assignment;
     }
@@ -464,7 +462,6 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
         // all partitions that needed to be assigned
         List<TopicPartition> unassignedPartitions = getUnassignedPartitions(sortedAllPartitions, assignedPartitions, topic2AllPotentialConsumers);
-        assignedPartitions = null;
 
         if (log.isDebugEnabled()) {
             log.debug("unassigned Partitions: {}", unassignedPartitions);
@@ -482,9 +479,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             consumer2AllPotentialTopics, topic2AllPotentialConsumers, currentPartitionConsumer, revocationRequired,
             partitionsPerTopic, totalPartitionsCount);
 
-        if (log.isDebugEnabled()) {
-            log.debug("final assignment: {}", currentAssignment);
-        }
+        log.info("Final assignment of partitions to consumers: \n{}", currentAssignment);
 
         return currentAssignment;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -16,16 +16,23 @@
  */
 package org.apache.kafka.clients.consumer;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignorTest;
 import org.apache.kafka.common.TopicPartition;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static java.util.Collections.emptyList;
 
 public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
@@ -37,6 +44,65 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
     @Override
     public Subscription buildSubscription(List<String> topics, List<TopicPartition> partitions) {
         return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions);
+    }
+
+    @Override
+    public Subscription buildSubscriptionWithGeneration(List<String> topics, List<TopicPartition> partitions, int generation) {
+        assignor.onAssignment(null, new ConsumerGroupMetadata("dummy-group-id", generation, "dummy-member-id", Optional.empty()));
+        return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions);
+    }
+
+    @Test
+    public void testEncodeAndDecodeGeneration() {
+        Subscription subscription = new Subscription(topics(topic), assignor.subscriptionUserData(new HashSet<>(topics(topic))));
+
+        // initially the generation defaults to NO_GENERATION, which gets encoded as Optional.empty()
+        assertFalse(((CooperativeStickyAssignor) assignor).memberData(subscription).generation.isPresent());
+
+        int generation = 10;
+        assignor.onAssignment(null, new ConsumerGroupMetadata("dummy-group-id", generation, "dummy-member-id", Optional.empty()));
+
+        subscription = new Subscription(topics(topic), assignor.subscriptionUserData(new HashSet<>(topics(topic))));
+        assertTrue(((CooperativeStickyAssignor) assignor).memberData(subscription).generation.isPresent());
+        assertEquals(((CooperativeStickyAssignor) assignor).memberData(subscription).generation.get(), generation);
+    }
+
+    @Test
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithEqualPartitionsPerConsumer() {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 3);
+
+        subscriptions.put(consumer1, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 1))));
+        subscriptions.put(consumer2, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 2))));
+        subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
+        // In the cooperative assignor, topic-0 has to be considered "owned" and so it cant be assigned until both have "revoked" it
+        assertTrue(assignment.get(consumer3).isEmpty());
+
+        verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
+        assertTrue(isFullyBalanced(assignment));
+    }
+
+    @Test
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithUnequalPartitionsPerConsumer() {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 4);
+
+        subscriptions.put(consumer1, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 1))));
+        subscriptions.put(consumer2, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 2))));
+        subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2), tp(topic, 3)), assignment.get(consumer2));
+        // In the cooperative assignor, topic-0 has to be considered "owned" and so it cant be assigned until both have "revoked" it
+        assertTrue(assignment.get(consumer3).isEmpty());
+
+        verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
+        assertTrue(isFullyBalanced(assignment));
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -107,8 +107,8 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
-        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
-        assertEquals(partitions(tp(topic, 2), tp(topic, 3)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic, 1), tp(topic, 3)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         // In the cooperative assignor, topic-0 has to be considered "owned" and so it cant be assigned until both have "revoked" it
         assertTrue(assignment.get(consumer3).isEmpty());
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -89,8 +89,8 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
-        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
-        assertEquals(partitions(tp(topic, 2), tp(topic, 3)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic, 1), tp(topic, 3)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static java.util.Collections.emptyList;
+
 public class StickyAssignorTest extends AbstractStickyAssignorTest {
 
     @Override
@@ -51,6 +53,48 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
     public Subscription buildSubscription(List<String> topics, List<TopicPartition> partitions) {
         return new Subscription(topics,
             serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(DEFAULT_GENERATION))));
+    }
+
+    @Override
+    public Subscription buildSubscriptionWithGeneration(List<String> topics, List<TopicPartition> partitions, int generation) {
+        return new Subscription(topics,
+                                serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(generation))));
+    }
+
+    @Test
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithEqualPartitionsPerConsumer() {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 3);
+
+        subscriptions.put(consumer1, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 1))));
+        subscriptions.put(consumer2, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 2))));
+        subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
+
+        verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
+        assertTrue(isFullyBalanced(assignment));
+    }
+
+    @Test
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithUnequalPartitionsPerConsumer() {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 4);
+
+        subscriptions.put(consumer1, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 1))));
+        subscriptions.put(consumer2, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 2))));
+        subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2), tp(topic, 3)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
+
+        verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
+        assertTrue(isFullyBalanced(assignment));
     }
 
     @ParameterizedTest(name = "testAssignmentWithMultipleGenerations1 with isAllSubscriptionsEqual: {0}")
@@ -226,11 +270,6 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(c2partitions0.containsAll(c2partitions));
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
-    }
-
-    private Subscription buildSubscriptionWithGeneration(List<String> topics, List<TopicPartition> partitions, int generation) {
-        return new Subscription(topics,
-            serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(generation))));
     }
 
     private static Subscription buildSubscriptionWithOldSchema(List<String> topics, List<TopicPartition> partitions) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -230,8 +230,8 @@ public abstract class AbstractStickyAssignorTest {
             buildSubscription(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 2))));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
-        assertEquals(partitions(tp(topic1, 0), tp(topic2, 1), tp(topic2, 0)), assignment.get(consumer1));
-        assertEquals(partitions(tp(topic1, 1), tp(topic2, 2)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic1, 0), tp(topic2, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic1, 1), tp(topic2, 2), tp(topic2, 0)), assignment.get(consumer2));
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -284,9 +284,9 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
-        assertEquals(partitions(tp(topic1, 0), tp(topic2, 0)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic1, 0), tp(topic2, 2)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 1)), assignment.get(consumer2));
-        assertEquals(partitions(tp(topic2, 2)), assignment.get(consumer3));
+        assertEquals(partitions(tp(topic2, 0)), assignment.get(consumer3));
 
         assertTrue(isFullyBalanced(assignment));
     }
@@ -359,8 +359,8 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer3, buildSubscription(allTopics, assignment.get(consumer3)));
         subscriptions.put(consumer4, buildSubscription(allTopics, assignment.get(consumer4)));
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
-        assertEquals(partitions(tp(topic2, 1), tp(topic2, 3), tp(topic1, 0), tp(topic1, 2)), assignment.get(consumer3));
-        assertEquals(partitions(tp(topic2, 2), tp(topic1, 1), tp(topic2, 0)), assignment.get(consumer4));
+        assertEquals(partitions(tp(topic2, 1), tp(topic2, 3), tp(topic1, 0), tp(topic2, 0)), assignment.get(consumer3));
+        assertEquals(partitions(tp(topic2, 2), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer4));
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -40,7 +40,6 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static java.util.Collections.emptyList;
 
 public abstract class AbstractStickyAssignorTest {
     protected AbstractStickyAssignor assignor;
@@ -75,7 +74,7 @@ public abstract class AbstractStickyAssignorTest {
     @Test
     public void testOneConsumerNoTopic() {
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(emptyList()));
+        subscriptions = Collections.singletonMap(consumerId, new Subscription(Collections.emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
@@ -230,8 +229,8 @@ public abstract class AbstractStickyAssignorTest {
             buildSubscription(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 2))));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
-        assertEquals(partitions(tp(topic1, 0), tp(topic2, 1)), assignment.get(consumer1));
-        assertEquals(partitions(tp(topic1, 1), tp(topic2, 2), tp(topic2, 0)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic1, 0), tp(topic2, 1), tp(topic2, 0)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic1, 1), tp(topic2, 2)), assignment.get(consumer2));
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -252,7 +251,7 @@ public abstract class AbstractStickyAssignorTest {
             buildSubscription(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 0))));
         subscriptions.put(consumer2,
             buildSubscription(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 1))));
-        subscriptions.put(consumer3, buildSubscription(subscribedTopics, emptyList()));
+        subscriptions.put(consumer3, buildSubscription(subscribedTopics, Collections.emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
 
@@ -268,7 +267,7 @@ public abstract class AbstractStickyAssignorTest {
      * This unit test is testing all consumers owned less than minQuota partitions situation
      */
     @Test
-    public void testAllConsumerAreUnderMinQuota() {
+    public void testAllConsumersAreUnderMinQuota() {
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
         partitionsPerTopic.put(topic1, 2);
         partitionsPerTopic.put(topic2, 3);
@@ -279,13 +278,13 @@ public abstract class AbstractStickyAssignorTest {
             buildSubscription(subscribedTopics, partitions(tp(topic1, 0))));
         subscriptions.put(consumer2,
             buildSubscription(subscribedTopics, partitions(tp(topic1, 1))));
-        subscriptions.put(consumer3, buildSubscription(subscribedTopics, emptyList()));
+        subscriptions.put(consumer3, buildSubscription(subscribedTopics, Collections.emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
-        assertEquals(partitions(tp(topic1, 0), tp(topic2, 2)), assignment.get(consumer1));
-        assertEquals(partitions(tp(topic1, 1), tp(topic2, 1)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic1, 0), tp(topic2, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic1, 1), tp(topic2, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic2, 0)), assignment.get(consumer3));
 
         assertTrue(isFullyBalanced(assignment));
@@ -304,7 +303,7 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
 
         subscriptions.put(consumer1, buildSubscription(topics(topic), assignment.get(consumer1)));
-        subscriptions.put(consumer2, buildSubscription(topics(topic), emptyList()));
+        subscriptions.put(consumer2, buildSubscription(topics(topic), Collections.emptyList()));
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -342,8 +341,8 @@ public abstract class AbstractStickyAssignorTest {
         // add 2 consumers
         subscriptions.put(consumer1, buildSubscription(allTopics, assignment.get(consumer1)));
         subscriptions.put(consumer2, buildSubscription(allTopics, assignment.get(consumer2)));
-        subscriptions.put(consumer3, buildSubscription(allTopics, emptyList()));
-        subscriptions.put(consumer4, buildSubscription(allTopics, emptyList()));
+        subscriptions.put(consumer3, buildSubscription(allTopics, Collections.emptyList()));
+        subscriptions.put(consumer4, buildSubscription(allTopics, Collections.emptyList()));
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -800,7 +799,7 @@ public abstract class AbstractStickyAssignorTest {
 
         subscriptions.put(consumer1, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 1))));
         subscriptions.put(consumer2, buildSubscription(topics(topic), partitions(tp(topic, 2))));
-        subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
+        subscriptions.put(consumer3, buildSubscription(topics(topic), Collections.emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumer1));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -558,7 +558,7 @@ public abstract class AbstractStickyAssignorTest {
         assignor.assign(partitionsPerTopic, subscriptions);
     }
 
-    @Timeout(40)
+    @Timeout(60)
     @Test
     public void testLargeAssignmentAndGroupWithNonEqualSubscription() {
         // 1 million partitions!


### PR DESCRIPTION
The primary goal of this PR is to address the problem we've seen in the wild in which the ConsumerCoordinator fails to update its SubscriptionState and ultimately feeds invalid `ownedPartitions` data as input to the assignor. Previously the assignor would detect that something was wrong and just throw an exception, now we make several efforts to detect this earlier in the assignment process and then fix it if possible, and work around it if not.

Specifically, this PR does a few things:
1) Bring the `generation` field back to the CooperativeStickyAssignor so we don't need to rely so heavily on the ConsumerCoordinator properly updating its SubscriptionState after eg falling out of the group. The plain StickyAssignor always used the generation since it had to, so we just make sure the CooperativeStickyAssignor has this tool as well
2) In case of unforeseen problems or further bugs that slip past the `generation` field safety net, the assignor will now explicitly look out for partitions that are being claimed by multiple consumers as owned in the same generation. Such a case should never occur, but if it does, we have to invalidate this partition from the `ownedPartitions` of both consumers, since we can't tell who, if anyone, has the valid claim to this partition.
3) Fix a subtle bug that I discovered while writing tests for the above two fixes: in the constrained algorithm, we compute the exact number of partitions each consumer should end up with, and keep track of the "unfilled" members who must -- or _might_ -- require more partitions to hit their quota. The problem was that members at the `minQuota` were being considered as "unfilled" even after we had already hit the maximum number of consumers allowed to go up to the `maxQuota`, meaning those `minQuota` members could/should not accept any more partitions beyond that. I believe this was introduced in [#10509](https://github.com/apache/kafka/pull/10509), so it shouldn't be in any released versions and does not need to be backported.