### PR TITLE
MINOR: Upgrade compression libraries (Q3 2021)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,7 +97,7 @@ versions += [
   kafka_26: "2.6.2",
   kafka_27: "2.7.1",
   kafka_28: "2.8.0",
-  lz4: "1.7.1",
+  lz4: "1.8.0",
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "3.12.4",
@@ -110,11 +110,11 @@ versions += [
   scalaJava8Compat : "1.0.0",
   scoverage: "1.4.1",
   slf4j: "1.7.30",
-  snappy: "1.1.8.1",
+  snappy: "1.1.8.4",
   spotbugs: "4.2.2",
   zinc: "1.3.5",
   zookeeper: "3.6.3",
-  zstd: "1.5.0-2"
+  zstd: "1.5.0-4"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
lz4-java: 1.7.1 -> 1.8.0

The most noteworthy change is the upgrade of the
underlying C library to 1.9.3. Details:

* https://github.com/lz4/lz4-java/releases/tag/1.8.0
* https://github.com/lz4/lz4/releases/tag/v1.9.3

snappy-java: 1.1.8.1 -> 1.1.8.4

The most noteworthy change is support for Apple M1.
Details:

* https://github.com/xerial/snappy-java/releases/tag/1.1.8.2 
* https://github.com/xerial/snappy-java/releases/tag/1.1.8.3
* https://github.com/xerial/snappy-java/releases/tag/1.1.8.4

zstd-jni: 1.5.0-2 -> 1.5.0-4

Minor fixes, details:

* https://github.com/luben/zstd-jni/releases/tag/v1.5.0-3
* https://github.com/luben/zstd-jni/releases/tag/v1.5.0-4

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
