### PR TITLE
MINOR: Fix broker registration log problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1121,6 +1121,7 @@ project(':metadata') {
     testImplementation libs.junitJupiter
     testImplementation libs.hamcrest
     testImplementation libs.slf4jlog4j
+    testImplementation libs.mockitoCore
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':raft').sourceSets.test.output
   }

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -250,10 +250,10 @@ public class ClusterControlManager {
                 feature.minSupportedVersion(), feature.maxSupportedVersion()));
         }
         // Update broker registrations.
-        brokerRegistrations.put(brokerId, new BrokerRegistration(brokerId,
-            record.brokerEpoch(), record.incarnationId(), listeners, features,
-            Optional.ofNullable(record.rack()), record.fenced()));
-        BrokerRegistration prevRegistration = brokerRegistrations.get(brokerId);
+        BrokerRegistration prevRegistration = brokerRegistrations.put(brokerId,
+            new BrokerRegistration(brokerId, record.brokerEpoch(),
+                record.incarnationId(), listeners, features,
+                Optional.ofNullable(record.rack()), record.fenced()));
         if (prevRegistration == null) {
             log.info("Registered new broker: {}", record);
         } else if (prevRegistration.incarnationId().equals(record.incarnationId())) {


### PR DESCRIPTION
*More detailed description of your change*

I found some error that says "Re-registered broker" but I didn't see "Registered new broker":
```
[2021-09-02 09:47:02,532] INFO [Controller 3000] Re-registered broker incarnation: RegisterBrokerRecord(brokerId=0, incarnationId=ScFuLmWTQ3WUF3P3XCkWEw, brokerEpoch=0, endPoints=[BrokerEndpoint(name='EXTERNAL', host='localhost', port=56409, securityProtocol=0)], features=[], rack=null, fenced=true) (org.apache.kafka.controller.ClusterControlManager:260)
```
After reviewing the code, I found we are doomed to get a not-null previous value if we put a value and get a value.

The log became normal after applying this change:
```
[2021-09-02 09:51:02,191] INFO [Controller 3000] Registered new broker: RegisterBrokerRecord(brokerId=0, incarnationId=Z398mgq4Q36J5DYoIrQW0g, brokerEpoch=0, endPoints=[BrokerEndpoint(name='EXTERNAL', host='localhost', port=57231, securityProtocol=0)], features=[], rack=null, fenced=true) (org.apache.kafka.controller.ClusterControlManager:259)
```

