### PR TITLE
KAFKA-13139: Empty response after requesting to restart a connector without the tasks results in NPE

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -269,7 +269,7 @@ public class ConnectorsResource {
             FutureCallback<Void> cb = new FutureCallback<>();
             herder.restartConnector(connector, cb);
             completeOrForwardRequest(cb, forwardingPath, "POST", headers, null, forward);
-            return Response.ok().build();
+            return Response.noContent().build();
         }
 
         // In all other cases, submit the async restart request and return connector state

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -803,7 +803,8 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null);
+        Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null);
+        assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         PowerMock.verifyAll();
     }
@@ -874,7 +875,9 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null);
+        Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        PowerMock.verifyAll();
 
         PowerMock.verifyAll();
     }
@@ -892,7 +895,9 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true);
+        Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        PowerMock.verifyAll();
 
         PowerMock.verifyAll();
     }


### PR DESCRIPTION
Currently tested via the system test `connect_distributed_test.py::ConnectDistributedTest.test_restart_failed_connector`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
