### PR TITLE
MINOR: fix CreateTopic to return the same as DescribeTopic

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -36,14 +36,14 @@ import scala.jdk.CollectionConverters._
 
 class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepository: ConfigRepository) extends Logging {
 
+  def allConfigs(config: AbstractConfig) = {
+    config.originals.asScala.filter(_._2 != null) ++ config.nonInternalValues.asScala
+  }
+
   def describeConfigs(resourceToConfigNames: List[DescribeConfigsResource],
                       includeSynonyms: Boolean,
                       includeDocumentation: Boolean): List[DescribeConfigsResponseData.DescribeConfigsResult] = {
     resourceToConfigNames.map { case resource =>
-
-      def allConfigs(config: AbstractConfig) = {
-        config.originals.asScala.filter(_._2 != null) ++ config.nonInternalValues.asScala
-      }
 
       def createResponseConfig(configs: Map[String, Any],
                                createConfigEntry: (String, Any) => DescribeConfigsResponseData.DescribeConfigsResourceResult): DescribeConfigsResponseData.DescribeConfigsResult = {

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -118,7 +118,7 @@ class ZkAdminManager(val config: KafkaConfig,
     metadataAndConfigs.get(topicName).foreach { result =>
       val logConfig = LogConfig.fromProps(LogConfig.extractLogConfigMap(config), configs)
       val createEntry = configHelper.createTopicConfigEntry(logConfig, configs, includeSynonyms = false, includeDocumentation = false)(_, _)
-      val topicConfigs = logConfig.nonInternalValues.asScala.map { case (k, v) =>
+      val topicConfigs = (logConfig.originals.asScala.filter(_._2 != null) ++ logConfig.nonInternalValues.asScala).map { case (k, v) =>
         val entry = createEntry(k, v)
         new CreatableTopicConfigs()
           .setName(k)

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -118,7 +118,7 @@ class ZkAdminManager(val config: KafkaConfig,
     metadataAndConfigs.get(topicName).foreach { result =>
       val logConfig = LogConfig.fromProps(LogConfig.extractLogConfigMap(config), configs)
       val createEntry = configHelper.createTopicConfigEntry(logConfig, configs, includeSynonyms = false, includeDocumentation = false)(_, _)
-      val topicConfigs = (logConfig.originals.asScala.filter(_._2 != null) ++ logConfig.nonInternalValues.asScala).map { case (k, v) =>
+      val topicConfigs = configHelper.allConfigs(logConfig).map { case (k, v) =>
         val entry = createEntry(k, v)
         new CreatableTopicConfigs()
           .setName(k)


### PR DESCRIPTION
DescribeTopic returns

https://github.com/ccding/kafka/blob/79788ca042330faea7dc736f1f6ceb75b3f4d1d9/core/src/main/scala/kafka/server/ConfigHelper.scala#L45
```
config.originals.asScala.filter(_._2 != null) ++ config.nonInternalValues.asScala
```
so we should do the same for CreateTopic.

I am not able to come up with a unit test for this because we don't have a config that is defineInternal in LogConfig and would be used.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
