### PR TITLE
KAFKA-13233 Log zkVersion in more places

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2344,17 +2344,17 @@ class KafkaController(val config: KafkaConfig,
               debug(s"ISR for partition $partition updated to [${updatedIsr.isr.mkString(",")}] and zkVersion updated to [${updatedIsr.zkVersion}]")
               partitionResponses(partition) = Right(updatedIsr)
               Some(partition -> updatedIsr)
-            case Left(error) =>
-              this.error(s"Failed to update ISR for partition $partition", error)
-              partitionResponses(partition) = Left(Errors.forException(error))
+            case Left(err) =>
+              error(s"Failed to update ISR for partition $partition", err)
+              partitionResponses(partition) = Left(Errors.forException(err))
               None
           }
       }
 
-      badVersionUpdates.foreach(partition => {
+      badVersionUpdates.foreach { partition =>
         info(s"Failed to update ISR to ${adjustedIsrs(partition)} for partition $partition, bad ZK version.")
         partitionResponses(partition) = Left(Errors.INVALID_UPDATE_VERSION)
-      })
+      }
 
       def processUpdateNotifications(partitions: Seq[TopicPartition]): Unit = {
         val liveBrokers: Seq[Int] = controllerContext.liveOrShuttingDownBrokerIds.toSeq

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2344,9 +2344,9 @@ class KafkaController(val config: KafkaConfig,
               debug(s"ISR for partition $partition updated to [${updatedIsr.isr.mkString(",")}] and zkVersion updated to [${updatedIsr.zkVersion}]")
               partitionResponses(partition) = Right(updatedIsr)
               Some(partition -> updatedIsr)
-            case Left(err) =>
-              error(s"Failed to update ISR for partition $partition", err)
-              partitionResponses(partition) = Left(Errors.forException(err))
+            case Left(e) =>
+              error(s"Failed to update ISR for partition $partition", e)
+              partitionResponses(partition) = Left(Errors.forException(e))
               None
           }
       }

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -437,6 +437,11 @@ class ZkPartitionStateMachine(config: KafkaConfig,
       }
     }
 
+    updatesToRetry.foreach { partition =>
+      debug(s"Controller failed to elect leader for partition $partition. " +
+        s"Attempted to write state ${adjustedLeaderAndIsrs(partition)}, but failed with bad ZK version. This will be retried.")
+    }
+
     (finishedUpdates ++ failedElections, updatesToRetry)
   }
 

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -437,9 +437,11 @@ class ZkPartitionStateMachine(config: KafkaConfig,
       }
     }
 
-    updatesToRetry.foreach { partition =>
-      debug(s"Controller failed to elect leader for partition $partition. " +
-        s"Attempted to write state ${adjustedLeaderAndIsrs(partition)}, but failed with bad ZK version. This will be retried.")
+    if (isDebugEnabled) {
+      updatesToRetry.foreach { partition =>
+        debug(s"Controller failed to elect leader for partition $partition. " +
+          s"Attempted to write state ${adjustedLeaderAndIsrs(partition)}, but failed with bad ZK version. This will be retried.")
+      }
     }
 
     (finishedUpdates ++ failedElections, updatesToRetry)

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -370,9 +370,11 @@ class ZkReplicaStateMachine(config: KafkaConfig,
         })
       }
 
-    updatesToRetry.foreach { partition =>
-      debug(s"Controller failed to remove replica $replicaId from ISR of partition $partition. " +
-        s"Attempted to write state ${adjustedLeaderAndIsrs(partition)}, but failed with bad ZK version. This will be retried.")
+    if (isDebugEnabled) {
+      updatesToRetry.foreach { partition =>
+        debug(s"Controller failed to remove replica $replicaId from ISR of partition $partition. " +
+          s"Attempted to write state ${adjustedLeaderAndIsrs(partition)}, but failed with bad ZK version. This will be retried.")
+      }
     }
 
     (leaderIsrAndControllerEpochs ++ exceptionsForPartitionsWithNoLeaderAndIsrInZk, updatesToRetry)

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -370,6 +370,11 @@ class ZkReplicaStateMachine(config: KafkaConfig,
         })
       }
 
+    updatesToRetry.foreach { partition =>
+      debug(s"Controller failed to remove replica $replicaId from ISR of partition $partition. " +
+        s"Attempted to write state ${adjustedLeaderAndIsrs(partition)}, but failed with bad ZK version. This will be retried.")
+    }
+
     (leaderIsrAndControllerEpochs ++ exceptionsForPartitionsWithNoLeaderAndIsrInZk, updatesToRetry)
   }
 


### PR DESCRIPTION
When debugging issues with partition state, it's very useful to know the zkVersion that was written. This patch adds the zkVersion of LeaderAndIsr in a few more places.