### PR TITLE
KAFKA-13046: add test coverage for AbstractStickyAssignorTest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -142,12 +142,11 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                 for (final TopicPartition tp : memberData.partitions) {
                     // filter out any topics that no longer exist or aren't part of the current subscription
                     if (allTopics.contains(tp.topic())) {
-
-                        if (!allPreviousPartitionsToOwner.containsKey(tp)) {
-                            allPreviousPartitionsToOwner.put(tp, consumer);
+                        String otherConsumer = allPreviousPartitionsToOwner.put(tp, consumer);
+                        if (otherConsumer == null) {
+                            // this partition is not owned by other consumer in the same generation
                             ownedPartitions.add(tp);
                         } else {
-                            String otherConsumer = allPreviousPartitionsToOwner.get(tp);
                             log.error("Found multiple consumers {} and {} claiming the same TopicPartition {} in the "
                                 + "same generation {}, this will be invalidated and removed from their previous assignment.",
                                      consumer, otherConsumer, tp, maxGeneration);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -34,11 +34,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import static java.util.Collections.emptyList;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractStickyAssignorTest {
@@ -79,6 +81,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(assignment.get(consumerId).isEmpty());
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -94,6 +97,7 @@ public abstract class AbstractStickyAssignorTest {
 
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(assignment.get(consumerId).isEmpty());
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -107,6 +111,7 @@ public abstract class AbstractStickyAssignorTest {
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -127,6 +132,7 @@ public abstract class AbstractStickyAssignorTest {
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumerId));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -141,6 +147,7 @@ public abstract class AbstractStickyAssignorTest {
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerId));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -155,6 +162,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer2, new Subscription(topics(topic)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -171,6 +179,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 1)), assignment.get(consumer2));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -190,6 +199,7 @@ public abstract class AbstractStickyAssignorTest {
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic1, 1)), assignment.get(consumer3));
+        assertNull(assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -207,6 +217,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -231,6 +242,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 1), tp(topic2, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 2)), assignment.get(consumer2));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -254,6 +266,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer3, buildSubscription(subscribedTopics, Collections.emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(Collections.singletonMap(tp(topic2, 0), consumer3), assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertEquals(partitions(tp(topic1, 0)), assignment.get(consumer1));
@@ -281,6 +294,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer3, buildSubscription(subscribedTopics, Collections.emptyList()));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 1)), assignment.get(consumer1));
@@ -305,6 +319,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer1, buildSubscription(topics(topic), assignment.get(consumer1)));
         subscriptions.put(consumer2, buildSubscription(topics(topic), Collections.emptyList()));
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(Collections.singletonMap(tp(topic, 2), consumer2), assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumer1));
@@ -316,6 +331,7 @@ public abstract class AbstractStickyAssignorTest {
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 2), tp(topic, 1), tp(topic, 0))),
             new HashSet<>(assignment.get(consumer2)));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -334,6 +350,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1), tp(topic2, 3)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -344,6 +361,12 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer3, buildSubscription(allTopics, Collections.emptyList()));
         subscriptions.put(consumer4, buildSubscription(allTopics, Collections.emptyList()));
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+
+        Map<TopicPartition, String> expectedPartitionsTransferringOwnership = new HashMap<>();
+        expectedPartitionsTransferringOwnership.put(tp(topic2, 1), consumer3);
+        expectedPartitionsTransferringOwnership.put(tp(topic2, 3), consumer3);
+        expectedPartitionsTransferringOwnership.put(tp(topic2, 2), consumer4);
+        assertEquals(expectedPartitionsTransferringOwnership, assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2)), assignment.get(consumer1));
@@ -360,6 +383,8 @@ public abstract class AbstractStickyAssignorTest {
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic2, 1), tp(topic2, 3), tp(topic1, 0), tp(topic2, 0)), assignment.get(consumer3));
         assertEquals(partitions(tp(topic2, 2), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer4));
+
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -411,6 +436,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer2, new Subscription(topics(topic)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         assertTrue(isFullyBalanced(assignment));
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -425,6 +451,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer2, buildSubscription(topics(topic, topic2), assignment.get(consumer2)));
 
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -440,6 +467,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer2, buildSubscription(topics(topic2), assignment.get(consumer2)));
 
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -491,12 +519,14 @@ public abstract class AbstractStickyAssignorTest {
                 new Subscription(topics("topic")));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         // add a new consumer
         subscriptions.put(getConsumerName(10, 10), new Subscription(topics("topic")));
 
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
@@ -514,6 +544,7 @@ public abstract class AbstractStickyAssignorTest {
         }
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < 9; i++) {
@@ -524,6 +555,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.remove(getConsumerName(5, 9));
 
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
@@ -673,6 +705,7 @@ public abstract class AbstractStickyAssignorTest {
                 partitions(tp(topic4, 0), tp(topic5, 0), tp(topic6, 0))));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertNull(assignor.partitionsTransferringOwnership);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
@@ -687,6 +720,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions.put(consumer4, new Subscription(topics(topic1)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         Map<String, TopicPartition> partitionsAssigned = new HashMap<>();
 
@@ -711,6 +745,7 @@ public abstract class AbstractStickyAssignorTest {
 
 
         assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         assignments = assignment.entrySet();
@@ -731,6 +766,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2, topic3)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         assertEquals(assignment.values().stream().mapToInt(List::size).sum(), 1 + 100);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(isFullyBalanced(assignment));
@@ -742,9 +778,11 @@ public abstract class AbstractStickyAssignorTest {
         partitionsPerTopic.put(topic, 3);
         subscriptions.put(consumerId, new Subscription(topics(topic)));
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         subscriptions.put(consumerId, buildSubscription(topics(topic), assignment.get(consumerId)));
 
         assignment = assignor.assign(Collections.emptyMap(), subscriptions);
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         assertEquals(assignment.size(), 1);
         assertTrue(assignment.get(consumerId).isEmpty());
     }
@@ -805,6 +843,7 @@ public abstract class AbstractStickyAssignorTest {
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 3)), assignment.get(consumer3));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -824,6 +863,7 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1))), new HashSet<>(assignment.get(consumer1)));
         assertEquals(new HashSet<>(partitions(tp(topic, 1), tp(topic2, 0), tp(topic2, 2))), new HashSet<>(assignment.get(consumer2)));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
@@ -843,8 +883,30 @@ public abstract class AbstractStickyAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1))), new HashSet<>(assignment.get(consumer1)));
         assertEquals(new HashSet<>(partitions(tp(topic, 1), tp(topic2, 0), tp(topic2, 2))), new HashSet<>(assignment.get(consumer2)));
+        assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
+        assertTrue(isFullyBalanced(assignment));
+    }
+
+    @Test
+    public void testPartitionsTransferringOwnershipIncludeThePartitionClaimedByMultipleConsumersInSameGeneration() {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 3);
+
+        // partition topic-0 is owned by multiple consumer
+        subscriptions.put(consumer1, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 1))));
+        subscriptions.put(consumer2, buildSubscription(topics(topic), partitions(tp(topic, 0), tp(topic, 2))));
+        subscriptions.put(consumer3, buildSubscription(topics(topic), emptyList()));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        // we should include the partitions claimed by multiple consumers in partitionsTransferringOwnership
+        assertEquals(Collections.singletonMap(tp(topic, 0), consumer3), assignor.partitionsTransferringOwnership);
+
+        verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
+        assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
+        assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
         assertTrue(isFullyBalanced(assignment));
     }
 


### PR DESCRIPTION
1. Add tests for `partitionsTransferringOwnership`
  a. it should include revoked partitions and partitions claimed by multiple consumers. 
  b. for non-equal assignment case (general case), it should be null so that the cooperative assignor knows to compute it from scratch
  
2. small optimization for `allPreviousPartitionsToOwner` check.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
