### PR TITLE
KAFKA-12648: allow users to set a StreamsUncaughtExceptionHandler on individual named topologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -513,8 +513,8 @@ public class KafkaStreams implements AutoCloseable {
         return action;
     }
 
-    private void handleStreamsUncaughtException(final Throwable throwable,
-                                                final StreamsUncaughtExceptionHandler streamsUncaughtExceptionHandler) {
+    protected void handleStreamsUncaughtException(final Throwable throwable,
+                                                  final StreamsUncaughtExceptionHandler streamsUncaughtExceptionHandler) {
         final StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse action = getActionForThrowable(throwable, streamsUncaughtExceptionHandler);
         if (oldHandler) {
             log.warn("Stream's new uncaught exception handler is set as well as the deprecated old handler." +

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -174,7 +174,8 @@ public class KafkaStreams implements AutoCloseable {
     private StateRestoreListener globalStateRestoreListener;
     private boolean oldHandler;
     private java.util.function.Consumer<Throwable> streamsUncaughtExceptionHandler;
-    private final Object changeThreadCount = new Object();
+    protected Map<String, java.util.function.Consumer<Throwable>> topologyExceptionHandlers = new HashMap<>();
+    protected final Object changeThreadCount = new Object();
 
     // container states
     /**
@@ -971,6 +972,9 @@ public class KafkaStreams implements AutoCloseable {
             streamsUncaughtExceptionHandler
         );
         streamThread.setStateListener(streamStateListener);
+        for (final Map.Entry<String, Consumer<Throwable>> exceptionHandler : topologyExceptionHandlers.entrySet()) {
+            streamThread.setUncaughtExceptionHandlerForTopology(exceptionHandler.getKey(), exceptionHandler.getValue());
+        }
         threads.add(streamThread);
         threadState.put(streamThread.getId(), streamThread.state());
         queryableStoreProvider.addStoreProviderForThread(streamThread.getName(), new StreamThreadStateStoreProvider(streamThread));

--- a/streams/src/main/java/org/apache/kafka/streams/errors/NamedTopologyException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/NamedTopologyException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+import org.apache.kafka.common.KafkaException;
+
+public class NamedTopologyException extends KafkaException {
+
+    final String topologyName;
+
+    public NamedTopologyException(final String topologyName, final Throwable throwable) {
+        super(throwable);
+        this.topologyName = topologyName;
+    }
+
+    public String topologyName() {
+        return topologyName;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -659,7 +659,11 @@ public class StreamThread extends Thread {
     }
 
     public void setUncaughtExceptionHandlerForTopology(final String topologyName, final java.util.function.Consumer<Throwable> exceptionHandler) {
-        topologyExceptionHandlers.put(topologyName, exceptionHandler);
+        if (exceptionHandler == null) {
+            topologyExceptionHandlers.remove(topologyName);
+        } else {
+            topologyExceptionHandlers.put(topologyName, exceptionHandler);
+        }
     }
 
     public void maybeSendShutdown() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1310,6 +1310,8 @@ public class TaskManager {
                 final String topologyName = task.id().topologyName();
                 if (topologyName != null) {
                     throw new NamedTopologyException(topologyName, e);
+                } else {
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
In the current exception handler, there's not much granularity and all exceptions from all sources are treated equally. With the introduction of independent named topologies, it would be nice to have some way to differentiate which topology an exception was thrown from during processing.

Currently we only consider exceptions thrown from the `process()` method of a task in that named topology, but eventually we can expand this to other exceptions that are tied to a particular topology, for example errors pertaining to the topics of that query
