### PR TITLE
MINOR: Update streams doc to close KeyValueIterator in example code

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -640,7 +640,7 @@ KGroupedTable&lt;String, Integer&gt; groupedTable = table.groupBy(
 
                             <p class="first">Cogroup does not cause a repartition as it has the prerequisite that the input streams are grouped. In the process of creating these groups they will have already been repartitioned if the stream was already marked for repartitioning.</p>
                             <pre class="line-numbers"><code class="language-java">KStream&lt;byte[], String&gt; stream = ...;
-                        KStream&lt;byte[], String&gt; stream2 = ...;
+KStream&lt;byte[], String&gt; stream2 = ...;
 
 // Group by the existing key, using the application&#39;s configured
 // default serdes for keys and values.
@@ -1385,7 +1385,7 @@ KTable&lt;String, Integer&gt; aggregated = groupedStream.aggregate(
                             <a class="reference internal" href="memory-mgmt.html#streams-developer-guide-memory-management-record-cache"><span class="std std-ref">record caches</span></a> are disabled (default: enabled).
                             When record caches are enabled, what might happen for example is that the output results of the rows with timestamps
                             4 and 5 would be <a class="reference internal" href="memory-mgmt.html#streams-developer-guide-memory-management-record-cache"><span class="std std-ref">compacted</span></a>, and there would only be
-                            a single state update for the key <code class="docutils literal"><span class="pre">kafka</span></code> in the KTable (here: from <code class="docutils literal"><span class="pre">(kafka</span> <span class="pre">1)</span></code> directly to <code class="docutils literal"><span class="pre">(kafka,</span> <span class="pre">3)</span></code>.
+                            a single state update for the key <code class="docutils literal"><span class="pre">kafka</span></code> in the KTable (here: from <code class="docutils literal"><span class="pre">(kafka,</span> <span class="pre">1)</span></code> directly to <code class="docutils literal"><span class="pre">(kafka,</span> <span class="pre">3)</span></code>.
                             Typically, you should only disable record caches for testing or debugging purposes &#8211; under normal circumstances it
                             is better to leave record caches enabled.</p>
                     </div>
@@ -1505,7 +1505,7 @@ KTable&lt;String, Integer&gt; aggregated = groupedTable.aggregate(
                             <a class="reference internal" href="memory-mgmt.html#streams-developer-guide-memory-management-record-cache"><span class="std std-ref">record caches</span></a> are disabled (default: enabled).
                             When record caches are enabled, what might happen for example is that the output results of the rows with timestamps
                             4 and 5 would be <a class="reference internal" href="memory-mgmt.html#streams-developer-guide-memory-management-record-cache"><span class="std std-ref">compacted</span></a>, and there would only be
-                            a single state update for the key <code class="docutils literal"><span class="pre">kafka</span></code> in the KTable (here: from <code class="docutils literal"><span class="pre">(kafka</span> <span class="pre">1)</span></code> directly to <code class="docutils literal"><span class="pre">(kafka,</span> <span class="pre">3)</span></code>.
+                            a single state update for the key <code class="docutils literal"><span class="pre">kafka</span></code> in the KTable (here: from <code class="docutils literal"><span class="pre">(kafka,</span> <span class="pre">1)</span></code> directly to <code class="docutils literal"><span class="pre">(kafka,</span> <span class="pre">3)</span></code>.
                             Typically, you should only disable record caches for testing or debugging purposes &#8211; under normal circumstances it
                             is better to leave record caches enabled.</p>
                     </div>

--- a/docs/streams/developer-guide/interactive-queries.html
+++ b/docs/streams/developer-guide/interactive-queries.html
@@ -153,17 +153,21 @@ ReadOnlyKeyValueStore&lt;String, Long&gt; keyValueStore =
 System.out.println(&quot;count for hello:&quot; + keyValueStore.get(&quot;hello&quot;));
 
 // Get the values for a range of keys available in this application instance
-KeyValueIterator&lt;String, Long&gt; range = keyValueStore.range(&quot;all&quot;, &quot;streams&quot;);
-while (range.hasNext()) {
-  KeyValue&lt;String, Long&gt; next = range.next();
-  System.out.println(&quot;count for &quot; + next.key + &quot;: &quot; + next.value);
+// Note: the KeyValueIterator instance should be closed explicitly to avoid resource leakage
+try (KeyValueIterator&lt;String, Long&gt; range = keyValueStore.range(&quot;all&quot;, &quot;streams&quot;)) {
+    while (range.hasNext()) {
+      KeyValue&lt;String, Long&gt; next = range.next();
+      System.out.println(&quot;count for &quot; + next.key + &quot;: &quot; + next.value);
+    }
 }
 
 // Get the values for all of the keys available in this application instance
-KeyValueIterator&lt;String, Long&gt; range = keyValueStore.all();
-while (range.hasNext()) {
-  KeyValue&lt;String, Long&gt; next = range.next();
-  System.out.println(&quot;count for &quot; + next.key + &quot;: &quot; + next.value);
+// Note: the KeyValueIterator instance should be closed explicitly to avoid resource leakage
+try (KeyValueIterator&lt;String, Long&gt; range = keyValueStore.all()) {
+    while (range.hasNext()) {
+      KeyValue&lt;String, Long&gt; next = range.next();
+      System.out.println(&quot;count for &quot; + next.key + &quot;: &quot; + next.value);
+}
 }</code></pre>
                 <p>You can also materialize the results of stateless operators by using the overloaded methods that take a <code class="docutils literal"><span class="pre">queryableStoreName</span></code>
                     as shown in the example below:</p>


### PR DESCRIPTION
Update the streams doc:
1. close `KeyValueIterator` in example code (add a comment to remind user: `Note: the KeyValueIterator instance should be closed explicitly to avoid resource leakage`)
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/43372967/129201334-326ff4f9-e06e-426d-9d2d-ce70e13cbf9c.png">

2. Fix the example code indent
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/43372967/129201406-632b62a5-9062-4a1f-b529-103f92966541.png">


3. Add missing comma between key/value
<img width="746" alt="image" src="https://user-images.githubusercontent.com/43372967/129201511-e69b6225-9e8c-4f08-b9a2-615aee21e52b.png">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
