### PR TITLE
KAFKA-13021: disallow grace called after grace set via new API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindows.java
@@ -76,9 +76,13 @@ public final class SessionWindows {
 
     private final long graceMs;
 
-    private SessionWindows(final long gapMs, final long graceMs) {
+    // flag to check if the grace is already set via ofInactivityGapAndGrace or ofInactivityGapWithNoGrace
+    private final boolean hasSetGrace;
+
+    private SessionWindows(final long gapMs, final long graceMs, final boolean hasSetGrace) {
         this.gapMs = gapMs;
         this.graceMs = graceMs;
+        this.hasSetGrace = hasSetGrace;
 
         if (gapMs <= 0) {
             throw new IllegalArgumentException("Gap time cannot be zero or negative.");
@@ -123,7 +127,7 @@ public final class SessionWindows {
      * @param afterWindowEnd The grace period to admit out-of-order events to a window.
      * @return A SessionWindows object with the specified inactivity gap and grace period
      * @throws IllegalArgumentException if {@code inactivityGap} is zero or negative or can't be represented as {@code long milliseconds}
-     *                                  if the {@code afterWindowEnd} is negative or can't be represented as {@code long milliseconds}
+     *                                  if {@code afterWindowEnd} is negative or can't be represented as {@code long milliseconds}
      */
     public static SessionWindows ofInactivityGapAndGrace(final Duration inactivityGap, final Duration afterWindowEnd) {
         final String inactivityGapMsgPrefix = prepareMillisCheckFailMsgPrefix(inactivityGap, "inactivityGap");
@@ -132,7 +136,7 @@ public final class SessionWindows {
         final String afterWindowEndMsgPrefix = prepareMillisCheckFailMsgPrefix(afterWindowEnd, "afterWindowEnd");
         final long afterWindowEndMs = validateMillisecondDuration(afterWindowEnd, afterWindowEndMsgPrefix);
 
-        return new SessionWindows(inactivityGapMs, afterWindowEndMs);
+        return new SessionWindows(inactivityGapMs, afterWindowEndMs, true);
     }
 
     /**
@@ -148,7 +152,7 @@ public final class SessionWindows {
         final String msgPrefix = prepareMillisCheckFailMsgPrefix(inactivityGap, "inactivityGap");
         final long inactivityGapMs = validateMillisecondDuration(inactivityGap, msgPrefix);
 
-        return new SessionWindows(inactivityGapMs, Math.max(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - inactivityGapMs, 0));
+        return new SessionWindows(inactivityGapMs, Math.max(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - inactivityGapMs, 0), false);
     }
 
     /**
@@ -162,15 +166,20 @@ public final class SessionWindows {
      * @param afterWindowEnd The grace period to admit out-of-order events to a window.
      * @return this updated builder
      * @throws IllegalArgumentException if the {@code afterWindowEnd} is negative or can't be represented as {@code long milliseconds}
+     * @throws IllegalStateException if {@link #grace(Duration)} is called after {@link #ofInactivityGapAndGrace(Duration, Duration)} or {@link #ofInactivityGapWithNoGrace(Duration)}
      * @deprecated since 3.0. Use {@link #ofInactivityGapAndGrace(Duration, Duration)} instead
      */
     @Deprecated
     public SessionWindows grace(final Duration afterWindowEnd) throws IllegalArgumentException {
-        //TODO KAFKA-13021: disallow calling grace() if it was already set via ofTimeDifferenceAndGrace/WithNoGrace()
+        if (this.hasSetGrace) {
+            throw new IllegalStateException(
+                "Cannot call grace() after setting grace value via ofInactivityGapAndGrace or ofInactivityGapWithNoGrace.");
+        }
+
         final String msgPrefix = prepareMillisCheckFailMsgPrefix(afterWindowEnd, "afterWindowEnd");
         final long afterWindowEndMs = validateMillisecondDuration(afterWindowEnd, msgPrefix);
 
-        return new SessionWindows(gapMs, afterWindowEndMs);
+        return new SessionWindows(gapMs, afterWindowEndMs, false);
     }
 
     public long gracePeriodMs() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -80,6 +80,12 @@ public class JoinWindowsTest {
     }
 
     @Test
+    public void graceShouldNotCalledAfterGraceSet() {
+        assertThrows(IllegalStateException.class, () -> JoinWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));
+        assertThrows(IllegalStateException.class, () -> JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(10)).grace(ofMillis(10)));
+    }
+
+    @Test
     public void endTimeShouldNotBeBeforeStart() {
         final JoinWindows windowSpec = JoinWindows.of(ofMillis(ANY_SIZE));
         try {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -78,6 +78,12 @@ public class SessionWindowsTest {
     }
 
     @Test
+    public void graceShouldNotCalledAfterGraceSet() {
+        assertThrows(IllegalStateException.class, () -> SessionWindows.ofInactivityGapAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));
+        assertThrows(IllegalStateException.class, () -> SessionWindows.ofInactivityGapWithNoGrace(ofMillis(10)).grace(ofMillis(10)));
+    }
+
+    @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
         verifyEquality(SessionWindows.with(ofMillis(1)), SessionWindows.with(ofMillis(1)));
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -61,6 +61,12 @@ public class TimeWindowsTest {
     }
 
     @Test
+    public void graceShouldNotCalledAfterGraceSet() {
+        assertThrows(IllegalStateException.class, () -> TimeWindows.ofSizeAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));
+        assertThrows(IllegalStateException.class, () -> TimeWindows.ofSizeWithNoGrace(ofMillis(10)).grace(ofMillis(10)));
+    }
+
+    @Test
     public void advanceIntervalMustNotBeZero() {
         final TimeWindows windowSpec = TimeWindows.of(ofMillis(ANY_SIZE));
         try {


### PR DESCRIPTION
Saw this `TODO` comment while reading codes. 
`//TODO KAFKA-13021: disallow calling grace() if it was already set via ofTimeDifferenceAndGrace/WithNoGrace()`

Add the check to disallow grace called after grace set via new API, and add tests for them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
