### PR TITLE
MINOR: only request rejoin and log if necessary for metadata snapshot and subscription checks

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -984,6 +984,12 @@ public abstract class AbstractCoordinator implements Closeable {
         resetStateAndRejoin("consumer pro-actively leaving the group");
     }
 
+    public synchronized void requestRejoinIfNecessary(final String reason) {
+        if (!this.rejoinNeeded) {
+            requestRejoin(reason);
+        }
+    }
+
     public synchronized void requestRejoin(final String reason) {
         log.info("Request joining group due to: {}", reason);
         this.rejoinNeeded = true;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -771,7 +771,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (assignmentSnapshot != null && !assignmentSnapshot.matches(metadataSnapshot)) {
             final String reason = String.format("cached metadata has changed from %s at the beginning of the rebalance to %s",
                 assignmentSnapshot, metadataSnapshot);
-            requestRejoin(reason);
+            requestRejoinIfNecessary(reason);
             return true;
         }
 
@@ -779,7 +779,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (joinedSubscription != null && !joinedSubscription.equals(subscriptions.subscription())) {
             final String reason = String.format("subscription has changed from %s at the beginning of the rebalance to %s",
                 joinedSubscription, subscriptions.subscription());
-            requestRejoin(reason);
+            requestRejoinIfNecessary(reason);
             return true;
         }
 


### PR DESCRIPTION
Since now we call do not necessarily complete the rebalance within a poll call, we may keep checking the `rejoinNeededOrPending` which hits either of the conditions and returns true, but then returns early, resulting in flooding log entries. This PR would only log/set the flag when it was not set yet, effectively only logging for the first time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
