### PR TITLE
MINOR: Add "controller" listener to AlterConfigsRequest

### DIFF
--- a/clients/src/main/resources/common/message/AlterConfigsRequest.json
+++ b/clients/src/main/resources/common/message/AlterConfigsRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 33,
   "type": "request",
-  "listeners": ["zkBroker", "broker"],
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "AlterConfigsRequest",
   // Version 1 is the same as version 0.
   // Version 2 enables flexible versions.


### PR DESCRIPTION
AlterConfigsRequest is handled in ControllerApis but does not have the "controller" listener. This PR adds the listener to the RPC.