### PR TITLE
Use ByteBuffers for LZ4 OutputStream

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/compress/KafkaLZ4Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/compress/KafkaLZ4Test.java
@@ -19,13 +19,13 @@ package org.apache.kafka.common.compress;
 import net.jpountz.xxhash.XXHashFactory;
 
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -136,9 +136,8 @@ public class KafkaLZ4Test {
     @ParameterizedTest
     @ArgumentsSource(Lz4ArgumentsProvider.class)
     public void testNotSupported(Args args) throws Exception {
-        byte[] compressed = compressedBytes(args);
-        compressed[0] = 0x00;
-        ByteBuffer buffer = ByteBuffer.wrap(compressed);
+        ByteBuffer buffer = compressedBytes(args);
+        buffer.put(0, (byte) 0x00);
         IOException e = assertThrows(IOException.class, () -> makeInputStream(buffer, args.ignoreFlagDescriptorChecksum));
         assertEquals(KafkaLZ4BlockInputStream.NOT_SUPPORTED, e.getMessage());
     }
@@ -146,9 +145,8 @@ public class KafkaLZ4Test {
     @ParameterizedTest
     @ArgumentsSource(Lz4ArgumentsProvider.class)
     public void testBadFrameChecksum(Args args) throws Exception {
-        byte[] compressed = compressedBytes(args);
-        compressed[6] = (byte) 0xFF;
-        ByteBuffer buffer = ByteBuffer.wrap(compressed);
+        ByteBuffer buffer = compressedBytes(args);
+        buffer.put(6, (byte) 0xFF);
 
         if (args.ignoreFlagDescriptorChecksum) {
             makeInputStream(buffer, args.ignoreFlagDescriptorChecksum);
@@ -163,9 +161,7 @@ public class KafkaLZ4Test {
     public void testBadBlockSize(Args args) throws Exception {
         if (!args.close || (args.useBrokenFlagDescriptorChecksum && !args.ignoreFlagDescriptorChecksum))
             return;
-
-        byte[] compressed = compressedBytes(args);
-        ByteBuffer buffer = ByteBuffer.wrap(compressed).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer buffer = compressedBytes(args).order(ByteOrder.LITTLE_ENDIAN);
 
         int blockSize = buffer.getInt(7);
         blockSize = (blockSize & LZ4_FRAME_INCOMPRESSIBLE_MASK) | (1 << 24 & ~LZ4_FRAME_INCOMPRESSIBLE_MASK);
@@ -180,17 +176,16 @@ public class KafkaLZ4Test {
     @ParameterizedTest
     @ArgumentsSource(Lz4ArgumentsProvider.class)
     public void testCompression(Args args) throws Exception {
-        byte[] compressed = compressedBytes(args);
+        ByteBuffer compressed = compressedBytes(args);
 
         // Check magic bytes stored as little-endian
-        int offset = 0;
-        assertEquals(0x04, compressed[offset++]);
-        assertEquals(0x22, compressed[offset++]);
-        assertEquals(0x4D, compressed[offset++]);
-        assertEquals(0x18, compressed[offset++]);
+        assertEquals(0x04, compressed.get());
+        assertEquals(0x22, compressed.get());
+        assertEquals(0x4D, compressed.get());
+        assertEquals(0x18, compressed.get());
 
         // Check flg descriptor
-        byte flg = compressed[offset++];
+        byte flg = compressed.get();
 
         // 2-bit version must be 01
         int version = (flg >>> 6) & 3;
@@ -201,7 +196,7 @@ public class KafkaLZ4Test {
         assertEquals(0, reserved);
 
         // Check block descriptor
-        byte bd = compressed[offset++];
+        byte bd = compressed.get();
 
         // Block max-size
         int blockMaxSize = (bd >>> 4) & 7;
@@ -219,50 +214,49 @@ public class KafkaLZ4Test {
         // there are 8 additional bytes before checksum
         boolean contentSize = ((flg >>> 3) & 1) != 0;
         if (contentSize)
-            offset += 8;
+            compressed.position(compressed.position() + 8);
 
         // Checksum applies to frame descriptor: flg, bd, and optional contentsize
         // so initial offset should be 4 (for magic bytes)
         int off = 4;
-        int len = offset - 4;
+        int len = compressed.position() - 4;
 
         // Initial implementation of checksum incorrectly applied to full header
         // including magic bytes
         if (args.useBrokenFlagDescriptorChecksum) {
             off = 0;
-            len = offset;
+            len = compressed.position();
         }
 
         int hash = XXHashFactory.fastestInstance().hash32().hash(compressed, off, len, 0);
 
-        byte hc = compressed[offset++];
+        byte hc = compressed.get();
         assertEquals((byte) ((hash >> 8) & 0xFF), hc);
 
         // Check EndMark, data block with size `0` expressed as a 32-bits value
         if (args.close) {
-            offset = compressed.length - 4;
-            assertEquals(0, compressed[offset++]);
-            assertEquals(0, compressed[offset++]);
-            assertEquals(0, compressed[offset++]);
-            assertEquals(0, compressed[offset++]);
+            compressed.position(compressed.limit() - 4);
+            assertEquals(0, compressed.get());
+            assertEquals(0, compressed.get());
+            assertEquals(0, compressed.get());
+            assertEquals(0, compressed.get());
         }
     }
 
     @ParameterizedTest
     @ArgumentsSource(Lz4ArgumentsProvider.class)
     public void testArrayBackedBuffer(Args args) throws IOException {
-        byte[] compressed = compressedBytes(args);
-        testDecompression(ByteBuffer.wrap(compressed), args);
+        testDecompression(compressedBytes(args), args);
     }
 
     @ParameterizedTest
     @ArgumentsSource(Lz4ArgumentsProvider.class)
     public void testArrayBackedBufferSlice(Args args) throws IOException {
-        byte[] compressed = compressedBytes(args);
+        ByteBuffer compressed = compressedBytes(args);
 
         int sliceOffset = 12;
 
-        ByteBuffer buffer = ByteBuffer.allocate(compressed.length + sliceOffset + 123);
+        ByteBuffer buffer = ByteBuffer.allocate(compressed.remaining() + sliceOffset + 123);
         buffer.position(sliceOffset);
         buffer.put(compressed).flip();
         buffer.position(sliceOffset);
@@ -270,8 +264,9 @@ public class KafkaLZ4Test {
         ByteBuffer slice = buffer.slice();
         testDecompression(slice, args);
 
+        compressed.rewind();
         int offset = 42;
-        buffer = ByteBuffer.allocate(compressed.length + sliceOffset + offset);
+        buffer = ByteBuffer.allocate(compressed.remaining() + sliceOffset + offset);
         buffer.position(sliceOffset + offset);
         buffer.put(compressed).flip();
         buffer.position(sliceOffset);
@@ -284,15 +279,16 @@ public class KafkaLZ4Test {
     @ParameterizedTest
     @ArgumentsSource(Lz4ArgumentsProvider.class)
     public void testDirectBuffer(Args args) throws IOException {
-        byte[] compressed = compressedBytes(args);
+        ByteBuffer compressed = compressedBytes(args);
         ByteBuffer buffer;
 
-        buffer = ByteBuffer.allocateDirect(compressed.length);
+        buffer = ByteBuffer.allocateDirect(compressed.remaining());
         buffer.put(compressed).flip();
         testDecompression(buffer, args);
 
+        compressed.rewind();
         int offset = 42;
-        buffer = ByteBuffer.allocateDirect(compressed.length + offset + 123);
+        buffer = ByteBuffer.allocateDirect(compressed.remaining() + offset + 123);
         buffer.position(offset);
         buffer.put(compressed).flip();
         buffer.position(offset);
@@ -304,7 +300,7 @@ public class KafkaLZ4Test {
     public void testSkip(Args args) throws Exception {
         if (!args.close || (args.useBrokenFlagDescriptorChecksum && !args.ignoreFlagDescriptorChecksum)) return;
 
-        final KafkaLZ4BlockInputStream in = makeInputStream(ByteBuffer.wrap(compressedBytes(args)),
+        final KafkaLZ4BlockInputStream in = makeInputStream(compressedBytes(args),
             args.ignoreFlagDescriptorChecksum);
 
         int n = 100;
@@ -356,8 +352,8 @@ public class KafkaLZ4Test {
         if (!args.close) assertNotNull(error);
     }
 
-    private byte[] compressedBytes(Args args) throws IOException {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private ByteBuffer compressedBytes(Args args) throws IOException {
+        ByteBufferOutputStream output = new ByteBufferOutputStream(1024);
         KafkaLZ4BlockOutputStream lz4 = new KafkaLZ4BlockOutputStream(
             output,
             KafkaLZ4BlockOutputStream.BLOCKSIZE_64KB,
@@ -370,6 +366,8 @@ public class KafkaLZ4Test {
         } else {
             lz4.flush();
         }
-        return output.toByteArray();
+        ByteBuffer compressed = output.buffer().duplicate();
+        compressed.flip();
+        return compressed;
     }
 }


### PR DESCRIPTION
Our current LZ4 OutputStream implementation allocates compression buffers
internally and relies on intermediate byte arrays for input and output buffers.

With this change we now use ByteBuffers internally, and as a result:
* we write directly to the target ByteBuffer, avoiding an additional copy
* we no longer allocate an output compression buffer, reducing allocations by half
* we pave the way to make compression buffers reusable, similar to what we do
  for decompression