### PR TITLE
KAFKA-10865: Log transformed record in WorkerSinkTask

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * from those partitions. As records are fetched from Kafka, they will be passed to the sink task using the
  * {@link #put(Collection)} API, which should either write them to the downstream system or batch them for
  * later writing. Periodically, Connect will call {@link #flush(Map)} to ensure that batched records are
- * actually pushed to the downstream system..
+ * actually pushed to the downstream system.
  *
  * Below we describe the lifecycle of a SinkTask.
  *

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -478,6 +478,8 @@ class WorkerSinkTask extends WorkerTask {
                     new OffsetAndMetadata(msg.offset() + 1)
             );
             if (transRecord != null) {
+                log.trace("{} Appending transformed record from topic {} with key {}, value {}",
+                        this, transRecord.topic(), transRecord.key(), transRecord.value());
                 messageBatch.add(transRecord);
             } else {
                 log.trace(


### PR DESCRIPTION
This PR adds a log message with the **topic**, **key** and **value** to the transformed record in **WorkerSinkTask** similar to was already being done in **WorkerSinkTask**.

Also fixed a small typo in javadocs where there was a double period.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
