### PR TITLE
KAFKA-13294: Upgrade Netty to 4.1.68 for CVE fixes

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,7 +101,7 @@ versions += [
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "3.12.4",
-  netty: "4.1.62.Final",
+  netty: "4.1.68.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
   rocksDB: "6.22.1.1",


### PR DESCRIPTION
`netty-codec` `4.1.62.Final` has the following security vulnerabilities, which in turn effects `netty-transport-native-epoll` Apache Kafka depends on.

- [CVE-2021-37136](https://github.com/netty/netty/security/advisories/GHSA-grg4-wf29-r9vv)
- [CVE-2021-37137](https://github.com/netty/netty/security/advisories/GHSA-9vjp-v76f-g363)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
