### PR TITLE
MINOR: StreamsPartitionAssignor should log the individual members of each client

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -105,7 +105,7 @@ import static org.apache.kafka.streams.processor.internals.ClientUtils.fetchEndO
  * sends output to zero, one, or more output topics.
  * <p>
  * The computational logic can be specified either by using the {@link Topology} to define a DAG topology of
- * {@link Processor}s or by using the {@link StreamsBuilder} which provides the high-level DSL to define
+ * {@link org.apache.kafka.streams.processor.api.Processor}s or by using the {@link StreamsBuilder} which provides the high-level DSL to define
  * transformations.
  * <p>
  * One {@code KafkaStreams} instance can contain one or more threads specified in the configs for the processing work.

--- a/streams/src/main/java/org/apache/kafka/streams/ThreadMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/ThreadMetadata.java
@@ -103,7 +103,9 @@ public interface ThreadMetadata {
      *             mainConsumerClientId,
      *             restoreConsumerClientId,
      *             producerClientIds,
-     *             adminClientId);
+     *             adminClientId
+     *             );
+     * }
      * </pre>
      *
      * @return a hash code value for this object.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -578,11 +578,16 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         final boolean lagComputationSuccessful =
             populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
 
+        log.info("All members participating in this rebalance: \n{}.",
+                 clientStates.entrySet().stream()
+                     .map(entry -> entry.getKey() + ": " + entry.getValue().consumers())
+                     .collect(Collectors.joining(Utils.NL)));
+
         final Set<TaskId> allTasks = partitionsForTask.keySet();
         statefulTasks.addAll(changelogTopics.statefulTaskIds());
 
-        log.debug("Assigning tasks {} to clients {} with number of replicas {}",
-            allTasks, clientStates, numStandbyReplicas());
+        log.debug("Assigning tasks {} including stateful {} to clients {} with number of replicas {}",
+            allTasks, statefulTasks, clientStates, numStandbyReplicas());
 
         final TaskAssignor taskAssignor = createTaskAssignor(lagComputationSuccessful);
 
@@ -661,6 +666,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             state.computeTaskLags(uuid, allTaskEndOffsetSums);
             clientStates.put(uuid, state);
         }
+
         return fetchEndOffsetsSuccessful;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -360,6 +360,10 @@ public class ClientState {
         }
     }
 
+    public String consumers() {
+        return consumerToPreviousStatefulTaskIds.keySet().toString();
+    }
+
     public String currentAssignment() {
         return "[activeTasks: (" + assignedActiveTasks.taskIds() +
                ") standbyTasks: (" + assignedStandbyTasks.taskIds() + ")]";


### PR DESCRIPTION
Often when debugging things like continuous rebalancing in Streams, we want to check whether the input conditions to the assignor are stable and if not, why. One of the common scenarios is regular changes to the group membership resulting in an unstable/non-deterministic assignment, so it's very useful to be able to tell at a glance how many members are participating in the rebalance, and which ones are missing, if any. This is currently a pretty terrible experience to tease out of the existing logs, so let's just make our lives easier by logging the info we want directly. 

Also fixes some warnings I saw when compiling. I'd like to get this into 3.0 cc @kkonstantine 