### PR TITLE
MINOR: Do not copy on range for in-memory shared store in stream stream left/out joins

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=3.1.0-SNAPSHOT
+version=3.1.0-SNAPSHOT-SSJOIN
 scalaVersion=2.13.6
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
-version=3.1.0-SNAPSHOT-SSJOIN
+version=3.1.0-SNAPSHOT
 scalaVersion=2.13.6
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.JoinWindows;
@@ -30,9 +29,8 @@ import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
-import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
+import org.apache.kafka.streams.state.internals.InMemoryKeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSide;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -316,23 +314,8 @@ class KStreamImplJoin {
             new ListValueStoreBuilder<>(
                 persistent ?
                     Stores.persistentKeyValueStore(storeName) :
-                    new KeyValueBytesStoreSupplier() {
-                    @Override
-                    public String name() {
-                        return storeName;
-                    }
-
-                    @Override
-                    public KeyValueStore<Bytes, byte[]> get() {
-                        // do not copy of range since it would not be used for IQ
-                        return new InMemoryKeyValueStore(storeName, false);
-                    }
-
-                    @Override
-                    public String metricsScope() {
-                        return "in-memory";
-                    }
-                },
+                    // do not copy on range since it would not be used for IQ
+                    new InMemoryKeyValueBytesStoreSupplier(storeName, false),
                 timestampedKeyAndJoinSideSerde,
                 leftOrRightValueSerde,
                 Time.SYSTEM

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.state;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
+import org.apache.kafka.streams.state.internals.InMemoryKeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.InMemorySessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.InMemoryWindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
@@ -122,22 +122,7 @@ public final class Stores {
      */
     public static KeyValueBytesStoreSupplier inMemoryKeyValueStore(final String name) {
         Objects.requireNonNull(name, "name cannot be null");
-        return new KeyValueBytesStoreSupplier() {
-            @Override
-            public String name() {
-                return name;
-            }
-
-            @Override
-            public KeyValueStore<Bytes, byte[]> get() {
-                return new InMemoryKeyValueStore(name);
-            }
-
-            @Override
-            public String metricsScope() {
-                return "in-memory";
-            }
-        };
+        return new InMemoryKeyValueBytesStoreSupplier(name, true);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueBytesStoreSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+public class InMemoryKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupplier {
+    private final String name;
+    private final boolean copyOnRange;
+
+    public InMemoryKeyValueBytesStoreSupplier(final String name, final boolean copyOnRange) {
+        this.name = name;
+        this.copyOnRange = copyOnRange;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public KeyValueStore<Bytes, byte[]> get() {
+        return new InMemoryKeyValueStore(name, copyOnRange);
+    }
+
+    @Override
+    public String metricsScope() {
+        return "in-memory";
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -45,6 +45,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private volatile boolean open = false;
     private long size = 0L; // SkipListMap#size is O(N) so we just do our best to track it
 
+    // for tests-only
     public InMemoryKeyValueStore(final String name) {
         this(name, true);
     }
@@ -52,6 +53,8 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     public InMemoryKeyValueStore(final String name, final boolean copyOnRange) {
         this.name = name;
         this.copyOnRange = copyOnRange;
+        // if we do not need to copy on range, then we should use concurrent skiplist map
+        // to avoid concurrent modificiation exception
         this.map = copyOnRange ? new TreeMap<>() : new ConcurrentSkipListMap<>();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -32,6 +32,7 @@ import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
@@ -39,7 +40,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     private final String name;
     private final boolean copyOnRange;
-    private final NavigableMap<Bytes, byte[]> map = new TreeMap<>();
+    private final NavigableMap<Bytes, byte[]> map;
 
     private volatile boolean open = false;
     private long size = 0L; // SkipListMap#size is O(N) so we just do our best to track it
@@ -51,6 +52,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     public InMemoryKeyValueStore(final String name, final boolean copyOnRange) {
         this.name = name;
         this.copyOnRange = copyOnRange;
+        this.map = copyOnRange ? new TreeMap<>() : new ConcurrentSkipListMap<>();
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ListValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ListValueStoreTest.java
@@ -180,7 +180,7 @@ public class ListValueStoreTest {
     }
 
     @Test
-    public void shouldAllowDeleteWhileIterateRecords2() {
+    public void shouldAllowDeleteWhileIterateRecords() {
         final Random rand = new Random();
         int count = 0;
         for (int i = 0; i < 10000; i++) {


### PR DESCRIPTION
Note this is a bit hacky solution to improve the performance of stream-stream join for in-memory shared stores: theoretically deleting while iterating is not a good pattern and hence have undefined behavior. After looking through the source code I think the only reason it works here is because we only delete keys that we have iterated over.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
