### PR TITLE
MINOR Refactored the existing CheckpointFile in core module, moved to server-common module and introduced it as SnapshotFile.

### DIFF
--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFileWithFailureHandler.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFileWithFailureHandler.scala
@@ -18,23 +18,23 @@ package kafka.server.checkpoints
 
 import kafka.server.LogDirFailureChannel
 import org.apache.kafka.common.errors.KafkaStorageException
-import org.apache.kafka.server.common.SnapshotFile
-import org.apache.kafka.server.common.SnapshotFile.EntryFormatter
+import org.apache.kafka.server.common.CheckpointFile
+import CheckpointFile.EntryFormatter
 
 import java.io._
 import scala.collection.Seq
 import scala.jdk.CollectionConverters._
 
-class CheckpointFile[T](val file: File,
-                        version: Int,
-                        formatter: EntryFormatter[T],
-                        logDirFailureChannel: LogDirFailureChannel,
-                        logDir: String) {
-  private val snapshotFile = new SnapshotFile[T](file, version, formatter)
+class CheckpointFileWithFailureHandler[T](val file: File,
+                                          version: Int,
+                                          formatter: EntryFormatter[T],
+                                          logDirFailureChannel: LogDirFailureChannel,
+                                          logDir: String) {
+  private val checkpointFile = new CheckpointFile[T](file, version, formatter)
 
   def write(entries: Iterable[T]): Unit = {
       try {
-        snapshotFile.write(entries.toSeq.asJava);
+        checkpointFile.write(entries.toSeq.asJava)
       } catch {
         case e: IOException =>
           val msg = s"Error while writing to checkpoint file ${file.getAbsolutePath}"
@@ -45,7 +45,7 @@ class CheckpointFile[T](val file: File,
 
   def read(): Seq[T] = {
       try {
-        snapshotFile.read().asScala
+        checkpointFile.read().asScala
       } catch {
         case e: IOException =>
           val msg = s"Error while reading checkpoint file ${file.getAbsolutePath}"

--- a/core/src/main/scala/kafka/server/checkpoints/LeaderEpochCheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/LeaderEpochCheckpointFile.scala
@@ -16,12 +16,13 @@
  */
 package kafka.server.checkpoints
 
-import java.io._
-import java.util.regex.Pattern
-
 import kafka.server.LogDirFailureChannel
 import kafka.server.epoch.EpochEntry
+import org.apache.kafka.server.common.SnapshotFile.EntryFormatter
 
+import java.io._
+import java.util.Optional
+import java.util.regex.Pattern
 import scala.collection._
 
 trait LeaderEpochCheckpoint {
@@ -36,15 +37,15 @@ object LeaderEpochCheckpointFile {
 
   def newFile(dir: File): File = new File(dir, LeaderEpochCheckpointFilename)
 
-  object Formatter extends CheckpointFileFormatter[EpochEntry] {
+  object Formatter extends EntryFormatter[EpochEntry] {
 
-    override def toLine(entry: EpochEntry): String = s"${entry.epoch} ${entry.startOffset}"
+    override def toString(entry: EpochEntry): String = s"${entry.epoch} ${entry.startOffset}"
 
-    override def fromLine(line: String): Option[EpochEntry] = {
+    override def fromString(line: String): Optional[EpochEntry] = {
       WhiteSpacesPattern.split(line) match {
         case Array(epoch, offset) =>
-          Some(EpochEntry(epoch.toInt, offset.toLong))
-        case _ => None
+          Optional.of(EpochEntry(epoch.toInt, offset.toLong))
+        case _ => Optional.empty()
       }
     }
 

--- a/core/src/main/scala/kafka/server/checkpoints/LeaderEpochCheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/LeaderEpochCheckpointFile.scala
@@ -18,7 +18,7 @@ package kafka.server.checkpoints
 
 import kafka.server.LogDirFailureChannel
 import kafka.server.epoch.EpochEntry
-import org.apache.kafka.server.common.SnapshotFile.EntryFormatter
+import org.apache.kafka.server.common.CheckpointFile.EntryFormatter
 
 import java.io._
 import java.util.Optional
@@ -66,7 +66,7 @@ object LeaderEpochCheckpointFile {
 class LeaderEpochCheckpointFile(val file: File, logDirFailureChannel: LogDirFailureChannel = null) extends LeaderEpochCheckpoint {
   import LeaderEpochCheckpointFile._
 
-  val checkpoint = new CheckpointFile[EpochEntry](file, CurrentVersion, Formatter, logDirFailureChannel, file.getParentFile.getParent)
+  val checkpoint = new CheckpointFileWithFailureHandler[EpochEntry](file, CurrentVersion, Formatter, logDirFailureChannel, file.getParentFile.getParent)
 
   def write(epochs: Iterable[EpochEntry]): Unit = checkpoint.write(epochs)
 

--- a/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
@@ -16,29 +16,30 @@
   */
 package kafka.server.checkpoints
 
-import java.io._
-import java.util.regex.Pattern
-
 import kafka.server.LogDirFailureChannel
 import kafka.server.epoch.EpochEntry
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.common.SnapshotFile.EntryFormatter
 
+import java.io._
+import java.util.Optional
+import java.util.regex.Pattern
 import scala.collection._
 
 object OffsetCheckpointFile {
   private val WhiteSpacesPattern = Pattern.compile("\\s+")
   private[checkpoints] val CurrentVersion = 0
 
-  object Formatter extends CheckpointFileFormatter[(TopicPartition, Long)] {
-    override def toLine(entry: (TopicPartition, Long)): String = {
+  object Formatter extends EntryFormatter[(TopicPartition, Long)] {
+    override def toString(entry: (TopicPartition, Long)): String = {
       s"${entry._1.topic} ${entry._1.partition} ${entry._2}"
     }
 
-    override def fromLine(line: String): Option[(TopicPartition, Long)] = {
+    override def fromString(line: String): Optional[(TopicPartition, Long)] = {
       WhiteSpacesPattern.split(line) match {
         case Array(topic, partition, offset) =>
-          Some(new TopicPartition(topic, partition.toInt), offset.toLong)
-        case _ => None
+          Optional.of(new TopicPartition(topic, partition.toInt), offset.toLong)
+        case _ => Optional.empty()
       }
     }
   }

--- a/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
@@ -19,7 +19,7 @@ package kafka.server.checkpoints
 import kafka.server.LogDirFailureChannel
 import kafka.server.epoch.EpochEntry
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.server.common.SnapshotFile.EntryFormatter
+import org.apache.kafka.server.common.CheckpointFile.EntryFormatter
 
 import java.io._
 import java.util.Optional
@@ -62,7 +62,7 @@ trait OffsetCheckpoint {
  *  -----checkpoint file end----------
  */
 class OffsetCheckpointFile(val file: File, logDirFailureChannel: LogDirFailureChannel = null) {
-  val checkpoint = new CheckpointFile[(TopicPartition, Long)](file, OffsetCheckpointFile.CurrentVersion,
+  val checkpoint = new CheckpointFileWithFailureHandler[(TopicPartition, Long)](file, OffsetCheckpointFile.CurrentVersion,
     OffsetCheckpointFile.Formatter, logDirFailureChannel, file.getParent)
 
   def write(offsets: Map[TopicPartition, Long]): Unit = checkpoint.write(offsets)

--- a/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileWithFailureHandlerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileWithFailureHandlerTest.scala
@@ -23,7 +23,7 @@ import kafka.utils.Logging
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
-class LeaderEpochCheckpointFileTest extends Logging {
+class LeaderEpochCheckpointFileWithFailureHandlerTest extends Logging {
 
   @Test
   def shouldPersistAndOverwriteAndReloadFile(): Unit ={

--- a/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileWithFailureHandlerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileWithFailureHandlerTest.scala
@@ -26,7 +26,7 @@ import org.mockito.Mockito
 
 import scala.collection.Map
 
-class OffsetCheckpointFileTest extends Logging {
+class OffsetCheckpointFileWithFailureHandlerTest extends Logging {
 
   @Test
   def shouldPersistAndOverwriteAndReloadFile(): Unit = {
@@ -93,7 +93,7 @@ class OffsetCheckpointFileTest extends Logging {
   def shouldThrowIfVersionIsNotRecognised(): Unit = {
     val file = TestUtils.tempFile()
     val logDirFailureChannel = new LogDirFailureChannel(10)
-    val checkpointFile = new CheckpointFile(file, OffsetCheckpointFile.CurrentVersion + 1,
+    val checkpointFile = new CheckpointFileWithFailureHandler(file, OffsetCheckpointFile.CurrentVersion + 1,
       OffsetCheckpointFile.Formatter, logDirFailureChannel, file.getParent)
     checkpointFile.write(Seq(new TopicPartition("foo", 5) -> 10L))
     assertThrows(classOf[KafkaStorageException], () => new OffsetCheckpointFile(checkpointFile.file, logDirFailureChannel).read())

--- a/server-common/src/main/java/org/apache/kafka/server/common/CheckpointFile.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/CheckpointFile.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.server.common;
 
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.utils.Utils;
 
 import java.io.BufferedReader;
@@ -60,7 +59,7 @@ public class CheckpointFile<T> {
 
     public CheckpointFile(File file,
                           int version,
-                          EntryFormatter<T> formatter) {
+                          EntryFormatter<T> formatter) throws IOException {
         this.version = version;
         this.formatter = formatter;
         try {
@@ -68,8 +67,6 @@ public class CheckpointFile<T> {
             Files.createFile(file.toPath());
         } catch (FileAlreadyExistsException ex) {
             // Ignore if file already exists.
-        } catch (IOException ex) {
-            throw new KafkaException(ex);
         }
         absolutePath = file.toPath().toAbsolutePath();
         tempPath = Paths.get(absolutePath.toString() + ".tmp");

--- a/server-common/src/main/java/org/apache/kafka/server/common/CheckpointFile.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/CheckpointFile.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * This class represents a utility to capture a snapshot in a file. It writes down to the file in the below format.
+ * This class represents a utility to capture a checkpoint in a file. It writes down to the file in the below format.
  *
  * ========= File beginning =========
  * version: int
@@ -45,12 +45,12 @@ import java.util.Optional;
  * entry-as-string-on-each-line
  * ========= File end ===============
  *
- * Each entry is represented as a string on each line in the snapshot file. {@link EntryFormatter} is used
+ * Each entry is represented as a string on each line in the checkpoint file. {@link EntryFormatter} is used
  * to convert the entry into a string and vice versa.
  *
  * @param <T> entry type.
  */
-public class SnapshotFile<T> {
+public class CheckpointFile<T> {
 
     private final int version;
     private final EntryFormatter<T> formatter;
@@ -58,9 +58,9 @@ public class SnapshotFile<T> {
     private final Path absolutePath;
     private final Path tempPath;
 
-    public SnapshotFile(File file,
-                        int version,
-                        EntryFormatter<T> formatter) {
+    public CheckpointFile(File file,
+                          int version,
+                          EntryFormatter<T> formatter) {
         this.version = version;
         this.formatter = formatter;
         try {

--- a/server-common/src/main/java/org/apache/kafka/server/common/SnapshotFile.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/SnapshotFile.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.common;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This class represents a utility to capture a snapshot in a file. It writes down to the file in the below format.
+ *
+ * ========= File beginning =========
+ * version: int
+ * entries-count: int
+ * entry-as-string-on-each-line
+ * ========= File end ===============
+ *
+ * Each entry is represented as a string on each line in the snapshot file. {@link EntryFormatter} is used
+ * to convert the entry into a string and vice versa.
+ *
+ * @param <T> entry type.
+ */
+public class SnapshotFile<T> {
+
+    private final int version;
+    private final EntryFormatter<T> formatter;
+    private final Object lock = new Object();
+    private final Path absolutePath;
+    private final Path tempPath;
+
+    public SnapshotFile(File file,
+                        int version,
+                        EntryFormatter<T> formatter) {
+        this.version = version;
+        this.formatter = formatter;
+        try {
+            // Create the file if it does not exist.
+            Files.createFile(file.toPath());
+        } catch (FileAlreadyExistsException ex) {
+            // Ignore if file already exists.
+        } catch (IOException ex) {
+            throw new KafkaException(ex);
+        }
+        absolutePath = file.toPath().toAbsolutePath();
+        tempPath = Paths.get(absolutePath.toString() + ".tmp");
+    }
+
+    public void write(Collection<T> entries) throws IOException {
+        synchronized (lock) {
+            // write to temp file and then swap with the existing file
+            try (FileOutputStream fileOutputStream = new FileOutputStream(tempPath.toFile());
+                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8))) {
+                // Write the version
+                writer.write(Integer.toString(version));
+                writer.newLine();
+
+                // Write the entries count
+                writer.write(Integer.toString(entries.size()));
+                writer.newLine();
+
+                // Write each entry on a new line.
+                for (T entry : entries) {
+                    writer.write(formatter.toString(entry));
+                    writer.newLine();
+                }
+
+                writer.flush();
+                fileOutputStream.getFD().sync();
+            }
+
+            Utils.atomicMoveWithFallback(tempPath, absolutePath);
+        }
+    }
+
+    public List<T> read() throws IOException {
+        synchronized (lock) {
+            try (BufferedReader reader = Files.newBufferedReader(absolutePath)) {
+                CheckpointReadBuffer<T> checkpointBuffer = new CheckpointReadBuffer<>(absolutePath.toString(), reader, version, formatter);
+                return checkpointBuffer.read();
+            }
+        }
+    }
+
+    private static class CheckpointReadBuffer<T> {
+
+        private final String location;
+        private final BufferedReader reader;
+        private final int version;
+        private final EntryFormatter<T> formatter;
+
+        CheckpointReadBuffer(String location,
+                             BufferedReader reader,
+                             int version,
+                             EntryFormatter<T> formatter) {
+            this.location = location;
+            this.reader = reader;
+            this.version = version;
+            this.formatter = formatter;
+        }
+
+        List<T> read() throws IOException {
+            String line = reader.readLine();
+            if (line == null)
+                return Collections.emptyList();
+
+            int readVersion = toInt(line);
+            if (readVersion != version) {
+                throw new IOException();
+            }
+
+            line = reader.readLine();
+            if (line == null) {
+                return Collections.emptyList();
+            }
+            int expectedSize = toInt(line);
+            List<T> entries = new ArrayList<>(expectedSize);
+            line = reader.readLine();
+            while (line != null) {
+                Optional<T> maybeEntry = formatter.fromString(line);
+                if (!maybeEntry.isPresent()) {
+                    throw buildMalformedLineException(line);
+                }
+                entries.add(maybeEntry.get());
+                line = reader.readLine();
+            }
+
+            if (entries.size() != expectedSize) {
+                throw new IOException("Expected [" + expectedSize + "] entries in checkpoint file ["
+                                              + location + "], but found only [" + entries.size() + "]");
+            }
+
+            return entries;
+        }
+
+        private int toInt(String line) throws IOException {
+            try {
+                return Integer.parseInt(line);
+            } catch (NumberFormatException e) {
+                throw buildMalformedLineException(line);
+            }
+        }
+
+        private IOException buildMalformedLineException(String line) {
+            return new IOException(String.format("Malformed line in checkpoint file [%s]: %s", location, line));
+        }
+    }
+
+    /**
+     * This is used to convert the given entry of type {@code T} into a string and vice versa.
+     *
+     * @param <T> entry type
+     */
+    public interface EntryFormatter<T> {
+
+        /**
+         * @param entry entry to be converted into string.
+         * @return String representation of the given entry.
+         */
+        String toString(T entry);
+
+        /**
+         * @param value string representation of an entry.
+         * @return entry converted from the given string representation if possible. {@link Optional#empty()} represents
+         * that the given string representation could not be converted into an entry.
+         */
+        Optional<T> fromString(String value);
+    }
+}


### PR DESCRIPTION
MINOR Refactored the existing CheckpointFile in core module, moved to server-common module.

 - Refactored CheckpointFile to server-common module as a Java class and it is reused by LeaderCheckpointFile, OffsetCheckpointFile.
 - This will be used by CommittedOffsetsFile which checkpoints remote log metadata partitions with respective offsets in the default RemoteLogMetadataManager implementation.
 - Existing tests are available for LeaderCheckpointFile, OffsetCheckpointFile.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
