### PR TITLE
KAFKA-13288; Include internal topics when searching hanging transactions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
@@ -19,6 +19,8 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Objects;
+
 /**
  * Options for {@link Admin#listTopics()}.
  *
@@ -57,5 +59,25 @@ public class ListTopicsOptions extends AbstractOptions<ListTopicsOptions> {
      */
     public boolean shouldListInternal() {
         return listInternal;
+    }
+
+    @Override
+    public String toString() {
+        return "ListTopicsOptions(" +
+            "listInternal=" + listInternal +
+            ')';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListTopicsOptions that = (ListTopicsOptions) o;
+        return listInternal == that.listInternal;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(listInternal);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.DescribeProducersOptions;
 import org.apache.kafka.clients.admin.DescribeProducersResult;
 import org.apache.kafka.clients.admin.DescribeTransactionsResult;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.ListTransactionsOptions;
 import org.apache.kafka.clients.admin.ProducerState;
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -719,7 +720,8 @@ public abstract class TransactionsCommand {
             Admin admin
         ) throws Exception {
             try {
-                return new ArrayList<>(admin.listTopics().names().get());
+                ListTopicsOptions listOptions = new ListTopicsOptions().listInternal(true);
+                return new ArrayList<>(admin.listTopics(listOptions).names().get());
             } catch (ExecutionException e) {
                 printErrorAndExit("Failed to list topics", e.getCause());
                 return Collections.emptyList();

--- a/tools/src/test/java/org/apache/kafka/tools/TransactionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TransactionsCommandTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.DescribeProducersResult;
 import org.apache.kafka.clients.admin.DescribeProducersResult.PartitionProducerState;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.DescribeTransactionsResult;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.ListTransactionsOptions;
 import org.apache.kafka.clients.admin.ListTransactionsResult;
@@ -533,7 +534,8 @@ public class TransactionsCommandTest {
     ) {
         ListTopicsResult result = Mockito.mock(ListTopicsResult.class);
         Mockito.when(result.names()).thenReturn(completedFuture(topics));
-        Mockito.when(admin.listTopics()).thenReturn(result);
+        ListTopicsOptions listOptions = new ListTopicsOptions().listInternal(true);
+        Mockito.when(admin.listTopics(listOptions)).thenReturn(result);
     }
 
     private void expectDescribeTopics(


### PR DESCRIPTION
This patch ensures that internal topics are included when searching for hanging transactions with the `--broker-id` argument in `kafka-transactions.sh`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
