### PR TITLE
KAFKA-13262: Remove final from `MockConsumer.close()` and delegate implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
+import static org.apache.kafka.clients.consumer.KafkaConsumer.DEFAULT_CLOSE_TIMEOUT_MS;
 
 
 /**
@@ -446,8 +447,8 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
-    public final synchronized void close() {
-        this.closed = true;
+    public synchronized void close() {
+        close(Duration.ofMillis(DEFAULT_CLOSE_TIMEOUT_MS));
     }
 
     public synchronized boolean closed() {
@@ -571,6 +572,6 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void close(Duration timeout) {
-        close();
+        this.closed = true;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -447,8 +447,13 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
-    public synchronized void close() {
+    public void close() {
         close(Duration.ofMillis(DEFAULT_CLOSE_TIMEOUT_MS));
+    }
+
+    @Override
+    public synchronized void close(Duration timeout) {
+        this.closed = true;
     }
 
     public synchronized boolean closed() {
@@ -568,10 +573,5 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
     public Duration lastPollTimeout() {
         return lastPollTimeout;
-    }
-
-    @Override
-    public void close(Duration timeout) {
-        this.closed = true;
     }
 }


### PR DESCRIPTION
I added the final via 2f3600198722 to catch overriding mistakes
since the implementation was moved from the deprecated and
overloaded `close` with two parameters to the no-arg
`close`.

I didn't realize then that `MockConsumer` is a public
API (seems like a bit of a mistake since we tweak the
implementation and sometimes adds methods without a KIP).

Given that this is a public API, I have also moved the implementation
of `close` to the one arg overload. This makes it easier for a
subclass to have specific overriding behavior depending on the
timeout.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
