### PR TITLE
KAFKA-13058; AlterConsumerGroupOffsetsHandler does not handle partition errors correctly.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3642,9 +3642,11 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public AlterConsumerGroupOffsetsResult alterConsumerGroupOffsets(String groupId,
-                                                        Map<TopicPartition, OffsetAndMetadata> offsets,
-                                                        AlterConsumerGroupOffsetsOptions options) {
+    public AlterConsumerGroupOffsetsResult alterConsumerGroupOffsets(
+        String groupId,
+        Map<TopicPartition, OffsetAndMetadata> offsets,
+        AlterConsumerGroupOffsetsOptions options
+    ) {
         SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, Errors>> future =
                 AlterConsumerGroupOffsetsHandler.newFuture(groupId);
         AlterConsumerGroupOffsetsHandler handler = new AlterConsumerGroupOffsetsHandler(groupId, offsets, logContext);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandler.java
@@ -75,9 +75,7 @@ public class AlterConsumerGroupOffsetsHandler implements AdminApiHandler<Coordin
         return AdminApiFuture.forKeys(Collections.singleton(CoordinatorKey.byGroupId(groupId)));
     }
 
-    private void validateKeys(
-        Set<CoordinatorKey> groupIds
-    ) {
+    private void validateKeys(Set<CoordinatorKey> groupIds) {
         if (!groupIds.equals(singleton(groupId))) {
             throw new IllegalArgumentException("Received unexpected group ids " + groupIds +
                 " (expected only " + singleton(groupId) + ")");
@@ -146,17 +144,9 @@ public class AlterConsumerGroupOffsetsHandler implements AdminApiHandler<Coordin
         }
 
         if (groupsToUnmap.isEmpty() && groupsToRetry.isEmpty()) {
-            return new ApiResult<>(
-                Collections.singletonMap(groupId, partitionResults),
-                Collections.emptyMap(),
-                Collections.emptyList()
-            );
+            return ApiResult.completed(groupId, partitionResults);
         } else {
-            return new ApiResult<>(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                new ArrayList<>(groupsToUnmap)
-            );
+            return ApiResult.unmapped(new ArrayList<>(groupsToUnmap));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandler.java
@@ -16,10 +16,12 @@
  */
 package org.apache.kafka.clients.admin.internals;
 
+import static java.util.Collections.singleton;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -73,29 +75,40 @@ public class AlterConsumerGroupOffsetsHandler implements AdminApiHandler<Coordin
         return AdminApiFuture.forKeys(Collections.singleton(CoordinatorKey.byGroupId(groupId)));
     }
 
+    private void validateKeys(
+        Set<CoordinatorKey> groupIds
+    ) {
+        if (!groupIds.equals(singleton(groupId))) {
+            throw new IllegalArgumentException("Received unexpected group ids " + groupIds +
+                " (expected only " + singleton(groupId) + ")");
+        }
+    }
+
     @Override
-    public OffsetCommitRequest.Builder buildRequest(int coordinatorId, Set<CoordinatorKey> keys) {
-        List<OffsetCommitRequestTopic> topics = new ArrayList<>();
-        Map<String, List<OffsetCommitRequestPartition>> offsetData = new HashMap<>();
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
-            String topic = entry.getKey().topic();
-            OffsetAndMetadata oam = entry.getValue();
-            OffsetCommitRequestPartition partition = new OffsetCommitRequestPartition()
-                    .setCommittedOffset(oam.offset())
-                    .setCommittedLeaderEpoch(oam.leaderEpoch().orElse(-1))
-                    .setCommittedMetadata(oam.metadata())
-                    .setPartitionIndex(entry.getKey().partition());
-            offsetData.computeIfAbsent(topic, key -> new ArrayList<>()).add(partition);
-        }
-        for (Map.Entry<String, List<OffsetCommitRequestPartition>> entry : offsetData.entrySet()) {
-            OffsetCommitRequestTopic topic = new OffsetCommitRequestTopic()
-                    .setName(entry.getKey())
-                    .setPartitions(entry.getValue());
-            topics.add(topic);
-        }
+    public OffsetCommitRequest.Builder buildRequest(
+        int coordinatorId,
+        Set<CoordinatorKey> groupIds
+    ) {
+        validateKeys(groupIds);
+
+        Map<String, OffsetCommitRequestTopic> offsetData = new HashMap<>();
+        offsets.forEach((topicPartition, offsetAndMetadata) -> {
+            OffsetCommitRequestTopic topic = offsetData.computeIfAbsent(
+                topicPartition.topic(),
+                key -> new OffsetCommitRequestTopic().setName(topicPartition.topic())
+            );
+
+            topic.partitions().add(new OffsetCommitRequestPartition()
+                .setCommittedOffset(offsetAndMetadata.offset())
+                .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(-1))
+                .setCommittedMetadata(offsetAndMetadata.metadata())
+                .setPartitionIndex(topicPartition.partition()));
+        });
+
         OffsetCommitRequestData data = new OffsetCommitRequestData()
             .setGroupId(groupId.idValue)
-            .setTopics(topics);
+            .setTopics(new ArrayList<>(offsetData.values()));
+
         return new OffsetCommitRequest.Builder(data);
     }
 
@@ -105,53 +118,96 @@ public class AlterConsumerGroupOffsetsHandler implements AdminApiHandler<Coordin
         Set<CoordinatorKey> groupIds,
         AbstractResponse abstractResponse
     ) {
-        final OffsetCommitResponse response = (OffsetCommitResponse) abstractResponse;
-        Map<CoordinatorKey, Map<TopicPartition, Errors>> completed = new HashMap<>();
-        Map<CoordinatorKey, Throwable> failed = new HashMap<>();
-        List<CoordinatorKey> unmapped = new ArrayList<>();
+        validateKeys(groupIds);
 
-        Map<TopicPartition, Errors> partitions = new HashMap<>();
+        final OffsetCommitResponse response = (OffsetCommitResponse) abstractResponse;
+        final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
+        final Set<CoordinatorKey> groupsToRetry = new HashSet<>();
+        final Map<TopicPartition, Errors> partitionResults = new HashMap<>();
+
         for (OffsetCommitResponseTopic topic : response.data().topics()) {
             for (OffsetCommitResponsePartition partition : topic.partitions()) {
-                TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
+                TopicPartition topicPartition = new TopicPartition(topic.name(), partition.partitionIndex());
                 Errors error = Errors.forCode(partition.errorCode());
+
                 if (error != Errors.NONE) {
-                    handleError(groupId, error, failed, unmapped);
+                    handleError(
+                        groupId,
+                        topicPartition,
+                        error,
+                        partitionResults,
+                        groupsToUnmap,
+                        groupsToRetry
+                    );
                 } else {
-                    partitions.put(tp, error);
+                    partitionResults.put(topicPartition, error);
                 }
             }
         }
-        if (failed.isEmpty() && unmapped.isEmpty())
-            completed.put(groupId, partitions);
 
-        return new ApiResult<>(completed, failed, unmapped);
+        if (groupsToUnmap.isEmpty() && groupsToRetry.isEmpty()) {
+            return new ApiResult<>(
+                Collections.singletonMap(groupId, partitionResults),
+                Collections.emptyMap(),
+                Collections.emptyList()
+            );
+        } else {
+            return new ApiResult<>(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                new ArrayList<>(groupsToUnmap)
+            );
+        }
     }
 
     private void handleError(
         CoordinatorKey groupId,
+        TopicPartition topicPartition,
         Errors error,
-        Map<CoordinatorKey, Throwable> failed,
-        List<CoordinatorKey> unmapped
+        Map<TopicPartition, Errors> partitionResults,
+        Set<CoordinatorKey> groupsToUnmap,
+        Set<CoordinatorKey> groupsToRetry
     ) {
         switch (error) {
-            case GROUP_AUTHORIZATION_FAILED:
-                log.error("Received authorization failure for group {} in `OffsetCommit` response", groupId,
-                        error.exception());
-                failed.put(groupId, error.exception());
-                break;
+            // If the coordinator is in the middle of loading, then we just need to retry.
             case COORDINATOR_LOAD_IN_PROGRESS:
+                log.debug("OffsetCommit request for group id {} failed because the coordinator" +
+                    " is still in the process of loading state. Will retry.", groupId.idValue);
+                groupsToRetry.add(groupId);
+                break;
+
+            // If the coordinator is not available, then we unmap and retry.
             case COORDINATOR_NOT_AVAILABLE:
             case NOT_COORDINATOR:
-                log.debug("OffsetCommit request for group {} returned error {}. Will retry", groupId, error);
-                unmapped.add(groupId);
+                log.debug("OffsetCommit request for group id {} returned error {}. Will retry.",
+                    groupId.idValue, error);
+                groupsToUnmap.add(groupId);
                 break;
+
+            // Group level errors.
+            case INVALID_GROUP_ID:
+            case REBALANCE_IN_PROGRESS:
+            case INVALID_COMMIT_OFFSET_SIZE:
+            case GROUP_AUTHORIZATION_FAILED:
+                log.debug("OffsetCommit request for group id {} failed due to error {}.",
+                    groupId.idValue, error);
+                partitionResults.put(topicPartition, error);
+                break;
+
+            // TopicPartition level errors.
+            case UNKNOWN_TOPIC_OR_PARTITION:
+            case OFFSET_METADATA_TOO_LARGE:
+            case TOPIC_AUTHORIZATION_FAILED:
+                log.debug("OffsetCommit request for group id {} and partition {} failed due" +
+                    " to error {}.", groupId.idValue, topicPartition, error);
+                partitionResults.put(topicPartition, error);
+                break;
+
+            // Unexpected errors.
             default:
-                log.error("Received unexpected error for group {} in `OffsetCommit` response",
-                        groupId, error.exception());
-                failed.put(groupId, error.exception(
-                        "Received unexpected error for group " + groupId + " in `OffsetCommit` response"));
+                log.error("OffsetCommit request for group id {} and partition {} failed due" +
+                    " to unexpected error {}.", groupId.idValue, topicPartition, error);
+                partitionResults.put(topicPartition, error);
         }
     }
-
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2544,6 +2544,39 @@ public class KafkaAdminClientTest {
     }
 
     @Test
+    public void testOffsetCommitWithMultipleErrors() throws Exception {
+        final Cluster cluster = mockCluster(3, 0);
+        final Time time = new MockTime();
+
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, cluster,
+            AdminClientConfig.RETRIES_CONFIG, "0")) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            final TopicPartition foo0 = new TopicPartition("foo", 0);
+            final TopicPartition foo1 = new TopicPartition("foo", 1);
+
+            env.kafkaClient().prepareResponse(
+                prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
+
+            Map<TopicPartition, Errors> responseData = new HashMap<>();
+            responseData.put(foo0, Errors.NONE);
+            responseData.put(foo1, Errors.UNKNOWN_TOPIC_OR_PARTITION);
+            env.kafkaClient().prepareResponse(new OffsetCommitResponse(0, responseData));
+
+            Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+            offsets.put(foo0, new OffsetAndMetadata(123L));
+            offsets.put(foo1, new OffsetAndMetadata(456L));
+            final AlterConsumerGroupOffsetsResult result = env.adminClient()
+                .alterConsumerGroupOffsets(GROUP_ID, offsets);
+
+            assertNull(result.partitionResult(foo0).get());
+            TestUtils.assertFutureError(result.partitionResult(foo1), UnknownTopicOrPartitionException.class);
+
+            TestUtils.assertFutureError(result.all(), UnknownTopicOrPartitionException.class);
+        }
+    }
+
+    @Test
     public void testOffsetCommitRetryBackoff() throws Exception {
         MockTime time = new MockTime();
         int retryBackoff = 100;
@@ -4108,9 +4141,6 @@ public class KafkaAdminClientTest {
 
             env.kafkaClient().prepareResponse(
                 prepareOffsetCommitResponse(tp1, Errors.COORDINATOR_LOAD_IN_PROGRESS));
-
-            env.kafkaClient().prepareResponse(
-                prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
 
             env.kafkaClient().prepareResponse(
                 prepareOffsetCommitResponse(tp1, Errors.NOT_COORDINATOR));


### PR DESCRIPTION
While reviewing https://github.com/apache/kafka/pull/10973, I have noticed that `AlterConsumerGroupOffsetsHandler` does not handle partition errors correctly. The issue is that any partition error fails the entire future instead of being passed as an error for its corresponding partition. `KafkaAdminClientTest#testOffsetCommitWithMultipleErrors` reproduces the bug.

The regression was introduced by KIP-699.

Context: https://github.com/apache/kafka/pull/10973#discussion_r667335981.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
