### PR TITLE
KAFKA-13337: fix of possible java.nio.file.AccessDeniedException during Con…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -143,7 +143,7 @@ public class PluginUtils {
             + ")$");
 
     private static final DirectoryStream.Filter<Path> PLUGIN_PATH_FILTER = path ->
-        Files.isDirectory(path) || isArchive(path) || isClassFile(path);
+        Files.isReadable(path) && (Files.isDirectory(path) || isArchive(path) || isClassFile(path));
 
     /**
      * Return whether the class with the given name should be loaded in isolation using a plugin

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -472,6 +473,16 @@ public class PluginUtilsTest {
     }
 
     @Test
+    public void testPluginUrlsWithProtectedDirectory() throws IOException {
+        createBasicDirectoryLayout();
+        createProtectedDirectory();
+
+        List<Path> expectedUrls = createBasicExpectedUrls();
+        assertUrls(expectedUrls, PluginUtils.pluginUrls(pluginPath));
+    }
+
+
+    @Test
     public void testPluginUrlsWithRelativeSymlinkForwards() throws Exception {
         // Since this test case defines a relative symlink within an already included path, the main
         // assertion of this test is absence of exceptions and correct resolution of paths.
@@ -497,6 +508,12 @@ public class PluginUtilsTest {
         Files.createDirectories(pluginPath.resolve("transformC/more-deps"));
         Files.createFile(pluginPath.resolve("transformC/more-deps/README.txt"));
     }
+
+    private void createProtectedDirectory() throws IOException {
+        Files.createDirectories(pluginPath.resolve(".protected"),
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("--x--x---")));
+    }
+
 
     private List<Path> createBasicExpectedUrls() throws IOException {
         List<Path> expectedUrls = new ArrayList<>();


### PR DESCRIPTION
…nect plugin directory scan

org.apache.kafka.connect.runtime.isolation.PluginUtils.pluginUrls scans a path and collects plugin candidates from there. However, if a directory is not readable, it fails with AccessDeniedException instead of skipping it. This commit fixes this minor problem with the change of plugin path filter used during scanning.

I've also added a unit test for proof.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
