### PR TITLE
[WIP] MINOR: POC for KIP-591: Add config to set default store impl class

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -74,10 +74,18 @@ public class StreamsBuilder {
 
     protected final InternalStreamsBuilder internalStreamsBuilder;
 
+    protected final StreamsConfig config;
+
     public StreamsBuilder() {
+        this(null);
+    }
+
+    // new constructor
+    public StreamsBuilder(Properties props) {
         topology = getNewTopology();
         internalTopologyBuilder = topology.internalTopologyBuilder;
-        internalStreamsBuilder = new InternalStreamsBuilder(internalTopologyBuilder);
+        config = props == null ? null : new StreamsConfig(props);
+        internalStreamsBuilder = new InternalStreamsBuilder(internalTopologyBuilder, config);
     }
 
     protected Topology getNewTopology() {
@@ -255,6 +263,7 @@ public class StreamsBuilder {
 
         final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal =
             new MaterializedInternal<>(materialized, internalStreamsBuilder, topic + "-");
+
 
         return internalStreamsBuilder.table(topic, consumedInternal, materializedInternal);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -81,7 +81,7 @@ public class StreamsBuilder {
     }
 
     // new constructor
-    public StreamsBuilder(Properties props) {
+    public StreamsBuilder(final Properties props) {
         topology = getNewTopology();
         internalTopologyBuilder = topology.internalTopologyBuilder;
         config = props == null ? null : new StreamsConfig(props);

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
+import org.apache.kafka.streams.state.RocksDBStoreImplementation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -387,6 +388,12 @@ public class StreamsConfig extends AbstractConfig {
     public static final String DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG = "default.production.exception.handler";
     private static final String DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_DOC = "Exception handling class that implements the <code>org.apache.kafka.streams.errors.ProductionExceptionHandler</code> interface.";
 
+    /** {@code default.store.impl.class} */
+    @SuppressWarnings("WeakerAccess")
+    public static final String DEFAULT_STORE_IMPLEMENTATION_CLASS_CONFIG = "default.store.impl.class";
+    private static final String DEFAULT_STORE_IMPLEMENTATION_CLASS_DOC = "Store supplier implementation class to use. Default is set as RocksDBStoreImplementation. " +
+        "It can be overwritten dynamically during streaming operation.";
+
     /** {@code default.windowed.key.serde.inner} */
     @SuppressWarnings("WeakerAccess")
     @Deprecated
@@ -685,6 +692,11 @@ public class StreamsConfig extends AbstractConfig {
                     FailOnInvalidTimestamp.class.getName(),
                     Importance.MEDIUM,
                     DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_DOC)
+            .define(DEFAULT_STORE_IMPLEMENTATION_CLASS_CONFIG,
+                    Type.CLASS,
+                    RocksDBStoreImplementation.class.getName(),
+                    Importance.MEDIUM,
+                    DEFAULT_STORE_IMPLEMENTATION_CLASS_DOC)
             .define(DEFAULT_VALUE_SERDE_CLASS_CONFIG,
                     Type.CLASS,
                     null,

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -42,6 +42,7 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.apache.kafka.streams.state.RocksDBStoreImplementation;
+import org.apache.kafka.streams.state.StoreImplementation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1505,6 +1506,10 @@ public class StreamsConfig extends AbstractConfig {
     @SuppressWarnings("WeakerAccess")
     public ProductionExceptionHandler defaultProductionExceptionHandler() {
         return getConfiguredInstance(DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, ProductionExceptionHandler.class);
+    }
+
+    public StoreImplementation defaultStoreImplementation() {
+        return getConfiguredInstance(DEFAULT_STORE_IMPLEMENTATION_CLASS_CONFIG, StoreImplementation.class);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -111,9 +111,9 @@ public class Materialized<K, V, S extends StateStore> {
     }
 
     /**
-     * Materialize a {@link StateStore} with the given name.
+     * Materialize a {@link StateStore} with the store implementation.
      *
-     * @param storeImplementation  the name of the underlying {@link KTable} state store; valid characters are ASCII
+     * @param storeImplementation  store implementation used to materialize the store
      * alphanumerics, '.', '_' and '-'.
      * @param <K>       key type of the store
      * @param <V>       value type of the store

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StoreImplementation;
 import org.apache.kafka.streams.state.StoreSupplier;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
@@ -64,6 +65,7 @@ public class Materialized<K, V, S extends StateStore> {
     protected boolean cachingEnabled = true;
     protected Map<String, String> topicConfig = new HashMap<>();
     protected Duration retention;
+    protected StoreImplementation storeImplementation;
 
     private Materialized(final StoreSupplier<S> storeSupplier) {
         this.storeSupplier = storeSupplier;
@@ -71,6 +73,10 @@ public class Materialized<K, V, S extends StateStore> {
 
     private Materialized(final String storeName) {
         this.storeName = storeName;
+    }
+
+    private Materialized(final StoreImplementation storeImplementation) {
+        this.storeImplementation = storeImplementation;
     }
 
     /**
@@ -86,6 +92,7 @@ public class Materialized<K, V, S extends StateStore> {
         this.cachingEnabled = materialized.cachingEnabled;
         this.topicConfig = materialized.topicConfig;
         this.retention = materialized.retention;
+        this.storeImplementation = materialized.storeImplementation;
     }
 
     /**
@@ -101,6 +108,21 @@ public class Materialized<K, V, S extends StateStore> {
     public static <K, V, S extends StateStore> Materialized<K, V, S> as(final String storeName) {
         Named.validate(storeName);
         return new Materialized<>(storeName);
+    }
+
+    /**
+     * Materialize a {@link StateStore} with the given name.
+     *
+     * @param storeImplementation  the name of the underlying {@link KTable} state store; valid characters are ASCII
+     * alphanumerics, '.', '_' and '-'.
+     * @param <K>       key type of the store
+     * @param <V>       value type of the store
+     * @param <S>       type of the {@link StateStore}
+     * @return a new {@link Materialized} instance with the given storeName
+     */
+    public static <K, V, S extends StateStore> Materialized<K, V, S> as(final StoreImplementation storeImplementation) {
+        Objects.requireNonNull(storeImplementation, "storeImplementation can't be null");
+        return new Materialized<>(storeImplementation);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -68,6 +68,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     private final LinkedHashMap<GraphNode, LinkedHashSet<OptimizableRepartitionNode<?, ?>>> keyChangingOperationsToOptimizableRepartitionNodes = new LinkedHashMap<>();
     private final LinkedHashSet<GraphNode> mergeNodes = new LinkedHashSet<>();
     private final LinkedHashSet<GraphNode> tableSourceNodes = new LinkedHashSet<>();
+    private final StreamsConfig config;
 
     private static final String TOPOLOGY_ROOT = "root";
     private static final Logger LOG = LoggerFactory.getLogger(InternalStreamsBuilder.class);
@@ -80,7 +81,12 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     };
 
     public InternalStreamsBuilder(final InternalTopologyBuilder internalTopologyBuilder) {
+        this(internalTopologyBuilder, null);
+    }
+
+    public InternalStreamsBuilder(final InternalTopologyBuilder internalTopologyBuilder, StreamsConfig config) {
         this.internalTopologyBuilder = internalTopologyBuilder;
+        this.config = config;
     }
 
     public <K, V> KStream<K, V> stream(final Collection<String> topics,
@@ -127,6 +133,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
         final String tableSourceName = named
             .orElseGenerateWithPrefix(this, KTableImpl.SOURCE_NAME);
+
 
         final KTableSource<K, V> tableSource = new KTableSource<>(materialized.storeName(), materialized.queryableStoreName());
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, tableSourceName);
@@ -546,5 +553,9 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     public GraphNode root() {
         return root;
+    }
+
+    public StreamsConfig config() {
+        return config;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -84,7 +84,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         this(internalTopologyBuilder, null);
     }
 
-    public InternalStreamsBuilder(final InternalTopologyBuilder internalTopologyBuilder, StreamsConfig config) {
+    public InternalStreamsBuilder(final InternalTopologyBuilder internalTopologyBuilder, final StreamsConfig config) {
         this.internalTopologyBuilder = internalTopologyBuilder;
         this.config = config;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -172,7 +172,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
 
     private KTable<K, Long> doCount(final Named named, final Materialized<K, Long, KeyValueStore<Bytes, byte[]>> materialized) {
         final MaterializedInternal<K, Long, KeyValueStore<Bytes, byte[]>> materializedInternal =
-            new MaterializedInternal<>(materialized, builder, AGGREGATE_NAME);
+            new MaterializedInternal<>(materialized, builder, AGGREGATE_NAME, builder.config());
 
         if (materializedInternal.keySerde() == null) {
             materializedInternal.withKeySerde(keySerde);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/MaterializedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/MaterializedInternal.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.StoreImplementation;
 import org.apache.kafka.streams.state.StoreSupplier;
 
 import java.time.Duration;
@@ -29,13 +31,25 @@ public class MaterializedInternal<K, V, S extends StateStore> extends Materializ
     private final boolean queryable;
 
     public MaterializedInternal(final Materialized<K, V, S> materialized) {
-        this(materialized, null, null);
+        this(materialized, null, null, null);
     }
 
     public MaterializedInternal(final Materialized<K, V, S> materialized,
                                 final InternalNameProvider nameProvider,
                                 final String generatedStorePrefix) {
+        this(materialized, nameProvider, generatedStorePrefix, null);
+    }
+
+    public MaterializedInternal(final Materialized<K, V, S> materialized,
+                                final InternalNameProvider nameProvider,
+                                final String generatedStorePrefix,
+                                final StreamsConfig config) {
         super(materialized);
+
+        if (config != null && this.storeSupplier == null && this.storeImplementation != null) {
+            // get default store implementation
+            this.storeImplementation = config.defaultStoreImplementation();
+        }
 
         // if storeName is not provided, the corresponding KTable would never be queryable;
         // but we still need to provide an internal name for it in case we materialize.
@@ -58,6 +72,10 @@ public class MaterializedInternal<K, V, S extends StateStore> extends Materializ
 
     public StoreSupplier<S> storeSupplier() {
         return storeSupplier;
+    }
+
+    public StoreImplementation storeImplementation() {
+        return storeImplementation;
     }
 
     public Serde<K> keySerde() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -240,7 +240,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             }
 
             // get from default store implementation
-            StoreImplementation storeImplementation = materialized.storeImplementation();
+            final StoreImplementation storeImplementation = materialized.storeImplementation();
             if (storeImplementation != null) {
                 supplier = storeImplementation.sessionBytesStoreSupplier(
                     materialized.storeName(),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
-import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.StoreImplementation;
 import org.apache.kafka.streams.state.Stores;
@@ -227,7 +226,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
             }
 
             // get from default store implementation
-            StoreImplementation storeImplementation = materialized.storeImplementation();
+            final StoreImplementation storeImplementation = materialized.storeImplementation();
             if (storeImplementation != null) {
                 supplier = storeImplementation.windowBytesStoreSupplier(
                     materialized.storeName(),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedKeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedKeyValueStoreMaterializer.java
@@ -39,7 +39,7 @@ public class TimestampedKeyValueStoreMaterializer<K, V> {
         if (supplier == null) {
             // get from default store implementation
             final String name = materialized.storeName();
-            StoreImplementation storeImplementation = materialized.storeImplementation();
+            final StoreImplementation storeImplementation = materialized.storeImplementation();
             if (storeImplementation != null) {
                 supplier = storeImplementation.keyValueSupplier(name);
             } else {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -97,6 +97,7 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
 
         // TODO: we assume source KTables can only be timestamped-key-value stores for now.
         // should be expanded for other types of stores as well.
+        // Luke
         final StoreBuilder<TimestampedKeyValueStore<K, V>> storeBuilder =
             new TimestampedKeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal).materialize();
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import java.util.Iterator;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
@@ -27,6 +28,7 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.StoreImplementation;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 
 import java.util.Collections;
@@ -97,7 +99,6 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
 
         // TODO: we assume source KTables can only be timestamped-key-value stores for now.
         // should be expanded for other types of stores as well.
-        // Luke
         final StoreBuilder<TimestampedKeyValueStore<K, V>> storeBuilder =
             new TimestampedKeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal).materialize();
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import java.util.Iterator;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
@@ -28,7 +27,6 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
-import org.apache.kafka.streams.state.StoreImplementation;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 
 import java.util.Collections;

--- a/streams/src/main/java/org/apache/kafka/streams/state/InMemoryStoreImplementation.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/InMemoryStoreImplementation.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import java.time.Duration;
+
+/**
+ * A In-memory state store supplier Implementation.
+ *
+ */
+public class InMemoryStoreImplementation implements StoreImplementation {
+    @Override
+    public KeyValueBytesStoreSupplier keyValueSupplier(final String name) {
+        return Stores.inMemoryKeyValueStore(name);
+    }
+
+    @Override
+    public WindowBytesStoreSupplier windowBytesStoreSupplier(final String name,
+                                                             final Duration retentionPeriod,
+                                                             final Duration windowSize,
+                                                             final boolean retainDuplicates) {
+        return Stores.inMemoryWindowStore(name, retentionPeriod, windowSize, retainDuplicates);
+    }
+
+    @Override
+    public SessionBytesStoreSupplier sessionBytesStoreSupplier(final String name, final Duration retentionPeriod) {
+        return Stores.inMemorySessionStore(name, retentionPeriod);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBStoreImplementation.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBStoreImplementation.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.state;
 
-import org.apache.kafka.streams.processor.StateStore;
-
 import java.time.Duration;
 
 /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBStoreImplementation.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBStoreImplementation.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.streams.processor.StateStore;
+
+import java.time.Duration;
+
+/**
+ * A Rocks DB state store supplier Implementation.
+ *
+ */
+public class RocksDBStoreImplementation implements StoreImplementation {
+    @Override
+    public KeyValueBytesStoreSupplier keyValueSupplier(final String name) {
+        return Stores.persistentTimestampedKeyValueStore(name);
+    }
+
+    @Override
+    public WindowBytesStoreSupplier windowBytesStoreSupplier(final String name,
+                                                             final Duration retentionPeriod,
+                                                             final Duration windowSize,
+                                                             final boolean retainDuplicates) {
+        return Stores.persistentTimestampedWindowStore(name, retentionPeriod, windowSize, retainDuplicates);
+    }
+
+    @Override
+    public SessionBytesStoreSupplier sessionBytesStoreSupplier(final String name, final Duration retentionPeriod) {
+        return Stores.persistentSessionStore(name, retentionPeriod);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/StoreImplementation.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StoreImplementation.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import java.time.Duration;
 
 /**
- * A state store supplier Implementation interface which can create one or more {@link StateStore} instances.
+ * A state store supplier Implementation interface which can create one or more 3 types of {@link StateStore} instances.
  *
  */
 public interface StoreImplementation {

--- a/streams/src/main/java/org/apache/kafka/streams/state/StoreImplementation.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StoreImplementation.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.streams.processor.StateStore;
+
+import java.time.Duration;
+
+/**
+ * A state store supplier Implementation interface which can create one or more {@link StateStore} instances.
+ *
+ */
+public interface StoreImplementation {
+    /**
+     * Return the name of this state store supplier.
+     * This must be a valid Kafka topic name; valid characters are ASCII alphanumerics, '.', '_' and '-'.
+     *
+     * @return the name of this state store supplier
+     */
+    KeyValueBytesStoreSupplier keyValueSupplier(String name);
+
+    /**
+     * Return a new {@link StateStore} instance.
+     *
+     * @return a new {@link StateStore} instance of type T
+     */
+    WindowBytesStoreSupplier windowBytesStoreSupplier(String name,
+                                                      Duration retentionPeriod,
+                                                      Duration windowSize,
+                                                      boolean retainDuplicates);
+
+
+    /**
+     * Return a String that is used as the scope for metrics recorded by Metered stores.
+     * @return metricsScope
+     */
+    SessionBytesStoreSupplier sessionBytesStoreSupplier(String name,
+                                                        Duration retentionPeriod);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -382,6 +382,30 @@ public final class Stores {
     }
 
     /**
+     * Creates a {@link StoreBuilder} that can be used to build a {@link KeyValueStore}.
+     * <p>
+     * The provided supplier should <strong>not</strong> be a supplier for
+     * {@link TimestampedKeyValueStore TimestampedKeyValueStores}.
+     *
+     * @param storeImplementation      a {@link StoreImplementation} (cannot be {@code null})
+     * @param storeName     the store name
+     * @param keySerde      the key serde to use
+     * @param valueSerde    the value serde to use; if the serialized bytes is {@code null} for put operations,
+     *                      it is treated as delete
+     * @param <K>           key type
+     * @param <V>           value type
+     * @return an instance of a {@link StoreBuilder} that can build a {@link KeyValueStore}
+     */
+    public static <K, V> StoreBuilder<KeyValueStore<K, V>> keyValueStoreBuilder(final StoreImplementation storeImplementation,
+                                                                                final String storeName,
+                                                                                final Serde<K> keySerde,
+                                                                                final Serde<V> valueSerde) {
+        Objects.requireNonNull(storeImplementation, "storeImplementation cannot be null");
+        Objects.requireNonNull(storeName, "storeName cannot be null");
+        return new KeyValueStoreBuilder<>(storeImplementation, storeName, keySerde, valueSerde, Time.SYSTEM);
+    }
+
+    /**
      * Creates a {@link StoreBuilder} that can be used to build a {@link TimestampedKeyValueStore}.
      * <p>
      * The provided supplier should <strong>not</strong> be a supplier for

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreImplementation;
 
 import java.util.Objects;
 
@@ -36,6 +37,15 @@ public class KeyValueStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, KeyVa
         Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
         Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
+    }
+
+    public KeyValueStoreBuilder(final StoreImplementation storeImplementation,
+                                final String storeName,
+                                final Serde<K> keySerde,
+                                final Serde<V> valueSerde,
+                                final Time time) {
+        super(storeName, keySerde, valueSerde, time);
+        this.storeSupplier = storeImplementation.keyValueSupplier(storeName);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -53,7 +53,9 @@ import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata;
 import org.apache.kafka.streams.processor.internals.ThreadMetadataImpl;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.InMemoryStoreImplementation;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.RocksDBStoreImplementation;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
@@ -1066,12 +1068,22 @@ public class KafkaStreamsTest {
                                          final String storeName,
                                          final String globalStoreName,
                                          final boolean isPersistentStore) {
+//        final StoreBuilder<KeyValueStore<String, Long>> storeBuilder = Stores.keyValueStoreBuilder(
+//            isPersistentStore ?
+//                Stores.persistentKeyValueStore(storeName)
+//                : Stores.inMemoryKeyValueStore(storeName),
+//            Serdes.String(),
+//            Serdes.Long());
+
+        // an example to use store implementation to create the store builder for processor API
         final StoreBuilder<KeyValueStore<String, Long>> storeBuilder = Stores.keyValueStoreBuilder(
             isPersistentStore ?
-                Stores.persistentKeyValueStore(storeName)
-                : Stores.inMemoryKeyValueStore(storeName),
+                new RocksDBStoreImplementation()
+                : new InMemoryStoreImplementation(),
+            storeName,
             Serdes.String(),
             Serdes.Long());
+
         final Topology topology = new Topology();
         topology.addSource("source", Serdes.String().deserializer(), Serdes.String().deserializer(), inputTopic)
             .addProcessor("process", () -> new Processor<String, String, String, String>() {

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -1169,7 +1169,7 @@ public class TopologyTest {
 
     @Test
     public void kGroupedStreamNamedMaterializedCountShouldPreserveTopologyStructure() {
-        Properties streamsProp = new Properties();
+        final Properties streamsProp = new Properties();
         streamsProp.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
         streamsProp.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         final StreamsBuilder builder = new StreamsBuilder(streamsProp);
@@ -1191,7 +1191,7 @@ public class TopologyTest {
 
     @Test
     public void kGroupedStreamNamedMaterializedCountWithDefaultStoreImplementation() {
-        Properties streamsProp = new Properties();
+        final Properties streamsProp = new Properties();
         streamsProp.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
         streamsProp.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         final StreamsBuilder builder = new StreamsBuilder(streamsProp);
@@ -1213,10 +1213,7 @@ public class TopologyTest {
 
     @Test
     public void kGroupedStreamNamedMaterializedCountWithCustomStoreImplementation() {
-        Properties streamsProp = new Properties();
-        streamsProp.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
-        streamsProp.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        final StreamsBuilder builder = new StreamsBuilder(streamsProp);
+        final StreamsBuilder builder = new StreamsBuilder();
         builder.stream("input-topic")
             .groupByKey()
             .count(Materialized.as(new InMemoryStoreImplementation()));
@@ -1255,7 +1252,7 @@ public class TopologyTest {
 
     @Test
     public void timeWindowZeroArgCountShouldPreserveTopologyStructure() {
-        Properties streamsProp = new Properties();
+        final Properties streamsProp = new Properties();
         streamsProp.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
         streamsProp.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         final StreamsBuilder builder = new StreamsBuilder(streamsProp);
@@ -1278,7 +1275,7 @@ public class TopologyTest {
 
     @Test
     public void timeWindowZeroArgCountWithDefaultStoreImplementation() {
-        Properties streamsProp = new Properties();
+        final Properties streamsProp = new Properties();
         streamsProp.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
         streamsProp.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         final StreamsBuilder builder = new StreamsBuilder(streamsProp);
@@ -1361,7 +1358,7 @@ public class TopologyTest {
 
     @Test
     public void sessionWindowZeroArgCountDefaultCustomStoreImplementation() {
-        Properties streamsProp = new Properties();
+        final Properties streamsProp = new Properties();
         streamsProp.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-config-test");
         streamsProp.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         final StreamsBuilder builder = new StreamsBuilder(streamsProp);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
@@ -488,7 +488,7 @@ public class KGroupedStreamImplTest {
     public void shouldNotAcceptNullStateStoreSupplierWhenReducingSessionWindows() {
         assertThrows(NullPointerException.class, () ->  groupedStream
                 .windowedBy(SessionWindows.with(ofMillis(30)))
-                .reduce(null, Materialized.<String, String, SessionStore<Bytes, byte[]>>as("null"))
+                .reduce(null, Materialized.<String, String, SessionStore<Bytes, byte[]>>as((String)null))
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
@@ -488,7 +488,7 @@ public class KGroupedStreamImplTest {
     public void shouldNotAcceptNullStateStoreSupplierWhenReducingSessionWindows() {
         assertThrows(NullPointerException.class, () ->  groupedStream
                 .windowedBy(SessionWindows.with(ofMillis(30)))
-                .reduce(null, Materialized.<String, String, SessionStore<Bytes, byte[]>>as(null))
+                .reduce(null, Materialized.<String, String, SessionStore<Bytes, byte[]>>as("null"))
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
@@ -488,7 +488,7 @@ public class KGroupedStreamImplTest {
     public void shouldNotAcceptNullStateStoreSupplierWhenReducingSessionWindows() {
         assertThrows(NullPointerException.class, () ->  groupedStream
                 .windowedBy(SessionWindows.with(ofMillis(30)))
-                .reduce(null, Materialized.<String, String, SessionStore<Bytes, byte[]>>as((String)null))
+                .reduce(null, Materialized.<String, String, SessionStore<Bytes, byte[]>>as((String) null))
         );
     }
 


### PR DESCRIPTION
original KIP link: https://cwiki.apache.org/confluence/display/KAFKA/KIP-591%3A+Add+Kafka+Streams+config+to+set+default+store+type
KIP discussion link: https://lists.apache.org/list.html?dev@kafka.apache.org:gte=1d:KIP-591
(You might need to read this discussion thread to re-cap, since it's a discussion 1 year ago :) )

Discussed with @mjsax , we think this KIP should be back to live since this is a feature that many users requested for. 

What I've done:
1. create a stream config: `default.store.impl.class` to store the default store implementation class, and default to RocksDB
2. create `StoreImplementation` interface, and 2 default implementation: RocksDB and In-memory
3. add a new method: `Materialized#as(storeImplementation)` to pass custom store implementation
4. **this is the place different from what described in KIP-591**: add a new constructor for `StreamsBuilder`, to accept a `properties` instance. (detailed below)
5. add a new constructor for `MaterializedInternal`, to accept `StreamsConfig`, so that we can store the storeImplementation provided, to create storeBuilder for the graph node
6. When creating store builder for a node, before, we check if the `storeSuppier` in materialized is null or not, if null, we use `RockDB store supplier`. Now, we'll get the default store supplier via store implementation
7. Add a `KeyValueStoreBuilder` constructor to accept a `StoreImplementation`, so that the processor API users can also benefit from it.

For (4), in KIP-591, we wanted to get the `Stream props` during `StreamBuilder.build(props)`, but I found it's too late to get the props. During `StreamBuilder#build`, we already built all the Stream graph nodes, including `StoreBuilder` in each node. So, I think we should get the props when creating `StreamBuilder`, so that when each node creation, we can initialize the store supplier via store implementation via config. This way, we can also adopt more optimization and customization in the future during building the stream graph nodes in `StreamBuilder`.

The problem I can think of, is that if the props passed to `StreamBuilder` constructor is different from the one passed into `build(props)`. We can actually just output a warning message and honor the one passed in that method, and `deprecate` the `build(props)` method in this KIP.

See if you have any thoughts about it. Thanks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
