### PR TITLE
KAFKA-13091; Ensure high watermark incremented after AlterIsr returns

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1130,7 +1130,7 @@ object TestUtils extends Logging {
 
     def completeIsrUpdate(newZkVersion: Int): Unit = {
       if (inFlight.compareAndSet(true, false)) {
-        val item = isrUpdates.head
+        val item = isrUpdates.dequeue()
         item.callback.apply(Right(item.leaderAndIsr.withZkVersion(newZkVersion)))
       } else {
         fail("Expected an in-flight ISR update, but there was none")


### PR DESCRIPTION
After we have shrunk the ISR, we have an opportunity to advance the high watermark. We do this currently in `maybeShrinkIsr` after the synchronous update through ZK. For the `AlterIsr` path, however, we cannot rely on this call since the request is sent asynchronously. Instead we should attempt to advance the high watermark in the callback when the `AlterIsr` response returns successfully.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
