### PR TITLE
KAFKA-10542: Migrate KTable mapValues, passthrough, and source to new Processor API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -235,7 +235,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             "-cogroup-merge",
             builder,
             CogroupedKStreamImpl.MERGE_NAME);
-        final KTableProcessorSupplier<K, VOut, VOut> passThrough = new KTablePassThrough<>(parentProcessors, storeName);
+        final KTableNewProcessorSupplier<K, VOut, K, VOut> passThrough = new KTablePassThrough<>(parentProcessors, storeName);
         final ProcessorParameters<K, VOut, ?, ?> processorParameters = new ProcessorParameters(passThrough, mergeProcessorName);
         final ProcessorGraphNode<K, VOut> mergeNode =
             new ProcessorGraphNode<>(mergeProcessorName, processorParameters);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -308,7 +308,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, MAPVALUES_NAME);
 
-        final KTableProcessorSupplier<K, V, VR> processorSupplier = new KTableMapValues<>(this, mapper, queryableStoreName);
+        final KTableNewProcessorSupplier<K, V, K, VR> processorSupplier = new KTableMapValues<>(this, mapper, queryableStoreName);
 
         // leaving in calls to ITB until building topology with graph
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
@@ -17,21 +17,23 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 
-@SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
-    private final KTableImpl<K, ?, V> parent;
-    private final ValueMapperWithKey<? super K, ? super V, ? extends V1> mapper;
+class KTableMapValues<KIn, VIn, VOut> implements KTableNewProcessorSupplier<KIn, VIn, KIn, VOut> {
+    private final KTableImpl<KIn, ?, VIn> parent;
+    private final ValueMapperWithKey<? super KIn, ? super VIn, ? extends VOut> mapper;
     private final String queryableName;
     private boolean sendOldValues = false;
 
-    KTableMapValues(final KTableImpl<K, ?, V> parent,
-                    final ValueMapperWithKey<? super K, ? super V, ? extends V1> mapper,
+    KTableMapValues(final KTableImpl<KIn, ?, VIn> parent,
+                    final ValueMapperWithKey<? super KIn, ? super VIn, ? extends VOut> mapper,
                     final String queryableName) {
         this.parent = parent;
         this.mapper = mapper;
@@ -39,21 +41,21 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
     }
 
     @Override
-    public org.apache.kafka.streams.processor.Processor<K, Change<V>> get() {
+    public Processor<KIn, Change<VIn>, KIn, Change<VOut>> get() {
         return new KTableMapValuesProcessor();
     }
 
     @Override
-    public KTableValueGetterSupplier<K, V1> view() {
+    public KTableValueGetterSupplier<KIn, VOut> view() {
         // if the KTable is materialized, use the materialized store to return getter value;
         // otherwise rely on the parent getter and apply map-values on-the-fly
         if (queryableName != null) {
             return new KTableMaterializedValueGetterSupplier<>(queryableName);
         } else {
-            return new KTableValueGetterSupplier<K, V1>() {
-                final KTableValueGetterSupplier<K, V> parentValueGetterSupplier = parent.valueGetterSupplier();
+            return new KTableValueGetterSupplier<KIn, VOut>() {
+                final KTableValueGetterSupplier<KIn, VIn> parentValueGetterSupplier = parent.valueGetterSupplier();
 
-                public KTableValueGetter<K, V1> get() {
+                public KTableValueGetter<KIn, VOut> get() {
                     return new KTableMapValuesValueGetter(parentValueGetterSupplier.get());
                 }
 
@@ -79,8 +81,8 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
         return sendOldValues;
     }
 
-    private V1 computeValue(final K key, final V value) {
-        V1 newValue = null;
+    private VOut computeValue(final KIn key, final VIn value) {
+        VOut newValue = null;
 
         if (value != null) {
             newValue = mapper.apply(key, value);
@@ -89,8 +91,8 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
         return newValue;
     }
 
-    private ValueAndTimestamp<V1> computeValueAndTimestamp(final K key, final ValueAndTimestamp<V> valueAndTimestamp) {
-        V1 newValue = null;
+    private ValueAndTimestamp<VOut> computeValueAndTimestamp(final KIn key, final ValueAndTimestamp<VIn> valueAndTimestamp) {
+        VOut newValue = null;
         long timestamp = 0;
 
         if (valueAndTimestamp != null) {
@@ -102,13 +104,14 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
     }
 
 
-    private class KTableMapValuesProcessor extends org.apache.kafka.streams.processor.AbstractProcessor<K, Change<V>> {
-        private TimestampedKeyValueStore<K, V1> store;
-        private TimestampedTupleForwarder<K, V1> tupleForwarder;
+    private class KTableMapValuesProcessor implements Processor<KIn, Change<VIn>, KIn, Change<VOut>> {
+        private ProcessorContext<KIn, Change<VOut>> context;
+        private TimestampedKeyValueStore<KIn, VOut> store;
+        private TimestampedTupleForwarder<KIn, VOut> tupleForwarder;
 
         @Override
-        public void init(final org.apache.kafka.streams.processor.ProcessorContext context) {
-            super.init(context);
+        public void init(final ProcessorContext<KIn, Change<VOut>> context) {
+            this.context = context;
             if (queryableName != null) {
                 store = context.getStateStore(queryableName);
                 tupleForwarder = new TimestampedTupleForwarder<>(
@@ -120,19 +123,19 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
         }
 
         @Override
-        public void process(final K key, final Change<V> change) {
-            final V1 newValue = computeValue(key, change.newValue);
-            final V1 oldValue = computeOldValue(key, change);
+        public void process(final Record<KIn, Change<VIn>> record) {
+            final VOut newValue = computeValue(record.key(), record.value().newValue);
+            final VOut oldValue = computeOldValue(record.key(), record.value());
 
             if (queryableName != null) {
-                store.put(key, ValueAndTimestamp.make(newValue, context().timestamp()));
-                tupleForwarder.maybeForward(key, newValue, oldValue);
+                store.put(record.key(), ValueAndTimestamp.make(newValue, record.timestamp()));
+                tupleForwarder.maybeForward(record.key(), newValue, oldValue);
             } else {
-                context().forward(key, new Change<>(newValue, oldValue));
+                context.forward(record.withValue(new Change<>(newValue, oldValue)));
             }
         }
 
-        private V1 computeOldValue(final K key, final Change<V> change) {
+        private VOut computeOldValue(final KIn key, final Change<VIn> change) {
             if (!sendOldValues) {
                 return null;
             }
@@ -144,10 +147,10 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
     }
 
 
-    private class KTableMapValuesValueGetter implements KTableValueGetter<K, V1> {
-        private final KTableValueGetter<K, V> parentGetter;
+    private class KTableMapValuesValueGetter implements KTableValueGetter<KIn, VOut> {
+        private final KTableValueGetter<KIn, VIn> parentGetter;
 
-        KTableMapValuesValueGetter(final KTableValueGetter<K, V> parentGetter) {
+        KTableMapValuesValueGetter(final KTableValueGetter<KIn, VIn> parentGetter) {
             this.parentGetter = parentGetter;
         }
 
@@ -157,7 +160,7 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
         }
 
         @Override
-        public ValueAndTimestamp<V1> get(final K key) {
+        public ValueAndTimestamp<VOut> get(final KIn key) {
             return computeValueAndTimestamp(key, parentGetter.get(key));
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -105,8 +105,7 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
                     LOG.warn(
                         "Skipping record due to null key. "
-                            + "value=[{}] topic=[{}] partition=[{}] offset=[{}]",
-                        record.value(),
+                            + "topic=[{}] partition=[{}] offset=[{}]",
                         recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset()
                     );
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -111,9 +111,7 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
                     );
                 } else {
                     LOG.warn(
-                        "Skipping record due to null key. "
-                            + "value=[{}]. Topic, partition, and offset not known.",
-                        record.value()
+                        "Skipping record due to null key. Topic, partition, and offset not known."
                     );
                 }
                 droppedRecordsSensor.record();
@@ -131,18 +129,17 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
                             LOG.warn(
                                 "Detected out-of-order KTable update for {}, "
                                     + "old timestamp=[{}] new timestamp=[{}]. "
-                                    + "value=[{}] topic=[{}] partition=[{}] offset=[{}].",
+                                    + "topic=[{}] partition=[{}] offset=[{}].",
                                 store.name(),
                                 oldValueAndTimestamp.timestamp(), record.timestamp(),
-                                record.value(),
                                 recordMetadata.topic(), recordMetadata.offset(), recordMetadata.partition()
                             );
                         } else {
                             LOG.warn(
                                 "Detected out-of-order KTable update for {}, "
                                     + "old timestamp=[{}] new timestamp=[{}]. "
-                                    + "value=[{}]. Topic, partition and offset not known.",
-                                store.name(), record.value(),
+                                    + "Topic, partition and offset not known.",
+                                store.name(),
                                 oldValueAndTimestamp.timestamp(), record.timestamp()
                             );
                         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
@@ -65,8 +65,7 @@ public class ProcessorParameters<KIn, VIn, KOut, VOut> {
 
     @SuppressWarnings("unchecked")
     KTableSource<KIn, VIn> kTableSourceSupplier() {
-        // This cast always works because KTableSource hasn't been converted yet.
-        return (KTableSource<KIn, VIn>) processorSupplier;
+        return processorSupplier instanceof KTableSource ? (KTableSource<KIn, VIn>) processorSupplier : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
@@ -63,13 +63,10 @@ public class ProcessorParameters<KIn, VIn, KOut, VOut> {
         return oldProcessorSupplier;
     }
 
+    @SuppressWarnings("unchecked")
     KTableSource<KIn, VIn> kTableSourceSupplier() {
         // This cast always works because KTableSource hasn't been converted yet.
-        return oldProcessorSupplier == null
-            ? null
-            : !(oldProcessorSupplier instanceof KTableSource)
-              ? null
-              : (KTableSource<KIn, VIn>) oldProcessorSupplier;
+        return (KTableSource<KIn, VIn>) processorSupplier;
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -99,16 +99,5 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
                 topologyBuilder.addStateStore(storeBuilder, processorName);
             }
         }
-
-        // temporary hack until KIP-478 is fully implemented
-        @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-        final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> oldProcessorSupplier =
-            processorParameters().oldProcessorSupplier();
-        if (oldProcessorSupplier != null && oldProcessorSupplier.stores() != null) {
-            for (final StoreBuilder<?> storeBuilder : oldProcessorSupplier.stores()) {
-                topologyBuilder.addStateStore(storeBuilder, processorName);
-            }
-        }
-
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -109,5 +109,6 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
                 topologyBuilder.addStateStore(storeBuilder, processorName);
             }
         }
+
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -99,5 +99,15 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
                 topologyBuilder.addStateStore(storeBuilder, processorName);
             }
         }
+
+        // temporary hack until KIP-478 is fully implemented
+        @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
+        final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> oldProcessorSupplier =
+            processorParameters().oldProcessorSupplier();
+        if (oldProcessorSupplier != null && oldProcessorSupplier.stores() != null) {
+            for (final StoreBuilder<?> storeBuilder : oldProcessorSupplier.stores()) {
+                topologyBuilder.addStateStore(storeBuilder, processorName);
+            }
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -696,7 +696,7 @@ public class InternalTopologyBuilder {
     private void validateGlobalStoreArguments(final String sourceName,
                                               final String topic,
                                               final String processorName,
-                                              final ProcessorSupplier<?, ?, ?, ?> stateUpdateSupplier,
+                                              final ProcessorSupplier<?, ?, Void, Void> stateUpdateSupplier,
                                               final String storeName,
                                               final boolean loggingEnabled) {
         Objects.requireNonNull(sourceName, "sourceName must not be null");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -550,14 +550,14 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
-    public final <KIn, VIn, KOut, VOut> void addGlobalStore(final StoreBuilder<?> storeBuilder,
+    public final <KIn, VIn> void addGlobalStore(final StoreBuilder<?> storeBuilder,
                                                 final String sourceName,
                                                 final TimestampExtractor timestampExtractor,
                                                 final Deserializer<KIn> keyDeserializer,
                                                 final Deserializer<VIn> valueDeserializer,
                                                 final String topic,
                                                 final String processorName,
-                                                final ProcessorSupplier<KIn, VIn, KOut, VOut> stateUpdateSupplier) {
+                                                final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         Objects.requireNonNull(storeBuilder, "store builder must not be null");
         ApiUtils.checkSupplier(stateUpdateSupplier);
         validateGlobalStoreArguments(sourceName,
@@ -571,7 +571,7 @@ public class InternalTopologyBuilder {
         final String[] topics = {topic};
         final String[] predecessors = {sourceName};
 
-        final ProcessorNodeFactory<KIn, VIn, KOut, VOut> nodeFactory = new ProcessorNodeFactory<>(
+        final ProcessorNodeFactory<KIn, VIn, Void, Void> nodeFactory = new ProcessorNodeFactory<>(
             processorName,
             predecessors,
             stateUpdateSupplier

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -217,14 +217,6 @@ public class InternalTopologyBuilder {
             this.supplier = supplier;
         }
 
-        @SuppressWarnings("deprecation") // Old PAPI compatibility.
-        ProcessorNodeFactory(final String name,
-                             final String[] predecessors,
-                             final org.apache.kafka.streams.processor.ProcessorSupplier<KIn, VIn> supplier) {
-            super(name, predecessors.clone());
-            this.supplier = () -> ProcessorAdapter.adapt(supplier.get());
-        }
-
         public void addStateStore(final String stateStoreName) {
             stateStoreNames.add(stateStoreName);
         }
@@ -558,14 +550,14 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
-    public final <KIn, VIn> void addGlobalStore(final StoreBuilder<?> storeBuilder,
+    public final <KIn, VIn, KOut, VOut> void addGlobalStore(final StoreBuilder<?> storeBuilder,
                                                 final String sourceName,
                                                 final TimestampExtractor timestampExtractor,
                                                 final Deserializer<KIn> keyDeserializer,
                                                 final Deserializer<VIn> valueDeserializer,
                                                 final String topic,
                                                 final String processorName,
-                                                final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
+                                                final ProcessorSupplier<KIn, VIn, KOut, VOut> stateUpdateSupplier) {
         Objects.requireNonNull(storeBuilder, "store builder must not be null");
         ApiUtils.checkSupplier(stateUpdateSupplier);
         validateGlobalStoreArguments(sourceName,
@@ -579,7 +571,7 @@ public class InternalTopologyBuilder {
         final String[] topics = {topic};
         final String[] predecessors = {sourceName};
 
-        final ProcessorNodeFactory<KIn, VIn, Void, Void> nodeFactory = new ProcessorNodeFactory<>(
+        final ProcessorNodeFactory<KIn, VIn, KOut, VOut> nodeFactory = new ProcessorNodeFactory<>(
             processorName,
             predecessors,
             stateUpdateSupplier
@@ -704,7 +696,7 @@ public class InternalTopologyBuilder {
     private void validateGlobalStoreArguments(final String sourceName,
                                               final String topic,
                                               final String processorName,
-                                              final ProcessorSupplier<?, ?, Void, Void> stateUpdateSupplier,
+                                              final ProcessorSupplier<?, ?, ?, ?> stateUpdateSupplier,
                                               final String storeName,
                                               final boolean loggingEnabled) {
         Objects.requireNonNull(sourceName, "sourceName must not be null");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
@@ -156,7 +156,7 @@ public class KTableSourceTest {
                     .filter(e -> e.getLevel().equals("WARN"))
                     .map(Event::getMessage)
                     .collect(Collectors.toList()),
-                hasItem("Skipping record due to null key. value=[value] topic=[topic] partition=[0] offset=[0]")
+                hasItem("Skipping record due to null key. topic=[topic] partition=[0] offset=[0]")
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
@@ -156,7 +156,7 @@ public class KTableSourceTest {
                     .filter(e -> e.getLevel().equals("WARN"))
                     .map(Event::getMessage)
                     .collect(Collectors.toList()),
-                hasItem("Skipping record due to null key. topic=[topic] partition=[0] offset=[0]")
+                hasItem("Skipping record due to null key. value=[value] topic=[topic] partition=[0] offset=[0]")
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -98,7 +98,7 @@ public class GlobalStreamThreadTest {
             null,
             GLOBAL_STORE_TOPIC_NAME,
             "processorName",
-            () -> ProcessorAdapter.adapt(new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME).get()));
+            () -> new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME).get());
 
         baseDirectoryName = TestUtils.tempDirectory().getAbsolutePath();
         final HashMap<String, Object> properties = new HashMap<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -30,10 +30,12 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.InternalNameProvider;
-import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.kstream.internals.TimestampedKeyValueStoreMaterializer;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.MockStateRestoreListener;
@@ -90,6 +92,13 @@ public class GlobalStreamThreadTest {
                 "store-"
             );
 
+        final ProcessorSupplier<Object, Object, Void, Void> processorSupplier = () ->
+            new ContextualProcessor<Object, Object, Void, Void>() {
+                @Override
+                public void process(final Record<Object, Object> record) {
+                }
+            };
+
         builder.addGlobalStore(
             new TimestampedKeyValueStoreMaterializer<>(materialized).materialize().withLoggingDisabled(),
             "sourceName",
@@ -98,7 +107,7 @@ public class GlobalStreamThreadTest {
             null,
             GLOBAL_STORE_TOPIC_NAME,
             "processorName",
-            () -> new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME).get());
+            processorSupplier);
 
         baseDirectoryName = TestUtils.tempDirectory().getAbsolutePath();
         final HashMap<String, Object> properties = new HashMap<>();


### PR DESCRIPTION
As part of the migration of KStream/KTable operations to the new Processor API https://issues.apache.org/jira/browse/KAFKA-8410, this PR includes the migration of KTable:

- mapValues, 
- passthrough,
- and source operations.

Testing strategy: operations should keep the same tests as new processor should be compatible. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
