### PR TITLE
KAFKA-13393 Documentation - Add missing arguments to create a topic

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -90,7 +90,7 @@ $ bin/kafka-server-start.sh config/server.properties</code></pre>
             So before you can write your first events, you must create a topic.  Open another terminal session and run:
         </p>
 
-        <pre class="line-numbers"><code class="language-bash">$ bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092</code></pre>
+        <pre class="line-numbers"><code class="language-bash">$ bin/kafka-topics.sh --create --topic quickstart-events --partitions 1 --replication-factor 1 --bootstrap-server localhost:9092</code></pre>
 
         <p>
             All of Kafka's command line tools have additional options: run the <code>kafka-topics.sh</code> command without any


### PR DESCRIPTION
In the quickstart documentation (quickstart_createtopic) , there is a command specified to create a topic:

 `$ bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092`

However, it is no longer working due to missing arguments:
  - partitions
  - replications-factor

The previous command should be replaced with this one:

 `$ bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1`
