### PR TITLE
KAFKA-13151: Disallow policy configs in KRaft

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -2008,5 +2008,10 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
     require(principalBuilderClass != null, s"${KafkaConfig.PrincipalBuilderClassProp} must be non-null")
     require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass), 
       s"${KafkaConfig.PrincipalBuilderClassProp} must implement KafkaPrincipalSerde")
+
+    if (usesSelfManagedQuorum) {
+      require(getClass(KafkaConfig.AlterConfigPolicyClassNameProp) == null, "alter.config.policy.class.name is not supported in KRaft, please disable.")
+      require(getClass(KafkaConfig.CreateTopicPolicyClassNameProp) == null, "create.topic.policy.class.name is not supported in KRaft, please disable.")
+    }
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -2010,8 +2010,8 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
       s"${KafkaConfig.PrincipalBuilderClassProp} must implement KafkaPrincipalSerde")
 
     if (usesSelfManagedQuorum) {
-      require(getClass(KafkaConfig.AlterConfigPolicyClassNameProp) == null, "alter.config.policy.class.name is not supported in KRaft, please disable.")
-      require(getClass(KafkaConfig.CreateTopicPolicyClassNameProp) == null, "create.topic.policy.class.name is not supported in KRaft, please disable.")
+      require(getClass(KafkaConfig.AlterConfigPolicyClassNameProp) == null, s"${KafkaConfig.AlterConfigPolicyClassNameProp} is not supported in KRaft, please disable.")
+      require(getClass(KafkaConfig.CreateTopicPolicyClassNameProp) == null, s"${KafkaConfig.CreateTopicPolicyClassNameProp} is not supported in KRaft, please disable.")
     }
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -2010,8 +2010,8 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
       s"${KafkaConfig.PrincipalBuilderClassProp} must implement KafkaPrincipalSerde")
 
     if (usesSelfManagedQuorum) {
-      require(getClass(KafkaConfig.AlterConfigPolicyClassNameProp) == null, s"${KafkaConfig.AlterConfigPolicyClassNameProp} is not supported in KRaft, please disable.")
-      require(getClass(KafkaConfig.CreateTopicPolicyClassNameProp) == null, s"${KafkaConfig.CreateTopicPolicyClassNameProp} is not supported in KRaft, please disable.")
+      require(getClass(KafkaConfig.AlterConfigPolicyClassNameProp) == null, s"${KafkaConfig.AlterConfigPolicyClassNameProp} is not supported in KRaft.")
+      require(getClass(KafkaConfig.CreateTopicPolicyClassNameProp) == null, s"${KafkaConfig.CreateTopicPolicyClassNameProp} is not supported in KRaft.")
     }
   }
 }


### PR DESCRIPTION
alter.config.policy.class.name and create.topic.policy.class.name are unsupported by KRaft. KRaft servers should fail startup if any of these are configured.

Tested this manually by enabling/disabling the configs statically in a KRaft cluster.

https://issues.apache.org/jira/browse/KAFKA-13151
