### PR TITLE
DRAFT: Add currentPosition and times to ProcessorContext

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -198,7 +198,7 @@
               files="(StreamsPartitionAssignorTest|StreamThreadTest|StreamTaskTest|TaskManagerTest|TopologyTestDriverTest).java"/>
 
     <suppress checks="MethodLength"
-              files="(EosIntegrationTest|EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|RocksDBWindowStoreTest).java"/>
+              files="(EosIntegrationTest|EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|RocksDBWindowStoreTest|ProcessorContextIntegrationTest).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files=".*[/\\]streams[/\\].*test[/\\].*.java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ProcessorContext.java
@@ -16,8 +16,12 @@
  */
 package org.apache.kafka.streams.processor.api;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -247,4 +251,45 @@ public interface ProcessorContext<KForward, VForward> {
      * @return the key/values matching the given prefix from the StreamsConfig properties.
      */
     Map<String, Object> appConfigsWithPrefix(final String prefix);
+
+    /**
+     * Return the current system timestamp (also called wall-clock time) in milliseconds.
+     *
+     * <p> Note: this method returns the internally cached system timestamp from the Kafka Stream runtime.
+     * Thus, it may return a different value compared to {@code System.currentTimeMillis()}.
+     *
+     * @return the current system timestamp in milliseconds
+     */
+    long currentSystemTimeMs();
+
+    /**
+     * Return the current stream-time in milliseconds.
+     *
+     * <p> Stream-time is the maximum observed {@link TimestampExtractor record timestamp} so far
+     * (including the currently processed record), i.e., it can be considered a high-watermark.
+     * Stream-time is tracked on a per-task basis and is preserved across restarts and during task migration.
+     *
+     * <p> Note: this method is not supported for global processors (cf. {@link Topology#addGlobalStore} (...)
+     * and {@link StreamsBuilder#addGlobalStore} (...),
+     * because there is no concept of stream-time for this case.
+     * Calling this method in a global processor will result in an {@link UnsupportedOperationException}.
+     *
+     * @return the current stream-time in milliseconds
+     */
+    long currentStreamTimeMs();
+
+    /**
+     * Returns the current offset positions of the input topic-partitions.
+     *
+     * "Current position" refers specifically to the offsets that Streams would commit, if it
+     * were to commit at the moment of this method call. Analogous to the
+     * {@link Consumer#position(TopicPartition)} method, this
+     * is actually the _next_ offset after the current record, not the current record's offset
+     * (which is available via {@link this#recordMetadata()}).
+     *
+     * The returned map is only scoped to the current task.
+     *
+     * Calling this method in a global processor will result in an {@link UnsupportedOperationException}.
+     */
+    Map<TopicPartition, Long> currentPositions();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
@@ -108,6 +110,11 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext<Object,
     @Override
     public long currentStreamTimeMs() {
         throw new UnsupportedOperationException("There is no concept of stream-time for a global processor.");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> currentPositions() {
+        throw new UnsupportedOperationException("currentPositions is not supported for global processors.");
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -306,6 +306,11 @@ public class ProcessorContextImpl extends AbstractProcessorContext<Object, Objec
     }
 
     @Override
+    public Map<TopicPartition, Long> currentPositions() {
+        return streamTask.currentPositions();
+    }
+
+    @Override
     public ProcessorNode<?, ?, ?, ?> currentNode() {
         throwUnsupportedOperationExceptionIfStandby("currentNode");
         return super.currentNode();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ProcessorContextIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ProcessorContextIntegrationTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkProperties;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.cleanStateBeforeTest;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.quietlyCleanStateAfterTest;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValueTimestamp;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+@Category(IntegrationTest.class)
+public class ProcessorContextIntegrationTest {
+
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
+        1,
+        mkProperties(mkMap()),
+        0L
+    );
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    @BeforeClass
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterClass
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    @Test
+    public void shouldReturnPositionAndTime() throws InterruptedException {
+        // set up the test itself.
+        final String testId = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
+        final String input1 = "input1-" + testId;
+        final String input2 = "input2-" + testId;
+        cleanStateBeforeTest(CLUSTER, 2, input1, input2);
+
+        // We're creating two partitions, so these will be the two tasks:
+        final TaskId task00 = new TaskId(0, 0);
+        final TaskId task01 = new TaskId(0, 1);
+
+        final long now = System.currentTimeMillis();
+
+        // create the input data
+        final List<KeyValueTimestamp<String, String>> input1Records = asList(
+            new KeyValueTimestamp<>("a", "v1", now + 1),
+            new KeyValueTimestamp<>("b", "v2", now + 2),
+            new KeyValueTimestamp<>("c", "v1", now + 3),
+            new KeyValueTimestamp<>("d", "x", now + 4)
+        );
+
+        produceSynchronously(input1, input1Records);
+
+        final List<KeyValueTimestamp<String, String>> input2Records = asList(
+            new KeyValueTimestamp<>("e", "v1", now + 5),
+            new KeyValueTimestamp<>("f", "v2", now + 6),
+            new KeyValueTimestamp<>("g", "v1", now + 7)
+        );
+
+        produceSynchronously(input2, input2Records);
+
+        // create the collectors for the observed properties
+        final ConcurrentHashMap<TaskId, Long> systemTimeOnPunctuate = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<TaskId, Long> streamTimeOnPunctuate = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<TaskId, Map<TopicPartition, Long>> positionOnPunctuate =
+            new ConcurrentHashMap<>();
+        final ConcurrentHashMap<TaskId, Long> systemTimeOnProcess = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<TaskId, Long> streamTimeOnProcess = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<TaskId, Map<TopicPartition, Long>> positionOnProcess =
+            new ConcurrentHashMap<>();
+
+        // create the latches so we can delay evaluation until we've processed everything
+        final CountDownLatch processLatch = new CountDownLatch(
+            input1Records.size() + input2Records.size());
+        // we just need to punctuate at least for each task
+        final ConcurrentHashMap<TaskId, CountDownLatch> punctuateLatches = new ConcurrentHashMap<>();
+
+        punctuateLatches.put(task00, new CountDownLatch(1));
+        punctuateLatches.put(task01, new CountDownLatch(1));
+
+        // create the streams app, which simply subscribes to both input topics and captures the
+        // desired properties during processing and punctuation
+        final Topology topology = new Topology();
+
+        topology.addSource("source1", new StringDeserializer(), new StringDeserializer(), input1);
+        topology.addSource("source2", new StringDeserializer(), new StringDeserializer(), input2);
+        topology.addProcessor("processor", () -> new Processor<Object, Object, Object, Object>() {
+            private ProcessorContext<Object, Object> context;
+
+            @Override
+            public void init(final ProcessorContext<Object, Object> context) {
+                this.context = context;
+                context.schedule(
+                    Duration.ofMillis(1),
+                    PunctuationType.WALL_CLOCK_TIME,
+                    timestamp -> {
+                        final TaskId taskId = context.taskId();
+                        positionOnPunctuate.put(taskId, context.currentPositions());
+                        streamTimeOnPunctuate.put(taskId, context.currentStreamTimeMs());
+                        systemTimeOnPunctuate.put(taskId, this.context.currentSystemTimeMs());
+                        punctuateLatches.get(taskId).countDown();
+                    }
+                );
+            }
+
+            @Override
+            public void process(final Record<Object, Object> record1) {
+                final TaskId taskId = context.taskId();
+                final Map<TopicPartition, Long> positions = context.currentPositions();
+                positionOnProcess.put(taskId, positions);
+                streamTimeOnProcess.put(taskId, context.currentStreamTimeMs());
+                systemTimeOnProcess.put(taskId, context.currentSystemTimeMs());
+                processLatch.countDown();
+            }
+        }, "source1", "source2");
+
+        final Properties streamsConfig = getStreamsConfig(testId);
+
+        // start Streams
+        final KafkaStreams driver =
+            IntegrationTestUtils.getRunningStreams(streamsConfig, topology, true);
+        try {
+
+            // wait until we've processed all the inputs and punctuated both tasks
+            processLatch.await(2, TimeUnit.MINUTES);
+            for (final CountDownLatch value : punctuateLatches.values()) {
+                value.await(2, TimeUnit.MINUTES);
+            }
+
+            // relying on the default partitioning of our test keys to be stable for this assertion
+            // based on that one assumption, and the fact that we waited for all the inputs to be
+            // processed, we can assert the exact position that the processors should have seen by now.
+            assertThat(
+                positionOnProcess,
+                equalTo(
+                    mkMap(
+                        mkEntry(
+                            task00,
+                            mkMap(
+                                mkEntry(new TopicPartition(input1, 0), 3L),
+                                mkEntry(new TopicPartition(input2, 0), 1L)
+                            )
+                        ),
+                        mkEntry(
+                            task01,
+                            mkMap(
+                                mkEntry(new TopicPartition(input1, 1), 1L),
+                                mkEntry(new TopicPartition(input2, 1), 2L)
+                            )
+                        )
+                    )
+                )
+            );
+
+            assertThat(
+                streamTimeOnProcess,
+                equalTo(
+                    mkMap(
+                        mkEntry(task00, now + 5),
+                        mkEntry(task01, now + 7)
+                    )
+                )
+            );
+
+            // for the rest of the properties, there's not much that we can reliably assert.
+            final Set<TaskId> tasks = mkSet(task00, task01);
+            assertThat(systemTimeOnProcess.keySet(), equalTo(tasks));
+            assertThat(systemTimeOnPunctuate.keySet(), equalTo(tasks));
+            assertThat(streamTimeOnPunctuate.keySet(), equalTo(tasks));
+            assertThat(positionOnPunctuate.keySet(), equalTo(tasks));
+            for (final TaskId task : tasks) {
+                assertThat(systemTimeOnProcess.get(task), greaterThanOrEqualTo(now));
+                assertThat(streamTimeOnProcess.get(task), greaterThanOrEqualTo(now));
+                assertThat(systemTimeOnPunctuate.get(task), greaterThanOrEqualTo(now));
+                final Map<TopicPartition, Long> positions = positionOnPunctuate.get(task);
+                final Set<TopicPartition> topicPartitions = mkSet(
+                    new TopicPartition(input1, task.partition()),
+                    new TopicPartition(input2, task.partition())
+                );
+                assertThat(positions.keySet(), equalTo(topicPartitions));
+                for (final TopicPartition partition : topicPartitions) {
+                    assertThat(positions.get(partition), greaterThanOrEqualTo(0L));
+                }
+            }
+        } finally {
+            driver.close();
+            quietlyCleanStateAfterTest(CLUSTER, driver);
+        }
+    }
+
+    private Properties getStreamsConfig(final String testId) {
+        return mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, testId),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+    }
+
+    private static void produceSynchronously(final String topic,
+        final List<KeyValueTimestamp<String, String>> toProduce) {
+        final Properties producerConfig = mkProperties(mkMap(
+            mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+            mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()),
+            mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()),
+            mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+        IntegrationTestUtils.produceSynchronously(producerConfig, false, topic, Optional.empty(),
+            toProduce);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -44,6 +44,7 @@ import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.StreamThread;
@@ -1212,7 +1213,13 @@ public class IntegrationTestUtils {
     public static KafkaStreams getRunningStreams(final Properties streamsConfig,
                                                  final StreamsBuilder builder,
                                                  final boolean clean) {
-        final KafkaStreams driver = new KafkaStreams(builder.build(), streamsConfig);
+        return getRunningStreams(streamsConfig, builder.build(), clean);
+    }
+
+    public static KafkaStreams getRunningStreams(final Properties streamsConfig,
+                                                 final Topology topology,
+                                                 final boolean clean) {
+        final KafkaStreams driver = new KafkaStreams(topology, streamsConfig);
         if (clean) {
             driver.cleanUp();
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -235,6 +237,11 @@ public class AbstractProcessorContextTest {
 
         @Override
         public long currentStreamTimeMs() {
+            throw new UnsupportedOperationException("this method is not supported in TestProcessorContext");
+        }
+
+        @Override
+        public Map<TopicPartition, Long> currentPositions() {
             throw new UnsupportedOperationException("this method is not supported in TestProcessorContext");
         }
 

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
@@ -381,6 +382,11 @@ public class InternalMockProcessorContext<KOut, VOut>
 
     @Override
     public long currentStreamTimeMs() {
+        throw new UnsupportedOperationException("this method is not supported in InternalMockProcessorContext");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> currentPositions() {
         throw new UnsupportedOperationException("this method is not supported in InternalMockProcessorContext");
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.MockProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
@@ -63,6 +64,11 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
     @Override
     public long currentSystemTimeMs() {
         return currentSystemTimeMs;
+    }
+
+    @Override
+    public Map<TopicPartition, Long> currentPositions() {
+        throw new UnsupportedOperationException("this method is not supported in MockInternalProcessorContext");
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
@@ -107,6 +108,11 @@ public class NoOpProcessorContext extends AbstractProcessorContext<Object, Objec
 
     @Override
     public long currentStreamTimeMs() {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> currentPositions() {
         throw new UnsupportedOperationException("Not implemented yet.");
     }
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -565,6 +565,11 @@ public class TopologyTestDriver implements Closeable {
                                    final byte[] value,
                                    final Headers headers) {
         final long offset = offsetsByTopicOrPatternPartition.get(topicOrPatternPartition).incrementAndGet() - 1;
+        // Since we're actually piping the records into the task buffer directly,
+        // we just need to keep the position updated to the correct offset on the consumer.
+        // The consumer's position should always be the next offset to fetch, so
+        // we set the consumer's position to the piped record's offset + 1.
+        consumer.seek(topicOrPatternPartition, offset + 1);
         task.addRecords(topicOrPatternPartition, Collections.singleton(new ConsumerRecord<>(
             inputTopic,
             topicOrPatternPartition.partition(),

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.api;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
@@ -281,6 +282,21 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
     @Override
     public Map<String, Object> appConfigsWithPrefix(final String prefix) {
         return config.originalsWithPrefix(prefix);
+    }
+
+    @Override
+    public long currentSystemTimeMs() {
+        throw new UnsupportedOperationException("Not available in the mock context.");
+    }
+
+    @Override
+    public long currentStreamTimeMs() {
+        throw new UnsupportedOperationException("Not available in the mock context.");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> currentPositions() {
+        throw new UnsupportedOperationException("Not available in the mock context.");
     }
 
     @Override


### PR DESCRIPTION
Similar to the currentStreamTime/currentSystemTime methods in KIP-622,
this PR demonstrates adding a currentPositions call to the ProcessorContext,
which returns the task's current offset position in each of its input topic partitions.

This is a fairly advanced requirement, which most applications would
never need, but if an application does need to know the current position,
there is no other way they could compute it.

If the initial reception to this POC is positive, I'll follow up with a KIP.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
