### PR TITLE
MINOR: The message of BufferExhaustedException should include pool st…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -162,7 +162,9 @@ public class BufferPool {
 
                         if (waitingTimeElapsed) {
                             this.metrics.sensor("buffer-exhausted-records").record();
-                            throw new BufferExhaustedException("Failed to allocate memory within the configured max blocking time " + maxTimeToBlockMs + " ms.");
+                            throw new BufferExhaustedException("Failed to allocate " + size + " bytes within the configured max blocking time "
+                                + maxTimeToBlockMs + " ms. Total memory: " + totalMemory() + " bytes. Available memory: " + availableMemory()
+                                + " bytes. Poolable size: " + poolableSize() + " bytes");
                         }
 
                         remainingTimeToBlockNs -= timeNs;


### PR DESCRIPTION
Including the pool status can help us to understand what happens in the moment. The new message is shown below.
`
Failed to allocate 200 bytes within the configured max blocking time 10 ms. Total memory: 300 bytes. Available memory: 100 bytes. Poolable size: 100 bytes
`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
