### PR TITLE
MINOR: Increase the Kafka shutdown timeout to 120

### DIFF
--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -96,7 +96,7 @@ class StreamsStaticMembershipTest(Test):
         stop_processors(processors, self.stopped_message)
 
         self.producer.stop()
-        self.kafka.stop()
+        self.kafka.stop(timeout_sec=120)
         self.zookeeper.stop()
 
     def verify_processing(self, processors):


### PR DESCRIPTION
The streams static membership test has failed several times due to hitting the Kafka shutdown timeout, but the logs were showing that the shutdown did actually succeed after the 60 second timeout.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
