### PR TITLE
KAFKA-13124: close KeyValueIterator instance in internals tests (part 1)

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -485,18 +485,20 @@ public abstract class AbstractKeyValueStoreTest {
     public void shouldNotThrowConcurrentModificationException() {
         store.put(0, "zero");
 
-        final KeyValueIterator<Integer, String> results = store.range(0, 2);
+        try (final KeyValueIterator<Integer, String> results = store.range(0, 2)) {
 
-        store.put(1, "one");
+            store.put(1, "one");
 
-        assertEquals(new KeyValue<>(0, "zero"), results.next());
+            assertEquals(new KeyValue<>(0, "zero"), results.next());
+        }
     }
 
     @Test
     public void shouldNotThrowInvalidRangeExceptionWithNegativeFromKey() {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
-            final KeyValueIterator<Integer, String> iterator = store.range(-1, 1);
-            assertFalse(iterator.hasNext());
+            try (final KeyValueIterator<Integer, String> iterator = store.range(-1, 1)) {
+                assertFalse(iterator.hasNext());
+            }
 
             final List<String> messages = appender.getMessages();
             assertThat(
@@ -512,8 +514,9 @@ public abstract class AbstractKeyValueStoreTest {
     @Test
     public void shouldNotThrowInvalidReverseRangeExceptionWithNegativeFromKey() {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
-            final KeyValueIterator<Integer, String> iterator = store.reverseRange(-1, 1);
-            assertFalse(iterator.hasNext());
+            try (final KeyValueIterator<Integer, String> iterator = store.reverseRange(-1, 1)) {
+                assertFalse(iterator.hasNext());
+            }
 
             final List<String> messages = appender.getMessages();
             assertThat(
@@ -529,8 +532,9 @@ public abstract class AbstractKeyValueStoreTest {
     @Test
     public void shouldNotThrowInvalidRangeExceptionWithFromLargerThanTo() {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
-            final KeyValueIterator<Integer, String> iterator = store.range(2, 1);
-            assertFalse(iterator.hasNext());
+            try (final KeyValueIterator<Integer, String> iterator = store.range(2, 1)) {
+                assertFalse(iterator.hasNext());
+            }
 
             final List<String> messages = appender.getMessages();
             assertThat(
@@ -546,8 +550,9 @@ public abstract class AbstractKeyValueStoreTest {
     @Test
     public void shouldNotThrowInvalidReverseRangeExceptionWithFromLargerThanTo() {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
-            final KeyValueIterator<Integer, String> iterator = store.reverseRange(2, 1);
-            assertFalse(iterator.hasNext());
+            try (final KeyValueIterator<Integer, String> iterator = store.reverseRange(2, 1)) {
+                assertFalse(iterator.hasNext());
+            }
 
             final List<String> messages = appender.getMessages();
             assertThat(

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -150,14 +150,15 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         bytesStore.put(serializeKey(new Windowed<>(key, windows[1])), serializeValue(50));
         bytesStore.put(serializeKey(new Windowed<>(key, windows[2])), serializeValue(100));
 
-        final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(Bytes.wrap(key.getBytes()), 0, 500);
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(Bytes.wrap(key.getBytes()), 0, 500)) {
 
-        final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
-            KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
-            KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
-        );
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
+            );
 
-        assertEquals(expected, toList(values));
+            assertEquals(expected, toList(values));
+        }
     }
 
     @Test
@@ -166,13 +167,14 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         bytesStore.put(serializeKey(new Windowed<>(key, windows[0])), serializeValue(10));
         bytesStore.put(serializeKey(new Windowed<>(key, windows[1])), serializeValue(50));
         bytesStore.put(serializeKey(new Windowed<>(key, windows[2])), serializeValue(100));
-        final KeyValueIterator<Bytes, byte[]> results = bytesStore.fetch(Bytes.wrap(key.getBytes()), 1, 999);
-        final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
-            KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
-            KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
-        );
+        try (final KeyValueIterator<Bytes, byte[]> results = bytesStore.fetch(Bytes.wrap(key.getBytes()), 1, 999)) {
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
+            );
 
-        assertEquals(expected, toList(results));
+            assertEquals(expected, toList(results));
+        }
     }
 
     @Test
@@ -181,8 +183,9 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         bytesStore.put(serializeKey(new Windowed<>("a", windows[1])), serializeValue(50));
 
         bytesStore.remove(serializeKey(new Windowed<>("a", windows[0])));
-        final KeyValueIterator<Bytes, byte[]> value = bytesStore.fetch(Bytes.wrap("a".getBytes()), 0, 100);
-        assertFalse(value.hasNext());
+        try (final KeyValueIterator<Bytes, byte[]> value = bytesStore.fetch(Bytes.wrap("a".getBytes()), 0, 100)) {
+            assertFalse(value.hasNext());
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -511,12 +511,13 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.put(new Windowed<>("a", new SessionWindow(10, 20)), 3L);
         sessionStore.put(new Windowed<>("aa", new SessionWindow(10, 20)), 4L);
 
-        final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.findSessions("a", 0L, 20);
+        try (final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.findSessions("a", 0L, 20)) {
 
-        assertEquals(iterator.peekNextKey(), new Windowed<>("a", new SessionWindow(0L, 0L)));
-        assertEquals(iterator.peekNextKey(), iterator.next().key);
-        assertEquals(iterator.peekNextKey(), iterator.next().key);
-        assertFalse(iterator.hasNext());
+            assertEquals(iterator.peekNextKey(), new Windowed<>("a", new SessionWindow(0L, 0L)));
+            assertEquals(iterator.peekNextKey(), iterator.next().key);
+            assertEquals(iterator.peekNextKey(), iterator.next().key);
+            assertFalse(iterator.hasNext());
+        }
     }
 
     @Test
@@ -526,12 +527,13 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.put(new Windowed<>("a", new SessionWindow(10, 20)), 3L);
         sessionStore.put(new Windowed<>("aa", new SessionWindow(10, 20)), 4L);
 
-        final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.backwardFindSessions("a", 0L, 20);
+        try (final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.backwardFindSessions("a", 0L, 20)) {
 
-        assertEquals(iterator.peekNextKey(), new Windowed<>("a", new SessionWindow(10L, 20L)));
-        assertEquals(iterator.peekNextKey(), iterator.next().key);
-        assertEquals(iterator.peekNextKey(), iterator.next().key);
-        assertFalse(iterator.hasNext());
+            assertEquals(iterator.peekNextKey(), new Windowed<>("a", new SessionWindow(10L, 20L)));
+            assertEquals(iterator.peekNextKey(), iterator.next().key);
+            assertEquals(iterator.peekNextKey(), iterator.next().key);
+            assertFalse(iterator.hasNext());
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -576,11 +578,12 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.put(new Windowed<>("b", new SessionWindow(10, 50)), 2L);
         sessionStore.put(new Windowed<>("c", new SessionWindow(100, 500)), 3L);
 
-        final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.fetch("a");
-        assertTrue(iterator.hasNext());
-        sessionStore.close();
+        try (final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.fetch("a")) {
+            assertTrue(iterator.hasNext());
+            sessionStore.close();
 
-        assertFalse(iterator.hasNext());
+            assertFalse(iterator.hasNext());
+        }
     }
 
     @Test
@@ -590,13 +593,14 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.put(new Windowed<>("aa", new SessionWindow(4, 5)), 2L);
         sessionStore.put(new Windowed<>("aaa", new SessionWindow(6, 7)), 3L);
 
-        final KeyValueIterator<Windowed<String>, Long> singleKeyIterator = sessionStore.findSessions("aa", 0L, 10L);
-        final KeyValueIterator<Windowed<String>, Long> rangeIterator = sessionStore.findSessions("aa", "aa", 0L, 10L);
+        try (final KeyValueIterator<Windowed<String>, Long> singleKeyIterator = sessionStore.findSessions("aa", 0L, 10L);
+             final KeyValueIterator<Windowed<String>, Long> rangeIterator = sessionStore.findSessions("aa", "aa", 0L, 10L)) {
 
-        assertEquals(singleKeyIterator.next(), rangeIterator.next());
-        assertEquals(singleKeyIterator.next(), rangeIterator.next());
-        assertFalse(singleKeyIterator.hasNext());
-        assertFalse(rangeIterator.hasNext());
+            assertEquals(singleKeyIterator.next(), rangeIterator.next());
+            assertEquals(singleKeyIterator.next(), rangeIterator.next());
+            assertFalse(singleKeyIterator.hasNext());
+            assertFalse(rangeIterator.hasNext());
+        }
     }
 
     @Test
@@ -707,8 +711,8 @@ public abstract class AbstractSessionBytesStoreTest {
         final String keyTo = Serdes.String().deserializer()
             .deserialize("", Serdes.Integer().serializer().serialize("", 1));
 
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
-            final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.findSessions(keyFrom, keyTo, 0L, 10L);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+             final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.findSessions(keyFrom, keyTo, 0L, 10L)) {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -299,44 +299,55 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldIterateAllStoredItems() {
         final int items = addItemsToCache();
-        final KeyValueIterator<Bytes, byte[]> all = store.all();
         final List<Bytes> results = new ArrayList<>();
-        while (all.hasNext()) {
-            results.add(all.next().key);
+
+        try (final KeyValueIterator<Bytes, byte[]> all = store.all()) {
+            while (all.hasNext()) {
+                results.add(all.next().key);
+            }
         }
+
         assertEquals(items, results.size());
         assertEquals(Arrays.asList(
             Bytes.wrap("0".getBytes()),
             Bytes.wrap("1".getBytes()),
             Bytes.wrap("2".getBytes())
         ), results);
+
     }
 
     @Test
     public void shouldReverseIterateAllStoredItems() {
         final int items = addItemsToCache();
-        final KeyValueIterator<Bytes, byte[]> all = store.reverseAll();
         final List<Bytes> results = new ArrayList<>();
-        while (all.hasNext()) {
-            results.add(all.next().key);
+
+        try (final KeyValueIterator<Bytes, byte[]> all = store.reverseAll()) {
+            while (all.hasNext()) {
+                results.add(all.next().key);
+            }
         }
+
         assertEquals(items, results.size());
         assertEquals(Arrays.asList(
             Bytes.wrap("2".getBytes()),
             Bytes.wrap("1".getBytes()),
             Bytes.wrap("0".getBytes())
         ), results);
+
     }
 
     @Test
     public void shouldIterateOverRange() {
         final int items = addItemsToCache();
-        final KeyValueIterator<Bytes, byte[]> range =
-            store.range(bytesKey(String.valueOf(0)), bytesKey(String.valueOf(items)));
         final List<Bytes> results = new ArrayList<>();
-        while (range.hasNext()) {
-            results.add(range.next().key);
+
+        try (final KeyValueIterator<Bytes, byte[]> range =
+                 store.range(bytesKey(String.valueOf(0)), bytesKey(String.valueOf(items)))) {
+            while (range.hasNext()) {
+                results.add(range.next().key);
+            }
         }
+
         assertEquals(items, results.size());
         assertEquals(Arrays.asList(
             Bytes.wrap("0".getBytes()),
@@ -348,12 +359,15 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldReverseIterateOverRange() {
         final int items = addItemsToCache();
-        final KeyValueIterator<Bytes, byte[]> range =
-            store.reverseRange(bytesKey(String.valueOf(0)), bytesKey(String.valueOf(items)));
         final List<Bytes> results = new ArrayList<>();
-        while (range.hasNext()) {
-            results.add(range.next().key);
+
+        try (final KeyValueIterator<Bytes, byte[]> range =
+                 store.reverseRange(bytesKey(String.valueOf(0)), bytesKey(String.valueOf(items)))) {
+            while (range.hasNext()) {
+                results.add(range.next().key);
+            }
         }
+
         assertEquals(items, results.size());
         assertEquals(Arrays.asList(
             Bytes.wrap("2".getBytes()),
@@ -374,20 +388,23 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         store.putAll(entries);
 
-        final KeyValueIterator<Bytes, byte[]> keysWithPrefix = store.prefixScan("p1", new StringSerializer());
         final List<String> keys = new ArrayList<>();
         final List<String> values = new ArrayList<>();
         int numberOfKeysReturned = 0;
 
-        while (keysWithPrefix.hasNext()) {
-            final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
-            keys.add(next.key.toString());
-            values.add(new String(next.value));
-            numberOfKeysReturned++;
+        try (final KeyValueIterator<Bytes, byte[]> keysWithPrefix = store.prefixScan("p1", new StringSerializer())) {
+            while (keysWithPrefix.hasNext()) {
+                final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
+                keys.add(next.key.toString());
+                values.add(new String(next.value));
+                numberOfKeysReturned++;
+            }
         }
+
         assertThat(numberOfKeysReturned, is(2));
         assertThat(keys, is(Arrays.asList("p1", "p11")));
         assertThat(values, is(Arrays.asList("2", "2")));
+
     }
 
     @Test
@@ -400,17 +417,19 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         store.putAll(entries);
 
-        final KeyValueIterator<Bytes, byte[]> keysWithPrefix = store.prefixScan("abcd", new StringSerializer());
         final List<String> keys = new ArrayList<>();
         final List<String> values = new ArrayList<>();
         int numberOfKeysReturned = 0;
 
-        while (keysWithPrefix.hasNext()) {
-            final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
-            keys.add(next.key.toString());
-            values.add(new String(next.value));
-            numberOfKeysReturned++;
+        try (final KeyValueIterator<Bytes, byte[]> keysWithPrefix = store.prefixScan("abcd", new StringSerializer())) {
+            while (keysWithPrefix.hasNext()) {
+                final KeyValue<Bytes, byte[]> next = keysWithPrefix.next();
+                keys.add(next.key.toString());
+                values.add(new String(next.value));
+                numberOfKeysReturned++;
+            }
         }
+
         assertThat(numberOfKeysReturned, is(2));
         assertThat(keys, is(Arrays.asList("abcd", "abcdd")));
         assertThat(values, is(Arrays.asList("2", "1")));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -112,15 +112,16 @@ public class CachingPersistentSessionStoreTest {
 
         assertEquals(3, cache.size());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> a =
-            cachingStore.findSessions(keyA, 0, 0);
-        final KeyValueIterator<Windowed<Bytes>, byte[]> b =
-            cachingStore.findSessions(keyB, 0, 0);
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> a =
+                 cachingStore.findSessions(keyA, 0, 0);
+             final KeyValueIterator<Windowed<Bytes>, byte[]> b =
+                 cachingStore.findSessions(keyB, 0, 0)) {
 
-        verifyWindowedKeyValue(a.next(), new Windowed<>(keyA, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(b.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
-        assertFalse(a.hasNext());
-        assertFalse(b.hasNext());
+            verifyWindowedKeyValue(a.next(), new Windowed<>(keyA, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(b.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
+            assertFalse(a.hasNext());
+            assertFalse(b.hasNext());
+        }
     }
 
     @Test
@@ -131,12 +132,13 @@ public class CachingPersistentSessionStoreTest {
 
         assertEquals(3, cache.size());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> all =
-            cachingStore.findSessions(keyA, keyB, 0, 0);
-        verifyWindowedKeyValue(all.next(), new Windowed<>(keyA, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(all.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(all.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
-        assertFalse(all.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> all =
+                 cachingStore.findSessions(keyA, keyB, 0, 0)) {
+            verifyWindowedKeyValue(all.next(), new Windowed<>(keyA, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(all.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(all.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
+            assertFalse(all.hasNext());
+        }
     }
 
     @Test
@@ -147,12 +149,13 @@ public class CachingPersistentSessionStoreTest {
 
         assertEquals(3, cache.size());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> all =
-            cachingStore.backwardFindSessions(keyA, keyB, 0, 0);
-        verifyWindowedKeyValue(all.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(all.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(all.next(), new Windowed<>(keyA, new SessionWindow(0, 0)), "1");
-        assertFalse(all.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> all =
+                 cachingStore.backwardFindSessions(keyA, keyB, 0, 0)) {
+            verifyWindowedKeyValue(all.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(all.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(all.next(), new Windowed<>(keyA, new SessionWindow(0, 0)), "1");
+            assertFalse(all.hasNext());
+        }
     }
 
     @Test
@@ -224,11 +227,12 @@ public class CachingPersistentSessionStoreTest {
 
         assertEquals(3, cache.size());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> some =
-            cachingStore.findSessions(keyAA, keyB, 0, 0);
-        verifyWindowedKeyValue(some.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(some.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
-        assertFalse(some.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> some =
+                 cachingStore.findSessions(keyAA, keyB, 0, 0)) {
+            verifyWindowedKeyValue(some.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(some.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
+            assertFalse(some.hasNext());
+        }
     }
 
     @Test
@@ -239,11 +243,12 @@ public class CachingPersistentSessionStoreTest {
 
         assertEquals(3, cache.size());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> some =
-            cachingStore.backwardFindSessions(keyAA, keyB, 0, 0);
-        verifyWindowedKeyValue(some.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
-        verifyWindowedKeyValue(some.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
-        assertFalse(some.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> some =
+                 cachingStore.backwardFindSessions(keyAA, keyB, 0, 0)) {
+            verifyWindowedKeyValue(some.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
+            verifyWindowedKeyValue(some.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
+            assertFalse(some.hasNext());
+        }
     }
 
     @Test
@@ -289,23 +294,25 @@ public class CachingPersistentSessionStoreTest {
     public void shouldFlushItemsToStoreOnEviction() {
         final List<KeyValue<Windowed<Bytes>, byte[]>> added = addSessionsUntilOverflow("a", "b", "c", "d");
         assertEquals(added.size() - 1, cache.size());
-        final KeyValueIterator<Windowed<Bytes>, byte[]> iterator =
-            cachingStore.findSessions(added.get(0).key.key(), 0, 0);
-        final KeyValue<Windowed<Bytes>, byte[]> next = iterator.next();
-        assertEquals(added.get(0).key, next.key);
-        assertArrayEquals(added.get(0).value, next.value);
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> iterator =
+                 cachingStore.findSessions(added.get(0).key.key(), 0, 0)) {
+            final KeyValue<Windowed<Bytes>, byte[]> next = iterator.next();
+            assertEquals(added.get(0).key, next.key);
+            assertArrayEquals(added.get(0).value, next.value);
+        }
     }
 
     @Test
     public void shouldQueryItemsInCacheAndStore() {
         final List<KeyValue<Windowed<Bytes>, byte[]>> added = addSessionsUntilOverflow("a");
-        final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.findSessions(
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.findSessions(
             Bytes.wrap("a".getBytes(StandardCharsets.UTF_8)),
             0,
             added.size() * 10L
-        );
-        final List<KeyValue<Windowed<Bytes>, byte[]>> actual = toList(iterator);
-        verifyKeyValueList(added, actual);
+        )) {
+            final List<KeyValue<Windowed<Bytes>, byte[]>> actual = toList(iterator);
+            verifyKeyValueList(added, actual);
+        }
     }
 
     @Test
@@ -316,9 +323,10 @@ public class CachingPersistentSessionStoreTest {
         cachingStore.put(b, "2".getBytes());
         cachingStore.remove(a);
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> rangeIter =
-            cachingStore.findSessions(keyA, 0, 0);
-        assertFalse(rangeIter.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> rangeIter =
+                 cachingStore.findSessions(keyA, 0, 0)) {
+            assertFalse(rangeIter.hasNext());
+        }
 
         assertNull(cachingStore.fetchSession(keyA, 0, 0));
         assertThat(cachingStore.fetchSession(keyB, 0, 0), equalTo("2".getBytes()));
@@ -340,15 +348,16 @@ public class CachingPersistentSessionStoreTest {
         cachingStore.put(a4, "4".getBytes());
         cachingStore.put(a5, "5".getBytes());
         cachingStore.put(a6, "6".getBytes());
-        final KeyValueIterator<Windowed<Bytes>, byte[]> results =
-            cachingStore.findSessions(keyA, 0, SEGMENT_INTERVAL * 5);
-        assertEquals(a1, results.next().key);
-        assertEquals(a2, results.next().key);
-        assertEquals(a3, results.next().key);
-        assertEquals(a4, results.next().key);
-        assertEquals(a5, results.next().key);
-        assertEquals(a6, results.next().key);
-        assertFalse(results.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> results =
+                 cachingStore.findSessions(keyA, 0, SEGMENT_INTERVAL * 5)) {
+            assertEquals(a1, results.next().key);
+            assertEquals(a2, results.next().key);
+            assertEquals(a3, results.next().key);
+            assertEquals(a4, results.next().key);
+            assertEquals(a5, results.next().key);
+            assertEquals(a6, results.next().key);
+            assertFalse(results.hasNext());
+        }
     }
 
     @Test
@@ -366,15 +375,16 @@ public class CachingPersistentSessionStoreTest {
         cachingStore.put(a4, "4".getBytes());
         cachingStore.put(a5, "5".getBytes());
         cachingStore.put(a6, "6".getBytes());
-        final KeyValueIterator<Windowed<Bytes>, byte[]> results =
-            cachingStore.backwardFindSessions(keyA, 0, SEGMENT_INTERVAL * 5);
-        assertEquals(a6, results.next().key);
-        assertEquals(a5, results.next().key);
-        assertEquals(a4, results.next().key);
-        assertEquals(a3, results.next().key);
-        assertEquals(a2, results.next().key);
-        assertEquals(a1, results.next().key);
-        assertFalse(results.hasNext());
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> results =
+                 cachingStore.backwardFindSessions(keyA, 0, SEGMENT_INTERVAL * 5)) {
+            assertEquals(a6, results.next().key);
+            assertEquals(a5, results.next().key);
+            assertEquals(a4, results.next().key);
+            assertEquals(a3, results.next().key);
+            assertEquals(a2, results.next().key);
+            assertEquals(a1, results.next().key);
+            assertFalse(results.hasNext());
+        }
     }
 
     @Test
@@ -574,15 +584,16 @@ public class CachingPersistentSessionStoreTest {
         cachingStore.put(new Windowed<>(keyAA, new SessionWindow(4, 5)), "3".getBytes());
         cachingStore.put(new Windowed<>(keyB, new SessionWindow(6, 7)), "4".getBytes());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> singleKeyIterator =
-            cachingStore.findSessions(keyAA, 0L, 10L);
-        final KeyValueIterator<Windowed<Bytes>, byte[]> keyRangeIterator =
-            cachingStore.findSessions(keyAA, keyAA, 0L, 10L);
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> singleKeyIterator =
+                 cachingStore.findSessions(keyAA, 0L, 10L);
+             final KeyValueIterator<Windowed<Bytes>, byte[]> keyRangeIterator =
+                 cachingStore.findSessions(keyAA, keyAA, 0L, 10L)) {
 
-        assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
-        assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
-        assertFalse(singleKeyIterator.hasNext());
-        assertFalse(keyRangeIterator.hasNext());
+            assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
+            assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
+            assertFalse(singleKeyIterator.hasNext());
+            assertFalse(keyRangeIterator.hasNext());
+        }
     }
 
     @Test
@@ -592,15 +603,16 @@ public class CachingPersistentSessionStoreTest {
         cachingStore.put(new Windowed<>(keyAA, new SessionWindow(4, 5)), "3".getBytes());
         cachingStore.put(new Windowed<>(keyB, new SessionWindow(6, 7)), "4".getBytes());
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> singleKeyIterator =
-            cachingStore.backwardFindSessions(keyAA, 0L, 10L);
-        final KeyValueIterator<Windowed<Bytes>, byte[]> keyRangeIterator =
-            cachingStore.backwardFindSessions(keyAA, keyAA, 0L, 10L);
+        try (final KeyValueIterator<Windowed<Bytes>, byte[]> singleKeyIterator =
+                 cachingStore.backwardFindSessions(keyAA, 0L, 10L);
+             final KeyValueIterator<Windowed<Bytes>, byte[]> keyRangeIterator =
+                 cachingStore.backwardFindSessions(keyAA, keyAA, 0L, 10L)) {
 
-        assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
-        assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
-        assertFalse(singleKeyIterator.hasNext());
-        assertFalse(keyRangeIterator.hasNext());
+            assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
+            assertEquals(singleKeyIterator.next(), keyRangeIterator.next());
+            assertFalse(singleKeyIterator.hasNext());
+            assertFalse(keyRangeIterator.hasNext());
+        }
     }
 
     @Test
@@ -681,9 +693,9 @@ public class CachingPersistentSessionStoreTest {
         final Bytes keyFrom = Bytes.wrap(Serdes.Integer().serializer().serialize("", -1));
         final Bytes keyTo = Bytes.wrap(Serdes.Integer().serializer().serialize("", 1));
 
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingSessionStore.class)) {
-            final KeyValueIterator<Windowed<Bytes>, byte[]> iterator =
-                cachingStore.backwardFindSessions(keyFrom, keyTo, 0L, 10L);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingSessionStore.class);
+             final KeyValueIterator<Windowed<Bytes>, byte[]> iterator =
+                 cachingStore.backwardFindSessions(keyFrom, keyTo, 0L, 10L)) {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
@@ -704,8 +716,8 @@ public class CachingPersistentSessionStoreTest {
         final Bytes keyFrom = Bytes.wrap(Serdes.Integer().serializer().serialize("", -1));
         final Bytes keyTo = Bytes.wrap(Serdes.Integer().serializer().serialize("", 1));
 
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingSessionStore.class)) {
-            final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.findSessions(keyFrom, keyTo, 0L, 10L);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingSessionStore.class);
+             final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.findSessions(keyFrom, keyTo, 0L, 10L)) {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();


### PR DESCRIPTION
Close KeyValueIterator instance in internals tests (part 1)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
