### PR TITLE
KAFKA-10859: Add test annotation to FileStreamSourceTaskTest.testInvalidFile and speed up the test

### DIFF
--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -220,12 +220,12 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
         task.stop();
     }
 
+    @Test
     public void testInvalidFile() throws InterruptedException {
+        replay();
         config.put(FileStreamSourceConnector.FILE_CONFIG, "bogusfilename");
         task.start(config);
-        // Currently the task retries indefinitely if the file isn't found, but shouldn't return any data.
-        for (int i = 0; i < 100; i++)
-            assertNull(task.poll());
+        assertNull(task.poll());
     }
 
 


### PR DESCRIPTION
*More detailed description of your change,
Added the missing @Test annotation to a test in FileStreamSourceTaskTest. The test used to loop 100 times, each time blocking for 1 second. Checking the assertion more than once is unnecessary for this test.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
