### PR TITLE
MINOR: Print the cached broker epoch

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2302,7 +2302,7 @@ class KafkaController(val config: KafkaConfig,
     }
 
     if (!brokerEpochOpt.contains(brokerEpoch)) {
-      info(s"Ignoring AlterIsr due to stale broker epoch $brokerEpoch for broker $brokerId")
+      info(s"Ignoring AlterIsr due to stale broker epoch $brokerEpoch and local broker epoch $brokerEpochOpt for broker $brokerId")
       callback.apply(Right(Errors.STALE_BROKER_EPOCH))
       return
     }


### PR DESCRIPTION
When the broker epochs do not match make sure to print both broker
epochs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
