### PR TITLE
MINOR: Fix redundant static modifier for Ops enum

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2432,7 +2432,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             return listener;
         }
 
-        private static enum Ops {
+        private enum Ops {
             REGISTER, UNREGISTER
         }
 


### PR DESCRIPTION
Ops enum in KafkaRaftClient.Registration has redundant static modifier.