### PR TITLE
MINOR: Write log differently according to the size of missingListenerPartitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1080,8 +1080,13 @@ public class NetworkClient implements KafkaClient {
                 .collect(Collectors.toList());
             if (!missingListenerPartitions.isEmpty()) {
                 int count = missingListenerPartitions.size();
-                log.warn("{} partitions have leader brokers without a matching listener, including {}",
-                        count, missingListenerPartitions.subList(0, Math.min(10, count)));
+                if (count == 1) {
+                    log.warn("{} partition has a leader broker without a matching listener, which is {}",
+                            count, missingListenerPartitions.get(0));
+                } else {
+                    log.warn("{} partitions have leader brokers without a matching listener, including {}",
+                            count, missingListenerPartitions.subList(0, Math.min(10, count)));
+                }
             }
 
             // Check if any topic's metadata failed to get updated

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1080,13 +1080,11 @@ public class NetworkClient implements KafkaClient {
                 .collect(Collectors.toList());
             if (!missingListenerPartitions.isEmpty()) {
                 int count = missingListenerPartitions.size();
-                if (count == 1) {
-                    log.warn("{} partition has a leader broker without a matching listener, which is {}",
-                            count, missingListenerPartitions.get(0));
-                } else {
-                    log.warn("{} partitions have leader brokers without a matching listener, including {}",
-                            count, missingListenerPartitions.subList(0, Math.min(10, count)));
-                }
+                String logStatement = "{} partition" +
+                    (count > 1 ? "s have leader brokers" : " has a leader broker") +
+                    " without a matching listener, " +
+                    (count > 1 ? "including " : "which is ") + "{}";
+                log.warn(logStatement, count, missingListenerPartitions.subList(0, Math.min(10, count)));
             }
 
             // Check if any topic's metadata failed to get updated


### PR DESCRIPTION
I think it may seem a little awkward when I got a log like below,

```
1 partitions have leader brokers without a matching listener, including [...]
```

So I divided it to 2 types:

```
// When more than one partition (* Same as the original)
2 partitions have leader brokers without a matching listener, including [...]
```

```
// When only one partition
1 partition has a leader broker without a matching listener, which is ...
```





### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
