### PR TITLE
KAFKA-8529: Flakey test ConsumerBounceTest#testCloseDuringRebalance

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -317,10 +317,6 @@ abstract class AbstractFetcherThread(name: String,
           warn(s"Error in response for fetch request $fetchRequest", t)
           inLock(partitionMapLock) {
             partitionsWithError ++= partitionStates.partitionSet.asScala
-            // there is an error occurred while fetching partitions, sleep a while
-            // note that `AbstractFetcherThread.handlePartitionsWithError` will also introduce the same delay for every
-            // partition with error effectively doubling the delay. It would be good to improve this.
-            partitionMapCond.await(fetchBackOffMs, TimeUnit.MILLISECONDS)
           }
         }
     }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -31,7 +31,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.Uuid
-import org.apache.kafka.common.errors.{FencedLeaderEpochException, UnknownLeaderEpochException}
+import org.apache.kafka.common.errors.{FencedLeaderEpochException, UnknownLeaderEpochException, UnknownTopicIdException}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -142,6 +142,44 @@ class AbstractFetcherThreadTest {
     val replicaState = fetcher.replicaPartitionState(partition)
     assertEquals(2L, replicaState.logEndOffset)
     assertEquals(2L, replicaState.highWatermark)
+  }
+
+  @Test
+  def testDelay(): Unit = {
+    val partition = new TopicPartition("topic", 0)
+
+    class ErrorMockFetcherThread(fetchBackOffMs: Int)
+      extends MockFetcherThread(fetchBackOffMs =  fetchBackOffMs) {
+
+      override def fetchFromLeader(fetchRequest: FetchRequest.Builder): Map[TopicPartition, FetchData] = {
+         throw new UnknownTopicIdException("Topic ID was unknown as expected for this test")
+      }
+    }
+    val fetcher = new ErrorMockFetcherThread(fetchBackOffMs = 1000)
+
+    fetcher.setReplicaState(partition, MockFetcherThread.PartitionState(leaderEpoch = 0))
+    fetcher.addPartitions(Map(partition -> initialFetchState(0L, leaderEpoch = 0)))
+
+    val batch = mkBatch(baseOffset = 0L, leaderEpoch = 0,
+      new SimpleRecord("a".getBytes), new SimpleRecord("b".getBytes))
+    val leaderState = MockFetcherThread.PartitionState(Seq(batch), leaderEpoch = 0, highWatermark = 2L)
+    fetcher.setLeaderState(partition, leaderState)
+
+    // Do work for the first time. This should result in all partitions in error.
+    val timeBeforeFirst = System.currentTimeMillis()
+    fetcher.doWork()
+    val timeAfterFirst = System.currentTimeMillis()
+    val firstWork = timeAfterFirst - timeBeforeFirst
+
+    // The second doWork will pause for fetchBackOffMs since all partitions will be delayed
+    val timeBeforeSecond = System.currentTimeMillis()
+    fetcher.doWork()
+    val timeAfterSecond = System.currentTimeMillis()
+    val secondWork = timeAfterSecond - timeBeforeSecond
+
+    assertTrue(firstWork < secondWork)
+    // The second call should have taken more than fetchBackOffMs
+    assertTrue(1000 < secondWork)
   }
 
   @Test
@@ -866,11 +904,12 @@ class AbstractFetcherThreadTest {
     }
   }
 
-  class MockFetcherThread(val replicaId: Int = 0, val leaderId: Int = 1)
+  class MockFetcherThread(val replicaId: Int = 0, val leaderId: Int = 1, fetchBackOffMs: Int = 0)
     extends AbstractFetcherThread("mock-fetcher",
       clientId = "mock-fetcher",
       sourceBroker = new BrokerEndPoint(leaderId, host = "localhost", port = Random.nextInt()),
       failedPartitions,
+      fetchBackOffMs = fetchBackOffMs,
       brokerTopicStats = new BrokerTopicStats) {
 
     import MockFetcherThread.PartitionState
@@ -993,7 +1032,12 @@ class AbstractFetcherThreadTest {
         }
       }
       val fetchRequest = FetchRequest.Builder.forReplica(version, replicaId, 0, 1, fetchData.asJava, topicIds)
-      ResultWithPartitions(Some(ReplicaFetch(fetchData.asJava, fetchRequest)), Set.empty)
+      val fetchRequestOpt =
+        if (fetchData.isEmpty)
+          None
+        else
+          Some(ReplicaFetch(fetchData.asJava, fetchRequest))
+      ResultWithPartitions(fetchRequestOpt, Set.empty)
     }
 
     override def latestEpoch(topicPartition: TopicPartition): Option[Int] = {


### PR DESCRIPTION
This test became more flaky due to 2b8aff5
One of the changes of adding topic IDs to fetch requests involved returning a top-level error when topic IDs were not yet found on the receiving broker. In this case, I thought it would be good to delay partitions so that brokers can receive the metadata updates they need. However, it seems like this approach actually introduces a double delay that slows things down. 

In general, the top-level error approach is being reconsidered here: https://issues.apache.org/jira/browse/KAFKA-13111 In the meantime, to fix the flakiness, we can remove this extra delay.

There are a few other issues related to the topic ID Fetch commit and I will follow up on those errors as well. Tickets are https://issues.apache.org/jira/browse/KAFKA-13079 and
 https://issues.apache.org/jira/browse/KAFKA-13102

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
