### PR TITLE
KAFKA-12994: Migrate TimeWindowsTest to new API

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -19,19 +19,16 @@ package org.apache.kafka.streams.kstream;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.Map;
 
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
-import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("deprecation")
 public class TimeWindowsTest {
 
     private static final long ANY_SIZE = 123L;
@@ -39,7 +36,6 @@ public class TimeWindowsTest {
 
     @Test
     public void shouldSetWindowSize() {
-        assertEquals(ANY_SIZE, TimeWindows.of(ofMillis(ANY_SIZE)).sizeMs);
         assertEquals(ANY_SIZE, TimeWindows.ofSizeWithNoGrace(ofMillis(ANY_SIZE)).sizeMs);
         assertEquals(ANY_SIZE, TimeWindows.ofSizeAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_GRACE)).sizeMs);
     }
@@ -47,22 +43,22 @@ public class TimeWindowsTest {
     @Test
     public void shouldSetWindowAdvance() {
         final long anyAdvance = 4;
-        assertEquals(anyAdvance, TimeWindows.of(ofMillis(ANY_SIZE)).advanceBy(ofMillis(anyAdvance)).advanceMs);
+        assertEquals(anyAdvance, TimeWindows.ofSizeWithNoGrace(ofMillis(ANY_SIZE)).advanceBy(ofMillis(anyAdvance)).advanceMs);
     }
 
     @Test
     public void windowSizeMustNotBeZero() {
-        assertThrows(IllegalArgumentException.class, () -> TimeWindows.of(ofMillis(0)));
+        assertThrows(IllegalArgumentException.class, () -> TimeWindows.ofSizeWithNoGrace(ofMillis(0)));
     }
 
     @Test
     public void windowSizeMustNotBeNegative() {
-        assertThrows(IllegalArgumentException.class, () -> TimeWindows.of(ofMillis(-1)));
+        assertThrows(IllegalArgumentException.class, () -> TimeWindows.ofSizeWithNoGrace(ofMillis(-1)));
     }
 
     @Test
     public void advanceIntervalMustNotBeZero() {
-        final TimeWindows windowSpec = TimeWindows.of(ofMillis(ANY_SIZE));
+        final TimeWindows windowSpec = TimeWindows.ofSizeWithNoGrace(ofMillis(ANY_SIZE));
         try {
             windowSpec.advanceBy(ofMillis(0));
             fail("should not accept zero advance parameter");
@@ -73,7 +69,7 @@ public class TimeWindowsTest {
 
     @Test
     public void advanceIntervalMustNotBeNegative() {
-        final TimeWindows windowSpec = TimeWindows.of(ofMillis(ANY_SIZE));
+        final TimeWindows windowSpec = TimeWindows.ofSizeWithNoGrace(ofMillis(ANY_SIZE));
         try {
             windowSpec.advanceBy(ofMillis(-1));
             fail("should not accept negative advance parameter");
@@ -84,7 +80,7 @@ public class TimeWindowsTest {
 
     @Test
     public void advanceIntervalMustNotBeLargerThanWindowSize() {
-        final TimeWindows windowSpec = TimeWindows.of(ofMillis(ANY_SIZE));
+        final TimeWindows windowSpec = TimeWindows.ofSizeWithNoGrace(ofMillis(ANY_SIZE));
         try {
             windowSpec.advanceBy(ofMillis(ANY_SIZE + 1));
             fail("should not accept advance greater than window size");
@@ -95,10 +91,10 @@ public class TimeWindowsTest {
 
     @Test
     public void gracePeriodShouldEnforceBoundaries() {
-        TimeWindows.of(ofMillis(3L)).grace(ofMillis(0L));
+        TimeWindows.ofSizeAndGrace(ofMillis(3L), ofMillis(0L));
 
         try {
-            TimeWindows.of(ofMillis(3L)).grace(ofMillis(-1L));
+            TimeWindows.ofSizeAndGrace(ofMillis(3L), ofMillis(-1L));
             fail("should not accept negatives");
         } catch (final IllegalArgumentException e) {
             //expected
@@ -106,16 +102,8 @@ public class TimeWindowsTest {
     }
 
     @Test
-    public void oldAPIShouldSetDefaultGracePeriod() {
-        assertEquals(Duration.ofDays(1).toMillis(), DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD);
-        assertEquals(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - 3L, TimeWindows.of(ofMillis(3L)).gracePeriodMs());
-        assertEquals(0L, TimeWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD)).gracePeriodMs());
-        assertEquals(0L, TimeWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD + 1L)).gracePeriodMs());
-    }
-
-    @Test
     public void shouldComputeWindowsForHoppingWindows() {
-        final TimeWindows windows = TimeWindows.of(ofMillis(12L)).advanceBy(ofMillis(5L));
+        final TimeWindows windows = TimeWindows.ofSizeWithNoGrace(ofMillis(12L)).advanceBy(ofMillis(5L));
         final Map<Long, TimeWindow> matched = windows.windowsFor(21L);
         assertEquals(12L / 5L + 1, matched.size());
         assertEquals(new TimeWindow(10L, 22L), matched.get(10L));
@@ -125,7 +113,7 @@ public class TimeWindowsTest {
 
     @Test
     public void shouldComputeWindowsForBarelyOverlappingHoppingWindows() {
-        final TimeWindows windows = TimeWindows.of(ofMillis(6L)).advanceBy(ofMillis(5L));
+        final TimeWindows windows = TimeWindows.ofSizeWithNoGrace(ofMillis(6L)).advanceBy(ofMillis(5L));
         final Map<Long, TimeWindow> matched = windows.windowsFor(7L);
         assertEquals(1, matched.size());
         assertEquals(new TimeWindow(5L, 11L), matched.get(5L));
@@ -133,7 +121,7 @@ public class TimeWindowsTest {
 
     @Test
     public void shouldComputeWindowsForTumblingWindows() {
-        final TimeWindows windows = TimeWindows.of(ofMillis(12L));
+        final TimeWindows windows = TimeWindows.ofSizeWithNoGrace(ofMillis(12L));
         final Map<Long, TimeWindow> matched = windows.windowsFor(21L);
         assertEquals(1, matched.size());
         assertEquals(new TimeWindow(12L, 24L), matched.get(12L));
@@ -142,20 +130,11 @@ public class TimeWindowsTest {
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        verifyEquality(TimeWindows.of(ofMillis(3)), TimeWindows.of(ofMillis(3)));
-
-        verifyEquality(TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(1)), TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(1)));
-
-        verifyEquality(TimeWindows.of(ofMillis(3)).grace(ofMillis(1)), TimeWindows.of(ofMillis(3)).grace(ofMillis(1)));
-
-        verifyEquality(TimeWindows.of(ofMillis(3)).grace(ofMillis(4)), TimeWindows.of(ofMillis(3)).grace(ofMillis(4)));
-
-        verifyEquality(
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(1)).grace(ofMillis(1)).grace(ofMillis(4)),
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(1)).grace(ofMillis(1)).grace(ofMillis(4))
-        );
-
         verifyEquality(TimeWindows.ofSizeWithNoGrace(ofMillis(3)), TimeWindows.ofSizeWithNoGrace(ofMillis(3)));
+
+        verifyEquality(TimeWindows.ofSizeWithNoGrace(ofMillis(3)).advanceBy(ofMillis(1)), TimeWindows.ofSizeWithNoGrace(ofMillis(3)).advanceBy(ofMillis(1)));
+
+        verifyEquality(TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(4)), TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(4)));
 
         verifyEquality(TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(33)),
                 TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(33))
@@ -175,28 +154,25 @@ public class TimeWindowsTest {
                 TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(9))
         );
 
-        verifyInEquality(TimeWindows.of(ofMillis(9)), TimeWindows.of(ofMillis(3)));
+        verifyInEquality(TimeWindows.ofSizeWithNoGrace(ofMillis(3)).advanceBy(ofMillis(2)), TimeWindows.ofSizeWithNoGrace(ofMillis(3)).advanceBy(ofMillis(1)));
 
-        verifyInEquality(TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(2)), TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(1)));
+        verifyInEquality(TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(2)), TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(1)));
 
-        verifyInEquality(TimeWindows.of(ofMillis(3)).grace(ofMillis(2)), TimeWindows.of(ofMillis(3)).grace(ofMillis(1)));
-
-        verifyInEquality(TimeWindows.of(ofMillis(3)).grace(ofMillis(9)), TimeWindows.of(ofMillis(3)).grace(ofMillis(4)));
-
+        verifyInEquality(TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(9)), TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(4)));
 
         verifyInEquality(
-            TimeWindows.of(ofMillis(4)).advanceBy(ofMillis(2)).grace(ofMillis(2)),
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(2)).grace(ofMillis(2))
+            TimeWindows.ofSizeAndGrace(ofMillis(4), ofMillis(2)).advanceBy(ofMillis(2)),
+            TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(2)).advanceBy(ofMillis(2))
         );
 
         verifyInEquality(
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(1)).grace(ofMillis(2)),
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(2)).grace(ofMillis(2))
+            TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(2)).advanceBy(ofMillis(1)),
+            TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(2)).advanceBy(ofMillis(2))
         );
 
         assertNotEquals(
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(2)).grace(ofMillis(1)),
-            TimeWindows.of(ofMillis(3)).advanceBy(ofMillis(2)).grace(ofMillis(2))
+            TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(1)).advanceBy(ofMillis(2)),
+            TimeWindows.ofSizeAndGrace(ofMillis(3), ofMillis(2)).advanceBy(ofMillis(2))
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -19,11 +19,13 @@ package org.apache.kafka.streams.kstream;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
+import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -34,8 +36,10 @@ public class TimeWindowsTest {
     private static final long ANY_SIZE = 123L;
     private static final long ANY_GRACE = 1024L;
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSetWindowSize() {
+        assertEquals(ANY_SIZE, TimeWindows.of(ofMillis(ANY_SIZE)).sizeMs);
         assertEquals(ANY_SIZE, TimeWindows.ofSizeWithNoGrace(ofMillis(ANY_SIZE)).sizeMs);
         assertEquals(ANY_SIZE, TimeWindows.ofSizeAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_GRACE)).sizeMs);
     }
@@ -99,6 +103,15 @@ public class TimeWindowsTest {
         } catch (final IllegalArgumentException e) {
             //expected
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void oldAPIShouldSetDefaultGracePeriod() {
+        assertEquals(Duration.ofDays(1).toMillis(), DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD);
+        assertEquals(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD - 3L, TimeWindows.of(ofMillis(3L)).gracePeriodMs());
+        assertEquals(0L, TimeWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD)).gracePeriodMs());
+        assertEquals(0L, TimeWindows.of(ofMillis(DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD + 1L)).gracePeriodMs());
     }
 
     @Test


### PR DESCRIPTION
As raised in [KAFKA-12994](https://issues.apache.org/jira/browse/KAFKA-12994), All tests that use the old API should be either eliminated or migrated to the new API in order to remove the `@SuppressWarnings("deprecation")` annotations.

As a starting point, this PR will migrate over all the relevant tests in `TimeWindowsTests.java`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
