### PR TITLE
KAFKA-13296: warn if previous assignment has duplicate partitions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -351,6 +351,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             // add the consumer and any info in its subscription to the client
             clientMetadata.addConsumer(consumerId, subscription.ownedPartitions());
+            if (allOwnedPartitions.stream().anyMatch(t -> subscription.ownedPartitions().contains(t))) {
+                log.warn("The previous assignment contains a partition more than once. " +
+                    "This might result in violation of EOS if enabled. \n" +
+                    "\tconsumerID: {} \n" +
+                    "\tpartitions validated so far: {} \n" +
+                    "\tproblem subscription: {}",
+                    consumerId,
+                    allOwnedPartitions,
+                    subscription.ownedPartitions()
+                );
+            }
             allOwnedPartitions.addAll(subscription.ownedPartitions());
             clientMetadata.addPreviousTasksAndOffsetSums(consumerId, info.taskOffsetSums());
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -317,6 +317,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         int minSupportedMetadataVersion = LATEST_SUPPORTED_VERSION;
 
         boolean shutdownRequested = false;
+        boolean assignementErrorFound = false;
         int futureMetadataVersion = UNKNOWN;
         for (final Map.Entry<String, Subscription> entry : subscriptions.entrySet()) {
             final String consumerId = entry.getKey();
@@ -351,19 +352,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             // add the consumer and any info in its subscription to the client
             clientMetadata.addConsumer(consumerId, subscription.ownedPartitions());
-            if (allOwnedPartitions.stream().anyMatch(t -> subscription.ownedPartitions().contains(t))) {
-                log.warn("The previous assignment contains a partition more than once. " +
-                    "This might result in violation of EOS if enabled. \n" +
-                    "\tconsumerID: {} \n" +
-                    "\tpartitions validated so far: {} \n" +
-                    "\tproblem subscription: {}",
-                    consumerId,
-                    allOwnedPartitions,
-                    subscription.ownedPartitions()
-                );
-            }
+            final int prevSize = allOwnedPartitions.size();
             allOwnedPartitions.addAll(subscription.ownedPartitions());
+            if (allOwnedPartitions.size() < prevSize + subscription.ownedPartitions().size()) {
+                assignementErrorFound = true;
+            }
             clientMetadata.addPreviousTasksAndOffsetSums(consumerId, info.taskOffsetSums());
+        }
+
+        if (assignementErrorFound) {
+            log.warn("The previous assignment contains a partition more than once. " +
+                "\t Mapping: {}", subscriptions);
         }
 
         try {


### PR DESCRIPTION
If for some reason partition revoked did not get called due to some bug it would be good to log a warning that the previous assignment was not clean. This could affect eos and it might be good to be able to revoke a partition instead of using partitions lost
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
