### PR TITLE
MINOR: Fix highest offset when loading KRaft metadata snapshots

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -237,6 +237,7 @@
     <allow pkg="org.apache.kafka.common.metadata" />
     <allow pkg="org.apache.kafka.common.protocol" />
     <allow pkg="org.apache.kafka.common.quota" />
+    <allow pkg="org.apache.kafka.raft" />
     <allow pkg="org.apache.kafka.common.requests" />
     <allow pkg="org.apache.kafka.metadata" />
     <allow pkg="org.apache.kafka.server.common" />
@@ -248,6 +249,7 @@
     <allow pkg="org.apache.kafka.common.message" />
     <allow pkg="org.apache.kafka.common.metadata" />
     <allow pkg="org.apache.kafka.common.protocol" />
+    <allow pkg="org.apache.kafka.image" />
     <allow pkg="org.apache.kafka.metadata" />
     <allow pkg="org.apache.kafka.metalog" />
     <allow pkg="org.apache.kafka.raft" />

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -331,7 +331,7 @@ class BrokerServer(
           setPort(if (ep.port == 0) socketServer.boundPort(ep.listenerName) else ep.port).
           setSecurityProtocol(ep.securityProtocol.id))
       }
-      lifecycleManager.start(() => metadataListener.highestMetadataOffset(),
+      lifecycleManager.start(() => metadataListener.highestMetadataOffset,
         BrokerToControllerChannelManager(controllerNodeProvider, time, metrics, config,
           "heartbeat", threadNamePrefix, config.brokerSessionTimeoutMs.toLong),
         metaProps.clusterId, networkListeners, supportedFeatures)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2104,10 +2104,10 @@ class ReplicaManager(val config: KafkaConfig,
   /**
    * Apply a KRaft topic change delta.
    *
-   * @param newImage        The new metadata image.
    * @param delta           The delta to apply.
+   * @param newImage        The new metadata image.
    */
-  def applyDelta(newImage: MetadataImage, delta: TopicsDelta): Unit = {
+  def applyDelta(delta: TopicsDelta, newImage: MetadataImage): Unit = {
     // Before taking the lock, compute the local changes
     val localChanges = delta.localChanges(config.nodeId)
 

--- a/core/src/main/scala/kafka/server/metadata/MetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/MetadataPublisher.scala
@@ -25,12 +25,9 @@ trait MetadataPublisher {
   /**
    * Publish a new metadata image.
    *
-   * @param newHighestMetadataOffset  The highest metadata offset contained within the image.
-   * @param delta                     The delta between the old image and the new one.
-   * @param newImage                  The new image, which is the result of applying the
-   *                                  delta to the previous image.
+   * @param delta                  The delta between the old image and the new one.
+   * @param newImage               The new image, which is the result of applying the
+   *                               delta to the previous image.
    */
-  def publish(newHighestMetadataOffset: Long,
-              delta: MetadataDelta,
-              newImage: MetadataImage): Unit
+  def publish(delta: MetadataDelta, newImage: MetadataImage): Unit
 }

--- a/core/src/main/scala/kafka/server/metadata/MetadataSnapshotter.scala
+++ b/core/src/main/scala/kafka/server/metadata/MetadataSnapshotter.scala
@@ -26,15 +26,10 @@ trait MetadataSnapshotter {
   /**
    * If there is no other snapshot being written out, start writing out a snapshot.
    *
-   * @param committedOffset       The highest metadata log offset of the snapshot.
-   * @param committedEpoch        The highest metadata log epoch of the snapshot.
    * @param lastContainedLogTime  The highest time contained in the snapshot.
    * @param image                 The metadata image to write out.
    *
    * @return                      True if we will write out a new snapshot; false otherwise.
    */
-  def maybeStartSnapshot(committedOffset: Long,
-                         committedEpoch: Int,
-                         lastContainedLogTime: Long,
-                         image: MetadataImage): Boolean
+  def maybeStartSnapshot(lastContainedLogTime: Long, image: MetadataImage): Boolean
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -341,14 +341,14 @@ class ReplicaManagerConcurrencyTest {
           val delta = new MetadataDelta(latestImage)
           topic.initialize(delta)
           latestImage = delta.apply()
-          replicaManager.applyDelta(latestImage, delta.topicsDelta)
+          replicaManager.applyDelta(delta.topicsDelta, latestImage)
 
         case AlterIsrEvent(future, topicPartition, leaderAndIsr) =>
           val delta = new MetadataDelta(latestImage)
           val updatedLeaderAndIsr = topic.alterIsr(topicPartition, leaderAndIsr, delta)
           latestImage = delta.apply()
           future.complete(updatedLeaderAndIsr)
-          replicaManager.applyDelta(latestImage, delta.topicsDelta)
+          replicaManager.applyDelta(delta.topicsDelta, latestImage)
 
         case ShutdownEvent =>
       }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -21,9 +21,9 @@ import java.util
 import java.util.concurrent.atomic.AtomicReference
 import java.util.{Collections, Optional}
 
-import org.apache.kafka.common.{Endpoint, Uuid}
 import org.apache.kafka.common.metadata.{PartitionChangeRecord, PartitionRecord, RegisterBrokerRecord, TopicRecord}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{Endpoint, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.metadata.{BrokerRegistration, RecordTestUtils, VersionRange}
 import org.apache.kafka.server.common.ApiMessageAndVersion
@@ -54,7 +54,7 @@ class BrokerMetadataListenerTest {
           setIncarnationId(Uuid.fromString("GFBwlTcpQUuLYQ2ig05CSg")), 0.toShort))))
       val imageRecords = listener.getImageRecords().get()
       assertEquals(0, imageRecords.size())
-      assertEquals(100L, listener.highestMetadataOffset())
+      assertEquals(100L, listener.highestMetadataOffset)
       listener.handleCommit(RecordTestUtils.mockBatchReader(200L,
         util.Arrays.asList(new ApiMessageAndVersion(new RegisterBrokerRecord().
           setBrokerId(1).
@@ -63,10 +63,8 @@ class BrokerMetadataListenerTest {
           setRack(null).
           setIncarnationId(Uuid.fromString("QkOQtNKVTYatADcaJ28xDg")), 0.toShort))))
       listener.startPublishing(new MetadataPublisher {
-        override def publish(newHighestMetadataOffset: Long,
-                             delta: MetadataDelta,
-                             newImage: MetadataImage): Unit = {
-          assertEquals(200L, newHighestMetadataOffset)
+        override def publish(delta: MetadataDelta, newImage: MetadataImage): Unit = {
+          assertEquals(200L, newImage.highestOffsetAndEpoch().offset)
           assertEquals(new BrokerRegistration(0, 100L,
             Uuid.fromString("GFBwlTcpQUuLYQ2ig05CSg"), Collections.emptyList[Endpoint](),
             Collections.emptyMap[String, VersionRange](), Optional.empty[String](), false),
@@ -90,20 +88,17 @@ class BrokerMetadataListenerTest {
     var prevCommittedEpoch = -1
     var prevLastContainedLogTime = -1L
 
-    override def maybeStartSnapshot(committedOffset: Long,
-                                    committedEpoch: Int,
-                                    lastContainedLogTime: Long,
-                                    newImage: MetadataImage): Boolean = {
+    override def maybeStartSnapshot(lastContainedLogTime: Long, newImage: MetadataImage): Boolean = {
       try {
         if (activeSnapshotOffset == -1L) {
-          assertTrue(prevCommittedOffset <= committedOffset)
-          assertTrue(prevCommittedEpoch <= committedEpoch)
+          assertTrue(prevCommittedOffset <= newImage.highestOffsetAndEpoch().offset)
+          assertTrue(prevCommittedEpoch <= newImage.highestOffsetAndEpoch().epoch)
           assertTrue(prevLastContainedLogTime <= lastContainedLogTime)
-          prevCommittedOffset = committedOffset
-          prevCommittedEpoch = committedEpoch
+          prevCommittedOffset = newImage.highestOffsetAndEpoch().offset
+          prevCommittedEpoch = newImage.highestOffsetAndEpoch().epoch
           prevLastContainedLogTime = lastContainedLogTime
           image = newImage
-          activeSnapshotOffset = committedOffset
+          activeSnapshotOffset = newImage.highestOffsetAndEpoch().offset
           true
         } else {
           false
@@ -117,9 +112,7 @@ class BrokerMetadataListenerTest {
   class MockMetadataPublisher extends MetadataPublisher {
     var image = MetadataImage.EMPTY
 
-    override def publish(newHighestMetadataOffset: Long,
-                         delta: MetadataDelta,
-                         newImage: MetadataImage): Unit = {
+    override def publish(delta: MetadataDelta, newImage: MetadataImage): Unit = {
       image = newImage
     }
   }
@@ -152,10 +145,10 @@ class BrokerMetadataListenerTest {
       registerBrokers(listener, brokerIds, endOffset = 100L)
       createTopicWithOnePartition(listener, replicas = brokerIds, endOffset = 200L)
       listener.getImageRecords().get()
-      assertEquals(200L, listener.highestMetadataOffset())
+      assertEquals(200L, listener.highestMetadataOffset)
 
       generateManyRecords(listener, endOffset = 1000L)
-      assertEquals(1000L, listener.highestMetadataOffset())
+      assertEquals(1000L, listener.highestMetadataOffset)
     } finally {
       listener.close()
     }
@@ -171,7 +164,7 @@ class BrokerMetadataListenerTest {
       registerBrokers(listener, brokerIds, endOffset = 100L)
       createTopicWithOnePartition(listener, replicas = brokerIds, endOffset = 200L)
       listener.getImageRecords().get()
-      assertEquals(200L, listener.highestMetadataOffset())
+      assertEquals(200L, listener.highestMetadataOffset)
 
       // Check that we generate at least one snapshot once we see enough records.
       assertEquals(-1L, snapshotter.prevCommittedOffset)

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataSnapshotterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataSnapshotterTest.scala
@@ -51,7 +51,11 @@ class BrokerMetadataSnapshotterTest {
                        lastContainedLogTime: Long): SnapshotWriter[ApiMessageAndVersion] = {
       val offsetAndEpoch = new OffsetAndEpoch(committedOffset, committedEpoch)
       SnapshotWriter.createWithHeader(
-        () => Optional.of(new MockRawSnapshotWriter(offsetAndEpoch, consumeSnapshotBuffer)),
+        () => {
+          Optional.of(
+            new MockRawSnapshotWriter(offsetAndEpoch, consumeSnapshotBuffer(committedOffset, committedEpoch))
+          )
+        },
         1024,
         MemoryPool.NONE,
         Time.SYSTEM,
@@ -61,7 +65,7 @@ class BrokerMetadataSnapshotterTest {
       ).get();
     }
 
-    def consumeSnapshotBuffer(buffer: ByteBuffer): Unit = {
+    def consumeSnapshotBuffer(committedOffset: Long, committedEpoch: Int)(buffer: ByteBuffer): Unit = {
       val delta = new MetadataDelta(MetadataImage.EMPTY)
       val memoryRecords = MemoryRecords.readableRecords(buffer)
       val batchIterator = memoryRecords.batchIterator()
@@ -72,7 +76,7 @@ class BrokerMetadataSnapshotterTest {
             val recordBuffer = record.value().duplicate()
             val messageAndVersion = MetadataRecordSerde.INSTANCE.read(
               new ByteBufferAccessor(recordBuffer), recordBuffer.remaining())
-            delta.replay(messageAndVersion.message())
+            delta.replay(committedOffset, committedEpoch, messageAndVersion.message())
           })
         }
       }
@@ -92,8 +96,8 @@ class BrokerMetadataSnapshotterTest {
     try {
       val blockingEvent = new BlockingEvent()
       snapshotter.eventQueue.append(blockingEvent)
-      assertTrue(snapshotter.maybeStartSnapshot(123L, 12, 10000L, MetadataImageTest.IMAGE1))
-      assertFalse(snapshotter.maybeStartSnapshot(124L, 12, 11000L, MetadataImageTest.IMAGE2))
+      assertTrue(snapshotter.maybeStartSnapshot(10000L, MetadataImageTest.IMAGE1))
+      assertFalse(snapshotter.maybeStartSnapshot(11000L, MetadataImageTest.IMAGE2))
       blockingEvent.latch.countDown()
       assertEquals(MetadataImageTest.IMAGE1, writerBuilder.image.get())
     } finally {

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.image;
 
+import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 import java.util.List;
@@ -31,11 +32,14 @@ import java.util.function.Consumer;
  */
 public final class MetadataImage {
     public final static MetadataImage EMPTY = new MetadataImage(
+        new OffsetAndEpoch(0, 0),
         FeaturesImage.EMPTY,
         ClusterImage.EMPTY,
         TopicsImage.EMPTY,
         ConfigurationsImage.EMPTY,
         ClientQuotasImage.EMPTY);
+
+    private final OffsetAndEpoch highestOffsetAndEpoch;
 
     private final FeaturesImage features;
 
@@ -47,11 +51,15 @@ public final class MetadataImage {
 
     private final ClientQuotasImage clientQuotas;
 
-    public MetadataImage(FeaturesImage features,
-                         ClusterImage cluster,
-                         TopicsImage topics,
-                         ConfigurationsImage configs,
-                         ClientQuotasImage clientQuotas) {
+    public MetadataImage(
+        OffsetAndEpoch highestOffsetAndEpoch,
+        FeaturesImage features,
+        ClusterImage cluster,
+        TopicsImage topics,
+        ConfigurationsImage configs,
+        ClientQuotasImage clientQuotas
+    ) {
+        this.highestOffsetAndEpoch = highestOffsetAndEpoch;
         this.features = features;
         this.cluster = cluster;
         this.topics = topics;
@@ -65,6 +73,10 @@ public final class MetadataImage {
             topics.isEmpty() &&
             configs.isEmpty() &&
             clientQuotas.isEmpty();
+    }
+
+    public OffsetAndEpoch highestOffsetAndEpoch() {
+        return highestOffsetAndEpoch;
     }
 
     public FeaturesImage features() {
@@ -99,7 +111,8 @@ public final class MetadataImage {
     public boolean equals(Object o) {
         if (!(o instanceof MetadataImage)) return false;
         MetadataImage other = (MetadataImage) o;
-        return features.equals(other.features) &&
+        return highestOffsetAndEpoch.equals(other.highestOffsetAndEpoch) &&
+            features.equals(other.features) &&
             cluster.equals(other.cluster) &&
             topics.equals(other.topics) &&
             configs.equals(other.configs) &&
@@ -108,12 +121,13 @@ public final class MetadataImage {
 
     @Override
     public int hashCode() {
-        return Objects.hash(features, cluster, topics, configs, clientQuotas);
+        return Objects.hash(highestOffsetAndEpoch, features, cluster, topics, configs, clientQuotas);
     }
 
     @Override
     public String toString() {
-        return "MetadataImage(features=" + features +
+        return "MetadataImage(highestOffsetAndEpoch=" + highestOffsetAndEpoch +
+            ", features=" + features +
             ", cluster=" + cluster +
             ", topics=" + topics +
             ", configs=" + configs +

--- a/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.image;
 
 import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.raft.OffsetAndEpoch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -33,20 +34,24 @@ public class MetadataImageTest {
     public final static MetadataImage IMAGE2;
 
     static {
-        IMAGE1 = new MetadataImage(FeaturesImageTest.IMAGE1,
+        IMAGE1 = new MetadataImage(
+            new OffsetAndEpoch(100, 4),
+            FeaturesImageTest.IMAGE1,
             ClusterImageTest.IMAGE1,
             TopicsImageTest.IMAGE1,
             ConfigurationsImageTest.IMAGE1,
             ClientQuotasImageTest.IMAGE1);
 
         DELTA1 = new MetadataDelta(IMAGE1);
-        RecordTestUtils.replayAll(DELTA1, FeaturesImageTest.DELTA1_RECORDS);
-        RecordTestUtils.replayAll(DELTA1, ClusterImageTest.DELTA1_RECORDS);
-        RecordTestUtils.replayAll(DELTA1, TopicsImageTest.DELTA1_RECORDS);
-        RecordTestUtils.replayAll(DELTA1, ConfigurationsImageTest.DELTA1_RECORDS);
-        RecordTestUtils.replayAll(DELTA1, ClientQuotasImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, 200, 5, FeaturesImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, 200, 5, ClusterImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, 200, 5, TopicsImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, 200, 5, ConfigurationsImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, 200, 5, ClientQuotasImageTest.DELTA1_RECORDS);
 
-        IMAGE2 = new MetadataImage(FeaturesImageTest.IMAGE2,
+        IMAGE2 = new MetadataImage(
+            new OffsetAndEpoch(200, 5),
+            FeaturesImageTest.IMAGE2,
             ClusterImageTest.IMAGE2,
             TopicsImageTest.IMAGE2,
             ConfigurationsImageTest.IMAGE2,
@@ -77,7 +82,8 @@ public class MetadataImageTest {
         MockSnapshotConsumer writer = new MockSnapshotConsumer();
         image.write(writer);
         MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
-        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        RecordTestUtils.replayAllBatches(
+            delta, image.highestOffsetAndEpoch().offset, image.highestOffsetAndEpoch().epoch, writer.batches());
         MetadataImage nextImage = delta.apply();
         assertEquals(image, nextImage);
     }

--- a/metadata/src/test/java/org/apache/kafka/metadata/RecordTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/RecordTestUtils.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
+import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.BatchReader;
 import org.apache.kafka.raft.internals.MemoryBatchReader;
@@ -48,7 +49,7 @@ public class RecordTestUtils {
      * Replay a list of records.
      *
      * @param target                The object to invoke the replay function on.
-     * @param recordsAndVersions    A list of batches of records.
+     * @param recordsAndVersions    A list of records.
      */
     public static void replayAll(Object target,
                                  List<ApiMessageAndVersion> recordsAndVersions) {
@@ -68,6 +69,26 @@ public class RecordTestUtils {
     }
 
     /**
+     * Replay a list of records to the metadata delta.
+     *
+     * @param delta the metadata delta on which to replay the records
+     * @param highestOffset highest offset from the list of records
+     * @param highestEpoch highest epoch from the list of records
+     * @param recordsAndVersions list of records
+     */
+    public static void replayAll(
+        MetadataDelta delta,
+        long highestOffset,
+        int highestEpoch,
+        List<ApiMessageAndVersion> recordsAndVersions
+    ) {
+        for (ApiMessageAndVersion recordAndVersion : recordsAndVersions) {
+            ApiMessage record = recordAndVersion.message();
+            delta.replay(highestOffset, highestEpoch, record);
+        }
+    }
+
+    /**
      * Replay a list of record batches.
      *
      * @param target        The object to invoke the replay function on.
@@ -77,6 +98,25 @@ public class RecordTestUtils {
                                         List<List<ApiMessageAndVersion>> batches) {
         for (List<ApiMessageAndVersion> batch : batches) {
             replayAll(target, batch);
+        }
+    }
+
+    /**
+     * Replay a list of record batches to the metadata delta.
+     *
+     * @param delta the metadata delta on which to replay the records
+     * @param highestOffset highest offset from the list of record batches
+     * @param highestEpoch highest epoch from the list of record batches
+     * @param recordsAndVersions list of batches of records
+     */
+    public static void replayAllBatches(
+        MetadataDelta delta,
+        long highestOffset,
+        int highestEpoch,
+        List<List<ApiMessageAndVersion>> batches
+    ) {
+        for (List<ApiMessageAndVersion> batch : batches) {
+            replayAll(delta, highestOffset, highestEpoch, batch);
         }
     }
 


### PR DESCRIPTION
There are a few fixes included in this commit.
1. When loading a snapshot the broker `BrokerMetadataListener` was using the batch's append time, offset and epoch. These are not the same as the append time, offset and epoch from the log. We must instead use the `lastContainedLogTimeStamp`, `lastContainedLogOffset` and `lastContainedLogEpoch` from the `SnapshotReader`.
2. Include the highest offset and epoch into the `MetadataImage` and `MetadataDelta`. Adding the offset and epoch to `MetadataImage` is useful to version the image and to simplify the API. Adding the offset and epoch to `MetadataDelta` is needed to generate the `MetadataImage`.
3. Swapped the order of the arguments for `ReplicaManager.applyDelta` for consistency to match the order of the arguments for `MetadataPublisher.publish`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
