### PR TITLE
KAFKA-13094: Session windows do not consider user-specified grace when computing retention time for changelog

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindows.java
@@ -187,7 +187,7 @@ public final class SessionWindows {
      */
     @Deprecated
     public long maintainMs() {
-        return Math.max(maintainDurationMs, gapMs);
+        return Math.max(maintainDurationMs, gapMs + graceMs);
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/WindowedChangelogRetentionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/WindowedChangelogRetentionIntegrationTest.java
@@ -178,7 +178,7 @@ public class WindowedChangelogRetentionIntegrationTest {
     @Test
     public void sessionWindowedChangelogShouldHaveRetentionOfGapIfGapLargerThanDefaultRetention() throws Exception {
         final Duration gap = DEFAULT_RETENTION.plus(Duration.ofHours(1));
-        final Duration expectedRetention = gap;
+        final Duration expectedRetention = gap.plus(Duration.ofMillis(-1L));
         runAndVerifySessionWindows(SessionWindows.with(gap), null, expectedRetention);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -18,12 +18,15 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
+import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+
+import java.time.Duration;
 
 @SuppressWarnings("deprecation")
 public class SessionWindowsTest {
@@ -84,7 +87,7 @@ public class SessionWindowsTest {
     @Test
     public void retentionTimeShouldBeGapIfGapIsLargerThanDefaultRetentionTime() {
         final long windowGap = 2 * SessionWindows.with(ofMillis(1)).maintainMs();
-        assertEquals(windowGap, SessionWindows.with(ofMillis(windowGap)).maintainMs());
+        assertEquals(windowGap - 1, SessionWindows.with(ofMillis(windowGap)).maintainMs());
     }
 
     @Deprecated
@@ -122,4 +125,14 @@ public class SessionWindowsTest {
 
         verifyInEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(0)).grace(ofMillis(7)), SessionWindows.with(ofMillis(1)).grace(ofMillis(6)));
     }
+
+    @Test
+    public void shouldUseGapAndGraceAsRetentionTimeIfBothCombinedAreLargerThanDefaultRetentionTime() {
+        final Duration gapSize = ofDays(1L);
+        final Duration gracePeriod = ofMillis(2);
+        assertEquals(
+            gapSize.toMillis() + gracePeriod.toMillis(), 
+            SessionWindows.with(gapSize).grace(gracePeriod).maintainMs()
+        );
+    }    
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-13094

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
