### PR TITLE
KAFKA-13143 Remove HandleMetadata from ControllerAPis as metadata is not completely implemented on KRaft controllers

### DIFF
--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 3,
   "type": "request",
-  "listeners": ["zkBroker", "broker", "controller"],
+  "listeners": ["zkBroker", "broker"],
   "name": "MetadataRequest",
   "validVersions": "0-11",
   "flexibleVersions": "9+",


### PR DESCRIPTION
This PR removes the `METADATA` API from the Kraft controller as the controller does not yet implement the metadata fetch functionality completely.

Without the change (as per the JIRA https://issues.apache.org/jira/browse/KAFKA-13143), the API would return an empty list of topics making the caller incorrectly think that there were no topics in the cluster which could be confusing. After this change the describe and list topic APIs timeout on the controller endpoint when using the `kafka-topics` CLI (which is the same behavior as create_topic).

Post 3.0 we want to follow up and align the controller's APIs with the bigger picture on how we want users to interact with it. The JIRA https://issues.apache.org/jira/browse/KAFKA-13146 describes the follow up needed. 

