### PR TITLE
KAFKA-13099; Transactional expiration should account for max batch size

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -408,6 +408,20 @@ public class MemoryRecords extends AbstractRecords {
         return builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, timestampType, baseOffset);
     }
 
+    public static MemoryRecordsBuilder builder(ByteBuffer buffer,
+                                               CompressionType compressionType,
+                                               TimestampType timestampType,
+                                               long baseOffset,
+                                               int maxSize) {
+        long logAppendTime = RecordBatch.NO_TIMESTAMP;
+        if (timestampType == TimestampType.LOG_APPEND_TIME)
+            logAppendTime = System.currentTimeMillis();
+
+        return new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, timestampType, baseOffset,
+            logAppendTime, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
+            false, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, maxSize);
+    }
+
     public static MemoryRecordsBuilder idempotentBuilder(ByteBuffer buffer,
                                                          CompressionType compressionType,
                                                          long baseOffset,

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -66,6 +66,8 @@ private[transaction] sealed trait TransactionState {
   def name: String
 
   def validPreviousStates: Set[TransactionState]
+
+  def isExpirationAllowed: Boolean = false
 }
 
 /**
@@ -78,6 +80,7 @@ private[transaction] case object Empty extends TransactionState {
   val id: Byte = 0
   val name: String = "Empty"
   val validPreviousStates: Set[TransactionState] = Set(Empty, CompleteCommit, CompleteAbort)
+  override def isExpirationAllowed: Boolean = true
 }
 
 /**
@@ -125,6 +128,7 @@ private[transaction] case object CompleteCommit extends TransactionState {
   val id: Byte = 4
   val name: String = "CompleteCommit"
   val validPreviousStates: Set[TransactionState] = Set(PrepareCommit)
+  override def isExpirationAllowed: Boolean = true
 }
 
 /**
@@ -136,6 +140,7 @@ private[transaction] case object CompleteAbort extends TransactionState {
   val id: Byte = 5
   val name: String = "CompleteAbort"
   val validPreviousStates: Set[TransactionState] = Set(PrepareAbort)
+  override def isExpirationAllowed: Boolean = true
 }
 
 /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -218,10 +218,6 @@ class TransactionStateManager(brokerId: Int,
       recordsBuilder.append(currentTimeMs, keyBytes, null, Record.EMPTY_HEADERS)
       true
     } else {
-      if (recordsBuilder.numRecords == 0) {
-        warn(s"Failed to write expiration record for transactionalId ${txnMetadata.transactionalId} " +
-          s"because the tombstone record exceeds the max allowed batch size of $maxBatchSize")
-      }
       false
     }
   }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -165,7 +165,7 @@ class TransactionStateManager(brokerId: Int,
             txnMetadata.inLock {
               if (!shouldExpire(txnMetadata, currentTimeMs)) {
                 true
-              } else if (maybeAppendExpiration(txnMetadata, recordsBuilder, currentTimeMs, maxBatchSize)) {
+              } else if (maybeAppendExpiration(txnMetadata, recordsBuilder, currentTimeMs)) {
                 val transitMetadata = txnMetadata.prepareDead()
                 expired += TransactionalIdCoordinatorEpochAndMetadata(
                   transactionalId,
@@ -211,7 +211,6 @@ class TransactionStateManager(brokerId: Int,
     txnMetadata: TransactionMetadata,
     recordsBuilder: MemoryRecordsBuilder,
     currentTimeMs: Long,
-    maxBatchSize: Int
   ): Boolean = {
     val keyBytes = TransactionLog.keyToBytes(txnMetadata.transactionalId)
     if (recordsBuilder.hasRoomFor(currentTimeMs, keyBytes, null, Record.EMPTY_HEADERS)) {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -189,13 +189,14 @@ class TransactionStateManager(brokerId: Int,
                     transitMetadata
                   )
                 } else {
-                  flushRecordsBuilder()
                   retryAppend = true
                 }
               }
             }
 
-            if (!retryAppend) {
+            if (retryAppend) {
+              flushRecordsBuilder()
+            } else {
               // Advance the iterator if we do not need to retry the append
               stateEntries.next()
             }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -167,7 +167,7 @@ class TransactionStateManager(brokerId: Int,
           while (stateEntries.hasNext) {
             val txnMetadata = stateEntries.head
             val transactionalId = txnMetadata.transactionalId
-            var retryAppend = false
+            var fullBatch = false
 
             txnMetadata.inLock {
               if (txnMetadata.pendingState.isEmpty && shouldExpire(txnMetadata, currentTimeMs)) {
@@ -189,12 +189,12 @@ class TransactionStateManager(brokerId: Int,
                     transitMetadata
                   )
                 } else {
-                  retryAppend = true
+                  fullBatch = true
                 }
               }
             }
 
-            if (retryAppend) {
+            if (fullBatch) {
               flushRecordsBuilder()
             } else {
               // Advance the iterator if we do not need to retry the append

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -21,6 +21,7 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantReadWriteLock
+
 import kafka.log.{AppendOrigin, LogConfig}
 import kafka.message.UncompressedCodec
 import kafka.server.{Defaults, FetchLogEnd, ReplicaManager, RequestLocal}
@@ -32,7 +33,7 @@ import org.apache.kafka.common.message.ListTransactionsResponseData
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.stats.{Avg, Max}
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.record.{FileRecords, MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.record.{FileRecords, MemoryRecords, MemoryRecordsBuilder, Record, SimpleRecord, TimestampType}
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.{Time, Utils}
@@ -140,79 +141,154 @@ class TransactionStateManager(brokerId: Int,
     }
   }
 
-  def enableTransactionalIdExpiration(): Unit = {
-    scheduler.schedule("transactionalId-expiration", () => {
-      val now = time.milliseconds()
-      inReadLock(stateLock) {
-        val transactionalIdByPartition: Map[Int, mutable.Iterable[TransactionalIdCoordinatorEpochAndMetadata]] =
-          transactionMetadataCache.flatMap { case (_, entry) =>
-            entry.metadataPerTransactionalId.filter { case (_, txnMetadata) => txnMetadata.state match {
-              case Empty | CompleteCommit | CompleteAbort => true
-              case _ => false
-            }
-            }.filter { case (_, txnMetadata) =>
-              txnMetadata.txnLastUpdateTimestamp <= now - config.transactionalIdExpirationMs
-            }.map { case (transactionalId, txnMetadata) =>
-              val txnMetadataTransition = txnMetadata.inLock {
-                txnMetadata.prepareDead()
+  private def collectExpiredTransactionalIds(
+    partitionId: Int,
+    partitionCacheEntry: TxnMetadataCacheEntry
+  ): (Iterable[TransactionalIdCoordinatorEpochAndMetadata], MemoryRecords) = {
+    val currentTimeMs = time.milliseconds()
+
+    inReadLock(stateLock) {
+      val transactionPartition = new TopicPartition(Topic.TRANSACTION_STATE_TOPIC_NAME, partitionId)
+      replicaManager.getLogConfig(transactionPartition) match {
+        case Some(logConfig) =>
+          val maxBatchSize = logConfig.maxMessageSize
+          val expired = mutable.ListBuffer.empty[TransactionalIdCoordinatorEpochAndMetadata]
+
+          lazy val recordsBuilder = MemoryRecords.builder(
+            ByteBuffer.allocate(math.min(16384, maxBatchSize)),
+            TransactionLog.EnforcedCompressionType,
+            TimestampType.CREATE_TIME,
+            0L,
+            maxBatchSize
+          )
+
+          partitionCacheEntry.metadataPerTransactionalId.foreachWhile { (transactionalId, txnMetadata) =>
+            txnMetadata.inLock {
+              if (!shouldExpire(txnMetadata, currentTimeMs)) {
+                true
+              } else if (maybeAppendExpiration(txnMetadata, recordsBuilder, currentTimeMs, maxBatchSize)) {
+                val transitMetadata = txnMetadata.prepareDead()
+                expired += TransactionalIdCoordinatorEpochAndMetadata(
+                  transactionalId,
+                  partitionCacheEntry.coordinatorEpoch,
+                  transitMetadata
+                )
+                true
+              } else {
+                // If the batch is full, return false to end the search. Any remaining
+                // transactionalIds eligible for expiration can be picked next time.
+                false
               }
-              TransactionalIdCoordinatorEpochAndMetadata(transactionalId, entry.coordinatorEpoch, txnMetadataTransition)
             }
-          }.groupBy { transactionalIdCoordinatorEpochAndMetadata =>
-            partitionFor(transactionalIdCoordinatorEpochAndMetadata.transactionalId)
           }
 
-        val recordsPerPartition = transactionalIdByPartition
-          .map { case (partition, transactionalIdCoordinatorEpochAndMetadatas) =>
-            val deletes: Array[SimpleRecord] = transactionalIdCoordinatorEpochAndMetadatas.map { entry =>
-              new SimpleRecord(now, TransactionLog.keyToBytes(entry.transactionalId), null)
-            }.toArray
-            val records = MemoryRecords.withRecords(TransactionLog.EnforcedCompressionType, deletes: _*)
-            val topicPartition = new TopicPartition(Topic.TRANSACTION_STATE_TOPIC_NAME, partition)
-            (topicPartition, records)
+          if (expired.isEmpty) {
+            (Seq.empty, MemoryRecords.EMPTY)
+          } else {
+            (expired, recordsBuilder.build())
           }
 
-        def removeFromCacheCallback(responses: collection.Map[TopicPartition, PartitionResponse]): Unit = {
-          responses.forKeyValue { (topicPartition, response) =>
-            inReadLock(stateLock) {
-              val toRemove = transactionalIdByPartition(topicPartition.partition)
-              transactionMetadataCache.get(topicPartition.partition).foreach { txnMetadataCacheEntry =>
-                toRemove.foreach { idCoordinatorEpochAndMetadata =>
-                  val transactionalId = idCoordinatorEpochAndMetadata.transactionalId
-                  val txnMetadata = txnMetadataCacheEntry.metadataPerTransactionalId.get(transactionalId)
-                  txnMetadata.inLock {
-                    if (txnMetadataCacheEntry.coordinatorEpoch == idCoordinatorEpochAndMetadata.coordinatorEpoch
-                      && txnMetadata.pendingState.contains(Dead)
-                      && txnMetadata.producerEpoch == idCoordinatorEpochAndMetadata.transitMetadata.producerEpoch
-                      && response.error == Errors.NONE) {
-                      txnMetadataCacheEntry.metadataPerTransactionalId.remove(transactionalId)
-                    } else {
-                      warn(s"Failed to remove expired transactionalId: $transactionalId" +
-                        s" from cache. Tombstone append error code: ${response.error}," +
-                        s" pendingState: ${txnMetadata.pendingState}, producerEpoch: ${txnMetadata.producerEpoch}," +
-                        s" expected producerEpoch: ${idCoordinatorEpochAndMetadata.transitMetadata.producerEpoch}," +
-                        s" coordinatorEpoch: ${txnMetadataCacheEntry.coordinatorEpoch}, expected coordinatorEpoch: " +
-                        s"${idCoordinatorEpochAndMetadata.coordinatorEpoch}")
-                      txnMetadata.pendingState = None
-                    }
+        case None =>
+          (Seq.empty, MemoryRecords.EMPTY)
+      }
+    }
+  }
+
+  private def shouldExpire(
+    txnMetadata: TransactionMetadata,
+    currentTimeMs: Long
+  ): Boolean = {
+    val isExpirableState = txnMetadata.state match {
+      case Empty | CompleteCommit | CompleteAbort => true
+      case _ => false
+    }
+
+    isExpirableState && txnMetadata.txnLastUpdateTimestamp <= currentTimeMs - config.transactionalIdExpirationMs
+  }
+
+  private def maybeAppendExpiration(
+    txnMetadata: TransactionMetadata,
+    recordsBuilder: MemoryRecordsBuilder,
+    currentTimeMs: Long,
+    maxBatchSize: Int
+  ): Boolean = {
+    val keyBytes = TransactionLog.keyToBytes(txnMetadata.transactionalId)
+    if (recordsBuilder.hasRoomFor(currentTimeMs, keyBytes, null, Record.EMPTY_HEADERS)) {
+      recordsBuilder.append(currentTimeMs, keyBytes, null, Record.EMPTY_HEADERS)
+      true
+    } else {
+      if (recordsBuilder.numRecords == 0) {
+        warn(s"Failed to write expiration record for transactionalId ${txnMetadata.transactionalId} " +
+          s"because the tombstone record exceeds the max allowed batch size of $maxBatchSize")
+      }
+      false
+    }
+  }
+
+  private[transaction] def removeExpiredTransactionalIds(): Unit = {
+    inReadLock(stateLock) {
+      val expirationRecords = mutable.Map.empty[TopicPartition, MemoryRecords]
+      val expiredTransactionalIds = mutable.Map.empty[TopicPartition, Iterable[TransactionalIdCoordinatorEpochAndMetadata]]
+
+      transactionMetadataCache.forKeyValue { (partitionId, partitionCacheEntry) =>
+        val (expiredForPartition, partitionRecords) = collectExpiredTransactionalIds(partitionId, partitionCacheEntry)
+        if (expiredForPartition.nonEmpty) {
+          val topicPartition = new TopicPartition(Topic.TRANSACTION_STATE_TOPIC_NAME, partitionId)
+          expirationRecords += topicPartition -> partitionRecords
+          expiredTransactionalIds += topicPartition -> expiredForPartition
+        }
+      }
+
+      def removeFromCacheCallback(responses: collection.Map[TopicPartition, PartitionResponse]): Unit = {
+        responses.forKeyValue { (topicPartition, response) =>
+          inReadLock(stateLock) {
+            val toRemove = expiredTransactionalIds(topicPartition)
+            transactionMetadataCache.get(topicPartition.partition).foreach { txnMetadataCacheEntry =>
+              toRemove.foreach { idCoordinatorEpochAndMetadata =>
+                val transactionalId = idCoordinatorEpochAndMetadata.transactionalId
+                val txnMetadata = txnMetadataCacheEntry.metadataPerTransactionalId.get(transactionalId)
+                txnMetadata.inLock {
+                  if (txnMetadataCacheEntry.coordinatorEpoch == idCoordinatorEpochAndMetadata.coordinatorEpoch
+                    && txnMetadata.pendingState.contains(Dead)
+                    && txnMetadata.producerEpoch == idCoordinatorEpochAndMetadata.transitMetadata.producerEpoch
+                    && response.error == Errors.NONE) {
+                    txnMetadataCacheEntry.metadataPerTransactionalId.remove(transactionalId)
+                  } else {
+                    warn(s"Failed to remove expired transactionalId: $transactionalId" +
+                      s" from cache. Tombstone append error code: ${response.error}," +
+                      s" pendingState: ${txnMetadata.pendingState}, producerEpoch: ${txnMetadata.producerEpoch}," +
+                      s" expected producerEpoch: ${idCoordinatorEpochAndMetadata.transitMetadata.producerEpoch}," +
+                      s" coordinatorEpoch: ${txnMetadataCacheEntry.coordinatorEpoch}, expected coordinatorEpoch: " +
+                      s"${idCoordinatorEpochAndMetadata.coordinatorEpoch}")
+                    txnMetadata.pendingState = None
                   }
                 }
               }
             }
           }
         }
+      }
 
+      if (expirationRecords.nonEmpty) {
         replicaManager.appendRecords(
           config.requestTimeoutMs,
           TransactionLog.EnforcedRequiredAcks,
           internalTopicsAllowed = true,
           origin = AppendOrigin.Coordinator,
-          recordsPerPartition,
+          expirationRecords,
           removeFromCacheCallback,
           requestLocal = RequestLocal.NoCaching)
       }
+    }
+  }
 
-    }, delay = config.removeExpiredTransactionalIdsIntervalMs, period = config.removeExpiredTransactionalIdsIntervalMs)
+  def enableTransactionalIdExpiration(): Unit = {
+    scheduler.schedule(
+      name = "transactionalId-expiration",
+      fun = removeExpiredTransactionalIds,
+      delay = config.removeExpiredTransactionalIdsIntervalMs,
+      period = config.removeExpiredTransactionalIdsIntervalMs
+    )
   }
 
   def getTransactionState(transactionalId: String): Either[Errors, Option[CoordinatorEpochAndTxnMetadata]] = {
@@ -689,7 +765,7 @@ class TransactionStateManager(brokerId: Int,
     }
   }
 
-  def startup(retrieveTransactionTopicPartitionCount: () => Int, enableTransactionalIdExpiration: Boolean = true): Unit = {
+  def startup(retrieveTransactionTopicPartitionCount: () => Int, enableTransactionalIdExpiration: Boolean): Unit = {
     this.retrieveTransactionTopicPartitionCount = retrieveTransactionTopicPartitionCount
     transactionTopicPartitionCount = retrieveTransactionTopicPartitionCount()
     if (enableTransactionalIdExpiration)

--- a/core/src/main/scala/kafka/utils/Pool.scala
+++ b/core/src/main/scala/kafka/utils/Pool.scala
@@ -80,7 +80,16 @@ class Pool[K,V](valueFactory: Option[K => V] = None) extends Iterable[(K, V)] {
   def foreachEntry(f: (K, V) => Unit): Unit = {
     pool.forEach((k, v) => f(k, v))
   }
-  
+
+  def foreachWhile(f: (K, V) => Boolean): Unit = {
+    val iter = pool.entrySet().iterator()
+    var finished = false
+    while (!finished && iter.hasNext) {
+      val entry = iter.next
+      finished = !f(entry.getKey, entry.getValue)
+    }
+  }
+
   override def size: Int = pool.size
   
   override def iterator: Iterator[(K, V)] = new Iterator[(K,V)]() {

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -21,8 +21,9 @@ import java.util.concurrent.{ConcurrentHashMap, Executors}
 import java.util.{Collections, Random}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.Lock
+
 import kafka.coordinator.AbstractCoordinatorConcurrencyTest._
-import kafka.log.{AppendOrigin, Log}
+import kafka.log.{AppendOrigin, Log, LogConfig}
 import kafka.server._
 import kafka.utils._
 import kafka.utils.timer.MockTimer
@@ -219,6 +220,10 @@ object AbstractCoordinatorConcurrencyTest {
 
     def updateLog(topicPartition: TopicPartition, log: Log, endOffset: Long): Unit = {
       getOrCreateLogs().put(topicPartition, (log, endOffset))
+    }
+
+    override def getLogConfig(topicPartition: TopicPartition): Option[LogConfig] = {
+      getOrCreateLogs().get(topicPartition).map(_._1.config)
     }
 
     override def getLog(topicPartition: TopicPartition): Option[Log] =

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -72,7 +72,8 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
 
     txnStateManager = new TransactionStateManager(0, scheduler, replicaManager, txnConfig, time,
       new Metrics())
-    txnStateManager.startup(() => zkClient.getTopicPartitionCount(TRANSACTION_STATE_TOPIC_NAME).get)
+    txnStateManager.startup(() => zkClient.getTopicPartitionCount(TRANSACTION_STATE_TOPIC_NAME).get,
+      enableTransactionalIdExpiration = true)
     for (i <- 0 until numPartitions)
       txnStateManager.addLoadedTransactionsToCache(i, coordinatorEpoch, new Pool[String, TransactionMetadata]())
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -17,11 +17,13 @@
 package kafka.coordinator.transaction
 
 import java.nio.ByteBuffer
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
+
 import kafka.coordinator.AbstractCoordinatorConcurrencyTest
 import kafka.coordinator.AbstractCoordinatorConcurrencyTest._
 import kafka.coordinator.transaction.TransactionCoordinatorConcurrencyTest._
-import kafka.log.Log
+import kafka.log.{Log, LogConfig}
 import kafka.server.{FetchDataInfo, FetchLogEnd, KafkaConfig, LogOffsetMetadata, MetadataCache, RequestLocal}
 import kafka.utils.{Pool, TestUtils}
 import org.apache.kafka.clients.{ClientResponse, NetworkClient}
@@ -456,8 +458,9 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
   }
 
   private def prepareTxnLog(partitionId: Int): Unit = {
-
     val logMock: Log =  EasyMock.mock(classOf[Log])
+    EasyMock.expect(logMock.config).andStubReturn(new LogConfig(Collections.emptyMap()))
+
     val fileRecordsMock: FileRecords = EasyMock.mock(classOf[FileRecords])
 
     val topicPartition = new TopicPartition(TRANSACTION_STATE_TOPIC_NAME, partitionId)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -673,8 +673,8 @@ class TransactionStateManagerTest {
     val expiredTransactionalIds = mutable.Set.empty[String]
     while (hasUnexpiredTransactionalIds) {
       removeExpiredTransactionalIds().forKeyValue { (_, records) =>
-        assertTrue(records.sizeInBytes() < maxBatchSize)
-        records.records().forEach { record =>
+        assertTrue(records.sizeInBytes < maxBatchSize)
+        records.records.forEach { record =>
           val transactionalId = TransactionLog.readTxnRecordKey(record.key).transactionalId
           expiredTransactionalIds += transactionalId
           assertEquals(Right(None), transactionManager.getTransactionState(transactionalId))


### PR DESCRIPTION
When expiring transactionalIds, we group the tombstones together into batches. Currently there is no limit on the size of these batches, which can lead to `MESSAGE_TOO_LARGE` errors when a bunch of transactionalIds need to be expired at the same time. This patch fixes the problem by ensuring that the batch size respects the configured limit. Any transactionalIds which are eligible for expiration and cannot be fit into the batch are postponed until the next periodic check.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
