### PR TITLE
MINOR: update the KStream#branch(split) doc and java doc and tests

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -360,14 +360,14 @@ GlobalKTable&lt;String, Long&gt; wordCounts = builder.globalTable(
                     <tbody valign="top">
                     <tr class="row-even"><td><p class="first"><strong>Branch</strong></p>
                         <ul class="last simple">
-                            <li>KStream &rarr; KStream[]</li>
+                            <li>KStream &rarr; BranchedKStream</li>
                         </ul>
                     </td>
                         <td><p class="first">Branch (or split) a <code class="docutils literal"><span class="pre">KStream</span></code> based on the supplied predicates into one or more <code class="docutils literal"><span class="pre">KStream</span></code> instances.
-                            (<a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/kstream/KStream.html#split">details</a>)</p>
+                            (<a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/kstream/KStream.html#split()">details</a>)</p>
                             <p>Predicates are evaluated in order.  A record is placed to one and only one output stream on the first match:
-                                if the n-th predicate evaluates to true, the record is placed to n-th stream.  If no predicate matches, the
-                                the record is dropped.</p>
+                                if the n-th predicate evaluates to true, the record is placed to n-th stream. If a record does not match any predicates,
+                                it will be routed to the default branch, or dropped if no default branch is created.</p>
                             <p>Branching is useful, for example, to route records to different downstream topics.</p>
                             <pre class="line-numbers"><code class="language-java">KStream&lt;String, Long&gt; stream = ...;
 Map&lt;String, KStream&lt;String, Long&gt;&gt; branches =
@@ -376,7 +376,7 @@ Map&lt;String, KStream&lt;String, Long&gt;&gt; branches =
              Branched.as(&quot;A&quot;))
         .branch((key, value) -&gt; key.startsWith(&quot;B&quot;),  /* second predicate */
              Branched.as(&quot;B&quot;))
-.defaultBranch(Branched.as(&quot;C&quot;))
+        .defaultBranch(Branched.as(&quot;C&quot;))              /* default branch */
 );
 
 // KStream branches.get(&quot;Branch-A&quot;) contains all records whose keys start with &quot;A&quot;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Branched.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Branched.java
@@ -143,6 +143,7 @@ public class Branched<K, V> implements NamedOperation<Branched<K, V>> {
      */
     @Override
     public Branched<K, V> withName(final String name) {
+        Objects.requireNonNull(name, "name cannot be null");
         return new Branched<>(name, chainFunction, chainConsumer);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/BranchedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/BranchedKStream.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * Branches the records in the original stream based on the predicates supplied for the branch definitions.
  * <p>
  * Branches are defined with {@link BranchedKStream#branch(Predicate, Branched)} or
- * {@link BranchedKStream#defaultBranch(Branched)} methods. Each record is evaluated against the predicates
+ * {@link BranchedKStream#defaultBranch(Branched)} methods. Each record is evaluated against the {@code predicate}
  * supplied via {@link Branched} parameters, and is routed to the first branch for which its respective predicate
  * evaluates to {@code true}. If a record does not match any predicates, it will be routed to the default branch,
  * or dropped if no default branch is created.
@@ -50,7 +50,7 @@ import java.util.Map;
  *     {@link Branched} parameter, its value is appended to the prefix to form the {@code Map} key
  *     <li>If a name is not provided for the branch, then the key defaults to {@code prefix + position} of the branch
  *     as a decimal number, starting from {@code "1"}
- *     <li>If a name is not provided for the {@link BranchedKStream#defaultBranch()} call, then the key defaults
+ *     <li>If a name is not provided for the {@link BranchedKStream#defaultBranch()}, then the key defaults
  *     to {@code prefix + "0"}
  * </ul>
  * The values of the respective {@code Map<Stream, KStream<K, V>>} entries are formed as following:
@@ -69,7 +69,8 @@ import java.util.Map;
  *     .branch(predicate1, Branched.as("bar"))                    // "foo-bar"
  *     .branch(predicate2, Branched.withConsumer(ks->ks.to("A"))  // no entry: a Consumer is provided
  *     .branch(predicate3, Branched.withFunction(ks->null))       // no entry: chain function returns null
- *     .branch(predicate4)                                        // "foo-4": name defaults to the branch position
+ *     .branch(predicate4, Branched.withFunction(ks->ks))         // "foo-4": chain function returns non-null value
+ *     .branch(predicate5)                                        // "foo-5": name defaults to the branch position
  *     .defaultBranch()                                           // "foo-0": "0" is the default name for the default branch
  * }</pre>
  *

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -782,18 +782,22 @@ public interface KStream<K, V> {
     KStream<K, V>[] branch(final Named named, final Predicate<? super K, ? super V>... predicates);
 
     /**
-     * Split this stream. {@link BranchedKStream} can be used for routing the records to different branches depending
-     * on evaluation against the supplied predicates.
-     * Stream branching is a stateless record-by-record operation.
+     * Split this stream into different branches. The returned {@link BranchedKStream} instance can be used for routing
+     * the records to different branches depending on evaluation against the supplied predicates.
+     * <p>
+     *     Note: Stream branching is a stateless record-by-record operation.
+     *     Please check {@link BranchedKStream} for detailed description and usage example
      *
      * @return {@link BranchedKStream} that provides methods for routing the records to different branches.
      */
     BranchedKStream<K, V> split();
 
     /**
-     * Split this stream. {@link BranchedKStream} can be used for routing the records to different branches depending
-     * on evaluation against the supplied predicates.
-     * Stream branching is a stateless record-by-record operation.
+     * Split this stream into different branches. The returned {@link BranchedKStream} instance can be used for routing
+     * the records to different branches depending on evaluation against the supplied predicates.
+     * <p>
+     *     Note: Stream branching is a stateless record-by-record operation.
+     *     Please check {@link BranchedKStream} for detailed description and usage example
      *
      * @param named  a {@link Named} config used to name the processor in the topology and also to set the name prefix
      *               for the resulting branches (see {@link BranchedKStream})


### PR DESCRIPTION
1. update documentation to fix some wrong (out-dated) content
After https://github.com/apache/kafka/pull/9107 (KIP-418), the returned content is not `kstream[]` anymore. Also, this description: `If no predicate matches, the the record is dropped.` is not right now. `It'll be routed to the default branch, or dropped if no default branch is created.` Fix them.
<img width="1462" alt="image" src="https://user-images.githubusercontent.com/43372967/128837876-71b1c57b-79f1-4b8b-a97d-ef57a3319959.png">

2. update java doc
3. add a test for `Branched.withFunction()` with non-null result test case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
