### PR TITLE
KAFKA-12994 Migrate JoinWindowsTest and SessionWindowsTest to new API

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -18,46 +18,40 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
-import java.time.Duration;
-
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
-import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("deprecation")
 public class JoinWindowsTest {
 
     private static final long ANY_SIZE = 123L;
     private static final long ANY_OTHER_SIZE = 456L; // should be larger than anySize
     private static final long ANY_GRACE = 1024L;
 
-    @SuppressWarnings("deprecation")
     @Test
     public void validWindows() {
-        JoinWindows.of(ofMillis(ANY_OTHER_SIZE))   // [ -anyOtherSize ; anyOtherSize ]
-                   .before(ofMillis(ANY_SIZE))                    // [ -anySize ; anyOtherSize ]
-                   .before(ofMillis(0))                          // [ 0 ; anyOtherSize ]
-                   .before(ofMillis(-ANY_SIZE))                   // [ anySize ; anyOtherSize ]
-                   .before(ofMillis(-ANY_OTHER_SIZE));             // [ anyOtherSize ; anyOtherSize ]
+        JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(ANY_OTHER_SIZE))   // [ -anyOtherSize ; anyOtherSize ]
+                   .before(ofMillis(ANY_SIZE))                              // [ -anySize ; anyOtherSize ]
+                   .before(ofMillis(0))                                     // [ 0 ; anyOtherSize ]
+                   .before(ofMillis(-ANY_SIZE))                             // [ anySize ; anyOtherSize ]
+                   .before(ofMillis(-ANY_OTHER_SIZE));                      // [ anyOtherSize ; anyOtherSize ]
 
-        JoinWindows.of(ofMillis(ANY_OTHER_SIZE))   // [ -anyOtherSize ; anyOtherSize ]
-                   .after(ofMillis(ANY_SIZE))                     // [ -anyOtherSize ; anySize ]
-                   .after(ofMillis(0))                           // [ -anyOtherSize ; 0 ]
-                   .after(ofMillis(-ANY_SIZE))                    // [ -anyOtherSize ; -anySize ]
-                   .after(ofMillis(-ANY_OTHER_SIZE));              // [ -anyOtherSize ; -anyOtherSize ]
+        JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(ANY_OTHER_SIZE))   // [ -anyOtherSize ; anyOtherSize ]
+                   .after(ofMillis(ANY_SIZE))                               // [ -anyOtherSize ; anySize ]
+                   .after(ofMillis(0))                                      // [ -anyOtherSize ; 0 ]
+                   .after(ofMillis(-ANY_SIZE))                              // [ -anyOtherSize ; -anySize ]
+                   .after(ofMillis(-ANY_OTHER_SIZE));                       // [ -anyOtherSize ; -anyOtherSize ]
     }
 
     @Test
     public void beforeShouldNotModifyGrace() {
-        final JoinWindows joinWindows = JoinWindows.of(ofMillis(ANY_SIZE))
-            .grace(ofMillis(ANY_OTHER_SIZE))
+        final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_OTHER_SIZE))
             .before(ofSeconds(ANY_SIZE));
 
         assertThat(joinWindows.gracePeriodMs(), equalTo(ANY_OTHER_SIZE));
@@ -65,8 +59,7 @@ public class JoinWindowsTest {
 
     @Test
     public void afterShouldNotModifyGrace() {
-        final JoinWindows joinWindows = JoinWindows.of(ofMillis(ANY_SIZE))
-            .grace(ofMillis(ANY_OTHER_SIZE))
+        final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_OTHER_SIZE))
             .after(ofSeconds(ANY_SIZE));
 
         assertThat(joinWindows.gracePeriodMs(), equalTo(ANY_OTHER_SIZE));
@@ -74,14 +67,13 @@ public class JoinWindowsTest {
 
     @Test
     public void timeDifferenceMustNotBeNegative() {
-        assertThrows(IllegalArgumentException.class, () -> JoinWindows.of(ofMillis(-1)));
         assertThrows(IllegalArgumentException.class, () -> JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(-1)));
         assertThrows(IllegalArgumentException.class, () -> JoinWindows.ofTimeDifferenceAndGrace(ofMillis(-1), ofMillis(ANY_GRACE)));
     }
 
     @Test
     public void endTimeShouldNotBeBeforeStart() {
-        final JoinWindows windowSpec = JoinWindows.of(ofMillis(ANY_SIZE));
+        final JoinWindows windowSpec = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(ANY_SIZE));
         try {
             windowSpec.after(ofMillis(-ANY_SIZE - 1));
             fail("window end time should not be before window start time");
@@ -92,7 +84,7 @@ public class JoinWindowsTest {
 
     @Test
     public void startTimeShouldNotBeAfterEnd() {
-        final JoinWindows windowSpec = JoinWindows.of(ofMillis(ANY_SIZE));
+        final JoinWindows windowSpec = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(ANY_SIZE));
         try {
             windowSpec.before(ofMillis(-ANY_SIZE - 1));
             fail("window start time should not be after window end time");
@@ -102,18 +94,11 @@ public class JoinWindowsTest {
     }
 
     @Test
-    public void untilShouldSetGraceDuration() {
-        final JoinWindows windowSpec = JoinWindows.of(ofMillis(ANY_SIZE));
-        final long windowSize = windowSpec.size();
-        assertEquals(windowSize, windowSpec.grace(ofMillis(windowSize)).gracePeriodMs());
-    }
-
-    @Test
     public void gracePeriodShouldEnforceBoundaries() {
-        JoinWindows.of(ofMillis(3L)).grace(ofMillis(0L));
+        JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3L), ofMillis(0L));
 
         try {
-            JoinWindows.of(ofMillis(3L)).grace(ofMillis(-1L));
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3L), ofMillis(-1L));
             fail("should not accept negatives");
         } catch (final IllegalArgumentException e) {
             //expected
@@ -121,82 +106,87 @@ public class JoinWindowsTest {
     }
 
     @Test
-    public void oldAPIShouldSetDefaultGracePeriod() {
-        assertEquals(Duration.ofDays(1).toMillis(), DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD);
-        assertEquals(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - 6L, JoinWindows.of(ofMillis(3L)).gracePeriodMs());
-        assertEquals(0L, JoinWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD)).gracePeriodMs());
-        assertEquals(0L, JoinWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD + 1L)).gracePeriodMs());
+    public void noGraceAPIShouldNotSetGracePeriod() {
+        assertEquals(0L, JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3L)).gracePeriodMs());
+        assertEquals(0L, JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(ANY_SIZE)).gracePeriodMs());
+        assertEquals(0L, JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(ANY_OTHER_SIZE)).gracePeriodMs());
+    }
+
+    @Test
+    public void withGraceAPIShouldSetGracePeriod() {
+        assertEquals(ANY_GRACE, JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3L), ofMillis(ANY_GRACE)).gracePeriodMs());
+        assertEquals(ANY_GRACE, JoinWindows.ofTimeDifferenceAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_GRACE)).gracePeriodMs());
+        assertEquals(ANY_GRACE, JoinWindows.ofTimeDifferenceAndGrace(ofMillis(ANY_OTHER_SIZE), ofMillis(ANY_GRACE)).gracePeriodMs());
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        verifyEquality(JoinWindows.of(ofMillis(3)), JoinWindows.of(ofMillis(3)));
-
-        verifyEquality(JoinWindows.of(ofMillis(3)).after(ofMillis(2)), JoinWindows.of(ofMillis(3)).after(ofMillis(2)));
-
-        verifyEquality(JoinWindows.of(ofMillis(3)).before(ofMillis(2)), JoinWindows.of(ofMillis(3)).before(ofMillis(2)));
-
-        verifyEquality(JoinWindows.of(ofMillis(3)).grace(ofMillis(2)), JoinWindows.of(ofMillis(3)).grace(ofMillis(2)));
-
-        verifyEquality(JoinWindows.of(ofMillis(3)).grace(ofMillis(60)), JoinWindows.of(ofMillis(3)).grace(ofMillis(60)));
-
         verifyEquality(
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3)).grace(ofMillis(60)),
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3)).grace(ofMillis(60))
-        );
-        // JoinWindows is a little weird in that before and after set the same fields as of.
-        verifyEquality(
-            JoinWindows.of(ofMillis(9)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3)).grace(ofMillis(60)),
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3)).grace(ofMillis(60))
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3))
         );
 
         verifyEquality(
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)),
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3))
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2))
         );
 
         verifyEquality(
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(4)),
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(4))
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).after(ofMillis(2)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).after(ofMillis(2))
+        );
+
+        verifyEquality(
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).before(ofMillis(2)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).before(ofMillis(2))
+        );
+
+        verifyEquality(
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2)).after(ofMillis(4)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2)).after(ofMillis(4))
+        );
+
+        verifyEquality(
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2)).before(ofMillis(4)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2)).before(ofMillis(4))
         );
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForNegativeCases() {
-        verifyInEquality(JoinWindows.of(ofMillis(9)), JoinWindows.of(ofMillis(3)));
-
-        verifyInEquality(JoinWindows.of(ofMillis(3)).after(ofMillis(9)), JoinWindows.of(ofMillis(3)).after(ofMillis(2)));
-
-        verifyInEquality(JoinWindows.of(ofMillis(3)).before(ofMillis(9)), JoinWindows.of(ofMillis(3)).before(ofMillis(2)));
-
-        verifyInEquality(JoinWindows.of(ofMillis(3)).grace(ofMillis(9)), JoinWindows.of(ofMillis(3)).grace(ofMillis(2)));
-
-        verifyInEquality(JoinWindows.of(ofMillis(3)).grace(ofMillis(90)), JoinWindows.of(ofMillis(3)).grace(ofMillis(60)));
-
-
         verifyInEquality(
-            JoinWindows.of(ofMillis(3)).before(ofMillis(9)).after(ofMillis(2)).grace(ofMillis(3)),
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3))
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(9)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3))
         );
 
         verifyInEquality(
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(9)).grace(ofMillis(3)),
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3))
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(9)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(2))
         );
 
         verifyInEquality(
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(9)),
-            JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3))
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).after(ofMillis(9)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).after(ofMillis(2))
         );
 
         verifyInEquality(
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(9)),
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3))
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).before(ofMillis(9)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)).before(ofMillis(2))
         );
 
         verifyInEquality(
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(9), ofMillis(9)),
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(9))
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(3)).before(ofMillis(9)).after(ofMillis(2)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(3)).before(ofMillis(1)).after(ofMillis(2))
+        );
+
+        verifyInEquality(
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(3)).before(ofMillis(1)).after(ofMillis(9)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(3)).before(ofMillis(1)).after(ofMillis(2))
+        );
+
+        verifyInEquality(
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(9)).before(ofMillis(1)).after(ofMillis(2)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(3)).before(ofMillis(1)).after(ofMillis(2))
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -18,10 +18,13 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
+import java.time.Duration;
+
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
+import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -93,6 +96,14 @@ public class JoinWindowsTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
+    public void untilShouldSetGraceDuration() {
+        final JoinWindows windowSpec = JoinWindows.of(ofMillis(ANY_SIZE));
+        final long windowSize = windowSpec.size();
+        assertEquals(windowSize, windowSpec.grace(ofMillis(windowSize)).gracePeriodMs());
+    }
+
     @Test
     public void gracePeriodShouldEnforceBoundaries() {
         JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3L), ofMillis(0L));
@@ -103,6 +114,15 @@ public class JoinWindowsTest {
         } catch (final IllegalArgumentException e) {
             //expected
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void oldAPIShouldSetDefaultGracePeriod() {
+        assertEquals(Duration.ofDays(1).toMillis(), DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD);
+        assertEquals(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - 6L, JoinWindows.of(ofMillis(3L)).gracePeriodMs());
+        assertEquals(0L, JoinWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD)).gracePeriodMs());
+        assertEquals(0L, JoinWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD + 1L)).gracePeriodMs());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -18,41 +18,33 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
-import java.time.Duration;
-
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
-import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("deprecation")
 public class SessionWindowsTest {
+
+    private static final long ANY_SIZE = 123L;
+    private static final long ANY_OTHER_SIZE = 456L; // should be larger than anySize
+    private static final long ANY_GRACE = 1024L;
 
     @Test
     public void shouldSetWindowGap() {
         final long anyGap = 42L;
-        final long anyGrace = 1024L;
 
-        assertEquals(anyGap, SessionWindows.with(ofMillis(anyGap)).inactivityGap());
         assertEquals(anyGap, SessionWindows.ofInactivityGapWithNoGrace(ofMillis(anyGap)).inactivityGap());
-        assertEquals(anyGap, SessionWindows.ofInactivityGapAndGrace(ofMillis(anyGap), ofMillis(anyGrace)).inactivityGap());
-    }
-
-    @Test
-    public void shouldSetWindowGraceTime() {
-        final long anyRetentionTime = 42L;
-        assertEquals(anyRetentionTime, SessionWindows.with(ofMillis(1)).grace(ofMillis(anyRetentionTime)).gracePeriodMs());
+        assertEquals(anyGap, SessionWindows.ofInactivityGapAndGrace(ofMillis(anyGap), ofMillis(ANY_GRACE)).inactivityGap());
     }
 
     @Test
     public void gracePeriodShouldEnforceBoundaries() {
-        SessionWindows.with(ofMillis(3L)).grace(ofMillis(0));
+        SessionWindows.ofInactivityGapAndGrace(ofMillis(3L), ofMillis(0));
 
         try {
-            SessionWindows.with(ofMillis(3L)).grace(ofMillis(-1L));
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(3L), ofMillis(-1L));
             fail("should not accept negatives");
         } catch (final IllegalArgumentException e) {
             //expected
@@ -60,62 +52,57 @@ public class SessionWindowsTest {
     }
 
     @Test
-    public void oldAPIShouldSetDefaultGracePeriod() {
-        assertEquals(Duration.ofDays(1).toMillis(), DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD);
-        assertEquals(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - 3L, SessionWindows.with(ofMillis(3L)).gracePeriodMs());
-        assertEquals(0L, SessionWindows.with(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD)).gracePeriodMs());
-        assertEquals(0L, SessionWindows.with(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD + 1L)).gracePeriodMs());
+    public void noGraceAPIShouldNotSetGracePeriod() {
+        assertEquals(0L, SessionWindows.ofInactivityGapWithNoGrace(ofMillis(3L)).gracePeriodMs());
+        assertEquals(0L, SessionWindows.ofInactivityGapWithNoGrace(ofMillis(ANY_SIZE)).gracePeriodMs());
+        assertEquals(0L, SessionWindows.ofInactivityGapWithNoGrace(ofMillis(ANY_OTHER_SIZE)).gracePeriodMs());
+    }
+
+    @Test
+    public void withGraceAPIShouldSetGracePeriod() {
+        assertEquals(ANY_GRACE, SessionWindows.ofInactivityGapAndGrace(ofMillis(3L), ofMillis(ANY_GRACE)).gracePeriodMs());
+        assertEquals(ANY_GRACE, SessionWindows.ofInactivityGapAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_GRACE)).gracePeriodMs());
+        assertEquals(ANY_GRACE, SessionWindows.ofInactivityGapAndGrace(ofMillis(ANY_OTHER_SIZE), ofMillis(ANY_GRACE)).gracePeriodMs());
     }
 
     @Test
     public void windowSizeMustNotBeNegative() {
-        assertThrows(IllegalArgumentException.class, () -> SessionWindows.with(ofMillis(-1)));
+        assertThrows(IllegalArgumentException.class, () -> SessionWindows.ofInactivityGapWithNoGrace(ofMillis(-1)));
     }
 
     @Test
     public void windowSizeMustNotBeZero() {
-        assertThrows(IllegalArgumentException.class, () -> SessionWindows.with(ofMillis(0)));
+        assertThrows(IllegalArgumentException.class, () -> SessionWindows.ofInactivityGapWithNoGrace(ofMillis(0)));
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        verifyEquality(SessionWindows.with(ofMillis(1)), SessionWindows.with(ofMillis(1)));
-
-        verifyEquality(SessionWindows.ofInactivityGapWithNoGrace(ofMillis(1)),
-                SessionWindows.ofInactivityGapWithNoGrace(ofMillis(1))
+        verifyEquality(
+            SessionWindows.ofInactivityGapWithNoGrace(ofMillis(1)),
+            SessionWindows.ofInactivityGapWithNoGrace(ofMillis(1))
         );
 
         verifyEquality(
-                SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(11)),
-                SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(11))
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(11)),
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(11))
         );
-
-        verifyEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(6)), SessionWindows.with(ofMillis(1)).grace(ofMillis(6)));
-
-        verifyEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(7)), SessionWindows.with(ofMillis(1)).grace(ofMillis(7)));
-
-        verifyEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(6)).grace(ofMillis(7)), SessionWindows.with(ofMillis(1)).grace(ofMillis(6)).grace(ofMillis(7)));
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForNegativeCases() {
+        verifyInEquality(
+            SessionWindows.ofInactivityGapWithNoGrace(ofMillis(9)),
+            SessionWindows.ofInactivityGapWithNoGrace(ofMillis(1))
+        );
 
         verifyInEquality(
-                SessionWindows.ofInactivityGapWithNoGrace(ofMillis(9)),
-                SessionWindows.ofInactivityGapWithNoGrace(ofMillis(1)));
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(9), ofMillis(9)),
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(9))
+        );
 
         verifyInEquality(
-                SessionWindows.ofInactivityGapAndGrace(ofMillis(9), ofMillis(9)),
-                SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(9)));
-
-        verifyInEquality(SessionWindows.with(ofMillis(9)), SessionWindows.with(ofMillis(1)));
-
-        verifyInEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(9)), SessionWindows.with(ofMillis(1)).grace(ofMillis(6)));
-
-        verifyInEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(9)), SessionWindows.with(ofMillis(1)).grace(ofMillis(7)));
-
-        verifyInEquality(SessionWindows.with(ofMillis(2)).grace(ofMillis(6)).grace(ofMillis(7)), SessionWindows.with(ofMillis(1)).grace(ofMillis(6)));
-
-        verifyInEquality(SessionWindows.with(ofMillis(1)).grace(ofMillis(0)).grace(ofMillis(7)), SessionWindows.with(ofMillis(1)).grace(ofMillis(6)));
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(9)),
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(1), ofMillis(6))
+        );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -18,9 +18,12 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
+import java.time.Duration;
+
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
+import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -63,6 +66,15 @@ public class SessionWindowsTest {
         assertEquals(ANY_GRACE, SessionWindows.ofInactivityGapAndGrace(ofMillis(3L), ofMillis(ANY_GRACE)).gracePeriodMs());
         assertEquals(ANY_GRACE, SessionWindows.ofInactivityGapAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_GRACE)).gracePeriodMs());
         assertEquals(ANY_GRACE, SessionWindows.ofInactivityGapAndGrace(ofMillis(ANY_OTHER_SIZE), ofMillis(ANY_GRACE)).gracePeriodMs());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void oldAPIShouldSetDefaultGracePeriod() {
+        assertEquals(Duration.ofDays(1).toMillis(), DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD);
+        assertEquals(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - 3L, SessionWindows.with(ofMillis(3L)).gracePeriodMs());
+        assertEquals(0L, SessionWindows.with(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD)).gracePeriodMs());
+        assertEquals(0L, SessionWindows.with(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD + 1L)).gracePeriodMs());
     }
 
     @Test


### PR DESCRIPTION
As detailed in [KAFKA-12994](https://issues.apache.org/jira/browse/KAFKA-12994), unit tests using the old API should be either removed or migrated to the new API.

This PR migrates relevant tests in `JoinWindowsTest.java` and `SessionWindowsTest.java`.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
