### PR TITLE
MINOR: improve the partitioner.class doc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -236,19 +236,19 @@ public class ProducerConfig extends AbstractConfig {
     public static final String PARTITIONER_CLASS_CONFIG = "partitioner.class";
     private static final String PARTITIONER_CLASS_DOC = "A class to use to determine which partition to be send to when produce the records. Available options are:" +
         "<ul>" +
-            "<li><code>org.apache.kafka.clients.producer.internals.DefaultPartitioner</code>: The default partitioner. Works with the strategy:" +
+            "<li><code>org.apache.kafka.clients.producer.internals.DefaultPartitioner</code>: The default partitioner. " +
+        "This strategy will try sticking to a partition until the batch is full, or linger.ms is up. It works with the strategy:" +
                 "<ul>" +
-                    "<li>If a partition is specified in the record, use it</li>" +
-                    "<li>If no partition is specified but a key is present choose a partition based on a hash of the key</li>" +
-                    "<li>If no partition or key is present choose the sticky partition that changes when the batch is full.</li>" +
+                    "<li>If no partition is specified but a key is present, choose a partition based on a hash of the key</li>" +
+                    "<li>If no partition or key is present, choose the sticky partition that changes when the batch is full, or linger.ms is up.</li>" +
                 "</ul>" +
             "</li>" +
-            "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: This partitioning strategy can be used when user wants to distribute the writes to all partitions equally.</li>" +
-            "<li><code>org.apache.kafka.clients.producer.UniformStickyPartitioner</code>: This partitioning works with the strategy:" +
-                "<ul>" +
-                    "<li>If a partition is specified in the record, use it</li>" +
-                    "<li>Otherwise choose the sticky partition that changes when the batch is full.</li>" +
-                "</ul>" +
+            "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: This partitioning strategy is that " +
+        "each record in a series of consecutive records will be sent to a different partition(no matter the 'key' is provided or not)," +
+        " until we run out of partitions and start over again." +
+            "</li>" +
+            "<li><code>org.apache.kafka.clients.producer.UniformStickyPartitioner</code>: This partitioning strategy will " +
+        "try sticking to a partition(no matter the 'key' is provided or not) until the batch is full, or linger.ms is up." +
             "</li>" +
         "</ul>" +
         "<p>Implementing the  <code>org.apache.kafka.clients.producer.Partitioner</code> interface allows you to plug in a custom partitioner.";

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -244,8 +244,9 @@ public class ProducerConfig extends AbstractConfig {
                 "</ul>" +
             "</li>" +
             "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: This partitioning strategy is that " +
-        "each record in a series of consecutive records will be sent to a different partition(no matter if the 'key' is provided or not)," +
-        " until we run out of partitions and start over again." +
+        "each record in a series of consecutive records will be sent to a different partition(no matter if the 'key' is provided or not), " +
+        "until we run out of partitions and start over again. Note: There's a known issue that will cause uneven distribution when new batch is created. " +
+        "Please check KAFKA-9965 for more detail." +
             "</li>" +
             "<li><code>org.apache.kafka.clients.producer.UniformStickyPartitioner</code>: This partitioning strategy will " +
         "try sticking to a partition(no matter if the 'key' is provided or not) until the batch is full, or <code>linger.ms</code> is up." +

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -234,7 +234,24 @@ public class ProducerConfig extends AbstractConfig {
 
     /** <code>partitioner.class</code> */
     public static final String PARTITIONER_CLASS_CONFIG = "partitioner.class";
-    private static final String PARTITIONER_CLASS_DOC = "Partitioner class that implements the <code>org.apache.kafka.clients.producer.Partitioner</code> interface.";
+    private static final String PARTITIONER_CLASS_DOC = "A class to use to determine which partition to be send to when produce the records. Available options are:" +
+        "<ul>" +
+            "<li><code>org.apache.kafka.clients.producer.internals.DefaultPartitioner</code>: The default partitioner. Works with the strategy:" +
+                "<ul>" +
+                    "<li>If a partition is specified in the record, use it</li>" +
+                    "<li>If no partition is specified but a key is present choose a partition based on a hash of the key</li>" +
+                    "<li>If no partition or key is present choose the sticky partition that changes when the batch is full.</li>" +
+                "</ul>" +
+            "</li>" +
+            "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: This partitioning strategy can be used when user wants to distribute the writes to all partitions equally.</li>" +
+            "<li><code>org.apache.kafka.clients.producer.UniformStickyPartitioner</code>: This partitioning works with the strategy:" +
+                "<ul>" +
+                    "<li>If a partition is specified in the record, use it</li>" +
+                    "<li>Otherwise choose the sticky partition that changes when the batch is full.</li>" +
+                "</ul>" +
+            "</li>" +
+        "</ul>" +
+        "<p>Implementing the  <code>org.apache.kafka.clients.producer.Partitioner</code> interface allows you to plug in a custom partitioner.";
 
     /** <code>interceptor.classes</code> */
     public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -237,21 +237,21 @@ public class ProducerConfig extends AbstractConfig {
     private static final String PARTITIONER_CLASS_DOC = "A class to use to determine which partition to be send to when produce the records. Available options are:" +
         "<ul>" +
             "<li><code>org.apache.kafka.clients.producer.internals.DefaultPartitioner</code>: The default partitioner. " +
-        "This strategy will try sticking to a partition until the batch is full, or linger.ms is up. It works with the strategy:" +
+        "This strategy will try sticking to a partition until the batch is full, or <code>linger.ms</code> is up. It works with the strategy:" +
                 "<ul>" +
                     "<li>If no partition is specified but a key is present, choose a partition based on a hash of the key</li>" +
-                    "<li>If no partition or key is present, choose the sticky partition that changes when the batch is full, or linger.ms is up.</li>" +
+                    "<li>If no partition or key is present, choose the sticky partition that changes when the batch is full, or <code>linger.ms</code> is up.</li>" +
                 "</ul>" +
             "</li>" +
             "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: This partitioning strategy is that " +
-        "each record in a series of consecutive records will be sent to a different partition(no matter the 'key' is provided or not)," +
+        "each record in a series of consecutive records will be sent to a different partition(no matter if the 'key' is provided or not)," +
         " until we run out of partitions and start over again." +
             "</li>" +
             "<li><code>org.apache.kafka.clients.producer.UniformStickyPartitioner</code>: This partitioning strategy will " +
-        "try sticking to a partition(no matter the 'key' is provided or not) until the batch is full, or linger.ms is up." +
+        "try sticking to a partition(no matter if the 'key' is provided or not) until the batch is full, or <code>linger.ms</code> is up." +
             "</li>" +
         "</ul>" +
-        "<p>Implementing the  <code>org.apache.kafka.clients.producer.Partitioner</code> interface allows you to plug in a custom partitioner.";
+        "<p>Implementing the <code>org.apache.kafka.clients.producer.Partitioner</code> interface allows you to plug in a custom partitioner.";
 
     /** <code>interceptor.classes</code> */
     public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";

--- a/clients/src/main/java/org/apache/kafka/clients/producer/UniformStickyPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/UniformStickyPartitioner.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.Cluster;
  * <li>If a partition is specified in the record, use it
  * <li>Otherwise choose the sticky partition that changes when the batch is full.
  * 
- * NOTE: In constrast to the DefaultPartitioner, the record key is NOT used as part of the partitioning strategy in this 
+ * NOTE: In contrast to the DefaultPartitioner, the record key is NOT used as part of the partitioning strategy in this
  *       partitioner. Records with the same key are not guaranteed to be sent to the same partition.
  * 
  * See KIP-480 for details about sticky partitioning.


### PR DESCRIPTION
Before the PR, the `partitioner.class` config doesn't describe what the config is use for, and what options user can choose.
![image](https://user-images.githubusercontent.com/43372967/124742380-3afcf980-df4f-11eb-99fa-a384013cfe86.png)

**After:**
<img width="926" alt="image" src="https://user-images.githubusercontent.com/43372967/124744345-3d605300-df51-11eb-9c12-f3fd136be7e9.png">




### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
