### PR TITLE
KAFKA-13037: "Thread state is already PENDING_SHUTDOWN" log spam

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -724,7 +724,7 @@ public class StreamThread extends Thread {
         // Should only proceed when the thread is still running after #pollRequests(), because no external state mutation
         // could affect the task manager state beyond this point within #runOnce().
         if (!isRunning()) {
-            log.info("Thread state is already {}, skipping the run once call after poll request", state);
+            log.debug("Thread state is already {}, skipping the run once call after poll request", state);
             return;
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-13037

Hey doesn't get much easier than this change. 