### PR TITLE
MINOR: Fix flaky shouldCreateTopicWhenTopicLeaderNotAvailableAndThenTopicNotFound

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -113,7 +113,7 @@ public class InternalTopicManagerTest {
             put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 1);
             put(StreamsConfig.producerPrefix(ProducerConfig.BATCH_SIZE_CONFIG), 16384);
             put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), 100);
-            put(StreamsConfig.RETRY_BACKOFF_MS_CONFIG, 50);
+            put(StreamsConfig.RETRY_BACKOFF_MS_CONFIG, 10);
         }
     };
 
@@ -822,9 +822,7 @@ public class InternalTopicManagerTest {
             .andReturn(new MockDescribeTopicsResult(
                 Collections.singletonMap(topic1, topicDescriptionLeaderNotAvailableFuture)))
             .once();
-        // return empty set for 1st time
-        EasyMock.expect(admin.createTopics(Collections.emptySet()))
-            .andReturn(new MockCreateTopicsResult(Collections.emptyMap())).once();
+        // we would not need to call create-topics for the first time
         EasyMock.expect(admin.describeTopics(Collections.singleton(topic1)))
             .andReturn(new MockDescribeTopicsResult(
                 Collections.singletonMap(topic1, topicDescriptionUnknownTopicFuture)))
@@ -868,8 +866,6 @@ public class InternalTopicManagerTest {
             .andReturn(new MockDescribeTopicsResult(
                 Collections.singletonMap(topic1, topicDescriptionFailFuture)))
             .once();
-        EasyMock.expect(admin.createTopics(Collections.emptySet()))
-            .andReturn(new MockCreateTopicsResult(Collections.emptyMap())).once();
         EasyMock.expect(admin.describeTopics(Collections.singleton(topic1)))
             .andReturn(new MockDescribeTopicsResult(
                 Collections.singletonMap(topic1, topicDescriptionSuccessFuture)))
@@ -901,8 +897,6 @@ public class InternalTopicManagerTest {
             .andReturn(new MockDescribeTopicsResult(
                 Collections.singletonMap(topic1, topicDescriptionFailFuture)))
             .anyTimes();
-        EasyMock.expect(admin.createTopics(Collections.emptySet()))
-            .andReturn(new MockCreateTopicsResult(Collections.emptyMap())).anyTimes();
 
         EasyMock.replay(admin);
 


### PR DESCRIPTION
1. This test is taking two iterations since the firs iteration is designed to fail due to unknow topic leader. However both the timeout and the backoff are set to 50ms, while the actual SYSTEM time is used. This means we are likely to timeout before executing the second iteration. I thought about using a mock time but dropped that idea as it may forgo the purpose of this test, instead I set the backoff time to 10ms so that we are almost unlikely to hit this error anymore.

2. Found a minor issue while fixing this which is that when we have non-empty not-ready topics, but the topics-to-create is empty (which is possible as the test shouldCreateTopicWhenTopicLeaderNotAvailableAndThenTopicNotFound itself illustrates), we still call an empty create-topic function. Though it does not incur any round-trip it would still waste some cycles, so I branched it off and hence also simplified some unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
