### PR TITLE
MINOR: fix typo in config for eos-v2 docs of the upgrade guide

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -54,7 +54,7 @@
 
     <p>
         Starting in Kafka Streams 2.6.x, a new processing mode is available, named EOS version 2. This can be configured
-        by setting <code>"processing.guarantee"</code> to <code>"exactly_once"</code> for
+        by setting <code>"processing.guarantee"</code> to <code>"exactly_once_v2"</code> for
         application versions 3.0+, or setting it to <code>"exactly_once_beta"</code> for versions between 2.6 and 2.8.
         To use this new feature, your brokers must be on version 2.5.x or newer.
         If you want to upgrade your EOS application from an older version and enable this feature in version 3.0+,


### PR DESCRIPTION
One of the configs has a typo and should have been `exactly_once _v2` rather than just `exactly_once`