### PR TITLE
KAFKA-13161: Update replica partition state and replica fetcher state on follower update

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedProduce.scala
+++ b/core/src/main/scala/kafka/server/DelayedProduce.scala
@@ -74,11 +74,12 @@ class DelayedProduce(delayMs: Long,
    * The delayed produce operation can be completed if every partition
    * it produces to is satisfied by one of the following:
    *
-   * Case A: This broker is no longer the leader: set an error in response
-   * Case B: This broker is the leader:
-   *   B.1 - If there was a local error thrown while checking if at least requiredAcks
+   * Case A: Replica not assigned to partition
+   * Case B: Replica is no longer the leader of this partition
+   * Case C: This broker is the leader:
+   *   C.1 - If there was a local error thrown while checking if at least requiredAcks
    *         replicas have caught up to this operation: set an error in response
-   *   B.2 - Otherwise, set the response with no error.
+   *   C.2 - Otherwise, set the response with no error.
    */
   override def tryComplete(): Boolean = {
     // check for each partition if it still has pending acks
@@ -95,7 +96,7 @@ class DelayedProduce(delayMs: Long,
             partition.checkEnoughReplicasReachOffset(status.requiredOffset)
         }
 
-        // Case B.1 || B.2
+        // Case B || C.1 || C.2
         if (error != Errors.NONE || hasEnough) {
           status.acksPending = false
           status.responseStatus.error = error

--- a/core/src/main/scala/kafka/server/DelayedProduce.scala
+++ b/core/src/main/scala/kafka/server/DelayedProduce.scala
@@ -104,7 +104,7 @@ class DelayedProduce(delayMs: Long,
       }
     }
 
-    // check if every partition has satisfied at least one of case A or B
+    // check if every partition has satisfied at least one of case A, B or C
     if (!produceMetadata.produceStatus.values.exists(_.acksPending))
       forceComplete()
     else

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2252,7 +2252,6 @@ class ReplicaManager(val config: KafkaConfig,
     stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionsToMakeFollower.size} partitions")
 
     updateLeaderAndFollowerMetrics(newFollowerTopicSet)
-
   }
 
   def deleteStrayReplicas(topicPartitions: Iterable[TopicPartition]): Unit = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2201,8 +2201,6 @@ class ReplicaManager(val config: KafkaConfig,
         try {
           newFollowerTopicSet.add(tp.topic())
 
-          completeDelayedFetchOrProduceRequests(tp)
-
           if (shuttingDown) {
             stateChangeLogger.trace(s"Unable to start fetching ${tp} with topic " +
               s"ID ${info.topicId} because the replica manager is shutting down.")
@@ -2250,6 +2248,8 @@ class ReplicaManager(val config: KafkaConfig,
 
     replicaFetcherManager.addFetcherForPartitions(partitionsToMakeFollower)
     stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionsToMakeFollower.size} partitions")
+
+    partitionsToMakeFollower.keySet.foreach(completeDelayedFetchOrProduceRequests)
 
     updateLeaderAndFollowerMetrics(newFollowerTopicSet)
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2863,8 +2863,7 @@ class ReplicaManagerTest {
     assertEquals(epoch + 1, followerPartition.getLeaderEpoch)
 
     val fetcher = replicaManager.replicaFetcherManager.getFetcher(topicPartition)
-    assertNotEquals(None, fetcher)
-    assertEquals(BrokerEndPoint(otherId, "localhost", 9093), fetcher.get.sourceBroker)
+    assertEquals(Some(BrokerEndPoint(otherId, "localhost", 9093)), fetcher.map(_.sourceBroker))
   }
 
   @Test
@@ -2886,8 +2885,7 @@ class ReplicaManagerTest {
     assertEquals(epoch, followerPartition.getLeaderEpoch)
 
     val fetcher = replicaManager.replicaFetcherManager.getFetcher(topicPartition)
-    assertNotEquals(None, fetcher)
-    assertEquals(BrokerEndPoint(otherId, "localhost", 9093), fetcher.get.sourceBroker)
+    assertEquals(Some(BrokerEndPoint(otherId, "localhost", 9093)), fetcher.map(_.sourceBroker))
 
     // Append on a follower should fail
     val followerResponse = sendProducerAppend(replicaManager, topicPartition, numOfRecords)
@@ -2936,8 +2934,7 @@ class ReplicaManagerTest {
     assertEquals(epoch, followerPartition.getLeaderEpoch)
 
     val fetcher = replicaManager.replicaFetcherManager.getFetcher(topicPartition)
-    assertNotEquals(None, fetcher)
-    assertEquals(BrokerEndPoint(otherId, "localhost", 9093), fetcher.get.sourceBroker)
+    assertEquals(Some(BrokerEndPoint(otherId, "localhost", 9093)), fetcher.map(_.sourceBroker))
 
     // Apply the same delta again
     replicaManager.applyDelta(followerMetadataImage, topicsDelta(localId, false, epoch))
@@ -2948,8 +2945,7 @@ class ReplicaManagerTest {
     assertEquals(epoch, noChangePartition.getLeaderEpoch)
 
     val noChangeFetcher = replicaManager.replicaFetcherManager.getFetcher(topicPartition)
-    assertNotEquals(None, noChangeFetcher)
-    assertEquals(BrokerEndPoint(otherId, "localhost", 9093), noChangeFetcher.get.sourceBroker)
+    assertEquals(Some(BrokerEndPoint(otherId, "localhost", 9093)), noChangeFetcher.map(_.sourceBroker))
   }
 
   private def topicsImage(replica: Int, isLeader: Boolean, epoch: Int): TopicsImage = {

--- a/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(value = 40)
 public class ClusterImageTest {
-    final static ClusterImage IMAGE1;
+    public final static ClusterImage IMAGE1;
 
     static final List<ApiMessageAndVersion> DELTA1_RECORDS;
 


### PR DESCRIPTION
When processing the topics delta, make sure that the replica manager partition state and replica fetcher state matches the information included in the topic delta.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
