### PR TITLE
KAFKA-13391: don't fsync directory on Windows OS

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -948,7 +948,7 @@ public final class Utils {
     /**
      * Flushes dirty directories to guarantee crash consistency.
      *
-     * Note: We don't fsync directory on Windows OS because it'll throw AccessDeniedException (KAFKA-13391)
+     * Note: We don't fsync directories on Windows OS because otherwise it'll throw AccessDeniedException (KAFKA-13391)
      *
      * @throws IOException if flushing the directory fails.
      */

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -948,10 +948,12 @@ public final class Utils {
     /**
      * Flushes dirty directories to guarantee crash consistency.
      *
+     * Note: We don't fsync directory on Windows OS because it'll throw AccessDeniedException (KAFKA-13391)
+     *
      * @throws IOException if flushing the directory fails.
      */
     public static void flushDir(Path path) throws IOException {
-        if (path != null) {
+        if (path != null && !OperatingSystem.IS_WINDOWS) {
             try (FileChannel dir = FileChannel.open(path, StandardOpenOption.READ)) {
                 dir.force(true);
             }


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/10680, we added `fysnc` on dir to maintain crash consistency. But, it looks like Windows OS doesn't support `fsync` on directory. The same issues also happen on [LUCENE](https://issues.apache.org/jira/browse/LUCENE-5588) and [HDFS](https://issues.apache.org/jira/browse/HDFS-13586) projects. And the way they fix it is pretty much the same: to skip fsync directory on Windows OS. Here are the patches for both [LUCENE-5588](https://patch-diff.githubusercontent.com/raw/apache/lucenenet/pull/43.patch) and [HDFS-13586](https://issues.apache.org/jira/secure/attachment/12924032/HDFS-13586.001.patch). 

I followed their way to fix this issue. No tests added since it's just an OS check added, no logic change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
