### PR TITLE
KAFKA-13160: Fix BrokerMetadataPublisher to pass the correct resource name to the config handler when processing config updates

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -228,7 +228,8 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
       else
         DefaultReplicationThrottledRate
     }
-    if (brokerId == ConfigEntityName.Default)
+    // In KRaft empty string can respresent the default resource configs instead of the znode "<default>".
+    if ((brokerId == ConfigEntityName.Default && brokerConfig.requiresZookeeper) || (brokerId.isEmpty && brokerConfig.usesSelfManagedQuorum))
       brokerConfig.dynamicConfig.updateDefaultConfig(properties)
     else if (brokerConfig.brokerId == brokerId.trim.toInt) {
       brokerConfig.dynamicConfig.updateBrokerConfig(brokerConfig.brokerId, properties)

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -228,8 +228,7 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
       else
         DefaultReplicationThrottledRate
     }
-    // In KRaft empty string can respresent the default resource configs instead of the znode "<default>".
-    if ((brokerId == ConfigEntityName.Default && brokerConfig.requiresZookeeper) || (brokerId.isEmpty && brokerConfig.usesSelfManagedQuorum))
+    if (brokerId == ConfigEntityName.Default)
       brokerConfig.dynamicConfig.updateDefaultConfig(properties)
     else if (brokerConfig.brokerId == brokerId.trim.toInt) {
       brokerConfig.dynamicConfig.updateBrokerConfig(brokerConfig.brokerId, properties)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -203,13 +203,9 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
           }
           tag.foreach { t =>
             val newProperties = newImage.configs().configProperties(configResource)
-            val maybeDefaultName = if (conf.usesSelfManagedQuorum) {
-              configResource.name() match {
-                case "" => ConfigEntityName.Default 
-                case k => k
-              }
-            } else {
-              configResource.name()
+            val maybeDefaultName = configResource.name() match {
+              case "" => ConfigEntityName.Default 
+              case k => k
             }
             dynamicConfigHandlers(t).processConfigChanges(maybeDefaultName, newProperties)
           }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -21,7 +21,7 @@ import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.{Log, LogManager}
 import kafka.server.ConfigType
-import kafka.server.{ConfigHandler, FinalizedFeatureCache, KafkaConfig, ReplicaManager, RequestLocal}
+import kafka.server.{ConfigEntityName, ConfigHandler, FinalizedFeatureCache, KafkaConfig, ReplicaManager, RequestLocal}
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.ConfigResource
@@ -203,7 +203,15 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
           }
           tag.foreach { t =>
             val newProperties = newImage.configs().configProperties(configResource)
-            dynamicConfigHandlers(t).processConfigChanges(configResource.name(), newProperties)
+            val maybeDefaultName = if (conf.usesSelfManagedQuorum) {
+              configResource.name() match {
+                case "" => ConfigEntityName.Default 
+                case k => k
+              }
+            } else {
+              configResource.name()
+            }
+            dynamicConfigHandlers(t).processConfigChanges(maybeDefaultName, newProperties)
           }
         }
       }


### PR DESCRIPTION
The KRaft brokers are throwing NumberFormatException when processing dynamic default broker config updates because they expect the default entity name that was used in zookeeper to be the resource name for dynamic default broker configs instead of empty string. 

https://issues.apache.org/jira/browse/KAFKA-13160