### PR TITLE
KAFKA-13132: Upgrading to topic IDs in LISR requests has gaps introduced in 3.0 (part 2)

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -553,6 +553,14 @@ class Log(@volatile var logStartOffset: Long,
 
   /** Only used for ZK clusters when we update and start using topic IDs on existing topics */
   def assignTopicId(topicId: Uuid): Unit = {
+    // defensively check that any newly assign topic ID matches any that is already set
+    _topicId.foreach { current =>
+      if (!current.equals(topicId))
+      // we should never get here as the topic IDs should have been checked in becomeLeaderOrFollower
+        throw new InconsistentTopicIdException(s"Tried to assign topic ID $topicId to log for topic partition $topicPartition," +
+          s"but log already contained topic ID $current")
+    }
+
     if (keepPartitionMetadataFile) {
       _topicId = Some(topicId)
       if (!partitionMetadataFile.exists()) {

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -555,10 +555,13 @@ class Log(@volatile var logStartOffset: Long,
   def assignTopicId(topicId: Uuid): Unit = {
     // defensively check that any newly assign topic ID matches any that is already set
     _topicId.foreach { current =>
-      if (!current.equals(topicId))
-      // we should never get here as the topic IDs should have been checked in becomeLeaderOrFollower
+      if (!current.equals(topicId)) {
+        // we should never get here as the topic IDs should have been checked in becomeLeaderOrFollower
         throw new InconsistentTopicIdException(s"Tried to assign topic ID $topicId to log for topic partition $topicPartition," +
           s"but log already contained topic ID $current")
+      }
+      // Topic ID already assigned so we can return
+      return
     }
 
     if (keepPartitionMetadataFile) {


### PR DESCRIPTION
Most of [KAFKA-13132](https://issues.apache.org/jira/browse/KAFKA-13132) has been resolved, but there is one part of one case not covered.
From the ticket:
`2. We only assign the topic ID when we are associating the log with the partition in replicamanager for the first time`

We covered the case where the log is already existing when the leader epoch is _equal_ (ie, no updates besides the topic ID), but we don't cover the update case where the leader epoch is bumped and we already have the log associated to the partition. 

This PR ensures we correctly assign topic ID in the makeLeaders/Followers path when the log already exists.
I've also added a test for the bumped leader epoch scenario.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
