### PR TITLE
KAFKA-13078: Closing FileRawSnapshotWriter too early

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -137,11 +137,11 @@ public class FollowerState implements EpochState {
         return fetchingSnapshot;
     }
 
-    public void setFetchingSnapshot(Optional<RawSnapshotWriter> fetchingSnapshot) {
+    public void setFetchingSnapshot(Optional<RawSnapshotWriter> newSnapshot) {
         if (fetchingSnapshot.isPresent()) {
             fetchingSnapshot.get().close();
         }
-        this.fetchingSnapshot = fetchingSnapshot;
+        fetchingSnapshot = newSnapshot;
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
@@ -60,8 +60,12 @@ public final class FileRawSnapshotWriter implements RawSnapshotWriter {
             return channel.size();
         } catch (IOException e) {
             throw new UncheckedIOException(
-                String.format("Error calculating snapshot size.temp path = %s, snapshotId = %s.",
-                    this.tempSnapshotPath, this.snapshotId), e);
+                String.format(
+                    "Error calculating snapshot size. temp path = %s, snapshotId = %s.",
+                    tempSnapshotPath,
+                    snapshotId),
+                e
+            );
         }
     }
 
@@ -177,14 +181,17 @@ public final class FileRawSnapshotWriter implements RawSnapshotWriter {
         try {
             return new FileRawSnapshotWriter(
                 path,
-                FileChannel.open(path, Utils.mkSet(StandardOpenOption.WRITE, StandardOpenOption.APPEND)),
+                FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.APPEND),
                 snapshotId,
                 replicatedLog
             );
         } catch (IOException e) {
             throw new UncheckedIOException(
-                String.format("Error creating snapshot writer, " +
-                    "temp path = %s, snapshotId %s.", path, snapshotId),
+                String.format(
+                    "Error creating snapshot writer. path = %s, snapshotId %s.",
+                    path,
+                    snapshotId
+                ),
                 e
             );
         }


### PR DESCRIPTION
FollowerState state should close the store fetchingSnapshot if it exists
instead of the new snapshot begin set.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
