### PR TITLE
KAFKA-12994: Migrated SlidingWindowsTest to new API

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SlidingWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SlidingWindowsTest.java
@@ -24,12 +24,12 @@ import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-@SuppressWarnings("deprecation")
 public class SlidingWindowsTest {
 
     private static final long ANY_SIZE = 123L;
     private static final long ANY_GRACE = 1024L;
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSetTimeDifference() {
         assertEquals(ANY_SIZE, SlidingWindows.withTimeDifferenceAndGrace(ofMillis(ANY_SIZE), ofMillis(3)).timeDifferenceMs());
@@ -39,17 +39,17 @@ public class SlidingWindowsTest {
 
     @Test
     public void timeDifferenceMustNotBeNegative() {
-        assertThrows(IllegalArgumentException.class, () ->  SlidingWindows.withTimeDifferenceAndGrace(ofMillis(-1), ofMillis(5)));
+        assertThrows(IllegalArgumentException.class, () ->  SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(-1), ofMillis(5)));
     }
 
     @Test
     public void shouldSetGracePeriod() {
-        assertEquals(ANY_SIZE, SlidingWindows.withTimeDifferenceAndGrace(ofMillis(10), ofMillis(ANY_SIZE)).gracePeriodMs());
+        assertEquals(ANY_SIZE, SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(ANY_SIZE)).gracePeriodMs());
     }
 
     @Test
     public void gracePeriodMustNotBeNegative() {
-        assertThrows(IllegalArgumentException.class, () ->  SlidingWindows.withTimeDifferenceAndGrace(ofMillis(10), ofMillis(-1)));
+        assertThrows(IllegalArgumentException.class, () ->  SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(-1)));
     }
 
     @Test
@@ -57,8 +57,8 @@ public class SlidingWindowsTest {
         final long grace = 1L + (long) (Math.random() * (20L - 1L));
         final long timeDifference = 1L + (long) (Math.random() * (20L - 1L));
         verifyEquality(
-                SlidingWindows.withTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(grace)),
-                SlidingWindows.withTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(grace))
+                SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(grace)),
+                SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(grace))
         );
 
         verifyEquality(
@@ -78,8 +78,8 @@ public class SlidingWindowsTest {
         final long timeDifferenceOne = 1L + (long) (Math.random() * (10L - 1L));
         final long timeDifferenceTwo = 21L + (long) (Math.random() * (41L - 21L));
         verifyInEquality(
-                SlidingWindows.withTimeDifferenceAndGrace(ofMillis(timeDifferenceOne), ofMillis(grace)),
-                SlidingWindows.withTimeDifferenceAndGrace(ofMillis(timeDifferenceTwo), ofMillis(grace))
+                SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(timeDifferenceOne), ofMillis(grace)),
+                SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(timeDifferenceTwo), ofMillis(grace))
         );
     }
 
@@ -89,8 +89,8 @@ public class SlidingWindowsTest {
         final long graceOne = 1L + (long) (Math.random() * (10L - 1L));
         final long graceTwo = 21L + (long) (Math.random() * (41L - 21L));
         verifyInEquality(
-                SlidingWindows.withTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(graceOne)),
-                SlidingWindows.withTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(graceTwo))
+                SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(graceOne)),
+                SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(timeDifference), ofMillis(graceTwo))
         );
     }
 }


### PR DESCRIPTION
As raised in KAFKA-12994, All tests that use the old API should be either eliminated or migrated to the new API in order to remove the @SuppressWarnings("deprecation") annotations.

This PR will migrate the SlidingWindowsTest to the new API.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
