### PR TITLE
KAFKA-13100: Create a snapshot during leadership promotion

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/timeline/TimelineHashMapBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/timeline/TimelineHashMapBenchmark.java
@@ -77,7 +77,7 @@ public class TimelineHashMapBenchmark {
             int key = (int) (0xffffffff & ((i * 2862933555777941757L) + 3037000493L));
             if (j > 10 && key % 3 == 0) {
                 snapshotRegistry.deleteSnapshotsUpTo(epoch - 1000);
-                snapshotRegistry.createSnapshot(epoch);
+                snapshotRegistry.getOrCreateSnapshot(epoch);
                 j = 0;
             } else {
                 j++;

--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
@@ -183,7 +183,7 @@ public class SnapshotRegistry {
      * @param epoch             The epoch to create the snapshot at.  The current epoch
      *                          will be advanced to one past this epoch.
      */
-    public Snapshot createSnapshot(long epoch) {
+    public Snapshot getOrCreateSnapshot(long epoch) {
         Snapshot last = head.prev();
         if (last.epoch() > epoch) {
             throw new RuntimeException("Can't create a new snapshot at epoch " + epoch +

--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
@@ -178,14 +178,18 @@ public class SnapshotRegistry {
     /**
      * Creates a new snapshot at the given epoch.
      *
+     * If {@code epoch} already exists and it is the last snapshot then just return that snapshot.
+     *
      * @param epoch             The epoch to create the snapshot at.  The current epoch
      *                          will be advanced to one past this epoch.
      */
     public Snapshot createSnapshot(long epoch) {
         Snapshot last = head.prev();
-        if (last.epoch() >= epoch) {
+        if (last.epoch() > epoch) {
             throw new RuntimeException("Can't create a new snapshot at epoch " + epoch +
                 " because there is already a snapshot with epoch " + last.epoch());
+        } else if (last.epoch() == epoch) {
+            return last;
         }
         Snapshot snapshot = new Snapshot(epoch);
         last.appendNext(snapshot);

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -56,7 +56,7 @@ public class FeatureControlManagerTest {
     @Test
     public void testUpdateFeatures() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        snapshotRegistry.createSnapshot(-1);
+        snapshotRegistry.getOrCreateSnapshot(-1);
         FeatureControlManager manager = new FeatureControlManager(
             rangeMap("foo", 1, 2), snapshotRegistry);
         assertEquals(new FeatureMapAndEpoch(new FeatureMap(Collections.emptyMap()), -1),
@@ -87,11 +87,11 @@ public class FeatureControlManagerTest {
         FeatureLevelRecord record = new FeatureLevelRecord().
             setName("foo").setMinFeatureLevel((short) 1).setMaxFeatureLevel((short) 2);
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        snapshotRegistry.createSnapshot(-1);
+        snapshotRegistry.getOrCreateSnapshot(-1);
         FeatureControlManager manager = new FeatureControlManager(
             rangeMap("foo", 1, 2), snapshotRegistry);
         manager.replay(record);
-        snapshotRegistry.createSnapshot(123);
+        snapshotRegistry.getOrCreateSnapshot(123);
         assertEquals(new FeatureMapAndEpoch(new FeatureMap(rangeMap("foo", 1, 2)), 123),
             manager.finalizedFeatures(123));
     }
@@ -124,7 +124,7 @@ public class FeatureControlManagerTest {
             rangeMap("foo", 1, 3), Collections.emptySet(), Collections.emptyMap());
         assertEquals(Collections.singletonMap("foo", ApiError.NONE), result.response());
         manager.replay((FeatureLevelRecord) result.records().get(0).message());
-        snapshotRegistry.createSnapshot(3);
+        snapshotRegistry.getOrCreateSnapshot(3);
 
         assertEquals(ControllerResult.atomicOf(Collections.emptyList(), Collections.
                 singletonMap("foo", new ApiError(Errors.INVALID_UPDATE_VERSION,

--- a/metadata/src/test/java/org/apache/kafka/timeline/SnapshotRegistryTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/SnapshotRegistryTest.java
@@ -55,23 +55,23 @@ public class SnapshotRegistryTest {
     @Test
     public void testCreateSnapshots() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        Snapshot snapshot123 = registry.createSnapshot(123);
+        Snapshot snapshot123 = registry.getOrCreateSnapshot(123);
         assertEquals(snapshot123, registry.getSnapshot(123));
         assertThrows(RuntimeException.class, () -> registry.getSnapshot(456));
         assertIteratorContains(registry.iterator(), snapshot123);
         assertEquals("Can't create a new snapshot at epoch 1 because there is already " +
             "a snapshot with epoch 123", assertThrows(RuntimeException.class,
-                () -> registry.createSnapshot(1)).getMessage());
-        Snapshot snapshot456 = registry.createSnapshot(456);
+                () -> registry.getOrCreateSnapshot(1)).getMessage());
+        Snapshot snapshot456 = registry.getOrCreateSnapshot(456);
         assertIteratorContains(registry.iterator(), snapshot123, snapshot456);
     }
 
     @Test
     public void testCreateAndDeleteSnapshots() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        Snapshot snapshot123 = registry.createSnapshot(123);
-        Snapshot snapshot456 = registry.createSnapshot(456);
-        Snapshot snapshot789 = registry.createSnapshot(789);
+        Snapshot snapshot123 = registry.getOrCreateSnapshot(123);
+        Snapshot snapshot456 = registry.getOrCreateSnapshot(456);
+        Snapshot snapshot789 = registry.getOrCreateSnapshot(789);
         registry.deleteSnapshot(snapshot456.epoch());
         assertIteratorContains(registry.iterator(), snapshot123, snapshot789);
     }
@@ -79,9 +79,9 @@ public class SnapshotRegistryTest {
     @Test
     public void testDeleteSnapshotUpTo() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        registry.createSnapshot(10);
-        registry.createSnapshot(12);
-        Snapshot snapshot14 = registry.createSnapshot(14);
+        registry.getOrCreateSnapshot(10);
+        registry.getOrCreateSnapshot(12);
+        Snapshot snapshot14 = registry.getOrCreateSnapshot(14);
         registry.deleteSnapshotsUpTo(14);
         assertIteratorContains(registry.iterator(), snapshot14);
     }
@@ -89,9 +89,9 @@ public class SnapshotRegistryTest {
     @Test
     public void testCreateSnapshotOfLatest() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        registry.createSnapshot(10);
-        Snapshot latest = registry.createSnapshot(12);
-        Snapshot duplicate = registry.createSnapshot(12);
+        registry.getOrCreateSnapshot(10);
+        Snapshot latest = registry.getOrCreateSnapshot(12);
+        Snapshot duplicate = registry.getOrCreateSnapshot(12);
 
         assertEquals(latest, duplicate);
     }

--- a/metadata/src/test/java/org/apache/kafka/timeline/SnapshotRegistryTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/SnapshotRegistryTest.java
@@ -85,4 +85,14 @@ public class SnapshotRegistryTest {
         registry.deleteSnapshotsUpTo(14);
         assertIteratorContains(registry.iterator(), snapshot14);
     }
+
+    @Test
+    public void testCreateSnapshotOfLatest() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        registry.createSnapshot(10);
+        Snapshot latest = registry.createSnapshot(12);
+        Snapshot duplicate = registry.createSnapshot(12);
+
+        assertEquals(latest, duplicate);
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
@@ -105,7 +105,7 @@ public class SnapshottableHashTableTest {
             new SnapshottableHashTable<>(registry, 1);
         assertTrue(null == table.snapshottableAddOrReplace(E_1B));
         assertEquals(1, table.snapshottableSize(Long.MAX_VALUE));
-        registry.createSnapshot(0);
+        registry.getOrCreateSnapshot(0);
         assertTrue(E_1B == table.snapshottableAddOrReplace(E_1A));
         assertTrue(E_1B == table.snapshottableGet(E_1A, 0));
         assertTrue(E_1A == table.snapshottableGet(E_1A, Long.MAX_VALUE));
@@ -113,7 +113,7 @@ public class SnapshottableHashTableTest {
         assertEquals(null, table.snapshottableAddOrReplace(E_3A));
         assertEquals(3, table.snapshottableSize(Long.MAX_VALUE));
         assertEquals(1, table.snapshottableSize(0));
-        registry.createSnapshot(1);
+        registry.getOrCreateSnapshot(1);
         assertEquals(E_1A, table.snapshottableRemove(E_1B));
         assertEquals(E_2A, table.snapshottableRemove(E_2A));
         assertEquals(E_3A, table.snapshottableRemove(E_3A));
@@ -137,7 +137,7 @@ public class SnapshottableHashTableTest {
         assertFalse(table.snapshottableAddUnlessPresent(E_1A));
         assertTrue(table.snapshottableAddUnlessPresent(E_2A));
         assertTrue(table.snapshottableAddUnlessPresent(E_3A));
-        registry.createSnapshot(0);
+        registry.getOrCreateSnapshot(0);
         assertIteratorYields(table.snapshottableIterator(0), E_1B, E_2A, E_3A);
         assertEquals(E_1B, table.snapshottableRemove(E_1B));
         assertIteratorYields(table.snapshottableIterator(0), E_1B, E_2A, E_3A);
@@ -154,7 +154,7 @@ public class SnapshottableHashTableTest {
         SnapshottableHashTable<TestElement> table =
             new SnapshottableHashTable<>(registry, 1);
         assertEquals(null, table.snapshottableAddOrReplace(E_1A));
-        registry.createSnapshot(0);
+        registry.getOrCreateSnapshot(0);
         Iterator<TestElement> iter = table.snapshottableIterator(0);
         assertTrue(table.snapshottableAddUnlessPresent(E_2A));
         assertTrue(table.snapshottableAddUnlessPresent(E_3A));
@@ -171,7 +171,7 @@ public class SnapshottableHashTableTest {
         assertEquals(null, table.snapshottableAddOrReplace(E_3A));
         assertEquals(E_1A, table.snapshottableRemove(E_1A));
         assertEquals(null, table.snapshottableAddOrReplace(E_1B));
-        registry.createSnapshot(0);
+        registry.getOrCreateSnapshot(0);
         Iterator<TestElement> iter = table.snapshottableIterator(0);
         List<TestElement> iterElements = new ArrayList<>();
         iterElements.add(iter.next());
@@ -192,10 +192,10 @@ public class SnapshottableHashTableTest {
         assertEquals(null, table.snapshottableAddOrReplace(E_1A));
         assertEquals(null, table.snapshottableAddOrReplace(E_2A));
         assertEquals(null, table.snapshottableAddOrReplace(E_3A));
-        registry.createSnapshot(0);
+        registry.getOrCreateSnapshot(0);
         assertEquals(E_1A, table.snapshottableAddOrReplace(E_1B));
         assertEquals(E_3A, table.snapshottableAddOrReplace(E_3B));
-        registry.createSnapshot(1);
+        registry.getOrCreateSnapshot(1);
         assertEquals(3, table.snapshottableSize(Long.MAX_VALUE));
         assertIteratorYields(table.snapshottableIterator(Long.MAX_VALUE), E_1B, E_2A, E_3B);
         table.snapshottableRemove(E_1B);
@@ -216,10 +216,10 @@ public class SnapshottableHashTableTest {
         assertEquals(null, table.snapshottableAddOrReplace(E_1A));
         assertEquals(null, table.snapshottableAddOrReplace(E_2A));
         assertEquals(null, table.snapshottableAddOrReplace(E_3A));
-        registry.createSnapshot(0);
+        registry.getOrCreateSnapshot(0);
         assertEquals(E_1A, table.snapshottableAddOrReplace(E_1B));
         assertEquals(E_3A, table.snapshottableAddOrReplace(E_3B));
-        registry.createSnapshot(1);
+        registry.getOrCreateSnapshot(1);
 
         registry.reset();
 

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineHashMapTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineHashMapTest.java
@@ -67,7 +67,7 @@ public class TimelineHashMapTest {
         assertTrue(map.containsValue("abc"));
         assertTrue(map.containsKey(456));
         assertFalse(map.isEmpty());
-        registry.createSnapshot(2);
+        registry.getOrCreateSnapshot(2);
         Iterator<Map.Entry<Integer, String>> iter = map.entrySet(2).iterator();
         map.clear();
         List<String> snapshotValues = new ArrayList<>();

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineHashSetTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineHashSetTest.java
@@ -62,7 +62,7 @@ public class TimelineHashSetTest {
         assertTrue(set.retainAll(Arrays.asList("a", "b", "c")));
         assertFalse(set.retainAll(Arrays.asList("a", "b", "c")));
         assertFalse(set.removeAll(Arrays.asList("d")));
-        registry.createSnapshot(2);
+        registry.getOrCreateSnapshot(2);
         assertTrue(set.removeAll(Arrays.asList("c")));
         assertThat(TimelineHashMapTest.iteratorToList(set.iterator(2)),
             containsInAnyOrder("a", "b", "c"));
@@ -99,7 +99,7 @@ public class TimelineHashSetTest {
         assertTrue(set.containsAll(Arrays.asList("def", "jkl")));
         assertFalse(set.containsAll(Arrays.asList("abc", "def", "xyz")));
         assertTrue(set.removeAll(Arrays.asList("def", "ghi", "xyz")));
-        registry.createSnapshot(5);
+        registry.getOrCreateSnapshot(5);
         assertThat(TimelineHashMapTest.iteratorToList(set.iterator(5)),
             containsInAnyOrder("abc", "jkl"));
         assertThat(TimelineHashMapTest.iteratorToList(set.iterator()),

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
@@ -56,14 +56,14 @@ public class TimelineIntegerTest {
     public void testSnapshot() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
         TimelineInteger integer = new TimelineInteger(registry);
-        registry.createSnapshot(2);
+        registry.getOrCreateSnapshot(2);
         integer.set(1);
-        registry.createSnapshot(3);
+        registry.getOrCreateSnapshot(3);
         integer.set(2);
         integer.increment();
         integer.increment();
         integer.decrement();
-        registry.createSnapshot(4);
+        registry.getOrCreateSnapshot(4);
         assertEquals(0, integer.get(2));
         assertEquals(1, integer.get(3));
         assertEquals(3, integer.get(4));
@@ -77,9 +77,9 @@ public class TimelineIntegerTest {
     public void testReset() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
         TimelineInteger value = new TimelineInteger(registry);
-        registry.createSnapshot(2);
+        registry.getOrCreateSnapshot(2);
         value.set(1);
-        registry.createSnapshot(3);
+        registry.getOrCreateSnapshot(3);
         value.set(2);
 
         registry.reset();

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
@@ -56,14 +56,14 @@ public class TimelineLongTest {
     public void testSnapshot() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
         TimelineLong value = new TimelineLong(registry);
-        registry.createSnapshot(2);
+        registry.getOrCreateSnapshot(2);
         value.set(1L);
-        registry.createSnapshot(3);
+        registry.getOrCreateSnapshot(3);
         value.set(2L);
         value.increment();
         value.increment();
         value.decrement();
-        registry.createSnapshot(4);
+        registry.getOrCreateSnapshot(4);
         assertEquals(0L, value.get(2));
         assertEquals(1L, value.get(3));
         assertEquals(3L, value.get(4));
@@ -77,9 +77,9 @@ public class TimelineLongTest {
     public void testReset() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
         TimelineLong value = new TimelineLong(registry);
-        registry.createSnapshot(2);
+        registry.getOrCreateSnapshot(2);
         value.set(1L);
-        registry.createSnapshot(3);
+        registry.getOrCreateSnapshot(3);
         value.set(2L);
 
         registry.reset();

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -399,7 +399,7 @@ public final class RaftClientTestContext {
         return localId.orElseThrow(() -> new AssertionError("Required local id is not defined"));
     }
 
-    void expectBeginEpoch(
+    private void expectBeginEpoch(
         int epoch
     ) throws Exception {
         pollUntilRequest();
@@ -1175,11 +1175,9 @@ public final class RaftClientTestContext {
             this.currentLeaderAndEpoch = leaderAndEpoch;
 
             currentClaimedEpoch().ifPresent(claimedEpoch -> {
-                if (claimedEpoch == leaderAndEpoch.epoch()) {
-                    long claimedEpochStartOffset = lastCommitOffset().isPresent() ?
-                        lastCommitOffset().getAsLong() + 1 : 0L;
-                    this.claimedEpochStartOffsets.put(leaderAndEpoch.epoch(), claimedEpochStartOffset);
-                }
+                long claimedEpochStartOffset = lastCommitOffset().isPresent() ?
+                    lastCommitOffset().getAsLong() + 1 : 0L;
+                this.claimedEpochStartOffsets.put(leaderAndEpoch.epoch(), claimedEpochStartOffset);
             });
         }
 


### PR DESCRIPTION
This commit includes a few changes:

1. The leader assumes that there is always an in-memory snapshot at the
last committed offset. This means that the controller needs to generate
an in-memory snapshot when getting promoted from inactive to active.

2. Delete all in-memory snapshots less that the last committed offset
when the on-disk snapshot is canceled or it completes.

3. The controller always starts inactive. When loading an on-disk
snapshot the controller is always inactive. This means that we don't
need to generate an in-memory snapshot at the offset -1 because there
is no requirement that there exists an in-memory snapshot at the last
committed offset when the controller is inactive.

4. SnapshotRegistry's createSnapshot should allow the creating of a
snapshot if the last snapshot's offset is the given offset. This allows
for simpler client code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
