### PR TITLE
MINOR: Add default for EndOffset and Epoch in FetchSnapshotResponse.

### DIFF
--- a/clients/src/main/resources/common/message/FetchSnapshotResponse.json
+++ b/clients/src/main/resources/common/message/FetchSnapshotResponse.json
@@ -37,8 +37,8 @@
         { "name": "SnapshotId", "type": "SnapshotId", "versions": "0+",
           "about": "The snapshot endOffset and epoch fetched",
           "fields": [
-          { "name": "EndOffset", "type": "int64", "versions": "0+" },
-          { "name": "Epoch", "type": "int32", "versions": "0+" }
+          { "name": "EndOffset", "type": "int64", "versions": "0+", "default": "-1" },
+          { "name": "Epoch", "type": "int32", "versions": "0+", "default": "-1" }
         ]},
         { "name": "CurrentLeader", "type": "LeaderIdAndEpoch",
           "versions": "0+", "taggedVersions": "0+", "tag": 0, "fields": [


### PR DESCRIPTION
This is *extremely, extremely* minor.

Our Rust protocol impl is using default values for some serialization logic, and I noticed in doing a review for https://github.com/0x1991babe/kafka-protocol-rs/issues/1 that there's an inconsistency between `FetchSnapshotResponse` and `FetchSnapshot`, namely, `FetchSnapshot` [provides default values for these fields](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/FetchResponse.json#L73-L74).

Without defaults, we're constructing the default with `0`, which I'm concerned may be a valid state for the struct (as opposed to `-1`).

It looks like this is for Raft (??) so may actually be totally and completely irrelevant for end users of our lib, in which case feel free to close. :)