### PR TITLE
KAFKA-13258/13259/13260: Fix error response generation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasRequest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.message.AlterClientQuotasRequestData.OpData;
 import org.apache.kafka.common.message.AlterClientQuotasResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 
@@ -117,6 +118,7 @@ public class AlterClientQuotasRequest extends AbstractRequest {
 
     @Override
     public AlterClientQuotasResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Errors error = Errors.forException(e);
         List<AlterClientQuotasResponseData.EntryData> responseEntries = new ArrayList<>();
         for (EntryData entryData : data.entries()) {
             List<AlterClientQuotasResponseData.EntityData> responseEntities = new ArrayList<>();
@@ -125,7 +127,10 @@ public class AlterClientQuotasRequest extends AbstractRequest {
                     .setEntityType(entityData.entityType())
                     .setEntityName(entityData.entityName()));
             }
-            responseEntries.add(new AlterClientQuotasResponseData.EntryData().setEntity(responseEntities));
+            responseEntries.add(new AlterClientQuotasResponseData.EntryData()
+                    .setEntity(responseEntities)
+                    .setErrorCode(error.code())
+                    .setErrorMessage(error.message()));
         }
         AlterClientQuotasResponseData responseData = new AlterClientQuotasResponseData()
                 .setThrottleTimeMs(throttleTimeMs)

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasRequest.java
@@ -128,9 +128,9 @@ public class AlterClientQuotasRequest extends AbstractRequest {
                     .setEntityName(entityData.entityName()));
             }
             responseEntries.add(new AlterClientQuotasResponseData.EntryData()
-                    .setEntity(responseEntities)
-                    .setErrorCode(error.code())
-                    .setErrorMessage(error.message()));
+                .setEntity(responseEntities)
+                .setErrorCode(error.code())
+                .setErrorMessage(error.message()));
         }
         AlterClientQuotasResponseData responseData = new AlterClientQuotasResponseData()
                 .setThrottleTimeMs(throttleTimeMs)

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersRequest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DescribeProducersRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DescribeProducersRequest> {
@@ -69,7 +71,7 @@ public class DescribeProducersRequest extends AbstractRequest {
     @Override
     public DescribeProducersResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         Errors error = Errors.forException(e);
-        DescribeProducersResponseData response = new DescribeProducersResponseData();
+        List<TopicResponse> topics = new ArrayList<>();
         for (TopicRequest topicRequest : data.topics()) {
             TopicResponse topicResponse = new TopicResponse()
                 .setName(topicRequest.name());
@@ -80,7 +82,10 @@ public class DescribeProducersRequest extends AbstractRequest {
                         .setErrorCode(error.code())
                 );
             }
+            topics.add(topicResponse);
         }
+        DescribeProducersResponseData response = new DescribeProducersResponseData()
+                .setTopics(topics);
         return new DescribeProducersResponse(response);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersRequest.java
@@ -26,8 +26,6 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 public class DescribeProducersRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DescribeProducersRequest> {
@@ -71,7 +69,7 @@ public class DescribeProducersRequest extends AbstractRequest {
     @Override
     public DescribeProducersResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         Errors error = Errors.forException(e);
-        List<TopicResponse> topics = new ArrayList<>();
+        DescribeProducersResponseData response = new DescribeProducersResponseData();
         for (TopicRequest topicRequest : data.topics()) {
             TopicResponse topicResponse = new TopicResponse()
                 .setName(topicRequest.name());
@@ -82,10 +80,8 @@ public class DescribeProducersRequest extends AbstractRequest {
                         .setErrorCode(error.code())
                 );
             }
-            topics.add(topicResponse);
+            response.topics().add(topicResponse);
         }
-        DescribeProducersResponseData response = new DescribeProducersResponseData()
-                .setTopics(topics);
         return new DescribeProducersResponse(response);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.protocol.Errors;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -73,7 +74,15 @@ public class FindCoordinatorResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(error());
+        if (!data.coordinators().isEmpty()) {
+            Map<Errors, Integer> errorCounts = new HashMap<>();
+            for (Coordinator coordinator : data.coordinators()) {
+                updateErrorCounts(errorCounts, Errors.forCode(coordinator.errorCode()));
+            }
+            return errorCounts;
+        } else {
+            return errorCounts(error());
+        }
     }
 
     public static FindCoordinatorResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -706,6 +706,8 @@ public class RequestResponseTest {
     private void checkErrorResponse(AbstractRequest req, Throwable e, boolean checkEqualityAndHashCode) {
         AbstractResponse response = req.getErrorResponse(e);
         checkResponse(response, req.version(), checkEqualityAndHashCode);
+        Map<Errors, Integer> errorCounts = response.errorCounts();
+        assertTrue(errorCounts.containsKey(Errors.forException(e)), "API Key " + req.apiKey().name + "V" + req.version() + " failed errorCounts test");
         if (e instanceof UnknownServerException) {
             String responseStr = response.toString();
             assertFalse(responseStr.contains(e.getMessage()),
@@ -803,7 +805,6 @@ public class RequestResponseTest {
         assertFalse(request.toString(true).contains("numPartitions"));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void produceRequestGetErrorResponseTest() {
         ProduceRequest request = createProduceRequest(ApiKeys.PRODUCE.latestVersion());
@@ -1758,7 +1759,6 @@ public class RequestResponseTest {
             Collections.singletonMap("group1", responseData));
     }
 
-    @SuppressWarnings("deprecation")
     private ProduceRequest createProduceRequest(int version) {
         if (version < 2)
             throw new IllegalArgumentException("Produce request version 2 is not supported");
@@ -2881,6 +2881,7 @@ public class RequestResponseTest {
     private DescribeProducersRequest createDescribeProducersRequest(short version) {
         DescribeProducersRequestData data = new DescribeProducersRequestData();
         DescribeProducersRequestData.TopicRequest topicRequest = new DescribeProducersRequestData.TopicRequest();
+        topicRequest.setName("test");
         topicRequest.partitionIndexes().add(0);
         topicRequest.partitionIndexes().add(1);
         data.topics().add(topicRequest);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -706,8 +706,11 @@ public class RequestResponseTest {
     private void checkErrorResponse(AbstractRequest req, Throwable e, boolean checkEqualityAndHashCode) {
         AbstractResponse response = req.getErrorResponse(e);
         checkResponse(response, req.version(), checkEqualityAndHashCode);
+        Errors error = Errors.forException(e);
         Map<Errors, Integer> errorCounts = response.errorCounts();
-        assertTrue(errorCounts.containsKey(Errors.forException(e)), "API Key " + req.apiKey().name + "V" + req.version() + " failed errorCounts test");
+        assertEquals(1, errorCounts.size());
+        assertTrue(errorCounts.containsKey(error), "API Key " + req.apiKey().name + " v" + req.version() + " failed errorCounts test");
+        assertTrue(errorCounts.get(error) > 0);
         if (e instanceof UnknownServerException) {
             String responseStr = response.toString();
             assertFalse(responseStr.contains(e.getMessage()),

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -708,8 +708,8 @@ public class RequestResponseTest {
         checkResponse(response, req.version(), checkEqualityAndHashCode);
         Errors error = Errors.forException(e);
         Map<Errors, Integer> errorCounts = response.errorCounts();
-        assertEquals(1, errorCounts.size());
-        assertTrue(errorCounts.containsKey(error), "API Key " + req.apiKey().name + " v" + req.version() + " failed errorCounts test");
+        assertEquals(Collections.singleton(error), errorCounts.keySet(),
+            "API Key " + req.apiKey().name + " v" + req.version() + " failed errorCounts test");
         assertTrue(errorCounts.get(error) > 0);
         if (e instanceof UnknownServerException) {
             String responseStr = response.toString();


### PR DESCRIPTION
AlterClientQuotas, DescribeProducers and FindCoordinator have issues when building error responses. This can lead to brokers returning responses without errors even when some have happened.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
