### PR TITLE
KAFKA-13312; 'NetworkDegradeTest#test_rate' should wait until iperf server is listening

### DIFF
--- a/tests/kafkatest/tests/core/network_degrade_test.py
+++ b/tests/kafkatest/tests/core/network_degrade_test.py
@@ -105,6 +105,13 @@ class NetworkDegradeTest(Test):
         # Run iperf server on zk1, iperf client on zk0
         iperf_server = zk1.account.ssh_capture("iperf -s")
 
+        # Wait until iperf server is listening before starting the client
+        for line in iperf_server:
+          self.logger.debug("iperf server output %s" % line)
+          if "server listening" in line.lower():
+            self.logger.info("iperf server is ready")
+            break
+
         # Capture the measured kbps between the two nodes.
         # [  3]  0.0- 1.0 sec  2952576 KBytes  24187503 Kbits/sec
         r = re.compile(r"^.*\s(?P<rate>[\d.]+)\sKbits/sec$")


### PR DESCRIPTION
We have seen multiple failures with the following logs:

```
[DEBUG - 2021-09-17 09:57:58,603 - remoteaccount - _log - lineno:160]: ubuntu@worker26: Running ssh command: iperf -i 1 -t 20 -f k -c worker25 [INFO - 2021-09-17 09:57:58,611 - network_degrade_test - test_rate - lineno:114]: iperf output connect failed: Connection refused
```

The iperf client can not connect to the iperf server. The test launches the server and then immediately launches the client but there is not guarantee that the server listens when the client is started.

It seems that we should add a condition to wait until the server prints `Server listening` before starting the client.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
