### PR TITLE
KAFKA-13255: use exclude filter for new topics

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -356,7 +356,7 @@ public class MirrorSourceConnector extends SourceConnector {
                 .map(sourceTopic -> {
                     String remoteTopic = formatRemoteTopic(sourceTopic);
                     int partitionCount = sourceTopicToPartitionCounts.get(sourceTopic).intValue();
-                    Map<String, String> configs = configToMap(sourceTopicToConfig.get(sourceTopic));
+                    Map<String, String> configs = configToMap(targetConfig(sourceTopicToConfig.get(sourceTopic)));
                     return new NewTopic(remoteTopic, partitionCount, (short) replicationFactor)
                             .configs(configs);
                 })

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -349,7 +349,8 @@ public class MirrorSourceConnector extends SourceConnector {
         }
     }
 
-    private void createNewTopics(Set<String> newSourceTopics, Map<String, Long> sourceTopicToPartitionCounts)
+    // visible for testing
+    void createNewTopics(Set<String> newSourceTopics, Map<String, Long> sourceTopicToPartitionCounts)
             throws ExecutionException, InterruptedException {
         Map<String, Config> sourceTopicToConfig = describeTopicConfigs(newSourceTopics);
         Map<String, NewTopic> newTopics = newSourceTopics.stream()

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -195,6 +195,7 @@ public class MirrorSourceConnectorTest {
             return null;
         }).when(connector).createNewTopics(any());
         connector.createNewTopics(Collections.singleton(topic), Collections.singletonMap(topic, 1L));
+        verify(connector).createNewTopics(any(), any());
     }
 
     @Test

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
@@ -86,6 +86,7 @@ public class IdentityReplicationIntegrationTest extends MirrorConnectorsIntegrat
         waitForTopicCreated(backup, "test-topic-1");
         assertEquals(TopicConfig.CLEANUP_POLICY_COMPACT, getTopicConfig(backup.kafka(), "test-topic-1", TopicConfig.CLEANUP_POLICY_CONFIG),
                 "topic config was not synced");
+        createAndTestNewTopicWithConfigFilter();
 
         assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
                 "Records were not produced to primary cluster.");
@@ -259,5 +260,13 @@ public class IdentityReplicationIntegrationTest extends MirrorConnectorsIntegrat
         // similar reasoning as above, no more records to consume by the same consumer group at backup cluster
         assertEquals(0, records.count(), "consumer record size is not zero");
         backupConsumer.close();
+    }
+
+    /*
+     * Returns expected topic name on target cluster.
+     */
+    @Override
+    String backupClusterTopicName(String topic) {
+        return topic;
     }
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -525,13 +525,8 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
     public void testTopicConfigPropertyFilteringExclude() throws Exception {
         // create exclude filter configuration and start MM2:
         mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
-        mm2Props.put(DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG, "follower\\.replication\\.throttled\\.replicas, "
-                + "leader\\.replication\\.throttled\\.replicas, "
-                + "message\\.timestamp\\.difference\\.max\\.ms, "
-                + "message\\.timestamp\\.type, "
-                + "unclean\\.leader\\.election\\.enable, "
-                + "min\\.insync\\.replicas,"
-                + "delete\\.retention\\..*"); // this is in addition to the default exclude list
+        // For the test, set only only one param to exclude and test.
+        mm2Props.put(DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG, "delete\\.retention\\..*");
 
         mm2Config = new MirrorMakerConfig(mm2Props);
         waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
@@ -558,7 +553,7 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
         backupConfig = getTopicConfig(backup.kafka(), PRIMARY_CLUSTER_ALIAS + "." + topic, "retention.bytes");
         assertEquals(primaryConfig, backupConfig,
                 "`retention.bytes` should be the same, because it isn't in exclude filter! ");
-        assertEquals(backupConfig, "1000",
+        assertEquals("1000", backupConfig,
                 "`retention.bytes` should be the same, because it's explicitly defined! ");
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.mirror.DefaultConfigPropertyFilter;
 import org.apache.kafka.connect.mirror.MirrorClient;
 import org.apache.kafka.connect.mirror.MirrorHeartbeatConnector;
 import org.apache.kafka.connect.mirror.MirrorMakerConfig;
@@ -60,6 +61,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -517,6 +519,47 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
         Set<String> primaryTopics = primary.kafka().createAdminClient().listTopics().names().get();
         assertFalse(primaryTopics.contains("mm2-offset-syncs." + PRIMARY_CLUSTER_ALIAS + ".internal"));
         assertFalse(primaryTopics.contains("mm2-offset-syncs." + BACKUP_CLUSTER_ALIAS + ".internal"));
+    }
+
+    @Test
+    public void testTopicConfigPropertyFilteringExclude() throws Exception {
+        // create exclude filter configuration and start MM2:
+        mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
+        mm2Props.put(DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG, "follower\\.replication\\.throttled\\.replicas, "
+                + "leader\\.replication\\.throttled\\.replicas, "
+                + "message\\.timestamp\\.difference\\.max\\.ms, "
+                + "message\\.timestamp\\.type, "
+                + "unclean\\.leader\\.election\\.enable, "
+                + "min\\.insync\\.replicas,"
+                + "delete\\.retention\\..*"); // this is in addition to the default exclude list
+
+        mm2Config = new MirrorMakerConfig(mm2Props);
+        waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
+
+        // create topic with configuration to test:
+        final Map<String, String> topicConfig = new HashMap<>();
+        topicConfig.put("delete.retention.ms", "1000"); // should be excluded (default value is 86400000)
+        topicConfig.put("retention.bytes", "1000"); // should be included, default value is -1
+
+
+        final String topic = "test-topic-with-config";
+        primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
+        waitForTopicCreated(backup, PRIMARY_CLUSTER_ALIAS + "." + topic);
+
+        String primaryConfig, backupConfig;
+
+        primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
+        backupConfig = getTopicConfig(backup.kafka(), PRIMARY_CLUSTER_ALIAS + "." + topic, "delete.retention.ms");
+        assertNotEquals(primaryConfig, backupConfig,
+                "`delete.retention.ms` should be different, because it's in exclude filter! ");
+
+        // regression test for the config that are still supposed to be replicated
+        primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
+        backupConfig = getTopicConfig(backup.kafka(), PRIMARY_CLUSTER_ALIAS + "." + topic, "retention.bytes");
+        assertEquals(primaryConfig, backupConfig,
+                "`retention.bytes` should be the same, because it isn't in exclude filter! ");
+        assertEquals(backupConfig, "1000",
+                "`retention.bytes` should be the same, because it's explicitly defined! ");
     }
 
     /*


### PR DESCRIPTION
MM2 needs to honor `config.properties.exclude` property when it replicates initial/new topics. Updates to `MirrorSourceConnector` in 2.8 break exclude filter. Prior to 2.8, MM2 would create a topic in target cluster without any config applied. The TopicSync would apply the configuration, honoring exclude filter.

But in 2.8, the change has been made to create a topic on target with all the configurations from the source cluster. While doing that, no filters applied at all.

This fix ensures that the same working logic filtering excluded properties is applied while creating new topics on target cluster.

Testing Strategy:
**Reproduce:**
1. On Source cluster create topic "Topic_Short_Retention"
2. Alter topic Topic_Short_Retention: `bin/kafka-configs.sh --bootstrap-server <broker_host> --alter --entity-type topics --entity-name Topic_Short_Retention --add-config retention.ms=300000`
3. include following line in MM2 config: `config.properties.exclude=follower.replication.throttled.replicas, leader.replication.throttled.replicas, message.timestamp.difference.max.ms, message.timestamp.type, unclean.leader.election.enable, min.insync.replicas, retention.ms`. *Note, I copied default exclude filter and added* `retention.ms` to it
4. Start MM2 connector. *Note, the topic on a target cluster will have* `retention.ms` *copied from source cluster*.

**Test the Fix:**
1. Stop MM2 connector
2. Apply patch
3. Delete the topic from target cluster
4. Start MM2 with configuration as described in step 3 of reproduction
5. Check topic's retention config - it should be preserved as cluster's default and not copied from source cluster.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
