### PR TITLE
MINOR: Let the list-store return null in putifabsent

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=3.1.0-SNAPSHOT
+version=3.1.0-SNAPSHOT-SSJOIN
 scalaVersion=2.13.6
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=3.1.0-SNAPSHOT-SSJOIN
+version=3.1.0-SNAPSHOT
 scalaVersion=2.13.6
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingListValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingListValueBytesStore.java
@@ -40,17 +40,10 @@ public class ChangeLoggingListValueBytesStore extends ChangeLoggingKeyValueBytes
 
     @Override
     public byte[] putIfAbsent(final Bytes key, final byte[] value) {
-        final byte[] oldValue = wrapped().putIfAbsent(key, value);
+        final byte[] oldValue = wrapped().get(key);
 
         if (oldValue != null) {
-            // the provided new value will be added to the list in the inner put()
-            // we need to log the full new list and thus call get() on the inner store below
-            // if the value is a tombstone, we delete the whole list and thus can save the get call
-            if (value == null) {
-                log(key, null);
-            } else {
-                log(key, wrapped().get(key));
-            }
+            put(key, value);
         }
 
         // TODO: here we always return null so that deser would not fail.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ListValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ListValueStore.java
@@ -72,7 +72,10 @@ public class ListValueStore
             }
         }
 
-        return oldValue;
+        // TODO: here we always return null so that deser would not fail.
+        //       we only do this since we know the only caller (stream-stream join processor)
+        //       would not need the actual value at all; the changelogging wrapper would not call this function
+        return null;
     }
 
     // this function assumes the addedValue is not null; callers should check null themselves


### PR DESCRIPTION
This is to make sure that even if logging is disabled, we would still return null in order to workaround the deserialization issue for stream-stream left/outer joins.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
