### PR TITLE
KAFKA-12648: extend IQ APIs to work with named topologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParameters.java
@@ -30,7 +30,7 @@ public class StoreQueryParameters<T> {
     private final String storeName;
     private final QueryableStoreType<T> queryableStoreType;
 
-    private StoreQueryParameters(final String storeName, final QueryableStoreType<T>  queryableStoreType, final Integer partition, final boolean staleStores) {
+    protected StoreQueryParameters(final String storeName, final QueryableStoreType<T>  queryableStoreType, final Integer partition, final boolean staleStores) {
         this.storeName = storeName;
         this.queryableStoreType = queryableStoreType;
         this.partition = partition;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.namedtopology;
+
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.state.QueryableStoreType;
+
+import java.util.Objects;
+
+public class NamedTopologyStoreQueryParameters<T> extends StoreQueryParameters<T> {
+
+    final String topologyName;
+
+    private NamedTopologyStoreQueryParameters(final String topologyName,
+                                              final String storeName,
+                                              final QueryableStoreType<T>  queryableStoreType,
+                                              final Integer partition,
+                                              final boolean staleStores) {
+        super(storeName, queryableStoreType, partition, staleStores);
+        this.topologyName = topologyName;
+    }
+
+    public static <T> StoreQueryParameters<T> fromNamedTopologyAndStoreNameAndType(final String topologyName,
+                                                                                   final String storeName,
+                                                                                   final QueryableStoreType<T> queryableStoreType) {
+        return new NamedTopologyStoreQueryParameters<>(topologyName, storeName, queryableStoreType, null, false);
+    }
+
+    public String topologyName() {
+        return topologyName;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final NamedTopologyStoreQueryParameters<?> that = (NamedTopologyStoreQueryParameters<?>) o;
+
+        return Objects.equals(topologyName, that.topologyName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (topologyName != null ? topologyName.hashCode() : 0);
+        return result;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStoreQueryParameters;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
@@ -42,12 +43,17 @@ public class StreamThreadStateStoreProvider {
 
     @SuppressWarnings("unchecked")
     public <T> List<T> stores(final StoreQueryParameters storeQueryParams) {
-        final String storeName = storeQueryParams.storeName();
-        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
-        if (streamThread.state() == StreamThread.State.DEAD) {
+        final StreamThread.State state = streamThread.state();
+        if (state == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }
-        final StreamThread.State state = streamThread.state();
+
+        final String storeName = storeQueryParams.storeName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
+        final String topologyName = storeQueryParams instanceof NamedTopologyStoreQueryParameters ?
+            ((NamedTopologyStoreQueryParameters) storeQueryParams).topologyName() :
+            null;
+
         if (storeQueryParams.staleStoresEnabled() ? state.isAlive() : state == StreamThread.State.RUNNING) {
             final Collection<Task> tasks = storeQueryParams.staleStoresEnabled() ?
                     streamThread.allTasks().values() : streamThread.activeTasks();
@@ -55,6 +61,7 @@ public class StreamThreadStateStoreProvider {
             if (storeQueryParams.partition() != null) {
                 for (final Task task : tasks) {
                     if (task.id().partition() == storeQueryParams.partition() &&
+                        (topologyName == null || topologyName.equals(task.id().topologyName())) &&
                         task.getStore(storeName) != null &&
                         storeName.equals(task.getStore(storeName).name())) {
                         final T typedStore = validateAndCastStores(task.getStore(storeName), queryableStoreType, storeName, task.id());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -36,8 +36,11 @@ import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStoreQueryParameters;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStreamsBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.utils.UniqueTopicSerdeScope;
 import org.apache.kafka.test.TestUtils;
@@ -310,6 +313,9 @@ public class NamedTopologyIntegrationTest {
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
+
+        final ReadOnlyKeyValueStore<String, Long> store = streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("topology-1", "store", QueryableStoreTypes.keyValueStore()));
+        assertThat(store.get("A"), equalTo(2L));
     }
 
     @Test


### PR DESCRIPTION
In the new NamedTopology API being worked on, state store names and their uniqueness requirement is going to be scoped only to the owning topology, rather than to the entire app. In other words, two different named topologies can have different state stores with the same name.

This is going to cause problems for some of the existing IQ APIs which require only a name to resolve the underlying state store. We're now going to need to take in the topology name in addition to the state store name to be able to locate the specific store a user wants to query