### PR TITLE
KAFKA-12933: Flaky test ReassignPartitionsIntegrationTest.testReassignmentWithAlterIsrDisabled

### DIFF
--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -127,7 +127,6 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     )
 
     val verifyAssignmentResult = runVerifyAssignment(cluster.adminClient, assignment, false)
-    assertTrue(verifyAssignmentResult.partsOngoing)
     assertFalse(verifyAssignmentResult.movesOngoing)
 
     // Wait for the assignment to complete


### PR DESCRIPTION
### What
Removes assertion added in #10471 
It's unsafe to assert that there are partition movements ongoing for some of the tests in the suite because partitions in some of the tests have 0 data, which may complete reassignment before `verify` can run.

### Testing
Tests pass locally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
