### PR TITLE
KAFKA-13237; Add ActiveBrokerCount and FencedBrokerCount metrics to the ZK controller (KIP-748)

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -128,6 +128,7 @@ class KafkaController(val config: KafkaConfig,
   @volatile private var replicasToDeleteCount = 0
   @volatile private var ineligibleTopicsToDeleteCount = 0
   @volatile private var ineligibleReplicasToDeleteCount = 0
+  @volatile private var activeBrokerCount = 0
 
   /* single-thread scheduler to clean expired tokens */
   private val tokenCleanScheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "delegation-token-cleaner")
@@ -142,6 +143,9 @@ class KafkaController(val config: KafkaConfig,
   newGauge("ReplicasToDeleteCount", () => replicasToDeleteCount)
   newGauge("TopicsIneligibleToDeleteCount", () => ineligibleTopicsToDeleteCount)
   newGauge("ReplicasIneligibleToDeleteCount", () => ineligibleReplicasToDeleteCount)
+  newGauge("ActiveBrokerCount", () => activeBrokerCount)
+  // FencedBrokerCount metric is always 0 in the ZK controller.
+  newGauge("FencedBrokerCount", () => 0)
 
   /**
    * Returns true if this broker is the current controller.
@@ -1459,6 +1463,8 @@ class KafkaController(val config: KafkaConfig,
         controllerContext.replicaState(replica) == ReplicaDeletionIneligible
       }
     }.sum
+
+    activeBrokerCount = if (isActive) controllerContext.liveOrShuttingDownBrokerIds.size else 0
   }
 
   // visible for testing

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -208,6 +208,8 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ReplicasToDeleteCount"), 1)
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=TopicsIneligibleToDeleteCount"), 1)
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ReplicasIneligibleToDeleteCount"), 1)
+    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ActiveBrokerCount"), 1)
+    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=FencedBrokerCount"), 1)
   }
 
   /**


### PR DESCRIPTION
This PR adds the `ActiveBrokerCount` and the `FencedBrokerCount` metrics to the ZK controller. Note that `FencedBrokerCount` is always set to zero in the ZK controller.

`testControllerMetrics` has been extended to ensure that the metrics are exposed. However, I was not able to build a test with multiple brokers to verify the counts due to the shared common yammer metrics registry which is used. I have tested the metrics manually as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
