### PR TITLE
KAFKA-13254: Fix deadlock when AlterIsr response returns

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -769,7 +769,7 @@ class Partition(val topicPartition: TopicPartition,
       }
       // Send the AlterIsr request outside of the LeaderAndIsr lock since the completion logic
       // may increment the high watermark (and consequently complete delayed operations).
-      alterIsrUpdateOpt.foreach(alterIsr)
+      alterIsrUpdateOpt.foreach(submitAlterIsr)
     }
   }
 
@@ -952,7 +952,7 @@ class Partition(val topicPartition: TopicPartition,
       }
       // Send the AlterIsr request outside of the LeaderAndIsr lock since the completion logic
       // may increment the high watermark (and consequently complete delayed operations).
-      alterIsrUpdateOpt.foreach(alterIsr)
+      alterIsrUpdateOpt.foreach(submitAlterIsr)
     }
   }
 
@@ -1347,7 +1347,7 @@ class Partition(val topicPartition: TopicPartition,
     updatedState
   }
 
-  private def alterIsr(proposedIsrState: PendingIsrChange): CompletableFuture[LeaderAndIsr] = {
+  private def submitAlterIsr(proposedIsrState: PendingIsrChange): CompletableFuture[LeaderAndIsr] = {
     debug(s"Submitting ISR state change $proposedIsrState")
     val future = alterIsrManager.submit(topicPartition, proposedIsrState.sentLeaderAndIsr, controllerEpoch)
     future.whenComplete { (leaderAndIsr, e) =>
@@ -1375,7 +1375,7 @@ class Partition(val topicPartition: TopicPartition,
       // Send the AlterIsr request outside of the LeaderAndIsr lock since the completion logic
       // may increment the high watermark (and consequently complete delayed operations).
       if (shouldRetry) {
-        alterIsr(proposedIsrState)
+        submitAlterIsr(proposedIsrState)
       }
     }
   }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -18,6 +18,8 @@ package kafka.cluster
 
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.Optional
+import java.util.concurrent.CompletableFuture
+
 import kafka.api.{ApiVersion, LeaderAndIsr}
 import kafka.common.UnexpectedAppendOffsetException
 import kafka.controller.{KafkaController, StateChangeLogger}
@@ -150,30 +152,38 @@ sealed trait IsrState {
   def isInflight: Boolean
 }
 
+sealed trait PendingIsrChange extends IsrState {
+  def sentLeaderAndIsr: LeaderAndIsr
+}
+
 case class PendingExpandIsr(
   isr: Set[Int],
-  newInSyncReplicaId: Int
-) extends IsrState {
+  newInSyncReplicaId: Int,
+  sentLeaderAndIsr: LeaderAndIsr
+) extends PendingIsrChange {
   val maximalIsr = isr + newInSyncReplicaId
   val isInflight = true
 
   override def toString: String = {
     s"PendingExpandIsr(isr=$isr" +
       s", newInSyncReplicaId=$newInSyncReplicaId" +
+      s", sentLeaderAndIsr=$sentLeaderAndIsr" +
       ")"
   }
 }
 
 case class PendingShrinkIsr(
   isr: Set[Int],
-  outOfSyncReplicaIds: Set[Int]
-) extends IsrState  {
+  outOfSyncReplicaIds: Set[Int],
+  sentLeaderAndIsr: LeaderAndIsr
+) extends PendingIsrChange  {
   val maximalIsr = isr
   val isInflight = true
 
   override def toString: String = {
     s"PendingShrinkIsr(isr=$isr" +
       s", outOfSyncReplicaIds=$outOfSyncReplicaIds" +
+      s", sentLeaderAndIsr=$sentLeaderAndIsr" +
       ")"
   }
 }
@@ -669,7 +679,7 @@ class Partition(val topicPartition: TopicPartition,
         val leaderLWIncremented = newLeaderLW > oldLeaderLW
 
         // Check if this in-sync replica needs to be added to the ISR.
-        maybeExpandIsr(followerReplica, followerFetchTimeMs)
+        maybeExpandIsr(followerReplica)
 
         // check if the HW of the partition can now be incremented
         // since the replica may already be in the ISR and its LEO has just incremented
@@ -744,17 +754,22 @@ class Partition(val topicPartition: TopicPartition,
    *
    * This function can be triggered when a replica's LEO has incremented.
    */
-  private def maybeExpandIsr(followerReplica: Replica, followerFetchTimeMs: Long): Unit = {
-    val needsIsrUpdate = canAddReplicaToIsr(followerReplica.brokerId) && inReadLock(leaderIsrUpdateLock) {
+  private def maybeExpandIsr(followerReplica: Replica): Unit = {
+    val needsIsrUpdate = !isrState.isInflight && canAddReplicaToIsr(followerReplica.brokerId) && inReadLock(leaderIsrUpdateLock) {
       needsExpandIsr(followerReplica)
     }
     if (needsIsrUpdate) {
-      inWriteLock(leaderIsrUpdateLock) {
+      val alterIsrUpdateOpt = inWriteLock(leaderIsrUpdateLock) {
         // check if this replica needs to be added to the ISR
-        if (needsExpandIsr(followerReplica)) {
-          expandIsr(followerReplica.brokerId)
+        if (!isrState.isInflight && needsExpandIsr(followerReplica)) {
+          Some(prepareIsrExpand(followerReplica.brokerId))
+        } else {
+          None
         }
       }
+      // Send the AlterIsr request outside of the LeaderAndIsr lock since the completion logic
+      // may increment the high watermark (and consequently complete delayed operations).
+      alterIsrUpdateOpt.foreach(alterIsr)
     }
   }
 
@@ -914,10 +929,10 @@ class Partition(val topicPartition: TopicPartition,
     }
 
     if (needsIsrUpdate) {
-      inWriteLock(leaderIsrUpdateLock) {
-        leaderLogIfLocal.foreach { leaderLog =>
+      val alterIsrUpdateOpt = inWriteLock(leaderIsrUpdateLock) {
+        leaderLogIfLocal.flatMap { leaderLog =>
           val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
-          if (outOfSyncReplicaIds.nonEmpty) {
+          if (!isrState.isInflight && outOfSyncReplicaIds.nonEmpty) {
             val outOfSyncReplicaLog = outOfSyncReplicaIds.map { replicaId =>
               val logEndOffsetMessage = getReplica(replicaId)
                 .map(_.logEndOffset.toString)
@@ -929,11 +944,15 @@ class Partition(val topicPartition: TopicPartition,
               s"Leader: (highWatermark: ${leaderLog.highWatermark}, " +
               s"endOffset: ${leaderLog.logEndOffset}). " +
               s"Out of sync replicas: $outOfSyncReplicaLog.")
-
-            shrinkIsr(outOfSyncReplicaIds)
+            Some(prepareIsrShrink(outOfSyncReplicaIds))
+          } else {
+            None
           }
         }
       }
+      // Send the AlterIsr request outside of the LeaderAndIsr lock since the completion logic
+      // may increment the high watermark (and consequently complete delayed operations).
+      alterIsrUpdateOpt.foreach(alterIsr)
     }
   }
 
@@ -1304,53 +1323,41 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  private[cluster] def expandIsr(newInSyncReplica: Int): Unit = {
-    // This is called from maybeExpandIsr which holds the ISR write lock
-    if (!isrState.isInflight) {
-      // When expanding the ISR, we can safely assume the new replica will make it into the ISR since this puts us in
-      // a more constrained state for advancing the HW.
-      sendAlterIsrRequest(PendingExpandIsr(isrState.isr, newInSyncReplica))
-    } else {
-      trace(s"ISR update in-flight, not adding new in-sync replica $newInSyncReplica")
-    }
-  }
-
-  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int]): Unit = {
-    // This is called from maybeShrinkIsr which holds the ISR write lock
-    if (!isrState.isInflight) {
-      // When shrinking the ISR, we cannot assume that the update will succeed as this could erroneously advance the HW
-      // We update pendingInSyncReplicaIds here simply to prevent any further ISR updates from occurring until we get
-      // the next LeaderAndIsr
-      sendAlterIsrRequest(PendingShrinkIsr(isrState.isr, outOfSyncReplicas))
-    } else {
-      trace(s"ISR update in-flight, not removing out-of-sync replicas $outOfSyncReplicas")
-    }
-  }
-
-  private def sendAlterIsrRequest(proposedIsrState: IsrState): Unit = {
-    val isrToSend: Set[Int] = proposedIsrState match {
-      case PendingExpandIsr(isr, newInSyncReplicaId) => isr + newInSyncReplicaId
-      case PendingShrinkIsr(isr, outOfSyncReplicaIds) => isr -- outOfSyncReplicaIds
-      case state =>
-        isrChangeListener.markFailed()
-        throw new IllegalStateException(s"Invalid state $state for ISR change for partition $topicPartition")
-    }
-
+  private def prepareIsrExpand(newInSyncReplicaId: Int): PendingExpandIsr = {
+    // When expanding the ISR, we assume that the new replica will make it into the ISR
+    // before we receive confirmation that it has. This ensures that the HW will already
+    // reflect the updated ISR even if there is a delay before we receive the confirmation.
+    // Alternatively, if the update fails, no harm is done since the expanded ISR puts
+    // a stricter requirement for advancement of the HW.
+    val isrToSend = isrState.isr + newInSyncReplicaId
     val newLeaderAndIsr = new LeaderAndIsr(localBrokerId, leaderEpoch, isrToSend.toList, zkVersion)
-    val alterIsrItem = AlterIsrItem(topicPartition, newLeaderAndIsr, handleAlterIsrResponse(proposedIsrState), controllerEpoch)
+    val updatedState = PendingExpandIsr(isrState.isr, newInSyncReplicaId, newLeaderAndIsr)
+    isrState = updatedState
+    updatedState
+  }
 
-    val oldState = isrState
-    isrState = proposedIsrState
+  private[cluster] def prepareIsrShrink(outOfSyncReplicaIds: Set[Int]): PendingShrinkIsr = {
+    // When shrinking the ISR, we cannot assume that the update will succeed as this could
+    // erroneously advance the HW if the `AlterIsr` were to fail. Hence the "maximal ISR"
+    // for `PendingShrinkIsr` is the the current ISR.
+    val isrToSend = isrState.isr -- outOfSyncReplicaIds
+    val newLeaderAndIsr = new LeaderAndIsr(localBrokerId, leaderEpoch, isrToSend.toList, zkVersion)
+    val updatedState = PendingShrinkIsr(isrState.isr, outOfSyncReplicaIds, newLeaderAndIsr)
+    isrState = updatedState
+    updatedState
+  }
 
-    if (!alterIsrManager.submit(alterIsrItem)) {
-      // If the ISR manager did not accept our update, we need to revert the proposed state.
-      // This can happen if the ISR state was updated by the controller (via LeaderAndIsr in ZK-mode or
-      // ChangePartitionRecord in KRaft mode) but we have an AlterIsr request still in-flight.
-      isrState = oldState
-      isrChangeListener.markFailed()
-      warn(s"Failed to enqueue ISR change state $newLeaderAndIsr for partition $topicPartition")
-    } else {
-      debug(s"Enqueued ISR change to state $newLeaderAndIsr after transition to $proposedIsrState")
+  private def alterIsr(proposedIsrState: PendingIsrChange): CompletableFuture[LeaderAndIsr] = {
+    debug(s"Submitting ISR state change $proposedIsrState")
+    val future = alterIsrManager.submit(topicPartition, proposedIsrState.sentLeaderAndIsr, controllerEpoch)
+
+    val callback = handleAlterIsrResponse(proposedIsrState) _
+    future.whenComplete { (leaderAndIsr, e) =>
+      if (leaderAndIsr != null) {
+        callback(Right(leaderAndIsr))
+      } else {
+        callback(Left(Errors.forException(e)))
+      }
     }
   }
 
@@ -1360,41 +1367,46 @@ class Partition(val topicPartition: TopicPartition,
    * Since our error was non-retryable we are okay staying in this state until we see new metadata from UpdateMetadata
    * or LeaderAndIsr
    */
-  private def handleAlterIsrResponse(proposedIsrState: IsrState)(result: Either[Errors, LeaderAndIsr]): Unit = {
-    val hwIncremented = inWriteLock(leaderIsrUpdateLock) {
+  private def handleAlterIsrResponse(proposedIsrState: PendingIsrChange)(result: Either[Errors, LeaderAndIsr]): Unit = {
+    var hwIncremented = false
+    var shouldRetry = false
+
+    inWriteLock(leaderIsrUpdateLock) {
       if (isrState != proposedIsrState) {
         // This means isrState was updated through leader election or some other mechanism before we got the AlterIsr
         // response. We don't know what happened on the controller exactly, but we do know this response is out of date
         // so we ignore it.
         debug(s"Ignoring failed ISR update to $proposedIsrState since we have already updated state to $isrState")
-        false
       } else {
         result match {
           case Left(error: Errors) =>
             isrChangeListener.markFailed()
             error match {
+              case Errors.OPERATION_NOT_ATTEMPTED =>
+                // Since the operation was not attempted, it is safe to reset back to the committed state.
+                isrState = CommittedIsr(proposedIsrState.isr)
+                debug(s"Failed to update ISR to $proposedIsrState since there is a pending ISR update still inflight. " +
+                  s"ISR state has been reset to the latest committed state $isrState")
               case Errors.UNKNOWN_TOPIC_OR_PARTITION =>
-                debug(s"Failed to update ISR to $proposedIsrState since it doesn't know about this topic or partition. Giving up.")
+                debug(s"Failed to update ISR to $proposedIsrState since the controller doesn't know about " +
+                  "this topic or partition. Giving up.")
               case Errors.FENCED_LEADER_EPOCH =>
-                debug(s"Failed to update ISR to $proposedIsrState since we sent an old leader epoch. Giving up.")
+                debug(s"Failed to update ISR to $proposedIsrState since the leader epoch is old. Giving up.")
               case Errors.INVALID_UPDATE_VERSION =>
-                debug(s"Failed to update ISR to $proposedIsrState due to invalid version. Giving up.")
+                debug(s"Failed to update ISR to $proposedIsrState because the version is invalid. Giving up.")
               case _ =>
                 warn(s"Failed to update ISR to $proposedIsrState due to unexpected $error. Retrying.")
-                sendAlterIsrRequest(proposedIsrState)
+                shouldRetry = true
             }
-            false
 
           case Right(leaderAndIsr: LeaderAndIsr) =>
             // Success from controller, still need to check a few things
             if (leaderAndIsr.leaderEpoch != leaderEpoch) {
-              debug(s"Ignoring new ISR ${leaderAndIsr} since we have a stale leader epoch $leaderEpoch.")
+              debug(s"Ignoring new ISR $leaderAndIsr since we have a stale leader epoch $leaderEpoch.")
               isrChangeListener.markFailed()
-              false
             } else if (leaderAndIsr.zkVersion < zkVersion) {
-              debug(s"Ignoring new ISR ${leaderAndIsr} since we have a newer version $zkVersion.")
+              debug(s"Ignoring new ISR $leaderAndIsr since we have a newer version $zkVersion.")
               isrChangeListener.markFailed()
-              false
             } else {
               // This is one of two states:
               //   1) leaderAndIsr.zkVersion > zkVersion: Controller updated to new version with proposedIsrState.
@@ -1404,14 +1416,15 @@ class Partition(val topicPartition: TopicPartition,
               isrState = CommittedIsr(leaderAndIsr.isr.toSet)
               zkVersion = leaderAndIsr.zkVersion
               info(s"ISR updated to ${isrState.isr.mkString(",")} and version updated to [$zkVersion]")
+
               proposedIsrState match {
-                case PendingExpandIsr(_, _) => isrChangeListener.markExpand()
-                case PendingShrinkIsr(_, _) => isrChangeListener.markShrink()
+                case PendingExpandIsr(_, _, _) => isrChangeListener.markExpand()
+                case PendingShrinkIsr(_, _, _) => isrChangeListener.markShrink()
                 case _ => // nothing to do, shouldn't get here
               }
 
               // we may need to increment high watermark since ISR could be down to 1
-              leaderLogIfLocal.exists(log => maybeIncrementLeaderHW(log))
+              hwIncremented = leaderLogIfLocal.exists(log => maybeIncrementLeaderHW(log))
             }
         }
       }
@@ -1419,6 +1432,12 @@ class Partition(val topicPartition: TopicPartition,
 
     if (hwIncremented) {
       tryCompleteDelayedRequests()
+    }
+
+    // Send the AlterIsr request outside of the LeaderAndIsr lock since the completion logic
+    // may increment the high watermark (and consequently complete delayed operations).
+    if (shouldRetry) {
+      alterIsr(proposedIsrState)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -18,10 +18,10 @@
 package kafka.cluster
 
 import java.util.Properties
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
 
-import kafka.api.ApiVersion
+import kafka.api.{ApiVersion, LeaderAndIsr}
 import kafka.log._
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpoints
@@ -29,16 +29,16 @@ import kafka.server.epoch.LeaderEpochFileCache
 import kafka.server.metadata.MockConfigRepository
 import kafka.utils._
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
-import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{mock, when}
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 /**
  * Verifies that slow appends to log don't block request threads processing replica fetch requests.
@@ -271,10 +271,10 @@ class PartitionLockTest extends Logging {
       logManager,
       alterIsrManager) {
 
-      override def shrinkIsr(newIsr: Set[Int]): Unit = {
+      override def prepareIsrShrink(outOfSyncReplicaIds: Set[Int]): PendingShrinkIsr = {
         shrinkIsrSemaphore.acquire()
         try {
-          super.shrinkIsr(newIsr)
+          super.prepareIsrShrink(outOfSyncReplicaIds)
         } finally {
           shrinkIsrSemaphore.release()
         }
@@ -309,8 +309,11 @@ class PartitionLockTest extends Logging {
     }
     when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
       .thenReturn(None)
-    when(alterIsrManager.submit(ArgumentMatchers.any[AlterIsrItem]))
-      .thenReturn(true)
+    when(alterIsrManager.submit(
+      ArgumentMatchers.eq(topicPartition),
+      ArgumentMatchers.any[LeaderAndIsr],
+      ArgumentMatchers.anyInt()))
+      .thenReturn(new CompletableFuture[LeaderAndIsr]())
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -307,13 +307,15 @@ class PartitionLockTest extends Logging {
         new SlowLog(log, offsets.logStartOffset, localLog, leaderEpochCache, producerStateManager, appendSemaphore)
       }
     }
-    when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
-      .thenReturn(None)
+    when(offsetCheckpoints.fetch(
+      ArgumentMatchers.anyString,
+      ArgumentMatchers.eq(topicPartition)
+    )).thenReturn(None)
     when(alterIsrManager.submit(
       ArgumentMatchers.eq(topicPartition),
       ArgumentMatchers.any[LeaderAndIsr],
-      ArgumentMatchers.anyInt()))
-      .thenReturn(new CompletableFuture[LeaderAndIsr]())
+      ArgumentMatchers.anyInt()
+    )).thenReturn(new CompletableFuture[LeaderAndIsr]())
 
     partition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.net.InetAddress
+import java.util
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{CompletableFuture, Executors, LinkedBlockingQueue, TimeUnit}
+import java.util.{Collections, Optional, Properties}
+
+import kafka.api.LeaderAndIsr
+import kafka.log.{AppendOrigin, LogConfig}
+import kafka.server.metadata.MockConfigRepository
+import kafka.utils.{MockTime, ShutdownableThread, TestUtils}
+import org.apache.kafka.common.metadata.{PartitionChangeRecord, PartitionRecord, TopicRecord}
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.SimpleRecord
+import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
+import org.apache.kafka.common.requests.{FetchRequest, ProduceResponse}
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{IsolationLevel, TopicPartition, Uuid}
+import org.apache.kafka.image.{MetadataDelta, MetadataImage}
+import org.apache.kafka.metadata.PartitionRegistration
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{AfterEach, Test}
+import org.mockito.Mockito
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+import scala.util.Random
+
+class ReplicaManagerConcurrencyTest {
+
+  private val time = new MockTime()
+  private val metrics = new Metrics()
+  private val executor = Executors.newScheduledThreadPool(8)
+  private val tasks = mutable.Buffer.empty[ShutdownableThread]
+
+  private def submit(task: ShutdownableThread): Unit = {
+    tasks += task
+    executor.submit(task)
+  }
+
+  @AfterEach
+  def cleanup(): Unit = {
+    tasks.foreach(_.shutdown())
+    executor.shutdownNow()
+    executor.awaitTermination(5, TimeUnit.SECONDS)
+    metrics.close()
+  }
+
+  @Test
+  def testIsrExpansionWithConcurrentProduce(): Unit = {
+    val localId = 0
+    val remoteId = 1
+    val channel = new ControllerChannel
+    val replicaManager = buildReplicaManager(localId, channel)
+
+    // Start with the remote replica out of the ISR
+    val initialPartitionRegistration = registration(
+      replicaIds = Seq(localId, remoteId),
+      isr = Seq(localId),
+      leader = localId
+    )
+
+    val topicModel = new TopicModel(Uuid.randomUuid(), "foo", Map(0 -> initialPartitionRegistration))
+    val topicPartition = new TopicPartition(topicModel.name, 0)
+    val controller = new ControllerModel(topicModel, channel, replicaManager)
+
+    submit(new Clock(time))
+    submit(controller)
+    controller.initialize()
+
+    val partition = replicaManager.getPartitionOrException(topicPartition)
+    assertTrue(partition.isLeader)
+
+    // Start several producers which are actively writing to the partition
+    (0 to 2).foreach { i =>
+      submit(new ProducerModel(
+        clientId = s"producer-$i",
+        topicPartition,
+        replicaManager
+      ))
+    }
+
+    // Start the remote replica fetcher and wait for it to join the ISR
+    submit(new FetcherModel(
+      clientId = s"replica-$remoteId",
+      replicaId = remoteId,
+      topicModel.topicId,
+      topicPartition,
+      replicaManager
+    ))
+
+    TestUtils.waitUntilTrue(() => {
+      partition.inSyncReplicaIds == Set(localId, remoteId)
+    }, "Test timed out before ISR was expanded")
+  }
+
+  private class Clock(
+    time: MockTime
+  ) extends ShutdownableThread(name = "clock", isInterruptible = false) {
+    override def doWork(): Unit = {
+      time.sleep(1)
+    }
+  }
+
+  private def buildReplicaManager(
+    localId: Int,
+    channel: ControllerChannel
+  ): ReplicaManager = {
+    val logDir = TestUtils.tempDir()
+
+    val props = new Properties
+    props.put(KafkaConfig.QuorumVotersProp, "100@localhost:12345")
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.NodeIdProp, localId.toString)
+    props.put(KafkaConfig.LogDirProp, logDir.getAbsolutePath)
+
+    val config = new KafkaConfig(props, doLog = false)
+
+    val logManager = TestUtils.createLogManager(
+      defaultConfig = new LogConfig(new Properties),
+      configRepository = new MockConfigRepository,
+      logDirs = Seq(logDir),
+      time = time
+    )
+
+    new ReplicaManager(
+      config,
+      metrics,
+      time,
+      None,
+      time.scheduler,
+      logManager,
+      new AtomicBoolean(false),
+      QuotaFactory.instantiate(config, metrics, time, ""),
+      new BrokerTopicStats,
+      MetadataCache.kRaftMetadataCache(config.brokerId),
+      new LogDirFailureChannel(config.logDirs.size),
+      new MockAlterIsrManager(channel)
+    ) {
+      override def createReplicaFetcherManager(
+        metrics: Metrics,
+        time: Time,
+        threadNamePrefix: Option[String],
+        quotaManager: ReplicationQuotaManager
+      ): ReplicaFetcherManager = {
+        Mockito.mock(classOf[ReplicaFetcherManager])
+      }
+    }
+  }
+
+  private class FetcherModel(
+    clientId: String,
+    replicaId: Int,
+    topicId: Uuid,
+    topicPartition: TopicPartition,
+    replicaManager: ReplicaManager
+  ) extends ShutdownableThread(name = clientId, isInterruptible = false) {
+    private val random = new Random()
+
+    private val clientMetadata = new DefaultClientMetadata(
+      "",
+      clientId,
+      InetAddress.getLocalHost,
+      KafkaPrincipal.ANONYMOUS,
+      "PLAINTEXT"
+    )
+
+    private var fetchOffset = 0L
+
+    override def doWork(): Unit = {
+      val partitionData = new FetchRequest.PartitionData(
+        fetchOffset,
+        -1,
+        65536,
+        Optional.empty(),
+        Optional.empty()
+      )
+
+      val future = new CompletableFuture[FetchPartitionData]()
+      def fetchCallback(results: collection.Seq[(TopicPartition, FetchPartitionData)]): Unit = {
+        try {
+          assertEquals(1, results.size)
+          val (topicPartition, result) = results.head
+          assertEquals(this.topicPartition, topicPartition)
+          assertEquals(Errors.NONE, result.error)
+          future.complete(result)
+        } catch {
+          case e: Throwable => future.completeExceptionally(e)
+        }
+      }
+
+      replicaManager.fetchMessages(
+        timeout = random.nextInt(100),
+        replicaId = replicaId,
+        fetchMinBytes = 1,
+        fetchMaxBytes = 1024 * 1024,
+        hardMaxBytesLimit = false,
+        fetchInfos = Seq(topicPartition -> partitionData),
+        topicIds = Collections.singletonMap(topicPartition.topic, topicId),
+        quota = QuotaFactory.UnboundedQuota,
+        responseCallback = fetchCallback,
+        isolationLevel = IsolationLevel.READ_UNCOMMITTED,
+        clientMetadata = Some(clientMetadata)
+      )
+
+      val fetchResult = future.get()
+      fetchResult.records.batches.forEach { batch =>
+        fetchOffset = batch.lastOffset + 1
+      }
+    }
+  }
+
+  private class ProducerModel(
+    clientId: String,
+    topicPartition: TopicPartition,
+    replicaManager: ReplicaManager
+  ) extends ShutdownableThread(name = clientId, isInterruptible = false) {
+    private val random = new Random()
+    private var sequence = 0
+
+    override def doWork(): Unit = {
+      val numRecords = (random.nextInt() % 10) + 1
+
+      val records = (0 until numRecords).map { i =>
+        new SimpleRecord(s"$clientId-${sequence + i}".getBytes)
+      }
+
+      val future = new CompletableFuture[ProduceResponse.PartitionResponse]()
+      def produceCallback(results: collection.Map[TopicPartition, ProduceResponse.PartitionResponse]): Unit = {
+        try {
+          assertEquals(1, results.size)
+          val (topicPartition, result) = results.head
+          assertEquals(this.topicPartition, topicPartition)
+          assertEquals(Errors.NONE, result.error)
+          future.complete(result)
+        } catch {
+          case e: Throwable => future.completeExceptionally(e)
+        }
+      }
+
+      replicaManager.appendRecords(
+        timeout = 30000,
+        requiredAcks = (-1).toShort,
+        internalTopicsAllowed = false,
+        origin = AppendOrigin.Client,
+        entriesPerPartition = collection.Map(topicPartition -> TestUtils.records(records)),
+        responseCallback = produceCallback
+      )
+
+      future.get()
+      sequence += numRecords
+    }
+  }
+
+  sealed trait ControllerEvent
+  case class InitializeEvent(future: CompletableFuture[Unit]) extends ControllerEvent
+  case object ShutdownEvent extends ControllerEvent
+  case class AlterIsrEvent(
+    future: CompletableFuture[LeaderAndIsr],
+    topicPartition: TopicPartition,
+    leaderAndIsr: LeaderAndIsr
+  ) extends ControllerEvent
+
+  private class ControllerChannel {
+    private val eventQueue = new LinkedBlockingQueue[ControllerEvent]()
+
+    def poll(): ControllerEvent = {
+      eventQueue.take()
+    }
+
+    def alterIsr(
+      topicPartition: TopicPartition,
+      leaderAndIsr: LeaderAndIsr
+    ): CompletableFuture[LeaderAndIsr] = {
+      val future = new CompletableFuture[LeaderAndIsr]()
+      eventQueue.offer(AlterIsrEvent(future, topicPartition, leaderAndIsr))
+      future
+    }
+
+    def initialize(): CompletableFuture[Unit] = {
+      val future = new CompletableFuture[Unit]()
+      eventQueue.offer(InitializeEvent(future))
+      future
+    }
+
+    def shutdown(): Unit = {
+      eventQueue.offer(ShutdownEvent)
+    }
+  }
+
+  private class ControllerModel(
+    topic: TopicModel,
+    channel: ControllerChannel,
+    replicaManager: ReplicaManager
+  ) extends ShutdownableThread(name = "controller", isInterruptible = false) {
+    private var latestImage = MetadataImage.EMPTY
+
+    def initialize(): Unit = {
+      channel.initialize().get()
+    }
+
+    override def shutdown(): Unit = {
+      super.initiateShutdown()
+      channel.shutdown()
+      super.awaitShutdown()
+    }
+
+    private def applyDelta(fn: MetadataDelta => Unit): Unit = {
+      val delta = new MetadataDelta(latestImage)
+      fn(delta)
+      latestImage = delta.apply()
+      replicaManager.applyDelta(latestImage, delta.topicsDelta)
+    }
+
+    override def doWork(): Unit = {
+      channel.poll() match {
+        case InitializeEvent(future) =>
+          applyDelta(topic.initialize)
+          future.complete(())
+
+        case AlterIsrEvent(future, topicPartition, leaderAndIsr) =>
+          applyDelta(delta => topic.alterIsr(topicPartition, leaderAndIsr, delta))
+          future.complete(leaderAndIsr)
+
+        case ShutdownEvent =>
+      }
+    }
+  }
+
+  private class TopicModel(
+    val topicId: Uuid,
+    val name: String,
+    initialRegistrations: Map[Int, PartitionRegistration]
+  ) {
+    private val partitions: Map[Int, PartitionModel] = initialRegistrations.map {
+      case (partitionId, registration) =>
+        partitionId -> new PartitionModel(this, partitionId, registration)
+    }
+
+    def initialize(delta: MetadataDelta): Unit = {
+      delta.replay(new TopicRecord()
+        .setName(name)
+        .setTopicId(topicId)
+      )
+      partitions.values.foreach(_.initialize(delta))
+    }
+
+    def alterIsr(
+      topicPartition: TopicPartition,
+      leaderAndIsr: LeaderAndIsr,
+      delta: MetadataDelta
+    ): Unit = {
+      val partitionModel = partitions.getOrElse(topicPartition.partition,
+        throw new IllegalStateException(s"Unexpected partition $topicPartition")
+      )
+      partitionModel.alterIsr(leaderAndIsr, delta)
+    }
+  }
+
+  private class PartitionModel(
+    val topic: TopicModel,
+    val partitionId: Int,
+    var registration: PartitionRegistration
+  ) {
+    def alterIsr(
+      leaderAndIsr: LeaderAndIsr,
+      delta: MetadataDelta
+    ): Unit = {
+      delta.replay(new PartitionChangeRecord()
+        .setTopicId(topic.topicId)
+        .setPartitionId(partitionId)
+        .setIsr(leaderAndIsr.isr.map(Int.box).asJava)
+        .setLeader(leaderAndIsr.leader)
+      )
+      this.registration = delta.topicsDelta
+        .changedTopic(topic.topicId)
+        .partitionChanges
+        .get(partitionId)
+    }
+
+    private def toList(ints: Array[Int]): util.List[Integer] = {
+      ints.map(Int.box).toList.asJava
+    }
+
+    def initialize(delta: MetadataDelta): Unit = {
+      delta.replay(new PartitionRecord()
+        .setTopicId(topic.topicId)
+        .setPartitionId(partitionId)
+        .setReplicas(toList(registration.replicas))
+        .setIsr(toList(registration.isr))
+        .setLeader(registration.leader)
+        .setLeaderEpoch(registration.leaderEpoch)
+        .setPartitionEpoch(registration.partitionEpoch)
+      )
+    }
+  }
+
+  private class MockAlterIsrManager(channel: ControllerChannel) extends AlterIsrManager {
+    override def submit(
+      topicPartition: TopicPartition,
+      leaderAndIsr: LeaderAndIsr,
+      controllerEpoch: Int
+    ): CompletableFuture[LeaderAndIsr] = {
+      channel.alterIsr(topicPartition, leaderAndIsr)
+    }
+  }
+
+  private def registration(
+    replicaIds: Seq[Int],
+    isr: Seq[Int],
+    leader: Int,
+    leaderEpoch: Int = 0,
+    version: Int = 0
+  ): PartitionRegistration = {
+    new PartitionRegistration(
+      replicaIds.toArray,
+      isr.toArray,
+      Array.empty[Int],
+      Array.empty[Int],
+      leader,
+      leaderEpoch,
+      version
+    )
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -74,7 +74,6 @@ import org.apache.zookeeper.ZooDefs._
 import org.apache.zookeeper.data.ACL
 import org.junit.jupiter.api.Assertions._
 import org.mockito.Mockito
-import java.net.InetAddress
 
 import scala.annotation.nowarn
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -25,7 +25,7 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.concurrent.{Callable, ExecutionException, Executors, TimeUnit}
+import java.util.concurrent.{Callable, CompletableFuture, ExecutionException, Executors, TimeUnit}
 import java.util.{Arrays, Collections, Optional, Properties}
 
 import com.yammer.metrics.core.Meter
@@ -50,7 +50,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.TOPIC
-import org.apache.kafka.common.errors.{KafkaStorageException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{KafkaStorageException, OperationNotAttemptedException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.memory.MemoryPool
@@ -74,6 +74,7 @@ import org.apache.zookeeper.ZooDefs._
 import org.apache.zookeeper.data.ACL
 import org.junit.jupiter.api.Assertions._
 import org.mockito.Mockito
+import java.net.InetAddress
 
 import scala.annotation.nowarn
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
@@ -1120,19 +1121,26 @@ object TestUtils extends Logging {
     val isrUpdates: mutable.Queue[AlterIsrItem] = new mutable.Queue[AlterIsrItem]()
     val inFlight: AtomicBoolean = new AtomicBoolean(false)
 
-    override def submit(alterIsrItem: AlterIsrItem): Boolean = {
+
+    override def submit(
+      topicPartition: TopicPartition,
+      leaderAndIsr: LeaderAndIsr,
+      controllerEpoch: Int
+    ): CompletableFuture[LeaderAndIsr]= {
+      val future = new CompletableFuture[LeaderAndIsr]()
       if (inFlight.compareAndSet(false, true)) {
-        isrUpdates += alterIsrItem
-        true
+        isrUpdates += AlterIsrItem(topicPartition, leaderAndIsr, future, controllerEpoch)
       } else {
-        false
+        future.completeExceptionally(new OperationNotAttemptedException(
+          s"Failed to enqueue AlterIsr request for $topicPartition since there is already an inflight request"))
       }
+      future
     }
 
     def completeIsrUpdate(newZkVersion: Int): Unit = {
       if (inFlight.compareAndSet(true, false)) {
         val item = isrUpdates.dequeue()
-        item.callback.apply(Right(item.leaderAndIsr.withZkVersion(newZkVersion)))
+        item.future.complete(item.leaderAndIsr.withZkVersion(newZkVersion))
       } else {
         fail("Expected an in-flight ISR update, but there was none")
       }
@@ -1141,7 +1149,7 @@ object TestUtils extends Logging {
     def failIsrUpdate(error: Errors): Unit = {
       if (inFlight.compareAndSet(true, false)) {
         val item = isrUpdates.dequeue()
-        item.callback.apply(Left(error))
+        item.future.completeExceptionally(error.exception)
       } else {
         fail("Expected an in-flight ISR update, but there was none")
       }


### PR DESCRIPTION
This patch fixes a deadlock when incrementing the high watermark after the synchronous zk ISR modification happens. The main difference is that we prevent the callback from executing while under the leader and ISR lock. The deadlock bug was introduced in https://github.com/apache/kafka/pull/11245.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
