### PR TITLE
KAFKA-13010: Retry getting tasks incase of rebalance for TaskMetadata tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -158,9 +158,13 @@ public class TaskMetadataIntegrationTest {
         }
     }
 
-    private TaskMetadata getTaskMetadata(final KafkaStreams kafkaStreams) {
+    private TaskMetadata getTaskMetadata(final KafkaStreams kafkaStreams) throws InterruptedException {
+        TestUtils.waitForCondition( () -> kafkaStreams
+                .metadataForLocalThreads()
+                .stream()
+                .mapToLong(t -> t.activeTasks().size())
+                .sum() == 1, "only one task");
         final List<TaskMetadata> taskMetadataList = kafkaStreams.metadataForLocalThreads().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList());
-        assertThat("only one task", taskMetadataList.size() == 1);
         return taskMetadataList.get(0);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -160,7 +160,7 @@ public class TaskMetadataIntegrationTest {
     }
 
     private TaskMetadata getTaskMetadata(final KafkaStreams kafkaStreams) throws InterruptedException {
-        AtomicReference<List<TaskMetadata>> taskMetadataList = new AtomicReference<>();
+        final AtomicReference<List<TaskMetadata>> taskMetadataList = new AtomicReference<>();
         TestUtils.waitForCondition( () -> {
             taskMetadataList.set(kafkaStreams.metadataForLocalThreads().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList()));
             return taskMetadataList.get().size() == 1;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -161,7 +161,7 @@ public class TaskMetadataIntegrationTest {
 
     private TaskMetadata getTaskMetadata(final KafkaStreams kafkaStreams) throws InterruptedException {
         final AtomicReference<List<TaskMetadata>> taskMetadataList = new AtomicReference<>();
-        TestUtils.waitForCondition( () -> {
+        TestUtils.waitForCondition(() -> {
             taskMetadataList.set(kafkaStreams.metadataForLocalThreads().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList()));
             return taskMetadataList.get().size() == 1;
         }, "The number of active tasks returned in the allotted time was not one.");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -164,7 +164,7 @@ public class TaskMetadataIntegrationTest {
         TestUtils.waitForCondition( () -> {
             taskMetadataList.set(kafkaStreams.metadataForLocalThreads().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList()));
             return taskMetadataList.get().size() == 1;
-        }, "The active tasks returned was not one in the allotted time.");
+        }, "The number of active tasks returned in the allotted time was not one.");
         return taskMetadataList.get().get(0);
     }
 


### PR DESCRIPTION
If there is a cooperative the tasks might not be assigned to a thread so retrying should work in a very short timeframe

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
