### PR TITLE
KAFKA-13396: allow create topic without partition/replicaFactor

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -625,8 +625,6 @@ object TopicCommand extends Logging {
       }
       if (!has(listOpt) && !has(describeOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, topicOpt)
-      if (has(createOpt) && !has(replicaAssignmentOpt))
-        CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt, replicationFactorOpt)
       if (has(alterOpt)) {
         CommandLineUtils.checkInvalidArgsSet(parser, options, Set(bootstrapServerOpt, configOpt), Set(alterOpt),
         Some(kafkaConfigsCanAlterTopicConfigsViaBootstrapServer))

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -82,23 +82,23 @@ class TopicCommandTest {
   }
 
   @Test
-  def testCreateWithPartitionCountWithoutReplicationFactor(): Unit = {
-    assertCheckArgsExitCode(1,
-      new TopicCommandOptions(
-        Array("--bootstrap-server", brokerList,
-          "--create",
-          "--partitions", "2",
-          "--topic", topicName)))
+  def testCreateWithPartitionCountWithoutReplicationFactorShouldSucceed(): Unit = {
+    val opts = new TopicCommandOptions(
+      Array("--bootstrap-server", brokerList,
+        "--create",
+        "--partitions", "2",
+        "--topic", topicName))
+    opts.checkArgs()
   }
 
   @Test
-  def testCreateWithReplicationFactorWithoutPartitionCount(): Unit = {
-    assertCheckArgsExitCode(1,
-      new TopicCommandOptions(
-        Array("--bootstrap-server", brokerList,
-          "--create",
-          "--replication-factor", "3",
-          "--topic", topicName)))
+  def testCreateWithReplicationFactorWithoutPartitionCountShouldSucceed(): Unit = {
+    val opts = new TopicCommandOptions(
+      Array("--bootstrap-server", brokerList,
+        "--create",
+        "--replication-factor", "3",
+        "--topic", topicName))
+    opts.checkArgs()
   }
 
   @Test
@@ -122,6 +122,25 @@ class TopicCommandTest {
           "--replication-factor", "2",
           "--topic", topicName)))
   }
+
+  @Test
+  def testCreateWithoutPartitionCountAndReplicationFactorShouldSucceed(): Unit = {
+    val opts = new TopicCommandOptions(
+      Array("--bootstrap-server", brokerList,
+        "--create",
+        "--topic", topicName))
+    opts.checkArgs()
+  }
+
+  @Test
+  def testDescribeShouldSucceed(): Unit = {
+    val opts = new TopicCommandOptions(
+      Array("--bootstrap-server", brokerList,
+        "--describe",
+        "--topic", topicName))
+    opts.checkArgs()
+  }
+
 
   @Test
   def testParseAssignmentDuplicateEntries(): Unit = {


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/10457/files#r635196307, the reviewer asked if there's a bug that we only check for zookeeper case, I didn't do a well check and directly confirm it. Now, after checking the change history, I found the change is because the [KIP-464](https://cwiki.apache.org/confluence/display/KAFKA/KIP-464%3A+Defaults+for+AdminClient%23createTopic) (PR: https://github.com/apache/kafka/pull/6728) added default values for partition count and replica factor for createTopic in AdminClient. So it didn't apply for zookeeper option case. 

Fix this bug and add tests for the command lines in quick start (i.e. create topic and describe topic), to make sure it won't be broken in the future.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
