### PR TITLE
KAFKA-13153: Disallow KRaft broker registration if the node.id is already in use by a controller

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
@@ -57,6 +57,10 @@ public class BrokerRegistrationRequest extends AbstractRequest {
         return data;
     }
 
+    public int brokerId() {
+        return data.brokerId();
+    }
+
     @Override
     public BrokerRegistrationResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         Errors error = Errors.forException(e);

--- a/config/kraft/broker.properties
+++ b/config/kraft/broker.properties
@@ -24,7 +24,7 @@
 process.roles=broker
 
 # The node id associated with this instance's roles
-node.id=1
+node.id=2
 
 # The connect string for the controller quorum
 controller.quorum.voters=1@localhost:9093

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -357,6 +357,10 @@ class BrokerToControllerRequestThread(
       }}
 
       requestQueue.putFirst(queueItem)
+    } else if (response.responseBody.errorCounts.containsKey(Errors.DUPLICATE_BROKER_REGISTRATION)) {
+      error(s"Request ${queueItem.request} failed because a controller with this node.id is already in use.",
+        response.authenticationException)
+      queueItem.callback.onComplete(response)
     } else {
       queueItem.callback.onComplete(response)
     }


### PR DESCRIPTION
Kraft brokers were previously able to register with the same `node.id` as a controller without failing startup but they would not unfence themselves because they never catch up to the last committed metadata offset. This PR explicitly disallows controllers and brokers from sharing `node.id`s and it also changes the `node.id` in the default config file for the Kraft broker from `node.id=1` to `node.id=2`.

https://issues.apache.org/jira/browse/KAFKA-13153