### PR TITLE
KAFKA-13067 Add internal config to lower the metadata log segment size

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -588,8 +588,8 @@ object KafkaMetadataLog {
 
     // Print a warning if users have overridden the internal config
     if (config.logSegmentMinBytes != KafkaRaftClient.MAX_BATCH_SIZE_BYTES) {
-      metadataLog.error(s"Overriding $MetadataLogSegmentMinBytesProp is unsupported! This may lead to an " +
-        s"inability to write batches of metadata records")
+      metadataLog.error(s"Overriding $MetadataLogSegmentMinBytesProp is only supported for testing. Setting " +
+        s"this value too low may lead to an inability to write batches of metadata records.")
     }
 
     // When recovering, truncate fully if the latest snapshot is after the log end offset. This can happen to a follower

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -378,6 +378,7 @@ object KafkaConfig {
   val MetadataSnapshotMaxNewRecordBytesProp = "metadata.log.max.record.bytes.between.snapshots"
   val ControllerListenerNamesProp = "controller.listener.names"
   val SaslMechanismControllerProtocolProp = "sasl.mechanism.controller.protocol"
+  val MetadataLogSegmentMinBytesProp = "metadata.log.segment.min.bytes"
   val MetadataLogSegmentBytesProp = "metadata.log.segment.bytes"
   val MetadataLogSegmentMillisProp = "metadata.log.segment.ms"
   val MetadataMaxRetentionBytesProp = "metadata.max.retention.bytes"
@@ -675,6 +676,8 @@ object KafkaConfig {
     "if running in KRaft mode. The ZK-based controller will not use this configuration."
   val SaslMechanismControllerProtocolDoc = "SASL mechanism used for communication with controllers. Default is GSSAPI."
   val MetadataLogSegmentBytesDoc = "The maximum size of a single metadata log file."
+  val MetadataLogSegmentMinBytesDoc = "Override the minimum size for a single metadata log file. This should be used for testing only."
+
   val MetadataLogSegmentMillisDoc = "The maximum time before a new metadata log file is rolled out (in milliseconds)."
   val MetadataMaxRetentionBytesDoc = "The maximum combined size of the metadata log and snapshots before deleting old " +
     "snapshots and log files. Since at least one snapshot must exist before any logs can be deleted, this is a soft limit."
@@ -1070,6 +1073,7 @@ object KafkaConfig {
       .define(SaslMechanismControllerProtocolProp, STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, null, HIGH, SaslMechanismControllerProtocolDoc)
       .define(MetadataLogDirProp, STRING, null, null, HIGH, MetadataLogDirDoc)
       .define(MetadataLogSegmentBytesProp, INT, Defaults.LogSegmentBytes, atLeast(Records.LOG_OVERHEAD), HIGH, MetadataLogSegmentBytesDoc)
+      .defineInternal(MetadataLogSegmentMinBytesProp, INT, 8 * 1024 * 1024, atLeast(Records.LOG_OVERHEAD), HIGH, MetadataLogSegmentMinBytesDoc)
       .define(MetadataLogSegmentMillisProp, LONG, Defaults.LogRollHours * 60 * 60 * 1000L, null, HIGH, MetadataLogSegmentMillisDoc)
       .define(MetadataMaxRetentionBytesProp, LONG, Defaults.LogRetentionBytes, null, HIGH, MetadataMaxRetentionBytesDoc)
       .define(MetadataMaxRetentionMillisProp, LONG, Defaults.LogRetentionHours * 60 * 60 * 1000L, null, HIGH, MetadataMaxRetentionMillisDoc)

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -17,9 +17,10 @@
 package kafka.raft
 
 import kafka.log.{Defaults, Log, SegmentDeletion}
-import kafka.server.KafkaRaftServer
+import kafka.server.KafkaConfig.{MetadataLogSegmentBytesProp, MetadataLogSegmentMillisProp, MetadataLogSegmentMinBytesProp, NodeIdProp, ProcessRolesProp}
+import kafka.server.{KafkaConfig, KafkaRaftServer}
 import kafka.utils.{MockTime, TestUtils}
-import org.apache.kafka.common.errors.RecordTooLargeException
+import org.apache.kafka.common.errors.{InvalidConfigurationException, RecordTooLargeException}
 import org.apache.kafka.common.protocol
 import org.apache.kafka.common.protocol.{ObjectSerializationCache, Writable}
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
@@ -35,7 +36,8 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
-import java.util.{Collections, Optional}
+import java.util
+import java.util.{Collections, Optional, Properties}
 
 final class KafkaMetadataLogTest {
   import KafkaMetadataLogTest._
@@ -51,6 +53,25 @@ final class KafkaMetadataLogTest {
   @AfterEach
   def tearDown(): Unit = {
     Utils.delete(tempDir)
+  }
+
+  @Test
+  def testConfig(): Unit = {
+    val props = new Properties()
+    props.put(ProcessRolesProp, util.Arrays.asList("broker"))
+    props.put(NodeIdProp, Int.box(1))
+    props.put(MetadataLogSegmentBytesProp, Int.box(10240))
+    props.put(MetadataLogSegmentMillisProp, Int.box(10 * 1024))
+    assertThrows(classOf[InvalidConfigurationException], () => {
+      val kafkaConfig = KafkaConfig.fromProps(props)
+      val metadataConfig = MetadataLogConfig.apply(kafkaConfig, KafkaRaftClient.MAX_BATCH_SIZE_BYTES, KafkaRaftClient.MAX_FETCH_SIZE_BYTES)
+      buildMetadataLog(tempDir, mockTime, metadataConfig)
+    })
+
+    props.put(MetadataLogSegmentMinBytesProp, Int.box(10240))
+    val kafkaConfig = KafkaConfig.fromProps(props)
+    val metadataConfig = MetadataLogConfig.apply(kafkaConfig, KafkaRaftClient.MAX_BATCH_SIZE_BYTES, KafkaRaftClient.MAX_FETCH_SIZE_BYTES)
+    buildMetadataLog(tempDir, mockTime, metadataConfig)
   }
 
   @Test
@@ -732,6 +753,7 @@ final class KafkaMetadataLogTest {
   def testAdvanceLogStartOffsetAfterCleaning(): Unit = {
     val config = MetadataLogConfig(
       logSegmentBytes = 512,
+      logSegmentMinBytes = 512,
       logSegmentMillis = 10 * 1000,
       retentionMaxBytes = 256,
       retentionMillis = 60 * 1000,
@@ -865,6 +887,7 @@ object KafkaMetadataLogTest {
 
   val DefaultMetadataLogConfig = MetadataLogConfig(
     logSegmentBytes = 100 * 1024,
+    logSegmentMinBytes = 100 * 1024,
     logSegmentMillis = 10 * 1000,
     retentionMaxBytes = 100 * 1024,
     retentionMillis = 60 * 1000,

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -798,6 +798,7 @@ final class KafkaMetadataLogTest {
     // Generate some logs and a few snapshots, set retention low and verify that cleaning occurs
     val config = DefaultMetadataLogConfig.copy(
       logSegmentBytes = 1024,
+      logSegmentMinBytes = 1024,
       logSegmentMillis = 10 * 1000,
       retentionMaxBytes = 1024,
       retentionMillis = 60 * 1000,
@@ -832,6 +833,7 @@ final class KafkaMetadataLogTest {
     // Set retention equal to the segment size and generate slightly more than one segment of logs
     val config = DefaultMetadataLogConfig.copy(
       logSegmentBytes = 10240,
+      logSegmentMinBytes = 10240,
       logSegmentMillis = 10 * 1000,
       retentionMaxBytes = 10240,
       retentionMillis = 60 * 1000,


### PR DESCRIPTION
In order to facilitate system and integration tests that use a smaller log segment size, we are adding this internal config to lower the minimum. During normal operation, this config will use the default size of 8Mb (as defined by KafkaRaftClient). 

The new config is named `metadata.log.segment.min.bytes`. If it is set to a non-default value, and ERROR level log will be printed