### PR TITLE
MINOR: remove unneeded size and add lock coarsening to inMemoryKeyValueStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -40,7 +40,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private final String name;
     private final NavigableMap<Bytes, byte[]> map = new TreeMap<>();
     private volatile boolean open = false;
-    private long size = 0L; // SkipListMap#size is O(N) so we just do our best to track it
 
     public InMemoryKeyValueStore(final String name) {
         this.name = name;
@@ -55,7 +54,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     @Override
     public void init(final ProcessorContext context,
                      final StateStore root) {
-        size = 0;
         if (root != null) {
             // register the store
             context.register(root, (key, value) -> put(Bytes.wrap(key), value));
@@ -82,9 +80,9 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     @Override
     public synchronized void put(final Bytes key, final byte[] value) {
         if (value == null) {
-            size -= map.remove(key) == null ? 0 : 1;
+            map.remove(key);
         } else {
-            size += map.put(key, value) == null ? 1 : 0;
+            map.put(key, value);
         }
     }
 
@@ -98,9 +96,15 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     }
 
     @Override
-    public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+    public synchronized void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
         for (final KeyValue<Bytes, byte[]> entry : entries) {
-            put(entry.key, entry.value);
+            // intended to duplicate codes in #put, to avoid continuously lock/unlock cost
+            // Although the JVM "might" do "lock coarsening" for us, it'd better we make sure it works as what we expected
+            if (entry.value == null) {
+                map.remove(entry.key);
+            } else {
+                map.put(entry.key, entry.value);
+            }
         }
     }
 
@@ -118,9 +122,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     @Override
     public synchronized byte[] delete(final Bytes key) {
-        final byte[] oldValue = map.remove(key);
-        size -= oldValue == null ? 0 : 1;
-        return oldValue;
+        return map.remove(key);
     }
 
     @Override
@@ -169,7 +171,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     @Override
     public long approximateNumEntries() {
-        return size;
+        return map.size();
     }
 
     @Override
@@ -180,7 +182,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     @Override
     public void close() {
         map.clear();
-        size = 0;
         open = false;
     }
 


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/7212, we reverted the change to use `TreeMap` instead of `ConcurrentSkipListMap`, but we forgot to remove the `size` computing codes.

Also, I found the `putAll` method might be slow because the method itself is not locked, but it calls a locked method inside a loop. That is, if we elements we put has 1000 size, we might do lock and unlock for 1000 times. Although the JVM "might" do "lock coarsening" for us, it'd better we make sure it works as what we expected.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
