### PR TITLE
KAFKA-12851: Fix Raft partition simulation

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -171,6 +171,12 @@ public class LeaderState<T> implements EpochState {
                         || (highWatermarkUpdateOffset == currentHighWatermarkMetadata.offset &&
                             !highWatermarkUpdateMetadata.metadata.equals(currentHighWatermarkMetadata.metadata))) {
                         highWatermark = highWatermarkUpdateOpt;
+                        log.debug(
+                            "High watermark updated to {} based on indexOfHw {} and voters {}",
+                            highWatermark,
+                            indexOfHw,
+                            followersByDescendingFetchOffset
+                        );
                         return true;
                     } else if (highWatermarkUpdateOffset < currentHighWatermarkMetadata.offset) {
                         log.error("The latest computed high watermark {} is smaller than the current " +
@@ -183,6 +189,12 @@ public class LeaderState<T> implements EpochState {
                     }
                 } else {
                     highWatermark = highWatermarkUpdateOpt;
+                    log.debug(
+                        "High watermark set to {} based on indexOfHw {} and voters {}",
+                        highWatermark,
+                        indexOfHw,
+                        followersByDescendingFetchOffset
+                    );
                     return true;
                 }
             }

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -171,7 +171,7 @@ public class LeaderState<T> implements EpochState {
                         || (highWatermarkUpdateOffset == currentHighWatermarkMetadata.offset &&
                             !highWatermarkUpdateMetadata.metadata.equals(currentHighWatermarkMetadata.metadata))) {
                         highWatermark = highWatermarkUpdateOpt;
-                        log.debug(
+                        log.trace(
                             "High watermark updated to {} based on indexOfHw {} and voters {}",
                             highWatermark,
                             indexOfHw,
@@ -189,7 +189,7 @@ public class LeaderState<T> implements EpochState {
                     }
                 } else {
                     highWatermark = highWatermarkUpdateOpt;
-                    log.debug(
+                    log.trace(
                         "High watermark set to {} based on indexOfHw {} and voters {}",
                         highWatermark,
                         indexOfHw,


### PR DESCRIPTION
Instead of waiting for a high-watermark of 20 after the partition, the
test should wait for the high-watermark to reach an offset greater than
the largest log end offset at the time of the partition. Only that offset
is guarantee to be reached as the high-watermark by the new majority.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
