### PR TITLE
KAFKA-2424: Introduce Scalafix linter

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rules = [
+  DisableSyntax, # Disables some constructs that make no semantic sense like `final val`
+  ProcedureSyntax, # Procedure syntax in Scala is always discouraged
+  ExplicitResultTypes, # To avoid public API breakages by mistake is good to always annotate the return types of public methods
+  NoValInForComprehension # `val` in for comprehensions are deprecated and shouldn't be used
+]
+
+ExplicitResultTypes.memberKind = [Def] # For now only enforced in methods
+ExplicitResultTypes.memberVisibility = [Public, Protected]
+ExplicitResultTypes.skipSimpleDefinitions = ['Lit', 'Term.New', 'Term.Ref']
+ExplicitResultTypes.fatalWarnings = true
+DisableSyntax.noFinalVal = true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@
 def doValidation() {
   sh """
     ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain checkScalafix rat \
         --profile --no-daemon --continue -PxmlSpotBugsReport=true
   """
 }

--- a/README.md
+++ b/README.md
@@ -217,7 +217,19 @@ You can run spotbugs using:
     ./gradlew spotbugsMain spotbugsTest -x test
 
 The spotbugs warnings will be found in `reports/spotbugs/main.html` and `reports/spotbugs/test.html` files in the subproject build
-directories.  Use -PxmlSpotBugsReport=true to generate an XML report instead of an HTML one.
+directories. Use `-PxmlSpotBugsReport=true` to generate an XML report instead of an HTML one.
+
+#### Scalafix ####
+Scalafix is a refactoring and linting tool for Scala.
+By running the following command, you will get a report of files that broke the predefined rules:
+
+    ./gradlew checkScalafix
+
+Scalafix can fix some those problems, to do so, you can run:
+
+    ./gradlew scalafix
+
+Make sure to check and supervise the changes Scalafix is doing. It's an automatic tool and sometimes might not infer the right return types for example.
 
 ### JMH microbenchmarks ###
 We use [JMH](https://openjdk.java.net/projects/code-tools/jmh/) to write microbenchmarks that produce reliable results in the JVM.

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '6.1.6'
   id 'org.nosphere.apache.rat' version "0.7.0"
 
+  id 'io.github.cosmicsilence.scalafix' version '0.1.11' apply false
   id "com.github.spotbugs" version '4.7.1' apply false
   id 'org.gradle.test-retry' version '1.3.1' apply false
   id 'org.scoverage' version '5.0.0' apply false
@@ -800,6 +801,7 @@ tasks.create(name: "testConnect", dependsOn: connectPkgs.collect { it + ":test" 
 
 project(':core') {
   apply plugin: 'scala'
+  apply plugin: 'io.github.cosmicsilence.scalafix'
 
   // scaladoc generation is configured at the sub-module level with an artifacts
   // block (cf. see streams-scala). If scaladoc generation is invoked explicitly
@@ -1863,6 +1865,8 @@ project(':streams') {
 
 project(':streams:streams-scala') {
   apply plugin: 'scala'
+  apply plugin: 'io.github.cosmicsilence.scalafix'
+
   archivesBaseName = "kafka-streams-scala_${versions.baseScala}"
   dependencies {
     api project(':streams')

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -41,6 +41,7 @@ import scala.reflect.ClassTag
 import org.apache.kafka.common.ConsumerGroupState
 import joptsimple.OptionException
 import org.apache.kafka.common.requests.ListOffsetsResponse
+import com.fasterxml.jackson.databind.{ ObjectReader, ObjectWriter }
 
 object ConsumerGroupCommand extends Logging {
 
@@ -147,12 +148,12 @@ object ConsumerGroupCommand extends Logging {
   private[admin] case class CsvUtils() {
     val mapper = new CsvMapper
     mapper.registerModule(DefaultScalaModule)
-    def readerFor[T <: CsvRecord : ClassTag] = {
+    def readerFor[T <: CsvRecord : ClassTag]: ObjectReader = {
       val schema = getSchema[T]
       val clazz = implicitly[ClassTag[T]].runtimeClass
       mapper.readerFor(clazz).`with`(schema)
     }
-    def writerFor[T <: CsvRecord : ClassTag] = {
+    def writerFor[T <: CsvRecord : ClassTag]: ObjectWriter = {
       val schema = getSchema[T]
       val clazz = implicitly[ClassTag[T]].runtimeClass
       mapper.writerFor(clazz).`with`(schema)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -130,7 +130,7 @@ object ReassignPartitionsCommand extends Logging {
    */
   sealed case class MissingReplicaMoveState(targetLogDir: String)
       extends LogDirMoveState {
-    override def done = false
+    override def done: Boolean = false
   }
 
   /**
@@ -140,7 +140,7 @@ object ReassignPartitionsCommand extends Logging {
    */
   sealed case class MissingLogDirMoveState(targetLogDir: String)
       extends LogDirMoveState {
-    override def done = false
+    override def done: Boolean = false
   }
 
   /**
@@ -154,7 +154,7 @@ object ReassignPartitionsCommand extends Logging {
                                     targetLogDir: String,
                                     futureLogDir: String)
       extends LogDirMoveState {
-    override def done = false
+    override def done: Boolean = false
   }
 
   /**
@@ -167,7 +167,7 @@ object ReassignPartitionsCommand extends Logging {
   sealed case class CancelledMoveState(currentLogDir: String,
                                        targetLogDir: String)
       extends LogDirMoveState {
-    override def done = true
+    override def done: Boolean = true
   }
 
   /**
@@ -177,7 +177,7 @@ object ReassignPartitionsCommand extends Logging {
    */
   sealed case class CompletedMoveState(targetLogDir: String)
       extends LogDirMoveState {
-    override def done = true
+    override def done: Boolean = true
   }
 
   /**

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -216,7 +216,7 @@ sealed trait ApiVersion extends Ordered[ApiVersion] {
  * For versions before 0.10.0, `version` and `shortVersion` were the same.
  */
 sealed trait LegacyApiVersion extends ApiVersion {
-  def version = shortVersion
+  def version: String = shortVersion
 }
 
 /**

--- a/core/src/main/scala/kafka/api/LeaderAndIsr.scala
+++ b/core/src/main/scala/kafka/api/LeaderAndIsr.scala
@@ -34,13 +34,13 @@ case class LeaderAndIsr(leader: Int,
                         leaderEpoch: Int,
                         isr: List[Int],
                         zkVersion: Int) {
-  def withZkVersion(zkVersion: Int) = copy(zkVersion = zkVersion)
+  def withZkVersion(zkVersion: Int): LeaderAndIsr = copy(zkVersion = zkVersion)
 
-  def newLeader(leader: Int) = newLeaderAndIsr(leader, isr)
+  def newLeader(leader: Int): LeaderAndIsr = newLeaderAndIsr(leader, isr)
 
-  def newLeaderAndIsr(leader: Int, isr: List[Int]) = LeaderAndIsr(leader, leaderEpoch + 1, isr, zkVersion)
+  def newLeaderAndIsr(leader: Int, isr: List[Int]): LeaderAndIsr = LeaderAndIsr(leader, leaderEpoch + 1, isr, zkVersion)
 
-  def newEpochAndZkVersion = newLeaderAndIsr(leader, isr)
+  def newEpochAndZkVersion: LeaderAndIsr = newLeaderAndIsr(leader, isr)
 
   def leaderOpt: Option[Int] = {
     if (leader == LeaderAndIsr.NoLeader) None else Some(leader)

--- a/core/src/main/scala/kafka/common/ClientIdAndBroker.scala
+++ b/core/src/main/scala/kafka/common/ClientIdAndBroker.scala
@@ -26,9 +26,9 @@ trait ClientIdBroker {
 }
 
 case class ClientIdAndBroker(clientId: String, brokerHost: String, brokerPort: Int) extends ClientIdBroker {
-  override def toString = "%s-%s-%d".format(clientId, brokerHost, brokerPort)
+  override def toString: String = "%s-%s-%d".format(clientId, brokerHost, brokerPort)
 }
 
 case class ClientIdAllBrokers(clientId: String) extends ClientIdBroker {
-  override def toString = "%s-%s".format(clientId, "AllBrokers")
+  override def toString: String = "%s-%s".format(clientId, "AllBrokers")
 }

--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -67,7 +67,7 @@ class ZkNodeChangeNotificationListener(private val zkClient: KafkaZkClient,
     thread.start()
   }
 
-  def close() = {
+  def close(): Unit = {
     isClosed.set(true)
     zkClient.unregisterStateChangeHandler(ZkStateChangeHandler.name)
     zkClient.unregisterZNodeChildChangeHandler(ChangeNotificationHandler.path)

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -66,7 +66,7 @@ class ControllerChannelManager(controllerContext: ControllerContext,
     }
   )
 
-  def startup() = {
+  def startup(): Unit = {
     controllerContext.liveOrShuttingDownBrokers.foreach(addNewBroker)
 
     brokerLock synchronized {
@@ -74,7 +74,7 @@ class ControllerChannelManager(controllerContext: ControllerContext,
     }
   }
 
-  def shutdown() = {
+  def shutdown(): Unit = {
     brokerLock synchronized {
       brokerStateInfo.values.toList.foreach(removeExistingBroker)
     }

--- a/core/src/main/scala/kafka/controller/ControllerState.scala
+++ b/core/src/main/scala/kafka/controller/ControllerState.scala
@@ -35,83 +35,83 @@ object ControllerState {
   // unless `rateAndTimeMetricName` is overridden.
 
   case object Idle extends ControllerState {
-    def value = 0
+    def value: Byte = 0
     override protected def hasRateAndTimeMetric: Boolean = false
   }
 
   case object ControllerChange extends ControllerState {
-    def value = 1
+    def value: Byte = 1
   }
 
   case object BrokerChange extends ControllerState {
-    def value = 2
+    def value: Byte = 2
     // The LeaderElectionRateAndTimeMs metric existed before `ControllerState` was introduced and we keep the name
     // for backwards compatibility. The alternative would be to have the same metric under two different names.
-    override def rateAndTimeMetricName = Some("LeaderElectionRateAndTimeMs")
+    override def rateAndTimeMetricName: Some[String] = Some("LeaderElectionRateAndTimeMs")
   }
 
   case object TopicChange extends ControllerState {
-    def value = 3
+    def value: Byte = 3
   }
 
   case object TopicDeletion extends ControllerState {
-    def value = 4
+    def value: Byte = 4
   }
 
   case object AlterPartitionReassignment extends ControllerState {
-    def value = 5
+    def value: Byte = 5
 
     override def rateAndTimeMetricName: Option[String] = Some("PartitionReassignmentRateAndTimeMs")
   }
 
   case object AutoLeaderBalance extends ControllerState {
-    def value = 6
+    def value: Byte = 6
   }
 
   case object ManualLeaderBalance extends ControllerState {
-    def value = 7
+    def value: Byte = 7
   }
 
   case object ControlledShutdown extends ControllerState {
-    def value = 8
+    def value: Byte = 8
   }
 
   case object IsrChange extends ControllerState {
-    def value = 9
+    def value: Byte = 9
   }
 
   case object LeaderAndIsrResponseReceived extends ControllerState {
-    def value = 10
+    def value: Byte = 10
   }
 
   case object LogDirChange extends ControllerState {
-    def value = 11
+    def value: Byte = 11
   }
 
   case object ControllerShutdown extends ControllerState {
-    def value = 12
+    def value: Byte = 12
   }
 
   case object UncleanLeaderElectionEnable extends ControllerState {
-    def value = 13
+    def value: Byte = 13
   }
 
   case object TopicUncleanLeaderElectionEnable extends ControllerState {
-    def value = 14
+    def value: Byte = 14
   }
 
   case object ListPartitionReassignment extends ControllerState {
-    def value = 15
+    def value: Byte = 15
   }
 
   case object UpdateMetadataResponseReceived extends ControllerState {
-    def value = 16
+    def value: Byte = 16
 
     override protected def hasRateAndTimeMetric: Boolean = false
   }
 
   case object UpdateFeatures extends ControllerState {
-    def value = 17
+    def value: Byte = 17
   }
 
   val values: Seq[ControllerState] = Seq(Idle, ControllerChange, BrokerChange, TopicChange, TopicDeletion,

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -29,7 +29,7 @@ case class MemberSummary(memberId: String,
                          assignment: Array[Byte])
 
 private object MemberMetadata {
-  def plainProtocolSet(supportedProtocols: List[(String, Array[Byte])]) = supportedProtocols.map(_._1).toSet
+  def plainProtocolSet(supportedProtocols: List[(String, Array[Byte])]): Set[String] = supportedProtocols.map(_._1).toSet
 }
 
 /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -163,17 +163,17 @@ private[transaction] case object PrepareEpochFence extends TransactionState {
 }
 
 private[transaction] object TransactionMetadata {
-  def apply(transactionalId: String, producerId: Long, producerEpoch: Short, txnTimeoutMs: Int, timestamp: Long) =
+  def apply(transactionalId: String, producerId: Long, producerEpoch: Short, txnTimeoutMs: Int, timestamp: Long): TransactionMetadata =
     new TransactionMetadata(transactionalId, producerId, RecordBatch.NO_PRODUCER_ID, producerEpoch,
       RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, Empty, collection.mutable.Set.empty[TopicPartition], timestamp, timestamp)
 
   def apply(transactionalId: String, producerId: Long, producerEpoch: Short, txnTimeoutMs: Int,
-            state: TransactionState, timestamp: Long) =
+            state: TransactionState, timestamp: Long): TransactionMetadata =
     new TransactionMetadata(transactionalId, producerId, RecordBatch.NO_PRODUCER_ID, producerEpoch,
       RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, state, collection.mutable.Set.empty[TopicPartition], timestamp, timestamp)
 
   def apply(transactionalId: String, producerId: Long, lastProducerId: Long, producerEpoch: Short,
-            lastProducerEpoch: Short, txnTimeoutMs: Int, state: TransactionState, timestamp: Long) =
+            lastProducerEpoch: Short, txnTimeoutMs: Int, state: TransactionState, timestamp: Long): TransactionMetadata =
     new TransactionMetadata(transactionalId, producerId, lastProducerId, producerEpoch, lastProducerEpoch,
       txnTimeoutMs, state, collection.mutable.Set.empty[TopicPartition], timestamp, timestamp)
 

--- a/core/src/main/scala/kafka/log/IndexEntry.scala
+++ b/core/src/main/scala/kafka/log/IndexEntry.scala
@@ -31,8 +31,8 @@ sealed trait IndexEntry {
  * given offset.
  */
 case class OffsetPosition(offset: Long, position: Int) extends IndexEntry {
-  override def indexKey = offset
-  override def indexValue = position.toLong
+  override def indexKey: Long = offset
+  override def indexValue: Long = position.toLong
 }
 
 
@@ -43,8 +43,8 @@ case class OffsetPosition(offset: Long, position: Int) extends IndexEntry {
  * @param offset The message offset.
  */
 case class TimestampOffset(timestamp: Long, offset: Long) extends IndexEntry {
-  override def indexKey = timestamp
-  override def indexValue = offset
+  override def indexKey: Long = timestamp
+  override def indexValue: Long = offset
 }
 
 object TimestampOffset {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -289,7 +289,7 @@ class LogCleaner(initialConfig: CleanerConfig,
   private[log] class CleanerThread(threadId: Int)
     extends ShutdownableThread(name = s"kafka-log-cleaner-thread-$threadId", isInterruptible = false) {
 
-    protected override def loggerName = classOf[LogCleaner].getName
+    protected override def loggerName: String = classOf[LogCleaner].getName
 
     if (config.dedupeBufferSize / config.numThreads > Int.MaxValue)
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
@@ -471,7 +471,7 @@ private[log] class Cleaner(val id: Int,
                            time: Time,
                            checkDone: TopicPartition => Unit) extends Logging {
 
-  protected override def loggerName = classOf[LogCleaner].getName
+  protected override def loggerName: String = classOf[LogCleaner].getName
 
   this.logIdent = s"Cleaner $id: "
 

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -64,7 +64,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   import LogCleanerManager._
 
 
-  protected override def loggerName = classOf[LogCleaner].getName
+  protected override def loggerName: String = classOf[LogCleaner].getName
 
   // package-private for testing
   private[log] val offsetCheckpointFile = "cleaner-offset-checkpoint"

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -32,6 +32,7 @@ import java.util.{Collections, Locale, Properties}
 import scala.annotation.nowarn
 import scala.collection.{Map, mutable}
 import scala.jdk.CollectionConverters._
+import java.{util => ju}
 
 object Defaults {
   val SegmentSize = kafka.server.Defaults.LogSegmentBytes
@@ -151,7 +152,7 @@ case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] 
   }
 
   private val _remoteLogConfig = new RemoteLogConfig()
-  def remoteLogConfig = _remoteLogConfig
+  def remoteLogConfig: RemoteLogConfig = _remoteLogConfig
 
   @nowarn("cat=deprecation")
   def recordVersion = messageFormatVersion.recordVersion
@@ -271,7 +272,7 @@ object LogConfig {
   private[log] class LogConfigDef(base: ConfigDef) extends ConfigDef(base) {
     def this() = this(new ConfigDef)
 
-    private final val serverDefaultConfigNames = mutable.Map[String, String]()
+    private val serverDefaultConfigNames = mutable.Map[String, String]()
     base match {
       case b: LogConfigDef => serverDefaultConfigNames ++= b.serverDefaultConfigNames
       case _ =>
@@ -298,7 +299,7 @@ object LogConfig {
       this
     }
 
-    override def headers = List("Name", "Description", "Type", "Default", "Valid Values", ServerDefaultHeaderName,
+    override def headers: ju.List[String] = List("Name", "Description", "Type", "Default", "Valid Values", ServerDefaultHeaderName,
       "Importance").asJava
 
     override def getConfigValue(key: ConfigKey, headerName: String): String = {

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -648,7 +648,7 @@ class LogSegment private[log] (val log: FileRecords,
   /**
    * The largest timestamp this segment contains.
    */
-  def largestTimestamp = if (maxTimestampSoFar >= 0) maxTimestampSoFar else lastModified
+  def largestTimestamp: Long = if (maxTimestampSoFar >= 0) maxTimestampSoFar else lastModified
 
   /**
    * Change the last modified time for this log segment

--- a/core/src/main/scala/kafka/log/LogSegments.scala
+++ b/core/src/main/scala/kafka/log/LogSegments.scala
@@ -237,7 +237,7 @@ class LogSegments(topicPartition: TopicPartition) {
   /**
    * The active segment that is currently taking appends
    */
-  def activeSegment = lastSegment.get
+  def activeSegment: LogSegment = lastSegment.get
 
   def sizeInBytes: Long = LogSegments.sizeInBytes(values)
 

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -54,7 +54,7 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
     extends AbstractIndex(_file, baseOffset, maxIndexSize, writable) {
   import OffsetIndex._
 
-  override def entrySize = 8
+  override def entrySize: Int = 8
 
   /* the last offset in the index */
   private[this] var _lastOffset = lastEntry.offset
@@ -155,7 +155,7 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
     }
   }
 
-  override def truncate() = truncateToEntries(0)
+  override def truncate(): Unit = truncateToEntries(0)
 
   override def truncateTo(offset: Long): Unit = {
     inLock(lock) {

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -61,7 +61,7 @@ private[log] case class TxnMetadata(
 private[log] object ProducerStateEntry {
   private[log] val NumBatchesToRetain = 5
 
-  def empty(producerId: Long) = new ProducerStateEntry(producerId,
+  def empty(producerId: Long): ProducerStateEntry = new ProducerStateEntry(producerId,
     batchMetadata = mutable.Queue[BatchMetadata](),
     producerEpoch = RecordBatch.NO_PRODUCER_EPOCH,
     coordinatorEpoch = -1,

--- a/core/src/main/scala/kafka/log/TimeIndex.scala
+++ b/core/src/main/scala/kafka/log/TimeIndex.scala
@@ -56,7 +56,7 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
 
   @volatile private var _lastEntry = lastEntryFromIndexFile
 
-  override def entrySize = 12
+  override def entrySize: Int = 12
 
   debug(s"Loaded index file ${file.getAbsolutePath} with maxEntries = $maxEntries, maxIndexSize = $maxIndexSize," +
     s" entries = ${_entries}, lastOffset = ${_lastEntry}, file position = ${mmap.position()}")
@@ -159,7 +159,7 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
     }
   }
 
-  override def truncate() = truncateToEntries(0)
+  override def truncate(): Unit = truncateToEntries(0)
 
   /**
    * Remove all entries from the index which have an offset greater than or equal to the given offset.

--- a/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
@@ -41,7 +41,7 @@ private class KafkaCSVMetricsReporter extends KafkaMetricsReporter
   private var initialized = false
 
 
-  override def getMBeanName = "kafka:type=kafka.metrics.KafkaCSVMetricsReporter"
+  override def getMBeanName: String = "kafka:type=kafka.metrics.KafkaCSVMetricsReporter"
 
 
   override def init(props: VerifiableProperties): Unit = {

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -281,7 +281,7 @@ object RequestChannel extends Logging {
       }
     }
 
-    override def toString = s"Request(processor=$processor, " +
+    override def toString: String = s"Request(processor=$processor, " +
       s"connectionId=${context.connectionId}, " +
       s"session=$session, " +
       s"listenerName=${context.listenerName}, " +

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -772,7 +772,7 @@ class FetcherLagMetrics(metricId: ClientIdTopicPartition) extends KafkaMetricsGr
     lagVal.set(newLag)
   }
 
-  def lag = lagVal.get
+  def lag: Long = lagVal.get
 
   def unregister(): Unit = {
     removeMetric(FetcherMetrics.ConsumerLag, tags)

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -52,7 +52,7 @@ case class FetchMetadata(fetchMinBytes: Int,
                          topicIds: util.Map[String, Uuid],
                          fetchPartitionStatus: Seq[(TopicPartition, FetchPartitionStatus)]) {
 
-  override def toString = "FetchMetadata(minBytes=" + fetchMinBytes + ", " +
+  override def toString: String = "FetchMetadata(minBytes=" + fetchMinBytes + ", " +
     "maxBytes=" + fetchMaxBytes + ", " +
     "onlyLeader=" + fetchOnlyLeader + ", " +
     "fetchIsolation=" + fetchIsolation + ", " +

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -164,7 +164,7 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
      * Return all the current watcher lists,
      * note that the returned watchers may be removed from the list by other threads
      */
-    def allWatchers = {
+    def allWatchers: Iterable[Watchers] = {
       watchersByKey.values
     }
   }

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -183,7 +183,7 @@ class DelegationTokenManager(val config: KafkaConfig,
   private val lock = new Object()
   private var tokenChangeListener: ZkNodeChangeNotificationListener = null
 
-  def startup() = {
+  def startup(): Unit = {
     if (config.tokenAuthEnabled) {
       zkClient.createDelegationTokenPaths()
       loadCache()
@@ -192,7 +192,7 @@ class DelegationTokenManager(val config: KafkaConfig,
     }
   }
 
-  def shutdown() = {
+  def shutdown(): Unit = {
     if (config.tokenAuthEnabled) {
       if (tokenChangeListener != null) tokenChangeListener.close()
     }

--- a/core/src/main/scala/kafka/server/DynamicConfigManager.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfigManager.scala
@@ -91,7 +91,7 @@ class DynamicConfigManager(private val zkClient: KafkaZkClient,
   val adminZkClient = new AdminZkClient(zkClient)
 
   object ConfigChangedNotificationHandler extends NotificationHandler {
-    override def processNotification(jsonBytes: Array[Byte]) = {
+    override def processNotification(jsonBytes: Array[Byte]): Unit = {
       // Ignore non-json notifications because they can be from the deprecated TopicConfigManager
       Json.parseBytes(jsonBytes).foreach { js =>
         val jsObject = js.asJsonObjectOption.getOrElse {

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -489,7 +489,7 @@ class IncrementalFetchContext(private val time: Time,
       element
     }
 
-    override def remove() = throw new UnsupportedOperationException
+    override def remove(): Unit = throw new UnsupportedOperationException
   }
 
   override def getResponseSize(updates: FetchSession.RESP_MAP, versionId: Short): Int = {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1686,7 +1686,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val controlledShutdownEnable = getBoolean(KafkaConfig.ControlledShutdownEnableProp)
 
   /** ********* Feature configuration ***********/
-  def isFeatureVersioningSupported = interBrokerProtocolVersion >= KAFKA_2_7_IV0
+  def isFeatureVersioningSupported: Boolean = interBrokerProtocolVersion >= KAFKA_2_7_IV0
 
   /** ********* Group coordinator configuration ***********/
   val groupMinSessionTimeoutMs = getInt(KafkaConfig.GroupMinSessionTimeoutMsProp)
@@ -1733,11 +1733,11 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
       Set.empty[String]
   }
 
-  def interBrokerListenerName = getInterBrokerListenerNameAndSecurityProtocol._1
-  def interBrokerSecurityProtocol = getInterBrokerListenerNameAndSecurityProtocol._2
-  def controlPlaneListenerName = getControlPlaneListenerNameAndSecurityProtocol.map { case (listenerName, _) => listenerName }
-  def controlPlaneSecurityProtocol = getControlPlaneListenerNameAndSecurityProtocol.map { case (_, securityProtocol) => securityProtocol }
-  def saslMechanismInterBrokerProtocol = getString(KafkaConfig.SaslMechanismInterBrokerProtocolProp)
+  def interBrokerListenerName: ListenerName = getInterBrokerListenerNameAndSecurityProtocol._1
+  def interBrokerSecurityProtocol: SecurityProtocol = getInterBrokerListenerNameAndSecurityProtocol._2
+  def controlPlaneListenerName: Option[ListenerName] = getControlPlaneListenerNameAndSecurityProtocol.map { case (listenerName, _) => listenerName }
+  def controlPlaneSecurityProtocol: Option[SecurityProtocol] = getControlPlaneListenerNameAndSecurityProtocol.map { case (_, securityProtocol) => securityProtocol }
+  def saslMechanismInterBrokerProtocol: String = getString(KafkaConfig.SaslMechanismInterBrokerProtocolProp)
   val saslInterBrokerHandshakeRequestEnable = interBrokerProtocolVersion >= KAFKA_0_10_0_IV1
 
   /** ********* DelegationToken Configuration **************/

--- a/core/src/main/scala/kafka/server/LogOffsetMetadata.scala
+++ b/core/src/main/scala/kafka/server/LogOffsetMetadata.scala
@@ -79,6 +79,6 @@ case class LogOffsetMetadata(messageOffset: Long,
     segmentBaseOffset == UnifiedLog.UnknownOffset && relativePositionInSegment == LogOffsetMetadata.UnknownFilePosition
   }
 
-  override def toString = s"(offset=$messageOffset segment=[$segmentBaseOffset:$relativePositionInSegment])"
+  override def toString: String = s"(offset=$messageOffset segment=[$segmentBaseOffset:$relativePositionInSegment])"
 
 }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -127,7 +127,7 @@ case class LogReadResult(info: FetchDataInfo,
   def withEmptyFetchInfo: LogReadResult =
     copy(info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY))
 
-  override def toString = {
+  override def toString: String = {
     "LogReadResult(" +
       s"info=$info, " +
       s"divergingEpoch=$divergingEpoch, " +
@@ -1929,7 +1929,7 @@ class ReplicaManager(val config: KafkaConfig,
     new ReplicaFetcherManager(config, this, metrics, time, threadNamePrefix, quotaManager)
   }
 
-  protected def createReplicaAlterLogDirsManager(quotaManager: ReplicationQuotaManager, brokerTopicStats: BrokerTopicStats) = {
+  protected def createReplicaAlterLogDirsManager(quotaManager: ReplicationQuotaManager, brokerTopicStats: BrokerTopicStats): ReplicaAlterLogDirsManager = {
     new ReplicaAlterLogDirsManager(config, this, quotaManager, brokerTopicStats)
   }
 

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -73,7 +73,7 @@ class ZkAdminManager(val config: KafkaConfig,
   private val alterConfigPolicy =
     Option(config.getConfiguredInstance(KafkaConfig.AlterConfigPolicyClassNameProp, classOf[AlterConfigPolicy]))
 
-  def hasDelayedTopicOperations = topicPurgatory.numDelayed != 0
+  def hasDelayedTopicOperations: Boolean = topicPurgatory.numDelayed != 0
 
   private val defaultNumPartitions = config.numPartitions.intValue()
   private val defaultReplicationFactor = config.defaultReplicationFactor.shortValue()

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -506,7 +506,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
 
     options = parser.parse(args: _*)
 
-    def checkArgs() = {
+    def checkArgs(): Unit = {
       CommandLineUtils.checkRequiredArgs(parser, options, consumerConfigOpt, producerConfigOpt)
       val consumerProps = Utils.loadProps(options.valueOf(consumerConfigOpt))
 

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -284,13 +284,13 @@ private class ReplicaBuffer(expectedReplicasPerTopicPartition: collection.Map[To
     fetcherBarrier.set(new CountDownLatch(expectedNumFetchers))
   }
 
-  def getFetcherBarrier() = fetcherBarrier.get
+  def getFetcherBarrier(): CountDownLatch = fetcherBarrier.get
 
   def createNewVerificationBarrier(): Unit = {
     verificationBarrier.set(new CountDownLatch(1))
   }
 
-  def getVerificationBarrier() = verificationBarrier.get
+  def getVerificationBarrier(): CountDownLatch = verificationBarrier.get
 
   private def initialize(): Unit = {
     for (topicPartition <- expectedReplicasPerTopicPartition.keySet)

--- a/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
+++ b/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
@@ -182,11 +182,11 @@ object StateChangeLogMerger extends Logging {
 
   class LineIterator(val line: String, val itr: Iterator[String]) {
     def this() = this("", null)
-    def isEmpty = line == "" && itr == null
+    def isEmpty: Boolean = line == "" && itr == null
   }
 
   implicit object dateBasedOrdering extends Ordering[LineIterator] {
-    def compare(first: LineIterator, second: LineIterator) = {
+    def compare(first: LineIterator, second: LineIterator): Int = {
       val firstDate = dateRegex.findFirstIn(first.line).get
       val secondDate = dateRegex.findFirstIn(second.line).get
       secondDate.compareTo(firstDate)

--- a/core/src/main/scala/kafka/utils/CommandLineUtils.scala
+++ b/core/src/main/scala/kafka/utils/CommandLineUtils.scala
@@ -52,7 +52,7 @@ object CommandLineUtils extends Logging {
     * @param commandOpts Acceptable options for a command
     * @param message     Message to display on successful check
     */
-  def printHelpAndExitIfNeeded(commandOpts: CommandDefaultOptions, message: String) = {
+  def printHelpAndExitIfNeeded(commandOpts: CommandDefaultOptions, message: String): Unit = {
     if (isPrintHelpNeeded(commandOpts))
       printUsageAndDie(commandOpts.parser, message)
     if (isPrintVersionNeeded(commandOpts))

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -200,7 +200,7 @@ object CoreUtils {
    * @param coll An iterable over the underlying collection.
    * @return A circular iterator over the collection.
    */
-  def circularIterator[T](coll: Iterable[T]) =
+  def circularIterator[T](coll: Iterable[T]): Iterator[T] =
     for (_ <- Iterator.continually(1); t <- coll) yield t
 
   /**

--- a/core/src/main/scala/kafka/utils/FileLock.scala
+++ b/core/src/main/scala/kafka/utils/FileLock.scala
@@ -73,7 +73,7 @@ class FileLock(val file: File) extends Logging {
   /**
    * Destroy this lock, closing the associated FileChannel
    */
-  def destroy() = {
+  def destroy(): Unit = {
     this synchronized {
       unlock()
       channel.close()

--- a/core/src/main/scala/kafka/utils/ToolsUtils.scala
+++ b/core/src/main/scala/kafka/utils/ToolsUtils.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable
 
 object ToolsUtils {
 
-  def validatePortOrDie(parser: OptionParser, hostPort: String) = {
+  def validatePortOrDie(parser: OptionParser, hostPort: String): Unit = {
     val hostPorts: Array[String] = if(hostPort.contains(','))
       hostPort.split(",")
     else

--- a/core/src/main/scala/kafka/utils/TopicFilter.scala
+++ b/core/src/main/scala/kafka/utils/TopicFilter.scala
@@ -38,7 +38,7 @@ sealed abstract class TopicFilter(rawRegex: String) extends Logging {
       throw new RuntimeException(regex + " is an invalid regex.")
   }
 
-  override def toString = regex
+  override def toString: String = regex
 
   def isTopicAllowed(topic: String, excludeInternalTopics: Boolean): Boolean
 }

--- a/core/src/main/scala/kafka/utils/VerifiableProperties.scala
+++ b/core/src/main/scala/kafka/utils/VerifiableProperties.scala
@@ -167,7 +167,7 @@ class VerifiableProperties(val props: Properties) extends Logging {
     }
   }
 
-  def getBoolean(name: String) = getString(name).toBoolean
+  def getBoolean(name: String): Boolean = getString(name).toBoolean
 
   /**
    * Get a string property, or, if no such property is defined, return the given default value
@@ -211,7 +211,7 @@ class VerifiableProperties(val props: Properties) extends Logging {
    * @param default Default compression codec
    * @return compression codec
    */
-  def getCompressionCodec(name: String, default: CompressionCodec) = {
+  def getCompressionCodec(name: String, default: CompressionCodec): CompressionCodec = {
     val prop = getString(name, NoCompressionCodec.name)
     try {
       CompressionCodec.getCompressionCodec(prop.toInt)

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -353,7 +353,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    * @param sanitizedEntityName entity name
    * @throws KeeperException if there is an error while setting or creating the znode
    */
-  def setOrCreateEntityConfigs(rootEntityType: String, sanitizedEntityName: String, config: Properties) = {
+  def setOrCreateEntityConfigs(rootEntityType: String, sanitizedEntityName: String, config: Properties): Unit = {
 
     def set(configData: Array[Byte]): SetDataResponse = {
       val setDataRequest = SetDataRequest(ConfigEntityZNode.path(rootEntityType, sanitizedEntityName),

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -52,7 +52,7 @@ import scala.util.{Failure, Success, Try}
 // This file contains objects for encoding/decoding data stored in ZooKeeper nodes (znodes).
 
 object ControllerZNode {
-  def path = "/controller"
+  def path: String = "/controller"
   def encode(brokerId: Int, timestamp: Long): Array[Byte] = {
     Json.encodeAsBytes(Map("version" -> 1, "brokerid" -> brokerId, "timestamp" -> timestamp.toString).asJava)
   }
@@ -62,21 +62,21 @@ object ControllerZNode {
 }
 
 object ControllerEpochZNode {
-  def path = "/controller_epoch"
+  def path: String = "/controller_epoch"
   def encode(epoch: Int): Array[Byte] = epoch.toString.getBytes(UTF_8)
   def decode(bytes: Array[Byte]): Int = new String(bytes, UTF_8).toInt
 }
 
 object ConfigZNode {
-  def path = "/config"
+  def path: String = "/config"
 }
 
 object BrokersZNode {
-  def path = "/brokers"
+  def path: String = "/brokers"
 }
 
 object BrokerIdsZNode {
-  def path = s"${BrokersZNode.path}/ids"
+  def path: String = s"${BrokersZNode.path}/ids"
   def encode: Array[Byte] = null
 }
 
@@ -124,7 +124,7 @@ object BrokerIdZNode {
   private val TimestampKey = "timestamp"
   private val FeaturesKey = "features"
 
-  def path(id: Int) = s"${BrokerIdsZNode.path}/$id"
+  def path(id: Int): String = s"${BrokerIdsZNode.path}/$id"
 
   /**
    * Encode to JSON bytes.
@@ -275,14 +275,14 @@ object BrokerIdZNode {
 }
 
 object TopicsZNode {
-  def path = s"${BrokersZNode.path}/topics"
+  def path: String = s"${BrokersZNode.path}/topics"
 }
 
 object TopicZNode {
   case class TopicIdReplicaAssignment(topic: String,
                                       topicId: Option[Uuid],
                                       assignment: Map[TopicPartition, ReplicaAssignment])
-  def path(topic: String) = s"${TopicsZNode.path}/$topic"
+  def path(topic: String): String = s"${TopicsZNode.path}/$topic"
   def encode(topicId: Option[Uuid],
              assignment: collection.Map[TopicPartition, ReplicaAssignment]): Array[Byte] = {
     val replicaAssignmentJson = mutable.Map[String, util.List[Int]]()
@@ -340,7 +340,7 @@ object TopicZNode {
 }
 
 object TopicPartitionsZNode {
-  def path(topic: String) = s"${TopicZNode.path(topic)}/partitions"
+  def path(topic: String): String = s"${TopicZNode.path(topic)}/partitions"
 }
 
 object TopicPartitionZNode {
@@ -369,11 +369,11 @@ object TopicPartitionStateZNode {
 }
 
 object ConfigEntityTypeZNode {
-  def path(entityType: String) = s"${ConfigZNode.path}/$entityType"
+  def path(entityType: String): String = s"${ConfigZNode.path}/$entityType"
 }
 
 object ConfigEntityZNode {
-  def path(entityType: String, entityName: String) = s"${ConfigEntityTypeZNode.path(entityType)}/$entityName"
+  def path(entityType: String, entityName: String): String = s"${ConfigEntityTypeZNode.path(entityType)}/$entityName"
   def encode(config: Properties): Array[Byte] = {
     Json.encodeAsBytes(Map("version" -> 1, "config" -> config).asJava)
   }
@@ -390,23 +390,23 @@ object ConfigEntityZNode {
 }
 
 object ConfigEntityChangeNotificationZNode {
-  def path = s"${ConfigZNode.path}/changes"
+  def path: String = s"${ConfigZNode.path}/changes"
 }
 
 object ConfigEntityChangeNotificationSequenceZNode {
   val SequenceNumberPrefix = "config_change_"
-  def createPath = s"${ConfigEntityChangeNotificationZNode.path}/$SequenceNumberPrefix"
+  def createPath: String = s"${ConfigEntityChangeNotificationZNode.path}/$SequenceNumberPrefix"
   def encode(sanitizedEntityPath: String): Array[Byte] = Json.encodeAsBytes(
     Map("version" -> 2, "entity_path" -> sanitizedEntityPath).asJava)
 }
 
 object IsrChangeNotificationZNode {
-  def path = "/isr_change_notification"
+  def path: String = "/isr_change_notification"
 }
 
 object IsrChangeNotificationSequenceZNode {
   val SequenceNumberPrefix = "isr_change_"
-  def path(sequenceNumber: String = "") = s"${IsrChangeNotificationZNode.path}/$SequenceNumberPrefix$sequenceNumber"
+  def path(sequenceNumber: String = ""): String = s"${IsrChangeNotificationZNode.path}/$SequenceNumberPrefix$sequenceNumber"
   def encode(partitions: collection.Set[TopicPartition]): Array[Byte] = {
     val partitionsJson = partitions.map(partition => Map("topic" -> partition.topic, "partition" -> partition.partition).asJava)
     Json.encodeAsBytes(Map("version" -> IsrChangeNotificationHandler.Version, "partitions" -> partitionsJson.asJava).asJava)
@@ -423,36 +423,36 @@ object IsrChangeNotificationSequenceZNode {
       }
     }
   }.map(_.toSet).getOrElse(Set.empty)
-  def sequenceNumber(path: String) = path.substring(path.lastIndexOf(SequenceNumberPrefix) + SequenceNumberPrefix.length)
+  def sequenceNumber(path: String): String = path.substring(path.lastIndexOf(SequenceNumberPrefix) + SequenceNumberPrefix.length)
 }
 
 object LogDirEventNotificationZNode {
-  def path = "/log_dir_event_notification"
+  def path: String = "/log_dir_event_notification"
 }
 
 object LogDirEventNotificationSequenceZNode {
   val SequenceNumberPrefix = "log_dir_event_"
   val LogDirFailureEvent = 1
-  def path(sequenceNumber: String) = s"${LogDirEventNotificationZNode.path}/$SequenceNumberPrefix$sequenceNumber"
-  def encode(brokerId: Int) = {
+  def path(sequenceNumber: String): String = s"${LogDirEventNotificationZNode.path}/$SequenceNumberPrefix$sequenceNumber"
+  def encode(brokerId: Int): Array[Byte] = {
     Json.encodeAsBytes(Map("version" -> 1, "broker" -> brokerId, "event" -> LogDirFailureEvent).asJava)
   }
   def decode(bytes: Array[Byte]): Option[Int] = Json.parseBytes(bytes).map { js =>
     js.asJsonObject("broker").to[Int]
   }
-  def sequenceNumber(path: String) = path.substring(path.lastIndexOf(SequenceNumberPrefix) + SequenceNumberPrefix.length)
+  def sequenceNumber(path: String): String = path.substring(path.lastIndexOf(SequenceNumberPrefix) + SequenceNumberPrefix.length)
 }
 
 object AdminZNode {
-  def path = "/admin"
+  def path: String = "/admin"
 }
 
 object DeleteTopicsZNode {
-  def path = s"${AdminZNode.path}/delete_topics"
+  def path: String = s"${AdminZNode.path}/delete_topics"
 }
 
 object DeleteTopicsTopicZNode {
-  def path(topic: String) = s"${DeleteTopicsZNode.path}/$topic"
+  def path(topic: String): String = s"${DeleteTopicsZNode.path}/$topic"
 }
 
 /**
@@ -480,7 +480,7 @@ object ReassignPartitionsZNode {
   case class LegacyPartitionAssignment(@BeanProperty @JsonProperty("version") version: Int,
                                        @BeanProperty @JsonProperty("partitions") partitions: java.util.List[ReplicaAssignment])
 
-  def path = s"${AdminZNode.path}/reassign_partitions"
+  def path: String = s"${AdminZNode.path}/reassign_partitions"
 
   def encode(reassignmentMap: collection.Map[TopicPartition, Seq[Int]]): Array[Byte] = {
     val reassignment = LegacyPartitionAssignment(1,
@@ -500,7 +500,7 @@ object ReassignPartitionsZNode {
 }
 
 object PreferredReplicaElectionZNode {
-  def path = s"${AdminZNode.path}/preferred_replica_election"
+  def path: String = s"${AdminZNode.path}/preferred_replica_election"
   def encode(partitions: Set[TopicPartition]): Array[Byte] = {
     val jsonMap = Map("version" -> 1,
       "partitions" -> partitions.map(tp => Map("topic" -> tp.topic, "partition" -> tp.partition).asJava).asJava)
@@ -519,11 +519,11 @@ object PreferredReplicaElectionZNode {
 
 //old consumer path znode
 object ConsumerPathZNode {
-  def path = "/consumers"
+  def path: String = "/consumers"
 }
 
 object ConsumerOffset {
-  def path(group: String, topic: String, partition: Integer) = s"${ConsumerPathZNode.path}/${group}/offsets/${topic}/${partition}"
+  def path(group: String, topic: String, partition: Integer): String = s"${ConsumerPathZNode.path}/${group}/offsets/${topic}/${partition}"
   def encode(offset: Long): Array[Byte] = offset.toString.getBytes(UTF_8)
   def decode(bytes: Array[Byte]): Option[Long] = Option(bytes).map(new String(_, UTF_8).toLong)
 }
@@ -539,7 +539,7 @@ object ZkStat {
 
 object StateChangeHandlers {
   val ControllerHandler = "controller-state-change-handler"
-  def zkNodeChangeListenerHandler(seqNodeRoot: String) = s"change-notification-$seqNodeRoot"
+  def zkNodeChangeListenerHandler(seqNodeRoot: String): String = s"change-notification-$seqNodeRoot"
 }
 
 /**
@@ -626,7 +626,7 @@ class ExtendedAclStore(val patternType: PatternType) extends ZkAclStore {
 }
 
 object ExtendedAclZNode {
-  def path = "/kafka-acl-extended"
+  def path: String = "/kafka-acl-extended"
 }
 
 trait AclChangeNotificationHandler {
@@ -664,7 +664,7 @@ sealed trait ZkAclChangeStore {
 object ZkAclChangeStore {
   val stores: Iterable[ZkAclChangeStore] = List(LiteralAclChangeStore, ExtendedAclChangeStore)
 
-  def SequenceNumberPrefix = "acl_changes_"
+  def SequenceNumberPrefix: String = "acl_changes_"
 }
 
 case object LiteralAclChangeStore extends ZkAclChangeStore {
@@ -744,11 +744,11 @@ case class ExtendedAclChangeEvent(@BeanProperty @JsonProperty("version") version
 }
 
 object ClusterZNode {
-  def path = "/cluster"
+  def path: String = "/cluster"
 }
 
 object ClusterIdZNode {
-  def path = s"${ClusterZNode.path}/id"
+  def path: String = s"${ClusterZNode.path}/id"
 
   def toJson(id: String): Array[Byte] = {
     Json.encodeAsBytes(Map("version" -> "1", "id" -> id).asJava)
@@ -762,13 +762,13 @@ object ClusterIdZNode {
 }
 
 object BrokerSequenceIdZNode {
-  def path = s"${BrokersZNode.path}/seqid"
+  def path: String = s"${BrokersZNode.path}/seqid"
 }
 
 object ProducerIdBlockZNode {
   val CurrentVersion: Long = 1L
 
-  def path = "/latest_producer_id_block"
+  def path: String = "/latest_producer_id_block"
 
   def generateProducerIdBlockJson(producerIdBlock: ProducerIdsBlock): Array[Byte] = {
     Json.encodeAsBytes(Map("version" -> CurrentVersion,
@@ -796,27 +796,27 @@ object ProducerIdBlockZNode {
 }
 
 object DelegationTokenAuthZNode {
-  def path = "/delegation_token"
+  def path: String = "/delegation_token"
 }
 
 object DelegationTokenChangeNotificationZNode {
-  def path =  s"${DelegationTokenAuthZNode.path}/token_changes"
+  def path: String =  s"${DelegationTokenAuthZNode.path}/token_changes"
 }
 
 object DelegationTokenChangeNotificationSequenceZNode {
   val SequenceNumberPrefix = "token_change_"
-  def createPath = s"${DelegationTokenChangeNotificationZNode.path}/$SequenceNumberPrefix"
-  def deletePath(sequenceNode: String) = s"${DelegationTokenChangeNotificationZNode.path}/${sequenceNode}"
+  def createPath: String = s"${DelegationTokenChangeNotificationZNode.path}/$SequenceNumberPrefix"
+  def deletePath(sequenceNode: String): String = s"${DelegationTokenChangeNotificationZNode.path}/${sequenceNode}"
   def encode(tokenId : String): Array[Byte] = tokenId.getBytes(UTF_8)
   def decode(bytes: Array[Byte]): String = new String(bytes, UTF_8)
 }
 
 object DelegationTokensZNode {
-  def path = s"${DelegationTokenAuthZNode.path}/tokens"
+  def path: String = s"${DelegationTokenAuthZNode.path}/tokens"
 }
 
 object DelegationTokenInfoZNode {
-  def path(tokenId: String) =  s"${DelegationTokensZNode.path}/$tokenId"
+  def path(tokenId: String): String =  s"${DelegationTokensZNode.path}/$tokenId"
   def encode(token: DelegationToken): Array[Byte] =  Json.encodeAsBytes(DelegationTokenManager.toJsonCompatibleMap(token).asJava)
   def decode(bytes: Array[Byte]): Option[TokenInformation] = DelegationTokenManager.fromBytes(bytes)
 }
@@ -874,7 +874,7 @@ object FeatureZNode {
   val V1 = 1
   val CurrentVersion = V1
 
-  def path = "/feature"
+  def path: String = "/feature"
 
   def asJavaMap(scalaMap: Map[String, Map[String, Short]]): util.Map[String, util.Map[String, java.lang.Short]] = {
     scalaMap

--- a/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
+++ b/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
@@ -74,7 +74,7 @@ class ZooKeeperMainWithTlsSupportForKafka(args: Array[String], val zkClientConfi
       System.err.println(s"\t$cmd ${ZooKeeperMain.commandMap.get(cmd)}"))
   }
 
-  override def connectToZK(newHost: String) = {
+  override def connectToZK(newHost: String): Unit = {
     // ZooKeeperAdmin has no constructor that supports passing in both readOnly and ZkClientConfig,
     // and readOnly ends up being set to false when passing in a ZkClientConfig instance;
     // therefore it is currently not possible for us to construct a ZooKeeperAdmin instance with

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -45,8 +45,8 @@ import scala.compat.java8.OptionConverters._
  */
 @Timeout(120)
 abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logging {
-  def brokerCount = 3
-  override def logDirCount = 2
+  def brokerCount: Int = 3
+  override def logDirCount: Int = 2
 
   var client: Admin = _
 

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -43,8 +43,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 
   override val brokerCount = 2
 
-  protected def producerClientId = "QuotasTestProducer-1"
-  protected def consumerClientId = "QuotasTestConsumer-1"
+  protected def producerClientId: String = "QuotasTestProducer-1"
+  protected def consumerClientId: String = "QuotasTestConsumer-1"
   protected def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients
 
   this.serverConfig.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")

--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.BeforeEach
 
 class ClientIdQuotaTest extends BaseQuotaTest {
 
-  override def producerClientId = "QuotasTestProducer-!@#$%^&*()"
-  override def consumerClientId = "QuotasTestConsumer-!@#$%^&*()"
+  override def producerClientId: String = "QuotasTestProducer-!@#$%^&*()"
+  override def consumerClientId: String = "QuotasTestConsumer-!@#$%^&*()"
 
   @BeforeEach
   override def setUp(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/SaslGssapiSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslGssapiSslEndToEndAuthorizationTest.scala
@@ -31,9 +31,9 @@ class SaslGssapiSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTe
   override val kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE,
     JaasTestUtils.KafkaServerPrincipalUnqualifiedName)
 
-  override protected def kafkaClientSaslMechanism = "GSSAPI"
-  override protected def kafkaServerSaslMechanisms = List("GSSAPI")
-  override protected def authorizerClass = classOf[AclAuthorizer]
+  override protected def kafkaClientSaslMechanism: String = "GSSAPI"
+  override protected def kafkaServerSaslMechanisms: List[String] = List("GSSAPI")
+  override protected def authorizerClass: Class[AclAuthorizer] = classOf[AclAuthorizer]
 
   // Configure brokers to require SSL client authentication in order to verify that SASL_SSL works correctly even if the
   // client doesn't have a keystore. We want to cover the scenario where a broker requires either SSL client

--- a/core/src/test/scala/integration/kafka/api/SaslOAuthBearerSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslOAuthBearerSslEndToEndAuthorizationTest.scala
@@ -20,8 +20,8 @@ import kafka.utils.JaasTestUtils
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 
 class SaslOAuthBearerSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
-  override protected def kafkaClientSaslMechanism = "OAUTHBEARER"
-  override protected def kafkaServerSaslMechanisms = List(kafkaClientSaslMechanism)
+  override protected def kafkaClientSaslMechanism: String = "OAUTHBEARER"
+  override protected def kafkaServerSaslMechanisms: List[String] = List(kafkaClientSaslMechanism)
   override val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaOAuthBearerUser)
   override val kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaOAuthBearerAdmin)
 }

--- a/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
@@ -29,7 +29,7 @@ class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
     s"${listenerName.value.toLowerCase(Locale.ROOT)}.${JaasTestUtils.KafkaServerContextName}"
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "false")
   // disable secure acls of zkClient in ZooKeeperTestHarness
-  override protected def zkAclsEnabled = Some(false)
+  override protected def zkAclsEnabled: Some[Boolean] = Some(false)
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
   override protected val serverSaslProperties = Some(kafkaServerSaslProperties(kafkaServerSaslMechanisms, kafkaClientSaslMechanism))

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -123,8 +123,8 @@ class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
   this.consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, plainLogin)
   this.adminClientConfig.put(SaslConfigs.SASL_JAAS_CONFIG, plainLogin)
 
-  override protected def kafkaClientSaslMechanism = "PLAIN"
-  override protected def kafkaServerSaslMechanisms = List("PLAIN")
+  override protected def kafkaClientSaslMechanism: String = "PLAIN"
+  override protected def kafkaServerSaslMechanisms: List[String] = List("PLAIN")
 
   override val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "user")
   override val kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "admin")

--- a/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
@@ -17,9 +17,9 @@
 package kafka.api
 
 import java.util.Properties
-
 import kafka.utils.JaasTestUtils
 import kafka.zk.ConfigEntityChangeNotificationZNode
+import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.test.TestSslUtils
@@ -28,8 +28,8 @@ import scala.jdk.CollectionConverters._
 import org.junit.jupiter.api.BeforeEach
 
 class SaslScramSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
-  override protected def kafkaClientSaslMechanism = "SCRAM-SHA-256"
-  override protected def kafkaServerSaslMechanisms = ScramMechanism.mechanismNames.asScala.toList
+  override protected def kafkaClientSaslMechanism: String = "SCRAM-SHA-256"
+  override protected def kafkaServerSaslMechanisms: List[String] = ScramMechanism.mechanismNames.asScala.toList
   override val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaScramUser)
   override val kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaScramAdmin)
   private val kafkaPassword = JaasTestUtils.KafkaScramAdminPassword
@@ -49,7 +49,7 @@ class SaslScramSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
     super.configureListeners(props)
   }
 
-  override def createPrivilegedAdminClient() = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)
+  override def createPrivilegedAdminClient(): Admin = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)
 
   @BeforeEach
   override def setUp(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -83,7 +83,7 @@ class TransactionsTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testBasicTransactions() = {
+  def testBasicTransactions(): Unit = {
     val producer = transactionalProducers.head
     val consumer = transactionalConsumers.head
     val unCommittedConsumer = nonTransactionalConsumers.head
@@ -229,19 +229,19 @@ class TransactionsTest extends KafkaServerTestHarness {
 
   @nowarn("cat=deprecation")
   @Test
-  def testSendOffsetsWithGroupId() = {
+  def testSendOffsetsWithGroupId(): Unit = {
     sendOffset((producer, groupId, consumer) =>
       producer.sendOffsetsToTransaction(TestUtils.consumerPositions(consumer).asJava, groupId))
   }
 
   @Test
-  def testSendOffsetsWithGroupMetadata() = {
+  def testSendOffsetsWithGroupMetadata(): Unit = {
     sendOffset((producer, _, consumer) =>
       producer.sendOffsetsToTransaction(TestUtils.consumerPositions(consumer).asJava, consumer.groupMetadata()))
   }
 
   private def sendOffset(commit: (KafkaProducer[Array[Byte], Array[Byte]],
-    String, KafkaConsumer[Array[Byte], Array[Byte]]) => Unit) = {
+    String, KafkaConsumer[Array[Byte], Array[Byte]]) => Unit): Unit = {
 
     // The basic plan for the test is as follows:
     //  1. Seed topic1 with 1000 unique, numbered, messages.
@@ -308,7 +308,7 @@ class TransactionsTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testFencingOnCommit() = {
+  def testFencingOnCommit(): Unit = {
     val producer1 = transactionalProducers(0)
     val producer2 = transactionalProducers(1)
     val consumer = transactionalConsumers(0)
@@ -337,7 +337,7 @@ class TransactionsTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testFencingOnSendOffsets() = {
+  def testFencingOnSendOffsets(): Unit = {
     val producer1 = transactionalProducers(0)
     val producer2 = transactionalProducers(1)
     val consumer = transactionalConsumers(0)
@@ -368,7 +368,7 @@ class TransactionsTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testOffsetMetadataInSendOffsetsToTransaction() = {
+  def testOffsetMetadataInSendOffsetsToTransaction(): Unit = {
     val tp = new TopicPartition(topic1, 0)
     val groupId = "group"
 

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -26,8 +26,8 @@ class UserClientIdQuotaTest extends BaseQuotaTest {
   override protected def securityProtocol = SecurityProtocol.SSL
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
 
-  override def producerClientId = "QuotasTestProducer-!@#$%^&*()"
-  override def consumerClientId = "QuotasTestConsumer-!@#$%^&*()"
+  override def producerClientId: String = "QuotasTestProducer-!@#$%^&*()"
+  override def consumerClientId: String = "QuotasTestConsumer-!@#$%^&*()"
 
   @BeforeEach
   override def setUp(): Unit = {

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -41,7 +41,7 @@ import scala.jdk.CollectionConverters._
 
 class DynamicConnectionQuotaTest extends BaseRequestTest {
 
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
 
   val topic = "test"
   val listener = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)

--- a/core/src/test/scala/kafka/metrics/LinuxIoMetricsCollectorTest.scala
+++ b/core/src/test/scala/kafka/metrics/LinuxIoMetricsCollectorTest.scala
@@ -23,6 +23,7 @@ import kafka.utils.{Logging, MockTime}
 import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{Test, Timeout}
+import java.nio.file.Path
 
 @Timeout(120)
 class LinuxIoMetricsCollectorTest extends Logging {
@@ -31,7 +32,7 @@ class LinuxIoMetricsCollectorTest extends Logging {
     val baseDir = TestUtils.tempDirectory()
     val selfDir = Files.createDirectories(baseDir.toPath.resolve("self"))
 
-    def writeProcFile(readBytes: Long, writeBytes: Long) = {
+    def writeProcFile(readBytes: Long, writeBytes: Long): Path = {
       val bld = new StringBuilder()
       bld.append("rchar: 0%n".format())
       bld.append("wchar: 0%n".format())

--- a/core/src/test/scala/kafka/tools/LogCompactionTester.scala
+++ b/core/src/test/scala/kafka/tools/LogCompactionTester.scala
@@ -231,7 +231,7 @@ object LogCompactionTester {
     null
   }
 
-  def peekLine(reader: BufferedReader) = {
+  def peekLine(reader: BufferedReader): String = {
     reader.mark(ReadAheadLimit)
     val line = reader.readLine
     reader.reset()
@@ -336,8 +336,8 @@ object LogCompactionTester {
 }
 
 case class TestRecord(topic: String, key: Int, value: Long, delete: Boolean) {
-  override def toString = topic + "\t" + key + "\t" + value + "\t" + (if (delete) "d" else "u")
-  def topicAndKey = topic + key
+  override def toString: String = topic + "\t" + key + "\t" + value + "\t" + (if (delete) "d" else "u")
+  def topicAndKey: String = topic + key
 }
 
 object TestRecord {

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -257,7 +257,7 @@ object ReplicationQuotasTestRig {
       dataset
     }
 
-    def record(rates: mutable.Map[Int, Array[Double]], brokerId: Int, currentRate: Double) = {
+    def record(rates: mutable.Map[Int, Array[Double]], brokerId: Int, currentRate: Double): Option[Array[Double]] = {
       var leaderRatesBroker: Array[Double] = rates.getOrElse(brokerId, Array[Double]())
       leaderRatesBroker = leaderRatesBroker ++ Array(currentRate)
       rates.put(brokerId, leaderRatesBroker)

--- a/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
+++ b/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
@@ -201,7 +201,7 @@ object TestPurgatoryPerformance {
       val dist = new LogNormalDistribution(normalMean, normalStDev)
       (0 until sampleSize).map { _ => dist.next().toLong }.toArray
     }
-    def next() = samples(rand.nextInt(sampleSize))
+    def next(): Long = samples(rand.nextInt(sampleSize))
 
     def printStats(): Unit = {
       val p75 = samples.sorted.apply((sampleSize.toDouble * 0.75d).toInt)
@@ -227,7 +227,7 @@ object TestPurgatoryPerformance {
       }.toArray
     }
 
-    def next() = samples(rand.nextInt(sampleSize))
+    def next(): Long = samples(rand.nextInt(sampleSize))
 
     def printStats(): Unit = {
       println(
@@ -270,7 +270,7 @@ object TestPurgatoryPerformance {
       delayQueue.offer(new Scheduled(operation))
     }
 
-    def shutdown() = {
+    def shutdown(): Unit = {
       thread.shutdown()
     }
 

--- a/core/src/test/scala/unit/kafka/admin/DelegationTokenCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DelegationTokenCommandTest.scala
@@ -38,7 +38,7 @@ class DelegationTokenCommandTest extends BaseRequestTest with SaslSetup {
   protected override val clientSaslProperties = Some(kafkaClientSaslProperties(kafkaClientSaslMechanism))
   var adminClient: Admin = null
 
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
 
   @BeforeEach
   override def setUp(): Unit = {
@@ -46,7 +46,7 @@ class DelegationTokenCommandTest extends BaseRequestTest with SaslSetup {
     super.setUp()
   }
 
-  override def generateConfigs = {
+  override def generateConfigs: collection.Seq[KafkaConfig] = {
     val props = TestUtils.createBrokerConfigs(brokerCount, zkConnect,
       enableControlledShutdown = false,
       interBrokerSecurityProtocol = Some(securityProtocol),

--- a/core/src/test/scala/unit/kafka/admin/UserScramCredentialsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/UserScramCredentialsCommandTest.scala
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 class UserScramCredentialsCommandTest extends BaseRequestTest {
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
   var exitStatus: Option[Int] = None
   var exitMessage: Option[String] = None
 

--- a/core/src/test/scala/unit/kafka/log/OffsetMapTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetMapTest.scala
@@ -57,7 +57,7 @@ class OffsetMapTest {
     assertEquals(map.get(key(i-1L)), i-1L)
   }
 
-  def key(key: Long) = ByteBuffer.wrap(key.toString.getBytes)
+  def key(key: Long): ByteBuffer = ByteBuffer.wrap(key.toString.getBytes)
   
   def validateMap(items: Int, loadFactor: Double = 0.5): SkimpyOffsetMap = {
     val map = new SkimpyOffsetMap((items/loadFactor * 24).toInt)

--- a/core/src/test/scala/unit/kafka/metrics/KafkaTimerTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/KafkaTimerTest.scala
@@ -44,11 +44,11 @@ class KafkaTimerTest {
 
     private var ticksInNanos = 0L
 
-    override def tick() = {
+    override def tick(): Long = {
       ticksInNanos
     }
 
-    override def time() = {
+    override def time(): Long = {
       TimeUnit.NANOSECONDS.toMillis(ticksInNanos)
     }
 

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -43,7 +43,7 @@ import scala.jdk.CollectionConverters._
 
 @Timeout(value = 12)
 class BrokerLifecycleManagerTest {
-  def configProperties = {
+  def configProperties: Properties = {
     val properties = new Properties()
     properties.setProperty(KafkaConfig.LogDirsProp, "/tmp/foo")
     properties.setProperty(KafkaConfig.ProcessRolesProp, "broker")

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -422,6 +422,6 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
     // The class under test expects only sanitized client configs. We pass both the default value (which should not be
     // sanitized to ensure it remains unique) and non-default values, so we need to take care in generating the sanitized
     // client ID
-    def sanitizedConfigClientId = configClientId.map(x => if (x == ConfigEntityName.Default) ConfigEntityName.Default else Sanitizer.sanitize(x))
+    def sanitizedConfigClientId: Option[String] = configClientId.map(x => if (x == ConfigEntityName.Default) ConfigEntityName.Default else Sanitizer.sanitize(x))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
@@ -29,7 +29,7 @@ import scala.concurrent.ExecutionException
 class DelegationTokenRequestsOnPlainTextTest extends BaseRequestTest {
   var adminClient: Admin = null
 
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
 
   @BeforeEach
   override def setUp(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -37,7 +37,7 @@ class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
   protected override val clientSaslProperties = Some(kafkaClientSaslProperties(kafkaClientSaslMechanism))
   var adminClient: Admin = null
 
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
 
   @BeforeEach
   override def setUp(): Unit = {
@@ -45,7 +45,7 @@ class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
     super.setUp()
   }
 
-  override def generateConfigs = {
+  override def generateConfigs: collection.Seq[KafkaConfig] = {
     val props = TestUtils.createBrokerConfigs(brokerCount, zkConnect,
       enableControlledShutdown = false,
       interBrokerSecurityProtocol = Some(securityProtocol),

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
@@ -35,7 +35,7 @@ class DelegationTokenRequestsWithDisableTokenFeatureTest extends BaseRequestTest
   protected override val clientSaslProperties = Some(kafkaClientSaslProperties(kafkaClientSaslMechanism))
   var adminClient: Admin = null
 
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
 
   @BeforeEach
   override def setUp(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class DynamicConfigTest extends ZooKeeperTestHarness {
-  private final val nonExistentConfig: String = "some.config.that.does.not.exist"
-  private final val someValue: String = "some interesting value"
+  private val nonExistentConfig: String = "some.config.that.does.not.exist"
+  private val someValue: String = "some interesting value"
 
   @Test
   def shouldFailWhenChangingClientIdUnknownConfig(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -17,12 +17,13 @@
 
 package kafka.server
 
-import kafka.log.{ClientRecordDeletion, UnifiedLog, LogSegment}
+import kafka.log.{ClientRecordDeletion, LogSegment, UnifiedLog}
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, ListOffsetsResponse}
+import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.easymock.{EasyMock, IAnswer}
 import org.junit.jupiter.api.Assertions._
@@ -38,9 +39,9 @@ class LogOffsetTest extends BaseRequestTest {
 
   private lazy val time = new MockTime
 
-  override def brokerCount = 1
+  override def brokerCount: Int = 1
 
-  protected override def brokerTime(brokerId: Int) = time
+  protected override def brokerTime(brokerId: Int): Time = time
 
   protected override def brokerPropertyOverrides(props: Properties): Unit = {
     props.put("log.flush.interval.messages", "1")

--- a/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
@@ -52,8 +52,8 @@ class LogRecoveryTest extends ZooKeeperTestHarness {
   var server1: KafkaServer = null
   var server2: KafkaServer = null
 
-  def configProps1 = configs.head
-  def configProps2 = configs.last
+  def configProps1: KafkaConfig = configs.head
+  def configProps2: KafkaConfig = configs.last
 
   val message = "hello"
 
@@ -64,7 +64,7 @@ class LogRecoveryTest extends ZooKeeperTestHarness {
 
   // Some tests restart the brokers then produce more data. But since test brokers use random ports, we need
   // to use a new producer that knows the new ports
-  def updateProducer() = {
+  def updateProducer(): Unit = {
     if (producer != null)
       producer.close()
     producer = TestUtils.createProducer(

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
@@ -147,7 +147,7 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
   }
 
   @Test
-  def testConsistentClusterIdFromZookeeperAndFromMetaProps() = {
+  def testConsistentClusterIdFromZookeeperAndFromMetaProps(): Unit = {
     // Check at the first boot
     val server = TestUtils.createServer(config1, threadNamePrefix = Option(this.getClass.getName))
     val clusterId = server.clusterId
@@ -168,7 +168,7 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
   }
 
   @Test
-  def testInconsistentClusterIdFromZookeeperAndFromMetaProps() = {
+  def testInconsistentClusterIdFromZookeeperAndFromMetaProps(): Unit = {
     forgeBrokerMetadata(config1.logDirs, config1.brokerId, "aclusterid")
 
     val server = new KafkaServer(config1, threadNamePrefix = Option(this.getClass.getName))

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -42,7 +42,7 @@ import scala.util.matching.Regex
 
 class UpdateFeaturesTest extends BaseRequestTest {
 
-  override def brokerCount = 3
+  override def brokerCount: Int = 3
 
   override def brokerPropertyOverrides(props: Properties): Unit = {
     props.put(KafkaConfig.InterBrokerProtocolVersionProp, KAFKA_2_7_IV0.toString)

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
@@ -59,7 +59,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldAddEpochAndMessageOffsetToCache() = {
+  def shouldAddEpochAndMessageOffsetToCache(): Unit = {
     //When
     cache.assign(epoch = 2, startOffset = 10)
     val logEndOffset = 11
@@ -71,7 +71,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldReturnLogEndOffsetIfLatestEpochRequested() = {
+  def shouldReturnLogEndOffsetIfLatestEpochRequested(): Unit = {
     //When just one epoch
     cache.assign(epoch = 2, startOffset = 11)
     cache.assign(epoch = 2, startOffset = 12)
@@ -82,7 +82,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldReturnUndefinedOffsetIfUndefinedEpochRequested() = {
+  def shouldReturnUndefinedOffsetIfUndefinedEpochRequested(): Unit = {
     val expectedEpochEndOffset = (UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET)
 
     // assign couple of epochs
@@ -98,7 +98,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldNotOverwriteLogEndOffsetForALeaderEpochOnceItHasBeenAssigned() = {
+  def shouldNotOverwriteLogEndOffsetForALeaderEpochOnceItHasBeenAssigned(): Unit = {
     //Given
     val logEndOffset = 9
 
@@ -113,7 +113,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldEnforceMonotonicallyIncreasingStartOffsets() = {
+  def shouldEnforceMonotonicallyIncreasingStartOffsets(): Unit = {
     //Given
     cache.assign(2, 9)
 
@@ -125,7 +125,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldNotOverwriteOffsetForALeaderEpochOnceItHasBeenAssigned() = {
+  def shouldNotOverwriteOffsetForALeaderEpochOnceItHasBeenAssigned(): Unit = {
     cache.assign(2, 6)
 
     //When called again later with a greater offset
@@ -178,7 +178,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldGetFirstOffsetOfSubsequentEpochWhenOffsetRequestedForPreviousEpoch() = {
+  def shouldGetFirstOffsetOfSubsequentEpochWhenOffsetRequestedForPreviousEpoch(): Unit = {
     //When several epochs
     cache.assign(epoch = 1, startOffset = 11)
     cache.assign(epoch = 1, startOffset = 12)
@@ -205,7 +205,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldNotUpdateEpochAndStartOffsetIfItDidNotChange() = {
+  def shouldNotUpdateEpochAndStartOffsetIfItDidNotChange(): Unit = {
     //When
     cache.assign(epoch = 2, startOffset = 6)
     cache.assign(epoch = 2, startOffset = 7)
@@ -282,7 +282,7 @@ class LeaderEpochFileCacheTest {
   }
 
   @Test
-  def shouldEnforceOffsetsIncreaseMonotonically() = {
+  def shouldEnforceOffsetsIncreaseMonotonically(): Unit = {
     //When epoch goes forward but offset goes backwards
     cache.assign(epoch = 2, startOffset = 6)
     cache.assign(epoch = 3, startOffset = 5)

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -33,7 +33,7 @@ object JaasTestUtils {
                              debug: Boolean,
                              serviceName: Option[String]) extends JaasModule {
 
-    def name =
+    def name: String =
       if (Java.isIbmJdk)
         "com.ibm.security.auth.module.Krb5LoginModule"
       else
@@ -59,7 +59,7 @@ object JaasTestUtils {
                               debug: Boolean = false,
                               validUsers: Map[String, String] = Map.empty) extends JaasModule {
 
-    def name = "org.apache.kafka.common.security.plain.PlainLoginModule"
+    def name: String = "org.apache.kafka.common.security.plain.PlainLoginModule"
 
     def entries: Map[String, String] = Map(
       "username" -> username,
@@ -70,7 +70,7 @@ object JaasTestUtils {
 
   case class ZkDigestModule(debug: Boolean = false,
                             entries: Map[String, String] = Map.empty) extends JaasModule {
-    def name = "org.apache.zookeeper.server.auth.DigestLoginModule"
+    def name: String = "org.apache.zookeeper.server.auth.DigestLoginModule"
   }
 
   case class ScramLoginModule(username: String,
@@ -78,7 +78,7 @@ object JaasTestUtils {
                               debug: Boolean = false,
                               tokenProps: Map[String, String] = Map.empty) extends JaasModule {
 
-    def name = "org.apache.kafka.common.security.scram.ScramLoginModule"
+    def name: String = "org.apache.kafka.common.security.scram.ScramLoginModule"
 
     def entries: Map[String, String] = Map(
       "username" -> username,
@@ -89,7 +89,7 @@ object JaasTestUtils {
   case class OAuthBearerLoginModule(username: String,
                               debug: Boolean = false) extends JaasModule {
 
-    def name = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule"
+    def name: String = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule"
 
     def entries: Map[String, String] = Map(
       "unsecuredLoginStringClaim_sub" -> username

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -117,7 +117,7 @@ class JsonTest {
   }
 
   @Test
-  def testParseTo() = {
+  def testParseTo(): Unit = {
     val foo = "baz"
     val bar = 1
 
@@ -127,7 +127,7 @@ class JsonTest {
   }
 
   @Test
-  def testParseToWithInvalidJson() = {
+  def testParseToWithInvalidJson(): Unit = {
     val result = Json.parseStringAs[TestObject]("{invalid json}")
     assertEquals(Left(classOf[JsonParseException]), result.left.map(_.getClass))
   }

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -39,7 +39,7 @@ class MockScheduler(val time: Time) extends Scheduler {
   /* a priority queue of tasks ordered by next execution time */
   private val tasks = new PriorityQueue[MockTask]()
   
-  def isStarted = true
+  def isStarted: Boolean = true
 
   def startup(): Unit = {}
   
@@ -103,7 +103,7 @@ class MockScheduler(val time: Time) extends Scheduler {
 }
 
 case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends ScheduledFuture[Unit] {
-  def periodic = period >= 0
+  def periodic: Boolean = period >= 0
   def compare(t: MockTask): Int = {
     if(t.nextExecution == nextExecution)
       0

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -886,7 +886,7 @@ object TestUtils extends Logging {
    * otherwise difficult to poll for. `computeUntilTrue` and `waitUntilTrue` should be preferred in cases where we can
    * easily wait on a condition before evaluating the assertions.
    */
-  def tryUntilNoAssertionError(waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L)(assertions: => Unit) = {
+  def tryUntilNoAssertionError(waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L)(assertions: => Unit): Unit = {
     val (error, success) = TestUtils.computeUntilTrue({
       try {
         assertions

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
@@ -45,7 +45,7 @@ class WordCountTest extends WordCountTestData {
 
   private val cluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)
 
-  final private val alignedTime = (System.currentTimeMillis() / 1000 + 1) * 1000
+  private val alignedTime = (System.currentTimeMillis() / 1000 + 1) * 1000
   private val mockTime: MockTime = cluster.time
   mockTime.setCurrentTimeMs(alignedTime)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/StreamToTableJoinScalaIntegrationTestBase.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/StreamToTableJoinScalaIntegrationTestBase.scala
@@ -37,7 +37,7 @@ class StreamToTableJoinScalaIntegrationTestBase extends StreamToTableJoinTestDat
 
   private val cluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)
 
-  final private val alignedTime = (System.currentTimeMillis() / 1000 + 1) * 1000
+  private val alignedTime = (System.currentTimeMillis() / 1000 + 1) * 1000
   private val mockTime: MockTime = cluster.time
   mockTime.setCurrentTimeMs(alignedTime)
 


### PR DESCRIPTION
Introduces Scalafix, a linter with some rewrite capabilities on
top (https://scalacenter.github.io/scalafix/)

By running the `checkScalafix` gradle tasks a report is printed with all
broken rules.

Running `scalafix` gradle task will apply some rewrites on the files,
for example: import ordering, and annotating return types.
This change uses the official gradle plugin for Scalafix, and Scalafix
itself is maintained by the Scala Center.

Current rules checked:
- Do not allow `final var`
- Explicit return types for public and protected methods (for public
  `val` and `var` the change was too big. This can be done at a later
time)
- Avoid procedure syntax in Scala
- Avoid use of val in for comprehensions (it's a deprecated feature)

*Known limitations*: when automatically inferring the return types,
Scalafix might fail and pick a "too wide" type, i.e. `Any` instead of
the correct one. After letting Scalafix fix the files, contributors
should still look at the changes done and validate they are correct.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
