### PR TITLE
KAFKA-13185 Clear message batch in rewind

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -396,6 +396,8 @@ class WorkerSinkTask extends WorkerTask {
                     log.debug("{} Rewinding topic partition {} to offset {}", this, entry.getKey(), entry.getValue().offset());
                     consumer.seek(entry.getKey(), entry.getValue().offset());
                 }
+                // Clear messages that might have been left in messageBatch after last poll
+                messageBatch.clear();
                 currentOffsets = new HashMap<>(lastCommittedOffsets);
                 onCommitCompleted(t, commitSeqno, null);
             }


### PR DESCRIPTION
*WorkerSinkTask - clear message batch after rewind*
Messages that are left in messageBatch after failed put due to RetriableException should be cleared after rewind caused by yet another RetriableException in flush/pre-commit. Message left in messageBatch will be read again in the next poll iteration.

*Test strategy*
Current test suite still works. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
