### PR TITLE
MINOR: Set session timeout back to 10s for Streams system tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.tests;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Exit;
@@ -54,7 +53,6 @@ public class StreamsUpgradeToCooperativeRebalanceTest {
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
-        config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10 * 1000);
         config.putAll(streamsProperties);
 
         final String sourceTopic = streamsProperties.getProperty("source.topic", "source");

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -671,7 +671,6 @@ class StreamsNamedRepartitionTopicService(StreamsTestBaseService):
                       "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
                       }
 
-        # Long.MAX_VALUE lets us do the assignment without a warmup
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -697,7 +696,6 @@ class StaticMemberTestService(StreamsTestBaseService):
                       "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
                       }
 
-        # Long.MAX_VALUE lets us do the assignment without a warmup
 
         cfg = KafkaConfig(**properties)
         return cfg.render()

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -347,7 +347,10 @@ class StreamsSmokeTestBaseService(StreamsTestBaseService):
                       "buffered.records.per.partition": 100,
                       "commit.interval.ms": 1000,
                       "auto.offset.reset": "earliest",
-                      "acks": "all"}
+                      "acks": "all",
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         if self.UPGRADE_FROM is not None:
             properties['upgrade.from'] = self.UPGRADE_FROM
@@ -391,10 +394,10 @@ class StreamsEosTestBaseService(StreamsTestBaseService):
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
                       streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
-                      streams_property.PROCESSING_GUARANTEE: self.PROCESSING_GUARANTEE}
-
-        # Long.MAX_VALUE lets us do the assignment without a warmup
-        properties['acceptable.recovery.lag'] = "9223372036854775807"
+                      streams_property.PROCESSING_GUARANTEE: self.PROCESSING_GUARANTEE,
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -473,10 +476,10 @@ class StreamsBrokerCompatibilityService(StreamsTestBaseService):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
                       streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
                       # the old broker (< 2.4) does not support configuration replication.factor=-1
-                      "replication.factor": 1}
-
-        # Long.MAX_VALUE lets us do the assignment without a warmup
-        properties['acceptable.recovery.lag'] = "9223372036854775807"
+                      "replication.factor": 1,
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -569,16 +572,17 @@ class StreamsOptimizedUpgradeTestService(StreamsTestBaseService):
 
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
-                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers()}
-
-        properties['topology.optimization'] = self.OPTIMIZED_CONFIG
-        properties['input.topic'] = self.INPUT_TOPIC
-        properties['aggregation.topic'] = self.AGGREGATION_TOPIC
-        properties['reduce.topic'] = self.REDUCE_TOPIC
-        properties['join.topic'] = self.JOIN_TOPIC
+                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
+                      'topology.optimization': self.OPTIMIZED_CONFIG,
+                      'input.topic': self.INPUT_TOPIC,
+                      'aggregation.topic': self.AGGREGATION_TOPIC,
+                      'reduce.topic': self.REDUCE_TOPIC,
+                      'join.topic': self.JOIN_TOPIC,
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         # Long.MAX_VALUE lets us do the assignment without a warmup
-        properties['acceptable.recovery.lag'] = "9223372036854775807"
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -618,6 +622,7 @@ class StreamsUpgradeTestJobRunnerService(StreamsTestBaseService):
 
         # Long.MAX_VALUE lets us do the assignment without a warmup
         properties['acceptable.recovery.lag'] = "9223372036854775807"
+        properties["session.timeout.ms"] = "10000" # set back to 10s for tests. See KIP-735
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -659,14 +664,15 @@ class StreamsNamedRepartitionTopicService(StreamsTestBaseService):
 
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
-                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers()}
-
-        properties['input.topic'] = self.INPUT_TOPIC
-        properties['aggregation.topic'] = self.AGGREGATION_TOPIC
-        properties['add.operations'] = self.ADD_ADDITIONAL_OPS
+                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
+                      'input.topic': self.INPUT_TOPIC,
+                      'aggregation.topic': self.AGGREGATION_TOPIC,
+                      'add.operations': self.ADD_ADDITIONAL_OPS,
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         # Long.MAX_VALUE lets us do the assignment without a warmup
-        properties['acceptable.recovery.lag'] = "9223372036854775807"
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -686,12 +692,13 @@ class StaticMemberTestService(StreamsTestBaseService):
                       streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
                       streams_property.NUM_THREADS: self.NUM_THREADS,
                       consumer_property.GROUP_INSTANCE_ID: self.GROUP_INSTANCE_ID,
-                      consumer_property.SESSION_TIMEOUT_MS: 60000}
-
-        properties['input.topic'] = self.INPUT_TOPIC
+                      consumer_property.SESSION_TIMEOUT_MS: 60000,
+                      'input.topic': self.INPUT_TOPIC,
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         # Long.MAX_VALUE lets us do the assignment without a warmup
-        properties['acceptable.recovery.lag'] = "9223372036854775807"
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -754,7 +761,14 @@ class CooperativeRebalanceUpgradeService(StreamsTestBaseService):
 
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
-                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers()}
+                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
+                      'source.topic': self.SOURCE_TOPIC,
+                      'sink.topic': self.SINK_TOPIC,
+                      'task.delimiter': self.TASK_DELIMITER,
+                      'report.interval': self.REPORT_INTERVAL,
+                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
+                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      }
 
         if self.UPGRADE_FROM is not None:
             properties['upgrade.from'] = self.UPGRADE_FROM
@@ -767,13 +781,6 @@ class CooperativeRebalanceUpgradeService(StreamsTestBaseService):
         if self.upgrade_phase is not None:
             properties['upgrade.phase'] = self.upgrade_phase
 
-        properties['source.topic'] = self.SOURCE_TOPIC
-        properties['sink.topic'] = self.SINK_TOPIC
-        properties['task.delimiter'] = self.TASK_DELIMITER
-        properties['report.interval'] = self.REPORT_INTERVAL
-
-        # Long.MAX_VALUE lets us do the assignment without a warmup
-        properties['acceptable.recovery.lag'] = "9223372036854775807"
 
         cfg = KafkaConfig(**properties)
         return cfg.render()

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -582,7 +582,6 @@ class StreamsOptimizedUpgradeTestService(StreamsTestBaseService):
                       "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
                       }
 
-        # Long.MAX_VALUE lets us do the assignment without a warmup
 
         cfg = KafkaConfig(**properties)
         return cfg.render()


### PR DESCRIPTION
We increased the default session timeout to 30s in KIP-735:
https://cwiki.apache.org/confluence/display/KAFKA/KIP-735%3A+Increase+default+consumer+session+timeout

Since then, we are observing sporadic system test failures due to rebalances taking
longer than the test timeout. Rather than increase the test wait times, we can 
just override the session timeout to a value more appropriate in the testing domain.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
