### PR TITLE
HOTFIX: Compilation fails due to unhandled deprecation warnings in streams tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -74,6 +74,7 @@ public class JoinWindowsTest {
         assertThrows(IllegalArgumentException.class, () -> JoinWindows.ofTimeDifferenceAndGrace(ofMillis(-1), ofMillis(ANY_GRACE)));
     }
 
+    @SuppressWarnings("deprecation") // grace is deprecated since 3.0.
     @Test
     public void graceShouldNotCalledAfterGraceSet() {
         assertThrows(IllegalStateException.class, () -> JoinWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -87,6 +87,7 @@ public class SessionWindowsTest {
         assertThrows(IllegalArgumentException.class, () -> SessionWindows.ofInactivityGapWithNoGrace(ofMillis(0)));
     }
 
+    @SuppressWarnings("deprecation") // grace is deprecated since 3.0.
     @Test
     public void graceShouldNotCalledAfterGraceSet() {
         assertThrows(IllegalStateException.class, () -> SessionWindows.ofInactivityGapAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -60,6 +60,7 @@ public class TimeWindowsTest {
         assertThrows(IllegalArgumentException.class, () -> TimeWindows.ofSizeWithNoGrace(ofMillis(-1)));
     }
 
+    @SuppressWarnings("deprecation") // grace is deprecated since 3.0.
     @Test
     public void graceShouldNotCalledAfterGraceSet() {
         assertThrows(IllegalStateException.class, () -> TimeWindows.ofSizeAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));


### PR DESCRIPTION
```
> Task :streams:compileTestJava FAILED
/Users/djacot/dev/src/github.com/dajac/kafka/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java:65: warning: [deprecation] grace(java.time.Duration) in org.apache.kafka.streams.kstream.TimeWindows has been deprecated
        assertThrows(IllegalStateException.class, () -> TimeWindows.ofSizeAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));
                                                                                                              ^
/Users/djacot/dev/src/github.com/dajac/kafka/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java:66: warning: [deprecation] grace(java.time.Duration) in org.apache.kafka.streams.kstream.TimeWindows has been deprecated
        assertThrows(IllegalStateException.class, () -> TimeWindows.ofSizeWithNoGrace(ofMillis(10)).grace(ofMillis(10)));
                                                                                                   ^
error: warnings found and -Werror specified
/Users/djacot/dev/src/github.com/dajac/kafka/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java:79: warning: [deprecation] grace(java.time.Duration) in org.apache.kafka.streams.kstream.JoinWindows has been deprecated
        assertThrows(IllegalStateException.class, () -> JoinWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));
                                                                                                                        ^
/Users/djacot/dev/src/github.com/dajac/kafka/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java:80: warning: [deprecation] grace(java.time.Duration) in org.apache.kafka.streams.kstream.JoinWindows has been deprecated
        assertThrows(IllegalStateException.class, () -> JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(10)).grace(ofMillis(10)));
                                                                                                             ^
/Users/djacot/dev/src/github.com/dajac/kafka/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java:92: warning: [deprecation] grace(java.time.Duration) in org.apache.kafka.streams.kstream.SessionWindows has been deprecated
        assertThrows(IllegalStateException.class, () -> SessionWindows.ofInactivityGapAndGrace(ofMillis(10), ofMillis(10)).grace(ofMillis(10)));
                                                                                                                          ^
/Users/djacot/dev/src/github.com/dajac/kafka/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java:93: warning: [deprecation] grace(java.time.Duration) in org.apache.kafka.streams.kstream.SessionWindows has been deprecated
        assertThrows(IllegalStateException.class, () -> SessionWindows.ofInactivityGapWithNoGrace(ofMillis(10)).grace(ofMillis(10)));
                                                                                                               ^
1 error
6 warnings
```

It seems that those tests were introduced in d1415866cc3ed7eeb198df6477a09584b6d1f8a2.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
