### PR TITLE
HOTFIX: fix backport of #11248 by future-proofing the EmbeddedKafkaCluster

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
@@ -31,7 +31,6 @@ import org.apache.kafka.test.IntegrationTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -52,7 +51,6 @@ public class MetricsReporterIntegrationTest {
 
     private static final int NUM_BROKERS = 1;
 
-    @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
     // topic names
@@ -64,6 +62,16 @@ public class MetricsReporterIntegrationTest {
 
     @Rule
     public TestName testName = new TestName();
+
+    @BeforeClass
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterClass
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
 
     @Before
     public void before() throws InterruptedException {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.test.IntegrationTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -51,6 +52,7 @@ public class MetricsReporterIntegrationTest {
 
     private static final int NUM_BROKERS = 1;
 
+    @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
     // topic names
@@ -62,16 +64,6 @@ public class MetricsReporterIntegrationTest {
 
     @Rule
     public TestName testName = new TestName();
-
-    @BeforeClass
-    public static void startCluster() throws IOException {
-        CLUSTER.start();
-    }
-
-    @AfterClass
-    public static void closeCluster() {
-        CLUSTER.stop();
-    }
 
     @Before
     public void before() throws InterruptedException {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
@@ -119,7 +119,7 @@ public class EmbeddedKafkaCluster extends ExternalResource {
     /**
      * Stop the Kafka cluster.
      */
-    private void stop() {
+    public void stop() {
         if (brokers.length > 1) {
             // delete the topics first to avoid cascading leader elections while shutting down the brokers
             final Set<String> topics = getAllTopicsInCluster();


### PR DESCRIPTION
A backport of #11248 broke the 2.8 build due to usage of the `EmbeddedKafkaCluster#stop` method, which used to be private. It seems we made this public when we upgraded to JUnit5 on the 3.0 branch and had to remove the ExternalResource that was previously responsible for calling `start()` and `stop()` for this class using the no-longer-available `@ClassRule` annotation. 

Rather than adapt this test to the 2.8 style by migrating it to use `@ClassRule` as well, I opted to just make the `stop() method public as well (since its analogue `start()` has always been public anyways). This should hopefully prevent any future backports that include integration tests from having to manually go in and adapt the test, or accidentally break the build as happened here.