### PR TITLE
MINOR: optimize the OrderedBytes#upperRange for not all query cases

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
@@ -128,7 +128,7 @@ public class WindowKeySchemaTest {
         final Bytes upper = windowKeySchema.upperRange(Bytes.wrap(new byte[] {0xC, 0xC, 0x9}), 0x0AffffffffffffffL);
 
         assertThat(
-            "shorter key with max timestamp should be in range",
+            "shorter key with customized timestamp should be in range",
             upper.compareTo(
                 WindowKeySchema.toStoreKeyBinary(
                     new byte[] {0xC, 0xC},


### PR DESCRIPTION
Currently in `OrderedBytes#upperRange` method, we'll check key bytes 1 by 1, to see if there's a byte value >= first timestamp byte value, so that we can skip the following key bytes, because we know `compareTo` will always return 0 or 1. 

Take this test for example (in `WindowKeySchemaTest`)
```java
public void testUpperBoundWithKeyBytesLargerAndSmallerThanFirstTimestampByte() {
        // here, because the 3rd byte of the key (0x9) < the first timestamp byte (0xA), we'll skip this type, and appending the timestamp directly
        final Bytes upper = windowKeySchema.upperRange(Bytes.wrap(new byte[] {0xC, 0xC, 0x9}), 0x0AffffffffffffffL);

        // so the tested shorter key should be included in the upper range
        assertThat(
            "shorter key with timestamp should be in range",
            upper.compareTo(
                WindowKeySchema.toStoreKeyBinary(
                    new byte[] {0xC, 0xC},
                    0x0AffffffffffffffL,
                    Integer.MAX_VALUE
                )
            ) >= 0
        );

        assertThat(upper, equalTo(WindowKeySchema.toStoreKeyBinary(new byte[] {0xC, 0xC}, 0x0AffffffffffffffL, Integer.MAX_VALUE)));
    }
```

Furthermore, since we don't know how many bytes are skipped, we did a byteBuffer copy to another byte array in the end.

However, in not all query cases, the first timestamp byte is alwyas **0**, because when we use the current timestamp (i.e. `System.currentTimeMillis()`), the first timestamp byte is `0`.

This PR optimizes the not all query cases  by not checking the key byte 1 by 1 (because we know the unsigned integer will always be >= 0), instead, put all bytes and timestamp directly. So, we won't have byte array copy in the end either.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
