### PR TITLE
KAFKA-10038: Supports default client.id for ConsoleConsumer, ProducerPerformance, ConsumerPerformance

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -148,6 +148,8 @@ object ConsoleConsumer extends Logging {
     props ++= config.extraConsumerProps
     setAutoOffsetResetValue(config, props)
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
+    if (props.getProperty(ConsumerConfig.CLIENT_ID_CONFIG) == null)
+      props.put(ConsumerConfig.CLIENT_ID_CONFIG, "console-consumer")
     CommandLineUtils.maybeMergeOptions(
       props, ConsumerConfig.ISOLATION_LEVEL_CONFIG, config.options, config.isolationLevelOpt)
     props

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -288,6 +288,8 @@ object ConsumerPerformance extends LazyLogging {
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer])
     props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer])
     props.put(ConsumerConfig.CHECK_CRCS_CONFIG, "false")
+    if (props.getProperty(ConsumerConfig.CLIENT_ID_CONFIG) == null)
+      props.put(ConsumerConfig.CLIENT_ID_CONFIG, "perf-consumer-client")
 
     val numThreads = options.valueOf(numThreadsOpt).intValue
     val topic = options.valueOf(topicOpt)

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -604,4 +604,37 @@ class ConsoleConsumerTest {
     try assertThrows(classOf[IllegalArgumentException], () => new ConsoleConsumer.ConsumerConfig(args))
     finally Exit.resetExitProcedure()
   }
+
+  @Test
+  def testClientIdOverride(): Unit = {
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--from-beginning",
+      "--consumer-property", "client.id=consumer-1")
+
+    //When
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+    val consumerProperties = ConsoleConsumer.consumerProps(config)
+
+    //Then
+    assertEquals("consumer-1", consumerProperties.getProperty(ConsumerConfig.CLIENT_ID_CONFIG))
+  }
+
+  @Test
+  def testDefaultClientId(): Unit = {
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--from-beginning")
+
+    //When
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+    val consumerProperties = ConsoleConsumer.consumerProps(config)
+
+    //Then
+    assertEquals("console-consumer", consumerProperties.getProperty(ConsumerConfig.CLIENT_ID_CONFIG))
+  }
 }

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -115,4 +115,12 @@ class ConsoleProducerTest {
     assertEquals("producer-1",
       producerConfig.getString(ProducerConfig.CLIENT_ID_CONFIG))
   }
+
+  @Test
+  def testDefaultClientId(): Unit = {
+    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
+    val producerConfig = new ProducerConfig(ConsoleProducer.producerProps(config))
+    assertEquals("console-producer",
+      producerConfig.getString(ProducerConfig.CLIENT_ID_CONFIG))
+  }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -193,6 +193,9 @@ public class ProducerPerformance {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
         if (transactionsEnabled) props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+        if (props.getProperty(ProducerConfig.CLIENT_ID_CONFIG) == null) {
+            props.put(ProducerConfig.CLIENT_ID_CONFIG, "perf-producer-client");
+        }
         return props;
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -84,7 +84,7 @@ public class ProducerPerformanceTest {
         Properties prop = ProducerPerformance.readProps(producerProps, producerConfig, transactionalId, transactionsEnabled);
 
         assertNotNull(prop);
-        assertEquals(5, prop.size());
+        assertEquals(6, prop.size());
     }
 
     @Test
@@ -153,5 +153,25 @@ public class ProducerPerformanceTest {
 
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> ProducerPerformance.generateRandomPayload(recordSize, payloadByteList, payload, random));
         assertEquals("no payload File Path or record Size provided", thrown.getMessage());
+    }
+
+    @Test
+    public void testClientIdOverride()  throws Exception {
+        List<String> producerProps = Collections.singletonList("client.id=producer-1");
+
+        Properties prop = ProducerPerformance.readProps(producerProps, null, "1234", true);
+
+        assertNotNull(prop);
+        assertEquals("producer-1", prop.getProperty("client.id"));
+    }
+
+    @Test
+    public void testDefaultClientId() throws Exception {
+        List<String> producerProps = Collections.singletonList("acks=1");
+
+        Properties prop = ProducerPerformance.readProps(producerProps, null, "1234", true);
+
+        assertNotNull(prop);
+        assertEquals("perf-producer-client", prop.getProperty("client.id"));
     }
 }


### PR DESCRIPTION
Currently in `ConsoleConsumer`/`ProducerPerformance`/`ConsolePerformance`, we will not set `client.id` if it is not provided by the user. Simiarly to what we already did for `ConsoleProducer`([code](https://github.com/apache/kafka/blob/99b9b3e84f4e98c3f07714e1de6a139a004cbc5b/core/src/main/scala/kafka/tools/ConsoleProducer.scala#L96)), this PR will set a default value of `client.id` so that we can better support quota testing. The default value is shown as follows:
* `client.id` in `ConsoleConsumer`: `console-consumer`
* `client.id` in `ConsumerPerformance`: `perf-consumer-client`
* `client.id` in `ProducerPerformance`: `perf-producer-client`

New unit testings are added to test both default `client.id` and `client.id` provided by users

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
