### PR TITLE
KAFKA-13104: Controller should notify raft client when it resigns

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -284,6 +284,7 @@ public final class QuorumController implements Controller {
             "Reverting to last committed offset {}.",
             this, exception.getClass().getSimpleName(), curClaimEpoch, deltaUs,
             lastCommittedOffset, exception);
+        raftClient.resign(curClaimEpoch);
         renounce();
         return new UnknownServerException(exception);
     }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -62,7 +62,7 @@ public interface RaftClient<T> extends AutoCloseable {
          * when a leader steps down or fails.
          *
          * If this node is the leader, then the notification of leadership will be delayed until
-         * the implementation of this interface has caughup to the high-watermark through calls to
+         * the implementation of this interface has caught up to the high-watermark through calls to
          * {@link #handleSnapshot(SnapshotReader)} and {@link #handleCommit(BatchReader)}.
          *
          * If this node is not the leader, then this method will be called as soon as possible. In


### PR DESCRIPTION
When the active controller encounters an event exception it attempts to renounce leadership. Unfortunately, this doesn't tell the RaftClient that it should attempt to give up leadership. This will result in inconsistent state with the RaftClient as leader but with the controller as inactive.

We should change this implementation so that the active controller asks the RaftClient to resign. 

https://issues.apache.org/jira/browse/KAFKA-13104