### PR TITLE
HOTFIX: Disable spurious left/outer stream-stream join fix

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
@@ -104,55 +104,11 @@ public class JoinWindows extends Windows<Window> {
      * Specifies that records of the same key are joinable if their timestamps are within {@code timeDifference},
      * i.e., the timestamp of a record from the secondary stream is max {@code timeDifference} before or after
      * the timestamp of the record from the primary stream.
-     * <p>
-     * Using this method explicitly sets the grace period to the duration specified by {@code afterWindowEnd}, which
-     * means that only out-of-order records arriving more than the grace period after the window end will be dropped.
-     * The window close, after which any incoming records are considered late and will be rejected, is defined as
-     * {@code windowEnd + afterWindowEnd}
-     *
-     * @param timeDifference join window interval
-     * @param afterWindowEnd The grace period to admit out-of-order events to a window.
-     * @return A new JoinWindows object with the specified window definition and grace period
-     * @throws IllegalArgumentException if {@code timeDifference} is negative or can't be represented as {@code long milliseconds}
-     *                                  if the {@code afterWindowEnd} is negative or can't be represented as {@code long milliseconds}
-     */
-    public static JoinWindows ofTimeDifferenceAndGrace(final Duration timeDifference, final Duration afterWindowEnd) {
-        final String timeDifferenceMsgPrefix = prepareMillisCheckFailMsgPrefix(timeDifference, "timeDifference");
-        final long timeDifferenceMs = validateMillisecondDuration(timeDifference, timeDifferenceMsgPrefix);
-
-        final String afterWindowEndMsgPrefix = prepareMillisCheckFailMsgPrefix(afterWindowEnd, "afterWindowEnd");
-        final long afterWindowEndMs = validateMillisecondDuration(afterWindowEnd, afterWindowEndMsgPrefix);
-
-        return new JoinWindows(timeDifferenceMs, timeDifferenceMs, afterWindowEndMs, true);
-    }
-
-    /**
-     * Specifies that records of the same key are joinable if their timestamps are within {@code timeDifference},
-     * i.e., the timestamp of a record from the secondary stream is max {@code timeDifference} before or after
-     * the timestamp of the record from the primary stream.
-     * <p>
-     * CAUTION: Using this method implicitly sets the grace period to zero, which means that any out-of-order
-     * records arriving after the window ends are considered late and will be dropped.
-     *
-     * @param timeDifference join window interval
-     * @return a new JoinWindows object with the window definition and no grace period. Note that this means out-of-order records arriving after the window end will be dropped
-     * @throws IllegalArgumentException if {@code timeDifference} is negative or can't be represented as {@code long milliseconds}
-     */
-    public static JoinWindows ofTimeDifferenceWithNoGrace(final Duration timeDifference) {
-        return ofTimeDifferenceAndGrace(timeDifference, Duration.ofMillis(NO_GRACE_PERIOD));
-    }
-
-    /**
-     * Specifies that records of the same key are joinable if their timestamps are within {@code timeDifference},
-     * i.e., the timestamp of a record from the secondary stream is max {@code timeDifference} before or after
-     * the timestamp of the record from the primary stream.
      *
      * @param timeDifference join window interval
      * @return a new JoinWindows object with the window definition with and grace period (default to 24 hours minus {@code timeDifference})
      * @throws IllegalArgumentException if {@code timeDifference} is negative or can't be represented as {@code long milliseconds}
-     * @deprecated since 3.0. Use {@link #ofTimeDifferenceWithNoGrace(Duration)}} instead
      */
-    @Deprecated
     public static JoinWindows of(final Duration timeDifference) throws IllegalArgumentException {
         final String msgPrefix = prepareMillisCheckFailMsgPrefix(timeDifference, "timeDifference");
         final long timeDifferenceMs = validateMillisecondDuration(timeDifference, msgPrefix);
@@ -216,9 +172,7 @@ public class JoinWindows extends Windows<Window> {
      * @param afterWindowEnd The grace period to admit out-of-order events to a window.
      * @return this updated builder
      * @throws IllegalArgumentException if the {@code afterWindowEnd} is negative or can't be represented as {@code long milliseconds}
-     * @deprecated since 3.0. Use {@link #ofTimeDifferenceAndGrace(Duration, Duration)} instead
      */
-    @Deprecated
     public JoinWindows grace(final Duration afterWindowEnd) throws IllegalArgumentException {
         //TODO KAFKA-13021: disallow calling grace() if it was already set via ofTimeDifferenceAndGrace/WithNoGrace()
         final String msgPrefix = prepareMillisCheckFailMsgPrefix(afterWindowEnd, "afterWindowEnd");

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -745,7 +745,7 @@ public class StreamsBuilderTest {
         streamOne.leftJoin(
             streamTwo,
             (value1, value2) -> value1,
-            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            JoinWindows.of(Duration.ofHours(1)).grace(Duration.ZERO),
             StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME)
                 .withName(STREAM_OPERATION_NAME)
         );
@@ -754,8 +754,7 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
             STREAM_OPERATION_NAME + "-this-join-store",
-            STREAM_OPERATION_NAME + "-outer-other-join-store",
-            STREAM_OPERATION_NAME + "-left-shared-join-store"
+            STREAM_OPERATION_NAME + "-outer-other-join-store"
         );
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",
@@ -775,7 +774,7 @@ public class StreamsBuilderTest {
         streamOne.leftJoin(
             streamTwo,
             (value1, value2) -> value1,
-            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            JoinWindows.of(Duration.ofHours(1)).grace(Duration.ZERO),
             StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
                 .withName(STREAM_OPERATION_NAME)
         );
@@ -784,8 +783,7 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  "KSTREAM-JOINTHIS-0000000004-store",
-                                 "KSTREAM-OUTEROTHER-0000000005-store",
-                                 "KSTREAM-OUTERSHARED-0000000004-store"
+                                 "KSTREAM-OUTEROTHER-0000000005-store"
         );
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",
@@ -851,7 +849,7 @@ public class StreamsBuilderTest {
         streamOne.outerJoin(
             streamTwo,
             (value1, value2) -> value1,
-            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            JoinWindows.of(Duration.ofHours(1)).grace(Duration.ZERO),
             StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME)
                 .withName(STREAM_OPERATION_NAME)
         );
@@ -859,8 +857,7 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  STREAM_OPERATION_NAME + "-outer-this-join-store",
-                                 STREAM_OPERATION_NAME + "-outer-other-join-store",
-                                 STREAM_OPERATION_NAME + "-outer-shared-join-store");
+                                 STREAM_OPERATION_NAME + "-outer-other-join-store");
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",
                                 "KSTREAM-SOURCE-0000000001",
@@ -880,7 +877,7 @@ public class StreamsBuilderTest {
         streamOne.outerJoin(
             streamTwo,
             (value1, value2) -> value1,
-            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            JoinWindows.of(Duration.ofHours(1)).grace(Duration.ZERO),
             StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
                 .withName(STREAM_OPERATION_NAME)
         );
@@ -889,8 +886,7 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  "KSTREAM-OUTERTHIS-0000000004-store",
-                                 "KSTREAM-OUTEROTHER-0000000005-store",
-                                 "KSTREAM-OUTERSHARED-0000000004-store"
+                                 "KSTREAM-OUTEROTHER-0000000005-store"
         );
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -853,7 +853,7 @@ public class TopologyTest {
         stream1.leftJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
+            JoinWindows.of(ofMillis(100)).grace(Duration.ZERO),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
 
         final TopologyDescription describe = builder.build().describe();
@@ -871,10 +871,10 @@ public class TopologyTest {
                 "    Processor: KSTREAM-WINDOWED-0000000003 (stores: [KSTREAM-OUTEROTHER-0000000005-store])\n" +
                 "      --> KSTREAM-OUTEROTHER-0000000005\n" +
                 "      <-- KSTREAM-SOURCE-0000000001\n" +
-                "    Processor: KSTREAM-JOINTHIS-0000000004 (stores: [KSTREAM-OUTEROTHER-0000000005-store, KSTREAM-OUTERSHARED-0000000004-store])\n" +
+                "    Processor: KSTREAM-JOINTHIS-0000000004 (stores: [KSTREAM-OUTEROTHER-0000000005-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000002\n" +
-                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [KSTREAM-JOINTHIS-0000000004-store, KSTREAM-OUTERSHARED-0000000004-store])\n" +
+                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [KSTREAM-JOINTHIS-0000000004-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000003\n" +
                 "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +
@@ -895,7 +895,7 @@ public class TopologyTest {
         stream1.leftJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
+            JoinWindows.of(ofMillis(100)).grace(Duration.ZERO),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
                 .withStoreName("custom-name"));
 
@@ -914,10 +914,10 @@ public class TopologyTest {
                 "    Processor: KSTREAM-WINDOWED-0000000003 (stores: [custom-name-outer-other-join-store])\n" +
                 "      --> KSTREAM-OUTEROTHER-0000000005\n" +
                 "      <-- KSTREAM-SOURCE-0000000001\n" +
-                "    Processor: KSTREAM-JOINTHIS-0000000004 (stores: [custom-name-outer-other-join-store, custom-name-left-shared-join-store])\n" +
+                "    Processor: KSTREAM-JOINTHIS-0000000004 (stores: [custom-name-outer-other-join-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000002\n" +
-                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [custom-name-this-join-store, custom-name-left-shared-join-store])\n" +
+                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [custom-name-this-join-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000003\n" +
                 "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +
@@ -935,7 +935,7 @@ public class TopologyTest {
         stream1 = builder.stream("input-topic1");
         stream2 = builder.stream("input-topic2");
 
-        final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100));
+        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100)).grace(Duration.ZERO);
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store",
             Duration.ofMillis(joinWindows.size() + joinWindows.gracePeriodMs()),
@@ -968,10 +968,10 @@ public class TopologyTest {
                 "    Processor: KSTREAM-WINDOWED-0000000003 (stores: [in-memory-join-store-other])\n" +
                 "      --> KSTREAM-OUTEROTHER-0000000005\n" +
                 "      <-- KSTREAM-SOURCE-0000000001\n" +
-                "    Processor: KSTREAM-JOINTHIS-0000000004 (stores: [in-memory-join-store-other, in-memory-join-store-left-shared-join-store])\n" +
+                "    Processor: KSTREAM-JOINTHIS-0000000004 (stores: [in-memory-join-store-other])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000002\n" +
-                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [in-memory-join-store, in-memory-join-store-left-shared-join-store])\n" +
+                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [in-memory-join-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000003\n" +
                 "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +
@@ -992,7 +992,7 @@ public class TopologyTest {
         stream1.outerJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
+            JoinWindows.of(ofMillis(100)).grace(Duration.ZERO),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
 
         final TopologyDescription describe = builder.build().describe();
@@ -1010,10 +1010,10 @@ public class TopologyTest {
                 "    Processor: KSTREAM-WINDOWED-0000000003 (stores: [KSTREAM-OUTEROTHER-0000000005-store])\n" +
                 "      --> KSTREAM-OUTEROTHER-0000000005\n" +
                 "      <-- KSTREAM-SOURCE-0000000001\n" +
-                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [KSTREAM-OUTERTHIS-0000000004-store, KSTREAM-OUTERSHARED-0000000004-store])\n" +
+                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [KSTREAM-OUTERTHIS-0000000004-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000003\n" +
-                "    Processor: KSTREAM-OUTERTHIS-0000000004 (stores: [KSTREAM-OUTEROTHER-0000000005-store, KSTREAM-OUTERSHARED-0000000004-store])\n" +
+                "    Processor: KSTREAM-OUTERTHIS-0000000004 (stores: [KSTREAM-OUTEROTHER-0000000005-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000002\n" +
                 "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +
@@ -1034,7 +1034,7 @@ public class TopologyTest {
         stream1.outerJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
+            JoinWindows.of(ofMillis(100)).grace(Duration.ZERO),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
                 .withStoreName("custom-name"));
 
@@ -1053,10 +1053,10 @@ public class TopologyTest {
                 "    Processor: KSTREAM-WINDOWED-0000000003 (stores: [custom-name-outer-other-join-store])\n" +
                 "      --> KSTREAM-OUTEROTHER-0000000005\n" +
                 "      <-- KSTREAM-SOURCE-0000000001\n" +
-                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [custom-name-outer-this-join-store, custom-name-outer-shared-join-store])\n" +
+                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [custom-name-outer-this-join-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000003\n" +
-                "    Processor: KSTREAM-OUTERTHIS-0000000004 (stores: [custom-name-outer-other-join-store, custom-name-outer-shared-join-store])\n" +
+                "    Processor: KSTREAM-OUTERTHIS-0000000004 (stores: [custom-name-outer-other-join-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000002\n" +
                 "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +
@@ -1074,7 +1074,7 @@ public class TopologyTest {
         stream1 = builder.stream("input-topic1");
         stream2 = builder.stream("input-topic2");
 
-        final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100));
+        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100)).grace(Duration.ZERO);
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store",
             Duration.ofMillis(joinWindows.size() + joinWindows.gracePeriodMs()),
@@ -1107,10 +1107,10 @@ public class TopologyTest {
                 "    Processor: KSTREAM-WINDOWED-0000000003 (stores: [in-memory-join-store-other])\n" +
                 "      --> KSTREAM-OUTEROTHER-0000000005\n" +
                 "      <-- KSTREAM-SOURCE-0000000001\n" +
-                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [in-memory-join-store-outer-shared-join-store, in-memory-join-store])\n" +
+                "    Processor: KSTREAM-OUTEROTHER-0000000005 (stores: [in-memory-join-store])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000003\n" +
-                "    Processor: KSTREAM-OUTERTHIS-0000000004 (stores: [in-memory-join-store-other, in-memory-join-store-outer-shared-join-store])\n" +
+                "    Processor: KSTREAM-OUTERTHIS-0000000004 (stores: [in-memory-join-store-other])\n" +
                 "      --> KSTREAM-MERGE-0000000006\n" +
                 "      <-- KSTREAM-WINDOWED-0000000002\n" +
                 "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -100,7 +100,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.join(
             rightStream,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
         ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
@@ -147,7 +147,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
                     .selectKey(MockMapper.selectKeyKeyValueMapper()),
                 valueJoiner,
-                JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+                JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
             ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
@@ -161,7 +161,10 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)),
+            Arrays.asList(
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L),
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)
+            ),
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
             Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-b", null, 6L),
@@ -192,7 +195,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.leftJoin(
             rightStream,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
         ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
@@ -206,7 +209,10 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)),
+            Arrays.asList(
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L),
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)
+            ),
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
             Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-b", null, 6L),
@@ -239,7 +245,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
                      .selectKey(MockMapper.selectKeyKeyValueMapper()),
                 valueJoiner,
-                JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+                JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
             ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
@@ -253,7 +259,10 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)),
+            Arrays.asList(
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L),
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)
+            ),
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
             Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-b", null, 6L),
@@ -284,7 +293,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.outerJoin(
             rightStream,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
         ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
@@ -298,7 +307,10 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)),
+            Arrays.asList(
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L),
+                new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)
+            ),
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
             Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-b", null, 6L),
@@ -331,7 +343,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
                     .selectKey(MockMapper.selectKeyKeyValueMapper()),
                 valueJoiner,
-                JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+                JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
             ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
@@ -424,11 +436,11 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.join(
             rightStream,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
         ).join(
             rightStream,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            JoinWindows.of(ofSeconds(10)).grace(ofHours(24))
         ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -75,8 +75,6 @@ public class JoinWindowsTest {
     @Test
     public void timeDifferenceMustNotBeNegative() {
         assertThrows(IllegalArgumentException.class, () -> JoinWindows.of(ofMillis(-1)));
-        assertThrows(IllegalArgumentException.class, () -> JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(-1)));
-        assertThrows(IllegalArgumentException.class, () -> JoinWindows.ofTimeDifferenceAndGrace(ofMillis(-1), ofMillis(ANY_GRACE)));
     }
 
     @Test
@@ -149,16 +147,6 @@ public class JoinWindowsTest {
             JoinWindows.of(ofMillis(9)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3)).grace(ofMillis(60)),
             JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3)).grace(ofMillis(60))
         );
-
-        verifyEquality(
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3)),
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3))
-        );
-
-        verifyEquality(
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(4)),
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(4))
-        );
     }
 
     @Test
@@ -187,16 +175,6 @@ public class JoinWindowsTest {
         verifyInEquality(
             JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(9)),
             JoinWindows.of(ofMillis(3)).before(ofMillis(1)).after(ofMillis(2)).grace(ofMillis(3))
-        );
-
-        verifyInEquality(
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(9)),
-                JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(3))
-        );
-
-        verifyInEquality(
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(9), ofMillis(9)),
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(3), ofMillis(9))
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplValueJoinerWithKeyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplValueJoinerWithKeyTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.Arrays;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -64,7 +65,7 @@ public class KStreamImplValueJoinerWithKeyTest {
 
     private final ValueJoinerWithKey<String, Integer, Integer, String> valueJoinerWithKey =
         (key, lv, rv) -> key + ":" + (lv + (rv == null ? 0 : rv));
-    private final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100), ofHours(24L));
+    private final JoinWindows joinWindows = JoinWindows.of(ofMillis(100)).grace(ofHours(24L));
     private final StreamJoined<String, Integer, Integer> streamJoined =
             StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
     private final Joined<String, Integer, Integer> joined =
@@ -108,7 +109,8 @@ public class KStreamImplValueJoinerWithKeyTest {
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, Right KV A, 5
         // TTD pipes records to left stream first, then right
-        final List<KeyValue<String, String>> expectedResults = Collections.singletonList(KeyValue.pair("A", "A:5"));
+        final List<KeyValue<String, String>> expectedResults =
+            Arrays.asList(KeyValue.pair("A", "A:3"), KeyValue.pair("A", "A:5"));
         runJoinTopology(
             builder,
             expectedResults,
@@ -128,7 +130,8 @@ public class KStreamImplValueJoinerWithKeyTest {
 
         // Left KV A, 3, Right KV A, 5
         // TTD pipes records to left stream first, then right
-        final List<KeyValue<String, String>> expectedResults = Collections.singletonList(KeyValue.pair("A", "A:5"));
+        final List<KeyValue<String, String>> expectedResults =
+            Arrays.asList(KeyValue.pair("A", "A:3"), KeyValue.pair("A", "A:5"));
         runJoinTopology(
             builder,
             expectedResults,

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -379,7 +379,7 @@ class TopologyTest {
       mappedStream
         .filter((k: String, _: String) => k == "A")
         .join(stream2)((v1: String, v2: Int) => v1 + ":" + v2.toString,
-                       JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24)))(
+                       JoinWindows.of(Duration.ofMillis(5000)).grace(Duration.ofHours(24)))(
           StreamJoined.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, NewSerdes.intSerde)
         )
         .to(JOINED_TOPIC)
@@ -387,7 +387,7 @@ class TopologyTest {
       mappedStream
         .filter((k: String, _: String) => k == "A")
         .join(stream3)((v1: String, v2: String) => v1 + ":" + v2.toString,
-                       JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24)))(
+                       JoinWindows.of(Duration.ofMillis(5000)).grace(Duration.ofHours(24)))(
           StreamJoined.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, NewSerdes.stringSerde)
         )
         .to(JOINED_TOPIC)
@@ -439,7 +439,7 @@ class TopologyTest {
         .join[Integer, String](
           stream2,
           valueJoiner2,
-          JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24)),
+          JoinWindows.of(Duration.ofMillis(5000)).grace(Duration.ofHours(24)),
           StreamJoinedJ.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, SerdesJ.Integer)
         )
         .to(JOINED_TOPIC)
@@ -449,7 +449,7 @@ class TopologyTest {
         .join(
           stream3,
           valueJoiner3,
-          JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24)),
+          JoinWindows.of(Duration.ofMillis(5000)).grace(Duration.ofHours(24)),
           StreamJoinedJ.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, SerdesJ.String)
         )
         .to(JOINED_TOPIC)

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -201,7 +201,7 @@ class KStreamTest extends TestDriver {
     val stream1 = builder.stream[String, String](sourceTopic1)
     val stream2 = builder.stream[String, String](sourceTopic2)
     stream1
-      .join(stream2)((a, b) => s"$a-$b", JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(1), Duration.ofHours(24)))
+      .join(stream2)((a, b) => s"$a-$b", JoinWindows.of(ofSeconds(1)).grace(Duration.ofHours(24)))
       .to(sinkTopic)
 
     val now = Instant.now()


### PR DESCRIPTION
KAFKA-10847 improves stream-stream left/outer joins to avoid spurious
left/outer join results. However, it introduces regression bug
KAFKA-13216.

This PR disables KAFKA-10847 by partially rolling back KIP-633 changes.
