### PR TITLE
KAFKA-13188 - Release the memory back into MemoryPool 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponseWithFinalize.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponseWithFinalize.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+
+/**
+ * This is a decorator for ClientResponse used to verify (at finalization time) that any underlying memory for this
+ * response has been returned to the pool. To be used only as a debugging aide.
+ */
+public class ClientResponseWithFinalize extends ClientResponse {
+    private final LogContext logContext;
+
+    public ClientResponseWithFinalize(RequestHeader requestHeader, RequestCompletionHandler callback,
+        String destination, long createdTimeMs, long receivedTimeMs, boolean disconnected,
+        UnsupportedVersionException versionMismatch, AuthenticationException authenticationException,
+        AbstractResponse responseBody, MemoryPool memoryPool, ByteBuffer responsePayload, LogContext logContext) {
+        super(requestHeader, callback, destination, createdTimeMs, receivedTimeMs, disconnected, versionMismatch,
+            authenticationException, responseBody, memoryPool, responsePayload);
+        this.logContext = logContext;
+    }
+
+    private Logger getLogger() {
+        if (logContext != null) {
+            return logContext.logger(ClientResponseWithFinalize.class);
+        }
+        return log;
+    }
+
+    protected void checkAndForceBufferRelease() {
+        if (memoryPool != null && responsePayload != null) {
+            getLogger().error("ByteBuffer[{}] not released. Ref Count: {}. RequestType: {}", responsePayload.position(),
+                refCount.get(), this.requestHeader.apiKey());
+            memoryPool.release(responsePayload);
+            responsePayload = null;
+        }
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        checkAndForceBufferRelease();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -182,6 +182,9 @@ public class CommonClientConfigs {
     public static final String DEFAULT_API_TIMEOUT_MS_DOC = "Specifies the timeout (in milliseconds) for client APIs. " +
             "This configuration is used as the default timeout for all client operations that do not specify a <code>timeout</code> parameter.";
 
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -182,7 +182,7 @@ public class CommonClientConfigs {
     public static final String DEFAULT_API_TIMEOUT_MS_DOC = "Specifies the timeout (in milliseconds) for client APIs. " +
             "This configuration is used as the default timeout for all client operations that do not specify a <code>timeout</code> parameter.";
 
-    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "enable.client.response.leakcheck";
     public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -558,6 +558,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
+                                .define(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK,
+                                        Type.BOOLEAN,
+                                        false,
+                                        Importance.MEDIUM,
+                                        CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -757,6 +757,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     apiVersions,
                     throttleTimeSensor,
                     logContext);
+            netClient.setEnableClientResponseWithFinalize(config.getBoolean(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK));
+
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -331,7 +331,8 @@ public class Fetcher<K, V> implements Closeable {
                                     short responseVersion = resp.requestHeader().apiVersion();
 
                                     completedFetches.add(new CompletedFetch(partition, partitionData,
-                                            metricAggregator, batches, fetchOffset, responseVersion));
+                                            metricAggregator, batches, fetchOffset, responseVersion, resp));
+                                    resp.incRefCount();
                                 }
                             }
 
@@ -653,12 +654,25 @@ public class Fetcher<K, V> implements Closeable {
         try {
             while (recordsRemaining > 0) {
                 if (nextInLineFetch == null || nextInLineFetch.isConsumed) {
+                    // The completed fetch object could be de-referenced and use the underlying buffer in
+                    // two different cases.
+                    // 1. The CompletedFetch could be a valid object containing fetched data from broker. In that case,
+                    //    the records are retrieved by fetchRecords() call below and then, underlying buffer is no
+                    //    longer needed and it's released via the Fetcher.CompletedFetch.drain() method.
+                    // 2. The CompletedFetch could be an object containing an error code from broker such as
+                    //    NOT_LEADER_FOR_PARTITION. In that case, we don't need to retrieve the records and ref count
+                    //    is decremented after initializeCompletedFetch() method.
                     CompletedFetch records = completedFetches.peek();
                     if (records == null) break;
 
                     if (records.notInitialized()) {
                         try {
                             nextInLineFetch = initializeCompletedFetch(records);
+
+                            // nextInLineRecords might be null when completedFetch contains error
+                            if (nextInLineFetch == null) {
+                                records.response.decRefCount();
+                            }
                         } catch (Exception e) {
                             // Remove a completedFetch upon a parse with exception if (1) it contains no records, and
                             // (2) there are no fetched records with actual content preceding this exception.
@@ -668,6 +682,7 @@ public class Fetcher<K, V> implements Closeable {
                             FetchResponseData.PartitionData partition = records.partitionData;
                             if (fetched.isEmpty() && FetchResponse.recordsOrFail(partition).sizeInBytes() == 0) {
                                 completedFetches.poll();
+                                records.response.decRefCount();
                             }
                             throw e;
                         }
@@ -1519,13 +1534,15 @@ public class Fetcher<K, V> implements Closeable {
         private Exception cachedRecordException = null;
         private boolean corruptLastRecord = false;
         private boolean initialized = false;
+        private final ClientResponse response;
 
         private CompletedFetch(TopicPartition partition,
                                FetchResponseData.PartitionData partitionData,
                                FetchResponseMetricAggregator metricAggregator,
                                Iterator<? extends RecordBatch> batches,
                                Long fetchOffset,
-                               short responseVersion) {
+                               short responseVersion,
+                               ClientResponse response) {
             this.partition = partition;
             this.partitionData = partitionData;
             this.metricAggregator = metricAggregator;
@@ -1535,12 +1552,14 @@ public class Fetcher<K, V> implements Closeable {
             this.lastEpoch = Optional.empty();
             this.abortedProducerIds = new HashSet<>();
             this.abortedTransactions = abortedTransactions(partitionData);
+            this.response = response;
         }
 
         private void drain() {
             if (!isConsumed) {
                 maybeCloseRecordStream();
                 cachedRecordException = null;
+                this.response.decRefCount();
                 this.isConsumed = true;
                 this.metricAggregator.record(partition, bytesRead, recordsRead);
 
@@ -1946,6 +1965,10 @@ public class Fetcher<K, V> implements Closeable {
     public void close() {
         if (nextInLineFetch != null)
             nextInLineFetch.drain();
+        for (CompletedFetch completedFetch : completedFetches) {
+            completedFetch.response.decRefCount();
+        }
+        completedFetches.clear();
         decompressionBufferSupplier.close();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -136,11 +136,15 @@ public class NetworkReceive implements Receive {
 
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (buffer != null && buffer != EMPTY_BUFFER) {
             memoryPool.release(buffer);
             buffer = null;
         }
+    }
+
+    public MemoryPool memoryPool() {
+        return memoryPool;
     }
 
     public ByteBuffer payload() {

--- a/clients/src/test/java/org/apache/kafka/clients/ClientResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientResponseTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+
+
+public class ClientResponseTest {
+
+    private ClientResponse clientResponseWithPool;
+    private ClientResponse clientResponse;
+    private ClientResponse clientResponseDisconnected;
+    private MemoryPool memoryPool;
+
+    @BeforeEach
+    public void setup() {
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.FETCH, (short) 1, "someclient", 1);
+        NetworkClientTest.TestCallbackHandler callbackHandler = new NetworkClientTest.TestCallbackHandler();
+        FetchResponseData responseData = new FetchResponseData()
+                .setErrorCode(Errors.NONE.code())
+                .setThrottleTimeMs(1)
+                .setSessionId(1);
+        FetchResponse fetchResponse = new FetchResponse(responseData);
+        memoryPool = Mockito.mock(MemoryPool.class);
+
+        clientResponseWithPool =
+            new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, false, null, null, fetchResponse,
+                memoryPool, ByteBuffer.allocate(1));
+        clientResponse =
+            new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, false, null, null, fetchResponse,
+                MemoryPool.NONE, ByteBuffer.allocate(1));
+        clientResponseDisconnected =
+            new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, true, null, null, fetchResponse);
+    }
+
+    private void decrementRefCountBelowZero(ClientResponse clientResponse) {
+        clientResponse.decRefCount();
+    }
+
+    private void incrementRefCountAfterBufferRelease(ClientResponse clientResponse) {
+        clientResponse.incRefCount();
+        clientResponse.decRefCount();
+
+        // Buffer released now. Try incrementing the ref count again.
+        clientResponse.incRefCount();
+    }
+
+    @Test
+    public void testClientResponseBufferRelease() {
+        Mockito.doNothing().when(memoryPool).release(Mockito.any());
+
+        clientResponseWithPool.incRefCount();
+        clientResponseWithPool.decRefCount();
+
+        Mockito.verify(memoryPool, Mockito.times(1)).release(Mockito.any());
+    }
+
+    @Test
+    public void testDecRefCountBelowZeroMemoryPoolNone() {
+        try {
+            decrementRefCountBelowZero(clientResponse);
+        } catch (Exception e) {
+            Assertions.fail("Client response with MemoryPool.NONE should not throw.");
+        }
+    }
+
+    @Test
+    public void testDecRefCountBelowZeroDisconnected() {
+        try {
+            decrementRefCountBelowZero(clientResponseDisconnected);
+        } catch (Exception e) {
+            Assertions.fail("Client response with disconnection should not throw.");
+        }
+    }
+
+    @Test
+    public void testDecRefCountBelowZeroShouldThrow() {
+        try {
+            decrementRefCountBelowZero(clientResponseWithPool);
+            Assertions.fail("Decrementing ref count below zero should throw.");
+        } catch (Exception e) {
+            Assertions.assertEquals(IllegalStateException.class, e.getClass());
+            Assertions.assertEquals("Ref count decremented below zero. This should never happen.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testIncRefCountAfterBufferReleaseMemoryPoolNone() {
+        try {
+            incrementRefCountAfterBufferRelease(clientResponse);
+        } catch (Exception e) {
+            Assertions.fail("Client response with MemoryPool.NONE should not throw.");
+        }
+    }
+
+    @Test
+    public void testIncRefCountAfterBufferReleaseDisconnected() {
+        try {
+            incrementRefCountAfterBufferRelease(clientResponseDisconnected);
+        } catch (Exception e) {
+            Assertions.fail("Client response with disconnection should not throw.");
+        }
+    }
+
+    @Test
+    public void testIncRefCountAfterBufferReleaseShouldThrow() {
+        try {
+            incrementRefCountAfterBufferRelease(clientResponseWithPool);
+            Assertions.fail("Incrementing ref count after releasing pool should throw.");
+        } catch (IllegalStateException e) {
+            Assertions.assertEquals("Ref count being incremented again after buffer release. This should never happen.",
+                e.getMessage());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -217,7 +217,7 @@ public class NetworkClientTest {
         client.poll(1, time.milliseconds());
         assertTrue(client.isReady(node, time.milliseconds()), "The client should be ready");
         ProduceRequestData data = new ProduceRequestData()
-                .setAcks((short)1)
+                .setAcks((short) 1)
                 .setTimeoutMs(1000);
 
         ProduceRequest.Builder builder = ProduceRequest.forCurrentMagic(data);
@@ -246,7 +246,7 @@ public class NetworkClientTest {
         client.poll(1, time.milliseconds());
         assertTrue(client.isReady(node, time.milliseconds()), "The client should be ready");
         ProduceRequestData data = new ProduceRequestData()
-                .setAcks((short)1)
+                .setAcks((short) 1)
                 .setTimeoutMs(1000);
 
         ProduceRequest.Builder builder = ProduceRequest.forCurrentMagic(data);


### PR DESCRIPTION
**Forward porting** - https://github.com/linkedin/kafka/pull/186

**TICKET** = [KAFKA-13188](https://issues.apache.org/jira/browse/KAFKA-13188)
**LI_DESCRIPTION** =
The current KafkaConsumer code includes support for allocating buffers from MemoryPool when allocating bytes for requests to Brokers. However, the code doesn't release them back to the pool and hence, rendering pooling moot. Currently, it works because it uses MemoryPool.NONE which just mallocs buffer every time a buffer is requested. However, this won't work if a different memory pool implementation is used.

The consumer can't just release the pool back into the memory because the fetch requests keep on holding on to the references to the pool in CompletedFetch objects which live across multiple poll calls. The idea here is to use ref counting based approach, where the ClientResponse increments ref count every time a CompletedFetch object is created and decrement when the fetch is drained after a poll calls returning records.

For the rest of the things such as metadata, offset commit, list offsets it is somewhat easier as the client is done with the response bytes after response future callback is completed.

This PR also adds the ClientResponseWithFinalize class for debugging purposes as well protected by linkedin.enable.client.resonse.leakcheck flag. The class uses finalizer to check whether there is some issue in code due to which the buffer wasn't released back to the pool yet. However, during in an actual production setting, the finalizers are costly and hence, not enabled by default.

**EXIT_CRITERIA** = If and when the upstream ticket is merged, and the changes are pulled in

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
