### PR TITLE
KAFKA-13236: TopologyTestDriver should not crash for EOS-beta config

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -1423,7 +1423,7 @@ public class TopologyTestDriver implements Closeable {
         public TestDriverProducer(final StreamsConfig config,
                                   final KafkaClientSupplier clientSupplier,
                                   final LogContext logContext) {
-            super(config, "TopologyTestDriver-Thread", clientSupplier, new TaskId(0, 0), UUID.randomUUID(), logContext);
+            super(config, "TopologyTestDriver-StreamThread-1", clientSupplier, new TaskId(0, 0), UUID.randomUUID(), logContext);
         }
 
         @Override


### PR DESCRIPTION
Already fixed in `trunk`/`3.0`. Should be cherry-picked to `2.6`, and `2.7`. -- Did not add a test, but we might want to add one for `trunk` ?

@dajac can we include this in 2.8.1 bug-fix release?

Call for review @ableegoldman 