### PR TITLE
MINOR: allow for reties of other InvalidStateStoreExceptions

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -152,11 +152,7 @@ public class StoreQueryIntegrationTest {
                 }
                 return true;
             } catch (final InvalidStateStoreException exception) {
-                assertThat(
-                    exception.getMessage(),
-                    containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING")
-                );
-                LOG.info("Streams wasn't running. Will try again.");
+                LOG.info("Streams wasn't running. Will try again.", exception);
                 return false;
             }
         });
@@ -243,11 +239,7 @@ public class StoreQueryIntegrationTest {
                 }
                 return true;
             } catch (final InvalidStateStoreException exception) {
-                assertThat(
-                    exception.getMessage(),
-                    containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING")
-                );
-                LOG.info("Streams wasn't running. Will try again.");
+                LOG.info("Streams wasn't running. Will try again.", exception);
                 return false;
             }
         });


### PR DESCRIPTION
Sometimes the test would hit a different InvalidStateStoreExcpetion but if retied it would still work. I think we can remove the check and log the exception. If the test recovers then it is fine. But if it times-out the exception will be in the logs. 

The other exception is:

java.lang.AssertionError: org.apache.kafka.streams.errors.InvalidStateStoreException: The state store, source-table, may have migrated to another instance.

I ran the test 300 times failing on any exception but checking if it would timeout or have recovered. 13 times it hit an exception 10 of the one check for 3 of the one failed. It never timed-out and in all cases recovered after a retry. 

I then ran the test 3117 times and it did not fail once where it would have failed about 1:100 times previously.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
