### PR TITLE
KAFKA-13324: KRaft: fix validateOnly in CreateTopics

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -416,8 +416,13 @@ public class ReplicationControlManager {
                 append("SUCCESS");
             resultsPrefix = ", ";
         }
-        log.info("createTopics result(s): {}", resultsBuilder.toString());
-        return ControllerResult.atomicOf(records, data);
+        if (request.validateOnly()) {
+            log.info("Validate-only CreateTopics result(s): {}", resultsBuilder.toString());
+            return ControllerResult.atomicOf(Collections.emptyList(), data);
+        } else {
+            log.info("CreateTopics result(s): {}", resultsBuilder.toString());
+            return ControllerResult.atomicOf(records, data);
+        }
     }
 
     private ApiError createTopic(CreatableTopic topic,


### PR DESCRIPTION
Fix a bug where the validateOnly flag for createTopics was being ignored.