### PR TITLE
MINOR: re-add removed test coverage for 'KAFKA-12983: reset needsJoinPrepare flag'

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -73,7 +73,6 @@ import org.apache.kafka.common.requests.SyncGroupResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.SystemTime;
-import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
In [11231](https://github.com/apache/kafka/pull/11231) we fixed a bug in which the consumer would reset its state unnecessarily, and fixed up the tests accordingly. Unfortunately this also wiped out the test coverage for https://issues.apache.org/jira/browse/KAFKA-12983 that was added in [10986](https://github.com/apache/kafka/pull/10986).

I noticed this when cherrypicking that fix back to the 2.7 branch and hitting merge conflicts in the test. I moved/replaced the test coverage for KAFKA-12983 in the cherrypicked fix, so we should now port this forward to the newer branches.

Verified that without the fix (resetting the flag), this does indeed cause the test to fail. Should be cherrypicked back to 2.8