### PR TITLE
KAFKA-13209: Upgrade jetty-server to fix CVE-2021-34429

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,7 +69,7 @@ versions += [
   jackson: "2.12.3",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",
-  jetty: "9.4.42.v20210604",
+  jetty: "9.4.43.v20210629",
   jersey: "2.34",
   jline: "3.12.1",
   jmh: "1.32",


### PR DESCRIPTION
Upgrading to 9.4.43.v20210629
Release notes: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.43.v20210629

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
