### PR TITLE
MINOR: reduce debug log spam and busy loop during shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -869,9 +869,7 @@ public class StreamThread extends Thread {
 
     private long pollPhase() {
         final ConsumerRecords<byte[], byte[]> records;
-        if (isRunning()) {
-            log.debug("Invoking poll on main Consumer");
-        }
+        log.debug("Invoking poll on main Consumer");
 
         if (state == State.PARTITIONS_ASSIGNED) {
             // try to fetch some records with zero poll millis

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -719,10 +719,8 @@ public class StreamThread extends Thread {
 
         final long pollLatency = pollPhase();
 
-        // Shutdown hook could potentially be triggered and transit the thread state to PENDING_SHUTDOWN during #pollRequests().
-        // The task manager internal states could be uninitialized if the state transition happens during #onPartitionsAssigned().
-        // Should only proceed when the thread is still running after #pollRequests(), because no external state mutation
-        // could affect the task manager state beyond this point within #runOnce().
+        // After transitioning to PENDING_SHUTDOWN/ERROR the StreamThread may continue the runLoop as long as the
+        // TaskManager reports a rebalance in progress
         if (!isRunning()) {
             log.debug("Thread state is already {}, skipping the run once call after poll request", state);
             return;
@@ -885,8 +883,8 @@ public class StreamThread extends Thread {
             records = pollRequests(pollTime);
         } else if (state == State.PENDING_SHUTDOWN) {
             // we are only here because there's rebalance in progress,
-            // just poll with zero to complete it
-            records = pollRequests(Duration.ZERO);
+            // just poll with enough time to complete it
+            records = pollRequests(pollTime);
         } else {
             // any other state should not happen
             log.error("Unexpected state {} during normal iteration", state);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -884,9 +884,15 @@ public class StreamThread extends Thread {
             // in order to get long polling
             records = pollRequests(pollTime);
         } else if (state == State.PENDING_SHUTDOWN) {
-            // we are only here because there's a rebalance still in progress, just
-            // wait in poll until it's completed since there's nothing more to do
-            records = pollRequests(Duration.ofMillis(Long.MAX_VALUE));
+            if (taskManager.isRebalanceInProgress()) {
+                // we're only continuing the runLoop because there's a rebalance still in progress, so
+                // just keep polling until it's completed since there's nothing more to do
+                records = pollRequests(pollTime);
+            } else {
+                // otherwise we must have only just been triggered to shut down, so just exit early and
+                // let the thread continue to complete the shutdown
+                return 0L;
+            }
         } else {
             // any other state should not happen
             log.error("Unexpected state {} during normal iteration", state);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -884,9 +884,9 @@ public class StreamThread extends Thread {
             // in order to get long polling
             records = pollRequests(pollTime);
         } else if (state == State.PENDING_SHUTDOWN) {
-            // we are only here because there's rebalance in progress,
-            // just long poll to give it enough time to complete it
-            records = pollRequests(pollTime);
+            // we are only here because there's a rebalance still in progress, just
+            // wait in poll until it's completed since there's nothing more to do
+            records = pollRequests(Duration.ofMillis(Long.MAX_VALUE));
         } else {
             // any other state should not happen
             log.error("Unexpected state {} during normal iteration", state);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -859,7 +859,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final List<TopicPartition> activePartitionsList = new ArrayList<>();
             final List<TaskId> assignedActiveList = new ArrayList<>();
 
-            final Set<TaskId> activeTasksRemovedPendingRevokation = populateActiveTaskAndPartitionsLists(
+            final Set<TaskId> activeTasksRemovedPendingRevocation = populateActiveTaskAndPartitionsLists(
                 activePartitionsList,
                 assignedActiveList,
                 consumer,
@@ -872,7 +872,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final Map<TaskId, Set<TopicPartition>> standbyTaskMap = buildStandbyTaskMap(
                     consumer,
                     standbyTaskAssignments.get(consumer),
-                    activeTasksRemovedPendingRevokation,
+                    activeTasksRemovedPendingRevocation,
                     statefulTasks,
                     partitionsForTask,
                     clientMetadata.state
@@ -888,7 +888,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 AssignorError.NONE.code()
             );
 
-            if (!activeTasksRemovedPendingRevokation.isEmpty()) {
+            if (!activeTasksRemovedPendingRevocation.isEmpty()) {
                 // TODO: once KAFKA-10078 is resolved we can leave it to the client to trigger this rebalance
                 log.info("Requesting followup rebalance be scheduled immediately by {} due to tasks changing ownership.", consumer);
                 info.setNextRebalanceTime(0L);
@@ -1372,7 +1372,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                     "%sNumber of assigned partitions %d is not equal to "
                         + "the number of active taskIds %d, assignmentInfo=%s",
                     logPrefix, partitions.size(),
-                    info.activeTasks().size(), info.toString()
+                    info.activeTasks().size(), info
                 )
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -155,7 +155,7 @@ public class TaskManager {
     }
 
     /**
-     * @throws TaskMigratedException
+     * @throws TaskMigratedException if committing offsets fails
      */
     void handleCorruption(final Set<TaskId> corruptedTasks) {
         final Set<Task> corruptedActiveTasks = new HashSet<>();
@@ -341,7 +341,7 @@ public class TaskManager {
             throw new IllegalArgumentException("Tasks to close-dirty should be empty");
         }
 
-        // for all tasks to close or recycle, we should first right a checkpoint as in post-commit
+        // for all tasks to close or recycle, we should first write a checkpoint as in post-commit
         final List<Task> tasksToCheckpoint = new ArrayList<>(tasksToCloseClean);
         tasksToCheckpoint.addAll(tasksToRecycle);
         for (final Task task : tasksToCheckpoint) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -994,7 +994,7 @@ public class TaskManager {
             if (activeTask == null) {
                 log.error("Unable to locate active task for received-record partition {}. Current tasks: {}",
                     partition, toString(">"));
-                throw new NullPointerException("Task was unexpectedly missing for partition " + partition);
+                throw new IllegalStateException("Task was unexpectedly missing for partition " + partition);
             }
 
             activeTask.addRecords(partition, records.records(partition));


### PR DESCRIPTION
While investigating some system test failures I found the Streams logs often got up to several GB in size, with much of it being due to these three lines being logged on repeat many times per ms:
```
[2021-07-19 11:15:26,880] DEBUG [] Invoking poll on main Consumer 
[2021-07-19 11:15:26,880] DEBUG [] Main Consumer poll completed in 0 ms and fetched 0 records 
[2021-07-19 11:15:26,880] DEBUG [] Thread state is already PENDING_SHUTDOWN, skipping the run once call 
```
Even though they're debug logs this is just way too much printed way too often, and also reveals how much cpu we're wasting just spinning in this busy loop doing nothing else. It seems the situation was that the thread had been told to shut down but was waiting for an in-progress rebalance to complete before it could exit the poll loop and complete its shutdown. Turns out we were polling with `Duration.ZERO` in this case and therefore just running through the loop again and again and again within a single millisecond.

So, we should be passing in a larger timeout to `poll()` when the thread is in `PENDING_SHUTDOWN` to let it actually wait for the ongoing rebalance to finish. Also threw in a few miscellaneous fixes/cleanups that I came across on the side