### PR TITLE
KAFKA-13192: Prevent inconsistent broker.id/node.id values

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1420,6 +1420,17 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   override def get(key: String): AnyRef =
     if (this eq currentConfig) super.get(key) else currentConfig.get(key)
 
+  override def postProcessParsedConfig(props: java.util.Map[String,Object]): java.util.Map[String,Object] = {
+    val nodeIdValue = props.get(KafkaConfig.NodeIdProp).asInstanceOf[Int]
+    if (nodeIdValue >= 0) {
+      val brokerIdValue = props.get(KafkaConfig.BrokerIdProp).asInstanceOf[Int]
+      if (!brokerIdValue.equals(Defaults.BrokerId) && !brokerIdValue.equals(nodeIdValue)) {
+        throw new ConfigException(s"The values for broker.id ($brokerIdValue) and node.id ($nodeIdValue) must be the same if both are specified")
+      }
+    }
+    Collections.emptyMap()
+  }
+
   //  During dynamic update, we use the values from this config, these are only used in DynamicBrokerConfig
   private[server] def originalsFromThisConfig: util.Map[String, AnyRef] = super.originals
   private[server] def valuesFromThisConfig: util.Map[String, _] = super.values

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1905,9 +1905,9 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
 
   @nowarn("cat=deprecation")
   private def validateValues(): Unit = {
-    val nodeIdValue = values.get(KafkaConfig.NodeIdProp).asInstanceOf[Int]
+    val nodeIdValue = getInt(KafkaConfig.NodeIdProp)
     if (nodeIdValue >= 0) {
-      val brokerIdValue = values.get(KafkaConfig.BrokerIdProp).asInstanceOf[Int]
+      val brokerIdValue = getInt(KafkaConfig.BrokerIdProp)
       if (brokerIdValue != Defaults.BrokerId && brokerIdValue != nodeIdValue) {
         throw new ConfigException(s"The values for broker.id ($brokerIdValue) and node.id ($nodeIdValue) must be the same if both are specified")
       }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1424,7 +1424,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
     val nodeIdValue = props.get(KafkaConfig.NodeIdProp).asInstanceOf[Int]
     if (nodeIdValue >= 0) {
       val brokerIdValue = props.get(KafkaConfig.BrokerIdProp).asInstanceOf[Int]
-      if (!brokerIdValue.equals(Defaults.BrokerId) && !brokerIdValue.equals(nodeIdValue)) {
+      if (brokerIdValue != Defaults.BrokerId && brokerIdValue != nodeIdValue) {
         throw new ConfigException(s"The values for broker.id ($brokerIdValue) and node.id ($nodeIdValue) must be the same if both are specified")
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1420,17 +1420,6 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   override def get(key: String): AnyRef =
     if (this eq currentConfig) super.get(key) else currentConfig.get(key)
 
-  override def postProcessParsedConfig(props: java.util.Map[String,Object]): java.util.Map[String,Object] = {
-    val nodeIdValue = props.get(KafkaConfig.NodeIdProp).asInstanceOf[Int]
-    if (nodeIdValue >= 0) {
-      val brokerIdValue = props.get(KafkaConfig.BrokerIdProp).asInstanceOf[Int]
-      if (brokerIdValue != Defaults.BrokerId && brokerIdValue != nodeIdValue) {
-        throw new ConfigException(s"The values for broker.id ($brokerIdValue) and node.id ($nodeIdValue) must be the same if both are specified")
-      }
-    }
-    Collections.emptyMap()
-  }
-
   //  During dynamic update, we use the values from this config, these are only used in DynamicBrokerConfig
   private[server] def originalsFromThisConfig: util.Map[String, AnyRef] = super.originals
   private[server] def valuesFromThisConfig: util.Map[String, _] = super.values
@@ -1916,6 +1905,13 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
 
   @nowarn("cat=deprecation")
   private def validateValues(): Unit = {
+    val nodeIdValue = values.get(KafkaConfig.NodeIdProp).asInstanceOf[Int]
+    if (nodeIdValue >= 0) {
+      val brokerIdValue = values.get(KafkaConfig.BrokerIdProp).asInstanceOf[Int]
+      if (brokerIdValue != Defaults.BrokerId && brokerIdValue != nodeIdValue) {
+        throw new ConfigException(s"The values for broker.id ($brokerIdValue) and node.id ($nodeIdValue) must be the same if both are specified")
+      }
+    }
     if (requiresZookeeper) {
       if (zkConnect == null) {
         throw new ConfigException(s"Missing required configuration `${KafkaConfig.ZkConnectProp}` which has no default value.")

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1235,4 +1235,19 @@ class KafkaConfigTest {
     assertEquals(dataDir1, config.metadataLogDir)
     assertEquals(Seq(dataDir1, dataDir2), config.logDirs)
   }
+
+  @Test
+  def testBrokerAndNodeIdInconsistent(): Unit = {
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
+    props.put(KafkaConfig.NodeIdProp, "1") // set just node.id for KRaft -- should be legal
+    assertTrue(isValidKafkaConfig(props))
+    props.put(KafkaConfig.BrokerIdProp, "0") // explicitly set broker.id differently than node.id, should be illegal
+    assertFalse(isValidKafkaConfig(props))
+    props.put(KafkaConfig.BrokerIdProp, "-1") // explicitly set broker.id to the default, different than node.id, should be legal
+    assertTrue(isValidKafkaConfig(props))
+    props.put(KafkaConfig.BrokerIdProp, "1") // explicitly set broker.id to be the same as node.id -- should be legal
+    assertTrue(isValidKafkaConfig(props))
+  }
 }


### PR DESCRIPTION
If both `broker.id` and `node.id` are set, and they are set inconsistently (e.g.`broker.id=0`, `node.id=1`) then currently the value of `node.id` is used and the `broker.id` value is left at the original value. The server should detect this inconsistency, throw a ConfigException, and fail to start.  This patch adds the check and a test for it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
