### PR TITLE
KAFKA-13032: add NPE checker for KeyValueMapper

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMap.java
@@ -43,7 +43,7 @@ class KStreamFlatMap<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn
         public void process(final Record<KIn, VIn> record) {
             final Iterable<? extends KeyValue<? extends KOut, ? extends VOut>> newKeyValues =
                 mapper.apply(record.key(), record.value());
-            Objects.requireNonNull(newKeyValues, String.format("KeyValueMapper can't return null from mapping the record: %s", record));
+            Objects.requireNonNull(newKeyValues, "The provided KeyValueMapper returned null which is not allowed.");
             for (final KeyValue<? extends KOut, ? extends VOut> newPair : newKeyValues) {
                 context().forward(record.withKey(newPair.key).withValue(newPair.value));
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMap.java
@@ -23,6 +23,8 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 
+import java.util.Objects;
+
 class KStreamFlatMap<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KOut, VOut> {
 
     private final KeyValueMapper<? super KIn, ? super VIn, ? extends Iterable<? extends KeyValue<? extends KOut, ? extends VOut>>> mapper;
@@ -41,6 +43,7 @@ class KStreamFlatMap<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn
         public void process(final Record<KIn, VIn> record) {
             final Iterable<? extends KeyValue<? extends KOut, ? extends VOut>> newKeyValues =
                 mapper.apply(record.key(), record.value());
+            Objects.requireNonNull(newKeyValues, String.format("KeyValueMapper can't return null from mapping the record: %s", record));
             for (final KeyValue<? extends KOut, ? extends VOut> newPair : newKeyValues) {
                 context().forward(record.withKey(newPair.key).withValue(newPair.value));
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMap.java
@@ -23,6 +23,8 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 
+import java.util.Objects;
+
 class KStreamMap<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KOut, VOut> {
 
     private final KeyValueMapper<? super KIn, ? super VIn, ? extends KeyValue<? extends KOut, ? extends VOut>> mapper;
@@ -42,6 +44,7 @@ class KStreamMap<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KO
         public void process(final Record<KIn, VIn> record) {
             final KeyValue<? extends KOut, ? extends VOut> newPair =
                 mapper.apply(record.key(), record.value());
+            Objects.requireNonNull(newPair, String.format("KeyValueMapper can't return null from mapping the record: %s", record));
             context().forward(record.withKey(newPair.key).withValue(newPair.value));
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMap.java
@@ -44,7 +44,7 @@ class KStreamMap<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KO
         public void process(final Record<KIn, VIn> record) {
             final KeyValue<? extends KOut, ? extends VOut> newPair =
                 mapper.apply(record.key(), record.value());
-            Objects.requireNonNull(newPair, String.format("KeyValueMapper can't return null from mapping the record: %s", record));
+            Objects.requireNonNull(newPair, "The provided KeyValueMapper returned null which is not allowed.");
             context().forward(record.withKey(newPair.key).withValue(newPair.value));
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
@@ -37,6 +37,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Properties;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -92,8 +94,8 @@ public class KStreamFlatMapTest {
     @Test
     public void testKeyValueMapperResultNotNull() {
         final KStreamFlatMap<String, Integer, String, Integer> supplier = new KStreamFlatMap<>((key, value) -> null);
-        final Record<String, Integer> record = new Record<>("K", 0, 0L);
-        final Throwable throwable = assertThrows(NullPointerException.class, () -> supplier.get().process(record));
-        assertEquals(throwable.getMessage(), String.format("KeyValueMapper can't return null from mapping the record: %s", record));
+        final Throwable throwable = assertThrows(NullPointerException.class,
+                () -> supplier.get().process(new Record<>("K", 0, 0L)));
+        assertThat(throwable.getMessage(), is("The provided KeyValueMapper returned null which is not allowed."));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
@@ -93,7 +93,7 @@ public class KStreamFlatMapTest {
     public void testKeyValueMapperResultNotNull() {
         final KStreamFlatMap<String, Integer, String, Integer> supplier = new KStreamFlatMap<>((key, value) -> null);
         final Record<String, Integer> record = new Record<>("K", 0, 0L);
-        assertThrows(String.format("KeyValueMapper can't return null from mapping the record: %s", record),
-                NullPointerException.class, () -> supplier.get().process(record));
+        final Throwable throwable = assertThrows(NullPointerException.class, () -> supplier.get().process(record));
+        assertEquals(throwable.getMessage(), String.format("KeyValueMapper can't return null from mapping the record: %s", record));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
@@ -92,6 +92,8 @@ public class KStreamFlatMapTest {
     @Test
     public void testKeyValueMapperResultNotNull() {
         final KStreamFlatMap<String, Integer, String, Integer> supplier = new KStreamFlatMap<>((key, value) -> null);
-        assertThrows(NullPointerException.class, () -> supplier.get().process(new Record<>("K", 0, 0L)));
+        final Record<String, Integer> record = new Record<>("K", 0, 0L);
+        assertThrows(String.format("KeyValueMapper can't return null from mapping the record: %s", record),
+                NullPointerException.class, () -> supplier.get().process(record));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class KStreamFlatMapTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
@@ -85,5 +87,11 @@ public class KStreamFlatMapTest {
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], supplier.theCapturedProcessor().processed().get(i));
         }
+    }
+
+    @Test
+    public void testKeyValueMapperResultNotNull() {
+        final KStreamFlatMap<String, Integer, String, Integer> supplier = new KStreamFlatMap<>((key, value) -> null);
+        assertThrows(NullPointerException.class, () -> supplier.get().process(new Record<>("K", 0, 0L)));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
@@ -73,7 +73,9 @@ public class KStreamMapTest {
     @Test
     public void testKeyValueMapperResultNotNull() {
         final KStreamMap<String, Integer, String, Integer> supplier = new KStreamMap<>((key, value) -> null);
-        assertThrows(NullPointerException.class, () -> supplier.get().process(new Record<>("K", 0, 0L)));
+        final Record<String, Integer> record = new Record<>("K", 0, 0L);
+        assertThrows(String.format("KeyValueMapper can't return null from mapping the record: %s", record),
+                NullPointerException.class, () -> supplier.get().process(record));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
@@ -35,6 +36,7 @@ import java.time.Instant;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class KStreamMapTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
@@ -66,6 +68,12 @@ public class KStreamMapTest {
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], supplier.theCapturedProcessor().processed().get(i));
         }
+    }
+
+    @Test
+    public void testKeyValueMapperResultNotNull() {
+        final KStreamMap<String, Integer, String, Integer> supplier = new KStreamMap<>((key, value) -> null);
+        assertThrows(NullPointerException.class, () -> supplier.get().process(new Record<>("K", 0, 0L)));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
@@ -74,8 +74,8 @@ public class KStreamMapTest {
     public void testKeyValueMapperResultNotNull() {
         final KStreamMap<String, Integer, String, Integer> supplier = new KStreamMap<>((key, value) -> null);
         final Record<String, Integer> record = new Record<>("K", 0, 0L);
-        assertThrows(String.format("KeyValueMapper can't return null from mapping the record: %s", record),
-                NullPointerException.class, () -> supplier.get().process(record));
+        final Throwable throwable = assertThrows(NullPointerException.class, () -> supplier.get().process(record));
+        assertEquals(throwable.getMessage(), String.format("KeyValueMapper can't return null from mapping the record: %s", record));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
@@ -35,6 +35,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Properties;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -73,9 +75,9 @@ public class KStreamMapTest {
     @Test
     public void testKeyValueMapperResultNotNull() {
         final KStreamMap<String, Integer, String, Integer> supplier = new KStreamMap<>((key, value) -> null);
-        final Record<String, Integer> record = new Record<>("K", 0, 0L);
-        final Throwable throwable = assertThrows(NullPointerException.class, () -> supplier.get().process(record));
-        assertEquals(throwable.getMessage(), String.format("KeyValueMapper can't return null from mapping the record: %s", record));
+        final Throwable throwable = assertThrows(NullPointerException.class,
+                () -> supplier.get().process(new Record<>("K", 0, 0L)));
+        assertThat(throwable.getMessage(), is("The provided KeyValueMapper returned null which is not allowed."));
     }
 
     @Test


### PR DESCRIPTION
Currently in both `KStreamMap` and `KStreamFlatMap` classes, they will throw NPE if the call to `KeyValueMapper#apply` return Null. We should check whether the result of that call is Null and throw a more meaningful error message for better debugging.

Two unit tests are also added to check if we successfully captured the Null.

@mjsax Please help review, thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
