### PR TITLE
KAFKA-13137: KRaft Controller Metric MBean names incorrectly quoted

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
@@ -42,4 +42,6 @@ public interface ControllerMetrics {
     void setPreferredReplicaImbalanceCount(int replicaImbalances);
 
     int preferredReplicaImbalanceCount();
+
+    void close();
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
@@ -18,7 +18,7 @@
 package org.apache.kafka.controller;
 
 
-public interface ControllerMetrics {
+public interface ControllerMetrics extends AutoCloseable {
     void setActive(boolean active);
 
     boolean active();

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1354,6 +1354,7 @@ public final class QuorumController implements Controller {
     @Override
     public void close() throws InterruptedException {
         queue.close();
+        controllerMetrics.close();
     }
 
     // VisibleForTesting

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -34,7 +34,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final static MetricName GLOBAL_PARTITION_COUNT = getMetricName(
         "KafkaController", "GlobalPartitionCount");
     private final static MetricName OFFLINE_PARTITION_COUNT = getMetricName(
-        "KafkaController", "OfflinePartitionCount");
+        "KafkaController", "OfflinePartitionsCount");
     private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
         "KafkaController", "PreferredReplicaImbalanceCount");
     

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -22,22 +22,21 @@ import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 
-
 public final class QuorumControllerMetrics implements ControllerMetrics {
-    private final static MetricName ACTIVE_CONTROLLER_COUNT = new MetricName(
-        "kafka.controller", "KafkaController", "ActiveControllerCount", null);
-    private final static MetricName EVENT_QUEUE_TIME_MS = new MetricName(
-        "kafka.controller", "ControllerEventManager", "EventQueueTimeMs", null);
-    private final static MetricName EVENT_QUEUE_PROCESSING_TIME_MS = new MetricName(
-        "kafka.controller", "ControllerEventManager", "EventQueueProcessingTimeMs", null);
-    private final static MetricName GLOBAL_TOPIC_COUNT = new MetricName(
-        "kafka.controller", "KafkaController", "GlobalTopicCount", null);
-    private final static MetricName GLOBAL_PARTITION_COUNT = new MetricName(
-        "kafka.controller", "KafkaController", "GlobalPartitionCount", null);
-    private final static MetricName OFFLINE_PARTITION_COUNT = new MetricName(
-        "kafka.controller", "KafkaController", "OfflinePartitionCount", null);
-    private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = new MetricName(
-        "kafka.controller", "KafkaController", "PreferredReplicaImbalanceCount", null);
+    private final static MetricName ACTIVE_CONTROLLER_COUNT = getMetricName(
+        "kafka.controller", "KafkaController", "ActiveControllerCount");
+    private final static MetricName EVENT_QUEUE_TIME_MS = getMetricName(
+        "kafka.controller", "ControllerEventManager", "EventQueueTimeMs");
+    private final static MetricName EVENT_QUEUE_PROCESSING_TIME_MS = getMetricName(
+        "kafka.controller", "ControllerEventManager", "EventQueueProcessingTimeMs");
+    private final static MetricName GLOBAL_TOPIC_COUNT = getMetricName(
+        "kafka.controller", "KafkaController", "GlobalTopicCount");
+    private final static MetricName GLOBAL_PARTITION_COUNT = getMetricName(
+        "kafka.controller", "KafkaController", "GlobalPartitionCount");
+    private final static MetricName OFFLINE_PARTITION_COUNT = getMetricName(
+        "kafka.controller", "KafkaController", "OfflinePartitionCount");
+    private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
+        "kafka.controller", "KafkaController", "PreferredReplicaImbalanceCount");
     
     private volatile boolean active;
     private volatile int globalTopicCount;
@@ -150,5 +149,11 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     @Override
     public int preferredReplicaImbalanceCount() {
         return this.preferredReplicaImbalanceCount;
+    }
+
+    private static MetricName getMetricName(String group, String type, String name) {
+        final StringBuilder mbeanNameBuilder = new StringBuilder();
+        mbeanNameBuilder.append(group).append(":type=").append(type).append(",name=").append(name);
+        return new MetricName(group, type, name, null, mbeanNameBuilder.toString());
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -24,19 +24,19 @@ import com.yammer.metrics.core.MetricsRegistry;
 
 public final class QuorumControllerMetrics implements ControllerMetrics {
     private final static MetricName ACTIVE_CONTROLLER_COUNT = getMetricName(
-        "kafka.controller", "KafkaController", "ActiveControllerCount");
+        "KafkaController", "ActiveControllerCount");
     private final static MetricName EVENT_QUEUE_TIME_MS = getMetricName(
-        "kafka.controller", "ControllerEventManager", "EventQueueTimeMs");
+        "ControllerEventManager", "EventQueueTimeMs");
     private final static MetricName EVENT_QUEUE_PROCESSING_TIME_MS = getMetricName(
-        "kafka.controller", "ControllerEventManager", "EventQueueProcessingTimeMs");
+        "ControllerEventManager", "EventQueueProcessingTimeMs");
     private final static MetricName GLOBAL_TOPIC_COUNT = getMetricName(
-        "kafka.controller", "KafkaController", "GlobalTopicCount");
+        "KafkaController", "GlobalTopicCount");
     private final static MetricName GLOBAL_PARTITION_COUNT = getMetricName(
-        "kafka.controller", "KafkaController", "GlobalPartitionCount");
+        "KafkaController", "GlobalPartitionCount");
     private final static MetricName OFFLINE_PARTITION_COUNT = getMetricName(
-        "kafka.controller", "KafkaController", "OfflinePartitionCount");
+        "KafkaController", "OfflinePartitionCount");
     private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
-        "kafka.controller", "KafkaController", "PreferredReplicaImbalanceCount");
+        "KafkaController", "PreferredReplicaImbalanceCount");
     
     private volatile boolean active;
     private volatile int globalTopicCount;
@@ -151,7 +151,8 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         return this.preferredReplicaImbalanceCount;
     }
 
-    private static MetricName getMetricName(String group, String type, String name) {
+    private static MetricName getMetricName(String type, String name) {
+        final String group = "kafka.controller";
         final StringBuilder mbeanNameBuilder = new StringBuilder();
         mbeanNameBuilder.append(group).append(":type=").append(type).append(",name=").append(name);
         return new MetricName(group, type, name, null, mbeanNameBuilder.toString());

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -22,6 +22,9 @@ import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public final class QuorumControllerMetrics implements ControllerMetrics {
     private final static MetricName ACTIVE_CONTROLLER_COUNT = getMetricName(
         "KafkaController", "ActiveControllerCount");
@@ -37,7 +40,8 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         "KafkaController", "OfflinePartitionsCount");
     private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
         "KafkaController", "PreferredReplicaImbalanceCount");
-    
+
+    private final MetricsRegistry registry;
     private volatile boolean active;
     private volatile int globalTopicCount;
     private volatile int globalPartitionCount;
@@ -52,6 +56,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final Histogram eventQueueProcessingTime;
 
     public QuorumControllerMetrics(MetricsRegistry registry) {
+        this.registry = Objects.requireNonNull(registry);
         this.active = false;
         this.globalTopicCount = 0;
         this.globalPartitionCount = 0;
@@ -149,6 +154,18 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     @Override
     public int preferredReplicaImbalanceCount() {
         return this.preferredReplicaImbalanceCount;
+    }
+
+    @Override
+    public void close() {
+        Arrays.asList(
+            ACTIVE_CONTROLLER_COUNT,
+            EVENT_QUEUE_TIME_MS,
+            EVENT_QUEUE_PROCESSING_TIME_MS,
+            GLOBAL_TOPIC_COUNT,
+            GLOBAL_PARTITION_COUNT,
+            OFFLINE_PARTITION_COUNT,
+            PREFERRED_REPLICA_IMBALANCE_COUNT).forEach(this.registry::removeMetric);
     }
 
     private static MetricName getMetricName(String type, String name) {

--- a/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
@@ -23,7 +23,7 @@ public final class MockControllerMetrics implements ControllerMetrics {
     private volatile int partitions;
     private volatile int offlinePartitions;
     private volatile int preferredReplicaImbalances;
-
+    private volatile boolean closed = false;
 
     public MockControllerMetrics() {
         this.active = false;
@@ -91,5 +91,14 @@ public final class MockControllerMetrics implements ControllerMetrics {
     @Override
     public int preferredReplicaImbalanceCount() {
         return this.preferredReplicaImbalances;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    public boolean isClosed() {
+        return this.closed;
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -21,10 +21,10 @@ import com.yammer.metrics.core.MetricsRegistry;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuorumControllerMetricsTest {
     @Test
@@ -36,7 +36,7 @@ public class QuorumControllerMetricsTest {
             "GlobalPartitionCount",
             "OfflinePartitionsCount",
             "PreferredReplicaImbalanceCount");
-        assertExpectedMetrics(expectedMetricNames, expectedType);
+        assertExpectedMetricsCreatedAndRemovedUponClose(expectedMetricNames, expectedType);
     }
 
     @Test
@@ -45,26 +45,36 @@ public class QuorumControllerMetricsTest {
         Set<String> expectedMetricNames = Utils.mkSet(
             "EventQueueTimeMs",
             "EventQueueProcessingTimeMs");
-        assertExpectedMetrics(expectedMetricNames, expectedType);
+        assertExpectedMetricsCreatedAndRemovedUponClose(expectedMetricNames, expectedType);
     }
 
-    private static void assertExpectedMetrics(Set<String> expectedMetricNames, String expectedType) {
+    private static void assertExpectedMetricsCreatedAndRemovedUponClose(Set<String> expectedMetricNames, String expectedType) {
         String expectedGroup = "kafka.controller";
         MetricsRegistry registry = new MetricsRegistry();
-        new QuorumControllerMetrics(registry); // populates the registry
-        expectedMetricNames.stream().forEach(expectedMetricName -> assertTrue(
-            registry.allMetrics().keySet().stream().anyMatch(metricName -> {
-                if (metricName.getGroup().equals(expectedGroup) && metricName.getType().equals(expectedType)
-                    && metricName.getScope() == null && metricName.getName().equals(expectedMetricName)) {
-                    // It has to exist AND the MBean name has to be correct;
-                    // fail right here if the MBean name doesn't match
-                    String expectedMBeanPrefix = expectedGroup + ":type=" + expectedType + ",name=";
-                    assertEquals(expectedMBeanPrefix + expectedMetricName, metricName.getMBeanName(),
-                        "Incorrect MBean name");
-                    return true; // the expected metric name exists and the associated MBean name matches
-                } else {
-                    return false; // this one didn't match
-                }
-            }), "Missing metric: " + expectedMetricName));
+        QuorumControllerMetrics quorumControllerMetrics = new QuorumControllerMetrics(registry); // populates the registry
+        Arrays.asList(true, false).forEach(checkMetricsExist -> {
+            if (!checkMetricsExist) {
+                quorumControllerMetrics.close(); // remove all the metrics
+            }
+            expectedMetricNames.stream().forEach(expectedMetricName -> assertEquals(
+                checkMetricsExist,
+                registry.allMetrics().keySet().stream().anyMatch(metricName -> {
+                    if (metricName.getGroup().equals(expectedGroup) && metricName.getType().equals(expectedType)
+                        && metricName.getScope() == null && metricName.getName().equals(expectedMetricName)) {
+                        if (checkMetricsExist) {
+                            // It has to exist AND the MBean name has to be correct;
+                            // fail right here if the MBean name doesn't match
+                            String expectedMBeanPrefix = expectedGroup + ":type=" + expectedType + ",name=";
+                            assertEquals(expectedMBeanPrefix + expectedMetricName, metricName.getMBeanName(),
+                                "Incorrect MBean name");
+                        }
+                        // the metric name exists (and the associated MBean name matches if we were checking for it)
+                        return true;
+                    } else {
+                        return false; // this one didn't match
+                    }
+                }), (checkMetricsExist ? "Missing metric: " : "Metric should not exist after close() invoked: ")
+                    + expectedMetricName));
+        });
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -38,7 +38,7 @@ public class QuorumControllerMetricsTest {
             "ActiveControllerCount",
             "GlobalTopicCount",
             "GlobalPartitionCount",
-            "OfflinePartitionCount",
+            "OfflinePartitionsCount",
             "PreferredReplicaImbalanceCount");
         Set<String> missingMetrics = getMissingMetricNames(expectedMetricNames, expectedGroup, expectedType);
         assertEquals(Collections.emptySet(), missingMetrics, "Expected metrics did not exist");

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -41,7 +41,7 @@ public class QuorumControllerMetricsTest {
             "OfflinePartitionsCount",
             "PreferredReplicaImbalanceCount");
         Set<String> missingMetrics = getMissingMetricNames(expectedMetricNames, expectedGroup, expectedType);
-        assertEquals(Collections.emptySet(), missingMetrics, "Expected metrics did not exist");
+        assertEquals(Collections.emptySet(), missingMetrics, "Expect no missing metrics");
     }
 
     @Test
@@ -52,7 +52,7 @@ public class QuorumControllerMetricsTest {
             "EventQueueTimeMs",
             "EventQueueProcessingTimeMs"));
         Set<String> missingMetrics = getMissingMetricNames(expectedMetricNames, expectedGroup, expectedType);
-        assertEquals(Collections.emptySet(), missingMetrics, "Expected metrics did not exist");
+        assertEquals(Collections.emptySet(), missingMetrics, "Expect no missing metrics");
     }
 
     private static Set<String> getMissingMetricNames(

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.controller;
 
 import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -33,12 +34,12 @@ public class QuorumControllerMetricsTest {
     public void testKafkaControllerMetricNames() {
         String expectedGroup = "kafka.controller";
         String expectedType = "KafkaController";
-        Set<String> expectedMetricNames = new HashSet<>(Arrays.asList(
+        Set<String> expectedMetricNames = Utils.mkSet(
             "ActiveControllerCount",
             "GlobalTopicCount",
             "GlobalPartitionCount",
             "OfflinePartitionCount",
-            "PreferredReplicaImbalanceCount"));
+            "PreferredReplicaImbalanceCount");
         Set<String> missingMetrics = getMissingMetricNames(expectedMetricNames, expectedGroup, expectedType);
         assertEquals(Collections.emptySet(), missingMetrics, "Expected metrics did not exist");
     }
@@ -71,12 +72,8 @@ public class QuorumControllerMetricsTest {
                     return false; // this one didn't match
                 }
             })).collect(Collectors.toSet());
-        if (foundMetricNames.size() == expectedMetricNames.size()) {
-            return Collections.emptySet(); // nothing missing
-        } else {
-            Set<String> missingMetricNames = new HashSet<>(expectedMetricNames);
-            missingMetricNames.removeAll(foundMetricNames);
-            return missingMetricNames;
-        }
+        Set<String> missingMetricNames = new HashSet<>(expectedMetricNames);
+        missingMetricNames.removeAll(foundMetricNames);
+        return missingMetricNames;
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import com.yammer.metrics.core.MetricsRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuorumControllerMetricsTest {
+    @Test
+    public void testKafkaControllerMetricNames() {
+        String expectedGroup = "kafka.controller";
+        String expectedType = "KafkaController";
+        Set<String> expectedMetricNames = new HashSet<>(Arrays.asList(
+            "ActiveControllerCount",
+            "GlobalTopicCount",
+            "GlobalPartitionCount",
+            "OfflinePartitionCount",
+            "PreferredReplicaImbalanceCount"));
+        Set<String> missingMetrics = getMissingMetricNames(expectedMetricNames, expectedGroup, expectedType);
+        assertEquals(Collections.emptySet(), missingMetrics, "Expected metrics did not exist");
+    }
+
+    @Test
+    public void testControllerEventManagerMetricNames() {
+        String expectedGroup = "kafka.controller";
+        String expectedType = "ControllerEventManager";
+        Set<String> expectedMetricNames = new HashSet<>(Arrays.asList(
+            "EventQueueTimeMs",
+            "EventQueueProcessingTimeMs"));
+        Set<String> missingMetrics = getMissingMetricNames(expectedMetricNames, expectedGroup, expectedType);
+        assertEquals(Collections.emptySet(), missingMetrics, "Expected metrics did not exist");
+    }
+
+    private static Set<String> getMissingMetricNames(
+        Set<String> expectedMetricNames, String expectedGroup, String expectedType) {
+        MetricsRegistry registry = new MetricsRegistry();
+        new QuorumControllerMetrics(registry); // populates the registry
+        Set<String> foundMetricNames = expectedMetricNames.stream().filter(expectedMetricName ->
+            registry.allMetrics().keySet().stream().anyMatch(metricName -> {
+                if (metricName.getGroup().equals(expectedGroup) && metricName.getType().equals(expectedType)
+                    && metricName.getScope() == null && metricName.getName().equals(expectedMetricName)) {
+                    // It has to exist AND the MBean name has to be correct;
+                    // fail right here if the MBean name doesn't match
+                    String expectedMBeanPrefix = expectedGroup + ":type=" + expectedType + ",name=";
+                    assertEquals(expectedMBeanPrefix + expectedMetricName, metricName.getMBeanName());
+                    return true; // the expected metric name exists and the associated MBean name matches
+                } else {
+                    return false; // this one didn't match
+                }
+            })).collect(Collectors.toSet());
+        if (foundMetricNames.size() == expectedMetricNames.size()) {
+            return Collections.emptySet(); // nothing missing
+        } else {
+            Set<String> missingMetricNames = new HashSet<>(expectedMetricNames);
+            missingMetricNames.removeAll(foundMetricNames);
+            return missingMetricNames;
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -97,11 +97,13 @@ public class QuorumControllerTest {
      */
     @Test
     public void testCreateAndClose() throws Throwable {
+        MockControllerMetrics metrics = new MockControllerMetrics();
         try (LocalLogManagerTestEnv logEnv = new LocalLogManagerTestEnv(1, Optional.empty())) {
             try (QuorumControllerTestEnv controlEnv =
-                     new QuorumControllerTestEnv(logEnv, __ -> { })) {
+                     new QuorumControllerTestEnv(logEnv, builder -> builder.setMetrics(metrics))) {
             }
         }
+        assertTrue(metrics.isClosed(), "metrics were not closed");
     }
 
     /**


### PR DESCRIPTION
Controller metric names that are in common between the ZooKeeper-based and KRaft-based controller must remain the same, but they were not in the AK 2.8 early access release of KRaft. For example, the non-KRaft MBean name `kafka.controller:type=KafkaController,name=OfflinePartitionsCount` incorrectly became `"kafka.controller":type="KafkaController",name="OfflinePartitionCount"` (note the added quotes and the lack of plural).  This patch fixes the issues, closes the test gap that allowed the divergence to occur, and adds deregistration logic to remove the metrics when the controller is closed (this logic was missing).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
