### PR TITLE
KAFKA-13322: Reducing amount of garbage that gets generated during a poll operation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1145,6 +1145,8 @@ public class Fetcher<K, V> implements Closeable {
         }
     }
 
+    private final List<TopicPartition> fetchablePartitionsResultBuffer = new ArrayList<>();
+
     private List<TopicPartition> fetchablePartitions() {
         Set<TopicPartition> exclude = new HashSet<>();
         if (nextInLineFetch != null && !nextInLineFetch.isConsumed) {
@@ -1153,7 +1155,9 @@ public class Fetcher<K, V> implements Closeable {
         for (CompletedFetch completedFetch : completedFetches) {
             exclude.add(completedFetch.partition);
         }
-        return subscriptions.fetchablePartitions(tp -> !exclude.contains(tp));
+        // Need to clear the buffer first otherwise it will contain results from the previous fetch
+        fetchablePartitionsResultBuffer.clear();
+        return subscriptions.fetchablePartitions(tp -> !exclude.contains(tp), fetchablePartitionsResultBuffer);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1145,6 +1145,10 @@ public class Fetcher<K, V> implements Closeable {
         }
     }
 
+    // fetchablePartitions below is called multiple times during a poll.
+    // On each invocation it creates a list, which puts pressure on gc.
+    // The buffer below allows to eliminate that allocation as then the
+    // same list would be used multiple times
     private final List<TopicPartition> fetchablePartitionsResultBuffer = new ArrayList<>();
 
     private List<TopicPartition> fetchablePartitions() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -423,9 +423,9 @@ public class SubscriptionState {
     }
 
     // Visible for testing
-    public synchronized List<TopicPartition> fetchablePartitions(Predicate<TopicPartition> isAvailable) {
+    // This method returns its results in a list provided as it is on hot path and causes considerable pressure on gc otherwise
+    public synchronized List<TopicPartition> fetchablePartitions(Predicate<TopicPartition> isAvailable, List<TopicPartition> result) {
         // Since this is in the hot-path for fetching, we do this instead of using java.util.stream API
-        List<TopicPartition> result = new ArrayList<>();
         assignment.forEach((topicPartition, topicPartitionState) -> {
             // Cheap check is first to avoid evaluating the predicate if possible
             if (topicPartitionState.isFetchable() && isAvailable.test(topicPartition)) {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/consumer/SubscriptionStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/consumer/SubscriptionStateBenchmark.java
@@ -36,6 +36,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -85,7 +86,7 @@ public class SubscriptionStateBenchmark {
 
     @Benchmark
     public int testFetchablePartitions() {
-        return subscriptionState.fetchablePartitions(tp -> true).size();
+        return subscriptionState.fetchablePartitions(tp -> true, new ArrayList<>()).size();
     }
 
     @Benchmark


### PR DESCRIPTION
Presently KafkaConsumer creates an enourmous amount of garbage during a poll. Polls are generaly very frequent and so allocations during a poll decrease efficiency of the overall solution. This commit removes a large (and unnecessary allocation).

This is a non functional change and so has been tested by existing tests.
