### PR TITLE
MINOR: fix quoted boolean in FetchRequest.json

### DIFF
--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -70,7 +70,7 @@
       "about": "The fetch session epoch, which is used for ordering requests in a session." },
     { "name": "Topics", "type": "[]FetchTopic", "versions": "0+",
       "about": "The topics to fetch.", "fields": [
-      { "name": "Topic", "type": "string", "versions": "0-12", "entityType": "topicName", "ignorable": "true",
+      { "name": "Topic", "type": "string", "versions": "0-12", "entityType": "topicName", "ignorable": true,
         "about": "The name of the topic to fetch." },
       { "name": "TopicId", "type": "uuid", "versions": "13+", "ignorable": true, "about": "The unique topic ID"},
       { "name": "Partitions", "type": "[]FetchPartition", "versions": "0+",
@@ -91,7 +91,7 @@
     ]},
     { "name": "ForgottenTopicsData", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,
       "about": "In an incremental fetch request, the partitions to remove.", "fields": [
-      { "name": "Topic", "type": "string", "versions": "7-12", "entityType": "topicName", "ignorable": "true",
+      { "name": "Topic", "type": "string", "versions": "7-12", "entityType": "topicName", "ignorable": true,
         "about": "The partition name." },
       { "name": "TopicId", "type": "uuid", "versions": "13+", "ignorable": true, "about": "The unique topic ID"},
       { "name": "Partitions", "type": "[]int32", "versions": "7+",


### PR DESCRIPTION
Hi, I'm working on maintaining an implementation of the protocol written in Rust: https://github.com/0x1991babe/kafka-protocol-rs. A recent change in 2b8aff58b5 breaks my deserialization logic for the `ignorable` field. I could work around this, but hope this minor change is acceptable. :)