### PR TITLE
KAFKA-10900: Add metrics enumerated in KIP-630

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
@@ -43,5 +43,13 @@ public interface ControllerMetrics extends AutoCloseable {
 
     int preferredReplicaImbalanceCount();
 
+    void updateGenSnapshotLatencyMs(long genSnapshotLatencyMs);
+
+    void updateLoadSnapshotLatencyMs(long loadSnapshotLatencyMs);
+
+    void setSnapshotLagSize(long snapshotLagSize);
+
+    void setSnapshotSizeBytesSize(long snapshotSizeBytesSize);
+
     void close();
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -41,12 +41,23 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
         "KafkaController", "PreferredReplicaImbalanceCount");
 
+    private final static MetricName GEN_SNAPSHOT_LATENCY_MS = getMetricName(
+            "KafkaController", "GenSnapshotLatencyMs");
+    private final static MetricName LOAD_SNAPSHOT_LATENCY_MS = getMetricName(
+            "KafkaController", "LoadSnapshotLatencyMs");
+    private final static MetricName SNAPSHOT_LAG = getMetricName(
+            "KafkaController", "SnapshotLag");
+    private final static MetricName SNAPSHOT_SIZE_BYTES = getMetricName(
+            "KafkaController", "SnapshotSizeBytes");
+
     private final MetricsRegistry registry;
     private volatile boolean active;
     private volatile int globalTopicCount;
     private volatile int globalPartitionCount;
     private volatile int offlinePartitionCount;
     private volatile int preferredReplicaImbalanceCount;
+    private volatile long snapshotLagSize;
+    private volatile long snapshotSizeBytesSize;
     private final Gauge<Integer> activeControllerCount;
     private final Gauge<Integer> globalPartitionCountGauge;
     private final Gauge<Integer> globalTopicCountGauge;
@@ -54,6 +65,8 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final Gauge<Integer> preferredReplicaImbalanceCountGauge;
     private final Histogram eventQueueTime;
     private final Histogram eventQueueProcessingTime;
+    private final Histogram genSnapshotLatencyTime;
+    private final Histogram loadSnapshotLatencyTime;
 
     public QuorumControllerMetrics(MetricsRegistry registry) {
         this.registry = Objects.requireNonNull(registry);
@@ -92,6 +105,23 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
             @Override
             public Integer value() {
                 return preferredReplicaImbalanceCount;
+            }
+        });
+
+        this.genSnapshotLatencyTime = registry.newHistogram(GEN_SNAPSHOT_LATENCY_MS, true);
+        this.loadSnapshotLatencyTime = registry.newHistogram(LOAD_SNAPSHOT_LATENCY_MS, true);
+
+        registry.newGauge(SNAPSHOT_LAG, new Gauge<Long>() {
+            @Override
+            public Long value() {
+                return snapshotLagSize;
+            }
+        });
+
+        registry.newGauge(SNAPSHOT_SIZE_BYTES, new Gauge<Long>() {
+            @Override
+            public Long value() {
+                return snapshotSizeBytesSize;
             }
         });
     }
@@ -154,6 +184,26 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     @Override
     public int preferredReplicaImbalanceCount() {
         return this.preferredReplicaImbalanceCount;
+    }
+
+    @Override
+    public void updateGenSnapshotLatencyMs(long genSnapshotLatencyMs) {
+        this.genSnapshotLatencyTime.update(genSnapshotLatencyMs);
+    }
+
+    @Override
+    public void updateLoadSnapshotLatencyMs(long loadSnapshotLatencyMs) {
+        this.loadSnapshotLatencyTime.update(loadSnapshotLatencyMs);
+    }
+
+    @Override
+    public void setSnapshotLagSize(long snapshotLagSize) {
+        this.snapshotLagSize = snapshotLagSize;
+    }
+
+    @Override
+    public void setSnapshotSizeBytesSize(long snapshotSizeBytesSize) {
+        this.snapshotSizeBytesSize = snapshotSizeBytesSize;
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
@@ -24,6 +24,8 @@ public final class MockControllerMetrics implements ControllerMetrics {
     private volatile int offlinePartitions;
     private volatile int preferredReplicaImbalances;
     private volatile boolean closed = false;
+    private volatile long snapshotLagSize;
+    private volatile long snapshotSizeBytesSize;
 
     public MockControllerMetrics() {
         this.active = false;
@@ -31,6 +33,8 @@ public final class MockControllerMetrics implements ControllerMetrics {
         this.partitions = 0;
         this.offlinePartitions = 0;
         this.preferredReplicaImbalances = 0;
+        this.snapshotLagSize = 0;
+        this.snapshotSizeBytesSize = 0;
     }
 
     @Override
@@ -93,6 +97,26 @@ public final class MockControllerMetrics implements ControllerMetrics {
         return this.preferredReplicaImbalances;
     }
 
+
+    @Override
+    public void updateGenSnapshotLatencyMs(long genSnapshotLatencyMs) {
+        // nothing to do
+    }
+
+    @Override
+    public void updateLoadSnapshotLatencyMs(long loadSnapshotLatencyMs) {
+        // nothing to do
+    }
+
+    @Override
+    public void setSnapshotLagSize(long snapshotLagSize) {
+        this.snapshotLagSize = snapshotLagSize;
+    }
+
+    @Override
+    public void setSnapshotSizeBytesSize(long snapshotSizeBytesSize) {
+        this.snapshotSizeBytesSize = snapshotSizeBytesSize;
+    }
     @Override
     public void close() {
         closed = true;


### PR DESCRIPTION
KIP-630 enumerates a few metrics. Makes sure that those metrics are implemented. Add the following Metrics.


kafka.controller:type=KafkaController,name=GenSnapshotLatencyMs | A histogram of the amount of time it took to generate a snapshot.
kafka.controller:type=KafkaController,name=LoadSnapshotLatencyMs | A histogram of the amount of time it took to load the snapshot.
kafka.controller:type=KafkaController,name=SnapshotLag | The number of offsets between the largest snapshot offset and the high-watermark.
kafka.controller:type=KafkaController,name=SnapshotSizeBytes | Size of the latest snapshot in bytes.

