### PR TITLE
HOTFIX: decrease session timeout in flaky NamedTopologyIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -167,6 +167,7 @@ public class NamedTopologyIntegrationTest {
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10 * 1000);
         return streamsConfiguration;
     }
 


### PR DESCRIPTION
Since the default session timeout was bumped to 45s a number of our integration tests have begun failing. Let's reset it back to 10s for these NamedTopologyIntegrationTests which have been a bit flaky to help parse out whether it's just environmental, or possibly something more...sinister 😈 