### PR TITLE
KAFKA-13079: Forgotten Topics in Fetch Requests may incorrectly use topic IDs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -280,9 +280,6 @@ public class FetchSessionHandler {
         }
 
         public FetchRequestData build() {
-            // For incremental sessions we don't have to worry about removed partitions when using topic IDs because we will either
-            //   a) already be using topic IDs and have the ID in the session
-            //   b) not be using topic IDs before and will close the session upon trying to use them
             boolean canUseTopicIds = partitionsWithoutTopicIds == 0;
 
             if (nextMetadata.isFull()) {
@@ -332,6 +329,9 @@ public class FetchSessionHandler {
                     iter.remove();
                     // Indicate that we no longer want to listen to this partition.
                     removed.add(topicPartition);
+                    // If we do not have this topic ID in the session, we can not use topic IDs
+                    if (canUseTopicIds && sessionTopicIds.get(topicPartition.topic()) == null)
+                        canUseTopicIds = false;
                 }
             }
             // Add any new partitions to the session.

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -329,8 +329,8 @@ public class FetchSessionHandler {
                     iter.remove();
                     // Indicate that we no longer want to listen to this partition.
                     removed.add(topicPartition);
-                    // If we do not have this topic ID in the session, we can not use topic IDs.
-                    if (canUseTopicIds && !sessionTopicIds.containsKey(topicPartition.topic()))
+                    // If we do not have this topic ID in the builder or the session, we can not use topic IDs.
+                    if (canUseTopicIds && !topicIds.containsKey(topicPartition.topic()) && !sessionTopicIds.containsKey(topicPartition.topic()))
                         canUseTopicIds = false;
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -329,8 +329,8 @@ public class FetchSessionHandler {
                     iter.remove();
                     // Indicate that we no longer want to listen to this partition.
                     removed.add(topicPartition);
-                    // If we do not have this topic ID in the session, we can not use topic IDs
-                    if (canUseTopicIds && sessionTopicIds.get(topicPartition.topic()) == null)
+                    // If we do not have this topic ID in the session, we can not use topic IDs.
+                    if (canUseTopicIds && !sessionTopicIds.containsKey(topicPartition.topic()))
                         canUseTopicIds = false;
                 }
             }

--- a/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
@@ -414,14 +414,14 @@ public class FetchSessionHandlerTest {
             // Should have the same session ID and next epoch, but we can now use topic IDs.
             // The receiving broker will close the session if we were previously not using topic IDs.
             assertEquals(123, data2.metadata().sessionId(), "Did not use same session when " + testType);
-            assertEquals(1, data2.metadata().epoch(), "Did not close session when " + testType);
+            assertEquals(1, data2.metadata().epoch(), "Did not have correct epoch when " + testType);
             assertTrue(data2.canUseTopicIds());
         });
     }
 
     @Test
     public void testIdUsageRevokedOnIdDowngrade() {
-        // We want to test removing topic ID to an existing partition and adding a new partition without an ID in the incremental request.
+        // We want to test removing topic ID from an existing partition and adding a new partition without an ID in the incremental request.
         // 0 is the existing partition and 1 is the new one.
         List<Integer> partitions = Arrays.asList(0, 1);
         partitions.forEach(partition -> {
@@ -443,14 +443,47 @@ public class FetchSessionHandlerTest {
 
             // Try to remove a topic ID from an existing topic partition (0) or add a new topic partition (1) without an ID.
             FetchSessionHandler.Builder builder2 = handler.newBuilder();
-            builder2.add(new TopicPartition("foo", 0), Uuid.ZERO_UUID,
+            builder2.add(new TopicPartition("foo", partition), Uuid.ZERO_UUID,
                     new FetchRequest.PartitionData(10, 110, 210, Optional.empty()));
             FetchSessionHandler.FetchRequestData data2 = builder2.build();
             // Should have the same session ID and next epoch, but can no longer use topic IDs.
             // The receiving broker will close the session if we were previously using topic IDs.
             assertEquals(123, data2.metadata().sessionId(), "Did not use same session when " + testType);
-            assertEquals(1, data2.metadata().epoch(), "Did not close session when " + testType);
+            assertEquals(1, data2.metadata().epoch(), "Did not have correct epoch when " + testType);
             assertFalse(data2.canUseTopicIds());
+        });
+    }
+
+    @Test
+    public void testIdUsageWithAllForgottenPartitions() {
+        // We want to test when all topics are removed from the session
+        List<Boolean> useTopicIdsTests = Arrays.asList(true, false);
+        useTopicIdsTests.forEach(useTopicIds -> {
+            Uuid topicId = useTopicIds ? Uuid.randomUuid() : Uuid.ZERO_UUID;
+            Short respVer = useTopicIds ? ApiKeys.FETCH.latestVersion() : 12;
+            Map<String, Uuid> topicIds = Collections.singletonMap("foo", topicId);
+            FetchSessionHandler handler = new FetchSessionHandler(LOG_CONTEXT, 1);
+            FetchSessionHandler.Builder builder = handler.newBuilder();
+            builder.add(new TopicPartition("foo", 0), topicIds.get("foo"),
+                    new FetchRequest.PartitionData(0, 100, 200, Optional.empty()));
+            FetchSessionHandler.FetchRequestData data = builder.build();
+            assertMapsEqual(reqMap(new ReqEntry("foo", 0, 0, 100, 200)),
+                    data.toSend(), data.sessionPartitions());
+            assertTrue(data.metadata().isFull());
+            assertEquals(useTopicIds, data.canUseTopicIds());
+
+            FetchResponse resp = FetchResponse.of(Errors.NONE, 0, 123,
+                    respMap(new RespEntry("foo", 0, 10, 20)), topicIds);
+            handler.handleResponse(resp, respVer.shortValue());
+
+            // Remove the topic from the session
+            FetchSessionHandler.Builder builder2 = handler.newBuilder();
+            FetchSessionHandler.FetchRequestData data2 = builder2.build();
+            // Should have the same session ID and next epoch, but can no longer use topic IDs.
+            // The receiving broker will close the session if we were previously using topic IDs.
+            assertEquals(123, data2.metadata().sessionId(), "Did not use same session when useTopicIds was " + useTopicIds);
+            assertEquals(1, data2.metadata().epoch(), "Did not have correct epoch when useTopicIds was " + useTopicIds);
+            assertEquals(useTopicIds, data2.canUseTopicIds());
         });
     }
 


### PR DESCRIPTION
The FetchSessionHandler had a small bug in the session build method where we did not consider building a session where no partitions were added and the session previously did not use topic IDs. (ie, it was relying on at least one partition being added to signify whether topic IDs were present)

Due to this, we could send forgotten partitions with the zero UUID. This would always result in an exception and closed session.

This PR fixes the logic to check that any forgotten partitions have topic IDs. There is also a test added for the empty session situation when topic IDs are used and when topic names are used.

I also fixed a few small things in some of the previous tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
