### PR TITLE
KAFKA-12930,KAFKA-12929: Deprecate Java 8 and Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/
 
 We build and test Apache Kafka with Java 8, 11 and 16. We set the `release` parameter in javac and scalac
 to `8` to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
-used for compilation).
+used for compilation). Java 8 support has been deprecated since Apache Kafka 3.0 and will be removed in Apache
+Kafka 4.0 (see [KIP-750](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223) for more details).
 
-Scala 2.13 is used by default, see below for how to use a different Scala version or all of the supported Scala versions.
+Scala 2.12 and 2.13 are supported and 2.13 is used by default. Scala 2.12 support has been deprecated since
+Apache Kafka 3.0 and will be removed in Apache Kafka 4.0 (see [KIP-751](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308218)
+for more details). See below for how to use a specific Scala version or all of the supported Scala versions.
 
 ### Build a jar and run it ###
     ./gradlew jar


### PR DESCRIPTION
Update the readme to note the deprecation. We will also mention the deprecation
in the downloads page when the release is done.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
