### PR TITLE
MINOR: Fix force kill of KRaft colocated controllers in system tests

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -858,12 +858,27 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         leader = self.leader(topic, partition)
         self.signal_node(leader, sig)
 
+    def controllers_required_for_quorum(self):
+        """
+        Assume N = the total number of controller nodes in the cluster, and positive
+        For N=1, we need 1 controller to be running to have a quorum
+        For N=2, we need 2 controllers
+        For N=3, we need 2 controllers
+        For N=4, we need 3 controllers
+        For N=5, we need 3 controllers
+
+        :return: the number of controller nodes that must be started for there to be a quorum
+        """
+        # Note that we need to add 0.1 to avoid floating point rounding issues.
+        # For example, round(5/2) yields 2 instead of 3
+        return round(0.1 + (1 + self.num_nodes_controller_role) / 2)
+
     def stop_node(self, node, clean_shutdown=True, timeout_sec=60):
         pids = self.pids(node)
         cluster_has_colocated_controllers = self.quorum_info.has_brokers and self.quorum_info.has_controllers
         force_sigkill_due_to_too_few_colocated_controllers =\
             clean_shutdown and cluster_has_colocated_controllers\
-            and self.colocated_nodes_started < round(self.num_nodes_controller_role / 2)
+            and self.colocated_nodes_started < self.controllers_required_for_quorum()
         if force_sigkill_due_to_too_few_colocated_controllers:
             self.logger.info("Forcing node to stop via SIGKILL due to too few co-located KRaft controllers: %i/%i" %\
                              (self.colocated_nodes_started, self.num_nodes_controller_role))

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import json
+import math
 import os.path
 import re
 import signal
@@ -869,9 +870,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         :return: the number of controller nodes that must be started for there to be a quorum
         """
-        # Note that we need to add 0.1 to avoid floating point rounding issues.
-        # For example, round(5/2) yields 2 instead of 3
-        return round(0.1 + (1 + self.num_nodes_controller_role) / 2)
+        # Note that we use math.ceil() to avoid floating point rounding issues
+        # associated with round() (e.g. round(5/2) yields 2 instead of 3)
+        return math.ceil((1 + self.num_nodes_controller_role) / 2)
 
     def stop_node(self, node, clean_shutdown=True, timeout_sec=60):
         pids = self.pids(node)

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -870,8 +870,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         :return: the number of controller nodes that must be started for there to be a quorum
         """
-        # Note that we use math.ceil() to avoid floating point rounding issues
-        # associated with round() (e.g. round(5/2) yields 2 instead of 3)
         return math.ceil((1 + self.num_nodes_controller_role) / 2)
 
     def stop_node(self, node, clean_shutdown=True, timeout_sec=60):


### PR DESCRIPTION
I noticed that a system test using a KRaft cluster with 3 brokers but only 1 co-located controller did not force-kill the second and third broker after shutting down the first broker (the one with the controller).  The issue was a floating point rounding error.  This patch adjusts for the rounding error and also makes the logic work for an even number of controllers.  A local run of `tests/kafkatest/sanity_checks/test_bounce.py` succeeded (and I manually increased the cluster size for the 1 co-located controller case and observed the correct kill behavior: the second and third brokers were force-killed as expected).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
