### PR TITLE
KAFKA-10540: Migrate KStream aggregate operations

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -38,6 +38,7 @@ import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 class CogroupedStreamAggregateBuilder<K, VOut> {
@@ -60,7 +61,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor =
+            final KStreamAggProcessorSupplier<K, ?, K, ?> parentProcessor =
                 new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue());
             parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
@@ -94,8 +95,8 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?>  parentProcessor =
-                (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamWindowAggregate<K, K, VOut, W>(
+            final KStreamAggProcessorSupplier<K, ?, K, ?>  parentProcessor =
+                (KStreamAggProcessorSupplier<K, ?, K, ?>) new KStreamWindowAggregate<K, K, VOut, W>(
                     windows,
                     storeBuilder.name(),
                     initializer,
@@ -132,8 +133,8 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor =
-                (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSessionWindowAggregate<K, K, VOut>(
+            final KStreamAggProcessorSupplier<K, ?, K, ?> parentProcessor =
+                (KStreamAggProcessorSupplier<K, ?, K, ?>) new KStreamSessionWindowAggregate<K, K, VOut>(
                     sessionWindows,
                     storeBuilder.name(),
                     initializer,
@@ -170,8 +171,8 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor =
-                (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSlidingWindowAggregate<K, K, VOut>(
+            final KStreamAggProcessorSupplier<K, ?, K, ?> parentProcessor =
+                (KStreamAggProcessorSupplier<K, ?, K, ?>) new KStreamSlidingWindowAggregate<K, K, VOut>(
                     slidingWindows,
                     storeBuilder.name(),
                     initializer,
@@ -253,11 +254,10 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             builder);
     }
 
-    @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
     private StatefulProcessorNode<K, ?> getStatefulProcessorNode(final String processorName,
                                                                  final boolean stateCreated,
                                                                  final StoreBuilder<?> storeBuilder,
-                                                                 final org.apache.kafka.streams.processor.ProcessorSupplier<K, ?> kStreamAggregate) {
+                                                                 final ProcessorSupplier<K, ?, K, ?> kStreamAggregate) {
         final StatefulProcessorNode<K, ?> statefulProcessorNode;
         if (!stateCreated) {
             statefulProcessorNode =

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -68,7 +68,7 @@ class GroupedStreamAggregateBuilder<K, V> {
 
     <KR, VR> KTable<KR, VR> build(final NamedInternal functionName,
                                   final StoreBuilder<?> storeBuilder,
-                                  final KStreamAggProcessorSupplier<K, KR, V, VR> aggregateSupplier,
+                                  final KStreamAggProcessorSupplier<K, V, KR, VR> aggregateSupplier,
                                   final String queryableStoreName,
                                   final Serde<KR> keySerde,
                                   final Serde<VR> valueSerde) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -233,7 +233,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
         );
     }
 
-    private <T> KTable<K, T> doAggregate(final KStreamAggProcessorSupplier<K, K, V, T> aggregateSupplier,
+    private <T> KTable<K, T> doAggregate(final KStreamAggProcessorSupplier<K, V, K, T> aggregateSupplier,
                                          final String functionName,
                                          final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materializedInternal) {
         return aggregateBuilder.build(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggProcessorSupplier.java
@@ -16,8 +16,9 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-@SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-public interface KStreamAggProcessorSupplier<K, RK, V, T> extends org.apache.kafka.streams.processor.ProcessorSupplier<K, V> {
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+
+public interface KStreamAggProcessorSupplier<K, V, RK, T> extends ProcessorSupplier<K, V, RK, Change<T>> {
 
     KTableValueGetterSupplier<RK, T> view();
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggProcessorSupplier.java
@@ -18,9 +18,9 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 
-public interface KStreamAggProcessorSupplier<K, V, RK, T> extends ProcessorSupplier<K, V, RK, Change<T>> {
+public interface KStreamAggProcessorSupplier<KIn, VIn, KAgg, VAgg> extends ProcessorSupplier<KIn, VIn, KAgg, Change<VAgg>> {
 
-    KTableValueGetterSupplier<RK, T> view();
+    KTableValueGetterSupplier<KAgg, VAgg> view();
 
     void enableSendingOldValues();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -86,7 +86,7 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
         public void process(final Record<KIn, VIn> record) {
             // If the key or value is null we don't need to proceed
             if (record.key() == null || record.value() == null) {
-                if (context.recordMetadata().isPresent()) {
+                if (context().recordMetadata().isPresent()) {
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
                     LOG.warn(
                         "Skipping record due to null key or value. "
@@ -95,7 +95,7 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
                     );
                 } else {
                     LOG.warn(
-                        "Skipping record due to null key. Topic, partition, and offset not known."
+                        "Skipping record due to null key or value. Topic, partition, and offset not known."
                     );
                 }
                 droppedRecordsSensor.record();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -87,7 +87,7 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
             // If the key or value is null we don't need to proceed
             if (record.key() == null || record.value() == null) {
                 if (context().recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     LOG.warn(
                         "Skipping record due to null key or value. "
                             + "topic=[{}] partition=[{}] offset=[{}]",

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -82,8 +82,8 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K,
         public void process(final Record<K, V> record) {
             // If the key or value is null we don't need to proceed
             if (record.key() == null || record.value() == null) {
-                if (context.recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     LOG.warn(
                         "Skipping record due to null key or value. "
                             + "topic=[{}] partition=[{}] offset=[{}]",

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -18,6 +18,9 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -27,8 +30,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
-@SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V, V> {
+public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K, V> {
     private static final Logger LOG = LoggerFactory.getLogger(KStreamReduce.class);
 
     private final String storeName;
@@ -42,7 +44,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
     }
 
     @Override
-    public org.apache.kafka.streams.processor.Processor<K, V> get() {
+    public Processor<K, V, K, Change<V>> get() {
         return new KStreamReduceProcessor();
     }
 
@@ -52,14 +54,13 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
     }
 
 
-    private class KStreamReduceProcessor extends org.apache.kafka.streams.processor.AbstractProcessor<K, V> {
+    private class KStreamReduceProcessor implements Processor<K, V, K, Change<V>> {
         private TimestampedKeyValueStore<K, V> store;
         private TimestampedTupleForwarder<K, V> tupleForwarder;
         private Sensor droppedRecordsSensor;
 
         @Override
-        public void init(final org.apache.kafka.streams.processor.ProcessorContext context) {
-            super.init(context);
+        public void init(final ProcessorContext<K, Change<V>> context) {
             droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
@@ -74,33 +75,33 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
         }
 
         @Override
-        public void process(final K key, final V value) {
+        public void process(final Record<K, V> record) {
             // If the key or value is null we don't need to proceed
-            if (key == null || value == null) {
-                LOG.warn(
-                    "Skipping record due to null key or value. key=[{}] value=[{}] topic=[{}] partition=[{}] offset=[{}]",
-                    key, value, context().topic(), context().partition(), context().offset()
-                );
+            if (record.key() == null || record.value() == null) {
+//                LOG.warn(
+//                    "Skipping record due to null key or value. key=[{}] value=[{}] topic=[{}] partition=[{}] offset=[{}]",
+//                    key, value, context().topic(), context().partition(), context().offset()
+//                );
                 droppedRecordsSensor.record();
                 return;
             }
 
-            final ValueAndTimestamp<V> oldAggAndTimestamp = store.get(key);
+            final ValueAndTimestamp<V> oldAggAndTimestamp = store.get(record.key());
             final V oldAgg = getValueOrNull(oldAggAndTimestamp);
 
             final V newAgg;
             final long newTimestamp;
 
             if (oldAgg == null) {
-                newAgg = value;
-                newTimestamp = context().timestamp();
+                newAgg = record.value();
+                newTimestamp = record.timestamp();
             } else {
-                newAgg = reducer.apply(oldAgg, value);
-                newTimestamp = Math.max(context().timestamp(), oldAggAndTimestamp.timestamp());
+                newAgg = reducer.apply(oldAgg, record.value());
+                newTimestamp = Math.max(record.timestamp(), oldAggAndTimestamp.timestamp());
             }
 
-            store.put(key, ValueAndTimestamp.make(newAgg, newTimestamp));
-            tupleForwarder.maybeForward(key, newAgg, sendOldValues ? oldAgg : null, newTimestamp);
+            store.put(record.key(), ValueAndTimestamp.make(newAgg, newTimestamp));
+            tupleForwarder.maybeForward(record.key(), newAgg, sendOldValues ? oldAgg : null, newTimestamp);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -107,7 +107,7 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
         public void process(final Record<KIn, VIn> record) {
             // if the key is null, we do not need proceed aggregating
             // the record with the table
-            if (record.value() == null) {
+            if (record.key() == null) {
                 if (context.recordMetadata().isPresent()) {
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
                     LOG.warn(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -24,9 +24,11 @@ import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.Merger;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
@@ -39,22 +41,23 @@ import java.util.List;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
-public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProcessorSupplier<K, V, Windowed<K>, Agg> {
+public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupplier<KIn, VIn, Windowed<KIn>, VAgg> {
+
     private static final Logger LOG = LoggerFactory.getLogger(KStreamSessionWindowAggregate.class);
 
     private final String storeName;
     private final SessionWindows windows;
-    private final Initializer<Agg> initializer;
-    private final Aggregator<? super K, ? super V, Agg> aggregator;
-    private final Merger<? super K, Agg> sessionMerger;
+    private final Initializer<VAgg> initializer;
+    private final Aggregator<? super KIn, ? super VIn, VAgg> aggregator;
+    private final Merger<? super KIn, VAgg> sessionMerger;
 
     private boolean sendOldValues = false;
 
     public KStreamSessionWindowAggregate(final SessionWindows windows,
-                                         final String storeName,
-                                         final Initializer<Agg> initializer,
-                                         final Aggregator<? super K, ? super V, Agg> aggregator,
-                                         final Merger<? super K, Agg> sessionMerger) {
+        final String storeName,
+        final Initializer<VAgg> initializer,
+        final Aggregator<? super KIn, ? super VIn, VAgg> aggregator,
+        final Merger<? super KIn, VAgg> sessionMerger) {
         this.windows = windows;
         this.storeName = storeName;
         this.initializer = initializer;
@@ -63,7 +66,7 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
     }
 
     @Override
-    public Processor<K, V, Windowed<K>, Change<Agg>> get() {
+    public Processor<KIn, VIn, Windowed<KIn>, Change<VAgg>> get() {
         return new KStreamSessionWindowAggregateProcessor();
     }
 
@@ -76,18 +79,21 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
         sendOldValues = true;
     }
 
-    private class KStreamSessionWindowAggregateProcessor implements Processor<K, V, Windowed<K>, Change<Agg>> {
+    private class KStreamSessionWindowAggregateProcessor extends
+        ContextualProcessor<KIn, VIn, Windowed<KIn>, Change<VAgg>> {
 
-        private SessionStore<K, Agg> store;
-        private SessionTupleForwarder<K, Agg> tupleForwarder;
+        private SessionStore<KIn, VAgg> store;
+        private SessionTupleForwarder<KIn, VAgg> tupleForwarder;
         private Sensor droppedRecordsSensor;
         private long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
 
         @Override
-        public void init(final ProcessorContext<Windowed<K>, Change<Agg>> context) {
+        public void init(final ProcessorContext<Windowed<KIn>, Change<VAgg>> context) {
+            super.init(context);
             final StreamsMetricsImpl metrics = (StreamsMetricsImpl) context.metrics();
             final String threadId = Thread.currentThread().getName();
-            droppedRecordsSensor = droppedRecordsSensor(threadId, context.taskId().toString(), metrics);
+            droppedRecordsSensor = droppedRecordsSensor(threadId, context.taskId().toString(),
+                metrics);
             store = context.getStateStore(storeName);
             tupleForwarder = new SessionTupleForwarder<>(
                 store,
@@ -98,14 +104,22 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
         }
 
         @Override
-        public void process(final Record<K, V> record) {
+        public void process(final Record<KIn, VIn> record) {
             // if the key is null, we do not need proceed aggregating
             // the record with the table
             if (record.value() == null) {
-//                LOG.warn(
-//                    "Skipping record due to null key. value=[{}] topic=[{}] partition=[{}] offset=[{}]",
-//                    value, context().topic(), context().partition(), context().offset()
-//                );
+                if (context.recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                    LOG.warn(
+                        "Skipping record due to null key. "
+                            + "topic=[{}] partition=[{}] offset=[{}]",
+                        recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset()
+                    );
+                } else {
+                    LOG.warn(
+                        "Skipping record due to null key. Topic, partition, and offset not known."
+                    );
+                }
                 droppedRecordsSensor.record();
                 return;
             }
@@ -114,20 +128,20 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
             observedStreamTime = Math.max(observedStreamTime, timestamp);
             final long closeTime = observedStreamTime - windows.gracePeriodMs() - windows.inactivityGap();
 
-            final List<KeyValue<Windowed<K>, Agg>> merged = new ArrayList<>();
+            final List<KeyValue<Windowed<KIn>, VAgg>> merged = new ArrayList<>();
             final SessionWindow newSessionWindow = new SessionWindow(timestamp, timestamp);
             SessionWindow mergedWindow = newSessionWindow;
-            Agg agg = initializer.apply();
+            VAgg agg = initializer.apply();
 
             try (
-                final KeyValueIterator<Windowed<K>, Agg> iterator = store.findSessions(
+                final KeyValueIterator<Windowed<KIn>, VAgg> iterator = store.findSessions(
                     record.key(),
                     timestamp - windows.inactivityGap(),
                     timestamp + windows.inactivityGap()
                 )
             ) {
                 while (iterator.hasNext()) {
-                    final KeyValue<Windowed<K>, Agg> next = iterator.next();
+                    final KeyValue<Windowed<KIn>, VAgg> next = iterator.next();
                     merged.add(next);
                     agg = sessionMerger.apply(record.key(), agg, next.value);
                     mergedWindow = mergeSessionWindow(mergedWindow, (SessionWindow) next.key.window());
@@ -135,37 +149,48 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
             }
 
             if (mergedWindow.end() < closeTime) {
-//                LOG.warn(
-//                    "Skipping record for expired window. " +
-//                        "key=[{}] " +
-//                        "topic=[{}] " +
-//                        "partition=[{}] " +
-//                        "offset=[{}] " +
-//                        "timestamp=[{}] " +
-//                        "window=[{},{}] " +
-//                        "expiration=[{}] " +
-//                        "streamTime=[{}]",
-//                    key,
-//                    context().topic(),
-//                    context().partition(),
-//                    context().offset(),
-//                    timestamp,
-//                    mergedWindow.start(),
-//                    mergedWindow.end(),
-//                    closeTime,
-//                    observedStreamTime
-//                );
+                final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context.recordMetadata().isPresent()) {
+                    LOG.warn(
+                        "Skipping record for expired window. " +
+                            "topic=[{}] " +
+                            "partition=[{}] " +
+                            "offset=[{}] " +
+                            "timestamp=[{}] " +
+                            "window=[{},{}] " +
+                            "expiration=[{}] " +
+                            "streamTime=[{}]",
+                        recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset(),
+                        timestamp,
+                        mergedWindow.start(), mergedWindow.end(),
+                        closeTime,
+                        observedStreamTime
+                    );
+                } else {
+                    LOG.warn(
+                        "Skipping record for expired window. Topic, partition, and offset not known. " +
+                            "timestamp=[{}] " +
+                            "window=[{},{}] " +
+                            "expiration=[{}] " +
+                            "streamTime=[{}]",
+                        timestamp,
+                        mergedWindow.start(), mergedWindow.end(),
+                        closeTime,
+                        observedStreamTime
+                    );
+                }
                 droppedRecordsSensor.record();
             } else {
                 if (!mergedWindow.equals(newSessionWindow)) {
-                    for (final KeyValue<Windowed<K>, Agg> session : merged) {
+                    for (final KeyValue<Windowed<KIn>, VAgg> session : merged) {
                         store.remove(session.key);
-                        tupleForwarder.maybeForward(session.key, null, sendOldValues ? session.value : null);
+                        tupleForwarder.maybeForward(session.key, null,
+                            sendOldValues ? session.value : null);
                     }
                 }
 
                 agg = aggregator.apply(record.key(), record.value(), agg);
-                final Windowed<K> sessionKey = new Windowed<>(record.key(), mergedWindow);
+                final Windowed<KIn> sessionKey = new Windowed<>(record.key(), mergedWindow);
                 store.put(sessionKey, agg);
                 tupleForwarder.maybeForward(sessionKey, agg, null);
             }
@@ -179,22 +204,23 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
     }
 
     @Override
-    public KTableValueGetterSupplier<Windowed<K>, Agg> view() {
-        return new KTableValueGetterSupplier<Windowed<K>, Agg>() {
+    public KTableValueGetterSupplier<Windowed<KIn>, VAgg> view() {
+        return new KTableValueGetterSupplier<Windowed<KIn>, VAgg>() {
             @Override
-            public KTableValueGetter<Windowed<K>, Agg> get() {
+            public KTableValueGetter<Windowed<KIn>, VAgg> get() {
                 return new KTableSessionWindowValueGetter();
             }
 
             @Override
             public String[] storeNames() {
-                return new String[] {storeName};
+                return new String[]{storeName};
             }
         };
     }
 
-    private class KTableSessionWindowValueGetter implements KTableValueGetter<Windowed<K>, Agg> {
-        private SessionStore<K, Agg> store;
+    private class KTableSessionWindowValueGetter implements KTableValueGetter<Windowed<KIn>, VAgg> {
+
+        private SessionStore<KIn, VAgg> store;
 
         @Override
         public void init(final org.apache.kafka.streams.processor.ProcessorContext context) {
@@ -202,7 +228,7 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
         }
 
         @Override
-        public ValueAndTimestamp<Agg> get(final Windowed<K> key) {
+        public ValueAndTimestamp<VAgg> get(final Windowed<KIn> key) {
             return ValueAndTimestamp.make(
                 store.fetchSession(key.key(), key.window().start(), key.window().end()),
                 key.window().end());

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -108,8 +108,8 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
             // if the key is null, we do not need proceed aggregating
             // the record with the table
             if (record.key() == null) {
-                if (context.recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     LOG.warn(
                         "Skipping record due to null key. "
                             + "topic=[{}] partition=[{}] offset=[{}]",
@@ -149,8 +149,8 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
             }
 
             if (mergedWindow.end() < closeTime) {
-                final RecordMetadata recordMetadata = context.recordMetadata().get();
-                if (context.recordMetadata().isPresent()) {
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     LOG.warn(
                         "Skipping record for expired window. " +
                             "topic=[{}] " +

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -112,7 +112,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                     );
                 } else {
                     log.warn(
-                        "Skipping record due to null key. Topic, partition, and offset not known."
+                        "Skipping record due to null key or value. Topic, partition, and offset not known."
                     );
                 }
                 droppedRecordsSensor.record();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -44,7 +44,7 @@ import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupplier<KIn, VIn, Windowed<KIn>, VAgg> {
 
-    private final Logger LOG = LoggerFactory.getLogger(getClass());
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final String storeName;
     private final SlidingWindows windows;
@@ -105,13 +105,13 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
             if (record.key() == null || record.value() == null) {
                 if (context.recordMetadata().isPresent()) {
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
-                    LOG.warn(
+                    log.warn(
                         "Skipping record due to null key or value. "
                             + "topic=[{}] partition=[{}] offset=[{}]",
                         recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset()
                     );
                 } else {
-                    LOG.warn(
+                    log.warn(
                         "Skipping record due to null key. Topic, partition, and offset not known."
                     );
                 }
@@ -126,7 +126,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
             if (inputRecordTimestamp + 1L + windows.timeDifferenceMs() <= closeTime) {
                 if (context.recordMetadata().isPresent()) {
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
-                    LOG.warn(
+                    log.warn(
                         "Skipping record for expired window. " +
                             "topic=[{}] " +
                             "partition=[{}] " +
@@ -142,7 +142,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                         observedStreamTime
                     );
                 } else {
-                    LOG.warn(
+                    log.warn(
                         "Skipping record for expired window. Topic, partition, and offset not known. " +
                             "timestamp=[{}] " +
                             "window=[{},{}] " +
@@ -167,10 +167,10 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                 try {
                     windowStore.backwardFetch(record.key(), 0L, 0L);
                     reverseIteratorPossible = true;
-                    LOG.debug("Sliding Windows aggregate using a reverse iterator");
+                    log.debug("Sliding Windows aggregate using a reverse iterator");
                 } catch (final UnsupportedOperationException e)  {
                     reverseIteratorPossible = false;
-                    LOG.debug("Sliding Windows aggregate using a forward iterator");
+                    log.debug("Sliding Windows aggregate using a forward iterator");
                 }
             }
 
@@ -225,7 +225,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                     } else if (startTime == inputRecordTimestamp + 1) {
                         rightWinAlreadyCreated = true;
                     } else {
-                        LOG.error(
+                        log.error(
                             "Unexpected window with start {} found when processing record at {} in `KStreamSlidingWindowAggregate`.",
                             startTime, inputRecordTimestamp
                         );
@@ -284,7 +284,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                         previousRecordTimestamp = windowMaxRecordTimestamp;
                         break;
                     } else {
-                        LOG.error(
+                        log.error(
                             "Unexpected window with start {} found when processing record at {} in `KStreamSlidingWindowAggregate`.",
                             startTime, inputRecordTimestamp
                         );
@@ -302,7 +302,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
          */
         private void processEarly(final KIn key, final VIn value, final long inputRecordTimestamp, final long closeTime) {
             if (inputRecordTimestamp < 0 || inputRecordTimestamp >= windows.timeDifferenceMs()) {
-                LOG.error(
+                log.error(
                     "Early record for sliding windows must fall between fall between 0 <= inputRecordTimestamp. Timestamp {} does not fall between 0 <= {}",
                     inputRecordTimestamp, windows.timeDifferenceMs()
                 );
@@ -346,7 +346,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                     } else if (startTime == inputRecordTimestamp + 1) {
                         rightWinAlreadyCreated = true;
                     } else {
-                        LOG.error(
+                        log.error(
                             "Unexpected window with start {} found when processing record at {} in `KStreamSlidingWindowAggregate`.",
                             startTime, inputRecordTimestamp
                         );
@@ -491,7 +491,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
             } else {
                 if (context.recordMetadata().isPresent()) {
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
-                    LOG.warn(
+                    log.warn(
                         "Skipping record for expired window. " +
                             "topic=[{}] " +
                             "partition=[{}] " +
@@ -507,7 +507,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                         observedStreamTime
                     );
                 } else {
-                    LOG.warn(
+                    log.warn(
                         "Skipping record for expired window. Topic, partition, and offset not known. " +
                             "timestamp=[{}] " +
                             "window=[{},{}] " +

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -103,8 +103,8 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
         @Override
         public void process(final Record<KIn, VIn> record) {
             if (record.key() == null || record.value() == null) {
-                if (context.recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     log.warn(
                         "Skipping record due to null key or value. "
                             + "topic=[{}] partition=[{}] offset=[{}]",
@@ -124,8 +124,8 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
             final long closeTime = observedStreamTime - windows.gracePeriodMs();
 
             if (inputRecordTimestamp + 1L + windows.timeDifferenceMs() <= closeTime) {
-                if (context.recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     log.warn(
                         "Skipping record for expired window. " +
                             "topic=[{}] " +
@@ -489,8 +489,8 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                     sendOldValues ? oldAgg : null,
                     newTimestamp);
             } else {
-                if (context.recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     log.warn(
                         "Skipping record for expired window. " +
                             "topic=[{}] " +

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -23,6 +23,9 @@ import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -35,8 +38,7 @@ import java.util.Map;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
-@SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStreamAggProcessorSupplier<K, Windowed<K>, V, Agg> {
+public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStreamAggProcessorSupplier<K, V, Windowed<K>, Agg> {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final String storeName;
@@ -57,7 +59,7 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
     }
 
     @Override
-    public org.apache.kafka.streams.processor.Processor<K, V> get() {
+    public Processor<K, V, Windowed<K>, Change<Agg>> get() {
         return new KStreamWindowAggregateProcessor();
     }
 
@@ -71,15 +73,14 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
     }
 
 
-    private class KStreamWindowAggregateProcessor extends org.apache.kafka.streams.processor.AbstractProcessor<K, V> {
+    private class KStreamWindowAggregateProcessor implements Processor<K, V, Windowed<K>, Change<Agg>> {
         private TimestampedWindowStore<K, Agg> windowStore;
         private TimestampedTupleForwarder<Windowed<K>, Agg> tupleForwarder;
         private Sensor droppedRecordsSensor;
         private long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
 
         @Override
-        public void init(final org.apache.kafka.streams.processor.ProcessorContext context) {
-            super.init(context);
+        public void init(final ProcessorContext<Windowed<K>, Change<Agg>> context) {
             final InternalProcessorContext internalProcessorContext = (InternalProcessorContext) context;
             final StreamsMetricsImpl metrics = internalProcessorContext.metrics();
             final String threadId = Thread.currentThread().getName();
@@ -93,18 +94,18 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
         }
 
         @Override
-        public void process(final K key, final V value) {
-            if (key == null) {
-                log.warn(
-                    "Skipping record due to null key. value=[{}] topic=[{}] partition=[{}] offset=[{}]",
-                    value, context().topic(), context().partition(), context().offset()
-                );
+        public void process(final Record<K, V> record) {
+            if (record.key() == null) {
+//                log.warn(
+//                    "Skipping record due to null key. value=[{}] topic=[{}] partition=[{}] offset=[{}]",
+//                    value, context().topic(), context().partition(), context().offset()
+//                );
                 droppedRecordsSensor.record();
                 return;
             }
 
             // first get the matching windows
-            final long timestamp = context().timestamp();
+            final long timestamp = record.timestamp();
             observedStreamTime = Math.max(observedStreamTime, timestamp);
             final long closeTime = observedStreamTime - windows.gracePeriodMs();
 
@@ -115,7 +116,7 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
                 final Long windowStart = entry.getKey();
                 final long windowEnd = entry.getValue().end();
                 if (windowEnd > closeTime) {
-                    final ValueAndTimestamp<Agg> oldAggAndTimestamp = windowStore.fetch(key, windowStart);
+                    final ValueAndTimestamp<Agg> oldAggAndTimestamp = windowStore.fetch(record.key(), windowStart);
                     Agg oldAgg = getValueOrNull(oldAggAndTimestamp);
 
                     final Agg newAgg;
@@ -123,40 +124,40 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
 
                     if (oldAgg == null) {
                         oldAgg = initializer.apply();
-                        newTimestamp = context().timestamp();
+                        newTimestamp = record.timestamp();
                     } else {
-                        newTimestamp = Math.max(context().timestamp(), oldAggAndTimestamp.timestamp());
+                        newTimestamp = Math.max(record.timestamp(), oldAggAndTimestamp.timestamp());
                     }
 
-                    newAgg = aggregator.apply(key, value, oldAgg);
+                    newAgg = aggregator.apply(record.key(), record.value(), oldAgg);
 
                     // update the store with the new value
-                    windowStore.put(key, ValueAndTimestamp.make(newAgg, newTimestamp), windowStart);
+                    windowStore.put(record.key(), ValueAndTimestamp.make(newAgg, newTimestamp), windowStart);
                     tupleForwarder.maybeForward(
-                        new Windowed<>(key, entry.getValue()),
+                        new Windowed<>(record.key(), entry.getValue()),
                         newAgg,
                         sendOldValues ? oldAgg : null,
                         newTimestamp);
                 } else {
-                    log.warn(
-                        "Skipping record for expired window. " +
-                            "key=[{}] " +
-                            "topic=[{}] " +
-                            "partition=[{}] " +
-                            "offset=[{}] " +
-                            "timestamp=[{}] " +
-                            "window=[{},{}) " +
-                            "expiration=[{}] " +
-                            "streamTime=[{}]",
-                        key,
-                        context().topic(),
-                        context().partition(),
-                        context().offset(),
-                        context().timestamp(),
-                        windowStart, windowEnd,
-                        closeTime,
-                        observedStreamTime
-                    );
+//                    log.warn(
+//                        "Skipping record for expired window. " +
+//                            "key=[{}] " +
+//                            "topic=[{}] " +
+//                            "partition=[{}] " +
+//                            "offset=[{}] " +
+//                            "timestamp=[{}] " +
+//                            "window=[{},{}) " +
+//                            "expiration=[{}] " +
+//                            "streamTime=[{}]",
+//                        key,
+//                        context().topic(),
+//                        context().partition(),
+//                        context().offset(),
+//                        context().timestamp(),
+//                        windowStart, windowEnd,
+//                        closeTime,
+//                        observedStreamTime
+//                    );
                     droppedRecordsSensor.record();
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -101,8 +101,8 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
         @Override
         public void process(final Record<KIn, VIn> record) {
             if (record.key() == null) {
-                if (context.recordMetadata().isPresent()) {
-                    final RecordMetadata recordMetadata = context.recordMetadata().get();
+                if (context().recordMetadata().isPresent()) {
+                    final RecordMetadata recordMetadata = context().recordMetadata().get();
                     log.warn(
                         "Skipping record due to null key. "
                             + "topic=[{}] partition=[{}] offset=[{}]",
@@ -152,8 +152,8 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
                         sendOldValues ? oldAgg : null,
                         newTimestamp);
                 } else {
-                    if (context.recordMetadata().isPresent()) {
-                        final RecordMetadata recordMetadata = context.recordMetadata().get();
+                    if (context().recordMetadata().isPresent()) {
+                        final RecordMetadata recordMetadata = context().recordMetadata().get();
                         log.warn(
                             "Skipping record for expired window. " +
                                 "topic=[{}] " +

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -42,7 +42,7 @@ import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements KStreamAggProcessorSupplier<KIn, VIn, Windowed<KIn>, VAgg> {
 
-    private final Logger LOG = LoggerFactory.getLogger(getClass());
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final String storeName;
     private final Windows<W> windows;
@@ -103,13 +103,13 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
             if (record.key() == null) {
                 if (context.recordMetadata().isPresent()) {
                     final RecordMetadata recordMetadata = context.recordMetadata().get();
-                    LOG.warn(
+                    log.warn(
                         "Skipping record due to null key. "
                             + "topic=[{}] partition=[{}] offset=[{}]",
                         recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset()
                     );
                 } else {
-                    LOG.warn(
+                    log.warn(
                         "Skipping record due to null key. Topic, partition, and offset not known."
                     );
                 }
@@ -154,7 +154,7 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
                 } else {
                     if (context.recordMetadata().isPresent()) {
                         final RecordMetadata recordMetadata = context.recordMetadata().get();
-                        LOG.warn(
+                        log.warn(
                             "Skipping record for expired window. " +
                                 "topic=[{}] " +
                                 "partition=[{}] " +
@@ -170,7 +170,7 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
                             observedStreamTime
                         );
                     } else {
-                        LOG.warn(
+                        log.warn(
                             "Skipping record for expired window. Topic, partition, and offset not known. " +
                                 "timestamp=[{}] " +
                                 "window=[{},{}] " +

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -832,7 +832,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             source.materialize();
             return new KTableSourceValueGetterSupplier<>(source.queryableName());
         } else if (processorSupplier instanceof KStreamAggProcessorSupplier) {
-            return ((KStreamAggProcessorSupplier<?, K, S, V>) processorSupplier).view();
+            return ((KStreamAggProcessorSupplier<?, S, K, V>) processorSupplier).view();
         } else if (processorSupplier instanceof KTableNewProcessorSupplier) {
             return ((KTableNewProcessorSupplier<?, ?, K, V>) processorSupplier).view();
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionCacheFlushListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionCacheFlushListener.java
@@ -17,8 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
@@ -30,8 +29,7 @@ class SessionCacheFlushListener<KOut, VOut> implements CacheFlushListener<Window
     @SuppressWarnings("rawtypes")
     private final ProcessorNode myNode;
 
-    @SuppressWarnings("unchecked")
-    SessionCacheFlushListener(final ProcessorContext context) {
+    SessionCacheFlushListener(final ProcessorContext<Windowed<KOut>, Change<VOut>> context) {
         this.context = (InternalProcessorContext<Windowed<KOut>, Change<VOut>>) context;
         myNode = this.context.currentNode();
     }
@@ -44,7 +42,7 @@ class SessionCacheFlushListener<KOut, VOut> implements CacheFlushListener<Window
         @SuppressWarnings("rawtypes") final ProcessorNode prev = context.currentNode();
         context.setCurrentNode(myNode);
         try {
-            context.forward(key, new Change<>(newValue, oldValue), To.all().withTimestamp(key.window().end()));
+            context.forward(new Record<>(key, new Change<>(newValue, oldValue), key.window().end()));
         } finally {
             context.setCurrentNode(prev);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionTupleForwarder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionTupleForwarder.java
@@ -17,9 +17,9 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.internals.CacheFlushListener;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 
@@ -32,13 +32,13 @@ import org.apache.kafka.streams.state.internals.WrappedStateStore;
  * @param <V>
  */
 class SessionTupleForwarder<K, V> {
-    private final ProcessorContext context;
+    private final ProcessorContext<Windowed<K>, Change<V>> context;
     private final boolean sendOldValues;
     private final boolean cachingEnabled;
 
     @SuppressWarnings("unchecked")
     SessionTupleForwarder(final StateStore store,
-                          final ProcessorContext context,
+                          final ProcessorContext<Windowed<K>, Change<V>> context,
                           final CacheFlushListener<Windowed<K>, V> flushListener,
                           final boolean sendOldValues) {
         this.context = context;
@@ -50,7 +50,10 @@ class SessionTupleForwarder<K, V> {
                              final V newValue,
                              final V oldValue) {
         if (!cachingEnabled) {
-            context.forward(key, new Change<>(newValue, sendOldValues ? oldValue : null), To.all().withTimestamp(key.window().end()));
+            context.forward(new Record<>(
+                key,
+                new Change<>(newValue, sendOldValues ? oldValue : null),
+                key.window().end()));
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtil.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.KStreamSessionWindowAggregate;
 import org.apache.kafka.streams.kstream.internals.KStreamSlidingWindowAggregate;
 import org.apache.kafka.streams.kstream.internals.KStreamWindowAggregate;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 
 public final class GraphGraceSearchUtil {
     private GraphGraceSearchUtil() {}
@@ -69,10 +70,10 @@ public final class GraphGraceSearchUtil {
         return inheritedGrace;
     }
 
+    @SuppressWarnings("rawtypes")
     private static Long extractGracePeriod(final GraphNode node) {
         if (node instanceof StatefulProcessorNode) {
-            @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-            final org.apache.kafka.streams.processor.ProcessorSupplier processorSupplier = ((StatefulProcessorNode) node).processorParameters().oldProcessorSupplier();
+            final ProcessorSupplier processorSupplier = ((StatefulProcessorNode) node).processorParameters().processorSupplier();
             if (processorSupplier instanceof KStreamWindowAggregate) {
                 final KStreamWindowAggregate kStreamWindowAggregate = (KStreamWindowAggregate) processorSupplier;
                 final Windows windows = kStreamWindowAggregate.windows();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ContextualProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ContextualProcessor.java
@@ -27,7 +27,7 @@ package org.apache.kafka.streams.processor.api;
  */
 public abstract class ContextualProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, KOut, VOut> {
 
-    protected ProcessorContext<KOut, VOut> context;
+    private ProcessorContext<KOut, VOut> context;
 
     protected ContextualProcessor() {}
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
@@ -590,7 +590,7 @@ public class KGroupedStreamImplTest {
 
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record due to null key or value. key=[3] value=[null] topic=[topic] partition=[0] "
+                hasItem("Skipping record due to null key or value. topic=[topic] partition=[0] "
                     + "offset=[6]")
             );
         }
@@ -640,7 +640,7 @@ public class KGroupedStreamImplTest {
 
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record due to null key or value. key=[3] value=[null] topic=[topic] partition=[0] "
+                hasItem("Skipping record due to null key or value. topic=[topic] partition=[0] "
                     + "offset=[6]")
             );
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -32,11 +32,11 @@ import org.apache.kafka.streams.kstream.Merger;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
-import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.ToInternal;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender.Event;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -70,29 +70,27 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
-@SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
 public class KStreamSessionWindowAggregateProcessorTest {
 
     private static final long GAP_MS = 5 * 60 * 1000L;
     private static final String STORE_NAME = "session-store";
 
     private final String threadId = Thread.currentThread().getName();
-    private final ToInternal toInternal = new ToInternal();
     private final Initializer<Long> initializer = () -> 0L;
     private final Aggregator<String, String, Long> aggregator = (aggKey, value, aggregate) -> aggregate + 1;
     private final Merger<String, Long> sessionMerger = (aggKey, aggOne, aggTwo) -> aggOne + aggTwo;
     private final KStreamSessionWindowAggregate<String, String, Long> sessionAggregator =
         new KStreamSessionWindowAggregate<>(
-            SessionWindows.with(ofMillis(GAP_MS)),
+            SessionWindows.ofInactivityGapWithNoGrace(ofMillis(GAP_MS)),
             STORE_NAME,
             initializer,
             aggregator,
             sessionMerger);
 
     private final List<KeyValueTimestamp<Windowed<String>, Change<Long>>> results = new ArrayList<>();
-    private final org.apache.kafka.streams.processor.Processor<String, String> processor = sessionAggregator.get();
+    private final Processor<String, String, Windowed<String>, Change<Long>> processor = sessionAggregator.get();
     private SessionStore<String, Long> sessionStore;
-    private InternalMockProcessorContext context;
+    private InternalMockProcessorContext<Windowed<String>, Change<Long>> context;
     private final Metrics metrics = new Metrics();
 
     @Before
@@ -103,7 +101,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private void setup(final boolean enableCache) {
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, "test", StreamsConfig.METRICS_LATEST, new MockTime());
-        context = new InternalMockProcessorContext<Object, Object>(
+        context = new InternalMockProcessorContext<Windowed<String>, Change<Long>>(
             TestUtils.tempDirectory(),
             Serdes.String(),
             Serdes.String(),
@@ -113,11 +111,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
             new ThreadCache(new LogContext("testCache "), 100000, streamsMetrics),
             Time.SYSTEM
         ) {
-            @SuppressWarnings("unchecked")
             @Override
-            public void forward(final Object key, final Object value, final To to) {
-                toInternal.update(to);
-                results.add(new KeyValueTimestamp<>((Windowed<String>) key, (Change<Long>) value, toInternal.timestamp()));
+            public <K extends Windowed<String>, V extends Change<Long>> void forward(final Record<K, V> record) {
+                results.add(new KeyValueTimestamp<>(record.key(), record.value(), record.timestamp()));
             }
         };
         TaskMetrics.droppedRecordsSensor(threadId, context.taskId().toString(), streamsMetrics);
@@ -152,10 +148,10 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldCreateSingleSessionWhenWithinGap() {
-        context.setTime(0);
-        processor.process("john", "first");
-        context.setTime(500);
-        processor.process("john", "second");
+//        context.setTime(0);
+        processor.process(new Record<>("john", "first", 0L));
+//        context.setTime(500);
+        processor.process(new Record<>("john", "second", 500L));
 
         try (final KeyValueIterator<Windowed<String>, Long> values =
                  sessionStore.findSessions("john", 0, 2000)) {
@@ -166,20 +162,20 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldMergeSessions() {
-        context.setTime(0);
+//        context.setTime(0);
         final String sessionId = "mel";
-        processor.process(sessionId, "first");
+        processor.process(new Record<>(sessionId, "first", 0L));
         assertTrue(sessionStore.findSessions(sessionId, 0, 0).hasNext());
 
         // move time beyond gap
-        context.setTime(GAP_MS + 1);
-        processor.process(sessionId, "second");
+//        context.setTime(GAP_MS + 1);
+        processor.process(new Record<>(sessionId, "second", GAP_MS + 1));
         assertTrue(sessionStore.findSessions(sessionId, GAP_MS + 1, GAP_MS + 1).hasNext());
         // should still exist as not within gap
         assertTrue(sessionStore.findSessions(sessionId, 0, 0).hasNext());
         // move time back
-        context.setTime(GAP_MS / 2);
-        processor.process(sessionId, "third");
+//        context.setTime(GAP_MS / 2);
+        processor.process(new Record<>(sessionId, "third", GAP_MS / 2));
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions(sessionId, 0, GAP_MS + 1)) {
@@ -192,9 +188,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldUpdateSessionIfTheSameTime() {
-        context.setTime(0);
-        processor.process("mel", "first");
-        processor.process("mel", "second");
+//        context.setTime(0);
+        processor.process(new Record<>("mel", "first", 0L));
+        processor.process(new Record<>("mel", "second", 0L));
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions("mel", 0, 0)) {
             assertEquals(Long.valueOf(2L), iterator.next().value);
@@ -206,15 +202,17 @@ public class KStreamSessionWindowAggregateProcessorTest {
     public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap() {
         final String sessionId = "mel";
         long time = 0;
-        context.setTime(time);
-        processor.process(sessionId, "first");
-        context.setTime(time += GAP_MS + 1);
-        processor.process(sessionId, "second");
-        processor.process(sessionId, "second");
-        context.setTime(time += GAP_MS + 1);
-        processor.process(sessionId, "third");
-        processor.process(sessionId, "third");
-        processor.process(sessionId, "third");
+//        context.setTime(time);
+        processor.process(new Record<>(sessionId, "first", time));
+//        context.setTime(time += GAP_MS + 1);
+        final long time1 = time += GAP_MS + 1;
+        processor.process(new Record<>(sessionId, "second", time1));
+        processor.process(new Record<>(sessionId, "second", time1));
+//        context.setTime(time += GAP_MS + 1);
+        final long time2 = time += GAP_MS + 1;
+        processor.process(new Record<>(sessionId, "third", time2));
+        processor.process(new Record<>(sessionId, "third", time2));
+        processor.process(new Record<>(sessionId, "third", time2));
 
         sessionStore.flush();
         assertEquals(
@@ -239,8 +237,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldRemoveMergedSessionsFromStateStore() {
-        context.setTime(0);
-        processor.process("a", "1");
+//        context.setTime(0);
+        processor.process(new Record<>("a", "1", 0L));
 
         // first ensure it is in the store
         try (final KeyValueIterator<Windowed<String>, Long> a1 =
@@ -249,8 +247,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
         }
 
 
-        context.setTime(100);
-        processor.process("a", "2");
+//        context.setTime(100);
+        processor.process(new Record<>("a", "2", 100L));
         // a1 from above should have been removed
         // should have merged session in store
         try (final KeyValueIterator<Windowed<String>, Long> a2 =
@@ -262,19 +260,19 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldHandleMultipleSessionsAndMerging() {
-        context.setTime(0);
-        processor.process("a", "1");
-        processor.process("b", "1");
-        processor.process("c", "1");
-        processor.process("d", "1");
-        context.setTime(GAP_MS / 2);
-        processor.process("d", "2");
-        context.setTime(GAP_MS + 1);
-        processor.process("a", "2");
-        processor.process("b", "2");
-        context.setTime(GAP_MS + 1 + GAP_MS / 2);
-        processor.process("a", "3");
-        processor.process("c", "3");
+//        context.setTime(0);
+        processor.process(new Record<>("a", "1", 0L));
+        processor.process(new Record<>("b", "1", 0L));
+        processor.process(new Record<>("c", "1", 0L));
+        processor.process(new Record<>("d", "1", 0L));
+//        context.setTime(GAP_MS / 2);
+        processor.process(new Record<>("d", "2", GAP_MS / 2));
+//        context.setTime(GAP_MS + 1);
+        processor.process(new Record<>("a", "2", GAP_MS + 1));
+        processor.process(new Record<>("b", "2", GAP_MS + 1));
+//        context.setTime(GAP_MS + 1 + GAP_MS / 2);
+        processor.process(new Record<>("a", "3", GAP_MS + 1 + GAP_MS / 2));
+        processor.process(new Record<>("c", "3", GAP_MS + 1 + GAP_MS / 2));
 
         sessionStore.flush();
 
@@ -317,11 +315,11 @@ public class KStreamSessionWindowAggregateProcessorTest {
     public void shouldGetAggregatedValuesFromValueGetter() {
         final KTableValueGetter<Windowed<String>, Long> getter = sessionAggregator.view().get();
         getter.init(context);
-        context.setTime(0);
-        processor.process("a", "1");
-        context.setTime(GAP_MS + 1);
-        processor.process("a", "1");
-        processor.process("a", "2");
+//        context.setTime(0);
+        processor.process(new Record<>("a", "1", 0L));
+//        context.setTime(GAP_MS + 1);
+        processor.process(new Record<>("a", "1", GAP_MS + 1));
+        processor.process(new Record<>("a", "2", GAP_MS + 1));
         final long t0 = getter.get(new Windowed<>("a", new SessionWindow(0, 0))).value();
         final long t1 = getter.get(new Windowed<>("a", new SessionWindow(GAP_MS + 1, GAP_MS + 1))).value();
         assertEquals(1L, t0);
@@ -333,10 +331,10 @@ public class KStreamSessionWindowAggregateProcessorTest {
         initStore(false);
         processor.init(context);
 
-        context.setTime(0);
-        processor.process("a", "1");
-        processor.process("b", "1");
-        processor.process("c", "1");
+//        context.setTime(0);
+        processor.process(new Record<>("a", "1", 0L));
+        processor.process(new Record<>("b", "1", 0L));
+        processor.process(new Record<>("c", "1", 0L));
 
         assertEquals(
             Arrays.asList(
@@ -362,10 +360,10 @@ public class KStreamSessionWindowAggregateProcessorTest {
         initStore(false);
         processor.init(context);
 
-        context.setTime(0);
-        processor.process("a", "1");
-        context.setTime(5);
-        processor.process("a", "1");
+//        context.setTime(0);
+        processor.process(new Record<>("a", "1", 0L));
+//        context.setTime(5);
+        processor.process(new Record<>("a", "1", 5L));
         assertEquals(
             Arrays.asList(
                 new KeyValueTimestamp<>(
@@ -396,7 +394,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
         try (final LogCaptureAppender appender =
                  LogCaptureAppender.createAndRegister(KStreamSessionWindowAggregate.class)) {
 
-            processor.process(null, "1");
+            processor.process(new Record<>(null, "1", 0L));
 
             assertThat(
                 appender.getEvents().stream()
@@ -416,8 +414,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
     @Test
     public void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace() {
         setup(false);
-        final org.apache.kafka.streams.processor.Processor<String, String> processor = new KStreamSessionWindowAggregate<>(
-            SessionWindows.with(ofMillis(10L)).grace(ofMillis(0L)),
+        final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(10L), ofMillis(0L)),
             STORE_NAME,
             initializer,
             aggregator,
@@ -426,23 +424,23 @@ public class KStreamSessionWindowAggregateProcessorTest {
         processor.init(context);
 
         // dummy record to establish stream time = 0
-        context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-        processor.process("dummy", "dummy");
+//        context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
+        processor.process(new Record<>("dummy", "dummy", 0L));
 
         // record arrives on time, should not be skipped
-        context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-        processor.process("OnTime1", "1");
+//        context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
+        processor.process(new Record<>("OnTime1", "1", 0L));
 
         // dummy record to advance stream time = 11, 10 for gap time plus 1 to place outside window
-        context.setRecordContext(new ProcessorRecordContext(11, -2, -3, "topic", new RecordHeaders()));
-        processor.process("dummy", "dummy");
+//        context.setRecordContext(new ProcessorRecordContext(11, -2, -3, "topic", new RecordHeaders()));
+        processor.process(new Record<>("dummy", "dummy", 11L));
 
         try (final LogCaptureAppender appender =
                  LogCaptureAppender.createAndRegister(KStreamSessionWindowAggregate.class)) {
 
             // record is late
-            context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-            processor.process("Late1", "1");
+//            context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
+            processor.process(new Record<>("Late1", "1", 0L));
 
             assertThat(
                 appender.getMessages(),
@@ -481,8 +479,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
     @Test
     public void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace() {
         setup(false);
-        final org.apache.kafka.streams.processor.Processor<String, String> processor = new KStreamSessionWindowAggregate<>(
-            SessionWindows.with(ofMillis(10L)).grace(ofMillis(1L)),
+        final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
+            SessionWindows.ofInactivityGapAndGrace(ofMillis(10L), ofMillis(1L)),
             STORE_NAME,
             initializer,
             aggregator,
@@ -495,27 +493,27 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
             // dummy record to establish stream time = 0
             context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-            processor.process("dummy", "dummy");
+            processor.process(new Record<>("dummy", "dummy", 0L));
 
             // record arrives on time, should not be skipped
             context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-            processor.process("OnTime1", "1");
+            processor.process(new Record<>("OnTime1", "1", 0L));
 
             // dummy record to advance stream time = 11, 10 for gap time plus 1 to place at edge of window
             context.setRecordContext(new ProcessorRecordContext(11, -2, -3, "topic", new RecordHeaders()));
-            processor.process("dummy", "dummy");
+            processor.process(new Record<>("dummy", "dummy", 11L));
 
             // delayed record arrives on time, should not be skipped
             context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-            processor.process("OnTime2", "1");
+            processor.process(new Record<>("OnTime2", "1", 0L));
 
             // dummy record to advance stream time = 12, 10 for gap time plus 2 to place outside window
             context.setRecordContext(new ProcessorRecordContext(12, -2, -3, "topic", new RecordHeaders()));
-            processor.process("dummy", "dummy");
+            processor.process(new Record<>("dummy", "dummy", 12L));
 
             // delayed record arrives late
             context.setRecordContext(new ProcessorRecordContext(0, -2, -3, "topic", new RecordHeaders()));
-            processor.process("Late1", "1");
+            processor.process(new Record<>("Late1", "1", 0L));
 
             assertThat(
                 appender.getMessages(),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
@@ -726,7 +726,7 @@ public class KStreamSlidingWindowAggregateTest {
                     .filter(e -> e.getLevel().equals("WARN"))
                     .map(Event::getMessage)
                     .collect(Collectors.toList()),
-                hasItem("Skipping record due to null key or value. value=[1] topic=[topic] partition=[0] offset=[0]")
+                hasItem("Skipping record due to null key or value. topic=[topic] partition=[0] offset=[0]")
             );
         }
     }
@@ -772,19 +772,19 @@ public class KStreamSlidingWindowAggregateTest {
 
             assertThat(appender.getMessages(), hasItems(
                     // left window for k@100
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[1] timestamp=[100] window=[90,100] expiration=[110] streamTime=[200]",
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[1] timestamp=[100] window=[90,100] expiration=[110] streamTime=[200]",
                     // left window for k@101
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[2] timestamp=[101] window=[91,101] expiration=[110] streamTime=[200]",
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[2] timestamp=[101] window=[91,101] expiration=[110] streamTime=[200]",
                     // left window for k@102
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[3] timestamp=[102] window=[92,102] expiration=[110] streamTime=[200]",
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[3] timestamp=[102] window=[92,102] expiration=[110] streamTime=[200]",
                     // left window for k@103
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[4] timestamp=[103] window=[93,103] expiration=[110] streamTime=[200]",
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[4] timestamp=[103] window=[93,103] expiration=[110] streamTime=[200]",
                     // left window for k@104
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[5] timestamp=[104] window=[94,104] expiration=[110] streamTime=[200]",
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[5] timestamp=[104] window=[94,104] expiration=[110] streamTime=[200]",
                     // left window for k@105
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[6] timestamp=[105] window=[95,105] expiration=[110] streamTime=[200]",
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[6] timestamp=[105] window=[95,105] expiration=[110] streamTime=[200]",
                     // left window for k@15
-                    "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[7] timestamp=[15] window=[5,15] expiration=[110] streamTime=[200]"
+                    "Skipping record for expired window. topic=[topic] partition=[0] offset=[7] timestamp=[15] window=[5,15] expiration=[110] streamTime=[200]"
             ));
             final TestOutputTopic<Windowed<String>, String> outputTopic =
                     driver.createOutputTopic("output", new TimeWindowedDeserializer<>(new StringDeserializer(), 10L), new StringDeserializer());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -288,7 +288,7 @@ public class KStreamWindowAggregateTest {
                 driver.createInputTopic(topic, new StringSerializer(), new StringSerializer());
             inputTopic.pipeInput(null, "1");
 
-            assertThat(appender.getMessages(), hasItem("Skipping record due to null key. value=[1] topic=[topic] partition=[0] offset=[0]"));
+            assertThat(appender.getMessages(), hasItem("Skipping record due to null key. topic=[topic] partition=[0] offset=[0]"));
         }
     }
 
@@ -335,13 +335,13 @@ public class KStreamWindowAggregateTest {
             );
 
             assertThat(appender.getMessages(), hasItems(
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[1] timestamp=[0] window=[0,10) expiration=[10] streamTime=[100]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[2] timestamp=[1] window=[0,10) expiration=[10] streamTime=[100]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[3] timestamp=[2] window=[0,10) expiration=[10] streamTime=[100]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[4] timestamp=[3] window=[0,10) expiration=[10] streamTime=[100]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[5] timestamp=[4] window=[0,10) expiration=[10] streamTime=[100]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[6] timestamp=[5] window=[0,10) expiration=[10] streamTime=[100]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[7] timestamp=[6] window=[0,10) expiration=[10] streamTime=[100]"
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[1] timestamp=[0] window=[0,10) expiration=[10] streamTime=[100]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[2] timestamp=[1] window=[0,10) expiration=[10] streamTime=[100]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[3] timestamp=[2] window=[0,10) expiration=[10] streamTime=[100]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[4] timestamp=[3] window=[0,10) expiration=[10] streamTime=[100]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[5] timestamp=[4] window=[0,10) expiration=[10] streamTime=[100]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[6] timestamp=[5] window=[0,10) expiration=[10] streamTime=[100]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[7] timestamp=[6] window=[0,10) expiration=[10] streamTime=[100]"
             ));
 
             final TestOutputTopic<String, String> outputTopic =
@@ -389,13 +389,13 @@ public class KStreamWindowAggregateTest {
             assertLatenessMetrics(driver, is(7.0), is(194.0), is(97.375));
 
             assertThat(appender.getMessages(), hasItems(
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[1] timestamp=[100] window=[100,110) expiration=[110] streamTime=[200]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[2] timestamp=[101] window=[100,110) expiration=[110] streamTime=[200]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[3] timestamp=[102] window=[100,110) expiration=[110] streamTime=[200]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[4] timestamp=[103] window=[100,110) expiration=[110] streamTime=[200]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[5] timestamp=[104] window=[100,110) expiration=[110] streamTime=[200]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[6] timestamp=[105] window=[100,110) expiration=[110] streamTime=[200]",
-                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[7] timestamp=[6] window=[0,10) expiration=[110] streamTime=[200]"
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[1] timestamp=[100] window=[100,110) expiration=[110] streamTime=[200]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[2] timestamp=[101] window=[100,110) expiration=[110] streamTime=[200]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[3] timestamp=[102] window=[100,110) expiration=[110] streamTime=[200]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[4] timestamp=[103] window=[100,110) expiration=[110] streamTime=[200]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[5] timestamp=[104] window=[100,110) expiration=[110] streamTime=[200]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[6] timestamp=[105] window=[100,110) expiration=[110] streamTime=[200]",
+                "Skipping record for expired window. topic=[topic] partition=[0] offset=[7] timestamp=[6] window=[0,10) expiration=[110] streamTime=[200]"
             ));
 
             final TestOutputTopic<String, String> outputTopic =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionCacheFlushListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionCacheFlushListenerTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.junit.Test;
 
@@ -35,9 +35,10 @@ public class SessionCacheFlushListenerTest {
         context.setCurrentNode(null);
         context.setCurrentNode(null);
         context.forward(
-            new Windowed<>("key", new SessionWindow(21L, 73L)),
-            new Change<>("newValue", "oldValue"),
-            To.all().withTimestamp(73L));
+            new Record<>(
+                new Windowed<>("key", new SessionWindow(21L, 73L)),
+                new Change<>("newValue", "oldValue"),
+                73L));
         expectLastCall();
         replay(context);
 


### PR DESCRIPTION
As part of the migration of KStream/KTable operations to the new Processor API https://issues.apache.org/jira/browse/KAFKA-8410, this PR includes the migration of KStream aggregate/reduce operations.

Testing strategy: operations should keep the same tests as new processor should be compatible.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
