### PR TITLE
MINOR:When rebalance times out, print the member's clientHost in the …

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1404,13 +1404,15 @@ class GroupCoordinator(val brokerId: Int,
     group.inLock {
       val notYetRejoinedDynamicMembers = group.notYetRejoinedMembers.filterNot(_._2.isStaticMember)
       if (notYetRejoinedDynamicMembers.nonEmpty) {
-        info(s"Group ${group.groupId} removed dynamic members " +
-          s"who haven't joined: ${notYetRejoinedDynamicMembers.keySet}")
+        val failMembersInfo = new mutable.HashMap[String, String]
 
         notYetRejoinedDynamicMembers.values.foreach { failedMember =>
           group.remove(failedMember.memberId)
           removeHeartbeatForLeavingMember(group, failedMember.memberId)
+          failMembersInfo.put(failedMember.memberId, failedMember.clientHost)
         }
+        info(s"Group ${group.groupId} removed dynamic members " +
+          s"who haven't joined: ${failMembersInfo.mkString("[", ",", "]")}")
       }
 
       if (group.is(Dead)) {


### PR DESCRIPTION
During the operation and maintenance of Kafka cluster, the rebalance timeout is a very serious case, hope to add a clientHost information to help quickly locate which member has a problem.