### PR TITLE
MINOR: Fix minor typo in the Admin API Javadoc example

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -81,7 +81,7 @@ import org.apache.kafka.common.requests.LeaveGroupResponse;
  *   // Create a compacted topic
  *   CreateTopicsResult result = admin.createTopics(Collections.singleton(
  *     new NewTopic(topicName, partitions, replicationFactor)
- *       .configs(Collections.singletonMap(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)));
+ *       .configs(Collections.singletonMap(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT))));
  *
  *   // Call values() to get the result for a specific topic
  *   KafkaFuture<Void> future = result.values().get(topicName);


### PR DESCRIPTION
The Javadoc of the Admin API (`Admin` interface) has an example of how to use the Admin API to create a topic. The example does not work because it is missing one `)`. This small PR fixes it.