### PR TITLE
MINOR: Make TestUtils usable for KRaft mode

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -100,7 +100,7 @@ class BrokerServer(
   val awaitShutdownCond = lock.newCondition()
   var status: ProcessStatus = SHUTDOWN
 
-  var dataPlaneRequestProcessor: KafkaApis = null
+  @volatile var dataPlaneRequestProcessor: KafkaApis = null
   var controlPlaneRequestProcessor: KafkaApis = null
 
   var authorizer: Option[Authorizer] = None
@@ -119,7 +119,7 @@ class BrokerServer(
   var credentialProvider: CredentialProvider = null
   var tokenCache: DelegationTokenCache = null
 
-  var groupCoordinator: GroupCoordinator = null
+  @volatile var groupCoordinator: GroupCoordinator = null
 
   var transactionCoordinator: TransactionCoordinator = null
 
@@ -133,7 +133,7 @@ class BrokerServer(
 
   var kafkaScheduler: KafkaScheduler = null
 
-  var metadataCache: KRaftMetadataCache = null
+  @volatile var metadataCache: KRaftMetadataCache = null
 
   var quotaManagers: QuotaFactory.QuotaManagers = null
 
@@ -442,7 +442,7 @@ class BrokerServer(
     }
   }
 
-  def shutdown(): Unit = {
+  override def shutdown(): Unit = {
     if (!maybeChangeStatus(STARTED, SHUTTING_DOWN)) return
     try {
       info("shutting down")
@@ -555,6 +555,6 @@ class BrokerServer(
     }
   }
 
-  def boundPort(listenerName: ListenerName): Int = socketServer.boundPort(listenerName)
+  override def boundPort(listenerName: ListenerName): Int = socketServer.boundPort(listenerName)
 
 }

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import com.yammer.metrics.core.MetricName
+import kafka.coordinator.group.GroupCoordinator
 import kafka.log.LogManager
 import kafka.metrics.{KafkaMetricsGroup, KafkaYammerMetrics, LinuxIoMetricsCollector}
 import kafka.network.SocketServer
@@ -25,6 +26,7 @@ import kafka.utils.KafkaScheduler
 import org.apache.kafka.common.ClusterResource
 import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.metrics.{Metrics, MetricsReporter}
+import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.authorizer.Authorizer
@@ -69,6 +71,7 @@ trait KafkaBroker extends KafkaMetricsGroup {
   def clusterId: String
   def config: KafkaConfig
   def dataPlaneRequestHandlerPool: KafkaRequestHandlerPool
+  def dataPlaneRequestProcessor: KafkaApis
   def kafkaScheduler: KafkaScheduler
   def kafkaYammerMetrics: KafkaYammerMetrics
   def logManager: LogManager
@@ -76,6 +79,10 @@ trait KafkaBroker extends KafkaMetricsGroup {
   def quotaManagers: QuotaFactory.QuotaManagers
   def replicaManager: ReplicaManager
   def socketServer: SocketServer
+  def metadataCache: MetadataCache
+  def groupCoordinator: GroupCoordinator
+  def boundPort(listenerName: ListenerName): Int
+  def shutdown(): Unit
 
   // For backwards compatibility, we need to keep older metrics tied
   // to their original name when this class was named `KafkaServer`

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -105,11 +105,11 @@ class KafkaServer(
   var kafkaYammerMetrics: KafkaYammerMetrics = null
   var metrics: Metrics = null
 
-  var dataPlaneRequestProcessor: KafkaApis = null
+  @volatile var dataPlaneRequestProcessor: KafkaApis = null
   var controlPlaneRequestProcessor: KafkaApis = null
 
   var authorizer: Option[Authorizer] = None
-  var socketServer: SocketServer = null
+  @volatile var socketServer: SocketServer = null
   var dataPlaneRequestHandlerPool: KafkaRequestHandlerPool = null
   var controlPlaneRequestHandlerPool: KafkaRequestHandlerPool = null
 
@@ -125,7 +125,7 @@ class KafkaServer(
   var credentialProvider: CredentialProvider = null
   var tokenCache: DelegationTokenCache = null
 
-  var groupCoordinator: GroupCoordinator = null
+  @volatile var groupCoordinator: GroupCoordinator = null
 
   var transactionCoordinator: TransactionCoordinator = null
 
@@ -141,7 +141,7 @@ class KafkaServer(
 
   var kafkaScheduler: KafkaScheduler = null
 
-  var metadataCache: ZkMetadataCache = null
+  @volatile var metadataCache: ZkMetadataCache = null
   var quotaManagers: QuotaFactory.QuotaManagers = null
 
   val zkClientConfig: ZKClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(config)
@@ -800,7 +800,7 @@ class KafkaServer(
 
   def getLogManager: LogManager = logManager
 
-  def boundPort(listenerName: ListenerName): Int = socketServer.boundPort(listenerName)
+  override def boundPort(listenerName: ListenerName): Int = socketServer.boundPort(listenerName)
 
   /** Return advertised listeners with the bound port (this may differ from the configured port if the latter is `0`). */
   def advertisedListeners: Seq[EndPoint] = {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -50,7 +50,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.TOPIC
-import org.apache.kafka.common.errors.{KafkaStorageException, OperationNotAttemptedException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{KafkaStorageException, OperationNotAttemptedException, TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.memory.MemoryPool
@@ -177,8 +177,8 @@ object TestUtils extends Logging {
     server
   }
 
-  def boundPort(server: KafkaServer, securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT): Int =
-    server.boundPort(ListenerName.forSecurityProtocol(securityProtocol))
+  def boundPort(broker: KafkaBroker, securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT): Int =
+    broker.boundPort(ListenerName.forSecurityProtocol(securityProtocol))
 
   def createBrokerAndEpoch(id: Int, host: String, port: Int, securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT,
                            epoch: Long = 0): (Broker, Long) = {
@@ -218,16 +218,18 @@ object TestUtils extends Logging {
     }
   }
 
-  def getBrokerListStrFromServers(servers: Seq[KafkaServer], protocol: SecurityProtocol = SecurityProtocol.PLAINTEXT): String = {
-    servers.map { s =>
+  def getBrokerListStrFromServers[B <: KafkaBroker](
+      brokers: Seq[B],
+      protocol: SecurityProtocol = SecurityProtocol.PLAINTEXT): String = {
+    brokers.map { s =>
       val listener = s.config.advertisedListeners.find(_.securityProtocol == protocol).getOrElse(
         sys.error(s"Could not find listener with security protocol $protocol"))
       formatAddress(listener.host, boundPort(s, protocol))
     }.mkString(",")
   }
 
-  def bootstrapServers(servers: Seq[KafkaServer], listenerName: ListenerName): String = {
-    servers.map { s =>
+  def bootstrapServers[B <: KafkaBroker](brokers: Seq[B], listenerName: ListenerName): String = {
+    brokers.map { s =>
       val listener = s.config.advertisedListeners.find(_.listenerName == listenerName).getOrElse(
         sys.error(s"Could not find listener with name ${listenerName.value}"))
       formatAddress(listener.host, s.boundPort(listenerName))
@@ -237,9 +239,9 @@ object TestUtils extends Logging {
   /**
     * Shutdown `servers` and delete their log directories.
     */
-  def shutdownServers(servers: Seq[KafkaServer]): Unit = {
+  def shutdownServers[B <: KafkaBroker](brokers: Seq[B]): Unit = {
     import ExecutionContext.Implicits._
-    val future = Future.traverse(servers) { s =>
+    val future = Future.traverse(brokers) { s =>
       Future {
         s.shutdown()
         CoreUtils.delete(s.config.logDirs)
@@ -290,8 +292,18 @@ object TestUtils extends Logging {
     }.mkString(",")
 
     val props = new Properties
-    if (nodeId >= 0) props.put(KafkaConfig.BrokerIdProp, nodeId.toString)
-    props.put(KafkaConfig.ListenersProp, listeners)
+    if (zkConnect == null) {
+      props.put(KafkaConfig.NodeIdProp, nodeId.toString)
+      props.put(KafkaConfig.BrokerIdProp, nodeId.toString)
+      props.put(KafkaConfig.AdvertisedListenersProp, listeners)
+      props.put(KafkaConfig.ListenersProp, listeners + ",CONTROLLER://localhost:0")
+      props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
+      props.put(KafkaConfig.ListenerSecurityProtocolMapProp, protocolAndPorts.
+        map(p => "%s:%s".format(p._1, p._1)).mkString(",") + ",CONTROLLER:PLAINTEXT")
+    } else {
+      if (nodeId >= 0) props.put(KafkaConfig.BrokerIdProp, nodeId.toString)
+      props.put(KafkaConfig.ListenersProp, listeners)
+    }
     if (logDirCount > 1) {
       val logDirs = (1 to logDirCount).toList.map(i =>
         // We would like to allow user to specify both relative path and absolute path as log directory for backward-compatibility reason
@@ -302,8 +314,17 @@ object TestUtils extends Logging {
     } else {
       props.put(KafkaConfig.LogDirProp, tempDir().getAbsolutePath)
     }
-    props.put(KafkaConfig.ZkConnectProp, zkConnect)
-    props.put(KafkaConfig.ZkConnectionTimeoutMsProp, "10000")
+    if (zkConnect == null) {
+      props.put(KafkaConfig.ProcessRolesProp, "broker")
+      // Note: this is just a placeholder value for controller.quorum.voters. JUnit
+      // tests use random port assignment, so the controller ports are not known ahead of
+      // time. Therefore, we ignore controller.quorum.voters and use
+      // controllerQuorumVotersFuture instead.
+      props.put(KafkaConfig.QuorumVotersProp, "1000@localhost:0")
+    } else {
+      props.put(KafkaConfig.ZkConnectProp, zkConnect)
+      props.put(KafkaConfig.ZkConnectionTimeoutMsProp, "10000")
+    }
     props.put(KafkaConfig.ReplicaSocketTimeoutMsProp, "1500")
     props.put(KafkaConfig.ControllerSocketTimeoutMsProp, "1500")
     props.put(KafkaConfig.ControlledShutdownEnableProp, enableControlledShutdown.toString)
@@ -344,6 +365,97 @@ object TestUtils extends Logging {
     // for clarity, only set the log message format version if it's not ignored
     if (!LogConfig.shouldIgnoreMessageFormatVersion(version))
       config.setProperty(KafkaConfig.LogMessageFormatVersionProp, version.version)
+  }
+
+  def createAdminClient[B <: KafkaBroker](
+      brokers: Seq[B],
+      adminConfig: Properties): Admin = {
+    val adminClientProperties = if (adminConfig.isEmpty) {
+      val newConfig = new Properties()
+      newConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokerListStrFromServers(brokers))
+      newConfig
+    } else {
+      adminConfig
+    }
+    Admin.create(adminClientProperties)
+  }
+
+  def createTopicWithAdmin[B <: KafkaBroker](
+      topic: String,
+      numPartitions: Int = 1,
+      replicationFactor: Int = 1,
+      brokers: Seq[B],
+      topicConfig: Properties = new Properties,
+      adminConfig: Properties = new Properties): scala.collection.immutable.Map[Int, Int] = {
+    val adminClient = createAdminClient(brokers, adminConfig)
+    try {
+      val configsMap = new java.util.HashMap[String, String]()
+      topicConfig.forEach((k, v) => configsMap.put(k.toString, v.toString))
+      try {
+        adminClient.createTopics(Collections.singletonList(new NewTopic(
+          topic, numPartitions, replicationFactor.toShort).configs(configsMap))).all().get()
+      } catch {
+        case e: ExecutionException => if (e.getCause != null &&
+          e.getCause.isInstanceOf[TopicExistsException] &&
+          topicHasSameNumPartitionsAndReplicationFactor(adminClient, topic, numPartitions, replicationFactor)) {
+        } else {
+          throw e
+        }
+      }
+    } finally {
+      adminClient.close()
+    }
+    // wait until we've propagated all partitions metadata to all brokers
+    val allPartitionsMetadata = waitForAllPartitionsMetadata(brokers, topic, numPartitions)
+
+    (0 until numPartitions).map { i =>
+      i -> allPartitionsMetadata.get(new TopicPartition(topic, i)).map(_.leader()).getOrElse(
+        throw new IllegalStateException(s"Cannot get the partition leader for topic: $topic, partition: $i in server metadata cache"))
+    }.toMap
+  }
+
+  def topicHasSameNumPartitionsAndReplicationFactor(adminClient: Admin,
+                                                    topic: String,
+                                                    numPartitions: Int,
+                                                    replicationFactor: Int): Boolean = {
+    val describedTopics = adminClient.describeTopics(Collections.
+      singleton(topic)).allTopicNames().get()
+    val description = describedTopics.get(topic)
+    (description != null &&
+      description.partitions().size() == numPartitions &&
+      description.partitions().iterator().next().replicas().size() == replicationFactor)
+  }
+
+  def createOffsetsTopicWithAdmin[B <: KafkaBroker](
+      brokers: Seq[B],
+      adminConfig: Properties = new Properties) = {
+    val broker = brokers.head
+    createTopicWithAdmin(topic = Topic.GROUP_METADATA_TOPIC_NAME,
+      numPartitions = broker.config.getInt(KafkaConfig.OffsetsTopicPartitionsProp),
+      replicationFactor = broker.config.getShort(KafkaConfig.OffsetsTopicReplicationFactorProp).toInt,
+      brokers = brokers,
+      topicConfig = broker.groupCoordinator.offsetsTopicConfigs,
+      adminConfig = adminConfig)
+  }
+
+  def deleteTopicWithAdmin[B <: KafkaBroker](
+      topic: String,
+      brokers: Seq[B],
+      adminConfig: Properties = new Properties): Unit = {
+    val adminClient = createAdminClient(brokers, adminConfig)
+    try {
+      adminClient.deleteTopics(Collections.singletonList(topic)).all().get()
+    } catch {
+      case e: ExecutionException => if (e.getCause != null &&
+          e.getCause.isInstanceOf[UnknownTopicOrPartitionException]) {
+        // ignore
+      } else {
+        throw e
+      }
+    } finally {
+      adminClient.close()
+    }
+    waitForAllPartitionsMetadata(brokers, topic, 0)
   }
 
   /**
@@ -902,22 +1014,22 @@ object TestUtils extends Logging {
     }
   }
 
-  def isLeaderLocalOnBroker(topic: String, partitionId: Int, server: KafkaServer): Boolean = {
-    server.replicaManager.onlinePartition(new TopicPartition(topic, partitionId)).exists(_.leaderLogIfLocal.isDefined)
+  def isLeaderLocalOnBroker(topic: String, partitionId: Int, broker: KafkaBroker): Boolean = {
+    broker.replicaManager.onlinePartition(new TopicPartition(topic, partitionId)).exists(_.leaderLogIfLocal.isDefined)
   }
 
   def findLeaderEpoch(brokerId: Int,
                       topicPartition: TopicPartition,
-                      servers: Iterable[KafkaServer]): Int = {
-    val leaderServer = servers.find(_.config.brokerId == brokerId)
-    val leaderPartition = leaderServer.flatMap(_.replicaManager.onlinePartition(topicPartition))
+                      brokers: Iterable[KafkaBroker]): Int = {
+    val leaderBroker = brokers.find(_.config.brokerId == brokerId)
+    val leaderPartition = leaderBroker.flatMap(_.replicaManager.onlinePartition(topicPartition))
       .getOrElse(throw new AssertionError(s"Failed to find expected replica on broker $brokerId"))
     leaderPartition.getLeaderEpoch
   }
 
   def findFollowerId(topicPartition: TopicPartition,
-                     servers: Iterable[KafkaServer]): Int = {
-    val followerOpt = servers.find { server =>
+                     brokers: Iterable[KafkaBroker]): Int = {
+    val followerOpt = brokers.find { server =>
       server.replicaManager.onlinePartition(topicPartition) match {
         case Some(partition) => !partition.leaderReplicaIdOpt.contains(server.config.brokerId)
         case None => false
@@ -931,13 +1043,14 @@ object TestUtils extends Logging {
   /**
     * Wait until all brokers know about each other.
     *
-    * @param servers The Kafka broker servers.
+    * @param brokers The Kafka brokers.
     * @param timeout The amount of time waiting on this condition before assert to fail
     */
-  def waitUntilBrokerMetadataIsPropagated(servers: Seq[KafkaServer],
-                                          timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
-    val expectedBrokerIds = servers.map(_.config.brokerId).toSet
-    waitUntilTrue(() => servers.forall(server =>
+  def waitUntilBrokerMetadataIsPropagated[B <: KafkaBroker](
+      brokers: Seq[B],
+      timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
+    val expectedBrokerIds = brokers.map(_.config.brokerId).toSet
+    waitUntilTrue(() => brokers.forall(server =>
       expectedBrokerIds == server.dataPlaneRequestProcessor.metadataCache.getAliveBrokers().map(_.id).toSet
     ), "Timed out waiting for broker metadata to propagate to all servers", timeout)
   }
@@ -945,22 +1058,27 @@ object TestUtils extends Logging {
   /**
    * Wait until the expected number of partitions is in the metadata cache in each broker.
    *
-   * @param servers The list of servers that the metadata should reach to
+   * @param brokers The list of brokers that the metadata should reach to
    * @param topic The topic name
    * @param expectedNumPartitions The expected number of partitions
    * @return all partitions metadata
    */
-  def waitForAllPartitionsMetadata(servers: Seq[KafkaServer],
-                                   topic: String, expectedNumPartitions: Int): Map[TopicPartition, UpdateMetadataPartitionState] = {
+  def waitForAllPartitionsMetadata[B <: KafkaBroker](
+      brokers: Seq[B],
+      topic: String, expectedNumPartitions: Int): Map[TopicPartition, UpdateMetadataPartitionState] = {
     waitUntilTrue(
-      () => servers.forall { server =>
-        server.metadataCache.numPartitions(topic) == Some(expectedNumPartitions)
+      () => brokers.forall { broker =>
+        if (expectedNumPartitions == 0) {
+          broker.metadataCache.numPartitions(topic) == None
+        } else {
+          broker.metadataCache.numPartitions(topic) == Some(expectedNumPartitions)
+        }
       },
       s"Topic [$topic] metadata not propagated after 60000 ms", waitTimeMs = 60000L)
 
     // since the metadata is propagated, we should get the same metadata from each server
     (0 until expectedNumPartitions).map { i =>
-      new TopicPartition(topic, i) -> servers.head.metadataCache.getPartitionInfo(topic, i).getOrElse(
+      new TopicPartition(topic, i) -> brokers.head.metadataCache.getPartitionInfo(topic, i).getOrElse(
           throw new IllegalStateException(s"Cannot get topic: $topic, partition: $i in server metadata cache"))
     }.toMap
   }
@@ -969,17 +1087,18 @@ object TestUtils extends Logging {
    * Wait until a valid leader is propagated to the metadata cache in each broker.
    * It assumes that the leader propagated to each broker is the same.
    *
-   * @param servers The list of servers that the metadata should reach to
+   * @param brokers The list of brokers that the metadata should reach to
    * @param topic The topic name
    * @param partition The partition Id
    * @param timeout The amount of time waiting on this condition before assert to fail
    * @return The metadata of the partition.
    */
-  def waitForPartitionMetadata(servers: Seq[KafkaServer], topic: String, partition: Int,
-                               timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): UpdateMetadataPartitionState = {
+  def waitForPartitionMetadata[B <: KafkaBroker](
+      brokers: Seq[B], topic: String, partition: Int,
+      timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): UpdateMetadataPartitionState = {
     waitUntilTrue(
-      () => servers.forall { server =>
-        server.metadataCache.getPartitionInfo(topic, partition) match {
+      () => brokers.forall { broker =>
+        broker.metadataCache.getPartitionInfo(topic, partition) match {
           case Some(partitionState) => Request.isValidBrokerId(partitionState.leader)
           case _ => false
         }
@@ -987,7 +1106,7 @@ object TestUtils extends Logging {
       "Partition [%s,%d] metadata not propagated after %d ms".format(topic, partition, timeout),
       waitTimeMs = timeout)
 
-    servers.head.metadataCache.getPartitionInfo(topic, partition).getOrElse(
+    brokers.head.metadataCache.getPartitionInfo(topic, partition).getOrElse(
       throw new IllegalStateException(s"Cannot get topic: $topic, partition: $partition in server metadata cache"))
   }
 
@@ -996,14 +1115,15 @@ object TestUtils extends Logging {
     controllerId.getOrElse(throw new AssertionError(s"Controller not elected after $timeout ms"))
   }
 
-  def awaitLeaderChange(servers: Seq[KafkaServer],
-                        tp: TopicPartition,
-                        oldLeader: Int,
-                        timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
+  def awaitLeaderChange[B <: KafkaBroker](
+      brokers: Seq[B],
+      tp: TopicPartition,
+      oldLeader: Int,
+      timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
     def newLeaderExists: Option[Int] = {
-      servers.find { server =>
-        server.config.brokerId != oldLeader &&
-          server.replicaManager.onlinePartition(tp).exists(_.leaderLogIfLocal.isDefined)
+      brokers.find { broker =>
+        broker.config.brokerId != oldLeader &&
+          broker.replicaManager.onlinePartition(tp).exists(_.leaderLogIfLocal.isDefined)
       }.map(_.config.brokerId)
     }
 
@@ -1013,12 +1133,13 @@ object TestUtils extends Logging {
     newLeaderExists.get
   }
 
-  def waitUntilLeaderIsKnown(servers: Seq[KafkaServer],
-                             tp: TopicPartition,
-                             timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
+  def waitUntilLeaderIsKnown[B <: KafkaBroker](
+      brokers: Seq[B],
+      tp: TopicPartition,
+      timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
     def leaderIfExists: Option[Int] = {
-      servers.find { server =>
-        server.replicaManager.onlinePartition(tp).exists(_.leaderLogIfLocal.isDefined)
+      brokers.find { broker =>
+        broker.replicaManager.onlinePartition(tp).exists(_.leaderLogIfLocal.isDefined)
       }.map(_.config.brokerId)
     }
 
@@ -1181,10 +1302,11 @@ object TestUtils extends Logging {
     new MockIsrChangeListener()
   }
 
-  def produceMessages(servers: Seq[KafkaServer],
-                      records: Seq[ProducerRecord[Array[Byte], Array[Byte]]],
-                      acks: Int = -1): Unit = {
-    val producer = createProducer(TestUtils.getBrokerListStrFromServers(servers), acks = acks)
+  def produceMessages[B <: KafkaBroker](
+      brokers: Seq[B],
+      records: Seq[ProducerRecord[Array[Byte], Array[Byte]]],
+      acks: Int = -1): Unit = {
+    val producer = createProducer(TestUtils.getBrokerListStrFromServers(brokers), acks = acks)
     try {
       val futures = records.map(producer.send)
       futures.foreach(_.get)
@@ -1196,22 +1318,28 @@ object TestUtils extends Logging {
     debug(s"Sent ${records.size} messages for topics ${topics.mkString(",")}")
   }
 
-  def generateAndProduceMessages(servers: Seq[KafkaServer],
-                                 topic: String,
-                                 numMessages: Int,
-                                 acks: Int = -1): Seq[String] = {
+  def generateAndProduceMessages[B <: KafkaBroker](
+      brokers: Seq[B],
+      topic: String,
+      numMessages: Int,
+      acks: Int = -1): Seq[String] = {
     val values = (0 until numMessages).map(x =>  s"test-$x")
     val intSerializer = new IntegerSerializer()
     val records = values.zipWithIndex.map { case (v, i) =>
       new ProducerRecord(topic, intSerializer.serialize(topic, i), v.getBytes)
     }
-    produceMessages(servers, records, acks)
+    produceMessages(brokers, records, acks)
     values
   }
 
-  def produceMessage(servers: Seq[KafkaServer], topic: String, message: String, timestamp: java.lang.Long = null,
-                     deliveryTimeoutMs: Int = 30 * 1000, requestTimeoutMs: Int = 20 * 1000): Unit = {
-    val producer = createProducer(TestUtils.getBrokerListStrFromServers(servers),
+  def produceMessage[B <: KafkaBroker](
+      brokers: Seq[B],
+      topic: String,
+      message: String,
+      timestamp: java.lang.Long = null,
+      deliveryTimeoutMs: Int = 30 * 1000,
+      requestTimeoutMs: Int = 20 * 1000): Unit = {
+    val producer = createProducer(TestUtils.getBrokerListStrFromServers(brokers),
       deliveryTimeoutMs = deliveryTimeoutMs, requestTimeoutMs = requestTimeoutMs)
     try {
       producer.send(new ProducerRecord(topic, null, timestamp, topic.getBytes, message.getBytes)).get
@@ -1220,37 +1348,42 @@ object TestUtils extends Logging {
     }
   }
 
-
-  def verifyTopicDeletion(zkClient: KafkaZkClient, topic: String, numPartitions: Int, servers: Seq[KafkaServer]): Unit = {
+  def verifyTopicDeletion[B <: KafkaBroker](
+      zkClient: KafkaZkClient,
+      topic: String,
+      numPartitions: Int,
+      brokers: Seq[B]): Unit = {
     val topicPartitions = (0 until numPartitions).map(new TopicPartition(topic, _))
-    // wait until admin path for delete topic is deleted, signaling completion of topic deletion
-    waitUntilTrue(() => !zkClient.isTopicMarkedForDeletion(topic),
-      "Admin path /admin/delete_topics/%s path not deleted even after a replica is restarted".format(topic))
-    waitUntilTrue(() => !zkClient.topicExists(topic),
-      "Topic path /brokers/topics/%s not deleted after /admin/delete_topics/%s path is deleted".format(topic, topic))
+    if (zkClient != null) {
+      // wait until admin path for delete topic is deleted, signaling completion of topic deletion
+      waitUntilTrue(() => !zkClient.isTopicMarkedForDeletion(topic),
+        "Admin path /admin/delete_topics/%s path not deleted even after a replica is restarted".format(topic))
+      waitUntilTrue(() => !zkClient.topicExists(topic),
+        "Topic path /brokers/topics/%s not deleted after /admin/delete_topics/%s path is deleted".format(topic, topic))
+    }
     // ensure that the topic-partition has been deleted from all brokers' replica managers
     waitUntilTrue(() =>
-      servers.forall(server => topicPartitions.forall(tp => server.replicaManager.onlinePartition(tp).isEmpty)),
+      brokers.forall(broker => topicPartitions.forall(tp => broker.replicaManager.onlinePartition(tp).isEmpty)),
       "Replica manager's should have deleted all of this topic's partitions")
     // ensure that logs from all replicas are deleted if delete topic is marked successful in ZooKeeper
-    assertTrue(servers.forall(server => topicPartitions.forall(tp => server.getLogManager.getLog(tp).isEmpty)),
+    assertTrue(brokers.forall(broker => topicPartitions.forall(tp => broker.logManager.getLog(tp).isEmpty)),
       "Replica logs not deleted after delete topic is complete")
     // ensure that topic is removed from all cleaner offsets
-    waitUntilTrue(() => servers.forall(server => topicPartitions.forall { tp =>
-      val checkpoints = server.getLogManager.liveLogDirs.map { logDir =>
+    waitUntilTrue(() => brokers.forall(broker => topicPartitions.forall { tp =>
+      val checkpoints = broker.logManager.liveLogDirs.map { logDir =>
         new OffsetCheckpointFile(new File(logDir, "cleaner-offset-checkpoint")).read()
       }
       checkpoints.forall(checkpointsPerLogDir => !checkpointsPerLogDir.contains(tp))
     }), "Cleaner offset for deleted partition should have been removed")
-    waitUntilTrue(() => servers.forall(server =>
-      server.config.logDirs.forall { logDir =>
+    waitUntilTrue(() => brokers.forall(broker =>
+      broker.config.logDirs.forall { logDir =>
         topicPartitions.forall { tp =>
           !new File(logDir, tp.topic + "-" + tp.partition).exists()
         }
       }
     ), "Failed to soft-delete the data to a delete directory")
-    waitUntilTrue(() => servers.forall(server =>
-      server.config.logDirs.forall { logDir =>
+    waitUntilTrue(() => brokers.forall(broker =>
+      broker.config.logDirs.forall { logDir =>
         topicPartitions.forall { tp =>
           !Arrays.asList(new File(logDir).list()).asScala.exists { partitionDirectoryName =>
             partitionDirectoryName.startsWith(tp.topic + "-" + tp.partition) &&
@@ -1262,23 +1395,23 @@ object TestUtils extends Logging {
   }
 
 
-  def causeLogDirFailure(failureType: LogDirFailureType, leaderServer: KafkaServer, partition: TopicPartition): Unit = {
+  def causeLogDirFailure(failureType: LogDirFailureType, leaderBroker: KafkaBroker, partition: TopicPartition): Unit = {
     // Make log directory of the partition on the leader broker inaccessible by replacing it with a file
-    val localLog = leaderServer.replicaManager.localLogOrException(partition)
+    val localLog = leaderBroker.replicaManager.localLogOrException(partition)
     val logDir = localLog.dir.getParentFile
     CoreUtils.swallow(Utils.delete(logDir), this)
     logDir.createNewFile()
     assertTrue(logDir.isFile)
 
     if (failureType == Roll) {
-      assertThrows(classOf[KafkaStorageException], () => leaderServer.replicaManager.getLog(partition).get.roll())
+      assertThrows(classOf[KafkaStorageException], () => leaderBroker.replicaManager.getLog(partition).get.roll())
     } else if (failureType == Checkpoint) {
-      leaderServer.replicaManager.checkpointHighWatermarks()
+      leaderBroker.replicaManager.checkpointHighWatermarks()
     }
 
     // Wait for ReplicaHighWatermarkCheckpoint to happen so that the log directory of the topic will be offline
-    waitUntilTrue(() => !leaderServer.logManager.isLogDirOnline(logDir.getAbsolutePath), "Expected log directory offline", 3000L)
-    assertTrue(leaderServer.replicaManager.localLog(partition).isEmpty)
+    waitUntilTrue(() => !leaderBroker.logManager.isLogDirOnline(logDir.getAbsolutePath), "Expected log directory offline", 3000L)
+    assertTrue(leaderBroker.replicaManager.localLog(partition).isEmpty)
   }
 
   /**
@@ -1450,14 +1583,15 @@ object TestUtils extends Logging {
     assertTrue(exceptions.isEmpty, s"$message failed with exception(s) $exceptions")
   }
 
-  def consumeTopicRecords[K, V](servers: Seq[KafkaServer],
-                                topic: String,
-                                numMessages: Int,
-                                groupId: String = "group",
-                                securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT,
-                                trustStoreFile: Option[File] = None,
-                                waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Seq[ConsumerRecord[Array[Byte], Array[Byte]]] = {
-    val consumer = createConsumer(TestUtils.getBrokerListStrFromServers(servers, securityProtocol),
+  def consumeTopicRecords[K, V, B <: KafkaBroker](
+      brokers: Seq[B],
+      topic: String,
+      numMessages: Int,
+      groupId: String = "group",
+      securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT,
+      trustStoreFile: Option[File] = None,
+      waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Seq[ConsumerRecord[Array[Byte], Array[Byte]]] = {
+    val consumer = createConsumer(TestUtils.getBrokerListStrFromServers(brokers, securityProtocol),
       groupId = groupId,
       securityProtocol = securityProtocol,
       trustStoreFile = trustStoreFile)
@@ -1507,16 +1641,17 @@ object TestUtils extends Logging {
     records
   }
 
-  def createTransactionalProducer(transactionalId: String,
-                                  servers: Seq[KafkaServer],
-                                  batchSize: Int = 16384,
-                                  transactionTimeoutMs: Long = 60000,
-                                  maxBlockMs: Long = 60000,
-                                  deliveryTimeoutMs: Int = 120000,
-                                  requestTimeoutMs: Int = 30000,
-                                  maxInFlight: Int = 5): KafkaProducer[Array[Byte], Array[Byte]] = {
+  def createTransactionalProducer[B <: KafkaBroker](
+      transactionalId: String,
+      brokers: Seq[B],
+      batchSize: Int = 16384,
+      transactionTimeoutMs: Long = 60000,
+      maxBlockMs: Long = 60000,
+      deliveryTimeoutMs: Int = 120000,
+      requestTimeoutMs: Int = 30000,
+      maxInFlight: Int = 5): KafkaProducer[Array[Byte], Array[Byte]] = {
     val props = new Properties()
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokerListStrFromServers(servers))
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokerListStrFromServers(brokers))
     props.put(ProducerConfig.ACKS_CONFIG, "all")
     props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize.toString)
     props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
@@ -1530,10 +1665,13 @@ object TestUtils extends Logging {
   }
 
   // Seeds the given topic with records with keys and values in the range [0..numRecords)
-  def seedTopicWithNumberedRecords(topic: String, numRecords: Int, servers: Seq[KafkaServer]): Unit = {
+  def seedTopicWithNumberedRecords[B <: KafkaBroker](
+      topic: String,
+      numRecords: Int,
+      brokers: Seq[B]): Unit = {
     val props = new Properties()
     props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokerListStrFromServers(servers))
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokerListStrFromServers(brokers))
     val producer = new KafkaProducer[Array[Byte], Array[Byte]](props, new ByteArraySerializer, new ByteArraySerializer)
     try {
       for (i <- 0 until numRecords) {
@@ -1601,8 +1739,30 @@ object TestUtils extends Logging {
     }
   }
 
-  def incrementalAlterConfigs(servers: Seq[KafkaServer], adminClient: Admin, props: Properties,
-                              perBrokerConfig: Boolean, opType: OpType = OpType.SET): AlterConfigsResult  = {
+  def fetchEntityConfigWithAdmin[B <: KafkaBroker](
+        configResource: ConfigResource,
+        brokers: Seq[B],
+        adminConfig: Properties = new Properties): Properties = {
+    val properties = new Properties()
+    val adminClient = createAdminClient(brokers, adminConfig)
+    try {
+      val result = adminClient.describeConfigs(Collections.singletonList(configResource)).all().get()
+      val config = result.get(configResource)
+      if (config != null) {
+        config.entries().forEach(e => properties.setProperty(e.name(), e.value()))
+      }
+    } finally {
+      adminClient.close()
+    }
+    properties
+  }
+
+  def incrementalAlterConfigs[B <: KafkaBroker](
+      servers: Seq[B],
+      adminClient: Admin,
+      props: Properties,
+      perBrokerConfig: Boolean,
+      opType: OpType = OpType.SET): AlterConfigsResult  = {
     val configEntries = props.asScala.map { case (k, v) => new AlterConfigOp(new ConfigEntry(k, v), opType) }.toList.asJavaCollection
     val configs = if (perBrokerConfig) {
       servers.map { server =>
@@ -1638,6 +1798,37 @@ object TestUtils extends Logging {
       val nodes = client.describeCluster().nodes().get()
       nodes.asScala.exists(_.id == brokerId)
     }, s"Timed out waiting for brokerId $brokerId to come online")
+  }
+
+  def getReplicaAssignmentForTopics[B <: KafkaBroker](
+      topicNames: Seq[String],
+      brokers: Seq[B],
+      adminConfig: Properties = new Properties): Map[TopicPartition, Seq[Int]] = {
+    val adminClient = createAdminClient(brokers, adminConfig)
+    val results = new mutable.HashMap[TopicPartition, Seq[Int]]
+    try {
+      adminClient.describeTopics(topicNames.toList.asJava).topicNameValues().forEach {
+        case (topicName, future) =>
+          try {
+            val description = future.get()
+            description.partitions().forEach {
+              case partition =>
+                val topicPartition = new TopicPartition(topicName, partition.partition())
+                results.put(topicPartition, partition.replicas().asScala.map(_.id))
+            }
+          } catch {
+            case e: ExecutionException => if (e.getCause != null &&
+              e.getCause.isInstanceOf[UnknownTopicOrPartitionException]) {
+              // ignore
+            } else {
+              throw e
+            }
+          }
+      }
+    } finally {
+      adminClient.close()
+    }
+    results
   }
 
   def waitForLeaderToBecome(
@@ -1757,8 +1948,8 @@ object TestUtils extends Logging {
       s" does not contain expected error message : $message"))
   }
 
-  def totalMetricValue(server: KafkaServer, metricName: String): Long = {
-    totalMetricValue(server.metrics, metricName)
+  def totalMetricValue(broker: KafkaBroker, metricName: String): Long = {
+    totalMetricValue(broker.metrics, metricName)
   }
 
   def totalMetricValue(metrics: Metrics, metricName: String): Long = {
@@ -1873,8 +2064,8 @@ object TestUtils extends Logging {
       s"There still are ongoing reassignments", pause = pause)
   }
 
-  def addAndVerifyAcls(server: KafkaServer, acls: Set[AccessControlEntry], resource: ResourcePattern): Unit = {
-    val authorizer = server.dataPlaneRequestProcessor.authorizer.get
+  def addAndVerifyAcls(broker: KafkaBroker, acls: Set[AccessControlEntry], resource: ResourcePattern): Unit = {
+    val authorizer = broker.dataPlaneRequestProcessor.authorizer.get
     val aclBindings = acls.map { acl => new AclBinding(resource, acl) }
     authorizer.createAcls(null, aclBindings.toList.asJava).asScala
       .map(_.toCompletableFuture.get)
@@ -1887,8 +2078,8 @@ object TestUtils extends Logging {
       authorizer, resource)
   }
 
-  def removeAndVerifyAcls(server: KafkaServer, acls: Set[AccessControlEntry], resource: ResourcePattern): Unit = {
-    val authorizer = server.dataPlaneRequestProcessor.authorizer.get
+  def removeAndVerifyAcls(broker: KafkaBroker, acls: Set[AccessControlEntry], resource: ResourcePattern): Unit = {
+    val authorizer = broker.dataPlaneRequestProcessor.authorizer.get
     val aclBindingFilters = acls.map { acl => new AclBindingFilter(resource.toFilter, acl.toFilter) }
     authorizer.deleteAcls(null, aclBindingFilters.toList.asJava).asScala
       .map(_.toCompletableFuture.get)


### PR DESCRIPTION
Make TestUtils usable for KRaft mode by using KafkaBroker instead of KafkaServer where appropriate,
and adding some alternate functions that use AdminClient instead of ZooKeeper.