### PR TITLE
KAFKA-13207: Skip truncation on fetch response with diverging epoch if partition removed from fetcher

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -285,7 +285,7 @@ abstract class AbstractFetcherThread(name: String,
         // Partitions may have been removed from the fetcher while the thread was waiting for fetch
         // response. Removed partitions are filtered out while holding `partitionMapLock` to ensure that we
         // don't update state for any partition that may have already been migrated to another thread.
-        trace(s"Ignoring epoch offsets for partition '$tp' since it has been removed from this fetcher thread.")
+        trace(s"Ignoring epoch offsets for partition $tp since it has been removed from this fetcher thread.")
       }
     }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -232,13 +232,7 @@ abstract class AbstractFetcherThread(name: String,
   // Visibility for unit tests
   protected[server] def truncateOnFetchResponse(epochEndOffsets: Map[TopicPartition, EpochEndOffset]): Unit = {
     inLock(partitionMapLock) {
-      // Partitions may have been removed from the fetcher while the thread was waiting for fetch
-      // response. Filter out removed partitions while holding `partitionMapLock` to ensure that we
-      // don't update state for any partition that may have already been migrated to another thread.
-      val filteredEpochEndOffsets = epochEndOffsets.filter { case (tp, _) =>
-        partitionStates.contains(tp)
-      }
-      val ResultWithPartitions(fetchOffsets, partitionsWithError) = maybeTruncateToEpochEndOffsets(filteredEpochEndOffsets, Map.empty)
+      val ResultWithPartitions(fetchOffsets, partitionsWithError) = maybeTruncateToEpochEndOffsets(epochEndOffsets, Map.empty)
       handlePartitionsWithErrors(partitionsWithError, "truncateOnFetchResponse")
       updateFetchOffsetAndMaybeMarkTruncationComplete(fetchOffsets)
     }
@@ -268,7 +262,10 @@ abstract class AbstractFetcherThread(name: String,
     val fetchOffsets = mutable.HashMap.empty[TopicPartition, OffsetTruncationState]
     val partitionsWithError = mutable.HashSet.empty[TopicPartition]
 
-    fetchedEpochs.forKeyValue { (tp, leaderEpochOffset) =>
+    // Partitions may have been removed from the fetcher while the thread was waiting for fetch
+    // response. Filter out removed partitions while holding `partitionMapLock` to ensure that we
+    // don't update state for any partition that may have already been migrated to another thread.
+    fetchedEpochs.filter { case (tp, _) => partitionStates.contains(tp) }.forKeyValue { (tp, leaderEpochOffset) =>
       Errors.forCode(leaderEpochOffset.errorCode) match {
         case Errors.NONE =>
           val offsetTruncationState = getOffsetTruncationState(tp, leaderEpochOffset)


### PR DESCRIPTION
`AbstractFetcherThread#truncateOnFetchResponse` is used with IBP 2.7 and above to truncate partitions based on diverging epoch returned in fetch responses. Truncation should only be performed for partitions that are still owned by the fetcher and this check should be done while holding `partitionMapLock` to ensure that any partitions removed from the fetcher thread are not truncated. The PR adds this check. Truncation will be performed by any new fetcher that owns the partition when it restarts fetching.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
