### PR TITLE
KAFKA-13276: Prefer KafkaFuture in admin Result constructors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.Map;
 
@@ -30,9 +29,9 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class AbortTransactionResult {
-    private final Map<TopicPartition, KafkaFutureImpl<Void>> futures;
+    private final Map<TopicPartition, KafkaFuture<Void>> futures;
 
-    AbortTransactionResult(Map<TopicPartition, KafkaFutureImpl<Void>> futures) {
+    AbortTransactionResult(Map<TopicPartition, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
@@ -29,9 +29,9 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class AbortTransactionResult {
-    private final Map<TopicPartition, ? extends KafkaFuture<Void>> futures;
+    private final Map<TopicPartition, KafkaFuture<Void>> futures;
 
-    AbortTransactionResult(Map<TopicPartition, ? extends KafkaFuture<Void>> futures) {
+    AbortTransactionResult(Map<TopicPartition, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
@@ -29,9 +29,9 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class AbortTransactionResult {
-    private final Map<TopicPartition, KafkaFuture<Void>> futures;
+    private final Map<TopicPartition, ? extends KafkaFuture<Void>> futures;
 
-    AbortTransactionResult(Map<TopicPartition, KafkaFuture<Void>> futures) {
+    AbortTransactionResult(Map<TopicPartition, ? extends KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -32,9 +31,9 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class DeleteConsumerGroupsResult {
-    private final Map<CoordinatorKey, KafkaFutureImpl<Void>> futures;
+    private final Map<CoordinatorKey, KafkaFuture<Void>> futures;
 
-    DeleteConsumerGroupsResult(final Map<CoordinatorKey, KafkaFutureImpl<Void>> futures) {
+    DeleteConsumerGroupsResult(final Map<CoordinatorKey, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
@@ -31,9 +30,9 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class DeleteConsumerGroupsResult {
-    private final Map<CoordinatorKey, KafkaFuture<Void>> futures;
+    private final Map<String, KafkaFuture<Void>> futures;
 
-    DeleteConsumerGroupsResult(final Map<CoordinatorKey, KafkaFuture<Void>> futures) {
+    DeleteConsumerGroupsResult(final Map<String, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 
@@ -43,7 +42,7 @@ public class DeleteConsumerGroupsResult {
      */
     public Map<String, KafkaFuture<Void>> deletedGroups() {
         Map<String, KafkaFuture<Void>> deletedGroups = new HashMap<>(futures.size());
-        futures.forEach((key, future) -> deletedGroups.put(key.idValue, future));
+        futures.forEach((key, future) -> deletedGroups.put(key, future));
         return deletedGroups;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -20,7 +20,6 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,9 +34,9 @@ import java.util.concurrent.ExecutionException;
 @InterfaceStability.Evolving
 public class DescribeConsumerGroupsResult {
 
-    private final Map<CoordinatorKey, KafkaFutureImpl<ConsumerGroupDescription>> futures;
+    private final Map<CoordinatorKey, KafkaFuture<ConsumerGroupDescription>> futures;
 
-    public DescribeConsumerGroupsResult(final Map<CoordinatorKey, KafkaFutureImpl<ConsumerGroupDescription>> futures) {
+    public DescribeConsumerGroupsResult(final Map<CoordinatorKey, KafkaFuture<ConsumerGroupDescription>> futures) {
         this.futures = futures;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
@@ -34,9 +33,9 @@ import java.util.concurrent.ExecutionException;
 @InterfaceStability.Evolving
 public class DescribeConsumerGroupsResult {
 
-    private final Map<CoordinatorKey, KafkaFuture<ConsumerGroupDescription>> futures;
+    private final Map<String, KafkaFuture<ConsumerGroupDescription>> futures;
 
-    public DescribeConsumerGroupsResult(final Map<CoordinatorKey, KafkaFuture<ConsumerGroupDescription>> futures) {
+    public DescribeConsumerGroupsResult(final Map<String, KafkaFuture<ConsumerGroupDescription>> futures) {
         this.futures = futures;
     }
 
@@ -45,7 +44,7 @@ public class DescribeConsumerGroupsResult {
      */
     public Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups() {
         Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups = new HashMap<>();
-        futures.forEach((key, future) -> describedGroups.put(key.idValue, future));
+        futures.forEach((key, future) -> describedGroups.put(key, future));
         return describedGroups;
     }
 
@@ -58,7 +57,7 @@ public class DescribeConsumerGroupsResult {
                 Map<String, ConsumerGroupDescription> descriptions = new HashMap<>(futures.size());
                 futures.forEach((key, future) -> {
                     try {
-                        descriptions.put(key.idValue, future.get());
+                        descriptions.put(key, future.get());
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.HashMap;
 import java.util.List;
@@ -30,9 +29,9 @@ import java.util.concurrent.ExecutionException;
 @InterfaceStability.Evolving
 public class DescribeProducersResult {
 
-    private final Map<TopicPartition, KafkaFutureImpl<PartitionProducerState>> futures;
+    private final Map<TopicPartition, KafkaFuture<PartitionProducerState>> futures;
 
-    DescribeProducersResult(Map<TopicPartition, KafkaFutureImpl<PartitionProducerState>> futures) {
+    DescribeProducersResult(Map<TopicPartition, KafkaFuture<PartitionProducerState>> futures) {
         this.futures = futures;
     }
 
@@ -49,7 +48,7 @@ public class DescribeProducersResult {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
             .thenApply(nil -> {
                 Map<TopicPartition, PartitionProducerState> results = new HashMap<>(futures.size());
-                for (Map.Entry<TopicPartition, KafkaFutureImpl<PartitionProducerState>> entry : futures.entrySet()) {
+                for (Map.Entry<TopicPartition, KafkaFuture<PartitionProducerState>> entry : futures.entrySet()) {
                     try {
                         results.put(entry.getKey(), entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
@@ -29,9 +29,9 @@ import java.util.concurrent.ExecutionException;
 @InterfaceStability.Evolving
 public class DescribeProducersResult {
 
-    private final Map<TopicPartition, ? extends KafkaFuture<PartitionProducerState>> futures;
+    private final Map<TopicPartition, KafkaFuture<PartitionProducerState>> futures;
 
-    DescribeProducersResult(Map<TopicPartition, ? extends KafkaFuture<PartitionProducerState>> futures) {
+    DescribeProducersResult(Map<TopicPartition, KafkaFuture<PartitionProducerState>> futures) {
         this.futures = futures;
     }
 
@@ -48,7 +48,7 @@ public class DescribeProducersResult {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
             .thenApply(nil -> {
                 Map<TopicPartition, PartitionProducerState> results = new HashMap<>(futures.size());
-                for (Map.Entry<TopicPartition, ? extends KafkaFuture<PartitionProducerState>> entry : futures.entrySet()) {
+                for (Map.Entry<TopicPartition, KafkaFuture<PartitionProducerState>> entry : futures.entrySet()) {
                     try {
                         results.put(entry.getKey(), entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
@@ -29,9 +29,9 @@ import java.util.concurrent.ExecutionException;
 @InterfaceStability.Evolving
 public class DescribeProducersResult {
 
-    private final Map<TopicPartition, KafkaFuture<PartitionProducerState>> futures;
+    private final Map<TopicPartition, ? extends KafkaFuture<PartitionProducerState>> futures;
 
-    DescribeProducersResult(Map<TopicPartition, KafkaFuture<PartitionProducerState>> futures) {
+    DescribeProducersResult(Map<TopicPartition, ? extends KafkaFuture<PartitionProducerState>> futures) {
         this.futures = futures;
     }
 
@@ -48,7 +48,7 @@ public class DescribeProducersResult {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
             .thenApply(nil -> {
                 Map<TopicPartition, PartitionProducerState> results = new HashMap<>(futures.size());
-                for (Map.Entry<TopicPartition, KafkaFuture<PartitionProducerState>> entry : futures.entrySet()) {
+                for (Map.Entry<TopicPartition, ? extends KafkaFuture<PartitionProducerState>> entry : futures.entrySet()) {
                     try {
                         results.put(entry.getKey(), entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -28,9 +27,9 @@ import java.util.concurrent.ExecutionException;
 
 @InterfaceStability.Evolving
 public class DescribeTransactionsResult {
-    private final Map<CoordinatorKey, KafkaFutureImpl<TransactionDescription>> futures;
+    private final Map<CoordinatorKey, KafkaFuture<TransactionDescription>> futures;
 
-    DescribeTransactionsResult(Map<CoordinatorKey, KafkaFutureImpl<TransactionDescription>> futures) {
+    DescribeTransactionsResult(Map<CoordinatorKey, KafkaFuture<TransactionDescription>> futures) {
         this.futures = futures;
     }
 
@@ -66,7 +65,7 @@ public class DescribeTransactionsResult {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
             .thenApply(nil -> {
                 Map<String, TransactionDescription> results = new HashMap<>(futures.size());
-                for (Map.Entry<CoordinatorKey, KafkaFutureImpl<TransactionDescription>> entry : futures.entrySet()) {
+                for (Map.Entry<CoordinatorKey, KafkaFuture<TransactionDescription>> entry : futures.entrySet()) {
                     try {
                         results.put(entry.getKey().idValue, entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ExecutionException;
 
 @InterfaceStability.Evolving
 public class DescribeTransactionsResult {
-    private final Map<CoordinatorKey, KafkaFuture<TransactionDescription>> futures;
+    private final Map<CoordinatorKey, ? extends KafkaFuture<TransactionDescription>> futures;
 
-    DescribeTransactionsResult(Map<CoordinatorKey, KafkaFuture<TransactionDescription>> futures) {
+    DescribeTransactionsResult(Map<CoordinatorKey, ? extends KafkaFuture<TransactionDescription>> futures) {
         this.futures = futures;
     }
 
@@ -65,7 +65,7 @@ public class DescribeTransactionsResult {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
             .thenApply(nil -> {
                 Map<String, TransactionDescription> results = new HashMap<>(futures.size());
-                for (Map.Entry<CoordinatorKey, KafkaFuture<TransactionDescription>> entry : futures.entrySet()) {
+                for (Map.Entry<CoordinatorKey, ? extends KafkaFuture<TransactionDescription>> entry : futures.entrySet()) {
                     try {
                         results.put(entry.getKey().idValue, entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ExecutionException;
 
 @InterfaceStability.Evolving
 public class DescribeTransactionsResult {
-    private final Map<CoordinatorKey, ? extends KafkaFuture<TransactionDescription>> futures;
+    private final Map<CoordinatorKey, KafkaFuture<TransactionDescription>> futures;
 
-    DescribeTransactionsResult(Map<CoordinatorKey, ? extends KafkaFuture<TransactionDescription>> futures) {
+    DescribeTransactionsResult(Map<CoordinatorKey, KafkaFuture<TransactionDescription>> futures) {
         this.futures = futures;
     }
 
@@ -65,7 +65,7 @@ public class DescribeTransactionsResult {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
             .thenApply(nil -> {
                 Map<String, TransactionDescription> results = new HashMap<>(futures.size());
-                for (Map.Entry<CoordinatorKey, ? extends KafkaFuture<TransactionDescription>> entry : futures.entrySet()) {
+                for (Map.Entry<CoordinatorKey, KafkaFuture<TransactionDescription>> entry : futures.entrySet()) {
                     try {
                         results.put(entry.getKey().idValue, entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ElectLeadersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ElectLeadersResult.java
@@ -35,9 +35,9 @@ import org.apache.kafka.common.internals.KafkaFutureImpl;
  */
 @InterfaceStability.Evolving
 final public class ElectLeadersResult {
-    private final KafkaFutureImpl<Map<TopicPartition, Optional<Throwable>>> electionFuture;
+    private final KafkaFuture<Map<TopicPartition, Optional<Throwable>>> electionFuture;
 
-    ElectLeadersResult(KafkaFutureImpl<Map<TopicPartition, Optional<Throwable>>> electionFuture) {
+    ElectLeadersResult(KafkaFuture<Map<TopicPartition, Optional<Throwable>>> electionFuture) {
         this.electionFuture = electionFuture;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3178,7 +3178,8 @@ public class KafkaAdminClient extends AdminClient {
                 DescribeConsumerGroupsHandler.newFuture(groupIds);
         DescribeConsumerGroupsHandler handler = new DescribeConsumerGroupsHandler(options.includeAuthorizedOperations(), logContext);
         invokeDriver(handler, future, options.timeoutMs);
-        return new DescribeConsumerGroupsResult(future.all());
+        return new DescribeConsumerGroupsResult(future.all().entrySet().stream()
+                .collect(Collectors.toMap(x -> x.getKey().idValue, Map.Entry::getValue)));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3179,7 +3179,7 @@ public class KafkaAdminClient extends AdminClient {
         DescribeConsumerGroupsHandler handler = new DescribeConsumerGroupsHandler(options.includeAuthorizedOperations(), logContext);
         invokeDriver(handler, future, options.timeoutMs);
         return new DescribeConsumerGroupsResult(future.all().entrySet().stream()
-                .collect(Collectors.toMap(x -> x.getKey().idValue, Map.Entry::getValue)));
+                .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
     }
 
     /**
@@ -3379,7 +3379,8 @@ public class KafkaAdminClient extends AdminClient {
                 DeleteConsumerGroupsHandler.newFuture(groupIds);
         DeleteConsumerGroupsHandler handler = new DeleteConsumerGroupsHandler(logContext);
         invokeDriver(handler, future, options.timeoutMs);
-        return new DeleteConsumerGroupsResult(future.all());
+        return new DeleteConsumerGroupsResult(future.all().entrySet().stream()
+                .collect(Collectors.toMap(entry -> entry.getKey().idValue, Map.Entry::getValue)));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
@@ -35,7 +35,7 @@ public class ListConsumerGroupsResult {
     private final KafkaFutureImpl<Collection<ConsumerGroupListing>> valid;
     private final KafkaFutureImpl<Collection<Throwable>> errors;
 
-    ListConsumerGroupsResult(KafkaFutureImpl<Collection<Object>> future) {
+    ListConsumerGroupsResult(KafkaFuture<Collection<Object>> future) {
         this.all = new KafkaFutureImpl<>();
         this.valid = new KafkaFutureImpl<>();
         this.errors = new KafkaFutureImpl<>();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsResult.java
@@ -35,9 +35,9 @@ import java.util.Set;
  */
 @InterfaceStability.Evolving
 public class ListTransactionsResult {
-    private final KafkaFutureImpl<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future;
+    private final KafkaFuture<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future;
 
-    ListTransactionsResult(KafkaFutureImpl<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future) {
+    ListTransactionsResult(KafkaFuture<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future) {
         this.future = future;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.admin.internals;
 
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.Map;
@@ -76,7 +77,7 @@ public interface AdminApiFuture<K, V> {
      * This class can be used when the set of keys is known ahead of time.
      */
     class SimpleAdminApiFuture<K, V> implements AdminApiFuture<K, V> {
-        private final Map<K, KafkaFutureImpl<V>> futures;
+        private final Map<K, KafkaFuture<V>> futures;
 
         public SimpleAdminApiFuture(Set<K> keys) {
             this.futures = keys.stream().collect(Collectors.toMap(
@@ -109,7 +110,7 @@ public interface AdminApiFuture<K, V> {
         }
 
         private KafkaFutureImpl<V> futureOrThrow(K key) {
-            KafkaFutureImpl<V> future = futures.get(key);
+            KafkaFutureImpl<V> future = (KafkaFutureImpl<V>) futures.get(key);
             if (future == null) {
                 throw new IllegalArgumentException("Attempt to complete future for " + key +
                     ", which was not requested");
@@ -118,11 +119,11 @@ public interface AdminApiFuture<K, V> {
             }
         }
 
-        public Map<K, KafkaFutureImpl<V>> all() {
+        public Map<K, KafkaFuture<V>> all() {
             return futures;
         }
 
-        public KafkaFutureImpl<V> get(K key) {
+        public KafkaFuture<V> get(K key) {
             return futures.get(key);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
@@ -110,6 +110,7 @@ public interface AdminApiFuture<K, V> {
         }
 
         private KafkaFutureImpl<V> futureOrThrow(K key) {
+            // The below typecast is safe because we initialise futures using only KafkaFutureImpl.
             KafkaFutureImpl<V> future = (KafkaFutureImpl<V>) futures.get(key);
             if (future == null) {
                 throw new IllegalArgumentException("Attempt to complete future for " + key +

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
@@ -77,7 +77,7 @@ public interface AdminApiFuture<K, V> {
      * This class can be used when the set of keys is known ahead of time.
      */
     class SimpleAdminApiFuture<K, V> implements AdminApiFuture<K, V> {
-        private final Map<K, KafkaFuture<V>> futures;
+        private final Map<K, KafkaFutureImpl<V>> futures;
 
         public SimpleAdminApiFuture(Set<K> keys) {
             this.futures = keys.stream().collect(Collectors.toMap(
@@ -110,7 +110,7 @@ public interface AdminApiFuture<K, V> {
         }
 
         private KafkaFutureImpl<V> futureOrThrow(K key) {
-            KafkaFutureImpl<V> future = (KafkaFutureImpl<V>) futures.get(key);
+            KafkaFutureImpl<V> future = futures.get(key);
             if (future == null) {
                 throw new IllegalArgumentException("Attempt to complete future for " + key +
                     ", which was not requested");
@@ -119,7 +119,7 @@ public interface AdminApiFuture<K, V> {
             }
         }
 
-        public Map<K, KafkaFuture<V>> all() {
+        public Map<K, ? extends KafkaFuture<V>> all() {
             return futures;
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
@@ -77,7 +77,7 @@ public interface AdminApiFuture<K, V> {
      * This class can be used when the set of keys is known ahead of time.
      */
     class SimpleAdminApiFuture<K, V> implements AdminApiFuture<K, V> {
-        private final Map<K, KafkaFutureImpl<V>> futures;
+        private final Map<K, KafkaFuture<V>> futures;
 
         public SimpleAdminApiFuture(Set<K> keys) {
             this.futures = keys.stream().collect(Collectors.toMap(
@@ -110,7 +110,7 @@ public interface AdminApiFuture<K, V> {
         }
 
         private KafkaFutureImpl<V> futureOrThrow(K key) {
-            KafkaFutureImpl<V> future = futures.get(key);
+            KafkaFutureImpl<V> future = (KafkaFutureImpl<V>) futures.get(key);
             if (future == null) {
                 throw new IllegalArgumentException("Attempt to complete future for " + key +
                     ", which was not requested");
@@ -119,7 +119,7 @@ public interface AdminApiFuture<K, V> {
             }
         }
 
-        public Map<K, ? extends KafkaFuture<V>> all() {
+        public Map<K, KafkaFuture<V>> all() {
             return futures;
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.UnknownServerException;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.AbstractRequest;

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.admin.internals;
 import org.apache.kafka.clients.admin.internals.AdminApiDriver.RequestSpec;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
 import org.apache.kafka.clients.admin.internals.AdminApiLookupStrategy.LookupResult;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.UnknownServerException;
@@ -498,7 +499,7 @@ class AdminApiDriverTest {
     ) {
         OptionalInt brokerIdOpt = context.driver.keyToBrokerId(key);
         assertEquals(OptionalInt.empty(), brokerIdOpt);
-        KafkaFutureImpl<Long> future = context.future.all().get(key);
+        KafkaFuture<Long> future = context.future.all().get(key);
         assertFalse(future.isDone());
     }
 
@@ -507,7 +508,7 @@ class AdminApiDriverTest {
         String key,
         Throwable expectedException
     ) {
-        KafkaFutureImpl<Long> future = context.future.all().get(key);
+        KafkaFuture<Long> future = context.future.all().get(key);
         assertTrue(future.isCompletedExceptionally());
         Throwable exception = assertThrows(ExecutionException.class, future::get);
         assertEquals(expectedException, exception.getCause());
@@ -518,7 +519,7 @@ class AdminApiDriverTest {
         String key,
         Long expected
     ) {
-        KafkaFutureImpl<Long> future = context.future.all().get(key);
+        KafkaFuture<Long> future = context.future.all().get(key);
         assertTrue(future.isDone());
         try {
             assertEquals(expected, future.get());

--- a/core/src/test/scala/unit/kafka/admin/ConsumerGroupServiceTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConsumerGroupServiceTest.scala
@@ -32,7 +32,6 @@ import org.mockito.Mockito._
 import org.mockito.ArgumentMatcher
 
 import scala.jdk.CollectionConverters._
-import org.apache.kafka.clients.admin.internals.CoordinatorKey
 import org.apache.kafka.common.internals.KafkaFutureImpl
 
 class ConsumerGroupServiceTest {
@@ -112,7 +111,7 @@ class ConsumerGroupServiceTest {
     val future = new KafkaFutureImpl[ConsumerGroupDescription]()
     future.complete(consumerGroupDescription)
     when(admin.describeConsumerGroups(ArgumentMatchers.eq(Collections.singletonList(group)), any()))
-      .thenReturn(new DescribeConsumerGroupsResult(Collections.singletonMap(CoordinatorKey.byGroupId(group), future)))
+      .thenReturn(new DescribeConsumerGroupsResult(Collections.singletonMap(group, future)))
     when(admin.listConsumerGroupOffsets(ArgumentMatchers.eq(group), any()))
       .thenReturn(AdminClientTestUtils.listConsumerGroupOffsetsResult(commitedOffsets))
     when(admin.listOffsets(
@@ -190,7 +189,7 @@ class ConsumerGroupServiceTest {
       new Node(1, "localhost", 9092))
     val future = new KafkaFutureImpl[ConsumerGroupDescription]()
     future.complete(description)
-    new DescribeConsumerGroupsResult(Collections.singletonMap(CoordinatorKey.byGroupId(group), future))
+    new DescribeConsumerGroupsResult(Collections.singletonMap(group, future))
   }
 
   private def listGroupOffsetsResult: ListConsumerGroupOffsetsResult = {


### PR DESCRIPTION
Avoid using the non-public API KafkaFutureImpl in the Admin client's `*Result` class constructors. This is particularly problematic for `DescribeConsumerGroupsResult` which currently has a public constructor.  For the other classes the rationale is simply consistency with the majority of the `*Result` classes.