### PR TITLE
MINOR: Fix flaky deleteSnapshots test

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -404,13 +404,13 @@ final class KafkaMetadataLog private (
       return false
 
     var didClean = false
-    snapshots.keys.toSeq.sliding(2).toSeq.takeWhile {
+    snapshots.keys.toSeq.sliding(2).foreach {
       case Seq(snapshot: OffsetAndEpoch, nextSnapshot: OffsetAndEpoch) =>
         if (predicate(snapshot) && deleteBeforeSnapshot(nextSnapshot)) {
           didClean = true
           true
         } else {
-          false
+          return didClean
         }
       case _ => false // Shouldn't get here with the sliding window
     }


### PR DESCRIPTION
The sliding window + takeWhile behavior over a sequence seems somewhat different between Scala 2.12 and Scala 2.13. Worked around the each by using foreach with an early return.