### PR TITLE
KAFKA-13167; KRaft broker should send heartbeat immediately after starting controlled shutdown

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -206,6 +206,10 @@ class BrokerLifecycleManager(val config: KafkaConfig,
         case BrokerState.RUNNING =>
           info("Beginning controlled shutdown.")
           _state = BrokerState.PENDING_CONTROLLED_SHUTDOWN
+          // Send the next heartbeat immediately in order to let the controller
+          // begin processing the controlled shutdown as soon as possible.
+          scheduleNextCommunication(0)
+
         case _ =>
           info(s"Skipping controlled shutdown because we are in state ${_state}.")
           beginShutdown()


### PR DESCRIPTION
Controlled shutdown in KRaft is signaled through a heartbeat request with the `shouldShutDown` flag set to true. When we begin controlled shutdown, we should immediately schedule the next heartbeat instead of waiting for the next periodic heartbeat. This allows the broker to shutdown more quickly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
