### PR TITLE
KAFKA-13244: Control Which Brokers Host Partitions of Newly Created Topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicBrokerFilterPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicBrokerFilterPolicy.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.policy;
+
+import org.apache.kafka.common.Configurable;
+
+/**
+ * <p>Determines whether partitions should be placed on brokers as new topics or assignments are created.
+ */
+public interface CreateTopicBrokerFilterPolicy extends Configurable, AutoCloseable {
+    class Broker {
+        private final int brokerId;
+        private final String rack;
+
+        public Broker(final int brokerId, final String rack) {
+            this.brokerId = brokerId;
+            this.rack = rack;
+        }
+
+        public int getBrokerId() {
+            return brokerId;
+        }
+
+        public String getRack() {
+            return rack;
+        }
+
+        @Override
+        public String toString() {
+            return "Broker{" +
+                "brokerId=" + brokerId +
+                ", rack='" + rack + '\'' +
+                '}';
+        }
+    }
+
+    /**
+     * Determines whether partitions should be placed on a broker.
+     * @param broker  a broker in the cluster
+     * @return        <code>true</code> if the broker is allowed to host partitions
+     */
+    boolean isAllowedToHostPartitions(Broker broker);
+}

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -460,6 +460,7 @@ object KafkaConfig {
   val NumRecoveryThreadsPerDataDirProp = "num.recovery.threads.per.data.dir"
   val AutoCreateTopicsEnableProp = "auto.create.topics.enable"
   val MinInSyncReplicasProp = "min.insync.replicas"
+  val CreateTopicBrokerFilterPolicyClassNameProp = "create.topic.broker.filter.policy.class.name"
   val CreateTopicPolicyClassNameProp = "create.topic.policy.class.name"
   val AlterConfigPolicyClassNameProp = "alter.config.policy.class.name"
   val LogMessageDownConversionEnableProp = LogConfigPrefix + "message.downconversion.enable"
@@ -832,6 +833,8 @@ object KafkaConfig {
     "produce with acks of \"all\". This will ensure that the producer raises an exception " +
     "if a majority of replicas do not receive a write."
 
+  val CreateTopicBrokerFilterPolicyClassNameDoc = "The class that determines which brokers partitions should be placed on when a " +
+    "new topic is created. The class should implement the <code>org.apache.kafka.server.policy.CreateTopicBrokerFilterPolicy</code> interface."
   val CreateTopicPolicyClassNameDoc = "The create topic policy class that should be used for validation. The class should " +
     "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface."
   val AlterConfigPolicyClassNameDoc = "The alter configs policy class that should be used for validation. The class should " +
@@ -1157,6 +1160,7 @@ object KafkaConfig {
       .define(LogMessageFormatVersionProp, STRING, Defaults.LogMessageFormatVersion, ApiVersionValidator, MEDIUM, LogMessageFormatVersionDoc)
       .define(LogMessageTimestampTypeProp, STRING, Defaults.LogMessageTimestampType, in("CreateTime", "LogAppendTime"), MEDIUM, LogMessageTimestampTypeDoc)
       .define(LogMessageTimestampDifferenceMaxMsProp, LONG, Defaults.LogMessageTimestampDifferenceMaxMs, MEDIUM, LogMessageTimestampDifferenceMaxMsDoc)
+      .define(CreateTopicBrokerFilterPolicyClassNameProp, CLASS, null, LOW, CreateTopicBrokerFilterPolicyClassNameDoc)
       .define(CreateTopicPolicyClassNameProp, CLASS, null, LOW, CreateTopicPolicyClassNameDoc)
       .define(AlterConfigPolicyClassNameProp, CLASS, null, LOW, AlterConfigPolicyClassNameDoc)
       .define(LogMessageDownConversionEnableProp, BOOLEAN, Defaults.MessageDownConversionEnable, LOW, LogMessageDownConversionEnableDoc)

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithBrokerFilterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithBrokerFilterTest.scala
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util
+import java.util.Properties
+
+import org.apache.kafka.common.requests.MetadataRequest
+import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata
+import org.apache.kafka.server.policy.CreateTopicBrokerFilterPolicy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.{assertTrue, assertEquals}
+
+import scala.jdk.CollectionConverters._
+
+class CreateTopicsRequestWithBrokerFilterTest extends AbstractCreateTopicsRequestTest {
+  import kafka.server.CreateTopicsRequestWithBrokerFilterTest._
+
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    super.brokerPropertyOverrides(properties)
+    properties.put(KafkaConfig.CreateTopicBrokerFilterPolicyClassNameProp, classOf[EvenBrokersOnlyPolicy].getName)
+  }
+
+  @Test
+  def testNewTopicPartitionPlacement(): Unit = {
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic1", numPartitions = 6))))
+    validateTopicPartitionsOnEvenBrokers("topic1")
+  }
+
+  protected def validateTopicPartitionsOnEvenBrokers(topicName: String): Unit = {
+    validateTopicPartitionPlacement(topicName, partitionMeta => {
+      partitionMeta.replicaIds.asScala.foreach { replicaId =>
+        assertTrue(isEven(replicaId), s"Topic ${topicName} on odd replica: ${replicaId}")
+      }
+    })
+  }
+
+  protected def validateTopicPartitionPlacement(topicName: String, predicate: PartitionMetadata => Unit): Unit = {
+    val metadata = sendMetadataRequest(
+      new MetadataRequest.Builder(List(topicName).asJava, true).build()).topicMetadata.asScala
+
+    val metadataForTopic = metadata.filter(_.topic == topicName).head
+
+    metadataForTopic.partitionMetadata().asScala.foreach { partitionMeta => {
+      predicate(partitionMeta)
+    }}
+  }
+}
+
+// test default case: no custom filter is configured
+class CreateTopicsRequestWithoutBrokerFilterTest extends AbstractCreateTopicsRequestTest {
+  @Test
+  def testNewTopicPartitionPlacement(): Unit = {
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic1", numPartitions = 6))))
+    validateTopicPartitionsOnAllBrokers("topic1")
+  }
+
+  protected def validateTopicPartitionsOnAllBrokers(topicName: String): Unit = {
+    val metadata = sendMetadataRequest(
+      new MetadataRequest.Builder(List(topicName).asJava, true).build()).topicMetadata.asScala
+
+    val metadataForTopic = metadata.filter(_.topic == topicName).head
+
+    val brokersWithReplicas = metadataForTopic.partitionMetadata().asScala.flatMap { partitionMeta => {
+      partitionMeta.replicaIds.asScala
+    }}.toSet
+    val allBrokerIds = 0.until(brokerCount).toSet
+
+    assertEquals(allBrokerIds, brokersWithReplicas,
+      s"Partitions for ${topicName} are only on brokers ${brokersWithReplicas} instead of ${allBrokerIds}")
+  }
+}
+
+object CreateTopicsRequestWithBrokerFilterTest {
+  def isEven(num: Int): Boolean = num % 2 == 0
+
+  // a silly implementation for the unit test: only allows partitions to be placed on brokers with even IDs
+  class EvenBrokersOnlyPolicy extends CreateTopicBrokerFilterPolicy {
+    override def isAllowedToHostPartitions(broker: CreateTopicBrokerFilterPolicy.Broker): Boolean =
+      isEven(broker.getBrokerId)
+
+    override def configure(configs: util.Map[String, _]): Unit = {}
+
+    override def close(): Unit = {}
+  }
+}


### PR DESCRIPTION
When new topics are created through the admin interface, the Kafka controller creates the partition assignments for these topics according to the algorithm defined in `AdminUtils.assignReplicasToBrokers`. All (alive) brokers in the cluster become candidates for hosting partitions.

However, sometimes cluster administrators don't want certain brokers to host partitions for newly created topics. This can be for a variety of reasons, e.g.:
- a broker may be on a host that is slated for retirement and about to be shut down
- a broker may be acting as a canary of a new Kafka version and is being tested with a controlled set of topic-partitions, and should be restricted from hosting any other topics
- similarly, a broker may in use for administrative operations, such as dumping log segments, and consequently may be unstable and ideally as little-used as possible

One solution is for the cluster admins to not give out CREATE permissions to clients, and instead provide a service/abstraction for creating new topics with explicit partition assignments. Unfortunately, in a world with Kafka Streams applications, this is too restrictive: Kafka Streams clients expect to use the Kafka tooling to create topics when their topology changes, or when they need to reset their apps.

Since there is currently there is no way to control which brokers are eligible to be assigned newly created partitions, I am proposing a new configuration parameter, `create.topic.broker.filter.policy.class.name` to allow cluster administrators to provide a pluggable class to control whether a broker should be allowed to host new partitions. The class implements a simple interface to give a binary yes/no verdict on each broker:

```java
boolean isAllowedToHostPartitions(Broker broker);
```

This follows a pattern similar to `create.topic.policy.class.name` and `alter.topic.policy.class.name`, which also provide cluster-level control over other aspects of topic creation.

This contribution is my original work and I license the work to the project under the project's open source license.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
