### PR TITLE
KAFKA-13129: replace describe topic via zk with describe users

### DIFF
--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -220,16 +220,15 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         output = self.nodes[0].account.ssh_output(cmd)
         self.logger.debug(output)
 
-    def describe(self, topic):
+    def describeUsers(self):
         """
-        Describe the given topic using the ConfigCommand CLI
+        Describe the default user using the ConfigCommand CLI
         """
 
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
-        cmd = "%s kafka.admin.ConfigCommand --zookeeper %s %s --describe --topic %s" % \
+        cmd = "%s kafka.admin.ConfigCommand --zookeeper %s %s --describe --entity-type users --entity-default" % \
               (kafka_run_class, self.connect_setting(force_tls=self.zk_client_secure_port),
-               self.zkTlsConfigFileOption(),
-               topic)
+               self.zkTlsConfigFileOption())
         self.logger.debug(cmd)
         output = self.nodes[0].account.ssh_output(cmd)
         self.logger.debug(output)

--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -51,10 +51,10 @@ class TestUpgrade(ProduceConsumeValidateTest):
         self.logger.info("Upgrade ZooKeeper from %s to %s" % (str(self.zk.nodes[0].version), str(DEV_BRANCH)))
         self.zk.set_version(DEV_BRANCH)
         self.zk.restart_cluster()
-        # Confirm we have a successful ZooKeeper upgrade by describing the topic.
+        # Confirm we have a successful ZooKeeper upgrade by List ACLs for the topic.
         # Not trying to detect a problem here leads to failure in the ensuing Kafka roll, which would be a less
         # intuitive failure than seeing a problem here, so detect ZooKeeper upgrade problems before involving Kafka.
-        self.zk.describe(self.topic)
+        self.zk.list_acls(self.topic)
         # Do some stuff that exercises the use of ZooKeeper before we upgrade to the latest ZooKeeper client version
         self.logger.info("First pass bounce - rolling Kafka with old ZooKeeper client")
         for node in self.kafka.nodes:

--- a/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
@@ -81,7 +81,7 @@ class ZookeeperTlsEncryptOnlyTest(ProduceConsumeValidateTest):
 
         # Make sure the ConfigCommand CLI is able to talk to a TLS-enabled, encrypt-only ZooKeeper quorum
         # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated
-        self.zk.describe(self.topic)
+        self.zk.describeUsers()
 
         # Make sure the AclCommand CLI is able to talk to a TLS-enabled, encrypt-only ZooKeeper quorum
         # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated

--- a/tests/kafkatest/tests/core/zookeeper_tls_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_test.py
@@ -115,7 +115,7 @@ class ZookeeperTlsTest(ProduceConsumeValidateTest):
 
         # Make sure the ConfigCommand CLI is able to talk to a TLS-enabled ZooKeeper quorum
         # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated
-        self.zk.describe(self.topic)
+        self.zk.describeUsers()
 
         # Make sure the AclCommand CLI is able to talk to a TLS-enabled ZooKeeper quorum
         # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated


### PR DESCRIPTION
Replace the unsupported describe topic via zk with describe users to fix the system tests.
For the `upgrade_test` case where TLS support is not required, use `list_acls` instead.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
