### PR TITLE
MINOR: Use try-with-resource to close the stream opened by Files.list()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/provider/DirectoryConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/DirectoryConfigProvider.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 
@@ -81,9 +82,8 @@ public class DirectoryConfigProvider implements ConfigProvider {
             if (!Files.isDirectory(dir)) {
                 log.warn("The path {} is not a directory", path);
             } else {
-                try {
-                    map = Files.list(dir)
-                        .filter(fileFilter)
+                try (Stream<Path> stream = Files.list(dir)) {
+                    map = stream.filter(fileFilter)
                         .collect(Collectors.toMap(
                             p -> p.getFileName().toString(),
                             p -> read(p)));


### PR DESCRIPTION
It may cause the file handle not to be released.