### PR TITLE
MINOR: Fix use of ConfigException in AbstractConfig class

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -561,7 +561,7 @@ public class AbstractConfig {
         Map<String, String> providerMap = new HashMap<>();
 
         for (String provider: configProviders.split(",")) {
-            String providerClass = CONFIG_PROVIDERS_CONFIG + "." + provider + ".class";
+            String providerClass = providerClassProperty(provider);
             if (indirectConfigs.containsKey(providerClass))
                 providerMap.put(provider, indirectConfigs.get(providerClass));
 
@@ -577,11 +577,15 @@ public class AbstractConfig {
                 configProviderInstances.put(entry.getKey(), provider);
             } catch (ClassNotFoundException e) {
                 log.error("ClassNotFoundException exception occurred: " + entry.getValue());
-                throw new ConfigException("Invalid config:" + entry.getValue() + " ClassNotFoundException exception occurred", e);
+                throw new ConfigException(providerClassProperty(entry.getKey()), entry.getValue(), "ClassNotFoundException exception occurred");
             }
         }
 
         return configProviderInstances;
+    }
+
+    private static String providerClassProperty(String providerName) {
+        return String.format("%s.%s.class", CONFIG_PROVIDERS_CONFIG, providerName);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -576,8 +576,8 @@ public class AbstractConfig {
                 provider.configure(configProperties);
                 configProviderInstances.put(entry.getKey(), provider);
             } catch (ClassNotFoundException e) {
-                log.error("ClassNotFoundException exception occurred: " + entry.getValue());
-                throw new ConfigException(providerClassProperty(entry.getKey()), entry.getValue(), "ClassNotFoundException exception occurred");
+                log.error("Could not load config provider class " + entry.getValue(), e);
+                throw new ConfigException(providerClassProperty(entry.getKey()), entry.getValue(), "Could not load config provider class or one of its dependencies");
             }
         }
 


### PR DESCRIPTION
The two-arg variant is intended to take a property name and value, not an exception message and a cause.

As-is, this leads to confusing log messages like:
```
org.apache.kafka.common.config.ConfigException: Invalid value java.lang.ClassNotFoundException: io.strimzi.kafka.KubernetesConfigMapConfigProvider for configuration Invalid config:io.strimzi.kafka.KubernetesConfigMapConfigProvider ClassNotFoundException exception occurred
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
