### PR TITLE
KAFKA-4064: Add support for infinite endpoints for range queries

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -69,6 +69,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1157,6 +1158,17 @@ public final class Utils {
         List<T> res = new ArrayList<>();
         while (iterator.hasNext())
             res.add(iterator.next());
+        return res;
+    }
+
+    public static <T> List<T> toList(Iterator<T> iterator, Predicate<T> predicate) {
+        List<T> res = new ArrayList<>();
+        while (iterator.hasNext()) {
+            T e = iterator.next();
+            if (predicate.test(e)) {
+                res.add(e);
+            }
+        }
         return res;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -51,9 +51,10 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * Order is not guaranteed as bytes lexicographical ordering might not represent key order.
      *
      * @param from The first key that could be in the range, where iteration starts from.
+     *             A null value indicates that the range starts with the first element in the store.
      * @param to   The last key that could be in the range, where iteration ends.
+     *             A null value indicates that the range ends with the last element in the store.
      * @return The iterator for this range, from smallest to largest bytes.
-     * @throws NullPointerException       If null is used for from or to.
      * @throws InvalidStateStoreException if the store is not initialized
      */
     KeyValueIterator<K, V> range(K from, K to);
@@ -65,9 +66,10 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * Order is not guaranteed as bytes lexicographical ordering might not represent key order.
      *
      * @param from The first key that could be in the range, where iteration ends.
+     *             A null value indicates that the range starts with the first element in the store.
      * @param to   The last key that could be in the range, where iteration starts from.
+     *             A null value indicates that the range ends with the last element in the store.
      * @return The reverse iterator for this range, from largest to smallest key bytes.
-     * @throws NullPointerException       If null is used for from or to.
      * @throws InvalidStateStoreException if the store is not initialized
      */
     default KeyValueIterator<K, V> reverseRange(K from, K to) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -252,7 +252,7 @@ public class CachingKeyValueStore
     @Override
     public KeyValueIterator<Bytes, byte[]> range(final Bytes from,
                                                  final Bytes to) {
-        if (from.compareTo(to) > 0) {
+        if (Objects.nonNull(from) && Objects.nonNull(to) && from.compareTo(to) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. " +
                 "This may be due to range arguments set in the wrong order, " +
                 "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
@@ -269,7 +269,7 @@ public class CachingKeyValueStore
     @Override
     public KeyValueIterator<Bytes, byte[]> reverseRange(final Bytes from,
                                                         final Bytes to) {
-        if (from.compareTo(to) > 0) {
+        if (Objects.nonNull(from) && Objects.nonNull(to) && from.compareTo(to) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. " +
                 "This may be due to range arguments set in the wrong order, " +
                 "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
@@ -67,8 +67,6 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
 
     @Override
     public KeyValueIterator<K, V> range(final K from, final K to) {
-        Objects.requireNonNull(from);
-        Objects.requireNonNull(to);
         final NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>> nextIteratorFunction = new NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>>() {
             @Override
             public KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store) {
@@ -87,8 +85,6 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
 
     @Override
     public KeyValueIterator<K, V> reverseRange(final K from, final K to) {
-        Objects.requireNonNull(from);
-        Objects.requireNonNull(to);
         final NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>> nextIteratorFunction = new NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>>() {
             @Override
             public KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -266,10 +266,10 @@ public class MeteredKeyValueStore<K, V>
     @Override
     public KeyValueIterator<K, V> range(final K from,
                                         final K to) {
-        Objects.requireNonNull(from, "keyFrom cannot be null");
-        Objects.requireNonNull(to, "keyTo cannot be null");
+        final byte[] serFrom = from == null ? null : serdes.rawKey(from);
+        final byte[] serTo = to == null ? null : serdes.rawKey(to);
         return new MeteredKeyValueIterator(
-            wrapped().range(Bytes.wrap(serdes.rawKey(from)), Bytes.wrap(serdes.rawKey(to))),
+            wrapped().range(Bytes.wrap(serFrom), Bytes.wrap(serTo)),
             rangeSensor
         );
     }
@@ -277,10 +277,10 @@ public class MeteredKeyValueStore<K, V>
     @Override
     public KeyValueIterator<K, V> reverseRange(final K from,
                                                final K to) {
-        Objects.requireNonNull(from, "keyFrom cannot be null");
-        Objects.requireNonNull(to, "keyTo cannot be null");
+        final byte[] serFrom = from == null ? null : serdes.rawKey(from);
+        final byte[] serTo = to == null ? null : serdes.rawKey(to);
         return new MeteredKeyValueIterator(
-            wrapped().reverseRange(Bytes.wrap(serdes.rawKey(from)), Bytes.wrap(serdes.rawKey(to))),
+            wrapped().reverseRange(Bytes.wrap(serFrom), Bytes.wrap(serTo)),
             rangeSensor
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -368,10 +368,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     KeyValueIterator<Bytes, byte[]> range(final Bytes from,
                                           final Bytes to,
                                           final boolean forward) {
-        Objects.requireNonNull(from, "from cannot be null");
-        Objects.requireNonNull(to, "to cannot be null");
-
-        if (from.compareTo(to) > 0) {
+        if (Objects.nonNull(from) && Objects.nonNull(to) && from.compareTo(to) > 0) {
             log.warn("Returning empty iterator for fetch with invalid key range: from > to. "
                 + "This may be due to range arguments set in the wrong order, " +
                 "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -426,19 +426,23 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             this.forward = forward;
             this.toInclusive = toInclusive;
             if (forward) {
-                iterWithTimestamp.seek(from.get());
-                iterNoTimestamp.seek(from.get());
-                rawLastKey = to.get();
-                if (rawLastKey == null) {
-                    throw new NullPointerException("RocksDBDualCFRangeIterator: rawLastKey is null for key " + to);
+                if (from == null) {
+                    iterWithTimestamp.seekToFirst();
+                    iterNoTimestamp.seekToFirst();
+                } else {
+                    iterWithTimestamp.seek(from.get());
+                    iterNoTimestamp.seek(from.get());
                 }
+                rawLastKey = to == null ? null : to.get();
             } else {
-                iterWithTimestamp.seekForPrev(to.get());
-                iterNoTimestamp.seekForPrev(to.get());
-                rawLastKey = from.get();
-                if (rawLastKey == null) {
-                    throw new NullPointerException("RocksDBDualCFRangeIterator: rawLastKey is null for key " + from);
+                if (to == null) {
+                    iterWithTimestamp.seekToLast();
+                    iterNoTimestamp.seekToLast();
+                } else {
+                    iterWithTimestamp.seekForPrev(to.get());
+                    iterNoTimestamp.seekForPrev(to.get());
                 }
+                rawLastKey = from == null ? null : from.get();
             }
         }
 
@@ -448,9 +452,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
 
             if (next == null) {
                 return allDone();
+            } else if (rawLastKey == null) {
+                //null means range endpoint is open
+                return next;
             } else {
                 if (forward) {
-
                     if (comparator.compare(next.key.get(), rawLastKey) < 0) {
                         return next;
                     } else if (comparator.compare(next.key.get(), rawLastKey) == 0) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableEfficientRangeQueryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableEfficientRangeQueryTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkProperties;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(Parameterized.class)
+public class KTableEfficientRangeQueryTest {
+    private enum StoreType { InMemory, RocksDB, Timed };
+    private static final String TABLE_NAME = "mytable";
+    private static final int DATA_SIZE = 5;
+
+    private StoreType storeType;
+    private boolean enableLogging;
+    private boolean enableCaching;
+    private boolean forward;
+
+    private LinkedList<KeyValue<String, String>> records;
+    private String low;
+    private String high;
+    private String middle;
+    private String innerLow;
+    private String innerHigh;
+    private String innerLowBetween;
+    private String innerHighBetween;
+
+    private Properties streamsConfig;
+
+    public KTableEfficientRangeQueryTest(final StoreType storeType, final boolean enableLogging, final boolean enableCaching, final boolean forward) {
+        this.storeType = storeType;
+        this.enableLogging = enableLogging;
+        this.enableCaching = enableCaching;
+        this.forward = forward;
+
+        this.records = new LinkedList<>();
+        final int m = DATA_SIZE / 2;
+        for (int i = 0; i < DATA_SIZE; i++) {
+            final String key = "key-" + i * 2;
+            final String value = "val-" + i * 2;
+            records.add(new KeyValue<>(key, value));
+            high = key;
+            if (low == null) {
+                low = key;
+            }
+            if (i == m) {
+                middle = key;
+            }
+            if (i == 1) {
+                innerLow = key;
+                final int index = i * 2 - 1;
+                innerLowBetween = "key-" + index;
+            }
+            if (i == DATA_SIZE - 2) {
+                innerHigh = key;
+                final int index = i * 2 + 1;
+                innerHighBetween = "key-" + index;
+            }
+        }
+        Assert.assertNotNull(low);
+        Assert.assertNotNull(high);
+        Assert.assertNotNull(middle);
+        Assert.assertNotNull(innerLow);
+        Assert.assertNotNull(innerHigh);
+        Assert.assertNotNull(innerLowBetween);
+        Assert.assertNotNull(innerHighBetween);
+    }
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Parameterized.Parameters(name = "storeType={0}, enableLogging={1}, enableCaching={2}, forward={3}")
+    public static Collection<Object[]> data() {
+        final List<StoreType> types = Arrays.asList(StoreType.InMemory, StoreType.RocksDB, StoreType.Timed);
+        final List<Boolean> logging = Arrays.asList(true, false);
+        final List<Boolean> caching = Arrays.asList(true, false);
+        final List<Boolean> forward = Arrays.asList(true, false);
+        return buildParameters(types, logging, caching, forward);
+    }
+
+    @Before
+    public void setup() {
+        streamsConfig = mkProperties(mkMap(
+                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+        ));
+    }
+
+    @Test
+    public void testStoreConfig() {
+        final Materialized<String, String, KeyValueStore<Bytes, byte[]>> stateStoreConfig = getStoreConfig(storeType, TABLE_NAME, enableLogging, enableCaching);
+        //Create topology: table from input topic
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<String, String> table =
+                builder.table("input", stateStoreConfig);
+        final Topology topology = builder.build();
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology)) {
+            //get input topic and stateStore
+            final TestInputTopic<String, String> input = driver
+                    .createInputTopic("input", new StringSerializer(), new StringSerializer());
+            final ReadOnlyKeyValueStore<String, String> stateStore = driver.getKeyValueStore(TABLE_NAME);
+
+            //write some data
+            for (final KeyValue<String, String> kv : records) {
+                input.pipeInput(kv.key, kv.value);
+            }
+
+            //query the state store
+            try (final KeyValueIterator<String, String> scanIterator = forward ? stateStore.range(null, null) : stateStore.reverseRange(null, null)) {
+                final Iterator<KeyValue<String, String>> dataIterator = forward ? records.iterator() : records.descendingIterator();
+                TestUtils.checkEquals(scanIterator, dataIterator);
+            }
+
+            try (final KeyValueIterator<String, String> allIterator = forward ? stateStore.all() : stateStore.reverseAll()) {
+                final Iterator<KeyValue<String, String>> dataIterator = forward ? records.iterator() : records.descendingIterator();
+                TestUtils.checkEquals(allIterator, dataIterator);
+            }
+
+            testRange("range", stateStore, innerLow, innerHigh, forward);
+            testRange("until", stateStore, null, middle, forward);
+            testRange("from", stateStore, middle, null, forward);
+
+            testRange("untilBetween", stateStore, null, innerHighBetween, forward);
+            testRange("fromBetween", stateStore, innerLowBetween, null, forward);
+        }
+    }
+
+    private List<KeyValue<String, String>> filterList(final KeyValueIterator<String, String> iterator, final String from, final String to) {
+        final Predicate<KeyValue<String, String>> pred = new Predicate<KeyValue<String, String>>() {
+            @Override
+            public boolean test(final KeyValue<String, String> elem) {
+                if (from != null && elem.key.compareTo(from) < 0) {
+                    return false;
+                }
+                if (to != null && elem.key.compareTo(to) > 0) {
+                    return false;
+                }
+                return elem != null;
+            }
+        };
+
+        return Utils.toList(iterator, pred);
+    }
+
+    private void testRange(final String name, final ReadOnlyKeyValueStore<String, String> store, final String from, final String to, final boolean forward) {
+        try (final KeyValueIterator<String, String> resultIterator = forward ? store.range(from, to) : store.reverseRange(from, to);
+             final KeyValueIterator<String, String> expectedIterator = forward ? store.all() : store.reverseAll()) {
+            final List<KeyValue<String, String>> result = Utils.toList(resultIterator);
+            final List<KeyValue<String, String>> expected = filterList(expectedIterator, from, to);
+            assertThat(result, is(expected));
+        }
+    }
+
+    private static Collection<Object[]> buildParameters(final List<?>... argOptions) {
+        List<Object[]> result = new LinkedList<>();
+        result.add(new Object[0]);
+
+        for (final List<?> argOption : argOptions) {
+            result = times(result, argOption);
+        }
+
+        return result;
+    }
+
+    private static List<Object[]> times(final List<Object[]> left, final List<?> right) {
+        final List<Object[]> result = new LinkedList<>();
+        for (final Object[] args : left) {
+            for (final Object rightElem : right) {
+                final Object[] resArgs = new Object[args.length + 1];
+                System.arraycopy(args, 0, resArgs, 0, args.length);
+                resArgs[args.length] = rightElem;
+                result.add(resArgs);
+            }
+        }
+        return result;
+    }
+
+    private Materialized<String, String, KeyValueStore<Bytes, byte[]>> getStoreConfig(final StoreType type, final String name, final boolean cachingEnabled, final boolean loggingEnabled) {
+        final Supplier<KeyValueBytesStoreSupplier> createStore = () -> {
+            if (type == StoreType.InMemory) {
+                return Stores.inMemoryKeyValueStore(TABLE_NAME);
+            } else if (type == StoreType.RocksDB) {
+                return Stores.persistentKeyValueStore(TABLE_NAME);
+            } else if (type == StoreType.Timed) {
+                return Stores.persistentTimestampedKeyValueStore(TABLE_NAME);
+            } else {
+                return Stores.inMemoryKeyValueStore(TABLE_NAME);
+            }
+        };
+
+        final KeyValueBytesStoreSupplier stateStoreSupplier = createStore.get();
+        final Materialized<String, String, KeyValueStore<Bytes, byte[]>> stateStoreConfig = Materialized
+                .<String, String>as(stateStoreSupplier)
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String());
+        if (cachingEnabled) {
+            stateStoreConfig.withCachingEnabled();
+        } else {
+            stateStoreConfig.withCachingDisabled();
+        }
+        if (loggingEnabled) {
+            stateStoreConfig.withLoggingEnabled(new HashMap<String, String>());
+        } else {
+            stateStoreConfig.withLoggingDisabled();
+        }
+        return stateStoreConfig;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+@SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
+@RunWith(Parameterized.class)
+@Category({IntegrationTest.class})
+public class RangeQueryIntegrationTest {
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+    private static final Properties STREAMS_CONFIG = new Properties();
+    private static final String APP_ID = "range-query-integration-test";
+    private static final Long COMMIT_INTERVAL = 100L;
+    private static String inputStream;
+    private static final String TABLE_NAME = "mytable";
+    private static final int DATA_SIZE = 5;
+
+    private enum StoreType { InMemory, RocksDB, Timed };
+    private StoreType storeType;
+    private boolean enableLogging;
+    private boolean enableCaching;
+    private boolean forward;
+    private KafkaStreams kafkaStreams;
+
+    private LinkedList<KeyValue<String, String>> records;
+    private String low;
+    private String high;
+    private String middle;
+    private String innerLow;
+    private String innerHigh;
+    private String innerLowBetween;
+    private String innerHighBetween;
+
+    public RangeQueryIntegrationTest(final StoreType storeType, final boolean enableLogging, final boolean enableCaching, final boolean forward) {
+        this.storeType = storeType;
+        this.enableLogging = enableLogging;
+        this.enableCaching = enableCaching;
+        this.forward = forward;
+
+        records = new LinkedList<>();
+        final int m = DATA_SIZE / 2;
+        for (int i = 0; i < DATA_SIZE; i++) {
+            final String key = "key-" + i * 2;
+            final String value = "val-" + i * 2;
+            records.add(new KeyValue<>(key, value));
+            high = key;
+            if (low == null) {
+                low = key;
+            }
+            if (i == m) {
+                middle = key;
+            }
+            if (i == 1) {
+                innerLow = key;
+                final int index = i * 2 - 1;
+                innerLowBetween = "key-" + index;
+            }
+            if (i == DATA_SIZE - 2) {
+                innerHigh = key;
+                final int index = i * 2 + 1;
+                innerHighBetween = "key-" + index;
+            }
+        }
+        Assert.assertNotNull(low);
+        Assert.assertNotNull(high);
+        Assert.assertNotNull(middle);
+        Assert.assertNotNull(innerLow);
+        Assert.assertNotNull(innerHigh);
+        Assert.assertNotNull(innerLowBetween);
+        Assert.assertNotNull(innerHighBetween);
+    }
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Parameterized.Parameters(name = "storeType={0}, enableLogging={1}, enableCaching={2}, forward={3}")
+    public static Collection<Object[]> data() {
+        final List<StoreType> types = Arrays.asList(StoreType.InMemory, StoreType.RocksDB, StoreType.Timed);
+        final List<Boolean> logging = Arrays.asList(true, false);
+        final List<Boolean> caching = Arrays.asList(true, false);
+        final List<Boolean> forward = Arrays.asList(true, false);
+        return buildParameters(types, logging, caching, forward);
+    }
+
+    @BeforeClass
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+        STREAMS_CONFIG.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL);
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
+        STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+    }
+
+    @AfterClass
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    @Before
+    public void setupTopics() throws Exception {
+        inputStream = "input-topic";
+        CLUSTER.createTopic(inputStream);
+    }
+
+    @After
+    public void cleanup() throws InterruptedException {
+        CLUSTER.deleteAllTopicsAndWait(120000);
+    }
+
+    @Test
+    public void testStoreConfig() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final Materialized<String, String, KeyValueStore<Bytes, byte[]>> stateStoreConfig = getStoreConfig(storeType, TABLE_NAME, enableLogging, enableCaching);
+        final KTable<String, String> table = builder.table(inputStream, stateStoreConfig);
+
+        try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), STREAMS_CONFIG)) {
+            final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams);
+
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+
+            writeInputData();
+
+            final ReadOnlyKeyValueStore<String, String> stateStore = IntegrationTestUtils.getStore(1000_000L, TABLE_NAME, kafkaStreams, QueryableStoreTypes.keyValueStore());
+
+            // wait for the store to populate
+            TestUtils.waitForCondition(() -> stateStore.get(high) != null, "The store never finished populating");
+
+            //query the state store
+            try (final KeyValueIterator<String, String> scanIterator = forward ? stateStore.range(null, null) : stateStore.reverseRange(null, null)) {
+                final Iterator<KeyValue<String, String>> dataIterator = forward ? records.iterator() : records.descendingIterator();
+                TestUtils.checkEquals(scanIterator, dataIterator);
+            }
+
+            try (final KeyValueIterator<String, String> allIterator = forward ? stateStore.all() : stateStore.reverseAll()) {
+                final Iterator<KeyValue<String, String>> dataIterator = forward ? records.iterator() : records.descendingIterator();
+                TestUtils.checkEquals(allIterator, dataIterator);
+            }
+
+            testRange("range", stateStore, innerLow, innerHigh, forward);
+            testRange("until", stateStore, null, middle, forward);
+            testRange("from", stateStore, middle, null, forward);
+
+            testRange("untilBetween", stateStore, null, innerHighBetween, forward);
+            testRange("fromBetween", stateStore, innerLowBetween, null, forward);
+        }
+    }
+
+    private void writeInputData() {
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputStream,
+                records,
+                TestUtils.producerConfig(CLUSTER.bootstrapServers(), StringSerializer.class, StringSerializer.class),
+                CLUSTER.time
+        );
+    }
+
+    private List<KeyValue<String, String>> filterList(final KeyValueIterator<String, String> iterator, final String from, final String to) {
+        final Predicate<KeyValue<String, String>> pred = new Predicate<KeyValue<String, String>>() {
+            @Override
+            public boolean test(final KeyValue<String, String> elem) {
+                if (from != null && elem.key.compareTo(from) < 0) {
+                    return false;
+                }
+                if (to != null && elem.key.compareTo(to) > 0) {
+                    return false;
+                }
+                return elem != null;
+            }
+        };
+
+        return Utils.toList(iterator, pred);
+    }
+
+    private void testRange(final String name, final ReadOnlyKeyValueStore<String, String> store, final String from, final String to, final boolean forward) {
+        try (final KeyValueIterator<String, String> resultIterator = forward ? store.range(from, to) : store.reverseRange(from, to);
+             final KeyValueIterator<String, String> expectedIterator = forward ? store.all() : store.reverseAll();) {
+            final List<KeyValue<String, String>> result = Utils.toList(resultIterator);
+            final List<KeyValue<String, String>> expected = filterList(expectedIterator, from, to);
+            assertThat(result, is(expected));
+        }
+    }
+
+    private Materialized<String, String, KeyValueStore<Bytes, byte[]>> getStoreConfig(final StoreType type, final String name, final boolean cachingEnabled, final boolean loggingEnabled) {
+        final Supplier<KeyValueBytesStoreSupplier> createStore = () -> {
+            if (type == StoreType.InMemory) {
+                return Stores.inMemoryKeyValueStore(TABLE_NAME);
+            } else if (type == StoreType.RocksDB) {
+                return Stores.persistentKeyValueStore(TABLE_NAME);
+            } else if (type == StoreType.Timed) {
+                return Stores.persistentTimestampedKeyValueStore(TABLE_NAME);
+            } else {
+                return Stores.inMemoryKeyValueStore(TABLE_NAME);
+            }
+        };
+
+        final KeyValueBytesStoreSupplier stateStoreSupplier = createStore.get();
+        final Materialized<String, String, KeyValueStore<Bytes, byte[]>> stateStoreConfig = Materialized
+                .<String, String>as(stateStoreSupplier)
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String());
+        if (cachingEnabled) {
+            stateStoreConfig.withCachingEnabled();
+        } else {
+            stateStoreConfig.withCachingDisabled();
+        }
+        if (loggingEnabled) {
+            stateStoreConfig.withLoggingEnabled(new HashMap<String, String>());
+        } else {
+            stateStoreConfig.withLoggingDisabled();
+        }
+        return stateStoreConfig;
+    }
+
+    private static Collection<Object[]> buildParameters(final List<?>... argOptions) {
+        List<Object[]> result = new LinkedList<>();
+        result.add(new Object[0]);
+
+        for (final List<?> argOption : argOptions) {
+            result = times(result, argOption);
+        }
+
+        return result;
+    }
+
+    private static List<Object[]> times(final List<Object[]> left, final List<?> right) {
+        final List<Object[]> result = new LinkedList<>();
+        for (final Object[] args : left) {
+            for (final Object rightElem : right) {
+                final Object[] resArgs = new Object[args.length + 1];
+                System.arraycopy(args, 0, resArgs, 0, args.length);
+                resArgs[args.length] = rightElem;
+                result.add(resArgs);
+            }
+        }
+        return result;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
@@ -36,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -383,13 +385,95 @@ public abstract class AbstractKeyValueStoreTest {
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionOnRangeNullFromKey() {
-        assertThrows(NullPointerException.class, () -> store.range(null, 2));
+    public void shouldReturnValueOnRangeNullToKey() {
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+
+        final LinkedList<KeyValue<Integer, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>(0, "zero"));
+        expectedContents.add(new KeyValue<>(1, "one"));
+
+        try (final KeyValueIterator<Integer, String> iterator = store.range(null, 1)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionOnRangeNullToKey() {
-        assertThrows(NullPointerException.class, () -> store.range(2, null));
+    public void shouldReturnValueOnRangeKeyToNull() {
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+
+        final LinkedList<KeyValue<Integer, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>(1, "one"));
+        expectedContents.add(new KeyValue<>(2, "two"));
+
+        try (final KeyValueIterator<Integer, String> iterator = store.range(1, null)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnValueOnRangeNullToNull() {
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+
+        final LinkedList<KeyValue<Integer, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>(0, "zero"));
+        expectedContents.add(new KeyValue<>(1, "one"));
+        expectedContents.add(new KeyValue<>(2, "two"));
+
+        try (final KeyValueIterator<Integer, String> iterator = store.range(null, null)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnValueOnReverseRangeNullToKey() {
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+
+        final LinkedList<KeyValue<Integer, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>(1, "one"));
+        expectedContents.add(new KeyValue<>(0, "zero"));
+
+        try (final KeyValueIterator<Integer, String> iterator = store.reverseRange(null, 1)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnValueOnReverseRangeKeyToNull() {
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+
+        final LinkedList<KeyValue<Integer, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>(2, "two"));
+        expectedContents.add(new KeyValue<>(1, "one"));
+
+        try (final KeyValueIterator<Integer, String> iterator = store.reverseRange(1, null)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnValueOnReverseRangeNullToNull() {
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+
+        final LinkedList<KeyValue<Integer, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>(2, "two"));
+        expectedContents.add(new KeyValue<>(1, "one"));
+        expectedContents.add(new KeyValue<>(0, "zero"));
+
+        try (final KeyValueIterator<Integer, String> iterator = store.reverseRange(null, null)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -35,6 +36,7 @@ import org.apache.kafka.test.StateStoreProviderStub;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -104,13 +106,33 @@ public class CompositeReadOnlyKeyValueStoreTest {
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionOnRangeNullFromKey() {
-        assertThrows(NullPointerException.class, () -> theStore.range(null, "to"));
+    public void shouldReturnValueOnRangeNullFromKey() {
+        stubOneUnderlying.put("0", "zero");
+        stubOneUnderlying.put("1", "one");
+        stubOneUnderlying.put("2", "two");
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>("0", "zero"));
+        expectedContents.add(new KeyValue<>("1", "one"));
+
+        try (final KeyValueIterator<String, String> iterator = theStore.range(null, "1")) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionOnRangeNullToKey() {
-        assertThrows(NullPointerException.class, () -> theStore.range("from", null));
+    public void shouldReturnValueOnRangeNullToKey() {
+        stubOneUnderlying.put("0", "zero");
+        stubOneUnderlying.put("1", "one");
+        stubOneUnderlying.put("2", "two");
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>("1", "one"));
+        expectedContents.add(new KeyValue<>("2", "two"));
+
+        try (final KeyValueIterator<String, String> iterator = theStore.range("1", null)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
     }
 
     @Test
@@ -124,13 +146,33 @@ public class CompositeReadOnlyKeyValueStoreTest {
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionOnReverseRangeNullFromKey() {
-        assertThrows(NullPointerException.class, () -> theStore.reverseRange(null, "to"));
+    public void shouldReturnValueOnReverseRangeNullFromKey() {
+        stubOneUnderlying.put("0", "zero");
+        stubOneUnderlying.put("1", "one");
+        stubOneUnderlying.put("2", "two");
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>("1", "one"));
+        expectedContents.add(new KeyValue<>("0", "zero"));
+
+        try (final KeyValueIterator<String, String> iterator = theStore.reverseRange(null, "1")) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionOnReverseRangeNullToKey() {
-        assertThrows(NullPointerException.class, () -> theStore.reverseRange("from", null));
+    public void shouldReturnValueOnReverseRangeNullToKey() {
+        stubOneUnderlying.put("0", "zero");
+        stubOneUnderlying.put("1", "one");
+        stubOneUnderlying.put("2", "two");
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(new KeyValue<>("2", "two"));
+        expectedContents.add(new KeyValue<>("1", "one"));
+
+        try (final KeyValueIterator<String, String> iterator = theStore.reverseRange("1", null)) {
+            assertEquals(expectedContents, Utils.toList(iterator));
+        }
     }
 
     @Test
@@ -482,5 +524,4 @@ public class CompositeReadOnlyKeyValueStoreTest {
             storeName
         );
     }
-
 }


### PR DESCRIPTION
This PR adds support to open endpoint queries in the state store. 

KIP:
https://cwiki.apache.org/confluence/display/KAFKA/KIP-763%3A+Range+queries+with+open+endpoints

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
