### PR TITLE
KAFKA-13175; Optimization TopicExistsException,When a topic is marked…

### DIFF
--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -126,7 +126,9 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
                           partitionReplicaAssignment: Map[Int, Seq[Int]],
                           config: Properties): Unit = {
     Topic.validate(topic)
-
+    if (zkClient.isTopicMarkedForDeletion(topic)) {
+      throw new TopicExistsException(s"Topic '$topic' is marked for deletion.")
+    }
     if (zkClient.topicExists(topic))
       throw new TopicExistsException(s"Topic '$topic' already exists.")
     else if (Topic.hasCollisionChars(topic)) {


### PR DESCRIPTION
… for deletion.

After a topic is deleted, the topic is marked for deletion, create topic with the same name throw exception topic already exists. It should throw exception the topic is marked for deletion. I can choose to wait for the topic to be completely deleted. If the topic is still not deleted for a long time, we need to check the reason why it is not deleted.

Signed-off-by: yangshengwei <yangshengwei@cmss.chinamobile.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
