### PR TITLE
KAFKA-13173 Making the controller fence stale brokers one at a time if multiple stale brokers are discovered at the same time

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -425,17 +425,16 @@ public class BrokerHeartbeatManager {
      * @return      An Optional broker node id.
      */
     Optional<Integer> findOneStaleBroker() {
-        Optional<Integer> node = Optional.empty();
         BrokerHeartbeatStateIterator iterator = unfenced.iterator();
         if (iterator.hasNext()) {
             BrokerHeartbeatState broker = iterator.next();
             // The unfenced list is sorted on last contact time from each
             // broker. If the first broker is not stale, then none is.
             if (!hasValidSession(broker)) {
-                node = Optional.of(broker.id);
+                return Optional.of(broker.id);
             }
         }
-        return node;
+        return Optional.empty();
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.metadata.UsableBroker;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -420,22 +419,23 @@ public class BrokerHeartbeatManager {
     }
 
     /**
-     * Find the stale brokers which haven't heartbeated in a long time, and which need to
-     * be fenced.
+     * Check if the oldest broker to have hearbeated has already violated the
+     * sessionTimeoutNs timeout and needs to be fenced.
      *
-     * @return      A list of node IDs.
+     * @return      An Optional broker node id.
      */
-    List<Integer> findStaleBrokers() {
-        List<Integer> nodes = new ArrayList<>();
+    Optional<Integer> findOneStaleBroker() {
+        Optional<Integer> node = Optional.empty();
         BrokerHeartbeatStateIterator iterator = unfenced.iterator();
-        while (iterator.hasNext()) {
+        if (iterator.hasNext()) {
             BrokerHeartbeatState broker = iterator.next();
-            if (hasValidSession(broker)) {
-                break;
+            // The unfenced list is sorted on last contact time from each
+            // broker. If the first broker is not stale, then none is.
+            if (!hasValidSession(broker)) {
+                node = Optional.of(broker.id);
             }
-            nodes.add(broker.id);
         }
-        return nodes;
+        return node;
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.controller;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
@@ -159,6 +161,14 @@ public class ClusterControlManager {
 
     Map<Integer, BrokerRegistration> brokerRegistrations() {
         return brokerRegistrations;
+    }
+
+    Set<Integer> fencedBrokerIds() {
+        return brokerRegistrations.values()
+            .stream()
+            .filter(BrokerRegistration::fenced)
+            .map(BrokerRegistration::id)
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -858,7 +858,9 @@ public final class QuorumController implements Controller {
             return;
         }
         scheduleDeferredWriteEvent(MAYBE_FENCE_REPLICAS, nextCheckTimeNs, () -> {
-            ControllerResult<Void> result = replicationControl.maybeFenceStaleBrokers();
+            ControllerResult<Void> result = replicationControl.maybeFenceOneStaleBroker();
+            // This following call ensures that if there are multiple brokers that
+            // are currently stale, then fencing for them is scheduled immediately
             rescheduleMaybeFenceStaleBrokers();
             return result;
         });

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -928,16 +928,14 @@ public class ReplicationControlManager {
     ControllerResult<Void> maybeFenceOneStaleBroker() {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         BrokerHeartbeatManager heartbeatManager = clusterControl.heartbeatManager();
-        Optional<Integer> staleBroker = heartbeatManager.findOneStaleBroker();
-        if (staleBroker.isPresent()) {
+        heartbeatManager.findOneStaleBroker().ifPresent(brokerId -> {
             // Even though multiple brokers can go stale at a time, we will process
             // fencing one at a time so that the effect of fencing each broker is visible
             // to the system prior to processing the next one
-            int brokerId = staleBroker.get();
             log.info("Fencing broker {} because its session has timed out.", brokerId);
             handleBrokerFenced(brokerId, records);
             heartbeatManager.fence(brokerId);
-        }
+        });
         return ControllerResult.of(records, null);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -925,16 +925,25 @@ public class ReplicationControlManager {
         return ControllerResult.of(records, null);
     }
 
-    ControllerResult<Void> maybeFenceStaleBrokers() {
+    ControllerResult<Void> maybeFenceOneStaleBroker() {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         BrokerHeartbeatManager heartbeatManager = clusterControl.heartbeatManager();
-        List<Integer> staleBrokers = heartbeatManager.findStaleBrokers();
-        for (int brokerId : staleBrokers) {
+        Optional<Integer> staleBroker = heartbeatManager.findOneStaleBroker();
+        if (staleBroker.isPresent()) {
+            // Even though multiple brokers can go stale at a time, we will process
+            // fencing one at a time so that the effect of fencing each broker is visible
+            // to the system prior to processing the next one
+            int brokerId = staleBroker.get();
             log.info("Fencing broker {} because its session has timed out.", brokerId);
             handleBrokerFenced(brokerId, records);
             heartbeatManager.fence(brokerId);
         }
         return ControllerResult.of(records, null);
+    }
+
+    // Visible for testing
+    Boolean isBrokerUnfenced(int brokerId) {
+        return clusterControl.unfenced(brokerId);
     }
 
     ControllerResult<List<CreatePartitionsTopicResult>>

--- a/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
@@ -105,12 +105,10 @@ public class BrokerHeartbeatManagerTest {
         assertFalse(iter.hasNext());
 
         time.sleep(20);
-        Integer nodeId = 1;
-        while (manager.findOneStaleBroker().isPresent()) {
-           assertEquals(Optional.of(nodeId), manager.findOneStaleBroker());
-           manager.fence(nodeId);
-           nodeId++;
-        }
+        assertEquals(Optional.of(1), manager.findOneStaleBroker());
+        manager.fence(1);
+        assertEquals(Optional.of(2), manager.findOneStaleBroker());
+        manager.fence(2);
 
         assertEquals(Optional.empty(), manager.findOneStaleBroker());
         iter = manager.unfenced().iterator();
@@ -136,13 +134,13 @@ public class BrokerHeartbeatManagerTest {
         assertEquals(Optional.of(0), manager.findOneStaleBroker());
         manager.fence(0);
         assertEquals(12_000_000, manager.nextCheckTimeNs());
+
         time.sleep(3);
-        Integer nodeId = 1;
-        while (manager.findOneStaleBroker().isPresent()) {
-            assertEquals(Optional.of(nodeId), manager.findOneStaleBroker());
-            manager.fence(nodeId);
-            nodeId++;
-        }
+        assertEquals(Optional.of(1), manager.findOneStaleBroker());
+        manager.fence(1);
+        assertEquals(Optional.of(2), manager.findOneStaleBroker());
+        manager.fence(2);
+
         assertEquals(14_000_000, manager.nextCheckTimeNs());
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.controller;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/BrokerHeartbeatManagerTest.java
@@ -78,7 +78,7 @@ public class BrokerHeartbeatManagerTest {
     }
 
     @Test
-    public void testFindStaleBrokers() {
+    public void testFindOneStaleBroker() {
         BrokerHeartbeatManager manager = newBrokerHeartbeatManager();
         MockTime time = (MockTime)  manager.time();
         assertFalse(manager.hasValidSession(0));
@@ -93,22 +93,26 @@ public class BrokerHeartbeatManagerTest {
         assertEquals(1, iter.next().id());
         assertEquals(2, iter.next().id());
         assertFalse(iter.hasNext());
-        assertEquals(Collections.emptyList(), manager.findStaleBrokers());
+        assertEquals(Optional.empty(), manager.findOneStaleBroker());
 
         time.sleep(5);
-        assertEquals(Collections.singletonList(0), manager.findStaleBrokers());
+        assertEquals(Optional.of(0), manager.findOneStaleBroker());
         manager.fence(0);
-        assertEquals(Collections.emptyList(), manager.findStaleBrokers());
+        assertEquals(Optional.empty(), manager.findOneStaleBroker());
         iter = manager.unfenced().iterator();
         assertEquals(1, iter.next().id());
         assertEquals(2, iter.next().id());
         assertFalse(iter.hasNext());
 
         time.sleep(20);
-        assertEquals(Arrays.asList(1, 2), manager.findStaleBrokers());
-        manager.fence(1);
-        manager.fence(2);
-        assertEquals(Collections.emptyList(), manager.findStaleBrokers());
+        Integer nodeId = 1;
+        while (manager.findOneStaleBroker().isPresent()) {
+           assertEquals(Optional.of(nodeId), manager.findOneStaleBroker());
+           manager.fence(nodeId);
+           nodeId++;
+        }
+
+        assertEquals(Optional.empty(), manager.findOneStaleBroker());
         iter = manager.unfenced().iterator();
         assertFalse(iter.hasNext());
     }
@@ -125,17 +129,20 @@ public class BrokerHeartbeatManagerTest {
         manager.touch(2, false, 0);
         time.sleep(1);
         manager.touch(3, false, 0);
-        assertEquals(Collections.emptyList(), manager.findStaleBrokers());
+        assertEquals(Optional.empty(), manager.findOneStaleBroker());
         assertEquals(10_000_000, manager.nextCheckTimeNs());
         time.sleep(7);
         assertEquals(10_000_000, manager.nextCheckTimeNs());
-        assertEquals(Collections.singletonList(0), manager.findStaleBrokers());
+        assertEquals(Optional.of(0), manager.findOneStaleBroker());
         manager.fence(0);
         assertEquals(12_000_000, manager.nextCheckTimeNs());
         time.sleep(3);
-        assertEquals(Arrays.asList(1, 2), manager.findStaleBrokers());
-        manager.fence(1);
-        manager.fence(2);
+        Integer nodeId = 1;
+        while (manager.findOneStaleBroker().isPresent()) {
+            assertEquals(Optional.of(nodeId), manager.findOneStaleBroker());
+            manager.fence(nodeId);
+            nodeId++;
+        }
         assertEquals(14_000_000, manager.nextCheckTimeNs());
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.controller;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -182,7 +181,7 @@ public class QuorumControllerTest {
         int brokersToKeepUnfenced = 1;
         short replicationFactor = 5;
         Long sessionTimeout = 1L;
-        Long sleepMillis = (sessionTimeout*1000)/2;
+        Long sleepMillis = (sessionTimeout * 1000) / 2;
 
         try (LocalLogManagerTestEnv logEnv = new LocalLogManagerTestEnv(1, Optional.empty())) {
             try (QuorumControllerTestEnv controlEnv =
@@ -192,7 +191,7 @@ public class QuorumControllerTest {
                     setHost("localhost").setPort(9092));
                 QuorumController active = controlEnv.activeController();
                 Map<Integer, Long> brokerEpochs = new HashMap<>();
-                for (int brokerId = 0; brokerId<brokerCount; brokerId++) {
+                for (int brokerId = 0; brokerId < brokerCount; brokerId++) {
                     CompletableFuture<BrokerRegistrationReply> reply = active.registerBroker(
                         new BrokerRegistrationRequestData().
                             setBrokerId(brokerId).
@@ -213,7 +212,7 @@ public class QuorumControllerTest {
                     createTopicsRequestData).get();
                 assertEquals(Errors.INVALID_REPLICATION_FACTOR.code(),
                     createTopicsResponseData.topics().find("foo").errorCode());
-                assertEquals("Unable to replicate the partition "+replicationFactor+" time(s): All brokers " +
+                assertEquals("Unable to replicate the partition " + replicationFactor + " time(s): All brokers " +
                     "are currently fenced.", createTopicsResponseData.topics().find("foo").errorMessage());
 
                 // Unfence all brokers
@@ -237,7 +236,7 @@ public class QuorumControllerTest {
                                     singleton(new CreateableTopicConfig().setName("min.insync.replicas").
                                         setValue("2")).iterator())).
                                 setReplicationFactor(replicationFactor)).iterator()));
-                createTopicsResponseData = active.createTopics( createTopicsRequestData).get();
+                createTopicsResponseData = active.createTopics(createTopicsRequestData).get();
                 assertEquals(Errors.NONE.code(), createTopicsResponseData.topics().find("bar").errorCode());
                 Uuid topicIdBar = createTopicsResponseData.topics().find("bar").topicId();
 
@@ -247,15 +246,15 @@ public class QuorumControllerTest {
                 do {
                     fencingComplete = true;
                     sendBrokerheartbeat(active, brokersToKeepUnfenced, brokerEpochs);
-                    for (int i = brokersToKeepUnfenced ; i < brokerCount ; i++) {
-                        if(active.replicationControl().isBrokerUnfenced(i)) {
+                    for (int i = brokersToKeepUnfenced; i < brokerCount; i++) {
+                        if (active.replicationControl().isBrokerUnfenced(i)) {
                             fencingComplete = false;
                         }
                     }
                     Thread.sleep(1000);
                     waitIterations++;
 
-                    if (waitIterations >= sessionTimeout*3) {
+                    if (waitIterations >= sessionTimeout * 3) {
                         assertTrue(false, "Fencing of brokers did not process within expected time");
                     }
                 } while (!fencingComplete);
@@ -276,21 +275,21 @@ public class QuorumControllerTest {
                 }
 
                 // Verify the isr and leaders for the topic partitions
-                int[] sortedIsrFoo = active.replicationControl().getPartition(topicIdFoo,0).isr.clone();
-                int[] sortedIsrBar = active.replicationControl().getPartition(topicIdBar,0).isr.clone();
+                int[] sortedIsrFoo = active.replicationControl().getPartition(topicIdFoo, 0).isr.clone();
+                int[] sortedIsrBar = active.replicationControl().getPartition(topicIdBar, 0).isr.clone();
                 Arrays.sort(sortedIsrFoo);
                 Arrays.sort(sortedIsrBar);
                 assertTrue(Arrays.equals(sortedIsrFoo, expectedIsr)
-                    && Arrays.equals(sortedIsrBar,expectedIsr),
+                    && Arrays.equals(sortedIsrBar, expectedIsr),
                     "The ISR for topic foo was " + Arrays.toString(sortedIsrFoo) +
                     " and for topic bar was " + Arrays.toString(sortedIsrBar) +
                         ". Both are expected to be " + Arrays.toString(expectedIsr));
 
-                int fooLeader = active.replicationControl().getPartition(topicIdFoo,0).leader;
+                int fooLeader = active.replicationControl().getPartition(topicIdFoo, 0).leader;
                 boolean leaderInIsr = IntStream.of(sortedIsrFoo).anyMatch(i -> i == fooLeader);
                 assertTrue(leaderInIsr, "Leader for topic foo not in isr");
 
-                int barLeader = active.replicationControl().getPartition(topicIdBar,0).leader;
+                int barLeader = active.replicationControl().getPartition(topicIdBar, 0).leader;
                 leaderInIsr = IntStream.of(sortedIsrFoo).anyMatch(i -> i == barLeader);
                 assertTrue(leaderInIsr, "Leader for topic bar not in isr");
             }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -208,9 +208,8 @@ public class QuorumControllerTest {
                     "Broker " + brokerId + " should have been fenced");
             });
 
-            // Unfence all brokers and retry topic creation for foo
+            // Unfence all brokers and create a topic foo
             sendBrokerheartbeat(active, allBrokers, brokerEpochs);
-            // Create a topic foo
             CreateTopicsRequestData createTopicsRequestData = new CreateTopicsRequestData().setTopics(
                 new CreatableTopicCollection(Collections.singleton(
                     new CreatableTopic().setName("foo").setNumPartitions(1).

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTestEnv.java
@@ -41,15 +41,18 @@ public class QuorumControllerTestEnv implements AutoCloseable {
     private final List<QuorumController> controllers;
     private final LocalLogManagerTestEnv logEnv;
 
-    public QuorumControllerTestEnv(LocalLogManagerTestEnv logEnv,
-        Consumer<QuorumController.Builder> builderConsumer)
-                                   throws Exception {
+    public QuorumControllerTestEnv(
+        LocalLogManagerTestEnv logEnv,
+        Consumer<QuorumController.Builder> builderConsumer
+    ) throws Exception {
         this(logEnv, builderConsumer, Optional.empty());
     }
 
-    public QuorumControllerTestEnv(LocalLogManagerTestEnv logEnv,
-        Consumer<Builder> builderConsumer, Optional<Long> sessionTimeoutSeconds)
-                                   throws Exception {
+    public QuorumControllerTestEnv(
+        LocalLogManagerTestEnv logEnv,
+        Consumer<Builder> builderConsumer,
+        Optional<Long> sessionTimeoutSeconds
+    ) throws Exception {
         this.logEnv = logEnv;
         int numControllers = logEnv.logManagers().size();
         this.controllers = new ArrayList<>(numControllers);

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTestEnv.java
@@ -51,7 +51,7 @@ public class QuorumControllerTestEnv implements AutoCloseable {
     public QuorumControllerTestEnv(
         LocalLogManagerTestEnv logEnv,
         Consumer<Builder> builderConsumer,
-        Optional<Long> sessionTimeoutSeconds
+        Optional<Long> sessionTimeoutMillis
     ) throws Exception {
         this.logEnv = logEnv;
         int numControllers = logEnv.logManagers().size();
@@ -60,9 +60,9 @@ public class QuorumControllerTestEnv implements AutoCloseable {
             for (int i = 0; i < numControllers; i++) {
                 QuorumController.Builder builder = new QuorumController.Builder(i);
                 builder.setRaftClient(logEnv.logManagers().get(i));
-                if (sessionTimeoutSeconds.isPresent()) {
+                if (sessionTimeoutMillis.isPresent()) {
                     builder.setSessionTimeoutNs(NANOSECONDS.convert(
-                        sessionTimeoutSeconds.get(), TimeUnit.SECONDS));
+                        sessionTimeoutMillis.get(), TimeUnit.MILLISECONDS));
                 }
                 builderConsumer.accept(builder);
                 this.controllers.add(builder.build());

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1064,7 +1064,9 @@ public class ReplicationControlManagerTest {
         ctx.fenceBrokers(Utils.mkSet(2, 3));
 
         PartitionRegistration partition0 = replication.getPartition(fooId, 0);
+        assertArrayEquals(new int[]{1,2,3}, partition0.replicas);
         assertArrayEquals(new int[]{1}, partition0.isr);
+        assertEquals(1, partition0.leader);
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -99,6 +99,7 @@ import static org.apache.kafka.controller.BrokersToIsrs.TopicIdPartition;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1061,12 +1062,24 @@ public class ReplicationControlManagerTest {
         Uuid fooId = ctx.createTestTopic("foo", new int[][]{
             new int[]{1, 2, 3}, new int[]{2, 3, 4}, new int[]{0, 2, 1}}).topicId();
 
+        assertTrue(ctx.clusterControl.fencedBrokerIds().isEmpty());
         ctx.fenceBrokers(Utils.mkSet(2, 3));
 
         PartitionRegistration partition0 = replication.getPartition(fooId, 0);
+        PartitionRegistration partition1 = replication.getPartition(fooId, 1);
+        PartitionRegistration partition2 = replication.getPartition(fooId, 2);
+
         assertArrayEquals(new int[]{1, 2, 3}, partition0.replicas);
         assertArrayEquals(new int[]{1}, partition0.isr);
         assertEquals(1, partition0.leader);
+
+        assertArrayEquals(new int[]{2, 3, 4}, partition1.replicas);
+        assertArrayEquals(new int[]{4}, partition1.isr);
+        assertEquals(4, partition1.leader);
+
+        assertArrayEquals(new int[]{0, 2, 1}, partition2.replicas);
+        assertArrayEquals(new int[]{0, 1}, partition2.isr);
+        assertNotEquals(2, partition2.leader);
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.controller;
 
+import java.util.Optional;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
@@ -61,6 +62,7 @@ import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.metadata.Replicas;
@@ -94,6 +96,7 @@ import static org.apache.kafka.common.protocol.Errors.NO_REASSIGNMENT_IN_PROGRES
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
 import static org.apache.kafka.controller.BrokersToIsrs.TopicIdPartition;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -105,6 +108,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Timeout(40)
 public class ReplicationControlManagerTest {
     private final static Logger log = LoggerFactory.getLogger(ReplicationControlManagerTest.class);
+    private final static int BROKER_SESSION_TIMEOUT_MS = 1000;
 
     private static class ReplicationControlTestContext {
         final SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
@@ -112,7 +116,7 @@ public class ReplicationControlManagerTest {
         final MockTime time = new MockTime();
         final MockRandom random = new MockRandom();
         final ClusterControlManager clusterControl = new ClusterControlManager(
-            logContext, time, snapshotRegistry, 1000,
+            logContext, time, snapshotRegistry, BROKER_SESSION_TIMEOUT_MS,
             new StripedReplicaPlacer(random));
         final ControllerMetrics metrics = new MockControllerMetrics();
         final ConfigurationControlManager configurationControl = new ConfigurationControlManager(
@@ -206,6 +210,24 @@ public class ReplicationControlManagerTest {
                     result.response());
                 replay(result.records());
             }
+        }
+
+        void fenceBrokers(Set<Integer> brokerIds) throws Exception {
+            time.sleep(BROKER_SESSION_TIMEOUT_MS);
+
+            Set<Integer> unfencedBrokerIds = clusterControl.brokerRegistrations().keySet().stream()
+                .filter(brokerId -> !brokerIds.contains(brokerId))
+                .collect(Collectors.toSet());
+            unfenceBrokers(unfencedBrokerIds.toArray(new Integer[0]));
+
+            Optional<Integer> staleBroker = clusterControl.heartbeatManager().findOneStaleBroker();
+            while (staleBroker.isPresent()) {
+                ControllerResult<Void> fenceResult = replicationControl.maybeFenceOneStaleBroker();
+                replay(fenceResult.records());
+                staleBroker = clusterControl.heartbeatManager().findOneStaleBroker();
+            }
+
+            assertEquals(brokerIds, clusterControl.fencedBrokerIds());
         }
 
         long currentBrokerEpoch(int brokerId) {
@@ -1027,6 +1049,22 @@ public class ReplicationControlManagerTest {
         assertEquals(new PartitionRegistration(new int[] {2, 4, 5},
                 new int[] {2}, Replicas.NONE, Replicas.NONE, 2, 0, 0),
             ctx.replicationControl.getPartition(fooId, 1));
+    }
+
+    @Test
+    public void testFenceMultipleBrokers() throws Exception {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        ReplicationControlManager replication = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2, 3, 4);
+        ctx.unfenceBrokers(0, 1, 2, 3, 4);
+
+        Uuid fooId = ctx.createTestTopic("foo", new int[][]{
+            new int[]{1, 2, 3}, new int[]{2, 3, 4}, new int[]{0, 2, 1}}).topicId();
+
+        ctx.fenceBrokers(Utils.mkSet(2, 3));
+
+        PartitionRegistration partition0 = replication.getPartition(fooId, 0);
+        assertArrayEquals(new int[]{1}, partition0.isr);
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1064,7 +1064,7 @@ public class ReplicationControlManagerTest {
         ctx.fenceBrokers(Utils.mkSet(2, 3));
 
         PartitionRegistration partition0 = replication.getPartition(fooId, 0);
-        assertArrayEquals(new int[]{1,2,3}, partition0.replicas);
+        assertArrayEquals(new int[]{1, 2, 3}, partition0.replicas);
         assertArrayEquals(new int[]{1}, partition0.isr);
         assertEquals(1, partition0.leader);
     }


### PR DESCRIPTION
This is necessary as the effect of each fencing is visible to the
controller one the corresponding record for it has been generated and
applied. Processing stale brokers one at a time ensures that subsequent 
fencing records are generated correctly with the correct view of the system.