### PR TITLE
KAFKA-13348: Allow Source Tasks to Handle Producer Exceptions

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -115,8 +115,9 @@ public abstract class SourceTask implements Task {
     /**
      * <p>
      * Commit an individual {@link SourceRecord} when the callback from the producer client is received. This method is
-     * also called when a record is filtered by a transformation, and thus will never be ACK'd by a broker. In this case
-     * {@code metadata} will be null.
+     * also called when a record is filtered by a transformation or when {@link ConnectorConfig} "errors.tolerance" is set to "all"
+     * and thus will never be ACK'd by a broker.
+     * In both cases {@code metadata} will be null.
      * </p>
      * <p>
      * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
@@ -128,8 +129,8 @@ public abstract class SourceTask implements Task {
      * not necessary to implement both methods.
      * </p>
      *
-     * @param record {@link SourceRecord} that was successfully sent via the producer or filtered by a transformation
-     * @param metadata {@link RecordMetadata} record metadata returned from the broker, or null if the record was filtered
+     * @param record {@link SourceRecord} that was successfully sent via the producer, filtered by a transformation, or dropped on producer exception
+     * @param metadata {@link RecordMetadata} record metadata returned from the broker, or null if the record was filtered or if producer exceptions are ignored
      * @throws InterruptedException
      */
     public void commitRecord(SourceRecord record, RecordMetadata metadata)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -365,14 +365,16 @@ class WorkerSourceTask extends WorkerTask {
                     producerRecord,
                     (recordMetadata, e) -> {
                         if (e != null) {
-                            log.error("{} failed to send record to {}: ", WorkerSourceTask.this, topic, e);
-                            log.trace("{} Failed record: {}", WorkerSourceTask.this, preTransformRecord);
                             if (retryWithToleranceOperator.getErrorToleranceType() == ToleranceType.ALL) {
+                                log.trace("Ignoring failed record send: {} failed to send record to {}: ",
+                                        WorkerSourceTask.this, topic, e);
                                 // executeFailed here allows the use of existing logging infrastructure/configuration
                                 retryWithToleranceOperator.executeFailed(Stage.KAFKA_PRODUCE, WorkerSourceTask.class,
                                         preTransformRecord, e);
                                 commitTaskRecord(preTransformRecord, null);
                             } else {
+                                log.error("{} failed to send record to {}: ", WorkerSourceTask.this, topic, e);
+                                log.trace("{} Failed record: {}", WorkerSourceTask.this, preTransformRecord);
                                 producerSendException.compareAndSet(null, e);
                             }
                         } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -365,11 +365,14 @@ class WorkerSourceTask extends WorkerTask {
                     producerRecord,
                     (recordMetadata, e) -> {
                         if (e != null) {
-                            log.error("{} failed to send record to {}: ", WorkerSourceTask.this, topic, e);
-                            log.trace("{} Failed record: {}", WorkerSourceTask.this, preTransformRecord);
                             if (retryWithToleranceOperator.getErrorToleranceType().equals(ToleranceType.ALL)) {
+                                // executeFailed here allows the use of existing logging infrastructure/configuration
+                                retryWithToleranceOperator.executeFailed(Stage.KAFKA_PRODUCE, WorkerSourceTask.class,
+                                        preTransformRecord, e);
                                 commitTaskRecord(preTransformRecord, null);
                             } else {
+                                log.error("{} failed to send record to {}: ", WorkerSourceTask.this, topic, e);
+                                log.trace("{} Failed record: {}", WorkerSourceTask.this, preTransformRecord);
                                 producerSendException.compareAndSet(null, e);
                             }
                         } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -365,14 +365,14 @@ class WorkerSourceTask extends WorkerTask {
                     producerRecord,
                     (recordMetadata, e) -> {
                         if (e != null) {
-                            if (retryWithToleranceOperator.getErrorToleranceType().equals(ToleranceType.ALL)) {
+                            log.error("{} failed to send record to {}: ", WorkerSourceTask.this, topic, e);
+                            log.trace("{} Failed record: {}", WorkerSourceTask.this, preTransformRecord);
+                            if (retryWithToleranceOperator.getErrorToleranceType() == ToleranceType.ALL) {
                                 // executeFailed here allows the use of existing logging infrastructure/configuration
                                 retryWithToleranceOperator.executeFailed(Stage.KAFKA_PRODUCE, WorkerSourceTask.class,
                                         preTransformRecord, e);
                                 commitTaskRecord(preTransformRecord, null);
                             } else {
-                                log.error("{} failed to send record to {}: ", WorkerSourceTask.this, topic, e);
-                                log.trace("{} Failed record: {}", WorkerSourceTask.this, preTransformRecord);
                                 producerSendException.compareAndSet(null, e);
                             }
                         } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -123,7 +123,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         Future<Void> errantRecordFuture = context.report();
         if (!withinToleranceLimits()) {
             errorHandlingMetrics.recordError();
-            throw new ConnectException("Tolerance exceeded in error handler", error);
+            throw new ConnectException("Tolerance exceeded in Source Worker error handler", error);
         }
         return errantRecordFuture;
     }
@@ -249,7 +249,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
     // For source connectors that want to skip kafka producer errors.
     // They cannot use withinToleranceLimits() as no failure may have actually occurred prior to the producer failing
     // to write to kafka.
-    public synchronized ToleranceType getErrorToleranceType() {
+    public ToleranceType getErrorToleranceType() {
         return errorToleranceType;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -229,6 +229,13 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         }
     }
 
+    // For source connectors that want to skip kafka producer errors.
+    // They cannot use withinToleranceLimits() as no failure may have actually occurred prior to the producer failing
+    // to write to kafka.
+    public synchronized ToleranceType getErrorToleranceType() {
+        return errorToleranceType;
+    }
+
     // Visible for testing
     boolean checkRetry(long startTime) {
         return (time.milliseconds() - startTime) < errorRetryTimeout;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -844,7 +844,6 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
         Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(false, Whitebox.getInternalState(workerTask, "lastSendFailed"));
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -78,6 +78,8 @@ public class RetryWithToleranceOperatorTest {
 
     public static final RetryWithToleranceOperator NOOP_OPERATOR = new RetryWithToleranceOperator(
             ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, SYSTEM);
+    public static final RetryWithToleranceOperator ALL_OPERATOR = new RetryWithToleranceOperator(
+            ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, SYSTEM);
     static {
         Map<String, String> properties = new HashMap<>();
         properties.put(CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG, Objects.toString(2));
@@ -91,6 +93,11 @@ public class RetryWithToleranceOperatorTest {
         NOOP_OPERATOR.metrics(new ErrorHandlingMetrics(
             new ConnectorTaskId("noop-connector", -1),
             new ConnectMetrics("noop-worker", new TestableWorkerConfig(properties), new SystemTime(), "test-cluster"))
+        );
+        ALL_OPERATOR.metrics(new ErrorHandlingMetrics(
+                new ConnectorTaskId("errors-all-tolerate-connector", -1),
+                new ConnectMetrics("errors-all-tolerate-worker", new TestableWorkerConfig(properties),
+                        new SystemTime(), "test-cluster"))
         );
     }
 


### PR DESCRIPTION
This change allows Source Connectors the option to set "error.tolerance" to "all" to allow them to handle/ignore producer exceptions. In the event the producer cannot write to Kafka, the connector commitRecord() callback is invoked with null RecordMetadata. This is new behavior for the errors.tolerance setting. Default behavior is still to kill the task unconditionally if errors.tolerance is "none".

A unit test has been added to validate the producer callback for failure being invoked. The sourceTask will ignore the exception and the task will not be killed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
