### PR TITLE
Kafka 12766 - Disabling WAL-related Options in RocksDB

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -37,7 +37,6 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.DbPath;
 import org.rocksdb.Env;
 import org.rocksdb.InfoLogLevel;
-
 import org.rocksdb.MemTableConfig;
 import org.rocksdb.MergeOperator;
 import org.rocksdb.Options;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -251,7 +251,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setMaxTotalWalSize(final long maxTotalWalSize) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'maxTotalWalSize' will be ignored");
+        logIgnoreWalOption("maxTotalWalSize");
         return this;
     }
 
@@ -306,7 +306,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalDir(final String walDir) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walDir' will be ignored");
+        logIgnoreWalOption("walDir");
         return this;
     }
 
@@ -475,7 +475,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalTtlSeconds(final long walTtlSeconds) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walTtlSeconds' will be ignored");
+        logIgnoreWalOption("walTtlSeconds");
         return this;
     }
 
@@ -486,7 +486,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalSizeLimitMB(final long sizeLimitMB) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walSizeLimitMB' will be ignored");
+        logIgnoreWalOption("walSizeLimitMB");
         return this;
     }
 
@@ -679,7 +679,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalBytesPerSync(final long walBytesPerSync) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walBytesPerSync' will be ignored");
+        logIgnoreWalOption("walBytesPerSync");
         return this;
     }
 
@@ -767,7 +767,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalRecoveryMode(final WALRecoveryMode walRecoveryMode) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walRecoveryMode' will be ignored");
+        logIgnoreWalOption("walRecoveryMode");
         return this;
     }
 
@@ -1467,7 +1467,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalFilter(final AbstractWalFilter walFilter) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walFilter' will be ignored");
+        logIgnoreWalOption("walFilter");
         return this;
     }
 
@@ -1511,7 +1511,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setManualWalFlush(final boolean manualWalFlush) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'manualWalFlush' will be ignored");
+        logIgnoreWalOption("manualWalFlush");
         return this;
     }
 
@@ -1680,5 +1680,9 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
         columnFamilyOptions.close();
         // close super last since we initialized it first
         super.close();
+    }
+
+    private void logIgnoreWalOption(final String option) {
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option '{}' will be ignored", option);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -37,7 +37,7 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.DbPath;
 import org.rocksdb.Env;
 import org.rocksdb.InfoLogLevel;
-import org.rocksdb.Logger;
+
 import org.rocksdb.MemTableConfig;
 import org.rocksdb.MergeOperator;
 import org.rocksdb.Options;
@@ -49,6 +49,7 @@ import org.rocksdb.TableFormatConfig;
 import org.rocksdb.WALRecoveryMode;
 import org.rocksdb.WalFilter;
 import org.rocksdb.WriteBufferManager;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
@@ -61,11 +62,12 @@ import java.util.List;
  *
  * This class do the translation between generic {@link Options} into {@link DBOptions} and {@link ColumnFamilyOptions}.
  */
-public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options {
+class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class);
+
     private final DBOptions dbOptions;
     private final ColumnFamilyOptions columnFamilyOptions;
-
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class);
 
     RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(final DBOptions dbOptions,
                                                                final ColumnFamilyOptions columnFamilyOptions) {
@@ -249,7 +251,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setMaxTotalWalSize(final long maxTotalWalSize) {
-        dbOptions.setMaxTotalWalSize(maxTotalWalSize);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'maxTotalWalSize' will be ignored");
         return this;
     }
 
@@ -304,7 +306,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setWalDir(final String walDir) {
-        dbOptions.setWalDir(walDir);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalDir' will be ignored");
         return this;
     }
 
@@ -473,7 +475,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setWalTtlSeconds(final long walTtlSeconds) {
-        LOG.warn("option walTtlSeconds will be ignored: Streams does not expose RocksDB ttl functionality");
+        LOGGER.warn("option walTtlSeconds will be ignored: Streams does not expose RocksDB ttl functionality");
         dbOptions.setWalTtlSeconds(walTtlSeconds);
         return this;
     }
@@ -485,7 +487,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setWalSizeLimitMB(final long sizeLimitMB) {
-        dbOptions.setWalSizeLimitMB(sizeLimitMB);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalSizeLimitMB' will be ignored");
         return this;
     }
 
@@ -678,7 +680,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setWalBytesPerSync(final long walBytesPerSync) {
-        dbOptions.setWalBytesPerSync(walBytesPerSync);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalBytesPerSync' will be ignored");
         return this;
     }
 
@@ -766,7 +768,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setWalRecoveryMode(final WALRecoveryMode walRecoveryMode) {
-        dbOptions.setWalRecoveryMode(walRecoveryMode);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalRecoveryMode' will be ignored");
         return this;
     }
 
@@ -865,7 +867,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
     }
 
     @Override
-    public Options setLogger(final Logger logger) {
+    public Options setLogger(final org.rocksdb.Logger logger) {
         dbOptions.setLogger(logger);
         return this;
     }
@@ -1466,7 +1468,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setWalFilter(final AbstractWalFilter walFilter) {
-        dbOptions.setWalFilter(walFilter);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalFilter' will be ignored");
         return this;
     }
 
@@ -1510,7 +1512,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public Options setManualWalFlush(final boolean manualWalFlush) {
-        dbOptions.setManualWalFlush(manualWalFlush);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'ManualWalFlush' will be ignored");
         return this;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -251,7 +251,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setMaxTotalWalSize(final long maxTotalWalSize) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'maxTotalWalSize' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'maxTotalWalSize' will be ignored");
         return this;
     }
 
@@ -306,7 +306,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalDir(final String walDir) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalDir' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walDir' will be ignored");
         return this;
     }
 
@@ -475,8 +475,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalTtlSeconds(final long walTtlSeconds) {
-        LOGGER.warn("option walTtlSeconds will be ignored: Streams does not expose RocksDB ttl functionality");
-        dbOptions.setWalTtlSeconds(walTtlSeconds);
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walTtlSeconds' will be ignored");
         return this;
     }
 
@@ -487,7 +486,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalSizeLimitMB(final long sizeLimitMB) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalSizeLimitMB' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walSizeLimitMB' will be ignored");
         return this;
     }
 
@@ -680,7 +679,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalBytesPerSync(final long walBytesPerSync) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalBytesPerSync' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walBytesPerSync' will be ignored");
         return this;
     }
 
@@ -768,7 +767,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalRecoveryMode(final WALRecoveryMode walRecoveryMode) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalRecoveryMode' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walRecoveryMode' will be ignored");
         return this;
     }
 
@@ -1468,7 +1467,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setWalFilter(final AbstractWalFilter walFilter) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'WalFilter' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'walFilter' will be ignored");
         return this;
     }
 
@@ -1512,7 +1511,7 @@ class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options
 
     @Override
     public Options setManualWalFlush(final boolean manualWalFlush) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. 'ManualWalFlush' will be ignored");
+        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option 'manualWalFlush' will be ignored");
         return this;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -64,7 +64,7 @@ import java.util.List;
  */
 public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class);
+    private static final Logger log = LoggerFactory.getLogger(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class);
 
     private final DBOptions dbOptions;
     private final ColumnFamilyOptions columnFamilyOptions;
@@ -1683,6 +1683,6 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
     }
 
     private void logIgnoreWalOption(final String option) {
-        LOGGER.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option '{}' will be ignored", option);
+        log.warn("WAL is explicitly disabled by Streams in RocksDB. Setting option '{}' will be ignored", option);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -62,7 +62,7 @@ import java.util.List;
  *
  * This class do the translation between generic {@link Options} into {@link DBOptions} and {@link ColumnFamilyOptions}.
  */
-class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options {
+public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends Options {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -178,7 +178,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         // Setup statistics before the database is opened, otherwise the statistics are not updated
         // with the measurements from Rocks DB
-        setStatisticsIfNeeded(configs);
+        maybeSetUpStatistics(configs);
 
         openRocksDB(dbOptions, columnFamilyOptions);
         open = true;
@@ -186,7 +186,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         addValueProvidersToMetricsRecorder();
     }
 
-    private void setStatisticsIfNeeded(final Map<String, Object> configs) {
+    private void maybeSetUpStatistics(final Map<String, Object> configs) {
         if (userSpecifiedOptions.statistics() != null) {
             userSpecifiedStatistics = true;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -178,7 +178,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         // Setup statistics before the database is opened, otherwise the statistics are not updated
         // with the measurements from Rocks DB
-        maybeSetUpStatistics(configs);
+        setStatisticsIfNeeded(configs);
 
         openRocksDB(dbOptions, columnFamilyOptions);
         open = true;
@@ -186,7 +186,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         addValueProvidersToMetricsRecorder();
     }
 
-    private void maybeSetUpStatistics(final Map<String, Object> configs) {
+    private void setStatisticsIfNeeded(final Map<String, Object> configs) {
         if (userSpecifiedOptions.statistics() != null) {
             userSpecifiedStatistics = true;
         }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -334,7 +334,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class)) {
 
             final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter adapter
-                    = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), new ColumnFamilyOptions());
+                = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), new ColumnFamilyOptions());
 
             for (final Method method : RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class.getDeclaredMethods()) {
                 if (walRelatedMethods.contains(method.getName())) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -349,11 +349,8 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
                 .map(LogCaptureAppender.Event::getMessage)
                 .collect(Collectors.toSet());
 
-            walOptions.forEach(option -> {
-                assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option)));
-            });
+            walOptions.forEach(option -> assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option))));
 
         }
     }
 }
-

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -114,7 +114,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         for (final Method method : Options.class.getMethods()) {
             if (!ignoreMethods.contains(method.getName())) {
                 RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class
-                        .getDeclaredMethod(method.getName(), method.getParameterTypes());
+                    .getDeclaredMethod(method.getName(), method.getParameterTypes());
             }
         }
     }
@@ -134,7 +134,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
     private void verifyDBOptionsMethodCall(final Method method) throws Exception {
         final DBOptions mockedDbOptions = mock(DBOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
-                = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
 
         final Object[] parameters = getDBOptionsParameters(method.getParameterTypes());
 
@@ -147,7 +147,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         } catch (final InvocationTargetException undeclaredMockMethodCall) {
             assertThat(undeclaredMockMethodCall.getCause(), instanceOf(AssertionError.class));
             assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
-                    matchesPattern("Unexpected method call DBOptions\\." + method.getName() + "((.*\n*)*):"));
+                matchesPattern("Unexpected method call DBOptions\\." + method.getName() + "((.*\n*)*):"));
         }
     }
 
@@ -239,7 +239,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
     private void verifyColumnFamilyOptionsMethodCall(final Method method) throws Exception {
         final ColumnFamilyOptions mockedColumnFamilyOptions = mock(ColumnFamilyOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeColumnFamilyOptions
-                = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), mockedColumnFamilyOptions);
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), mockedColumnFamilyOptions);
 
         final Object[] parameters = getColumnFamilyOptionsParameters(method.getParameterTypes());
 
@@ -252,7 +252,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         } catch (final InvocationTargetException undeclaredMockMethodCall) {
             assertThat(undeclaredMockMethodCall.getCause(), instanceOf(AssertionError.class));
             assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
-                    matchesPattern("Unexpected method call ColumnFamilyOptions\\." + method.getName() +  "(.*)"));
+                matchesPattern("Unexpected method call ColumnFamilyOptions\\." + method.getName() +  "(.*)"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -345,9 +345,9 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             final List<String> walOptions = Arrays.asList("walDir", "walFilter", "walRecoveryMode", "walBytesPerSync", "walSizeLimitMB", "manualWalFlush", "maxTotalWalSize", "walTtlSeconds");
 
             final Set<String> logMessages = appender.getEvents().stream()
-                    .filter(e -> e.getLevel().equals("WARN"))
-                    .map(LogCaptureAppender.Event::getMessage)
-                    .collect(Collectors.toSet());
+                .filter(e -> e.getLevel().equals("WARN"))
+                .map(LogCaptureAppender.Event::getMessage)
+                .collect(Collectors.toSet());
 
             walOptions.forEach(option -> {
                 assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option)));


### PR DESCRIPTION
**description**
Streams disables the write-ahead log (WAL) provided by RocksDB since it replicates the data in changelog topics. Hence, it does not make much sense to set WAL-related configs for RocksDB.
 
**Proposed solution**
Ignore any WAL-related configuration and state in the log that we are ignoring them.  

**Implementation details**
See below
In addition - I made very small refactoring - class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter is now package private, as this class is internal to Streams



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
