### PR TITLE
KAFKA-13255 Fixed code so user can use config.properties.exclude to exclude prope…

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
@@ -38,7 +38,7 @@ public class DefaultConfigPropertyFilter implements ConfigPropertyFilter {
                                                                    + "message\\.timestamp\\.difference\\.max\\.ms, "
                                                                    + "message\\.timestamp\\.type, "
                                                                    + "unclean\\.leader\\.election\\.enable, "
-                                                                   + "min\\.insync\\.replicas";
+                                                                   + "min\\.insync\\.replicas,";
     private Pattern excludePattern = MirrorUtils.compilePatternList(CONFIG_PROPERTIES_EXCLUDE_DEFAULT);
 
     @Override

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -203,7 +203,7 @@ public class MirrorSourceConnector extends SourceConnector {
     List<TopicPartition> findTargetTopicPartitions()
             throws InterruptedException, ExecutionException {
         Set<String> topics = listTopics(targetAdminClient).stream()
-            .filter(t -> !t.equals(config.checkpointsTopic()))
+                .filter(t -> !t.equals(config.checkpointsTopic()))
             .collect(Collectors.toSet());
         return describeTopics(targetAdminClient, topics).stream()
                 .flatMap(MirrorSourceConnector::expandTopicDescription)
@@ -401,7 +401,7 @@ public class MirrorSourceConnector extends SourceConnector {
         return adminClient.describeTopics(topics).allTopicNames().get().values();
     }
 
-    static Map<String, String> configToMap(Config config) {
+    Map<String, String> configToMap(Config config) {
         return config.entries().stream().filter(x -> shouldReplicateTopicConfigurationProperty(x.name()))
                 .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -203,7 +203,6 @@ public class MirrorSourceConnector extends SourceConnector {
     List<TopicPartition> findTargetTopicPartitions()
             throws InterruptedException, ExecutionException {
         Set<String> topics = listTopics(targetAdminClient).stream()
-            .filter(t -> sourceAndTarget.source().equals(replicationPolicy.topicSource(t)))
             .filter(t -> !t.equals(config.checkpointsTopic()))
             .collect(Collectors.toSet());
         return describeTopics(targetAdminClient, topics).stream()
@@ -403,7 +402,7 @@ public class MirrorSourceConnector extends SourceConnector {
     }
 
     static Map<String, String> configToMap(Config config) {
-        return config.entries().stream()
+        return config.entries().stream().filter(x -> shouldReplicateTopicConfigurationProperty(x.name()))
                 .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -222,7 +222,7 @@ public class MirrorSourceConnectorTest {
 
         Map<String, Long> expectedPartitionCounts = new HashMap<>();
         expectedPartitionCounts.put("source.topic", 1L);
-        Map<String, String> configMap = MirrorSourceConnector.configToMap(topicConfig);
+        Map<String, String> configMap = connector.configToMap(topicConfig);
         assertEquals(2, configMap.size(), "configMap has incorrect size");
 
         Map<String, NewTopic> expectedNewTopics = new HashMap<>();


### PR DESCRIPTION
Objective - Use MM2 (kafka connect in distributed cluster) for data migration between cluster hosted in private data center and aws msk cluster.

Steps performed -

Started kafka-connect service.
Created 3 MM2 connectors (i.e. source connector, checkpoint connector and heartbeat connector). Curl commands used to create connectors are in the attached file.  To exclude certain config properties while topic replication, we are using the 'config.properties.exclude' property in the MM2 source connector.
Expected -

Source topic 'dev.portlandDc.anamika.helloMsk' should be successfully created in destination cluster.

Actual -

Creation of the source topic 'dev.portlandDc.anamika.helloMsk' in destination cluster fails with an error. Error is

[2021-08-06 06:13:40,944] WARN [mm2-msc|worker] Could not create topic dev.portlandDc.anamika.helloMsk. (org.apache.kafka.connect.mirror.MirrorSourceConnector:371)
org.apache.kafka.common.errors.InvalidConfigurationException: Unknown topic config name: confluent.value.schema.validation

