### PR TITLE
HOTFIX: Init stream-stream left/outer join emit interval correctly

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -58,7 +58,7 @@ class KStreamImplJoin {
     private final boolean rightOuter;
 
     static class TimeTracker {
-        private long emitIntervalMs = 500L;
+        private long emitIntervalMs = 1000L;
         long streamTime = ConsumerRecord.NO_TIMESTAMP;
         long minTime = Long.MAX_VALUE;
         long nextTimeToEmit;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -58,7 +58,7 @@ class KStreamImplJoin {
     private final boolean rightOuter;
 
     static class TimeTracker {
-        private long emitIntervalMs = 200L;
+        private long emitIntervalMs = 500L;
         long streamTime = ConsumerRecord.NO_TIMESTAMP;
         long minTime = Long.MAX_VALUE;
         long nextTimeToEmit;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -58,7 +58,7 @@ class KStreamImplJoin {
     private final boolean rightOuter;
 
     static class TimeTracker {
-        private long emitIntervalMs = 100L;
+        private long emitIntervalMs = 200L;
         long streamTime = ConsumerRecord.NO_TIMESTAMP;
         long minTime = Long.MAX_VALUE;
         long nextTimeToEmit;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -58,7 +58,7 @@ class KStreamImplJoin {
     private final boolean rightOuter;
 
     static class TimeTracker {
-        private long emitIntervalMs = 50L;
+        private long emitIntervalMs = 100L;
         long streamTime = ConsumerRecord.NO_TIMESTAMP;
         long minTime = Long.MAX_VALUE;
         long nextTimeToEmit;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -108,7 +108,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                     StreamsConfig.InternalConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-                        500L
+                        1000L
                     )
                 );
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -108,7 +108,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                     StreamsConfig.InternalConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-                        100L
+                        200L
                     )
                 );
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -108,7 +108,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                     StreamsConfig.InternalConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-                        50L
+                        100L
                     )
                 );
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -108,7 +108,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                     StreamsConfig.InternalConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-                        200L
+                        500L
                     )
                 );
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -103,13 +103,12 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                     true
                 )) {
                 outerJoinWindowStore = outerJoinWindowName.map(context::getStateStore);
-                sharedTimeTracker.nextTimeToEmit = context.currentSystemTimeMs();
 
                 sharedTimeTracker.setEmitInterval(
                     StreamsConfig.InternalConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-                        1000L
+                        50L
                     )
                 );
             }
@@ -207,6 +206,9 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
             // as throttling is a non-functional performance optimization
             if (context.currentSystemTimeMs() < sharedTimeTracker.nextTimeToEmit) {
                 return;
+            }
+            if (sharedTimeTracker.nextTimeToEmit == 0) {
+                sharedTimeTracker.nextTimeToEmit = context.currentSystemTimeMs();
             }
             sharedTimeTracker.advanceNextTimeToEmit();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -946,6 +946,7 @@ public class KStreamKStreamLeftJoinTest {
 
         // push a dummy record to produce all left-join non-joined items
         time += 301L;
+        driver.advanceWallClockTime(Duration.ofMillis(50L));
         inputTopic1.pipeInput(0, "dummy", time);
         processor.checkAndClearProcessResult(
             new KeyValueTimestamp<>(0, "C0+null", 1101L),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -946,7 +946,7 @@ public class KStreamKStreamLeftJoinTest {
 
         // push a dummy record to produce all left-join non-joined items
         time += 301L;
-        driver.advanceWallClockTime(Duration.ofMillis(50L));
+        driver.advanceWallClockTime(Duration.ofMillis(1000L));
         inputTopic1.pipeInput(0, "dummy", time);
         processor.checkAndClearProcessResult(
             new KeyValueTimestamp<>(0, "C0+null", 1101L),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -207,6 +207,7 @@ public class KStreamKStreamOuterJoinTest {
 
             // this record should expired non-joined records; only null+a0 will be emitted because
             // it did not have a join
+            driver.advanceWallClockTime(Duration.ofMillis(50L));
             inputTopic2.pipeInput(3, "dummy", 1500L);
 
             processor.checkAndClearProcessResult(
@@ -890,6 +891,7 @@ public class KStreamKStreamOuterJoinTest {
 
         // push a dummy record to produce all left-join non-joined items
         time += 301L;
+        driver.advanceWallClockTime(Duration.ofMillis(50L));
         inputTopic1.pipeInput(0, "dummy", time);
         processor.checkAndClearProcessResult(
             new KeyValueTimestamp<>(0, "C0+null", 1101L),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -207,7 +207,7 @@ public class KStreamKStreamOuterJoinTest {
 
             // this record should expired non-joined records; only null+a0 will be emitted because
             // it did not have a join
-            driver.advanceWallClockTime(Duration.ofMillis(50L));
+            driver.advanceWallClockTime(Duration.ofMillis(1000L));
             inputTopic2.pipeInput(3, "dummy", 1500L);
 
             processor.checkAndClearProcessResult(
@@ -891,7 +891,7 @@ public class KStreamKStreamOuterJoinTest {
 
         // push a dummy record to produce all left-join non-joined items
         time += 301L;
-        driver.advanceWallClockTime(Duration.ofMillis(50L));
+        driver.advanceWallClockTime(Duration.ofMillis(1000L));
         inputTopic1.pipeInput(0, "dummy", time);
         processor.checkAndClearProcessResult(
             new KeyValueTimestamp<>(0, "C0+null", 1101L),


### PR DESCRIPTION
Follow up to KAFKA-10847 (https://github.com/apache/kafka/pull/10917).

The above fix intended to reduce the emit frequency to save the creation cost of RocksDB iterators. However, we incorrectly initialized the "timer" with timestamp zero, and thus, the timer was always in the past and we did try to emit left/outer join result too often and got a throughput of only 500 record/sec.

This PR fixes the initialization of the emit interval timer. After re-running the benchmark, we determined that a default emit interval of 1000ms provides the best performance of 12K rec/sec, so this PR also changes the emit frequency to 1000ms.