### PR TITLE
KAFKA-13385: In the KRPC request header, translate null clientID to empty

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
@@ -92,8 +92,14 @@ public class RequestHeader implements AbstractRequestResponse {
             short apiVersion = buffer.getShort();
             short headerVersion = ApiKeys.forId(apiKey).requestHeaderVersion(apiVersion);
             buffer.position(position);
-            return new RequestHeader(new RequestHeaderData(
-                new ByteBufferAccessor(buffer), headerVersion), headerVersion);
+            RequestHeaderData headerData = new RequestHeaderData(
+                new ByteBufferAccessor(buffer), headerVersion);
+            // Due to a quirk in the protocol, client ID is marked as nullable.
+            // However, we treat a null client ID as equivalent to an empty client ID.
+            if (headerData.clientId() == null) {
+                headerData.setClientId("");
+            }
+            return new RequestHeader(headerData, headerVersion);
         } catch (UnsupportedVersionException e) {
             throw new InvalidRequestException("Unknown API key " + apiKey, e);
         } catch (Throwable ex) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Writable;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -92,5 +95,23 @@ public class RequestHeaderTest {
 
         RequestHeader parsed = RequestHeader.parse(buffer);
         assertEquals(header, parsed);
+    }
+
+    @Test
+    public void parseHeaderWithNullClientId() {
+        RequestHeaderData headerData = new RequestHeaderData().
+            setClientId(null).
+            setCorrelationId(123).
+            setRequestApiKey(ApiKeys.FIND_COORDINATOR.id).
+            setRequestApiVersion((short) 10);
+        ObjectSerializationCache serializationCache = new ObjectSerializationCache();
+        ByteBuffer buffer = ByteBuffer.allocate(headerData.size(serializationCache, (short) 2));
+        headerData.write(new ByteBufferAccessor(buffer), serializationCache, (short) 2);
+        buffer.flip();
+        RequestHeader parsed = RequestHeader.parse(buffer);
+        assertEquals("", parsed.clientId());
+        assertEquals(123, parsed.correlationId());
+        assertEquals(ApiKeys.FIND_COORDINATOR, parsed.apiKey());
+        assertEquals((short) 10, parsed.apiVersion());
     }
 }


### PR DESCRIPTION
Due to a historical quirk, the clientId field is nullable in the request header schema. However, the code does
not handle null clientIds. They should be treated as the empty string, as they were previously.