### PR TITLE
MINOR: Refactored BrokerHeartbeatManager::findOneStaleBroker to not use iterator

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -425,11 +425,10 @@ public class BrokerHeartbeatManager {
      * @return      An Optional broker node id.
      */
     Optional<Integer> findOneStaleBroker() {
-        BrokerHeartbeatStateIterator iterator = unfenced.iterator();
-        if (iterator.hasNext()) {
-            BrokerHeartbeatState broker = iterator.next();
-            // The unfenced list is sorted on last contact time from each
-            // broker. If the first broker is not stale, then none is.
+        // The unfenced list is sorted on last contact time from each
+        // broker. If the first broker is not stale, then none is.
+        BrokerHeartbeatState broker = unfenced.first();
+        if (broker != null) {
             if (!hasValidSession(broker)) {
                 return Optional.of(broker.id);
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.controller;
 
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
@@ -161,14 +159,6 @@ public class ClusterControlManager {
 
     Map<Integer, BrokerRegistration> brokerRegistrations() {
         return brokerRegistrations;
-    }
-
-    Set<Integer> fencedBrokerIds() {
-        return brokerRegistrations.values()
-            .stream()
-            .filter(BrokerRegistration::fenced)
-            .map(BrokerRegistration::id)
-            .collect(Collectors.toSet());
     }
 
     /**

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -200,6 +200,14 @@ public class ReplicationControlManagerTest {
             }
         }
 
+        Set<Integer> fencedBrokerIds() {
+            return clusterControl.brokerRegistrations().values()
+                .stream()
+                .filter(BrokerRegistration::fenced)
+                .map(BrokerRegistration::id)
+                .collect(Collectors.toSet());
+        }
+
         void unfenceBrokers(Integer... brokerIds) throws Exception {
             for (int brokerId : brokerIds) {
                 ControllerResult<BrokerHeartbeatReply> result = replicationControl.
@@ -228,7 +236,7 @@ public class ReplicationControlManagerTest {
                 staleBroker = clusterControl.heartbeatManager().findOneStaleBroker();
             }
 
-            assertEquals(brokerIds, clusterControl.fencedBrokerIds());
+            assertEquals(brokerIds, fencedBrokerIds());
         }
 
         long currentBrokerEpoch(int brokerId) {
@@ -1062,7 +1070,7 @@ public class ReplicationControlManagerTest {
         Uuid fooId = ctx.createTestTopic("foo", new int[][]{
             new int[]{1, 2, 3}, new int[]{2, 3, 4}, new int[]{0, 2, 1}}).topicId();
 
-        assertTrue(ctx.clusterControl.fencedBrokerIds().isEmpty());
+        assertEquals(Collections.emptySet(), ctx.fencedBrokerIds());
         ctx.fenceBrokers(Utils.mkSet(2, 3));
 
         PartitionRegistration partition0 = replication.getPartition(fooId, 0);

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -200,7 +200,7 @@ public class ReplicationControlManagerTest {
             }
         }
 
-        Set<Integer> fencedBrokerIds() {
+        private Set<Integer> fencedBrokerIds() {
             return clusterControl.brokerRegistrations().values()
                 .stream()
                 .filter(BrokerRegistration::fenced)


### PR DESCRIPTION
Some code refactoring based on https://github.com/apache/kafka/pull/11191 feedback