### PR TITLE
MINOR: change log.dirs for config/kraft/controller.properties

### DIFF
--- a/config/kraft/controller.properties
+++ b/config/kraft/controller.properties
@@ -70,7 +70,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/raft-controller-logs
+log.dirs=/tmp/kraft-controller-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across


### PR DESCRIPTION
Prior to this change the logs for the example controller were in raft-controller-logs which wasn't consistent (raft vs kraft) with kraft-broker-logs or kraft-combined-logs used for the broker or combined server respectively:

  $ grep log.dirs config/kraft/*.properties
  config/kraft/broker.properties:log.dirs=/tmp/kraft-broker-logs
  config/kraft/controller.properties:log.dirs=/tmp/raft-controller-logs
  config/kraft/server.properties:log.dirs=/tmp/kraft-combined-logs

