### PR TITLE
KAFKA-12226: Commit source task offsets without blocking on batch delivery

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * Used to track source records that have been (or are about to be) dispatched to a producer and their accompanying
+ * source offsets.
+ * Note that this class is not thread-safe.
+ */
+class SubmittedRecords {
+    private final Map<Map<String, Object>, Deque<SubmittedRecord>> records;
+
+    public SubmittedRecords() {
+        this.records = new HashMap<>();
+    }
+
+    /**
+     * Enqueue a new source record before dispatching it to a producer.
+     * @param record the record about to be dispatched; may not be null but may have a null
+     * {@link SourceRecord#sourcePartition()} and/or {@link SourceRecord#sourceOffset()}
+     * @return a {@link SubmittedRecord} that can be either {@link SubmittedRecord#ack() acknowledged} once ack'd by
+     * the producer, or {@link #remove removed} if synchronously rejected by the producer
+     */
+    @SuppressWarnings("unchecked")
+    public SubmittedRecord submit(SourceRecord record) {
+        return submit((Map<String, Object>) record.sourcePartition(), (Map<String, Object>) record.sourceOffset());
+    }
+
+    // Convenience method for testing
+    SubmittedRecord submit(Map<String, Object> partition, Map<String, Object> offset) {
+        SubmittedRecord result = new SubmittedRecord(partition, offset);
+        records.computeIfAbsent(result.partition(), p -> new LinkedList<>())
+                .add(result);
+        return result;
+    }
+
+    /**
+     * Remove a source record and do not take it into account any longer when tracking offsets.
+     * Useful if the record has been synchronously rejected by the producer.
+     * @param record the {@link #submit previously-submitted} record to stop tracking; may not be null
+     */
+    public void remove(SubmittedRecord record) {
+        records.get(record.partition())
+                .removeLastOccurrence(record);
+    }
+
+    /**
+     * Clear out any acknowledged records and return the latest offset for each source partition that can be committed.
+     * Note that this may take some time to complete if a large number of records has built up, which may occur if a
+     * Kafka partition is offline and all records targeting that partition go unacknowledged while records targeting
+     * other partitions continue to be dispatched to the producer and sent successfully
+     * @return the latest-possible offsets to commit for each source partition; may be empty but never null
+     */
+    public Map<Map<String, Object>, Map<String, Object>> committableOffsets() {
+        Map<Map<String, Object>, Map<String, Object>> result = new HashMap<>();
+        records.forEach((partition, queuedRecords) -> {
+            if (canCommitHead(queuedRecords)) {
+                Map<String, Object> offset = committableOffset(queuedRecords);
+                result.put(partition, offset);
+            }
+        });
+        // Clear out all empty deques from the map to keep it from growing indefinitely
+        records.values().removeIf(Deque::isEmpty);
+        return result;
+    }
+
+    // Note that this will return null if either there are no committable offsets for the given deque, or the latest
+    // committable offset is itself null. The caller is responsible for distinguishing between the two cases.
+    private Map<String, Object> committableOffset(Deque<SubmittedRecord> queuedRecords) {
+        Map<String, Object> result = null;
+        while (canCommitHead(queuedRecords)) {
+            result = queuedRecords.poll().offset();
+        }
+        return result;
+    }
+
+    private boolean canCommitHead(Deque<SubmittedRecord> queuedRecords) {
+        return queuedRecords.peek() != null && queuedRecords.peek().acked();
+    }
+
+    static class SubmittedRecord {
+        private final Map<String, Object> partition;
+        private final Map<String, Object> offset;
+        private volatile boolean acked;
+
+        public SubmittedRecord(Map<String, Object> partition, Map<String, Object> offset) {
+            this.partition = partition;
+            this.offset = offset;
+            this.acked = false;
+        }
+
+        /**
+         * Acknowledge this record; signals that its offset may be safely committed.
+         */
+        public void ack() {
+            this.acked = true;
+        }
+
+        private boolean acked() {
+            return acked;
+        }
+
+        private Map<String, Object> partition() {
+            return partition;
+        }
+
+        private Map<String, Object> offset() {
+            return offset;
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -26,7 +26,8 @@ import java.util.Map;
 /**
  * Used to track source records that have been (or are about to be) dispatched to a producer and their accompanying
  * source offsets.
- * Note that this class is not thread-safe.
+ * Note that this class is not thread-safe, though a {@link SubmittedRecord} can be
+ * {@link SubmittedRecord#ack() acknowledged} from a different thread.
  */
 class SubmittedRecords {
     private final Map<Map<String, Object>, Deque<SubmittedRecord>> records;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -66,7 +66,7 @@ class SubmittedRecords {
     }
 
     /**
-     * Clear out any acknowledged records and return the latest offset for each source partition that can be committed.
+     * Clear out any acknowledged records at the head of the deques and return the latest offset for each source partition that can be committed.
      * Note that this may take some time to complete if a large number of records has built up, which may occur if a
      * Kafka partition is offline and all records targeting that partition go unacknowledged while records targeting
      * other partitions continue to be dispatched to the producer and sent successfully

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -79,7 +79,7 @@ class SubmittedRecords {
     public void remove(SubmittedRecord record) {
         Deque<SubmittedRecord> deque = records.get(record.partition());
         if (deque == null) {
-            log.warn("Attempted to remove record for partition {}, but no records with that partition are present", record.partition());
+            log.warn("Attempted to remove record from submitted queue for partition {}, but no records with that partition appear to have been submitted", record.partition());
             return;
         }
         deque.removeLastOccurrence(record);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -38,6 +38,10 @@ class SubmittedRecords {
 
     /**
      * Enqueue a new source record before dispatching it to a producer.
+     * The returned {@link SubmittedRecord} should either be {@link SubmittedRecord#ack() acknowledged} in the
+     * producer callback, or {@link #remove(SubmittedRecord) removed} if the record could not be successfully
+     * sent to the producer.
+     * 
      * @param record the record about to be dispatched; may not be null but may have a null
      *               {@link SourceRecord#sourcePartition()} and/or {@link SourceRecord#sourceOffset()}
      * @return a {@link SubmittedRecord} that can be either {@link SubmittedRecord#ack() acknowledged} once ack'd by

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -30,9 +30,8 @@ import java.util.Map;
  * Used to track source records that have been (or are about to be) dispatched to a producer and their accompanying
  * source offsets. Records are tracked in the order in which they are submitted, which should match the order they were
  * returned from {@link SourceTask#poll()}. The latest-eligible offsets for each source partition can be retrieved via
- * {@link #committableOffsets()}, the latest-eligible offsets for each source partition can be retrieved, where every
- * record up to and including the record for each returned offset has been either
- * {@link SubmittedRecord#ack() acknowledged} or {@link #removeLastOccurrence(SubmittedRecord) removed}.
+ * {@link #committableOffsets()}, where every record up to and including the record for each returned offset has been
+ * either {@link SubmittedRecord#ack() acknowledged} or {@link #removeLastOccurrence(SubmittedRecord) removed}.
  * Note that this class is not thread-safe, though a {@link SubmittedRecord} can be
  * {@link SubmittedRecord#ack() acknowledged} from a different thread.
  */

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -117,6 +117,7 @@ class SubmittedRecords {
 
         /**
          * Acknowledge this record; signals that its offset may be safely committed.
+         * This is safe to be called from a different thread than what called {@link SubmittedRecords#submit(SourceRecord)}.
          */
         public void ack() {
             this.acked = true;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -38,9 +38,9 @@ class SubmittedRecords {
     /**
      * Enqueue a new source record before dispatching it to a producer.
      * @param record the record about to be dispatched; may not be null but may have a null
-     * {@link SourceRecord#sourcePartition()} and/or {@link SourceRecord#sourceOffset()}
+     *               {@link SourceRecord#sourcePartition()} and/or {@link SourceRecord#sourceOffset()}
      * @return a {@link SubmittedRecord} that can be either {@link SubmittedRecord#ack() acknowledged} once ack'd by
-     * the producer, or {@link #remove removed} if synchronously rejected by the producer
+     *         the producer, or {@link #remove removed} if synchronously rejected by the producer
      */
     @SuppressWarnings("unchecked")
     public SubmittedRecord submit(SourceRecord record) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -66,6 +66,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.connect.runtime.SubmittedRecords.SubmittedRecord;
+import static org.apache.kafka.connect.runtime.SubmittedRecords.CommittableOffsets;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG;
 
 /**
@@ -94,7 +95,7 @@ class WorkerSourceTask extends WorkerTask {
     private final TopicCreation topicCreation;
 
     private List<SourceRecord> toSend;
-    private volatile SubmittedRecords.CommittableOffsets committableOffsets;
+    private volatile CommittableOffsets committableOffsets;
     private final SubmittedRecords submittedRecords;
     private final CountDownLatch stopRequestedLatch;
 
@@ -140,7 +141,7 @@ class WorkerSourceTask extends WorkerTask {
         this.closeExecutor = closeExecutor;
 
         this.toSend = null;
-        this.committableOffsets = SubmittedRecords.CommittableOffsets.EMPTY;
+        this.committableOffsets = CommittableOffsets.EMPTY;
         this.submittedRecords = new SubmittedRecords();
         this.stopRequestedLatch = new CountDownLatch(1);
         this.sourceTaskMetricsGroup = new SourceTaskMetricsGroup(id, connectMetrics);
@@ -288,7 +289,7 @@ class WorkerSourceTask extends WorkerTask {
     }
 
     private void updateCommittableOffsets() {
-        SubmittedRecords.CommittableOffsets newOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets newOffsets = submittedRecords.committableOffsets();
         synchronized (this) {
             this.committableOffsets = this.committableOffsets.updatedWith(newOffsets);
         }
@@ -469,10 +470,10 @@ class WorkerSourceTask extends WorkerTask {
         long started = time.milliseconds();
         long timeout = started + commitTimeoutMs;
 
-        SubmittedRecords.CommittableOffsets offsetsToCommit;
+        CommittableOffsets offsetsToCommit;
         synchronized (this) {
             offsetsToCommit = this.committableOffsets;
-            this.committableOffsets = SubmittedRecords.CommittableOffsets.EMPTY;
+            this.committableOffsets = CommittableOffsets.EMPTY;
         }
 
         if (committableOffsets.isEmpty()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -231,6 +231,8 @@ class WorkerSourceTask extends WorkerTask {
         try {
             log.info("{} Executing source task", this);
             while (!isStopping()) {
+                updateCommittableOffsets();
+
                 if (shouldPause()) {
                     onPause();
                     if (awaitUnpause()) {
@@ -249,8 +251,6 @@ class WorkerSourceTask extends WorkerTask {
                     }
                 }
 
-                updateCommittableOffsets();
-
                 if (toSend == null)
                     continue;
                 log.trace("{} About to send {} records to Kafka", this, toSend.size());
@@ -264,6 +264,7 @@ class WorkerSourceTask extends WorkerTask {
             // simply resulted in not getting more records but all the existing records should be ok to flush
             // and commit offsets. Worst case, task.flush() will also throw an exception causing the offset commit
             // to fail.
+            updateCommittableOffsets();
             commitOffsets();
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -95,7 +95,7 @@ class WorkerSourceTask extends WorkerTask {
     private final TopicCreation topicCreation;
 
     private List<SourceRecord> toSend;
-    private Map<Map<String, Object>, Map<String, Object>> offsets;
+    private volatile Map<Map<String, Object>, Map<String, Object>> offsets;
     private final SubmittedRecords submittedRecords;
     private final CountDownLatch stopRequestedLatch;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
@@ -89,9 +89,8 @@ public class OffsetStorageWriter {
      * @param partition the partition to store an offset for
      * @param offset the offset
      */
-    @SuppressWarnings("unchecked")
-    public synchronized void offset(Map<String, ?> partition, Map<String, ?> offset) {
-        data.put((Map<String, Object>) partition, (Map<String, Object>) offset);
+    public synchronized void offset(Map<String, Object> partition, Map<String, Object> offset) {
+        data.put(partition, offset);
     }
 
     private boolean flushing() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -378,8 +378,6 @@ public class ErrorHandlingTaskTest {
 
         EasyMock.expect(workerSourceTask.commitOffsets()).andReturn(true);
 
-        offsetWriter.offset(EasyMock.anyObject(), EasyMock.anyObject());
-        EasyMock.expectLastCall().times(2);
         sourceTask.initialize(EasyMock.anyObject());
         EasyMock.expectLastCall();
 
@@ -444,8 +442,6 @@ public class ErrorHandlingTaskTest {
 
         EasyMock.expect(workerSourceTask.commitOffsets()).andReturn(true);
 
-        offsetWriter.offset(EasyMock.anyObject(), EasyMock.anyObject());
-        EasyMock.expectLastCall().times(2);
         sourceTask.initialize(EasyMock.anyObject());
         EasyMock.expectLastCall();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.kafka.connect.runtime.SubmittedRecords.SubmittedRecord;
+import static org.junit.Assert.assertEquals;
+
+public class SubmittedRecordsTest {
+
+    private static final Map<String, Object> PARTITION1 = Collections.singletonMap("subreddit", "apachekafka");
+    private static final Map<String, Object> PARTITION2 = Collections.singletonMap("subreddit", "pcj");
+    private static final Map<String, Object> PARTITION3 = Collections.singletonMap("subreddit", "asdfqweoicus");
+
+    private AtomicInteger offset;
+
+    SubmittedRecords submittedRecords;
+
+    @Before
+    public void setup() {
+        submittedRecords = new SubmittedRecords();
+        offset = new AtomicInteger();
+    }
+
+    @Test
+    public void testNoRecords() {
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+    }
+
+    @Test
+    public void testNoCommittedRecords() {
+        for (int i = 0; i < 3; i++) {
+            for (Map<String, Object> partition : Arrays.asList(PARTITION1, PARTITION2, PARTITION3)) {
+                submittedRecords.submit(partition, newOffset());
+            }
+        }
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+    }
+
+    @Test
+    public void testSingleAck() {
+        Map<String, Object> offset = newOffset();
+
+        SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, offset);
+        // Record has been submitted but not yet acked; cannot commit offsets for it yet
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+
+        submittedRecord.ack();
+        // Record has been acked; can commit offsets for it
+        assertEquals(Collections.singletonMap(PARTITION1, offset), submittedRecords.committableOffsets());
+
+        // Old offsets should be wiped
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+    }
+
+    @Test
+    public void testMultipleAcksAcrossMultiplePartitions() {
+        Map<String, Object> partition1Offset1 = newOffset();
+        Map<String, Object> partition1Offset2 = newOffset();
+        Map<String, Object> partition2Offset1 = newOffset();
+        Map<String, Object> partition2Offset2 = newOffset();
+
+        SubmittedRecord partition1Record1 = submittedRecords.submit(PARTITION1, partition1Offset1);
+        SubmittedRecord partition1Record2 = submittedRecords.submit(PARTITION1, partition1Offset2);
+        SubmittedRecord partition2Record1 = submittedRecords.submit(PARTITION2, partition2Offset1);
+        SubmittedRecord partition2Record2 = submittedRecords.submit(PARTITION2, partition2Offset2);
+
+        // No records ack'd yet; can't commit any offsets
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+
+        partition1Record2.ack();
+        // One record has been ack'd, but a record that comes before it and corresponds to the same source partition hasn't been
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+
+        partition2Record1.ack();
+        // We can commit the first offset for the second partition
+        assertEquals(Collections.singletonMap(PARTITION2, partition2Offset1), submittedRecords.committableOffsets());
+
+        // No new offsets to commit
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+
+        partition1Record1.ack();
+        partition2Record2.ack();
+        // We can commit new offsets for both partitions now
+        Map<Map<String, Object>, Map<String, Object>> expectedOffsets = new HashMap<>();
+        expectedOffsets.put(PARTITION1, partition1Offset2);
+        expectedOffsets.put(PARTITION2, partition2Offset2);
+        assertEquals(expectedOffsets, submittedRecords.committableOffsets());
+
+        // No new offsets to commit
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+    }
+
+    @Test
+    public void testRemove() {
+        SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, newOffset());
+        submittedRecords.remove(submittedRecord);
+
+        // Even if SubmittedRecords::remove is broken, we haven't ack'd anything yet, so there should be no committable offsets
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+
+        submittedRecord.ack();
+        // Even though the record has somehow been acknowledged, it should not be counted when collecting committable offsets
+        assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
+    }
+
+    @Test
+    public void testNullPartitionAndOffset() {
+        SubmittedRecord submittedRecord = submittedRecords.submit(null, null);
+        submittedRecord.ack();
+        assertEquals(Collections.singletonMap(null, null), submittedRecords.committableOffsets());
+    }
+
+    private Map<String, Object> newOffset() {
+        return Collections.singletonMap("timestamp", offset.getAndIncrement());
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.kafka.connect.runtime.SubmittedRecords.SubmittedRecord;
+import static org.apache.kafka.connect.runtime.SubmittedRecords.CommittableOffsets;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -48,7 +49,7 @@ public class SubmittedRecordsTest {
 
     @Test
     public void testNoRecords() {
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertTrue(committableOffsets.isEmpty());
 
         committableOffsets = submittedRecords.committableOffsets();
@@ -68,7 +69,7 @@ public class SubmittedRecordsTest {
             }
         }
 
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertMetadata(committableOffsets, 0, 9, 3, 3, PARTITION1, PARTITION2, PARTITION3);
         assertEquals(Collections.emptyMap(), committableOffsets.offsets());
 
@@ -86,7 +87,7 @@ public class SubmittedRecordsTest {
         Map<String, Object> offset = newOffset();
 
         SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, offset);
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         // Record has been submitted but not yet acked; cannot commit offsets for it yet
         assertFalse(committableOffsets.isEmpty());
         assertEquals(Collections.emptyMap(), committableOffsets.offsets());
@@ -121,7 +122,7 @@ public class SubmittedRecordsTest {
         SubmittedRecord partition2Record1 = submittedRecords.submit(PARTITION2, partition2Offset1);
         SubmittedRecord partition2Record2 = submittedRecords.submit(PARTITION2, partition2Offset2);
 
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         // No records ack'd yet; can't commit any offsets
         assertEquals(Collections.emptyMap(), committableOffsets.offsets());
         assertMetadata(committableOffsets, 0, 4, 2, 2, PARTITION1, PARTITION2);
@@ -170,7 +171,7 @@ public class SubmittedRecordsTest {
     public void testRemoveLastSubmittedRecord() {
         SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, newOffset());
 
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertEquals(Collections.emptyMap(), committableOffsets.offsets());
         assertMetadata(committableOffsets, 0, 1, 1, 1, PARTITION1);
 
@@ -195,7 +196,7 @@ public class SubmittedRecordsTest {
         SubmittedRecord recordToRemove = submittedRecords.submit(PARTITION1, partition1Offset);
         SubmittedRecord lastSubmittedRecord = submittedRecords.submit(PARTITION2, partition2Offset);
 
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertMetadata(committableOffsets, 0, 2, 2, 1, PARTITION1, PARTITION2);
         assertNoEmptyDeques();
 
@@ -232,7 +233,7 @@ public class SubmittedRecordsTest {
     @Test
     public void testNullPartitionAndOffset() {
         SubmittedRecord submittedRecord = submittedRecords.submit(null, null);
-        SubmittedRecords.CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
+        CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertMetadata(committableOffsets, 0, 1, 1, 1, (Map<String, Object>) null);
 
         submittedRecord.ack();
@@ -264,7 +265,7 @@ public class SubmittedRecordsTest {
         return Collections.singletonMap("timestamp", offset.getAndIncrement());
     }
 
-    private void assertMetadataNoPending(SubmittedRecords.CommittableOffsets committableOffsets, int committableMessages) {
+    private void assertMetadataNoPending(CommittableOffsets committableOffsets, int committableMessages) {
         assertEquals(committableMessages, committableOffsets.numCommittableMessages());
         assertFalse(committableOffsets.hasPending());
     }
@@ -272,7 +273,7 @@ public class SubmittedRecordsTest {
     @SafeVarargs
     @SuppressWarnings("varargs")
     private final void assertMetadata(
-            SubmittedRecords.CommittableOffsets committableOffsets,
+            CommittableOffsets committableOffsets,
             int committableMessages,
             int uncommittableMessages,
             int numDeques,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.kafka.connect.runtime.SubmittedRecords.SubmittedRecord;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SubmittedRecordsTest {
 
@@ -137,7 +138,8 @@ public class SubmittedRecordsTest {
     @Test
     public void testRemoveLastSubmittedRecord() {
         SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, newOffset());
-        submittedRecords.remove(submittedRecord);
+        assertTrue("First attempt to remove record from submitted queue should succeed", submittedRecords.removeLastOccurrence(submittedRecord));
+        assertFalse("Attempt to remove already-removed record from submitted queue should fail", submittedRecords.removeLastOccurrence(submittedRecord));
 
         // Even if SubmittedRecords::remove is broken, we haven't ack'd anything yet, so there should be no committable offsets
         assertEquals(Collections.emptyMap(), submittedRecords.committableOffsets());
@@ -157,7 +159,7 @@ public class SubmittedRecordsTest {
 
         assertNoEmptyDeques();
 
-        submittedRecords.remove(recordToRemove);
+        assertTrue("First attempt to remove record from submitted queue should succeed", submittedRecords.removeLastOccurrence(recordToRemove));
 
         assertNoEmptyDeques();
         // The only record for this partition has been removed; we shouldn't be tracking a deque for it anymore

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -117,8 +117,8 @@ import static org.junit.Assert.assertTrue;
 public class WorkerSourceTaskTest extends ThreadedTest {
     private static final String TOPIC = "topic";
     private static final String OTHER_TOPIC = "other-topic";
-    private static final Map<String, byte[]> PARTITION = Collections.singletonMap("key", "partition".getBytes());
-    private static final Map<String, Integer> OFFSET = Collections.singletonMap("key", 12);
+    private static final Map<String, Object> PARTITION = Collections.singletonMap("key", "partition".getBytes());
+    private static final Map<String, Object> OFFSET = Collections.singletonMap("key", 12);
 
     // Connect-format data
     private static final Schema KEY_SCHEMA = Schema.INT32_SCHEMA;
@@ -286,6 +286,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         sourceTask.stop();
         EasyMock.expectLastCall();
+
+        offsetWriter.offset(PARTITION, OFFSET);
+        PowerMock.expectLastCall();
         expectOffsetFlush(true);
 
         statusListener.onShutdown(taskId);
@@ -333,6 +336,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         sourceTask.stop();
         EasyMock.expectLastCall();
+
+        offsetWriter.offset(PARTITION, OFFSET);
+        PowerMock.expectLastCall();
         expectOffsetFlush(true);
 
         statusListener.onShutdown(taskId);
@@ -716,25 +722,23 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         expectTopicCreation(TOPIC);
 
         // First round
-        expectSendRecordOnce(false);
+        expectSendRecordOnce();
         // Any Producer retriable exception should work here
         expectSendRecordSyncFailure(new org.apache.kafka.common.errors.TimeoutException("retriable sync failure"));
 
         // Second round
-        expectSendRecordOnce(true);
-        expectSendRecordOnce(false);
+        expectSendRecordOnce();
+        expectSendRecordOnce();
 
         PowerMock.replayAll();
 
         // Try to send 3, make first pass, second fail. Should save last two
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2, record3));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(true, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertEquals(Arrays.asList(record2, record3), Whitebox.getInternalState(workerTask, "toSend"));
 
         // Next they all succeed
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertNull(Whitebox.getInternalState(workerTask, "toSend"));
 
         PowerMock.verifyAll();
@@ -792,15 +796,14 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         expectTopicCreation(TOPIC);
 
         // Source task commit record failure will not cause the task to abort
-        expectSendRecordOnce(false);
-        expectSendRecordTaskCommitRecordFail(false, false);
-        expectSendRecordOnce(false);
+        expectSendRecordOnce();
+        expectSendRecordTaskCommitRecordFail(false);
+        expectSendRecordOnce();
 
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2, record3));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertNull(Whitebox.getInternalState(workerTask, "toSend"));
 
         PowerMock.verifyAll();
@@ -930,7 +933,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         expectTopicCreation(TOPIC);
 
-        Capture<ProducerRecord<byte[], byte[]>> sent = expectSendRecord(TOPIC, true, false, true, true, true, headers);
+        Capture<ProducerRecord<byte[], byte[]>> sent = expectSendRecord(TOPIC, true, true, true, true, headers);
 
         PowerMock.replayAll();
 
@@ -968,8 +971,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         expectTopicCreation(TOPIC);
 
-        Capture<ProducerRecord<byte[], byte[]>> sentRecordA = expectSendRecord(TOPIC, false, false, true, true, false, null);
-        Capture<ProducerRecord<byte[], byte[]>> sentRecordB = expectSendRecord(TOPIC, false, false, true, true, false, null);
+        Capture<ProducerRecord<byte[], byte[]>> sentRecordA = expectSendRecord(TOPIC, false, true, true, false, null);
+        Capture<ProducerRecord<byte[], byte[]>> sentRecordB = expectSendRecord(TOPIC, false, true, true, false, null);
 
         PowerMock.replayAll();
 
@@ -1009,8 +1012,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         TopicDescription topicDesc = new TopicDescription(TOPIC, false, Collections.singletonList(topicPartitionInfo));
         EasyMock.expect(admin.describeTopics(TOPIC)).andReturn(Collections.singletonMap(TOPIC, topicDesc));
 
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         PowerMock.replayAll();
 
@@ -1037,19 +1040,17 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // Second round - calls to describe and create succeed
         expectTopicCreation(TOPIC);
         // Exactly two records are sent
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(true, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertEquals(Arrays.asList(record1, record2), Whitebox.getInternalState(workerTask, "toSend"));
 
         // Next they all succeed
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertNull(Whitebox.getInternalState(workerTask, "toSend"));
     }
 
@@ -1073,19 +1074,17 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         // Second round
         expectTopicCreation(TOPIC);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(true, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertEquals(Arrays.asList(record1, record2), Whitebox.getInternalState(workerTask, "toSend"));
 
         // Next they all succeed
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertNull(Whitebox.getInternalState(workerTask, "toSend"));
     }
 
@@ -1105,8 +1104,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // First round
         expectPreliminaryCalls(OTHER_TOPIC);
         expectTopicCreation(TOPIC);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         // First call to describe the topic times out
         EasyMock.expect(admin.describeTopics(OTHER_TOPIC))
@@ -1114,19 +1113,17 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         // Second round
         expectTopicCreation(OTHER_TOPIC);
-        expectSendRecord(OTHER_TOPIC, false, true, true, true, true, emptyHeaders());
+        expectSendRecord(OTHER_TOPIC, false, true, true, true, emptyHeaders());
 
         PowerMock.replayAll();
 
         // Try to send 3, make first pass, second fail. Should save last two
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2, record3));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(true, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertEquals(Arrays.asList(record3), Whitebox.getInternalState(workerTask, "toSend"));
 
         // Next they all succeed
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertNull(Whitebox.getInternalState(workerTask, "toSend"));
 
         PowerMock.verifyAll();
@@ -1148,8 +1145,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // First round
         expectPreliminaryCalls(OTHER_TOPIC);
         expectTopicCreation(TOPIC);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         EasyMock.expect(admin.describeTopics(OTHER_TOPIC)).andReturn(Collections.emptyMap());
         // First call to create the topic times out
@@ -1159,19 +1156,17 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         // Second round
         expectTopicCreation(OTHER_TOPIC);
-        expectSendRecord(OTHER_TOPIC, false, true, true, true, true, emptyHeaders());
+        expectSendRecord(OTHER_TOPIC, false, true, true, true, emptyHeaders());
 
         PowerMock.replayAll();
 
         // Try to send 3, make first pass, second fail. Should save last two
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2, record3));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(true, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertEquals(Arrays.asList(record3), Whitebox.getInternalState(workerTask, "toSend"));
 
         // Next they all succeed
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
         assertNull(Whitebox.getInternalState(workerTask, "toSend"));
 
         PowerMock.verifyAll();
@@ -1264,8 +1259,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         Capture<NewTopic> newTopicCapture = EasyMock.newCapture();
         EasyMock.expect(admin.createOrFindTopics(EasyMock.capture(newTopicCapture))).andReturn(foundTopic(TOPIC));
 
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         PowerMock.replayAll();
 
@@ -1290,8 +1285,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         Capture<NewTopic> newTopicCapture = EasyMock.newCapture();
         EasyMock.expect(admin.createOrFindTopics(EasyMock.capture(newTopicCapture))).andReturn(createdTopic(TOPIC));
 
-        expectSendRecordTaskCommitRecordSucceed(false, false);
-        expectSendRecordTaskCommitRecordSucceed(false, false);
+        expectSendRecordTaskCommitRecordSucceed(false);
+        expectSendRecordTaskCommitRecordSucceed(false);
 
         PowerMock.replayAll();
 
@@ -1318,8 +1313,6 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     private void expectPreliminaryCalls(String topic) {
         expectConvertHeadersAndKeyValue(topic, true, emptyHeaders());
         expectApplyTransformationChain(false);
-        offsetWriter.offset(PARTITION, OFFSET);
-        PowerMock.expectLastCall();
     }
 
     private CountDownLatch expectEmptyPolls(int minimum, final AtomicInteger count) throws InterruptedException {
@@ -1363,9 +1356,6 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         expectConvertHeadersAndKeyValue(false);
         expectApplyTransformationChain(false);
 
-        offsetWriter.offset(PARTITION, OFFSET);
-        PowerMock.expectLastCall();
-
         EasyMock.expect(
             producer.send(EasyMock.anyObject(ProducerRecord.class),
                 EasyMock.anyObject(org.apache.kafka.clients.producer.Callback.class)))
@@ -1373,33 +1363,28 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     }
 
     private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordAnyTimes() throws InterruptedException {
-        return expectSendRecordTaskCommitRecordSucceed(true, false);
+        return expectSendRecordTaskCommitRecordSucceed(true);
     }
 
-    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordOnce(boolean isRetry) throws InterruptedException {
-        return expectSendRecordTaskCommitRecordSucceed(false, isRetry);
+    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordOnce() throws InterruptedException {
+        return expectSendRecordTaskCommitRecordSucceed(false);
     }
 
     private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordProducerCallbackFail() throws InterruptedException {
-        return expectSendRecord(TOPIC, false, false, false, false, true, emptyHeaders());
+        return expectSendRecord(TOPIC, false, false, false, true, emptyHeaders());
     }
 
-    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordTaskCommitRecordSucceed(boolean anyTimes, boolean isRetry) throws InterruptedException {
-        return expectSendRecord(TOPIC, anyTimes, isRetry, true, true, true, emptyHeaders());
+    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordTaskCommitRecordSucceed(boolean anyTimes) throws InterruptedException {
+        return expectSendRecord(TOPIC, anyTimes, true, true, true, emptyHeaders());
     }
 
-    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordTaskCommitRecordFail(boolean anyTimes, boolean isRetry) throws InterruptedException {
-        return expectSendRecord(TOPIC, anyTimes, isRetry, true, false, true, emptyHeaders());
-    }
-
-    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecord(boolean anyTimes, boolean isRetry, boolean succeed) throws InterruptedException {
-        return expectSendRecord(TOPIC, anyTimes, isRetry, succeed, true, true, emptyHeaders());
+    private Capture<ProducerRecord<byte[], byte[]>> expectSendRecordTaskCommitRecordFail(boolean anyTimes) throws InterruptedException {
+        return expectSendRecord(TOPIC, anyTimes, true, false, true, emptyHeaders());
     }
 
     private Capture<ProducerRecord<byte[], byte[]>> expectSendRecord(
         String topic,
         boolean anyTimes,
-        boolean isRetry,
         boolean sendSuccess,
         boolean commitSuccess,
         boolean isMockedConverters,
@@ -1413,16 +1398,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         Capture<ProducerRecord<byte[], byte[]>> sent = EasyMock.newCapture();
 
-        // 1. Offset data is passed to the offset storage.
-        if (!isRetry) {
-            offsetWriter.offset(PARTITION, OFFSET);
-            if (anyTimes)
-                PowerMock.expectLastCall().anyTimes();
-            else
-                PowerMock.expectLastCall();
-        }
-
-        // 2. Converted data passed to the producer, which will need callbacks invoked for flush to work
+        // 1. Converted data passed to the producer, which will need callbacks invoked for flush to work
         IExpectationSetters<Future<RecordMetadata>> expect = EasyMock.expect(
             producer.send(EasyMock.capture(sent),
                 EasyMock.capture(producerCallbacks)));
@@ -1446,7 +1422,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
             expect.andAnswer(expectResponse);
 
         if (sendSuccess) {
-            // 3. As a result of a successful producer send callback, we'll notify the source task of the record commit
+            // 2. As a result of a successful producer send callback, we'll notify the source task of the record commit
             expectTaskCommitRecordWithOffset(anyTimes, commitSuccess);
             expectTaskGetTopic(anyTimes);
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -553,6 +553,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         final CountDownLatch pollLatch = expectPolls(1);
         expectOffsetFlush(true);
 
+        offsetWriter.offset(PARTITION, OFFSET);
+        PowerMock.expectLastCall().atLeastOnce();
+
         expectTopicCreation(TOPIC);
 
         sourceTask.stop();
@@ -595,6 +598,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // We'll wait for some data, then trigger a flush
         final CountDownLatch pollLatch = expectPolls(1);
         expectOffsetFlush(true);
+
+        offsetWriter.offset(PARTITION, OFFSET);
+        PowerMock.expectLastCall().atLeastOnce();
 
         expectTopicCreation(TOPIC);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
@@ -47,8 +47,8 @@ import static org.junit.Assert.assertTrue;
 public class OffsetStorageWriterTest {
     private static final String NAMESPACE = "namespace";
     // Connect format - any types should be accepted here
-    private static final Map<String, String> OFFSET_KEY = Collections.singletonMap("key", "key");
-    private static final Map<String, Integer> OFFSET_VALUE = Collections.singletonMap("key", 12);
+    private static final Map<String, Object> OFFSET_KEY = Collections.singletonMap("key", "key");
+    private static final Map<String, Object> OFFSET_VALUE = Collections.singletonMap("key", 12);
 
     // Serialized
     private static final byte[] OFFSET_KEY_SERIALIZED = "key-serialized".getBytes();
@@ -229,8 +229,8 @@ public class OffsetStorageWriterTest {
      *                          ensure tests complete.
      * @return the captured set of ByteBuffer key-value pairs passed to the storage layer
      */
-    private void expectStore(Map<String, String> key, byte[] keySerialized,
-                             Map<String, Integer> value, byte[] valueSerialized,
+    private void expectStore(Map<String, Object> key, byte[] keySerialized,
+                             Map<String, Object> value, byte[] valueSerialized,
                              final Callback<Void> callback,
                              final boolean fail,
                              final CountDownLatch waitForCompletion) {


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-12226)

Replaces https://github.com/apache/kafka/pull/10112

Replaces the current batch-based logic for offset commits with a dynamic, non-blocking approach outlined in discussion on #10112 [here](https://github.com/apache/kafka/pull/10112#issuecomment-910510910), [here](https://github.com/apache/kafka/pull/10112#issuecomment-910540773), [here](https://github.com/apache/kafka/pull/10112#issuecomment-914348989), [here](https://github.com/apache/kafka/pull/10112#issuecomment-914547745), and [here](https://github.com/apache/kafka/pull/10112#issuecomment-915350922).

Essentially, a deque is kept for every source partition that a source task produces records for, and each element in that deque is a `SubmittedRecord` with a flag to track whether the producer has ack'd the delivery of that source record to Kafka yet. Periodically, the worker (on the same thread that polls the source task for records and transforms, converts, and dispatches them to the producer) polls acknowledged elements from the beginning of each of these deques and collects the latest offsets from these elements, storing them in a snapshot that is then committed on the separate source task offset thread.

The behavior of the `offset.flush.timeout.ms` property is retained, but essentially now only applies to the actual writing of offset data to the internal offsets topic (if running in distributed mode) or the offsets file (if running in standalone mode). No time is spent during `WorkerSourceTask::commitOffsets` blocking on the acknowledgment of records by the producer.

It's possible that memory exhaustion may occur if, for example, a single Kafka partition is offline for an extended period. In cases like this, the collection of deques in the `SubmittedRecords` class may continue to grow indefinitely until the partition comes back online and the `SubmittedRecord`s in those deques that targeted the formerly-offline Kafka partition are acknowledged and can be removed. Although this may be suboptimal, it is no worse than the existing behavior of the framework in these cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
