### PR TITLE
KAFKA-12840; Removing `compact` cleaning on a topic should abort on-going compactions

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -786,6 +786,25 @@ class LogManager(logDirs: Seq[File],
   }
 
   /**
+   * Update the configuration of the provided topic.
+   */
+  def updateTopicConfig(topic: String,
+                        newTopicConfig: Properties): Unit = {
+    topicConfigUpdated(topic)
+    val logs = logsByTopic(topic)
+    if (logs.nonEmpty) {
+      // Combine the default properties with the overrides in zk to create the new LogConfig
+      val newLogConfig = LogConfig.fromProps(currentDefaultConfig.originals, newTopicConfig)
+      logs.foreach { log =>
+        val oldLogConfig = log.updateConfig(newLogConfig)
+        if (oldLogConfig.compact && !newLogConfig.compact) {
+          abortCleaning(log.topicPartition)
+        }
+      }
+    }
+  }
+
+  /**
    * Mark all in progress partitions having dirty configuration if broker configuration is updated.
    */
   def brokerConfigUpdated(): Unit = {

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -724,6 +724,16 @@ class LogManager(logDirs: Seq[File],
   }
 
   /**
+   * Abort cleaning of the provided partition and log a message about it.
+   */
+  def abortCleaning(topicPartition: TopicPartition): Unit = {
+    if (cleaner != null) {
+      cleaner.abortCleaning(topicPartition)
+      info(s"The cleaning for partition $topicPartition is aborted")
+    }
+  }
+
+  /**
    * Resume cleaning of the provided partition and log a message about it.
    */
   private def resumeCleaning(topicPartition: TopicPartition): Unit = {

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -353,13 +353,14 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   def logDirFailureChannel: LogDirFailureChannel = localLog.logDirFailureChannel
 
-  def updateConfig(newConfig: LogConfig): Unit = {
+  def updateConfig(newConfig: LogConfig): LogConfig = {
     val oldConfig = localLog.config
     localLog.updateConfig(newConfig)
     val oldRecordVersion = oldConfig.recordVersion
     val newRecordVersion = newConfig.recordVersion
     if (newRecordVersion != oldRecordVersion)
       initializeLeaderEpochCache()
+    oldConfig
   }
 
   def highWatermark: Long = highWatermarkMetadata.messageOffset

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -23,13 +23,9 @@ import java.nio.charset.StandardCharsets
 import java.util.Properties
 import java.util.concurrent.ExecutionException
 import kafka.integration.KafkaServerTestHarness
-import kafka.log.LogConfig
 import kafka.log.LogConfig._
-import kafka.log.LogManager
-import kafka.log.UnifiedLog
 import kafka.utils._
 import kafka.server.Constants._
-import kafka.server.QuotaFactory.QuotaManagers
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, ConfigEntry}
@@ -42,10 +38,6 @@ import org.apache.kafka.common.record.{CompressionType, RecordVersion}
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.when
 
 import scala.annotation.nowarn
 import scala.collection.{Map, Seq}
@@ -101,51 +93,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     (1 to 50).foreach(i => TestUtils.produceMessage(servers, tp.topic, i.toString))
     // Verify that the new config is used for all segments
     assertTrue(log.logSegments.forall(_.size > 1000), "Log segment size change not applied")
-  }
-
-  @Test
-  def testDynamicTopicConfigChangeStopCleaningIfCompactIsRemoved(): Unit = {
-    val topic = "topic"
-    val tp0 = new TopicPartition(topic, 0)
-    val tp1 = new TopicPartition(topic, 1)
-
-    val logManager = mock(classOf[LogManager])
-    val replicationQuotaManager = mock(classOf[ReplicationQuotaManager])
-    val quotaManagers = mock(classOf[QuotaManagers])
-    val kafkaConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, zkConnect))
-    val logConfig = new LogConfig(new Properties)
-    val topicConfigHandler = new TopicConfigHandler(
-      logManager,
-      kafkaConfig,
-      quotaManagers,
-      None
-    )
-
-    val oldProperties = new Properties()
-    oldProperties.put(LogConfig.CleanupPolicyProp, LogConfig.Compact)
-    val oldLogConfig = LogConfig.fromProps(logConfig.originals, oldProperties)
-
-    val newProperties = new Properties()
-    newProperties.put(LogConfig.CleanupPolicyProp, LogConfig.Delete)
-    val newLogConfig = LogConfig.fromProps(logConfig.originals, newProperties)
-
-    val log0 = mock(classOf[UnifiedLog])
-    when(log0.topicPartition).thenReturn(tp0)
-    when(log0.updateConfig(newLogConfig)).thenReturn(oldLogConfig)
-
-    val log1 = mock(classOf[UnifiedLog])
-    when(log1.topicPartition).thenReturn(tp1)
-    when(log1.updateConfig(newLogConfig)).thenReturn(oldLogConfig)
-
-    when(logManager.logsByTopic(topic)).thenReturn(Seq(log0, log1))
-    when(logManager.currentDefaultConfig).thenReturn(logConfig)
-    when(quotaManagers.leader).thenReturn(replicationQuotaManager)
-    when(quotaManagers.follower).thenReturn(replicationQuotaManager)
-
-    topicConfigHandler.processConfigChanges(topic, newProperties)
-
-    verify(logManager, times(1)).abortCleaning(tp0)
-    verify(logManager, times(1)).abortCleaning(tp1)
   }
 
   @nowarn("cat=deprecation")


### PR DESCRIPTION
When `compact` is removed from the `cleanup.policy` of a topic, the compactions of that topic should be aborted.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
