### PR TITLE
MINOR: Fix testResolveDnsLookupResolveCanonicalBootstrapServers

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -114,7 +114,7 @@ public class ClientUtilsTest {
 
     @Test
     public void testResolveDnsLookupResolveCanonicalBootstrapServers() throws UnknownHostException {
-        assertEquals(2, resolveToTwoIps(ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY).size());
+        assertEquals(1, resolveToTwoIps(ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY).size());
     }
 
     private List<InetAddress> resolveToTwoIps(ClientDnsLookup dnsLookup) throws UnknownHostException {


### PR DESCRIPTION
testResolveDnsLookupResolveCanonicalBootstrapServers added in https://github.com/apache/kafka/pull/11091 treats the result from ClientUtils.resolve() when using specifying RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY as if it should differ from when specifying DEFAULT, yet the branching in resolve() is on ClientDnsLookup.USE_ALL_DNS_IPS == clientDnsLookup -- everything else gets the result squashed to a singletonList.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
