### PR TITLE
KAFKA-10548: Implement topic deletion logic with the LeaderAndIsr in KIP-516

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequestType.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequestType.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum LeaderAndIsrRequestType {
+    UNKNOWN_TYPE((byte) -1, "Unknown type"),
+    INCREMENTAL((byte) 0, "A LeaderAndIsrRequest that is not guaranteed to contain all topic partitions assigned to a broker."),
+    FULL((byte) 1, "A full LeaderAndIsrRequest containing all partitions the broker is a replica for.");
+
+    private static final Map<Byte, LeaderAndIsrRequestType> CODE_TO_TYPE = new HashMap<>();
+
+    static {
+        for (LeaderAndIsrRequestType type : LeaderAndIsrRequestType.values()) {
+            if (CODE_TO_TYPE.put(type.code(), type) != null) {
+                throw new ExceptionInInitializerError("Code " + type.code() + " for LeaderAndIsrRequestType " +
+                    "has already been used");
+            }
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(LeaderAndIsrRequestType.class);
+
+    private final byte code;
+    private final String description;
+
+    LeaderAndIsrRequestType(byte code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public byte code() {
+        return this.code;
+    }
+
+    public String description() {
+        return this.description;
+    }
+
+    public static LeaderAndIsrRequestType forCode(byte code) {
+        LeaderAndIsrRequestType type = CODE_TO_TYPE.get(code);
+        if (type != null) {
+            return type;
+        } else {
+            log.warn("Unexpected code for LeaderAndIsrRequestType: {}", code);
+            return UNKNOWN_TYPE;
+        }
+    }
+}

--- a/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+++ b/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
@@ -38,7 +38,7 @@
       "about": "The current controller epoch." },
     { "name": "BrokerEpoch", "type": "int64", "versions": "2+", "ignorable": true, "default": "-1",
       "about": "The current broker epoch." },
-    { "name": "Type", "type": "int8", "versions": "5+",
+    { "name": "Type", "type": "int8", "versions": "5+", "default": "-1",
       "about": "The type that indicates whether all topics are included in the request"},
     { "name": "UngroupedPartitionStates", "type": "[]LeaderAndIsrPartitionState", "versions": "0-1",
       "about": "The state of each partition, in a v0 or v1 message." },

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -496,11 +496,13 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
           .map(topic => (topic, controllerContext.topicIds.getOrElse(topic, Uuid.ZERO_UUID)))
           .toMap
         val leaderAndIsrRequestBuilder = new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, controllerId,
-          controllerEpoch, brokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava)
+          controllerEpoch, brokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava,
+          controllerContext.shouldSendFullLeaderAndIsr(broker))
         sendRequest(broker, leaderAndIsrRequestBuilder, (r: AbstractResponse) => {
           val leaderAndIsrResponse = r.asInstanceOf[LeaderAndIsrResponse]
           sendEvent(LeaderAndIsrResponseReceived(leaderAndIsrResponse, broker))
         })
+        controllerContext.markLeaderAndIsrSent(broker)
       }
     }
     leaderAndIsrRequestMap.clear()

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -366,12 +366,16 @@ class ControllerContext {
     topicsToBeDeleted
   }
 
+  def replicasInStates(topic: String, expectedStates: Set[ReplicaState]): Set[PartitionAndReplica] = {
+    replicasForTopic(topic).filter(replica => expectedStates.contains(replicaStates(replica))).toSet
+  }
+
   def replicasInState(topic: String, state: ReplicaState): Set[PartitionAndReplica] = {
     replicasForTopic(topic).filter(replica => replicaStates(replica) == state).toSet
   }
 
-  def areAllReplicasInState(topic: String, state: ReplicaState): Boolean = {
-    replicasForTopic(topic).forall(replica => replicaStates(replica) == state)
+  def areAllReplicasInStates(topic: String, expectedStates: Set[ReplicaState]): Boolean = {
+    replicasForTopic(topic).forall(replica => expectedStates.contains(replicaStates(replica)))
   }
 
   def isAnyReplicaInState(topic: String, state: ReplicaState): Boolean = {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -967,12 +967,8 @@ class KafkaController(val config: KafkaConfig,
 
   private def fetchTopicDeletionsInProgress(): (Set[String], Set[String]) = {
     val topicsToBeDeleted = zkClient.getTopicDeletions.toSet
-    val topicsWithOfflineReplicas = controllerContext.allTopics.filter { topic => {
-      val replicasForTopic = controllerContext.replicasForTopic(topic)
-      replicasForTopic.exists(r => !controllerContext.isReplicaOnline(r.replica, r.topicPartition))
-    }}
     val topicsForWhichPartitionReassignmentIsInProgress = controllerContext.partitionsBeingReassigned.map(_.topic)
-    val topicsIneligibleForDeletion = topicsWithOfflineReplicas | topicsForWhichPartitionReassignmentIsInProgress
+    val topicsIneligibleForDeletion = topicsForWhichPartitionReassignmentIsInProgress
     info(s"List of topics to be deleted: ${topicsToBeDeleted.mkString(",")}")
     info(s"List of topics ineligible for deletion: ${topicsIneligibleForDeletion.mkString(",")}")
     (topicsToBeDeleted, topicsIneligibleForDeletion)

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -477,7 +477,7 @@ case object ReplicaDeletionStarted extends ReplicaState {
 
 case object ReplicaDeletionSuccessful extends ReplicaState {
   val state: Byte = 5
-  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted)
+  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted, OfflineReplica)
 }
 
 case object ReplicaDeletionIneligible extends ReplicaState {

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -477,7 +477,7 @@ case object ReplicaDeletionStarted extends ReplicaState {
 
 case object ReplicaDeletionSuccessful extends ReplicaState {
   val state: Byte = 5
-  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted, OfflineReplica)
+  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted)
 }
 
 case object ReplicaDeletionIneligible extends ReplicaState {
@@ -487,5 +487,5 @@ case object ReplicaDeletionIneligible extends ReplicaState {
 
 case object NonExistentReplica extends ReplicaState {
   val state: Byte = 7
-  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionSuccessful)
+  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionSuccessful, OfflineReplica)
 }

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -285,7 +285,6 @@ class TopicDeletionManager(config: KafkaConfig,
   private def onPartitionDeletion(topicsToBeDeleted: Set[String]): Unit = {
     val allDeadReplicas = mutable.ListBuffer.empty[PartitionAndReplica]
     val allReplicasForDeletionRetry = mutable.ListBuffer.empty[PartitionAndReplica]
-    val allTopicsIneligibleForDeletion = mutable.Set.empty[String]
 
     topicsToBeDeleted.foreach { topic =>
       val (aliveReplicas, deadReplicas) = controllerContext.replicasForTopic(topic).partition { r =>
@@ -300,19 +299,14 @@ class TopicDeletionManager(config: KafkaConfig,
 
       if (deadReplicas.nonEmpty) {
         debug(s"Dead Replicas (${deadReplicas.mkString(",")}) found for topic $topic")
-        allTopicsIneligibleForDeletion += topic
       }
     }
 
-    // move dead replicas directly to failed state
-    replicaStateMachine.handleStateChanges(allDeadReplicas, ReplicaDeletionIneligible)
+    // move dead replicas directly to deletion successful state
+    replicaStateMachine.handleStateChanges(allDeadReplicas, ReplicaDeletionSuccessful)
     // send stop replica to all followers that are not in the OfflineReplica state so they stop sending fetch requests to the leader
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, OfflineReplica)
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, ReplicaDeletionStarted)
-
-    if (allTopicsIneligibleForDeletion.nonEmpty) {
-      markTopicIneligibleForDeletion(allTopicsIneligibleForDeletion, reason = "offline replicas")
-    }
   }
 
   private def resumeDeletions(): Unit = {

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1694,6 +1694,83 @@ class ControllerIntegrationTest extends QuorumTestHarness {
   }
 
   @Test
+  def testTopicDeletionWithOfflineBrokers(): Unit = {
+    val tp = new TopicPartition("t", 0)
+    val adminZkClient = new AdminZkClient(zkClient)
+
+    servers = makeServers(2)
+    TestUtils.createTopic(zkClient, tp.topic, 1, 2, servers)
+    val topicId1 = zkClient.getTopicIdsForTopics(Set(tp.topic())).get(tp.topic())
+
+    // shutdown one broker and then delete the topic
+    val broker0 = servers.find(_.config.brokerId == 0).get
+    broker0.shutdown()
+    broker0.awaitShutdown()
+    adminZkClient.deleteTopic(tp.topic())
+    val broker1 = servers.find(_.config.brokerId == 1).get
+    TestUtils.waitUntilTrue(() => {
+      !broker1.replicaManager.getLog(tp).isDefined
+    }, "The replica on broker1 cannot be deleted")
+    TestUtils.waitUntilTrue(() => {
+      !zkClient.pathExists(TopicZNode.path(tp.topic()))
+    }, s"The topic ${tp.topic} is not removed from zookeeper")
+
+    // recreate the topic and wait until broker1 get the log recreated
+    val assignment = Map(tp.partition -> Seq(0, 1))
+    adminZkClient.createTopicWithAssignment(tp.topic, config = new Properties(), assignment)
+    TestUtils.waitUntilTrue(() => {
+      broker1.replicaManager.getLog(tp).isDefined
+    }, "The replica on broker1 cannot be deleted")
+    val topicId2 = zkClient.getTopicIdsForTopics(Set(tp.topic())).get(tp.topic())
+    assertNotEquals(topicId2, topicId1, "Topic IDs across generations should not be the same")
+
+    // restart the offline broker0, and wait until convergence of topic ID on all brokers
+    broker0.startup()
+    TestUtils.waitUntilTrue(() => {
+      servers.forall{s => {
+        val logOpt = s.replicaManager.getLog(tp)
+        if (logOpt.isDefined) {
+          logOpt.get.topicId == topicId2
+        } else {
+          false
+        }
+      }}
+    }, s"Not every online broker has the correct topic ID for topic ${tp.topic()}")
+  }
+
+  @Test
+  def testDeletionOfStrayPartitions(): Unit = {
+    val tp = new TopicPartition("t1", 0)
+    val adminZkClient = new AdminZkClient(zkClient)
+
+    servers = makeServers(2)
+    TestUtils.createTopic(zkClient, tp.topic, 1, 2, servers)
+    TestUtils.waitUntilTrue(() => {
+      servers.forall{server => server.replicaManager.getLog(tp).isDefined}
+    }, "The replica on broker1 cannot be deleted")
+
+    // shutdown one broker and then delete the topic
+    val broker0 = servers.find(_.config.brokerId == 0).get
+    broker0.shutdown()
+    broker0.awaitShutdown()
+    adminZkClient.deleteTopic(tp.topic())
+    TestUtils.waitUntilTrue(() => {
+      !zkClient.pathExists(TopicZNode.path(tp.topic()))
+    }, "The replica on broker1 cannot be deleted")
+
+
+    // restart the offline broker and make sure the stray partitions will be deleted
+    broker0.startup()
+    val topic2 = "t2"
+    // create another topic to ensure at least one LeaderAndIsr request is being sent to the restarted broker
+    TestUtils.createTopic(zkClient, topic2, 1, 2, servers)
+
+    TestUtils.waitUntilTrue(() => {
+      !broker0.replicaManager.getLog(tp).isDefined
+    }, "The replica on broker0 cannot be deleted", waitTimeMs = 20000)
+  }
+
+  @Test
   def testTopicIdUpgradeAfterReassigningPartitions(): Unit = {
     val tp = new TopicPartition("t", 0)
     val reassignment = Map(tp -> Some(Seq(0)))

--- a/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
@@ -290,6 +290,11 @@ class ReplicaStateMachineTest {
   }
 
   @Test
+  def testInvalidOfflineReplicaToReplicaDeletionSuccessfulTransition(): Unit = {
+    testInvalidTransition(OfflineReplica, ReplicaDeletionSuccessful)
+  }
+
+  @Test
   def testInvalidReplicaDeletionStartedToNonexistentReplicaTransition(): Unit = {
     testInvalidTransition(ReplicaDeletionStarted, NonExistentReplica)
   }

--- a/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
@@ -290,11 +290,6 @@ class ReplicaStateMachineTest {
   }
 
   @Test
-  def testInvalidOfflineReplicaToReplicaDeletionSuccessfulTransition(): Unit = {
-    testInvalidTransition(OfflineReplica, ReplicaDeletionSuccessful)
-  }
-
-  @Test
   def testInvalidReplicaDeletionStartedToNonexistentReplicaTransition(): Unit = {
     testInvalidTransition(ReplicaDeletionStarted, NonExistentReplica)
   }

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -119,7 +119,7 @@ class TopicDeletionManagerTest {
 
     assertEquals(1, replicaStateMachine.stateChangesCalls(OfflineReplica))
     assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionStarted))
-    assertEquals(2, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
+    assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
   }
 
   @Test
@@ -161,7 +161,7 @@ class TopicDeletionManagerTest {
     assertEquals(fooPartitions, controllerContext.partitionsInState("foo", NonExistentPartition))
     verify(deletionClient).sendMetadataUpdate(fooPartitions)
     assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
+    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", OfflineReplica))
 
     assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
     assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
@@ -175,6 +175,7 @@ class TopicDeletionManagerTest {
     assertEquals(Set(), controllerContext.topicsToBeDeleted)
     assertEquals(Set(), controllerContext.topicsWithDeletionStarted)
     assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
+    assertFalse(controllerContext.allTopics.contains("foo"))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -117,10 +117,9 @@ class TopicDeletionManagerTest {
     assertEquals(1, partitionStateMachine.stateChangesCalls(OfflinePartition))
     assertEquals(1, partitionStateMachine.stateChangesCalls(NonExistentPartition))
 
-    assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionIneligible))
     assertEquals(1, replicaStateMachine.stateChangesCalls(OfflineReplica))
     assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionStarted))
-    assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
+    assertEquals(2, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
   }
 
   @Test
@@ -151,8 +150,6 @@ class TopicDeletionManagerTest {
 
     // Broker 2 is taken offline
     val failedBrokerId = 2
-    val offlineBroker = controllerContext.liveOrShuttingDownBroker(failedBrokerId).get
-    val lastEpoch = controllerContext.liveBrokerIdAndEpochs(failedBrokerId)
     controllerContext.removeLiveBrokers(Set(failedBrokerId))
     assertEquals(Set(1, 3), controllerContext.liveBrokerIds)
 
@@ -164,30 +161,15 @@ class TopicDeletionManagerTest {
     assertEquals(fooPartitions, controllerContext.partitionsInState("foo", NonExistentPartition))
     verify(deletionClient).sendMetadataUpdate(fooPartitions)
     assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionIneligible))
+    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
 
     assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
     assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
-    assertEquals(Set("foo"), controllerContext.topicsIneligibleForDeletion)
+    assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
 
     // Deletion succeeds for online replicas
     deletionManager.completeReplicaDeletion(onlineReplicas)
 
-    assertEquals(fooPartitions, controllerContext.partitionsInState("foo", NonExistentPartition))
-    assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
-    assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
-    assertEquals(Set("foo"), controllerContext.topicsIneligibleForDeletion)
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", OfflineReplica))
-
-    // Broker 2 comes back online and deletion is resumed
-    controllerContext.addLiveBrokers(Map(offlineBroker -> (lastEpoch + 1L)))
-    deletionManager.resumeDeletionForTopics(Set("foo"))
-
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-
-    deletionManager.completeReplicaDeletion(offlineReplicas)
     assertEquals(Set.empty, controllerContext.partitionsForTopic("foo"))
     assertEquals(Set.empty[PartitionAndReplica], controllerContext.replicaStates.keySet.filter(_.topic == "foo"))
     assertEquals(Set(), controllerContext.topicsToBeDeleted)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1493,8 +1493,7 @@ object TestUtils extends Logging {
     waitUntilTrue(() =>
       brokers.forall(broker => topicPartitions.forall(tp => broker.replicaManager.onlinePartition(tp).isEmpty)),
       "Replica manager's should have deleted all of this topic's partitions")
-    // ensure that logs from all replicas are deleted if delete topic is marked successful in ZooKeeper
-    assertTrue(brokers.forall(broker => topicPartitions.forall(tp => broker.logManager.getLog(tp).isEmpty)),
+    waitUntilTrue(() => brokers.forall(broker => topicPartitions.forall(tp => broker.logManager.getLog(tp).isEmpty)),
       "Replica logs not deleted after delete topic is complete")
     // ensure that topic is removed from all cleaner offsets
     waitUntilTrue(() => brokers.forall(broker => topicPartitions.forall { tp =>


### PR DESCRIPTION
This PR includes the following changes
1. Adding the type field to the LeaderAndIsr request as proposed in KIP-516
2. Letting the controller set the type of LeaderAndIsr requests to be either FULL or INCREMENTAL
3. Allowing topic deletion to complete even with offline brokers
4. Schedule the deletion of replicas with inconsistent topic IDs or not present in the full LeaderAndIsr request

Testing Strategy:
This PR added two tests 
1. testTopicDeletionWithOfflineBrokers: to ensure that topic deletion can proceed even with offline brokers 
2. testDeletionOfStrayPartitions: to ensure stray replicas whose topic has been deleted will be removed upon broker startup

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
