### PR TITLE
MINOR: Update `TransactionalMessageCopier` to use the latest transaction pattern

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -33,7 +33,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.Exit;
@@ -361,7 +361,7 @@ public class TransactionalMessageCopier {
                             numMessagesProcessedSinceLastRebalance.getAndAdd(messagesSentWithinCurrentTxn);
                             totalMessageProcessed.getAndAdd(messagesSentWithinCurrentTxn);
                         }
-                    } catch (ProducerFencedException | OutOfOrderSequenceException e) {
+                    } catch (ProducerFencedException | FencedInstanceIdException e) {
                         // We cannot recover from these errors, so just rethrow them and let the process fail
                         throw e;
                     } catch (KafkaException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -361,7 +361,7 @@ public class TransactionalMessageCopier {
                             numMessagesProcessedSinceLastRebalance.getAndAdd(messagesSentWithinCurrentTxn);
                             totalMessageProcessed.getAndAdd(messagesSentWithinCurrentTxn);
                         }
-                    } catch (ProducerFencedException | FencedInstanceIdException e) {
+                    } catch (ProducerFencedException e) {
                         // We cannot recover from these errors, so just rethrow them and let the process fail
                         throw e;
                     } catch (KafkaException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -33,7 +33,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.Exit;


### PR DESCRIPTION
`ExactlyOnceMessageProcessor` is the reference so this patch updates `TransactionalMessageCopier` to be similar.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
