### PR TITLE
KAFKA-13049: Name the threads used for log recovery

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -317,7 +317,7 @@ class LogManager(logDirs: Seq[File],
           private val threadNumber = new AtomicInteger(1)
           override def newThread(r: Runnable): Thread = {
             val thread = factory.newThread(r)
-            thread.setName(s"log-recovery(${dir.getAbsolutePath}, ${threadNumber.getAndIncrement()})")
+            thread.setName(s"log-recovery($logDirAbsolutePath, ${threadNumber.getAndIncrement()})")
             thread
           }
         })


### PR DESCRIPTION
See [KAFKA-13049](https://issues.apache.org/jira/browse/KAFKA-13049)
