### PR TITLE
Add DirectoryConfigProvider to the service provider list

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
@@ -26,6 +26,8 @@ import java.util.Set;
 /**
  * A provider of configuration data, which may optionally support subscriptions to configuration changes.
  * Implementations are required to safely support concurrent calls to any of the methods in this interface.
+ * Configuration provider implementations are in Kafka Connect loaded as Service Providers using the {@code ServiceLoader} class.
+ * To support this, implementations of this interface should also contain its service provider configuration file.
  */
 public interface ConfigProvider extends Configurable, Closeable {
 

--- a/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
@@ -26,8 +26,8 @@ import java.util.Set;
 /**
  * A provider of configuration data, which may optionally support subscriptions to configuration changes.
  * Implementations are required to safely support concurrent calls to any of the methods in this interface.
- * Configuration provider implementations are in Kafka Connect loaded as Service Providers using the {@code ServiceLoader} class.
- * To support this, implementations of this interface should also contain its service provider configuration file.
+ * Kafka Connect discovers configuration providers using Java's Service Provider mechanism (see {@code java.util.ServiceLoader}).
+ * To support this, implementations of this interface should also contain a service provider configuration file in {@code  META-INF/service/org.apache.kafka.common.config.provider.ConfigProvider}.
  */
 public interface ConfigProvider extends Configurable, Closeable {
 

--- a/clients/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/clients/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -14,3 +14,4 @@
  # limitations under the License.
 
 org.apache.kafka.common.config.provider.FileConfigProvider
+org.apache.kafka.common.config.provider.DirectoryConfigProvider

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.test.TestUtils.toSet;
@@ -150,17 +151,7 @@ public class DirectoryConfigProviderTest {
     @Test
     public void testServiceLoaderDiscovery() {
         ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
-
-        boolean discovered = false;
-
-        for (ConfigProvider service : serviceLoader)    {
-            System.out.println(service.getClass());
-            if (service instanceof DirectoryConfigProvider) {
-                discovered = true;
-            }
-        }
-
-        assertTrue(discovered);
+        assertTrue(StreamSupport.stream(serviceLoader.spliterator(), false).anyMatch(sl -> sl instanceof DirectoryConfigProvider));
     }
 }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
@@ -144,6 +145,22 @@ public class DirectoryConfigProviderTest {
         ConfigData configData = provider.get(null, Collections.singleton("foo"));
         assertTrue(configData.data().isEmpty());
         assertNull(configData.ttl());
+    }
+
+    @Test
+    public void testServiceLoaderDiscovery() {
+        ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
+
+        boolean discovered = false;
+
+        for (ConfigProvider service : serviceLoader)    {
+            System.out.println(service.getClass());
+            if (service instanceof DirectoryConfigProvider) {
+                discovered = true;
+            }
+        }
+
+        assertTrue(discovered);
     }
 }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
@@ -151,7 +151,7 @@ public class DirectoryConfigProviderTest {
     @Test
     public void testServiceLoaderDiscovery() {
         ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
-        assertTrue(StreamSupport.stream(serviceLoader.spliterator(), false).anyMatch(sl -> sl instanceof DirectoryConfigProvider));
+        assertTrue(StreamSupport.stream(serviceLoader.spliterator(), false).anyMatch(configProvider -> configProvider instanceof DirectoryConfigProvider));
     }
 }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -91,17 +92,8 @@ public class FileConfigProviderTest {
     @Test
     public void testServiceLoaderDiscovery() {
         ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
+        assertTrue(StreamSupport.stream(serviceLoader.spliterator(), false).anyMatch(sl -> sl instanceof FileConfigProvider));
 
-        boolean discovered = false;
-
-        for (ConfigProvider service : serviceLoader)    {
-            System.out.println(service.getClass());
-            if (service instanceof FileConfigProvider) {
-                discovered = true;
-            }
-        }
-
-        assertTrue(discovered);
     }
 
     public static class TestFileConfigProvider extends FileConfigProvider {

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
@@ -92,8 +92,7 @@ public class FileConfigProviderTest {
     @Test
     public void testServiceLoaderDiscovery() {
         ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
-        assertTrue(StreamSupport.stream(serviceLoader.spliterator(), false).anyMatch(sl -> sl instanceof FileConfigProvider));
-
+        assertTrue(StreamSupport.stream(serviceLoader.spliterator(), false).anyMatch(configProvider -> configProvider instanceof FileConfigProvider));
     }
 
     public static class TestFileConfigProvider extends FileConfigProvider {

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
@@ -26,6 +26,7 @@ import java.io.StringReader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -85,6 +86,22 @@ public class FileConfigProviderTest {
         ConfigData configData = configProvider.get(null, Collections.singleton("testKey"));
         assertTrue(configData.data().isEmpty());
         assertNull(configData.ttl());
+    }
+
+    @Test
+    public void testServiceLoaderDiscovery() {
+        ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
+
+        boolean discovered = false;
+
+        for (ConfigProvider service : serviceLoader)    {
+            System.out.println(service.getClass());
+            if (service instanceof FileConfigProvider) {
+                discovered = true;
+            }
+        }
+
+        assertTrue(discovered);
     }
 
     public static class TestFileConfigProvider extends FileConfigProvider {


### PR DESCRIPTION
Following the discussion in confluentinc/kafka-images#102, it seems that the `DirectoryConfigProvider` should be also listed in the list of the service providers.

CC: @C0urante

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
