### PR TITLE
MINOR: Handle some null cases in BrokerMetadataPublisher

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -46,8 +46,10 @@ object BrokerMetadataPublisher {
   def getTopicDelta(topicName: String,
                     newImage: MetadataImage,
                     delta: MetadataDelta): Option[TopicDelta] = {
-    Option(newImage.topics().getTopic(topicName)).map {
-      topicImage => delta.topicsDelta().changedTopic(topicImage.id())
+    Option(newImage.topics().getTopic(topicName)).flatMap {
+      topicImage => Option(delta.topicsDelta()).flatMap {
+        topicDelta => Option(topicDelta.changedTopic(topicImage.id()))
+      }
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -1,0 +1,25 @@
+package unit.kafka.server.metadata
+
+import kafka.server.metadata.BrokerMetadataPublisher
+import org.apache.kafka.image.MetadataImageTest
+import org.junit.jupiter.api.Test
+
+class BrokerMetadataPublisherTest {
+  @Test
+  def testGetTopicDelta(): Unit = {
+    assert(BrokerMetadataPublisher.getTopicDelta(
+      "not-a-topic",
+      MetadataImageTest.IMAGE1,
+      MetadataImageTest.DELTA1).isEmpty, "Expected no delta for unknown topic")
+
+    assert(BrokerMetadataPublisher.getTopicDelta(
+      "foo",
+      MetadataImageTest.IMAGE1,
+      MetadataImageTest.DELTA1).isEmpty, "Expected no delta for deleted topic")
+
+    assert(BrokerMetadataPublisher.getTopicDelta(
+      "bar",
+      MetadataImageTest.IMAGE1,
+      MetadataImageTest.DELTA1).isDefined, "Expected to see delta for changed topic")
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.kafka.server.metadata
 
 import kafka.server.metadata.BrokerMetadataPublisher


### PR DESCRIPTION
Found a few NPEs when running system tests. Added coverage for a few null cases in BrokerMetadataPublisher as well as a unit test