### PR TITLE
MINOR: fix mbean tag name ordering in JMX reporter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -193,14 +193,19 @@ public class JmxReporter implements MetricsReporter {
         mBeanName.append(prefix);
         mBeanName.append(":type=");
         mBeanName.append(metricName.group());
-        for (Map.Entry<String, String> entry : metricName.tags().entrySet()) {
-            if (entry.getKey().length() <= 0 || entry.getValue().length() <= 0)
-                continue;
-            mBeanName.append(",");
-            mBeanName.append(entry.getKey());
-            mBeanName.append("=");
-            mBeanName.append(Sanitizer.jmxSanitize(entry.getValue()));
-        }
+        metricName.tags().entrySet().stream()
+            // use sorted tag entries to ensure the generated mBean name is always consistent
+            // when updating or removing mbeans in our mbeans map and in JMX.
+            .sorted(Map.Entry.comparingByKey())
+            .forEachOrdered(entry -> {
+                if (entry.getKey().length() <= 0 || entry.getValue().length() <= 0) {
+                    return;
+                }
+                mBeanName.append(",");
+                mBeanName.append(entry.getKey());
+                mBeanName.append("=");
+                mBeanName.append(Sanitizer.jmxSanitize(entry.getValue()));
+            });
         return mBeanName.toString();
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -22,13 +22,14 @@ import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.Test;
 
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -74,6 +75,21 @@ public class JmxReporterTest {
         } finally {
             metrics.close();
         }
+    }
+
+    @Test
+    public void testMbeanTagOrdering() {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("tag_a", "x");
+        tags.put("tag_b", "y");
+        tags.put("tag_c", "z");
+        tags.put("tag_d", "1,2");
+        tags.put("tag_e", "");
+        tags.put("tag_f", "3");
+
+        final MetricName metricName = new MetricName("bean1", "grp1", "fancy description", tags);
+        final String expectedMbean = "prefix:type=grp1,tag_a=x,tag_b=y,tag_c=z,tag_d=\"1,2\",tag_f=3";
+        assertEquals(expectedMbean, JmxReporter.getMBeanName("prefix", metricName));
     }
 
     @Test


### PR DESCRIPTION
Metric tag maps do not offer any ordering guarantees. We should
always sort tags when generating mbean names, or we could end up
with duplicate means with different tag order or orphaned mbeans
that were not properly removed when metrics are updated / deleted