### PR TITLE
KAFKA-13201: Convert KTable suppress to new PAPI

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -58,6 +58,7 @@ import org.apache.kafka.streams.kstream.internals.suppress.FinalResultsSuppressi
 import org.apache.kafka.streams.kstream.internals.suppress.KTableSuppressProcessorSupplier;
 import org.apache.kafka.streams.kstream.internals.suppress.NamedSuppressed;
 import org.apache.kafka.streams.kstream.internals.suppress.SuppressedInternal;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopicProperties;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -542,8 +543,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final String storeName =
             suppressedInternal.name() != null ? suppressedInternal.name() + "-store" : builder.newStoreName(SUPPRESS_NAME);
 
-        @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-        final org.apache.kafka.streams.processor.ProcessorSupplier<K, Change<V>> suppressionSupplier = new KTableSuppressProcessorSupplier<>(
+        final ProcessorSupplier<K, Change<V>, K, Change<V>> suppressionSupplier = new KTableSuppressProcessorSupplier<>(
             suppressedInternal,
             storeName,
             this

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
@@ -162,7 +162,7 @@ public class KTableSuppressProcessorSupplier<K, V> implements KTableNewProcessor
         private void buffer(final Record<K, Change<V>> record) {
             final long bufferTime = bufferTimeDefinition.time(internalProcessorContext, record.key());
 
-            buffer.put(bufferTime, record.key(), record.value(), internalProcessorContext.recordContext());
+            buffer.put(bufferTime, record, internalProcessorContext.recordContext());
         }
 
         private void enforceConstraints() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
@@ -201,7 +201,9 @@ public class KTableSuppressProcessorSupplier<K, V> implements KTableNewProcessor
                 final ProcessorRecordContext prevRecordContext = internalProcessorContext.recordContext();
                 internalProcessorContext.setRecordContext(toEmit.recordContext());
                 try {
-                    internalProcessorContext.forward(toEmit.record());
+                    internalProcessorContext.forward(toEmit.record()
+                        .withTimestamp(toEmit.recordContext().timestamp())
+                        .withHeaders(toEmit.recordContext().headers()));
                     suppressionEmitSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
                 } finally {
                     internalProcessorContext.setRecordContext(prevRecordContext);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.kstream.internals.FullChangeSerde;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
@@ -467,14 +468,13 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
 
     @Override
     public void put(final long time,
-                    final K key,
-                    final Change<V> value,
+                    final Record<K, Change<V>> record,
                     final ProcessorRecordContext recordContext) {
-        requireNonNull(value, "value cannot be null");
+        requireNonNull(record.value(), "value cannot be null");
         requireNonNull(recordContext, "recordContext cannot be null");
 
-        final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(changelogTopic, key));
-        final Change<byte[]> serialChange = valueSerde.serializeParts(changelogTopic, value);
+        final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(changelogTopic, record.key()));
+        final Change<byte[]> serialChange = valueSerde.serializeParts(changelogTopic, record.value());
 
         final BufferValue buffered = getBuffered(serializedKey);
         final byte[] serializedPriorValue;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
@@ -48,6 +48,10 @@ public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
             return value;
         }
 
+        public Record<K, Change<V>> record() {
+            return new Record<>(key, value, recordContext.timestamp());
+        }
+
         public ProcessorRecordContext recordContext() {
             return recordContext;
         }
@@ -71,6 +75,7 @@ public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
         public int hashCode() {
             return Objects.hash(key, value, recordContext);
         }
+
     }
 
     void setSerdesIfNull(final SerdeGetter getter);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -78,7 +79,7 @@ public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
 
     Maybe<ValueAndTimestamp<V>> priorValueForBuffered(K key);
 
-    void put(long time, K key, Change<V> value, ProcessorRecordContext recordContext);
+    void put(long time, Record<K, Change<V>> record, ProcessorRecordContext recordContext);
 
     int numRecords();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals.suppress;
 
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -153,7 +152,7 @@ public class KTableSuppressProcessorMetricsTest {
         processor.init(context);
 
         final long timestamp = 100L;
-        context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
+        context.setRecordMetadata("", 0, 0L);
         final String key = "longKey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
         processor.process(new Record<>(key, value, timestamp));
@@ -176,7 +175,7 @@ public class KTableSuppressProcessorMetricsTest {
             verifyMetric(metrics, bufferCountMaxMetric, is(1.0));
         }
 
-        context.setRecordMetadata("", 0, 1L, new RecordHeaders(), timestamp + 1);
+        context.setRecordMetadata("", 0, 1L);
         processor.process(new Record<>("key", value, timestamp + 1));
 
         {
@@ -184,7 +183,7 @@ public class KTableSuppressProcessorMetricsTest {
 
             verifyMetric(metrics, evictionRateMetric, greaterThan(0.0));
             verifyMetric(metrics, evictionTotalMetric, is(1.0));
-            verifyMetric(metrics, bufferSizeAvgMetric, is(41.0));
+            verifyMetric(metrics, bufferSizeAvgMetric, is(42.0)); // check why this need to change from 41 to 42
             verifyMetric(metrics, bufferSizeMaxMetric, is(82.0));
             verifyMetric(metrics, bufferCountAvgMetric, is(1.0));
             verifyMetric(metrics, bufferCountMaxMetric, is(2.0));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -153,6 +153,7 @@ public class KTableSuppressProcessorMetricsTest {
 
         final long timestamp = 100L;
         context.setRecordMetadata("", 0, 0L);
+        context.setTimestamp(timestamp);
         final String key = "longKey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
         processor.process(new Record<>(key, value, timestamp));
@@ -176,6 +177,7 @@ public class KTableSuppressProcessorMetricsTest {
         }
 
         context.setRecordMetadata("", 0, 1L);
+        context.setTimestamp(timestamp + 1);
         processor.process(new Record<>("key", value, timestamp + 1));
 
         {
@@ -183,7 +185,7 @@ public class KTableSuppressProcessorMetricsTest {
 
             verifyMetric(metrics, evictionRateMetric, greaterThan(0.0));
             verifyMetric(metrics, evictionTotalMetric, is(1.0));
-            verifyMetric(metrics, bufferSizeAvgMetric, is(42.0)); // check why this need to change from 41 to 42
+            verifyMetric(metrics, bufferSizeAvgMetric, is(41.0));
             verifyMetric(metrics, bufferSizeMaxMetric, is(82.0));
             verifyMetric(metrics, bufferCountAvgMetric, is(1.0));
             verifyMetric(metrics, bufferCountMaxMetric, is(2.0));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorTest.java
@@ -106,7 +106,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final String key = "hey";
         final Change<Long> value = ARBITRARY_CHANGE;
-        harness.processor.process(new Record<>(key, value, 0L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -124,7 +124,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new TimeWindow(0L, 100L));
         final Change<Long> value = ARBITRARY_CHANGE;
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -166,7 +166,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("topic", 0, 0, new RecordHeaders(), recordTime);
         final Windowed<String> key = new Windowed<>("hey", new TimeWindow(windowStart, windowEnd));
         final Change<Long> value = ARBITRARY_CHANGE;
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, recordTime));
         assertThat(context.forwarded(), hasSize(0));
 
         // although the stream time is now 100, we have to wait 1 ms after the window *end* before we
@@ -209,7 +209,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new TimeWindow(0, windowEnd));
         final Change<Long> value = ARBITRARY_CHANGE;
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
         assertThat(context.forwarded(), hasSize(0));
 
         context.setRecordMetadata("", 0, 1L, new RecordHeaders(), windowEnd);
@@ -231,7 +231,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new TimeWindow(0, 100L));
         final Change<Long> value = ARBITRARY_CHANGE;
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -253,7 +253,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new TimeWindow(0, 100L));
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(0));
     }
@@ -273,7 +273,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new SessionWindow(0L, 0L));
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(0));
     }
@@ -292,7 +292,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new TimeWindow(0L, 100L));
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -315,7 +315,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final Windowed<String> key = new Windowed<>("hey", new SessionWindow(0L, 0L));
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -338,7 +338,7 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final String key = "hey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -356,10 +356,10 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final String key = "hey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         context.setRecordMetadata("", 0, 1L, new RecordHeaders(), timestamp + 1);
-        harness.processor.process(new Record<>("dummyKey", value, 1L));
+        harness.processor.process(new Record<>("dummyKey", value, timestamp + 1));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -377,10 +377,10 @@ public class KTableSuppressProcessorTest {
         context.setRecordMetadata("", 0, 0L, new RecordHeaders(), timestamp);
         final String key = "hey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         context.setRecordMetadata("", 0, 1L, new RecordHeaders(), timestamp + 1);
-        harness.processor.process(new Record<>("dummyKey", value, 1L));
+        harness.processor.process(new Record<>("dummyKey", value, timestamp + 1));
 
         assertThat(context.forwarded(), hasSize(1));
         final MockProcessorContext.CapturedForward capturedForward = context.forwarded().get(0);
@@ -399,11 +399,11 @@ public class KTableSuppressProcessorTest {
         context.setCurrentNode(new ProcessorNode("testNode"));
         final String key = "hey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         context.setRecordMetadata("", 0, 1L, new RecordHeaders(), timestamp);
         try {
-            harness.processor.process(new Record<>("dummyKey", value, 1L));
+            harness.processor.process(new Record<>("dummyKey", value, timestamp));
             fail("expected an exception");
         } catch (final StreamsException e) {
             assertThat(e.getMessage(), containsString("buffer exceeded its max capacity"));
@@ -421,11 +421,11 @@ public class KTableSuppressProcessorTest {
         context.setCurrentNode(new ProcessorNode("testNode"));
         final String key = "hey";
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
-        harness.processor.process(new Record<>(key, value, 1L));
+        harness.processor.process(new Record<>(key, value, timestamp));
 
         context.setRecordMetadata("", 0, 1L, new RecordHeaders(), timestamp);
         try {
-            harness.processor.process(new Record<>("dummyKey", value, 1L));
+            harness.processor.process(new Record<>("dummyKey", value, timestamp));
             fail("expected an exception");
         } catch (final StreamsException e) {
             assertThat(e.getMessage(), containsString("buffer exceeded its max capacity"));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -144,7 +145,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final MockInternalProcessorContext context = makeContext();
         buffer.init((StateStoreContext) context, buffer);
         try {
-            buffer.put(0, "asdf", null, getContext(0));
+            buffer.put(0, new Record<>("asdf", null, 0L), getContext(0));
             fail("expected an exception");
         } catch (final NullPointerException expected) {
             // expected
@@ -284,8 +285,8 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
 
         final ProcessorRecordContext recordContext = getContext(0L);
         context.setRecordContext(recordContext);
-        buffer.put(1L, "A", new Change<>("new-value", "old-value"), recordContext);
-        buffer.put(1L, "B", new Change<>("new-value", null), recordContext);
+        buffer.put(1L, new Record<>("A", new Change<>("new-value", "old-value"), 0L), recordContext);
+        buffer.put(1L, new Record<>("B", new Change<>("new-value", null), 0L), recordContext);
         assertThat(buffer.priorValueForBuffered("A"), is(Maybe.defined(ValueAndTimestamp.make("old-value", -1))));
         assertThat(buffer.priorValueForBuffered("B"), is(Maybe.defined(null)));
     }
@@ -1012,7 +1013,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                   final String value) {
         final ProcessorRecordContext recordContext = getContext(recordTimestamp);
         context.setRecordContext(recordContext);
-        buffer.put(streamTime, key, new Change<>(value, null), recordContext);
+        buffer.put(streamTime, new Record<>(key, new Change<>(value, null), 0L), recordContext);
     }
 
     private static BufferValue getBufferValue(final String value, final long timestamp) {

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
@@ -121,7 +121,6 @@ public class MockInternalNewProcessorContext<KOut, VOut> extends MockProcessorCo
 
     @Override
     public void register(final StateStore store, final StateRestoreCallback stateRestoreCallback) {
-//        restoreCallbacks.put(store.name(), stateRestoreCallback);
         addStateStore(store);
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.processor.MockProcessorContext;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.RecordCollector;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.Task.TaskType;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+public class MockInternalNewProcessorContext<KOut, VOut> extends MockProcessorContext implements InternalProcessorContext<KOut, VOut> {
+
+    private final Map<String, StateRestoreCallback> restoreCallbacks = new LinkedHashMap<>();
+    private ProcessorNode currentNode;
+    private RecordCollector recordCollector;
+    private long currentSystemTimeMs;
+    private TaskType taskType = TaskType.ACTIVE;
+
+    public MockInternalNewProcessorContext() {
+    }
+
+    public MockInternalNewProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
+        super(config, taskId, stateDir);
+    }
+
+    @Override
+    public void setSystemTimeMs(long timeMs) {
+        currentSystemTimeMs = timeMs;
+    }
+
+    @Override
+    public long currentSystemTimeMs() {
+        return currentSystemTimeMs;
+    }
+
+    @Override
+    public StreamsMetricsImpl metrics() {
+        return (StreamsMetricsImpl) super.metrics();
+    }
+
+    @Override
+    public <K extends KOut, V extends VOut> void forward(final Record<K, V> record) {
+        forward(record.key(), record.value(), To.all().withTimestamp(record.timestamp()));
+    }
+
+    @Override
+    public <K extends KOut, V extends VOut> void forward(final Record<K, V> record, final String childName) {
+        forward(record.key(), record.value(), To.child(childName).withTimestamp(record.timestamp()));
+    }
+
+    @Override
+    public ProcessorRecordContext recordContext() {
+        return new ProcessorRecordContext(timestamp(), offset(), partition(), topic(), headers());
+    }
+
+    @Override
+    public Optional<RecordMetadata> recordMetadata() {
+        return Optional.of(recordContext());
+    }
+
+    @Override
+    public void setRecordContext(final ProcessorRecordContext recordContext) {
+        setRecordMetadata(
+            recordContext.topic(),
+            recordContext.partition(),
+            recordContext.offset(),
+            recordContext.headers(),
+            recordContext.timestamp()
+        );
+    }
+
+    @Override
+    public void setCurrentNode(final ProcessorNode currentNode) {
+        this.currentNode = currentNode;
+    }
+
+    @Override
+    public ProcessorNode currentNode() {
+        return currentNode;
+    }
+
+    @Override
+    public ThreadCache cache() {
+        return null;
+    }
+
+    @Override
+    public void initialize() {}
+
+    @Override
+    public void uninitialize() {}
+
+    @Override
+    public RecordCollector recordCollector() {
+        return recordCollector;
+    }
+
+    public void setRecordCollector(final RecordCollector recordCollector) {
+        this.recordCollector = recordCollector;
+    }
+
+    @Override
+    public void register(final StateStore store, final StateRestoreCallback stateRestoreCallback) {
+        restoreCallbacks.put(store.name(), stateRestoreCallback);
+        super.register(store, stateRestoreCallback);
+    }
+
+    public StateRestoreCallback stateRestoreCallback(final String storeName) {
+        return restoreCallbacks.get(storeName);
+    }
+
+    @Override
+    public TaskType taskType() {
+        return taskType;
+    }
+
+    @Override
+    public void logChange(final String storeName,
+                          final Bytes key,
+                          final byte[] value,
+                          final long timestamp) {
+    }
+
+    @Override
+    public void transitionToActive(final StreamTask streamTask, final RecordCollector recordCollector, final ThreadCache newCache) {
+    }
+
+    @Override
+    public void transitionToStandby(final ThreadCache newCache) {
+    }
+
+    @Override
+    public void registerCacheFlushListener(final String namespace, final DirtyEntryFlushListener listener) {
+    }
+
+    @Override
+    public String changelogFor(final String storeName) {
+        return "mock-changelog";
+    }
+}

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -125,9 +125,10 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
     public static class CapturedForward {
         private final String childName;
         private final long timestamp;
+        private final Headers headers;
         private final KeyValue keyValue;
 
-        private CapturedForward(final To to, final KeyValue keyValue) {
+        private CapturedForward(final KeyValue keyValue, final To to, final Headers headers) {
             if (keyValue == null) {
                 throw new IllegalArgumentException();
             }
@@ -135,6 +136,7 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
             this.childName = to.childName;
             this.timestamp = to.timestamp;
             this.keyValue = keyValue;
+            this.headers = headers;
         }
 
         /**
@@ -174,6 +176,10 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
                 ", timestamp=" + timestamp +
                 ", keyValue=" + keyValue +
                 '}';
+        }
+
+        public Headers headers() {
+            return this.headers;
         }
     }
 
@@ -498,8 +504,9 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
     public <K, V> void forward(final K key, final V value, final To to) {
         capturedForwards.add(
             new CapturedForward(
+                new KeyValue<>(key, value),
                 to.timestamp == -1 ? to.withTimestamp(recordTimestamp == null ? -1 : recordTimestamp) : to,
-                new KeyValue<>(key, value)
+                headers
             )
         );
     }


### PR DESCRIPTION
As part of the migration of KStream/KTable operations to the new Processor API https://issues.apache.org/jira/browse/KAFKA-8410, this PR includes the migration of KTable suppress.

Testing strategy: operations should keep the same tests as new processor should be compatible.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
