### PR TITLE
Scala 3 Compilation with 2.12 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,25 @@ pipeline {
           }
         }
 
+        stage('JDK 11 and Scala 3.0') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_11_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS')
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=3.0
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            echo 'Skipping Kafka Streams archetype test for Java 16'
+          }
+        }
+
         stage('ARM') {
           agent { label 'arm4' }
           options {
@@ -220,6 +239,76 @@ pipeline {
           }
           environment {
             SCALA_VERSION=2.13
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            tryStreamsArchetype()
+          }
+        }
+
+        stage('JDK 8 and Scala 3.0') {
+          when {
+            not { changeRequest() }
+            beforeAgent true
+          }
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_1.8_latest'
+            maven 'maven_3_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS')
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=3.0
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            tryStreamsArchetype()
+          }
+        }
+
+        stage('JDK 15 and Scala 3.0') {
+          when {
+            not { changeRequest() }
+            beforeAgent true
+          }
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_15_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS')
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=3.0
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            tryStreamsArchetype()
+          }
+        }
+
+        stage('JDK 16 and Scala 3.0') {
+          when {
+            not { changeRequest() }
+            beforeAgent true
+          }
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_16_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS')
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=3.0
           }
           steps {
             doValidation()

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ allprojects {
           libs.javassist,
           // ensure we have a single version in the classpath despite transitive dependencies
           libs.scalaLibrary,
-          libs.scalaReflect,
+          libs.scalaCompiler,
           libs.jacksonAnnotations,
           // be explicit about the Netty dependency version instead of relying on the version set by
           // ZooKeeper (potentially older and containing CVEs)
@@ -590,6 +590,10 @@ subprojects {
       scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
     }
 
+    if (versions.baseScala == '3') {
+      scalaCompileOptions.additionalParameters += ["-Ytasty-reader"]
+    }
+
     // these options are valid for Scala versions < 2.13 only
     // Scala 2.13 removes them, see https://github.com/scala/scala/pull/6502 and https://github.com/scala/scala/pull/5969
     if (versions.baseScala == '2.12') {
@@ -803,6 +807,7 @@ project(':core') {
     // even though the `core` module doesn't expose any public API
     api project(':clients')
     api libs.scalaLibrary
+    api libs.scalaCompiler
 
     implementation project(':server-common')
     implementation project(':metadata')
@@ -819,7 +824,6 @@ project(':core') {
     implementation libs.scalaCollectionCompat
     implementation libs.scalaJava8Compat
     // only needed transitively, but set it explicitly to ensure it has the same version as scala-library
-    implementation libs.scalaReflect
     implementation libs.scalaLogging
     implementation libs.slf4jApi
     implementation(libs.zookeeper) {
@@ -1839,6 +1843,7 @@ project(':streams:streams-scala') {
     api project(':streams')
 
     api libs.scalaLibrary
+    api libs.scalaCompiler
     api libs.scalaCollectionCompat
 
     testImplementation project(':core')
@@ -2155,6 +2160,7 @@ project(':jmh-benchmarks') {
     implementation libs.slf4jlog4j
     implementation libs.scalaLibrary
     implementation libs.scalaJava8Compat
+    implementation libs.scalaCompiler
   }
 
   tasks.withType(JavaCompile) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,18 +23,25 @@ ext {
 
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
   // a higher minimum Java requirement than Kafka. This was previously the case for Scala 2.12 and Java 7.
-  availableScalaVersions = [ '2.12', '2.13' ]
+  availableScalaVersions = [ '2.12', '2.13', '3.0' ]
 }
 
 // Add Scala version
 def defaultScala212Version = '2.12.14'
+def defaultScala30Version = '3.0.0'
 def defaultScala213Version = '2.13.6'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version
   } else if (scalaVersion == '2.13') {
     versions["scala"] = defaultScala213Version
-  }  else {
+  } else if (scalaVersion == '3.0') {
+    versions["scala"] = defaultScala30Version
+    versions["baseScala"] = '3'
+    versions["baseScalaForSpecialLibs"] = '2.13'
+    versions["postfixScala"] = '3'
+    versions["postfixScalaOptionalVersion"] = '_3'
+  } else {
     versions["scala"] = scalaVersion
   }
 } else {
@@ -47,10 +54,16 @@ if (hasProperty('scalaVersion')) {
     rationale: pre-release Scala versions are not binary compatible with each other and that's the reason why libraries include the full
     Scala release string in their name for pre-releases (see dependencies below with an artifact name suffix '_$versions.baseScala')
 */
-if ( !versions.scala.contains('-') ) {
-  versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
-} else {
-  versions["baseScala"] = versions.scala
+if (versions.baseScala != '3') {
+  if ( !versions.scala.contains('-') ) {
+    versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
+    versions["baseScalaForSpecialLibs"] = versions.baseScala
+  } else {
+    versions["baseScala"] = versions.scala
+    versions["baseScalaForSpecialLibs"] = versions.scala
+  }
+  versions["postfixScala"] = ''
+  versions["postfixScalaOptionalVersion"] = ''
 }
 
 versions += [
@@ -74,7 +87,7 @@ versions += [
   jmh: "1.32",
   hamcrest: "2.2",
   log4j: "1.2.17",
-  scalaLogging: "3.9.3",
+  scalaLogging: "3.9.4",
   jaxb: "2.3.0",
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
@@ -132,7 +145,7 @@ libs += [
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
   jacksonDataformatCsv: "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:$versions.jackson",
-  jacksonModuleScala: "com.fasterxml.jackson.module:jackson-module-scala_$versions.baseScala:$versions.jackson",
+  jacksonModuleScala: "com.fasterxml.jackson.module:jackson-module-scala_$versions.baseScalaForSpecialLibs:$versions.jackson",
   jacksonJDK8Datatypes: "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$versions.jackson",
   jacksonJaxrsJsonProvider: "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$versions.jackson",
   jaxbApi: "javax.xml.bind:jaxb-api:$versions.jaxb",
@@ -180,10 +193,11 @@ libs += [
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",
-  scalaCollectionCompat: "org.scala-lang.modules:scala-collection-compat_$versions.baseScala:$versions.scalaCollectionCompat",
-  scalaJava8Compat: "org.scala-lang.modules:scala-java8-compat_$versions.baseScala:$versions.scalaJava8Compat",
-  scalaLibrary: "org.scala-lang:scala-library:$versions.scala",
-  scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScala:$versions.scalaLogging",
+  scalaCollectionCompat: "org.scala-lang.modules:scala-collection-compat_$versions.baseScalaForSpecialLibs:$versions.scalaCollectionCompat",
+  scalaJava8Compat: "org.scala-lang.modules:scala-java8-compat_$versions.baseScalaForSpecialLibs:$versions.scalaJava8Compat",
+  scalaLibrary: "org.scala-lang:scala$versions.postfixScala-library$versions.postfixScalaOptionalVersion:$versions.scala",
+  scalaCompiler: "org.scala-lang:scala$versions.postfixScala-compiler$versions.postfixScalaOptionalVersion:$versions.scala",
+  scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScalaForSpecialLibs:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",
   slf4jlog4j: "org.slf4j:slf4j-log4j12:$versions.slf4j",

--- a/gradlewAll
+++ b/gradlewAll
@@ -15,5 +15,5 @@
 
 # Convenient way to invoke a gradle command with all Scala versions supported
 # by default
-./gradlew "$@" -PscalaVersion=2.12 && ./gradlew "$@" -PscalaVersion=2.13
+./gradlew "$@" -PscalaVersion=2.12 && ./gradlew "$@" -PscalaVersion=2.13 && ./gradlew "$@" -PscalaVersion=3.0
 

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -790,7 +790,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * @param stateStoreNames   the names of the state store used by the processor
    * @see `org.apache.kafka.streams.kstream.KStream#process`
    */
-  @deprecated(since = "3.0", message = "Use process(ProcessorSupplier, String*) instead.")
+  @deprecated("Use process(ProcessorSupplier, String*) instead.", "3.0")
   def process(processorSupplier: () => org.apache.kafka.streams.processor.Processor[K, V],
               stateStoreNames: String*): Unit = {
     val processorSupplierJ: org.apache.kafka.streams.processor.ProcessorSupplier[K, V] = () => processorSupplier()
@@ -828,7 +828,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * @param stateStoreNames   the names of the state store used by the processor
    * @see `org.apache.kafka.streams.kstream.KStream#process`
    */
-  @deprecated(since = "3.0", message = "Use process(ProcessorSupplier, String*) instead.")
+  @deprecated("Use process(ProcessorSupplier, String*) instead.", "3.0")
   def process(processorSupplier: () => org.apache.kafka.streams.processor.Processor[K, V],
               named: Named,
               stateStoreNames: String*): Unit = {


### PR DESCRIPTION
This PR adds support to Scala 3.0 without the need to drop support for Scala 2.12
Did my best as well to add some new stages in Jenkis for Scala 3.0

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
