### PR TITLE
MINOR: fix ClusterControlManager log message

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -250,10 +250,10 @@ public class ClusterControlManager {
                 feature.minSupportedVersion(), feature.maxSupportedVersion()));
         }
         // Update broker registrations.
-        brokerRegistrations.put(brokerId, new BrokerRegistration(brokerId,
-            record.brokerEpoch(), record.incarnationId(), listeners, features,
-            Optional.ofNullable(record.rack()), record.fenced()));
-        BrokerRegistration prevRegistration = brokerRegistrations.get(brokerId);
+        BrokerRegistration prevRegistration = brokerRegistrations.put(brokerId,
+                new BrokerRegistration(brokerId, record.brokerEpoch(),
+                    record.incarnationId(), listeners, features,
+                    Optional.ofNullable(record.rack()), record.fenced()));
         if (prevRegistration == null) {
             log.info("Registered new broker: {}", record);
         } else if (prevRegistration.incarnationId().equals(record.incarnationId())) {


### PR DESCRIPTION
Fix a ClusterControlManager log message that should distinguish between
newly registered and re-registered brokers, but was not due to a bug.