### PR TITLE
KAFKA-13306: Null connector config value passes validation, but fails creation

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -447,7 +447,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                 .map(Map.Entry::getKey)
                 .forEach(prop ->
                     validatedConnectorConfig.computeIfAbsent(prop, ConfigValue::new)
-                        .addErrorMessage("The JSON literal `null` may not be used in connector configurations")
+                        .addErrorMessage("Null value can not be supplied as the configuration value.")
             );
             List<ConfigValue> configValues = new ArrayList<>(validatedConnectorConfig.values());
             Map<String, ConfigKey> configKeys = new LinkedHashMap<>(enrichedConfigDef.configKeys());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -442,6 +442,13 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                     enrichedConfigDef,
                     connectorProps
             );
+            connectorProps.entrySet().stream()
+                .filter(e -> e.getValue() == null)
+                .map(Map.Entry::getKey)
+                .forEach(prop ->
+                    validatedConnectorConfig.computeIfAbsent(prop, ConfigValue::new)
+                        .addErrorMessage("The JSON literal `null` may not be used in connector configurations")
+            );
             List<ConfigValue> configValues = new ArrayList<>(validatedConnectorConfig.values());
             Map<String, ConfigKey> configKeys = new LinkedHashMap<>(enrichedConfigDef.configKeys());
             Set<String> allGroups = new LinkedHashSet<>(enrichedConfigDef.groups());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConfigInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConfigInfo.java
@@ -60,6 +60,6 @@ public class ConfigInfo {
 
     @Override
     public String toString() {
-        return "[" + configKey.toString() + "," + configValue.toString() + "]";
+        return "[" + configKey + "," + configValue + "]";
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -97,7 +97,7 @@ public class ConnectorPluginsResourceTest {
 
         props = new HashMap<>(partialProps);
         props.put("connector.class", ConnectorPluginsResourceTestConnector.class.getSimpleName());
-        props.put("plugin.path", null);
+        props.put("plugin.path", "test.path");
     }
 
     private static final ConfigInfos CONFIG_INFOS;


### PR DESCRIPTION
This patch adds null value check to the connector config validation, and extends unit tests to cover this functionality.