### PR TITLE
HOTFIX: add import to fix checkstyle

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
When cherrypicking #11218 back to the 2.8 branch and resolving a minor merge conflict, I forgot to `git add` after adding a missing import that was breaking checkstyle
