### PR TITLE
KAFKA-13327, KAFKA-13328, KAFKA-13329: Clean up preflight connector validation

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -133,7 +133,7 @@
               files="(KafkaConfigBackingStore|Values).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|TopicAdmin).java"/>
+              files="(AbstractHerder|DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|TopicAdmin).java"/>
 
     <!-- connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Modifier;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Utils;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -555,7 +555,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                                                               connectorType,
                                                               ConnectorClientConfigRequest.ClientType.PRODUCER,
                                                               connectorClientConfigOverridePolicy);
-                return mergeConfigInfos(connType, configInfos, producerConfigInfos);
+                return mergeConfigInfos(connType, configInfos, producerConfigInfos, headerConverterConfigInfos);
             } else {
                 consumerConfigInfos = validateClientOverrides(connName,
                                                               ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -392,7 +392,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             return null;
         }
         if (configDef == null) {
-            log.warn("{}.configDef() has returned a null ConfigDef; no further preflight config validation for this converter will be performed", headerConverterClass);
+            log.warn("{}.config() has returned a null ConfigDef; no further preflight config validation for this converter will be performed", headerConverterClass);
             // Older versions of Connect didn't do any header converter validation.
             // Even though header converters are technically required to return a non-null ConfigDef object from HeaderConverter::config,
             // we permit this case in order to avoid breaking existing header converters that, despite not adhering to this requirement,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
@@ -58,7 +58,6 @@ public class SourceConnectorConfig extends ConnectorConfig {
         }
     }
 
-    private static ConfigDef config = SourceConnectorConfig.configDef();
     private final EnrichedSourceConnectorConfig enrichedSourceConfig;
 
     public static ConfigDef configDef() {
@@ -116,9 +115,9 @@ public class SourceConnectorConfig extends ConnectorConfig {
     }
 
     public SourceConnectorConfig(Plugins plugins, Map<String, String> props, boolean createTopics) {
-        super(plugins, config, props);
+        super(plugins, configDef(), props);
         if (createTopics && props.entrySet().stream().anyMatch(e -> e.getKey().startsWith(TOPIC_CREATION_PREFIX))) {
-            ConfigDef defaultConfigDef = embedDefaultGroup(config);
+            ConfigDef defaultConfigDef = embedDefaultGroup(configDef());
             // This config is only used to set default values for partitions and replication
             // factor from the default group and otherwise it remains unused
             AbstractConfig defaultGroup = new AbstractConfig(defaultConfigDef, props, false);
@@ -181,6 +180,6 @@ public class SourceConnectorConfig extends ConnectorConfig {
     }
 
     public static void main(String[] args) {
-        System.out.println(config.toHtml(4, config -> "sourceconnectorconfigs_" + config));
+        System.out.println(configDef().toHtml(4, config -> "sourceconnectorconfigs_" + config));
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
@@ -133,7 +133,7 @@ public class ConnectorClientPolicyIntegrationTest {
             connect.configureConnector(CONNECTOR_NAME, props);
             fail("Shouldn't be able to create connector");
         } catch (ConnectRestException e) {
-            assertEquals(e.statusCode(), 400);
+            assertEquals(400, e.statusCode());
         } finally {
             connect.stop();
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -85,35 +85,56 @@ public class ConnectorValidationIntegrationTest {
     }
 
     @Test
-    public void testSinkConnectorHasNeitherTopicsListNorTopicsRegex() {
+    public void testSinkConnectorHasNeitherTopicsListNorTopicsRegex() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
         config.remove(TOPICS_CONFIG);
         config.remove(TOPICS_REGEX_CONFIG);
-        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            2, // One error each for topics list and topics regex
+            "Sink connector config should fail preflight validation when neither topics list nor topics regex are provided"
+        );
     }
 
     @Test
-    public void testSinkConnectorHasBothTopicsListAndTopicsRegex() {
+    public void testSinkConnectorHasBothTopicsListAndTopicsRegex() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
         config.put(TOPICS_CONFIG, "t1");
         config.put(TOPICS_REGEX_CONFIG, "r.*");
-        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            2, // One error each for topics list and topics regex
+            "Sink connector config should fail preflight validation when both topics list and topics regex are provided"
+        );
     }
 
     @Test
-    public void testSinkConnectorDeadLetterQueueTopicInTopicsList() {
+    public void testSinkConnectorDeadLetterQueueTopicInTopicsList() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
         config.put(TOPICS_CONFIG, "t1");
         config.put(DLQ_TOPIC_NAME_CONFIG, "t1");
-        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Sink connector config should fail preflight validation when DLQ topic is included in topics list"
+        );
     }
 
     @Test
-    public void testSinkConnectorDeadLetterQueueTopicMatchesTopicsRegex() {
+    public void testSinkConnectorDeadLetterQueueTopicMatchesTopicsRegex() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
         config.put(TOPICS_REGEX_CONFIG, "r.*");
         config.put(DLQ_TOPIC_NAME_CONFIG, "ruh.roh");
-        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+        config.remove(TOPICS_CONFIG);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Sink connector config should fail preflight validation when DLQ topic matches topics regex"
+        );
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -1,0 +1,493 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.transforms.Filter;
+import org.apache.kafka.connect.transforms.predicates.RecordIsTombstone;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.PREDICATES_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TRANSFORMS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_REGEX_CONFIG;
+import static org.apache.kafka.connect.runtime.SourceConnectorConfig.TOPIC_CREATION_GROUPS_CONFIG;
+
+/**
+ * Integration test for preflight connector config validation
+ */
+@Category(IntegrationTest.class)
+public class ConnectorValidationIntegrationTest {
+
+    private static final String WORKER_GROUP_ID = "connect-worker-group-id";
+
+    // Use a single embedded cluster for all test cases in order to cut down on runtime
+    private static EmbeddedConnectCluster connect;
+
+    @BeforeClass
+    public static void setup() {
+        Map<String, String> workerProps = new HashMap<>();
+        workerProps.put(GROUP_ID_CONFIG, WORKER_GROUP_ID);
+
+        // build a Connect cluster backed by Kafka and Zk
+        connect = new EmbeddedConnectCluster.Builder()
+            .name("connector-validation-connect-cluster")
+            .workerProps(workerProps)
+            .build();
+        connect.start();
+    }
+
+    @AfterClass
+    public static void close() {
+        if (connect != null) {
+            // stop all Connect, Kafka and Zk threads.
+            Utils.closeQuietly(connect::stop, "Embedded Connect cluster");
+        }
+    }
+
+    @Test
+    public void testSinkConnectorHasNeitherTopicsListNorTopicsRegex() {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.remove(TOPICS_CONFIG);
+        config.remove(TOPICS_REGEX_CONFIG);
+        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+    }
+
+    @Test
+    public void testSinkConnectorHasBothTopicsListAndTopicsRegex() {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(TOPICS_CONFIG, "t1");
+        config.put(TOPICS_REGEX_CONFIG, "r.*");
+        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+    }
+
+    @Test
+    public void testSinkConnectorDeadLetterQueueTopicInTopicsList() {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(TOPICS_CONFIG, "t1");
+        config.put(DLQ_TOPIC_NAME_CONFIG, "t1");
+        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+    }
+
+    @Test
+    public void testSinkConnectorDeadLetterQueueTopicMatchesTopicsRegex() {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(TOPICS_REGEX_CONFIG, "r.*");
+        config.put(DLQ_TOPIC_NAME_CONFIG, "ruh.roh");
+        connect.validateConnectorConfig(config.get(CONNECTOR_CLASS_CONFIG), config);
+    }
+
+    @Test
+    public void testSinkConnectorDefaultGroupIdConflictsWithWorkerGroupId() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        // Combined with the logic in SinkUtils::consumerGroupId, this should conflict with the worker group ID
+        config.put(NAME_CONFIG, "worker-group-id");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Sink connector config should fail preflight validation when default consumer group ID conflicts with Connect worker group ID"
+        );
+    }
+
+    @Test
+    public void testSinkConnectorOverriddenGroupIdConflictsWithWorkerGroupId() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + GROUP_ID_CONFIG, WORKER_GROUP_ID);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Sink connector config should fail preflight validation when overridden consumer group ID conflicts with Connect worker group ID"
+        );
+    }
+
+    @Test
+    public void testSourceConnectorHasDuplicateTopicCreationGroups() throws InterruptedException {
+        Map<String, String> config = defaultSourceConnectorProps();
+        config.put(TOPIC_CREATION_GROUPS_CONFIG, "g1, g2, g1");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Source connector config should fail preflight validation when the same topic creation group is specified multiple times"
+        );
+    }
+
+    @Test
+    // TODO: Is this actually necessary? Should we permit the same SMT to be applied multiple times?
+    public void testConnectorHasDuplicateTransformations() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName + ", " + transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", Filter.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when the same transformation is specified multiple times"
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingTransformClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a transformation with a class not found on the worker is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasInvalidTransformClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", MonitorableSinkConnector.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a transformation with a class of the wrong type is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasNegationForUndefinedPredicate() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", Filter.class.getName());
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".negate", "true");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when an undefined predicate is negated"
+        );
+    }
+
+    @Test
+    public void testConnectorHasDuplicatePredicates() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String predicateName = "p";
+        config.put(PREDICATES_CONFIG, predicateName + ", " + predicateName);
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", RecordIsTombstone.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when the same predicate is specified multiple times"
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingPredicateClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String predicateName = "p";
+        config.put(PREDICATES_CONFIG, predicateName);
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a predicate with a class not found on the worker is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasInvalidPredicateClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String predicateName = "p";
+        config.put(PREDICATES_CONFIG, predicateName);
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", MonitorableSinkConnector.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a predicate with a class of the wrong type is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingConverterClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(KEY_CONVERTER_CLASS_CONFIG, "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a converter with a class not found on the worker is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasInvalidConverterClassType() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(KEY_CONVERTER_CLASS_CONFIG, MonitorableSinkConnector.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a converter with a class of the wrong type is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasAbstractConverter() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(KEY_CONVERTER_CLASS_CONFIG, AbstractTestConverter.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when an abstract converter class is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasConverterWithNoSuitableConstructor() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(KEY_CONVERTER_CLASS_CONFIG, TestConverterWithPrivateConstructor.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a converter class with no suitable constructor is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasConverterThatThrowsExceptionOnInstantiation() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(KEY_CONVERTER_CLASS_CONFIG, TestConverterWithConstructorThatThrowsException.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a converter class that throws an exception on instantiation is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingHeaderConverterClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a header converter with a class not found on the worker is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasInvalidHeaderConverterClassType() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, MonitorableSinkConnector.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a header converter with a class of the wrong type is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasAbstractHeaderConverter() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, AbstractTestConverter.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when an abstract header converter class is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasHeaderConverterWithNoSuitableConstructor() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestConverterWithPrivateConstructor.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a header converter class with no suitable constructor is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasHeaderConverterThatThrowsExceptionOnInstantiation() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestConverterWithConstructorThatThrowsException.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a header converter class that throws an exception on instantiation is specified"
+        );
+    }
+
+    @Test
+    public void testConnectorHasMisconfiguredHeaderConverter() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestConverterWithSinglePropertyConfigDef.class.getName());
+        config.put(HEADER_CONVERTER_CLASS_CONFIG + "." + TestConverterWithSinglePropertyConfigDef.BOOLEAN_PROPERTY_NAME, "notaboolean");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            1,
+            "Connector config should fail preflight validation when a header converter fails custom validation"
+        );
+    }
+
+    @Test
+    public void testConnectorHasHeaderConverterWithNoConfigDef() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestConverterWithNoConfigDef.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+            config.get(CONNECTOR_CLASS_CONFIG),
+            config,
+            0,
+            "Connector config should not fail preflight validation even when a header converter provides a null ConfigDef"
+        );
+    }
+
+    public static class TestConverter implements Converter, HeaderConverter {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+        }
+
+        @Override
+        public byte[] fromConnectData(String topic, Schema schema, Object value) {
+            return null;
+        }
+
+        @Override
+        public SchemaAndValue toConnectData(String topic, byte[] value) {
+            return null;
+        }
+
+        @Override
+        public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+            return null;
+        }
+
+        @Override
+        public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+            return null;
+        }
+
+        @Override
+        public ConfigDef config() {
+            return null;
+        }
+    }
+
+    public static abstract class AbstractTestConverter extends TestConverter {
+    }
+
+    public static class TestConverterWithPrivateConstructor extends TestConverter {
+        private TestConverterWithPrivateConstructor() {
+        }
+    }
+
+    public static class TestConverterWithConstructorThatThrowsException extends TestConverter {
+        public TestConverterWithConstructorThatThrowsException() {
+            throw new ConnectException("whoops");
+        }
+    }
+
+    public static class TestConverterWithSinglePropertyConfigDef extends TestConverter {
+        public static final String BOOLEAN_PROPERTY_NAME = "prop";
+        @Override
+        public ConfigDef config() {
+            return new ConfigDef().define(BOOLEAN_PROPERTY_NAME, ConfigDef.Type.BOOLEAN, ConfigDef.Importance.HIGH, "");
+        }
+    }
+
+    public static class TestConverterWithNoConfigDef extends TestConverter {
+        @Override
+        public ConfigDef config() {
+            return null;
+        }
+    }
+
+    private Map<String, String> defaultSourceConnectorProps() {
+        // setup up props for the source connector
+        Map<String, String> props = new HashMap<>();
+        props.put(NAME_CONFIG, "source-connector");
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, "1");
+        props.put(TOPIC_CONFIG, "t1");
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        return props;
+    }
+
+    private Map<String, String> defaultSinkConnectorProps() {
+        // setup up props for the sink connector
+        Map<String, String> props = new HashMap<>();
+        props.put(NAME_CONFIG, "sink-connector");
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, "1");
+        props.put(TOPICS_CONFIG, "t1");
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        return props;
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -114,8 +114,8 @@ public class MonitorableSourceConnector extends TestSourceConnector {
             taskId = props.get("task.id");
             connectorName = props.get("connector.name");
             topicName = props.getOrDefault(TOPIC_CONFIG, "sequential-topic");
-            throughput = Long.valueOf(props.getOrDefault("throughput", "-1"));
-            batchSize = Integer.valueOf(props.getOrDefault("messages.per.poll", "1"));
+            throughput = Long.parseLong(props.getOrDefault("throughput", "-1"));
+            batchSize = Integer.parseInt(props.getOrDefault("messages.per.poll", "1"));
             taskHandle = RuntimeHandles.get().connectorHandle(connectorName).taskHandle(taskId);
             Map<String, Object> offset = Optional.ofNullable(
                     context.offsetStorageReader().offset(Collections.singletonMap("task.id", taskId)))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigTransformer;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SaslConfigs;
@@ -420,7 +419,15 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1,topic2");
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
 
-        assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
+        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+
+        ConfigInfo topicsListInfo = findInfo(validation, SinkConnectorConfig.TOPICS_CONFIG);
+        assertNotNull(topicsListInfo);
+        assertEquals(1, topicsListInfo.configValue().errors().size());
+
+        ConfigInfo topicsRegexInfo = findInfo(validation, SinkConnectorConfig.TOPICS_REGEX_CONFIG);
+        assertNotNull(topicsRegexInfo);
+        assertEquals(1, topicsRegexInfo.configValue().errors().size());
 
         verifyAll();
     }
@@ -435,7 +442,11 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
+        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+
+        ConfigInfo topicsListInfo = findInfo(validation, SinkConnectorConfig.TOPICS_CONFIG);
+        assertNotNull(topicsListInfo);
+        assertEquals(1, topicsListInfo.configValue().errors().size());
 
         verifyAll();
     }
@@ -450,12 +461,15 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
+        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+
+        ConfigInfo topicsRegexInfo = findInfo(validation, SinkConnectorConfig.TOPICS_REGEX_CONFIG);
+        assertNotNull(topicsRegexInfo);
+        assertEquals(1, topicsRegexInfo.configValue().errors().size());
 
         verifyAll();
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test()
     public void testConfigValidationTransformsExtendResults() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy);
@@ -492,7 +506,7 @@ public class AbstractHerderTest {
                 "Transforms: xformB"
         );
         assertEquals(expectedGroups, result.groups());
-        assertEquals(2, result.errorCount());
+        assertEquals(1, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
         assertEquals(22, infos.size());
@@ -552,7 +566,7 @@ public class AbstractHerderTest {
                 "Predicates: predY"
         );
         assertEquals(expectedGroups, result.groups());
-        assertEquals(2, result.errorCount());
+        assertEquals(1, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
         assertEquals(24, infos.size());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -802,7 +802,7 @@ public class DistributedHerderTest {
         // CONN2 creation should fail because the worker group id (connect-test-group) conflicts with
         // the consumer group id we would use for this sink
         Map<String, ConfigValue> validatedConfigs =
-            herder.validateBasicConnectorConfig(connectorMock, ConnectorConfig.configDef(), config);
+            herder.validateSinkConnectorConfig(ConnectorConfig.configDef(), config);
 
         ConfigValue nameConfig = validatedConfigs.get(ConnectorConfig.NAME_CONFIG);
         assertNotNull(nameConfig.errorMessages());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -45,7 +45,7 @@ public class EmbeddedConnectClusterAssertions {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddedConnectClusterAssertions.class);
     public static final long WORKER_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
-    public static final long VALIDATION_DURATION_MS = TimeUnit.SECONDS.toMillis(30);
+    public static final long VALIDATION_DURATION_MS = TimeUnit.SECONDS.toMillis(5);
     public static final long CONNECTOR_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(30);
     private static final long CONNECT_INTERNAL_TOPIC_UPDATES_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
 
@@ -243,7 +243,7 @@ public class EmbeddedConnectClusterAssertions {
                     connectorClass,
                     connConfig,
                     numErrors,
-                    (actual, expected) -> actual == expected
+                    Number::equals
                 ).orElse(false),
                 VALIDATION_DURATION_MS,
                 "Didn't meet the exact requested number of validation errors: " + numErrors);


### PR DESCRIPTION
[KAFKA-13327](https://issues.apache.org/jira/browse/KAFKA-13327): Modify preflight validation logic to prevent 500 responses from being returned instead of valid 200 responses with detailed error messages pertaining to the relevant configuration properties.

[KAFKA-13328](https://issues.apache.org/jira/browse/KAFKA-13328): Add preflight validation logic for per-connector header converters.

[KAFKA-13329](https://issues.apache.org/jira/browse/KAFKA-13329): Add preflight validation logic for per-connector key and value converter classes.

Additionally, a small bug in the logic for [KAFKA-3829](https://issues.apache.org/jira/browse/KAFKA-3829) introduced by [KIP-458](https://cwiki.apache.org/confluence/display/KAFKA/KIP-458%3A+Connector+Client+Config+Override+Policy) is fixed; the preflight check to ensure that a sink connector's group ID doesn't conflict with the Connect worker's group ID now takes into account overrides made by the `consumer.override.group.id` connector property.

A new integration test is added that covers a wide variety of cases for sink connector, key/value converter, and header converter validation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
