### PR TITLE
KAFKA-13123: close KeyValueIterator instances in example code and tests

### DIFF
--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/docs/DeveloperGuideTesting.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/docs/DeveloperGuideTesting.java
@@ -173,10 +173,11 @@ public class DeveloperGuideTesting {
         }
 
         private void flushStore(final long timestamp) {
-            final KeyValueIterator<String, Long> it = store.all();
-            while (it.hasNext()) {
-                final KeyValue<String, Long> next = it.next();
-                context.forward(new Record<>(next.key, next.value, timestamp));
+            try (final KeyValueIterator<String, Long> it = store.all()) {
+                while (it.hasNext()) {
+                    final KeyValue<String, Long> next = it.next();
+                    context.forward(new Record<>(next.key, next.value, timestamp));
+                }
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -993,11 +993,12 @@ public class EosIntegrationTest {
             .getStore(300_000L, storeName, streams, QueryableStoreTypes.keyValueStore());
         assertNotNull(store);
 
-        final KeyValueIterator<Long, Long> it = store.all();
-        while (it.hasNext()) {
-            assertTrue(reason, expectedStoreContent.remove(it.next()));
-        }
+        try (final KeyValueIterator<Long, Long> it = store.all()) {
+            while (it.hasNext()) {
+                assertTrue(reason, expectedStoreContent.remove(it.next()));
+            }
 
-        assertTrue(reason, expectedStoreContent.isEmpty());
+            assertTrue(reason, expectedStoreContent.isEmpty());
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -923,10 +923,11 @@ public class KStreamAggregationIntegrationTest {
         final ReadOnlySessionStore<String, String> sessionStore =
             IntegrationTestUtils.getStore(userSessionsStore, kafkaStreams, QueryableStoreTypes.sessionStore());
 
-        final KeyValueIterator<Windowed<String>, String> bob = sessionStore.fetch("bob");
-        assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t1, t1)), "start")));
-        assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t3, t4)), "pause:resume")));
-        assertFalse(bob.hasNext());
+        try (final KeyValueIterator<Windowed<String>, String> bob = sessionStore.fetch("bob")) {
+            assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t1, t1)), "start")));
+            assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t3, t4)), "pause:resume")));
+            assertFalse(bob.hasNext());
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -846,9 +846,10 @@ public class QueryableStateIntegrationTest {
             assertEquals(Long.valueOf(batchEntry.value), myMapStore.get(batchEntry.key));
         }
 
-        final KeyValueIterator<String, Long> range = myMapStore.range("hello", "kafka");
-        while (range.hasNext()) {
-            System.out.println(range.next());
+        try (final KeyValueIterator<String, Long> range = myMapStore.range("hello", "kafka")) {
+            while (range.hasNext()) {
+                System.out.println(range.next());
+            }
         }
     }
 
@@ -899,9 +900,10 @@ public class QueryableStateIntegrationTest {
             IntegrationTestUtils.getStore("queryMapValues", kafkaStreams, keyValueStore());
 
         int index = 0;
-        final KeyValueIterator<String, Long> range = myMapStore.prefixScan("go", Serdes.String().serializer());
-        while (range.hasNext()) {
-            assertEquals(expectedPrefixScanResult.get(index++), range.next());
+        try (final KeyValueIterator<String, Long> range = myMapStore.prefixScan("go", Serdes.String().serializer())) {
+            while (range.hasNext()) {
+                assertEquals(expectedPrefixScanResult.get(index++), range.next());
+            }
         }
     }
 
@@ -1234,12 +1236,14 @@ public class QueryableStateIntegrationTest {
 
     private Set<KeyValue<String, Long>> fetch(final ReadOnlyWindowStore<String, Long> store,
                                               final String key) {
-        final WindowStoreIterator<Long> fetch =
-            store.fetch(key, ofEpochMilli(0), ofEpochMilli(System.currentTimeMillis()));
-        if (fetch.hasNext()) {
-            final KeyValue<Long, Long> next = fetch.next();
-            return Collections.singleton(KeyValue.pair(key, next.value));
+        try (final WindowStoreIterator<Long> fetch =
+                 store.fetch(key, ofEpochMilli(0), ofEpochMilli(System.currentTimeMillis()))) {
+            if (fetch.hasNext()) {
+                final KeyValue<Long, Long> next = fetch.next();
+                return Collections.singleton(KeyValue.pair(key, next.value));
+            }
         }
+
         return Collections.emptySet();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -157,10 +157,11 @@ public class KStreamSessionWindowAggregateProcessorTest {
         context.setTime(500);
         processor.process("john", "second");
 
-        final KeyValueIterator<Windowed<String>, Long> values =
-            sessionStore.findSessions("john", 0, 2000);
-        assertTrue(values.hasNext());
-        assertEquals(Long.valueOf(2), values.next().value);
+        try (final KeyValueIterator<Windowed<String>, Long> values =
+                 sessionStore.findSessions("john", 0, 2000)) {
+            assertTrue(values.hasNext());
+            assertEquals(Long.valueOf(2), values.next().value);
+        }
     }
 
     @Test
@@ -180,12 +181,13 @@ public class KStreamSessionWindowAggregateProcessorTest {
         context.setTime(GAP_MS / 2);
         processor.process(sessionId, "third");
 
-        final KeyValueIterator<Windowed<String>, Long> iterator =
-            sessionStore.findSessions(sessionId, 0, GAP_MS + 1);
-        final KeyValue<Windowed<String>, Long> kv = iterator.next();
+        try (final KeyValueIterator<Windowed<String>, Long> iterator =
+                 sessionStore.findSessions(sessionId, 0, GAP_MS + 1)) {
+            final KeyValue<Windowed<String>, Long> kv = iterator.next();
 
-        assertEquals(Long.valueOf(3), kv.value);
-        assertFalse(iterator.hasNext());
+            assertEquals(Long.valueOf(3), kv.value);
+            assertFalse(iterator.hasNext());
+        }
     }
 
     @Test
@@ -193,10 +195,11 @@ public class KStreamSessionWindowAggregateProcessorTest {
         context.setTime(0);
         processor.process("mel", "first");
         processor.process("mel", "second");
-        final KeyValueIterator<Windowed<String>, Long> iterator =
-            sessionStore.findSessions("mel", 0, 0);
-        assertEquals(Long.valueOf(2L), iterator.next().value);
-        assertFalse(iterator.hasNext());
+        try (final KeyValueIterator<Windowed<String>, Long> iterator =
+                 sessionStore.findSessions("mel", 0, 0)) {
+            assertEquals(Long.valueOf(2L), iterator.next().value);
+            assertFalse(iterator.hasNext());
+        }
     }
 
     @Test
@@ -240,18 +243,21 @@ public class KStreamSessionWindowAggregateProcessorTest {
         processor.process("a", "1");
 
         // first ensure it is in the store
-        final KeyValueIterator<Windowed<String>, Long> a1 =
-            sessionStore.findSessions("a", 0, 0);
-        assertEquals(KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 1L), a1.next());
+        try (final KeyValueIterator<Windowed<String>, Long> a1 =
+                 sessionStore.findSessions("a", 0, 0)) {
+            assertEquals(KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 1L), a1.next());
+        }
+
 
         context.setTime(100);
         processor.process("a", "2");
         // a1 from above should have been removed
         // should have merged session in store
-        final KeyValueIterator<Windowed<String>, Long> a2 =
-            sessionStore.findSessions("a", 0, 100);
-        assertEquals(KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 100)), 2L), a2.next());
-        assertFalse(a2.hasNext());
+        try (final KeyValueIterator<Windowed<String>, Long> a2 =
+                 sessionStore.findSessions("a", 0, 100)) {
+            assertEquals(KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 100)), 2L), a2.next());
+            assertFalse(a2.hasNext());
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -407,19 +407,20 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.putAll(entries);
         rocksDBStore.flush();
 
-        final KeyValueIterator<Bytes, byte[]> keysWithPrefix = rocksDBStore.prefixScan("prefix", stringSerializer);
-        final List<String> valuesWithPrefix = new ArrayList<>();
-        int numberOfKeysReturned = 0;
+        try (final KeyValueIterator<Bytes, byte[]> keysWithPrefix = rocksDBStore.prefixScan("prefix", stringSerializer)) {
+            final List<String> valuesWithPrefix = new ArrayList<>();
+            int numberOfKeysReturned = 0;
 
-        while (keysWithPrefix.hasNext()) {
-            final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
-            valuesWithPrefix.add(new String(next.value));
-            numberOfKeysReturned++;
+            while (keysWithPrefix.hasNext()) {
+                final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
+                valuesWithPrefix.add(new String(next.value));
+                numberOfKeysReturned++;
+            }
+            assertThat(numberOfKeysReturned, is(3));
+            assertThat(valuesWithPrefix.get(0), is("f"));
+            assertThat(valuesWithPrefix.get(1), is("d"));
+            assertThat(valuesWithPrefix.get(2), is("b"));
         }
-        assertThat(numberOfKeysReturned, is(3));
-        assertThat(valuesWithPrefix.get(0), is("f"));
-        assertThat(valuesWithPrefix.get(1), is("d"));
-        assertThat(valuesWithPrefix.get(2), is("b"));
     }
 
     @Test
@@ -441,15 +442,16 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.putAll(entries);
         rocksDBStore.flush();
 
-        final KeyValueIterator<Bytes, byte[]> keysWithPrefixAsabcd = rocksDBStore.prefixScan("abcd", stringSerializer);
-        int numberOfKeysReturned = 0;
+        try (final KeyValueIterator<Bytes, byte[]> keysWithPrefixAsabcd = rocksDBStore.prefixScan("abcd", stringSerializer)) {
+            int numberOfKeysReturned = 0;
 
-        while (keysWithPrefixAsabcd.hasNext()) {
-            keysWithPrefixAsabcd.next().key.get();
-            numberOfKeysReturned++;
+            while (keysWithPrefixAsabcd.hasNext()) {
+                keysWithPrefixAsabcd.next().key.get();
+                numberOfKeysReturned++;
+            }
+
+            assertThat(numberOfKeysReturned, is(1));
         }
-
-        assertThat(numberOfKeysReturned, is(1));
     }
 
     @Test
@@ -472,21 +474,22 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.putAll(entries);
         rocksDBStore.flush();
 
-        final KeyValueIterator<Bytes, byte[]> keysWithPrefix = rocksDBStore.prefixScan(prefix, stringSerializer);
-        final List<String> valuesWithPrefix = new ArrayList<>();
-        int numberOfKeysReturned = 0;
+        try (final KeyValueIterator<Bytes, byte[]> keysWithPrefix = rocksDBStore.prefixScan(prefix, stringSerializer)) {
+            final List<String> valuesWithPrefix = new ArrayList<>();
+            int numberOfKeysReturned = 0;
 
-        while (keysWithPrefix.hasNext()) {
-            final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
-            valuesWithPrefix.add(new String(next.value));
-            numberOfKeysReturned++;
-        }
+            while (keysWithPrefix.hasNext()) {
+                final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
+                valuesWithPrefix.add(new String(next.value));
+                numberOfKeysReturned++;
+            }
 
-        assertThat(numberOfKeysReturned, is(numMatches));
-        if (numMatches == 2) {
-            assertThat(valuesWithPrefix.get(0), either(is("a")).or(is("b")));
-        } else {
-            assertThat(valuesWithPrefix.get(0), is("a"));
+            assertThat(numberOfKeysReturned, is(numMatches));
+            if (numMatches == 2) {
+                assertThat(valuesWithPrefix.get(0), either(is("a")).or(is("b")));
+            } else {
+                assertThat(valuesWithPrefix.get(0), is("a"));
+            }
         }
     }
 
@@ -506,14 +509,15 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.putAll(entries);
         rocksDBStore.flush();
 
-        final KeyValueIterator<Bytes, byte[]> keysWithPrefix = rocksDBStore.prefixScan("d", stringSerializer);
-        int numberOfKeysReturned = 0;
+        try (final KeyValueIterator<Bytes, byte[]> keysWithPrefix = rocksDBStore.prefixScan("d", stringSerializer)) {
+            int numberOfKeysReturned = 0;
 
-        while (keysWithPrefix.hasNext()) {
-            keysWithPrefix.next();
-            numberOfKeysReturned++;
+            while (keysWithPrefix.hasNext()) {
+                keysWithPrefix.next();
+                numberOfKeysReturned++;
+            }
+            assertThat(numberOfKeysReturned, is(0));
         }
-        assertThat(numberOfKeysReturned, is(0));
     }
 
     @Test
@@ -562,14 +566,15 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
         context.restore(rocksDBStore.name(), entries);
 
-        final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all();
-        final Set<String> keys = new HashSet<>();
+        try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
+            final Set<String> keys = new HashSet<>();
 
-        while (iterator.hasNext()) {
-            keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
+            while (iterator.hasNext()) {
+                keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
+            }
+
+            assertThat(keys, equalTo(Utils.mkSet("2", "3")));
         }
-
-        assertThat(keys, equalTo(Utils.mkSet("2", "3")));
     }
 
     @Test
@@ -586,30 +591,31 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
         context.restore(rocksDBStore.name(), entries);
 
-        final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all();
-        final Set<String> keys = new HashSet<>();
+        try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
+            final Set<String> keys = new HashSet<>();
 
-        while (iterator.hasNext()) {
-            keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
+            while (iterator.hasNext()) {
+                keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
+            }
+
+            assertThat(keys, equalTo(Utils.mkSet("1", "2", "3")));
+
+            assertEquals(
+                "restored",
+                stringDeserializer.deserialize(
+                    null,
+                    rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))));
+            assertEquals(
+                "b",
+                stringDeserializer.deserialize(
+                    null,
+                    rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "2")))));
+            assertEquals(
+                "c",
+                stringDeserializer.deserialize(
+                    null,
+                    rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))));
         }
-
-        assertThat(keys, equalTo(Utils.mkSet("1", "2", "3")));
-
-        assertEquals(
-            "restored",
-            stringDeserializer.deserialize(
-                null,
-                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))));
-        assertEquals(
-            "b",
-            stringDeserializer.deserialize(
-                null,
-                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "2")))));
-        assertEquals(
-            "c",
-            stringDeserializer.deserialize(
-                null,
-                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))));
     }
 
     @Test
@@ -644,14 +650,15 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
 
         context.restore(rocksDBStore.name(), entries);
 
-        final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all();
-        final Set<String> keys = new HashSet<>();
+        try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
+            final Set<String> keys = new HashSet<>();
 
-        while (iterator.hasNext()) {
-            keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
+            while (iterator.hasNext()) {
+                keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
+            }
+
+            assertThat(keys, equalTo(Utils.mkSet("2", "3")));
         }
-
-        assertThat(keys, equalTo(Utils.mkSet("2", "3")));
     }
 
     @Test
@@ -872,10 +879,11 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context.setTime(1L);
         store.put(1, "hi");
         store.put(2, "goodbye");
-        final KeyValueIterator<Integer, String> range = store.range(1, 2);
-        assertEquals("hi", range.next().value);
-        assertEquals("goodbye", range.next().value);
-        assertFalse(range.hasNext());
+        try (final KeyValueIterator<Integer, String> range = store.range(1, 2)) {
+            assertEquals("hi", range.next().value);
+            assertEquals("goodbye", range.next().value);
+            assertFalse(range.hasNext());
+        }
     }
 
     @Test
@@ -883,10 +891,11 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context.setTime(1L);
         store.put(1, "hi");
         store.put(2, "goodbye");
-        final KeyValueIterator<Integer, String> range = store.all();
-        assertEquals("hi", range.next().value);
-        assertEquals("goodbye", range.next().value);
-        assertFalse(range.hasNext());
+        try (final KeyValueIterator<Integer, String> range = store.all()) {
+            assertEquals("hi", range.next().value);
+            assertEquals("goodbye", range.next().value);
+            assertFalse(range.hasNext());
+        }
     }
 
     @Test
@@ -894,40 +903,41 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context.setTime(1L);
         store.put(1, "hi");
         store.put(2, "goodbye");
-        final KeyValueIterator<Integer, String> iteratorOne = store.range(1, 5);
-        final KeyValueIterator<Integer, String> iteratorTwo = store.range(1, 4);
+        try (final KeyValueIterator<Integer, String> iteratorOne = store.range(1, 5);
+             final KeyValueIterator<Integer, String> iteratorTwo = store.range(1, 4)) {
 
-        assertTrue(iteratorOne.hasNext());
-        assertTrue(iteratorTwo.hasNext());
+            assertTrue(iteratorOne.hasNext());
+            assertTrue(iteratorTwo.hasNext());
 
-        store.close();
+            store.close();
 
-        try {
-            iteratorOne.hasNext();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
-            // ok
-        }
+            try {
+                iteratorOne.hasNext();
+                fail("should have thrown InvalidStateStoreException on closed store");
+            } catch (final InvalidStateStoreException e) {
+                // ok
+            }
 
-        try {
-            iteratorOne.next();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
-            // ok
-        }
+            try {
+                iteratorOne.next();
+                fail("should have thrown InvalidStateStoreException on closed store");
+            } catch (final InvalidStateStoreException e) {
+                // ok
+            }
 
-        try {
-            iteratorTwo.hasNext();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
-            // ok
-        }
+            try {
+                iteratorTwo.hasNext();
+                fail("should have thrown InvalidStateStoreException on closed store");
+            } catch (final InvalidStateStoreException e) {
+                // ok
+            }
 
-        try {
-            iteratorTwo.next();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
-            // ok
+            try {
+                iteratorTwo.next();
+                fail("should have thrown InvalidStateStoreException on closed store");
+            } catch (final InvalidStateStoreException e) {
+                // ok
+            }
         }
     }
         

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -52,6 +52,7 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.Cache;
@@ -89,7 +90,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
 
@@ -911,33 +911,10 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
 
             store.close();
 
-            try {
-                iteratorOne.hasNext();
-                fail("should have thrown InvalidStateStoreException on closed store");
-            } catch (final InvalidStateStoreException e) {
-                // ok
-            }
-
-            try {
-                iteratorOne.next();
-                fail("should have thrown InvalidStateStoreException on closed store");
-            } catch (final InvalidStateStoreException e) {
-                // ok
-            }
-
-            try {
-                iteratorTwo.hasNext();
-                fail("should have thrown InvalidStateStoreException on closed store");
-            } catch (final InvalidStateStoreException e) {
-                // ok
-            }
-
-            try {
-                iteratorTwo.next();
-                fail("should have thrown InvalidStateStoreException on closed store");
-            } catch (final InvalidStateStoreException e) {
-                // ok
-            }
+            Assertions.assertThrows(InvalidStateStoreException.class, () -> iteratorOne.hasNext());
+            Assertions.assertThrows(InvalidStateStoreException.class, () -> iteratorOne.next());
+            Assertions.assertThrows(InvalidStateStoreException.class, () -> iteratorTwo.hasNext());
+            Assertions.assertThrows(InvalidStateStoreException.class, () -> iteratorTwo.next());
         }
     }
         

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -79,16 +79,17 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
 
         windowStore.put(1, "three", currentTime);
 
-        final WindowStoreIterator<String> iterator = windowStore.fetch(1, 0L, currentTime);
+        try (final WindowStoreIterator<String> iterator = windowStore.fetch(1, 0L, currentTime)) {
 
-        // roll to the next segment that will close the first
-        currentTime = currentTime + SEGMENT_INTERVAL;
-        windowStore.put(1, "four", currentTime);
+            // roll to the next segment that will close the first
+            currentTime = currentTime + SEGMENT_INTERVAL;
+            windowStore.put(1, "four", currentTime);
 
-        // should only have 2 values as the first segment is no longer open
-        assertEquals(new KeyValue<>(SEGMENT_INTERVAL, "two"), iterator.next());
-        assertEquals(new KeyValue<>(2 * SEGMENT_INTERVAL, "three"), iterator.next());
-        assertFalse(iterator.hasNext());
+            // should only have 2 values as the first segment is no longer open
+            assertEquals(new KeyValue<>(SEGMENT_INTERVAL, "two"), iterator.next());
+            assertEquals(new KeyValue<>(2 * SEGMENT_INTERVAL, "three"), iterator.next());
+            assertFalse(iterator.hasNext());
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.test.KeyValueIteratorStub;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,6 +54,13 @@ public class SessionKeySchemaTest {
 
     private final SessionKeySchema sessionKeySchema = new SessionKeySchema();
     private DelegatingPeekingKeyValueIterator<Bytes, Integer> iterator;
+
+    @After
+    public void after() {
+        if (iterator != null) {
+            iterator.close();
+        }
+    }
 
     @Before
     public void before() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
@@ -63,14 +63,16 @@ public class WindowKeySchemaTest {
             KeyValue.pair(WindowKeySchema.toStoreKeyBinary(new Windowed<>(Bytes.wrap(new byte[] {0}), new TimeWindow(10, 20)), 4), 4),
             KeyValue.pair(WindowKeySchema.toStoreKeyBinary(new Windowed<>(Bytes.wrap(new byte[] {0, 0}), new TimeWindow(10, 20)), 5), 5),
             KeyValue.pair(WindowKeySchema.toStoreKeyBinary(new Windowed<>(Bytes.wrap(new byte[] {0, 0, 0}), new TimeWindow(10, 20)), 6), 6));
-        final DelegatingPeekingKeyValueIterator<Bytes, Integer> iterator = new DelegatingPeekingKeyValueIterator<>("foo", new KeyValueIteratorStub<>(keys.iterator()));
+        try (final DelegatingPeekingKeyValueIterator<Bytes, Integer> iterator = new DelegatingPeekingKeyValueIterator<>("foo", new KeyValueIteratorStub<>(keys.iterator()))) {
 
-        final HasNextCondition hasNextCondition = windowKeySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE);
-        final List<Integer> results = new ArrayList<>();
-        while (hasNextCondition.hasNext(iterator)) {
-            results.add(iterator.next().value);
+            final HasNextCondition hasNextCondition = windowKeySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE);
+            final List<Integer> results = new ArrayList<>();
+            while (hasNextCondition.hasNext(iterator)) {
+                results.add(iterator.next().value);
+            }
+
+            assertThat(results, equalTo(Arrays.asList(1, 2, 3, 4, 5, 6)));
         }
-        assertThat(results, equalTo(Arrays.asList(1, 2, 3, 4, 5, 6)));
     }
 
     @Test


### PR DESCRIPTION
Close KeyValueIterator instances in example code and tests

I split the originally huge PR into 3 sub PRs. Here's the other 2: https://github.com/apache/kafka/pull/11106, https://github.com/apache/kafka/pull/11107

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
