### PR TITLE
KAFKA-13243: KIP-773 Differentiate metric latency measured in ms and ns

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -82,7 +82,10 @@ public class BufferPool {
                                                    "The fraction of time an appender waits for space allocation.");
         MetricName totalMetricName = metrics.metricName("bufferpool-wait-time-total",
                                                    metricGrpName,
-                                                   "The total time an appender waits for space allocation.");
+                                                   "*Deprecated* The total time an appender waits for space allocation.");
+        MetricName totalNsMetricName = metrics.metricName("bufferpool-wait-time-ns-total",
+                                                    metricGrpName,
+                                                    "The total time in nanoseconds an appender waits for space allocation.");
 
         Sensor bufferExhaustedRecordSensor = metrics.sensor("buffer-exhausted-records");
         MetricName bufferExhaustedRateMetricName = metrics.metricName("buffer-exhausted-rate", metricGrpName, "The average per-second number of record sends that are dropped due to buffer exhaustion");
@@ -90,6 +93,7 @@ public class BufferPool {
         bufferExhaustedRecordSensor.add(new Meter(bufferExhaustedRateMetricName, bufferExhaustedTotalMetricName));
 
         this.waitTime.add(new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName));
+        this.waitTime.add(new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalNsMetricName));
         this.closed = false;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1275,7 +1275,7 @@ public class Selector implements Selectable, AutoCloseable {
         }
 
         /**
-         * This method generates `time-total` metrics with a couple of errors, no `-ns` suffix and no dash between basename
+         * This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
          * and `time-toal` suffix.
          * @deprecated use {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}} for new metrics instead
          */

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1225,11 +1225,13 @@ public class Selector implements Selectable, AutoCloseable {
                     new WindowedCount(), "select", "times the I/O layer checked for new I/O to perform"));
             metricName = metrics.metricName("io-wait-time-ns-avg", metricGrpName, "The average length of time the I/O thread spent waiting for a socket ready for reads or writes in nanoseconds.", metricTags);
             this.selectTime.add(metricName, new Avg());
+            this.selectTime.add(createIOThreadRatioMeterLegacy(metrics, metricGrpName, metricTags, "io-wait", "waiting"));
             this.selectTime.add(createIOThreadRatioMeter(metrics, metricGrpName, metricTags, "io-wait", "waiting"));
 
             this.ioTime = sensor("io-time:" + tagsSuffix);
             metricName = metrics.metricName("io-time-ns-avg", metricGrpName, "The average length of time for I/O per select call in nanoseconds.", metricTags);
             this.ioTime.add(metricName, new Avg());
+            this.ioTime.add(createIOThreadRatioMeterLegacy(metrics, metricGrpName, metricTags, "io", "doing I/O"));
             this.ioTime.add(createIOThreadRatioMeter(metrics, metricGrpName, metricTags, "io", "doing I/O"));
 
             this.connectionsByCipher = new IntGaugeSuite<>(log, "sslCiphers", metrics,
@@ -1272,12 +1274,27 @@ public class Selector implements Selectable, AutoCloseable {
             return createMeter(metrics, groupName, metricTags, null, baseName, descriptiveName);
         }
 
-        private Meter createIOThreadRatioMeter(Metrics metrics, String groupName,  Map<String, String> metricTags,
+        /**
+         * This method generates `time-total` metrics with a couple of errors, no `-ns` suffix and no dash between basename
+         * and `time-toal` suffix.
+         * @deprecated use {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}} for new metrics instead
+         */
+        @Deprecated
+        private Meter createIOThreadRatioMeterLegacy(Metrics metrics, String groupName,  Map<String, String> metricTags,
                 String baseName, String action) {
             MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
-                    String.format("The fraction of time the I/O thread spent %s", action), metricTags);
+                    String.format("*Deprecated* The fraction of time the I/O thread spent %s", action), metricTags);
             MetricName totalMetricName = metrics.metricName(baseName + "time-total", groupName,
-                    String.format("The total time the I/O thread spent %s", action), metricTags);
+                    String.format("*Deprecated* The total time the I/O thread spent %s", action), metricTags);
+            return new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName);
+        }
+
+        private Meter createIOThreadRatioMeter(Metrics metrics, String groupName,  Map<String, String> metricTags,
+                                               String baseName, String action) {
+            MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
+                String.format("The fraction of time the I/O thread spent %s", action), metricTags);
+            MetricName totalMetricName = metrics.metricName(baseName + "-time-ns-total", groupName,
+                String.format("The total time the I/O thread spent %s", action), metricTags);
             return new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName);
         }
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1891,6 +1891,16 @@ $ bin/kafka-acls.sh \
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
+        <td>io-wait-time-ns-total</td>
+        <td>The total time the I/O thread spent waiting in nanoseconds</td>
+        <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>io-waittime-total</td>
+        <td><b>*Deprecated*</b> The total time the I/O thread spent waiting in nanoseconds</td>
+        <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
         <td>io-wait-ratio</td>
         <td>The fraction of time the I/O thread spent waiting.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
@@ -1898,6 +1908,16 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>io-time-ns-avg</td>
         <td>The average length of time for I/O per select call in nanoseconds.</td>
+        <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>io-time-ns-total</td>
+        <td>The total time the I/O thread spent doing I/O in nanoseconds</td>
+        <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>iotime-total</td>
+        <td><b>*Deprecated*</b> The total time the I/O thread spent doing I/O in nanoseconds</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
@@ -2070,6 +2090,16 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>bufferpool-wait-time</td>
         <td>The fraction of time an appender waits for space allocation.</td>
+        <td>kafka.producer:type=producer-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>bufferpool-wait-time-total</td>
+        <td><b>*Deprecated*</b> The total time an appender waits for space allocation in nanoseconds.</td>
+        <td>kafka.producer:type=producer-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>bufferpool-wait-time-ns-total</td>
+        <td>The total time an appender waits for space allocation in nanoseconds.</td>
         <td>kafka.producer:type=producer-metrics,client-id=([-.\w]+)</td>
       </tr>
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1892,12 +1892,12 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>io-wait-time-ns-total</td>
-        <td>The total time the I/O thread spent waiting in nanoseconds</td>
+        <td>The total time the I/O thread spent waiting in nanoseconds.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
         <td>io-waittime-total</td>
-        <td><b>*Deprecated*</b> The total time the I/O thread spent waiting in nanoseconds</td>
+        <td><b>*Deprecated*</b> The total time the I/O thread spent waiting in nanoseconds. Replacement is <code>io-wait-time-ns-total</code>.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
@@ -1912,12 +1912,12 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>io-time-ns-total</td>
-        <td>The total time the I/O thread spent doing I/O in nanoseconds</td>
+        <td>The total time the I/O thread spent doing I/O in nanoseconds.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
         <td>iotime-total</td>
-        <td><b>*Deprecated*</b> The total time the I/O thread spent doing I/O in nanoseconds</td>
+        <td><b>*Deprecated*</b> The total time the I/O thread spent doing I/O in nanoseconds. Replacement is <code>io-time-ns-total</code>.</td>
         <td>kafka.[producer|consumer|connect]:type=[producer|consumer|connect]-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>
@@ -2094,7 +2094,7 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>bufferpool-wait-time-total</td>
-        <td><b>*Deprecated*</b> The total time an appender waits for space allocation in nanoseconds.</td>
+        <td><b>*Deprecated*</b> The total time an appender waits for space allocation in nanoseconds. Replacement is <code>bufferpool-wait-time-ns-total</code></td>
         <td>kafka.producer:type=producer-metrics,client-id=([-.\w]+)</td>
       </tr>
       <tr>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -22,9 +22,12 @@
 <h5><a id="upgrade_310_notable" href="#upgrade_310_notable">Notable changes in 3.1.0</a></h5>
 <ul>
     <li>Apache Kafka supports Java 17.</li>
+    <li>The following metrics have been deprecated: <code>bufferpool-wait-time-total</code>, <code>io-waittime-total</code>,
+        and <code>iotime-total</code>. Please use <code>bufferpool-wait-time-ns-total</code>, <code>io-wait-time-ns-total</code>,
+        and <code>io-time-ns-total</code> instead.</li>
 </ul>
 
-<h5><a id="upgrade_310_notable" href="#upgrade_300_notable">Notable changes in 3.0.0</a></h5>
+<h5><a id="upgrade_300_notable" href="#upgrade_300_notable">Notable changes in 3.0.0</a></h5>
 <ul>
     <li>ZooKeeper has been upgraded to version 3.6.3.</li>
     <li>A preview of KRaft mode is available, though upgrading to it from the 2.8 Early Access release is not possible. See

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -24,7 +24,8 @@
     <li>Apache Kafka supports Java 17.</li>
     <li>The following metrics have been deprecated: <code>bufferpool-wait-time-total</code>, <code>io-waittime-total</code>,
         and <code>iotime-total</code>. Please use <code>bufferpool-wait-time-ns-total</code>, <code>io-wait-time-ns-total</code>,
-        and <code>io-time-ns-total</code> instead.</li>
+        and <code>io-time-ns-total</code> instead. See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-773%3A+Differentiate+consistently+metric+latency+measured+in+millis+and+nanos">KIP-773</a>
+        for more details.</li>
 </ul>
 
 <h5><a id="upgrade_300_notable" href="#upgrade_300_notable">Notable changes in 3.0.0</a></h5>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTime.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTime.java
@@ -48,12 +48,12 @@ public class StreamThreadTotalBlockedTime {
     }
 
     public double compute() {
-        return metricValue(consumer.metrics(), "io-waittime-total")
-            + metricValue(consumer.metrics(), "iotime-total")
+        return metricValue(consumer.metrics(), "io-wait-time-ns-total")
+            + metricValue(consumer.metrics(), "io-time-ns-total")
             + metricValue(consumer.metrics(), "committed-time-ns-total")
             + metricValue(consumer.metrics(), "commit-sync-time-ns-total")
-            + metricValue(restoreConsumer.metrics(), "io-waittime-total")
-            + metricValue(restoreConsumer.metrics(), "iotime-total")
+            + metricValue(restoreConsumer.metrics(), "io-wait-time-ns-total")
+            + metricValue(restoreConsumer.metrics(), "io-time-ns-total")
             + producerTotalBlockedTime.get();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -215,7 +215,7 @@ public class StreamsProducer {
     }
 
     private double totalBlockedTime(final Producer<?, ?> producer) {
-        return getMetricValue(producer.metrics(), "bufferpool-wait-time-total")
+        return getMetricValue(producer.metrics(), "bufferpool-wait-time-ns-total")
             + getMetricValue(producer.metrics(), "flush-time-ns-total")
             + getMetricValue(producer.metrics(), "txn-init-time-ns-total")
             + getMetricValue(producer.metrics(), "txn-begin-time-ns-total")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTimeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTimeTest.java
@@ -36,8 +36,8 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class StreamThreadTotalBlockedTimeTest {
-    private static final int IOTIME_TOTAL = 1;
-    private static final int IO_WATTIME_TOTAL = 2;
+    private static final int IO_TIME_TOTAL = 1;
+    private static final int IO_WAIT_TIME_TOTAL = 2;
     private static final int COMMITTED_TIME_TOTAL = 3;
     private static final int COMMIT_SYNC_TIME_TOTAL = 4;
     private static final int RESTORE_IOTIME_TOTAL = 5;
@@ -60,15 +60,15 @@ public class StreamThreadTotalBlockedTimeTest {
     public void setup() {
         blockedTime = new StreamThreadTotalBlockedTime(consumer, restoreConsumer, producerBlocked);
         when(consumer.metrics()).thenAnswer(a -> new MetricsBuilder()
-            .addMetric("iotime-total", IOTIME_TOTAL)
-            .addMetric("io-waittime-total", IO_WATTIME_TOTAL)
+            .addMetric("io-time-ns-total", IO_TIME_TOTAL)
+            .addMetric("io-wait-time-ns-total", IO_WAIT_TIME_TOTAL)
             .addMetric("committed-time-ns-total", COMMITTED_TIME_TOTAL)
             .addMetric("commit-sync-time-ns-total", COMMIT_SYNC_TIME_TOTAL)
             .build()
         );
         when(restoreConsumer.metrics()).thenAnswer(a -> new MetricsBuilder()
-            .addMetric("iotime-total", RESTORE_IOTIME_TOTAL)
-            .addMetric("io-waittime-total", RESTORE_IO_WAITTIME_TOTAL)
+            .addMetric("io-time-ns-total", RESTORE_IOTIME_TOTAL)
+            .addMetric("io-wait-time-ns-total", RESTORE_IO_WAITTIME_TOTAL)
             .build()
         );
         when(producerBlocked.get()).thenReturn(PRODUCER_BLOCKED_TIME);
@@ -78,7 +78,7 @@ public class StreamThreadTotalBlockedTimeTest {
     public void shouldComputeTotalBlockedTime() {
         assertThat(
             blockedTime.compute(),
-            equalTo(IOTIME_TOTAL + IO_WATTIME_TOTAL + COMMITTED_TIME_TOTAL
+            equalTo(IO_TIME_TOTAL + IO_WAIT_TIME_TOTAL + COMMITTED_TIME_TOTAL
                 + COMMIT_SYNC_TIME_TOTAL + RESTORE_IOTIME_TOTAL + RESTORE_IO_WAITTIME_TOTAL
                 + PRODUCER_BLOCKED_TIME)
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -1244,7 +1244,7 @@ public class StreamsProducerTest {
         final double txnSendOffsetsTime,
         final double txnCommitTime,
         final double txnAbortTime) {
-        addMetric(producer, "bufferpool-wait-time-total", bufferPoolWaitTime);
+        addMetric(producer, "bufferpool-wait-time-ns-total", bufferPoolWaitTime);
         addMetric(producer, "flush-time-ns-total", flushTime);
         addMetric(producer, "txn-init-time-ns-total", txnInitTime);
         addMetric(producer, "txn-begin-time-ns-total", txnBeginTime);


### PR DESCRIPTION
Implementation of [KIP-773](https://cwiki.apache.org/confluence/x/ZwNACw)

- Deprecates inconsistent metrics `bufferpool-wait-time-total`, `io-waittime-total`, and `iotime-total`.
- Introduces new metrics `bufferpool-wait-time-ns-total`, `io-wait-time-ns-total`, and `io-time-ns-total` with the same semantics as before.
- Adds metrics (old and new) in ops.html.
- Adds upgrade guide for these metrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
