### PR TITLE
KAFKA-13236: TopologyTestDriver should not crash for EOS-beta config

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
@@ -33,7 +33,7 @@ public class TestDriverProducer extends StreamsProducer {
     public TestDriverProducer(final StreamsConfig config,
                               final KafkaClientSupplier clientSupplier,
                               final LogContext logContext) {
-        super(config, "TopologyTestDriver-Thread", clientSupplier, new TaskId(0, 0), UUID.randomUUID(), logContext);
+        super(config, "TopologyTestDriver-StreamThread-1", clientSupplier, new TaskId(0, 0), UUID.randomUUID(), logContext);
     }
 
     @Override


### PR DESCRIPTION
Port of #11271 for 2.7 branch.

Call for review @abbccdda 