### PR TITLE
[WIP] KAFKA-5966: let CacheFunction#key return ByteBuffer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Bytes.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Bytes.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.utils;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -38,6 +39,26 @@ public class Bytes implements Comparable<Bytes> {
         if (bytes == null)
             return null;
         return new Bytes(bytes);
+    }
+
+    /**
+     * Create a Bytes using the byte buffer. If the provided byteBuffer contains the whole content, we can directly
+     * use the backed array. If the byteBuffer has only partial of the content (ex: a sliced byteBuffer), we'll do array copy
+     *
+     * @param byteBuffer    The byteBuffer becomes the backing storage for the object.
+     */
+    public static Bytes wrap(ByteBuffer byteBuffer) {
+        if (byteBuffer == null)
+            return null;
+        else if (byteBuffer.hasArray() && byteBuffer.array().length == byteBuffer.capacity()) {
+            // the byte buffer is not a sub-byteBuffer
+            return new Bytes(byteBuffer.array());
+        } else {
+            // the byteBuffer has only partial of the content (ex: a sliced byteBuffer), do array copy to it
+            final byte[] bytes = new byte[byteBuffer.remaining()];
+            byteBuffer.get(bytes, 0, bytes.length);
+            return new Bytes(bytes);
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CacheFunction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CacheFunction.java
@@ -19,7 +19,12 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
 
+import java.nio.ByteBuffer;
+
 interface CacheFunction {
-    Bytes key(Bytes cacheKey);
+    // return ByteBuffer here since we usually do further content extraction (ex: extractKeyBytes) with the key.
+    // With ByteBuffer, we can better manipulate this partial content extraction without array copy
+    ByteBuffer key(Bytes cacheKey);
+    // return Bytes here since we won't have further operation to this cacheKey
     Bytes cacheKey(Bytes cacheKey);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -101,7 +102,7 @@ class CachingWindowStore
 
     private void putAndMaybeForward(final ThreadCache.DirtyEntry entry,
                                     final InternalProcessorContext context) {
-        final byte[] binaryWindowKey = cacheFunction.key(entry.key()).get();
+        final ByteBuffer binaryWindowKey = cacheFunction.key(entry.key());
         final Windowed<Bytes> windowedKeyBytes = WindowKeySchema.fromStoreBytesKey(binaryWindowKey, windowSize);
         final long windowStartTimestamp = windowedKeyBytes.window().start();
         final Bytes binaryKey = windowedKeyBytes.key();
@@ -120,7 +121,7 @@ class CachingWindowStore
                 context.setRecordContext(entry.entry().context());
                 try {
                     flushListener.apply(
-                        binaryWindowKey,
+                        Bytes.wrap(binaryWindowKey).get(),
                         rawNewValue,
                         sendOldValues ? rawOldValue : null,
                         entry.entry().context().timestamp());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/FilteredCacheIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/FilteredCacheIterator.java
@@ -44,7 +44,7 @@ class FilteredCacheIterator implements PeekingKeyValueIterator<Bytes, LRUCacheEn
 
             @Override
             public Bytes peekNextKey() {
-                return cacheFunction.key(cacheIterator.peekNextKey());
+                return Bytes.wrap(cacheFunction.key(cacheIterator.peekNextKey()));
             }
 
             @Override
@@ -58,7 +58,7 @@ class FilteredCacheIterator implements PeekingKeyValueIterator<Bytes, LRUCacheEn
             }
 
             private KeyValue<Bytes, LRUCacheEntry> cachedPair(final KeyValue<Bytes, LRUCacheEntry> next) {
-                return KeyValue.pair(cacheFunction.key(next.key), next.value);
+                return KeyValue.pair(Bytes.wrap(cacheFunction.key(next.key)), next.value);
             }
 
         };

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheSessionStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheSessionStoreIterator.java
@@ -22,6 +22,8 @@ import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
+import java.nio.ByteBuffer;
+
 /**
  * Merges two iterators. Assumes each of them is sorted by key
  *
@@ -45,8 +47,8 @@ class MergedSortedCacheSessionStoreIterator extends AbstractMergedSortedCacheSto
 
     @Override
     Windowed<Bytes> deserializeCacheKey(final Bytes cacheKey) {
-        final byte[] binaryKey = cacheFunction.key(cacheKey).get();
-        final byte[] keyBytes = SessionKeySchema.extractKeyBytes(binaryKey);
+        final ByteBuffer binaryKey = cacheFunction.key(cacheKey);
+        final ByteBuffer keyBytes = SessionKeySchema.extractKeyBytes(binaryKey);
         final Window window = SessionKeySchema.extractWindow(binaryKey);
         return new Windowed<>(Bytes.wrap(keyBytes), window);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWindowStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWindowStoreIterator.java
@@ -21,6 +21,8 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
+import java.nio.ByteBuffer;
+
 import static org.apache.kafka.streams.state.internals.SegmentedCacheFunction.bytesFromCacheKey;
 
 /**
@@ -43,7 +45,7 @@ class MergedSortedCacheWindowStoreIterator extends AbstractMergedSortedCacheStor
 
     @Override
     Long deserializeCacheKey(final Bytes cacheKey) {
-        final byte[] binaryKey = bytesFromCacheKey(cacheKey);
+        final ByteBuffer binaryKey = bytesFromCacheKey(cacheKey);
         return WindowKeySchema.extractStoreTimestamp(binaryKey);
     }
 
@@ -59,7 +61,7 @@ class MergedSortedCacheWindowStoreIterator extends AbstractMergedSortedCacheStor
 
     @Override
     public int compare(final Bytes cacheKey, final Long storeKey) {
-        final byte[] binaryKey = bytesFromCacheKey(cacheKey);
+        final ByteBuffer binaryKey = bytesFromCacheKey(cacheKey);
 
         final Long cacheTimestamp = WindowKeySchema.extractStoreTimestamp(binaryKey);
         return cacheTimestamp.compareTo(storeKey);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWindowStoreKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWindowStoreKeyValueIterator.java
@@ -23,6 +23,8 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
 
+import java.nio.ByteBuffer;
+
 class MergedSortedCacheWindowStoreKeyValueIterator
     extends AbstractMergedSortedCacheStoreIterator<Windowed<Bytes>, Windowed<Bytes>, byte[], byte[]> {
 
@@ -56,8 +58,8 @@ class MergedSortedCacheWindowStoreKeyValueIterator
 
     @Override
     Windowed<Bytes> deserializeCacheKey(final Bytes cacheKey) {
-        final byte[] binaryKey = cacheFunction.key(cacheKey).get();
-        return WindowKeySchema.fromStoreKey(binaryKey, windowSize, serdes.keyDeserializer(), serdes.topic());
+        final ByteBuffer byteBufferKey = cacheFunction.key(cacheKey);
+        return WindowKeySchema.fromStoreKey(byteBufferKey, windowSize, serdes.keyDeserializer(), serdes.topic());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
@@ -35,8 +35,8 @@ class SegmentedCacheFunction implements CacheFunction {
     }
 
     @Override
-    public Bytes key(final Bytes cacheKey) {
-        return Bytes.wrap(bytesFromCacheKey(cacheKey));
+    public ByteBuffer key(final Bytes cacheKey) {
+        return bytesFromCacheKey(cacheKey);
     }
 
     @Override
@@ -51,10 +51,14 @@ class SegmentedCacheFunction implements CacheFunction {
         return Bytes.wrap(buf.array());
     }
 
-    static byte[] bytesFromCacheKey(final Bytes cacheKey) {
-        final byte[] binaryKey = new byte[cacheKey.get().length - SEGMENT_ID_BYTES];
-        System.arraycopy(cacheKey.get(), SEGMENT_ID_BYTES, binaryKey, 0, binaryKey.length);
-        return binaryKey;
+    static ByteBuffer bytesFromCacheKey(final Bytes cacheKey) {
+        final ByteBuffer byteBuffer = ByteBuffer.wrap(cacheKey.get());
+        byteBuffer.position(SEGMENT_ID_BYTES);
+        final ByteBuffer keyByteBuffer = byteBuffer.slice();
+
+        byteBuffer.position(0);
+
+        return keyByteBuffer;
     }
 
     public long segmentId(final Bytes key) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/FilteredCacheIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/FilteredCacheIteratorTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.test.GenericInMemoryKeyValueStore;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,8 +41,8 @@ public class FilteredCacheIteratorTest {
 
     private static final CacheFunction IDENTITY_FUNCTION = new CacheFunction() {
         @Override
-        public Bytes key(final Bytes cacheKey) {
-            return cacheKey;
+        public ByteBuffer key(final Bytes cacheKey) {
+            return ByteBuffer.wrap(cacheKey.get());
         }
 
         @Override


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-5966

This PR doesn't meet what KAFKA-5966 expected, just makes `CacheFunction#key` return ByteBuffer, to avoid unnecessary array copy. But I want to make sure this is the right way to do. 

Although we can't avoid ALL array copy after this PR, we did reduce the array copy amounts after this change. The reason we can't avoid all array copy is that in many places, we still expect the `Bytes` and `byte array` type to be provided, ex: `ThreadCache`, `NamedCache`. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
