### PR TITLE
KAFKA-12465: Logic about inconsistent cluster id

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -60,7 +60,7 @@
               files="MemoryRecordsBuilder.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(KafkaConsumer|ConsumerCoordinator|Fetcher|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaRaftClient|KafkaRaftClientTest).java"/>
+              files="(KafkaConsumer|ConsumerCoordinator|Fetcher|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaRaftClient|KafkaRaftClientTest|RaftUtilTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling"
               files="(Errors|SaslAuthenticatorTest|AgentTest|CoordinatorTest).java"/>
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.FetchSnapshotRequestData;
+import org.apache.kafka.common.message.FetchSnapshotResponseData;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -158,5 +160,19 @@ public class RaftUtil {
                    data.topics().get(0).topicName().equals(topicPartition.topic()) &&
                    data.topics().get(0).partitions().size() == 1 &&
                    data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    }
+
+    static boolean hasValidTopicPartition(FetchSnapshotRequestData data, TopicPartition topicPartition) {
+        return data.topics().size() == 1 &&
+            data.topics().get(0).name().equals(topicPartition.topic()) &&
+            data.topics().get(0).partitions().size() == 1 &&
+            data.topics().get(0).partitions().get(0).partition() == topicPartition.partition();
+    }
+
+    static boolean hasValidTopicPartition(FetchSnapshotResponseData data, TopicPartition topicPartition) {
+        return data.topics().size() == 1 &&
+            data.topics().get(0).name().equals(topicPartition.topic()) &&
+            data.topics().get(0).partitions().size() == 1 &&
+            data.topics().get(0).partitions().get(0).index() == topicPartition.partition();
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -99,80 +99,135 @@ public class RaftUtil {
             .setResponses(Collections.singletonList(fetchableTopic));
     }
 
-    static boolean hasValidTopicPartition(FetchRequestData data, TopicPartition topicPartition, Uuid topicId) {
-        return data.topics().size() == 1 &&
-            data.topics().get(0).topicId().equals(topicId) &&
-            data.topics().get(0).partitions().size() == 1 &&
-            data.topics().get(0).partitions().get(0).partition() == topicPartition.partition();
+    static Errors validateTopicPartition(FetchRequestData data, TopicPartition topicPartition, Uuid topicId) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicId().equals(topicId) ||
+            data.topics().get(0).partitions().get(0).partition() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(FetchResponseData data, TopicPartition topicPartition, Uuid topicId) {
-        return data.responses().size() == 1 &&
-            data.responses().get(0).topicId().equals(topicId) &&
-            data.responses().get(0).partitions().size() == 1 &&
-            data.responses().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(FetchResponseData data, TopicPartition topicPartition, Uuid topicId) {
+        if (data.responses().size() != 1 ||
+            data.responses().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.responses().get(0).topicId().equals(topicId) ||
+            data.responses().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(VoteResponseData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(VoteResponseData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(VoteRequestData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(VoteRequestData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(BeginQuorumEpochRequestData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(BeginQuorumEpochRequestData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(BeginQuorumEpochResponseData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(BeginQuorumEpochResponseData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(EndQuorumEpochRequestData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(EndQuorumEpochRequestData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(EndQuorumEpochResponseData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(EndQuorumEpochResponseData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(DescribeQuorumRequestData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-                   data.topics().get(0).topicName().equals(topicPartition.topic()) &&
-                   data.topics().get(0).partitions().size() == 1 &&
-                   data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    static Errors validateTopicPartition(DescribeQuorumRequestData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).topicName().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partitionIndex() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(FetchSnapshotRequestData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-            data.topics().get(0).name().equals(topicPartition.topic()) &&
-            data.topics().get(0).partitions().size() == 1 &&
-            data.topics().get(0).partitions().get(0).partition() == topicPartition.partition();
+    static Errors validateTopicPartition(FetchSnapshotRequestData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).name().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).partition() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 
-    static boolean hasValidTopicPartition(FetchSnapshotResponseData data, TopicPartition topicPartition) {
-        return data.topics().size() == 1 &&
-            data.topics().get(0).name().equals(topicPartition.topic()) &&
-            data.topics().get(0).partitions().size() == 1 &&
-            data.topics().get(0).partitions().get(0).index() == topicPartition.partition();
+    static Errors validateTopicPartition(FetchSnapshotResponseData data, TopicPartition topicPartition) {
+        if (data.topics().size() != 1 ||
+            data.topics().get(0).partitions().size() != 1) {
+            return Errors.INVALID_REQUEST;
+        }
+        if (!data.topics().get(0).name().equals(topicPartition.topic()) ||
+            data.topics().get(0).partitions().get(0).index() != topicPartition.partition()) {
+            return Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        }
+        return Errors.NONE;
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -518,7 +518,7 @@ final public class KafkaRaftClientSnapshotTest {
 
         context.client.poll();
 
-        context.assertSentFetchSnapshotResponse(Errors.INVALID_REQUEST);
+        context.assertSentFetchSnapshotResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION);
     }
 
     @Test
@@ -1655,7 +1655,7 @@ final public class KafkaRaftClientSnapshotTest {
         // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
         assertDoesNotThrow(context.client::poll);
 
-        // It's impossible to receive a be begin quorum response before any other request so we don't test
+        // It's impossible to receive a FetchSnapshotResponse before any other request so we don't test
     }
 
     private static FetchSnapshotRequestData fetchSnapshotRequest(

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.InconsistentClusterIdException;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
@@ -57,6 +58,7 @@ import java.util.concurrent.TimeoutException;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.raft.RaftClientTestContext.Builder.DEFAULT_ELECTION_TIMEOUT_MS;
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1557,6 +1559,122 @@ public class KafkaRaftClientTest {
         context.deliverRequest(context.endEpochRequest("invalid-uuid", epoch, localId, Collections.singletonList(otherNodeId)));
         context.pollUntilResponse();
         context.assertSentEndQuorumEpochResponse(Errors.INCONSISTENT_CLUSTER_ID);
+    }
+
+    @Test
+    public void testInconsistentClusterIdInFetchResponse() throws Exception {
+        int localId = 0;
+        int otherNodeId = 1;
+        int epoch = 5;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withElectedLeader(epoch, otherNodeId)
+            .build();
+
+        // Send a request
+        context.pollUntilRequest();
+        int correlationId = context.assertSentFetchRequest(epoch, 0L, 0);
+
+        // Firstly receive a response with a valid cluster id
+        FetchResponseData fetchResponse = context.fetchResponse(epoch, otherNodeId,
+            MemoryRecords.EMPTY, 0L, Errors.NONE);
+        context.deliverResponse(correlationId, otherNodeId, fetchResponse);
+
+        // Send fetch request
+        context.pollUntilRequest();
+        correlationId = context.assertSentFetchRequest(epoch, 0L, 0);
+
+        // Secondly receive a response with an inconsistent cluster id
+        context.deliverResponse(correlationId, otherNodeId,
+            new FetchResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code()));
+
+        // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
+        assertDoesNotThrow(context.client::poll);
+
+        // This time we receive a inconsistent cluster id directly
+        context = new RaftClientTestContext.Builder(localId, voters)
+            .withElectedLeader(epoch, otherNodeId)
+            .build();
+
+        context.pollUntilRequest();
+        correlationId = context.assertSentFetchRequest(epoch, 0L, 0);
+        context.deliverResponse(correlationId, otherNodeId,
+            new FetchResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code()));
+        // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
+        assertThrows(InconsistentClusterIdException.class, context.client::poll);
+    }
+
+    @Test
+    public void testInconsistentClusterIdInBeginQuorumResponse() throws Exception {
+        int localId = 0;
+        int otherNodeId = 1;
+        int epoch = 5;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withVotedCandidate(epoch, localId)
+            .build();
+        context.assertVotedCandidate(epoch, localId);
+
+        // Send a request
+        context.pollUntilRequest();
+        int correlationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
+
+        // Firstly receive a response with a valid cluster id
+        context.deliverResponse(correlationId, otherNodeId, context.voteResponse(true, Optional.empty(), epoch));
+        context.client.poll();
+        context.assertElectedLeader(epoch, localId);
+
+        // Send begin quorum request
+        context.pollUntilRequest();
+        correlationId = context.assertSentBeginQuorumEpochRequest(epoch, 1);
+
+        // Secondly receive a response with an inconsistent cluster id
+        context.deliverResponse(correlationId, otherNodeId,
+            new BeginQuorumEpochResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code()));
+
+        // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
+        assertDoesNotThrow(context.client::poll);
+
+        // It's impossible to receive a be begin quorum response before any other request so we don't test
+    }
+
+    @Test
+    public void testInconsistentClusterIdInEndQuorumResponse() throws Exception {
+        int localId = 0;
+        int otherNodeId = 1;
+        int epoch = 5;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withVotedCandidate(epoch, localId)
+            .build();
+        context.assertVotedCandidate(epoch, localId);
+
+        // Send a request
+        context.pollUntilRequest();
+        int correlationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
+
+        // Firstly receive a response with a valid cluster id
+        context.deliverResponse(correlationId, otherNodeId, context.voteResponse(true, Optional.empty(), epoch));
+        context.client.poll();
+        context.assertElectedLeader(epoch, localId);
+
+        context.client.shutdown(5000);
+
+        // Send end quorum request
+        context.pollUntilRequest();
+        correlationId = context.assertSentEndQuorumEpochRequest(epoch, 1);
+
+        // Secondly receive a response with an inconsistent cluster id
+        context.deliverResponse(correlationId, otherNodeId,
+            new EndQuorumEpochResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code()));
+
+        // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
+        assertDoesNotThrow(context.client::poll);
+
+        // It's impossible to receive a be end quorum response before any other request so we don't test
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1601,7 +1601,7 @@ public class KafkaRaftClientTest {
         correlationId = context.assertSentFetchRequest(epoch, 0L, 0);
         context.deliverResponse(correlationId, otherNodeId,
             new FetchResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code()));
-        // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
+        // Inconsistent cluster id are fatal if this is the first rpc request
         assertThrows(InconsistentClusterIdException.class, context.client::poll);
     }
 
@@ -1637,7 +1637,7 @@ public class KafkaRaftClientTest {
         // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
         assertDoesNotThrow(context.client::poll);
 
-        // It's impossible to receive a be begin quorum response before any other request so we don't test
+        // It's impossible to receive a BeginQuorumEpochResponse before any other request so we don't test
     }
 
     @Test
@@ -1674,7 +1674,7 @@ public class KafkaRaftClientTest {
         // Inconsistent cluster id are not fatal if a previous response contained a valid cluster id
         assertDoesNotThrow(context.client::poll);
 
-        // It's impossible to receive a be end quorum response before any other request so we don't test
+        // It's impossible to receive an EndQuorumEpochResponse before any other request so we don't test
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -78,7 +78,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.raft.RaftUtil.hasValidTopicPartition;
+import static org.apache.kafka.raft.RaftUtil.validateTopicPartition;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -496,7 +496,7 @@ public final class RaftClientTestContext {
         RaftMessage raftMessage = sentMessages.get(0);
         assertTrue(raftMessage.data() instanceof VoteResponseData);
         VoteResponseData response = (VoteResponseData) raftMessage.data();
-        assertTrue(hasValidTopicPartition(response, metadataPartition));
+        assertEquals(Errors.NONE, validateTopicPartition(response, metadataPartition));
 
         VoteResponseData.PartitionData partitionResponse = response.topics().get(0).partitions().get(0);
 
@@ -914,7 +914,7 @@ public final class RaftClientTestContext {
     }
 
     private VoteRequestData.PartitionData unwrap(VoteRequestData voteRequest) {
-        assertTrue(RaftUtil.hasValidTopicPartition(voteRequest, metadataPartition));
+        assertEquals(Errors.NONE, validateTopicPartition(voteRequest, metadataPartition));
         return voteRequest.topics().get(0).partitions().get(0);
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
@@ -1,0 +1,835 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
+import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
+import org.apache.kafka.common.message.DescribeQuorumRequestData;
+import org.apache.kafka.common.message.EndQuorumEpochRequestData;
+import org.apache.kafka.common.message.EndQuorumEpochResponseData;
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.FetchSnapshotRequestData;
+import org.apache.kafka.common.message.FetchSnapshotResponseData;
+import org.apache.kafka.common.message.VoteRequestData;
+import org.apache.kafka.common.message.VoteResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RaftUtilTest {
+
+    private String topic = "__cluster_metadata";
+    private Uuid topicId = Uuid.METADATA_TOPIC_ID;
+    private int partition = 0;
+
+    @Test
+    public void testValidateFetchRequestData() {
+        FetchRequestData none = new FetchRequestData()
+            .setTopics(Collections.singletonList(
+                new FetchRequestData.FetchTopic().setTopic(topic).setTopicId(topicId)
+                    .setPartitions(Collections.singletonList(new FetchRequestData.FetchPartition().setPartition(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition), topicId)
+        );
+
+        List<FetchRequestData> invalidRequests = Arrays.asList(
+            new FetchRequestData(),
+            new FetchRequestData().setTopics(
+                Arrays.asList(
+                    new FetchRequestData.FetchTopic(),
+                    new FetchRequestData.FetchTopic())),
+            new FetchRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchRequestData.FetchTopic()
+                        .setTopic(topic)
+                        .setTopicId(topicId)
+                )
+            ),
+            new FetchRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchRequestData.FetchTopic()
+                        .setTopic(topic)
+                        .setTopicId(topicId)
+                        .setPartitions(
+                            Arrays.asList(
+                                new FetchRequestData.FetchPartition(),
+                                new FetchRequestData.FetchPartition()
+                            )
+                        )
+                )
+            )
+        );
+        for (FetchRequestData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition), topicId)
+            );
+        }
+
+        List<FetchRequestData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new FetchRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchRequestData.FetchTopic()
+                        .setTopic(topic)
+                        .setTopicId(Uuid.randomUuid())
+                        .setPartitions(
+                            Collections.singletonList(new FetchRequestData.FetchPartition().setPartition(0))
+                        )
+                )
+            ),
+            new FetchRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchRequestData.FetchTopic()
+                        .setTopic(topic)
+                        .setTopicId(topicId)
+                        .setPartitions(
+                            Collections.singletonList(new FetchRequestData.FetchPartition().setPartition(1))
+                        )
+                )
+            )
+        );
+        for (FetchRequestData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition), topicId)
+            );
+        }
+    }
+
+    @Test
+    public void testValidateFetchResponseData() {
+        FetchResponseData none = new FetchResponseData()
+            .setResponses(Collections.singletonList(
+                new FetchResponseData.FetchableTopicResponse().setTopic(topic).setTopicId(topicId)
+                    .setPartitions(Collections.singletonList(new FetchResponseData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition), topicId)
+        );
+
+        List<FetchResponseData> invalidRequestResponses = Arrays.asList(
+            new FetchResponseData(),
+            new FetchResponseData().setResponses(
+                Arrays.asList(
+                    new FetchResponseData.FetchableTopicResponse(),
+                    new FetchResponseData.FetchableTopicResponse())),
+            new FetchResponseData().setResponses(
+                Collections.singletonList(
+                    new FetchResponseData.FetchableTopicResponse()
+                        .setTopic(topic)
+                        .setTopicId(topicId)
+                )
+            ),
+            new FetchResponseData().setResponses(
+                Collections.singletonList(
+                    new FetchResponseData.FetchableTopicResponse()
+                        .setTopic(topic)
+                        .setTopicId(topicId)
+                        .setPartitions(
+                            Arrays.asList(
+                                new FetchResponseData.PartitionData(),
+                                new FetchResponseData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (FetchResponseData invalidRequest : invalidRequestResponses) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition), topicId)
+            );
+        }
+
+        List<FetchResponseData> unknownTopicOrPartitionResponses = Arrays.asList(
+            new FetchResponseData().setResponses(
+                Collections.singletonList(
+                    new FetchResponseData.FetchableTopicResponse()
+                        .setTopic(topic)
+                        .setTopicId(Uuid.randomUuid())
+                        .setPartitions(
+                            Collections.singletonList(new FetchResponseData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new FetchResponseData().setResponses(
+                Collections.singletonList(
+                    new FetchResponseData.FetchableTopicResponse()
+                        .setTopic(topic)
+                        .setTopicId(topicId)
+                        .setPartitions(
+                            Collections.singletonList(new FetchResponseData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (FetchResponseData unknownTopicOrPartition: unknownTopicOrPartitionResponses) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartition, new TopicPartition(topic, partition), topicId)
+            );
+        }
+    }
+
+    @Test
+    public void testValidateVoteRequestData() {
+        VoteRequestData none = new VoteRequestData()
+            .setTopics(Collections.singletonList(
+                new VoteRequestData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new VoteRequestData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<VoteRequestData> invalidRequests = Arrays.asList(
+            new VoteRequestData(),
+            new VoteRequestData().setTopics(
+                Arrays.asList(
+                    new VoteRequestData.TopicData(),
+                    new VoteRequestData.TopicData())),
+            new VoteRequestData().setTopics(
+                Collections.singletonList(
+                    new VoteRequestData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new VoteRequestData().setTopics(
+                Collections.singletonList(
+                    new VoteRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new VoteRequestData.PartitionData(),
+                                new VoteRequestData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (VoteRequestData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<VoteRequestData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new VoteRequestData().setTopics(
+                Collections.singletonList(
+                    new VoteRequestData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new VoteRequestData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new VoteRequestData().setTopics(
+                Collections.singletonList(
+                    new VoteRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new VoteRequestData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (VoteRequestData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateVoteResponseData() {
+        VoteResponseData none = new VoteResponseData()
+            .setTopics(Collections.singletonList(
+                new VoteResponseData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new VoteResponseData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<VoteResponseData> invalidRequests = Arrays.asList(
+            new VoteResponseData(),
+            new VoteResponseData().setTopics(
+                Arrays.asList(
+                    new VoteResponseData.TopicData(),
+                    new VoteResponseData.TopicData())),
+            new VoteResponseData().setTopics(
+                Collections.singletonList(
+                    new VoteResponseData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new VoteResponseData().setTopics(
+                Collections.singletonList(
+                    new VoteResponseData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new VoteResponseData.PartitionData(),
+                                new VoteResponseData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (VoteResponseData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<VoteResponseData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new VoteResponseData().setTopics(
+                Collections.singletonList(
+                    new VoteResponseData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new VoteResponseData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new VoteResponseData().setTopics(
+                Collections.singletonList(
+                    new VoteResponseData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new VoteResponseData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (VoteResponseData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateBeginQuorumEpochRequestData() {
+        BeginQuorumEpochRequestData none = new BeginQuorumEpochRequestData()
+            .setTopics(Collections.singletonList(
+                new BeginQuorumEpochRequestData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new BeginQuorumEpochRequestData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<BeginQuorumEpochRequestData> invalidRequests = Arrays.asList(
+            new BeginQuorumEpochRequestData(),
+            new BeginQuorumEpochRequestData().setTopics(
+                Arrays.asList(
+                    new BeginQuorumEpochRequestData.TopicData(),
+                    new BeginQuorumEpochRequestData.TopicData())),
+            new BeginQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new BeginQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new BeginQuorumEpochRequestData.PartitionData(),
+                                new BeginQuorumEpochRequestData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (BeginQuorumEpochRequestData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<BeginQuorumEpochRequestData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new BeginQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new BeginQuorumEpochRequestData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new BeginQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new BeginQuorumEpochRequestData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (BeginQuorumEpochRequestData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateBeginQuorumEpochResponseData() {
+        BeginQuorumEpochResponseData none = new BeginQuorumEpochResponseData()
+            .setTopics(Collections.singletonList(
+                new BeginQuorumEpochResponseData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new BeginQuorumEpochResponseData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<BeginQuorumEpochResponseData> invalidRequests = Arrays.asList(
+            new BeginQuorumEpochResponseData(),
+            new BeginQuorumEpochResponseData().setTopics(
+                Arrays.asList(
+                    new BeginQuorumEpochResponseData.TopicData(),
+                    new BeginQuorumEpochResponseData.TopicData())),
+            new BeginQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new BeginQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new BeginQuorumEpochResponseData.PartitionData(),
+                                new BeginQuorumEpochResponseData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (BeginQuorumEpochResponseData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<BeginQuorumEpochResponseData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new BeginQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new BeginQuorumEpochResponseData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new BeginQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new BeginQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new BeginQuorumEpochResponseData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (BeginQuorumEpochResponseData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateEndQuorumEpochRequestData() {
+        EndQuorumEpochRequestData none = new EndQuorumEpochRequestData()
+            .setTopics(Collections.singletonList(
+                new EndQuorumEpochRequestData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new EndQuorumEpochRequestData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<EndQuorumEpochRequestData> invalidRequests = Arrays.asList(
+            new EndQuorumEpochRequestData(),
+            new EndQuorumEpochRequestData().setTopics(
+                Arrays.asList(
+                    new EndQuorumEpochRequestData.TopicData(),
+                    new EndQuorumEpochRequestData.TopicData())),
+            new EndQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new EndQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new EndQuorumEpochRequestData.PartitionData(),
+                                new EndQuorumEpochRequestData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (EndQuorumEpochRequestData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<EndQuorumEpochRequestData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new EndQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new EndQuorumEpochRequestData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new EndQuorumEpochRequestData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new EndQuorumEpochRequestData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (EndQuorumEpochRequestData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateEndQuorumEpochResponseData() {
+        EndQuorumEpochResponseData none = new EndQuorumEpochResponseData()
+            .setTopics(Collections.singletonList(
+                new EndQuorumEpochResponseData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new EndQuorumEpochResponseData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<EndQuorumEpochResponseData> invalidRequests = Arrays.asList(
+            new EndQuorumEpochResponseData(),
+            new EndQuorumEpochResponseData().setTopics(
+                Arrays.asList(
+                    new EndQuorumEpochResponseData.TopicData(),
+                    new EndQuorumEpochResponseData.TopicData())),
+            new EndQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new EndQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new EndQuorumEpochResponseData.PartitionData(),
+                                new EndQuorumEpochResponseData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (EndQuorumEpochResponseData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<EndQuorumEpochResponseData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new EndQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new EndQuorumEpochResponseData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new EndQuorumEpochResponseData().setTopics(
+                Collections.singletonList(
+                    new EndQuorumEpochResponseData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new EndQuorumEpochResponseData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (EndQuorumEpochResponseData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateDescribeQuorumRequestData() {
+        DescribeQuorumRequestData none = new DescribeQuorumRequestData()
+            .setTopics(Collections.singletonList(
+                new DescribeQuorumRequestData.TopicData().setTopicName(topic)
+                    .setPartitions(Collections.singletonList(new DescribeQuorumRequestData.PartitionData().setPartitionIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<DescribeQuorumRequestData> invalidRequests = Arrays.asList(
+            new DescribeQuorumRequestData(),
+            new DescribeQuorumRequestData().setTopics(
+                Arrays.asList(
+                    new DescribeQuorumRequestData.TopicData(),
+                    new DescribeQuorumRequestData.TopicData())),
+            new DescribeQuorumRequestData().setTopics(
+                Collections.singletonList(
+                    new DescribeQuorumRequestData.TopicData()
+                        .setTopicName(topic)
+                )
+            ),
+            new DescribeQuorumRequestData().setTopics(
+                Collections.singletonList(
+                    new DescribeQuorumRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new DescribeQuorumRequestData.PartitionData(),
+                                new DescribeQuorumRequestData.PartitionData()
+                            )
+                        )
+                )
+            )
+        );
+        for (DescribeQuorumRequestData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<DescribeQuorumRequestData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new DescribeQuorumRequestData().setTopics(
+                Collections.singletonList(
+                    new DescribeQuorumRequestData.TopicData()
+                        .setTopicName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new DescribeQuorumRequestData.PartitionData().setPartitionIndex(0))
+                        )
+                )
+            ),
+            new DescribeQuorumRequestData().setTopics(
+                Collections.singletonList(
+                    new DescribeQuorumRequestData.TopicData()
+                        .setTopicName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new DescribeQuorumRequestData.PartitionData().setPartitionIndex(1))
+                        )
+                )
+            )
+        );
+        for (DescribeQuorumRequestData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateFetchSnapshotRequestData() {
+        FetchSnapshotRequestData none = new FetchSnapshotRequestData()
+            .setTopics(Collections.singletonList(
+                new FetchSnapshotRequestData.TopicSnapshot().setName(topic)
+                    .setPartitions(Collections.singletonList(new FetchSnapshotRequestData.PartitionSnapshot().setPartition(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<FetchSnapshotRequestData> invalidRequests = Arrays.asList(
+            new FetchSnapshotRequestData(),
+            new FetchSnapshotRequestData().setTopics(
+                Arrays.asList(
+                    new FetchSnapshotRequestData.TopicSnapshot(),
+                    new FetchSnapshotRequestData.TopicSnapshot())),
+            new FetchSnapshotRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotRequestData.TopicSnapshot()
+                        .setName(topic)
+                )
+            ),
+            new FetchSnapshotRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotRequestData.TopicSnapshot()
+                        .setName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new FetchSnapshotRequestData.PartitionSnapshot(),
+                                new FetchSnapshotRequestData.PartitionSnapshot()
+                            )
+                        )
+                )
+            )
+        );
+        for (FetchSnapshotRequestData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<FetchSnapshotRequestData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new FetchSnapshotRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotRequestData.TopicSnapshot()
+                        .setName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new FetchSnapshotRequestData.PartitionSnapshot().setPartition(0))
+                        )
+                )
+            ),
+            new FetchSnapshotRequestData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotRequestData.TopicSnapshot()
+                        .setName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new FetchSnapshotRequestData.PartitionSnapshot().setPartition(1))
+                        )
+                )
+            )
+        );
+        for (FetchSnapshotRequestData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+
+    @Test
+    public void testValidateFetchSnapshotResponseData() {
+        FetchSnapshotResponseData none = new FetchSnapshotResponseData()
+            .setTopics(Collections.singletonList(
+                new FetchSnapshotResponseData.TopicSnapshot().setName(topic)
+                    .setPartitions(Collections.singletonList(new FetchSnapshotResponseData.PartitionSnapshot().setIndex(partition)))));
+        assertEquals(
+            Errors.NONE,
+            RaftUtil.validateTopicPartition(none, new TopicPartition(topic, partition))
+        );
+
+        List<FetchSnapshotResponseData> invalidRequests = Arrays.asList(
+            new FetchSnapshotResponseData(),
+            new FetchSnapshotResponseData().setTopics(
+                Arrays.asList(
+                    new FetchSnapshotResponseData.TopicSnapshot(),
+                    new FetchSnapshotResponseData.TopicSnapshot())),
+            new FetchSnapshotResponseData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotResponseData.TopicSnapshot()
+                        .setName(topic)
+                )
+            ),
+            new FetchSnapshotResponseData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotResponseData.TopicSnapshot()
+                        .setName(topic)
+                        .setPartitions(
+                            Arrays.asList(
+                                new FetchSnapshotResponseData.PartitionSnapshot(),
+                                new FetchSnapshotResponseData.PartitionSnapshot()
+                            )
+                        )
+                )
+            )
+        );
+        for (FetchSnapshotResponseData invalidRequest : invalidRequests) {
+            assertEquals(
+                Errors.INVALID_REQUEST,
+                RaftUtil.validateTopicPartition(invalidRequest, new TopicPartition(topic, partition))
+            );
+        }
+
+        List<FetchSnapshotResponseData> unknownTopicOrPartitionRequests = Arrays.asList(
+            new FetchSnapshotResponseData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotResponseData.TopicSnapshot()
+                        .setName(topic + "1")
+                        .setPartitions(
+                            Collections.singletonList(new FetchSnapshotResponseData.PartitionSnapshot().setIndex(0))
+                        )
+                )
+            ),
+            new FetchSnapshotResponseData().setTopics(
+                Collections.singletonList(
+                    new FetchSnapshotResponseData.TopicSnapshot()
+                        .setName(topic)
+                        .setPartitions(
+                            Collections.singletonList(new FetchSnapshotResponseData.PartitionSnapshot().setIndex(1))
+                        )
+                )
+            )
+        );
+        for (FetchSnapshotResponseData unknownTopicOrPartitionRequest: unknownTopicOrPartitionRequests) {
+            assertEquals(
+                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                RaftUtil.validateTopicPartition(unknownTopicOrPartitionRequest, new TopicPartition(topic, partition))
+            );
+        }
+    }
+}


### PR DESCRIPTION
*More detailed description of your change*
When handling a response, we treat  INCONSISTENT_CLUSTER_ID as a fatal error unless a previous response contained a valid cluster id, this solution can catch misconfiguration as early as possible and also avoid cases when a misconfigured node kills a stable cluster. However, the node will continue executing with the misconfiguration in some edge cases, for example, 3 nodes with 3 different cluster ids. 


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
