### PR TITLE
MINOR: system test fix for 3 co-located KRaft controllers

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -321,6 +321,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.client_sasl_mechanism = client_sasl_mechanism
         self.topics = topics
         self.minikdc = None
+        self.concurrent_start = True # start concurrently by default
         self.authorizer_class_name = authorizer_class_name
         self.zk_set_acl = False
         if server_prop_overrides is None:
@@ -415,6 +416,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 else:
                     node.config = KafkaConfig(**kraft_broker_configs)
         self.colocated_nodes_started = 0
+        self.nodes_to_start = self.nodes
 
     def num_kraft_controllers(self, num_nodes_broker_role, controller_num_nodes_override):
         if controller_num_nodes_override < 0:
@@ -556,9 +558,17 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def alive(self, node):
         return len(self.pids(node)) > 0
 
-    def start(self, add_principals=""):
+    def start(self, add_principals="", nodes_to_skip=[], timeout_sec=60):
+        """
+        Start the Kafka broker and wait until it registers its ID in ZooKeeper
+        Startup will be skipped for any nodes in nodes_to_skip. These nodes can be started later via add_broker
+        """
         if self.quorum_info.using_zk and self.zk_client_secure and not self.zk.zk_client_secure_port:
             raise Exception("Unable to start Kafka: TLS to Zookeeper requested but Zookeeper secure port not enabled")
+
+        if not all([node in self.nodes for node in nodes_to_skip]):
+            raise Exception("nodes_to_skip should be a subset of this service's nodes")
+
         if self.quorum_info.has_brokers_and_controllers and (
                 self.controller_security_protocol != self.intercontroller_security_protocol or
                 self.controller_security_protocol in SecurityConfig.SASL_SECURITY_PROTOCOLS and self.controller_sasl_mechanism != self.intercontroller_sasl_mechanism):
@@ -577,18 +587,29 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         # than the number of nodes in the service
 
         self.start_minikdc_if_necessary(add_principals)
+
+        # save the nodes we want to start in a member variable so we know which nodes to start and which to skip
+        # in start_node
+        self.nodes_to_start = [node for node in self.nodes if node not in nodes_to_skip]
+
         if self.quorum_info.using_zk:
             self._ensure_zk_chroot()
 
         if self.remote_controller_quorum:
             self.remote_controller_quorum.start()
         Service.start(self)
+        if self.concurrent_start:
+            # We didn't wait while starting each individual node, so wait for them all now
+            for node in self.nodes_to_start:
+                with node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
+                    monitor.offset = 0
+                    self.wait_for_start(node, monitor, timeout_sec)
 
         if self.quorum_info.using_zk:
             self.logger.info("Waiting for brokers to register at ZK")
 
-            expected_broker_ids = set(self.nodes)
-            wait_until(lambda: {node for node in self.nodes if self.is_registered(node)} == expected_broker_ids,
+            expected_broker_ids = set(self.nodes_to_start)
+            wait_until(lambda: {node for node in self.nodes_to_start if self.is_registered(node)} == expected_broker_ids,
                        timeout_sec=30, backoff_sec=1, err_msg="Kafka servers didn't register at ZK within 30 seconds")
 
         # Create topics if necessary
@@ -599,6 +620,43 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
                 topic_cfg["topic"] = topic
                 self.create_topic(topic_cfg)
+        self.concurrent_start = False # in case it was True and this method was invoked directly instead of via start_concurrently()
+
+    def start_concurrently(self, add_principals="", timeout_sec=60):
+        self.concurrent_start = True # ensure it is True in case it has been explicitly disabled elsewhere
+        self.start(add_principals = add_principals, timeout_sec=timeout_sec)
+        self.concurrent_start = False
+
+    def add_broker(self, node):
+        """
+        Starts an individual node. add_broker should only be used for nodes skipped during initial kafka service startup
+        """
+        if node in self.nodes_to_start:
+            raise Exception("Add broker should only be used for nodes that haven't already been started")
+
+        self.logger.debug(self.who_am_i() + ": killing processes and attempting to clean up before starting")
+        # Added precaution - kill running processes, clean persistent files
+        # try/except for each step, since each of these steps may fail if there are no processes
+        # to kill or no files to remove
+        try:
+            self.stop_node(node)
+        except Exception:
+            pass
+
+        try:
+            self.clean_node(node)
+        except Exception:
+            pass
+
+        if node not in self.nodes_to_start:
+            self.nodes_to_start += [node]
+        self.logger.debug("%s: starting node" % self.who_am_i(node))
+        # ensure we wait for the broker to start by setting concurrent start to False for the invocation of start_node()
+        orig_concurrent_start = self.concurrent_start
+        self.concurrent_start = False
+        self.start_node(node)
+        self.concurrent_start = orig_concurrent_start
+        wait_until(lambda: self.is_registered(node), 30, 1)
 
     def _ensure_zk_chroot(self):
         self.logger.info("Ensuring zk_chroot %s exists", self.zk_chroot)
@@ -704,6 +762,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             else [broker_to_controller_listener_name, self.controller_listener_name(self.controller_quorum.intercontroller_security_protocol)]
 
     def start_node(self, node, timeout_sec=60):
+        if node not in self.nodes_to_start:
+            return
         node.account.mkdirs(KafkaService.PERSISTENT_ROOT)
 
         self.node_quorum_info = quorum.NodeQuorumInfo(self.quorum_info, node)
@@ -748,26 +808,21 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             node.account.ssh(cmd)
 
         cmd = self.start_cmd(node)
-        self.logger.debug("Attempting to start KafkaService on %s with command: %s" % (str(node.account), cmd))
-        with node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
-            node.account.ssh(cmd)
-            # Kafka will not start node-by-node for the co-located case with >1 controller
-            # because a single node won't be a majority and cannot form a Raft quorum; there will be no Raft quorum leader
-            # for that first Kafka node to connect to.  We therefore skip the startup log message check until we know
-            # we have started a majority of the controller nodes.
-            skip_startup_log_message_check = False
-            if self.node_quorum_info.has_controller_role and self.node_quorum_info.has_broker_role:
-                self.colocated_nodes_started += 1
-                skip_startup_log_message_check = self.colocated_nodes_started < round(self.num_nodes_controller_role / 2)
-            if skip_startup_log_message_check:
-                self.logger.info("Skipping successful startup log message check due to too few co-located KRaft controllers: %i/%i" %\
-                                 (self.colocated_nodes_started, self.num_nodes_controller_role))
-                # sleep for a few seconds to make sure we can identify the pid down below
-                time.sleep(5)
-            else:
-                # Kafka 1.0.0 and higher don't have a space between "Kafka" and "Server"
-                monitor.wait_until("Kafka\s*Server.*started", timeout_sec=timeout_sec, backoff_sec=.25,
-                                   err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
+        self.logger.debug("Attempting to start KafkaService %s on %s with command: %s" %\
+                          ("concurrently" if self.concurrent_start else "serially", str(node.account), cmd))
+        if self.node_quorum_info.has_controller_role and self.node_quorum_info.has_broker_role:
+            self.colocated_nodes_started += 1
+        if self.concurrent_start:
+            node.account.ssh(cmd) # and then don't wait for the startup message
+        else:
+            with node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
+                node.account.ssh(cmd)
+                self.wait_for_start(node, monitor, timeout_sec)
+
+    def wait_for_start(self, node, monitor, timeout_sec=60):
+        # Kafka 1.0.0 and higher don't have a space between "Kafka" and "Server"
+        monitor.wait_until("Kafka\s*Server.*started", timeout_sec=timeout_sec, backoff_sec=.25,
+                           err_msg="Kafka server didn't finish startup in %d seconds" % timeout_sec)
 
         if self.quorum_info.using_zk or self.quorum_info.has_brokers: # TODO: SCRAM currently unsupported for controller quorum
             # Credentials for inter-broker communication are created before starting Kafka.
@@ -1332,8 +1387,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def restart_node(self, node, clean_shutdown=True, timeout_sec=60):
         """Restart the given node."""
+        # ensure we wait for the broker to start by setting concurrent start to False for the invocation of start_node()
+        orig_concurrent_start = self.concurrent_start
+        self.concurrent_start = False
         self.stop_node(node, clean_shutdown, timeout_sec)
         self.start_node(node, timeout_sec)
+        self.concurrent_start = orig_concurrent_start
 
     def _describe_topic_line_for_partition(self, partition, describe_topic_output):
         # Lines look like this: Topic: test_topic	Partition: 0	Leader: 3	Replicas: 3,2	Isr: 3,2


### PR DESCRIPTION
This patch adds a sanity-check bounce system test for the case where we have 3 co-located KRaft controllers and fixes the system test code so that this case will pass by starting brokers in parallel by default instead of serially.  We now also send SIGKILL to any running KRaft broker or controller nodes for the co-located case when a majority of co-located controllers have been stopped -- otherwise they do not shutdown, and we spin for the 60 second timeout.  Finally, this patch adds the ability to specify that certain brokers should not be started when starting the cluster, and then we can start those nodes at a later time via the `add_broker()` method call; this is going to be helpful for KRaft snapshot system testing.

We were not testing the 3 co-located KRaft controller case previously, and it would not pass because the first Kafka node would never be considered started.  We were starting the Kafka nodes serially, and we decide that a node has successfully started when it logs a particular message.  This message is not logged until the broker has identified the controller (i.e. the leader of the KRaft quorum).  There cannot be a leader until a majority of the KRaft quorum has started, so with 3 co-located controllers the first node could never be considered "started" by the system test. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
