### PR TITLE
KAFKA-13352: Kafka Client does not support passwords starting with number in jaas config

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
@@ -50,12 +50,7 @@ class JaasConfig extends Configuration {
     private final List<AppConfigurationEntry> configEntries;
 
     public JaasConfig(String loginContextName, String jaasConfigParams) {
-        // All characters except space, comment, quote, equal and semicolon are considered to be alphabetic.
-        // Tokenizer rules:
-        // 1. All bytes from 0 to 32 ({@code ' '}) are considered to be whitespace.
-        // 2. {@code '/'} (47) is a comment character. '//', '/*', '*/' are also allowed.
-        // 3. Single quote ({@code '\u005C''}, 39) and double quote ({@code '"'}, 34) are considered to be quote.
-        // 4. Ends of lines are treated as white space, not as separate tokens.
+        // A-Z, a-z, $, _, -, * are treated as a character; If you have to mix numbers or other symbols, use quote.
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
         tokenizer.quoteChar('"');       // '"' is treated as a quote.
         tokenizer.wordChars('$', '$');  // '$' symbol is allowed.

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
@@ -57,17 +57,17 @@ class JaasConfig extends Configuration {
         // 3. Single quote ({@code '\u005C''}, 39) and double quote ({@code '"'}, 34) are considered to be quote.
         // 4. Ends of lines are treated as white space, not as separate tokens.
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
-        tokenizer.resetSyntax();
-        tokenizer.wordChars(32, 128);
-        tokenizer.wordChars(128 + 32, 255);
-        tokenizer.ordinaryChar(';');
-        tokenizer.ordinaryChar('=');
-        tokenizer.whitespaceChars(0, ' ');
-        tokenizer.commentChar('/');
-        tokenizer.quoteChar('"');
-        tokenizer.quoteChar('\'');
-        tokenizer.slashSlashComments(true);
-        tokenizer.slashStarComments(true);
+        tokenizer.resetSyntax();            // Reset the default configuration.
+        tokenizer.wordChars(32, 128);       // All characters in [32, 128] are allowed.
+        tokenizer.wordChars(128 + 32, 255); // All characters in [160, 255] are allowed.
+        tokenizer.ordinaryChar(';');        // ';' is treated as a reserved word.
+        tokenizer.ordinaryChar('=');        // '=' is treated as a reserved word.
+        tokenizer.whitespaceChars(0, ' ');  // All characters in [0, 32] (including ' ') are treated as space character.
+        tokenizer.commentChar('/');         // '/' is treated as a comment character.
+        tokenizer.quoteChar('"');           // '"' is treated as a quote.
+        tokenizer.quoteChar('\'');          // ''' is treated as a quote.
+        tokenizer.slashSlashComments(true); // Allow '//' comments.
+        tokenizer.slashStarComments(true);  // Allow '/*', '*/' comments.
 
         try {
             configEntries = new ArrayList<>();

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
@@ -50,6 +50,12 @@ class JaasConfig extends Configuration {
     private final List<AppConfigurationEntry> configEntries;
 
     public JaasConfig(String loginContextName, String jaasConfigParams) {
+        // A-Z, a-z, -, _, $ are considered to be alphabetic.
+        // All bytes from 0 to ' ' {@code ' '} are considered to be whitespace.
+        // '/' {@code '/'} is a comment character. '//', '/*', '*/' are also allowed.
+        // Single quote {@code '\u005C''} and double quote {@code '"'} are considered to be quote.
+        // Numbered are parsed, but can't be a part of alphabetic string.
+        // Ends of lines are treated as white space, not as separate tokens.
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
         tokenizer.slashSlashComments(true);
         tokenizer.slashStarComments(true);

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
@@ -51,14 +51,14 @@ class JaasConfig extends Configuration {
 
     public JaasConfig(String loginContextName, String jaasConfigParams) {
         // All characters except space, comment, quote, equal and semicolon are considered to be alphabetic.
-        // That is, numbers or symbols like '@' now can be a part of a word.
-        // All bytes from 0 to ' ' {@code ' '} are considered to be whitespace.
-        // '/' {@code '/'} is a comment character. '//', '/*', '*/' are also allowed.
-        // Single quote {@code '\u005C''} and double quote {@code '"'} are considered to be quote.
-        // Ends of lines are treated as white space, not as separate tokens.
+        // Tokenizer rules:
+        // 1. All bytes from 0 to 32 ({@code ' '}) are considered to be whitespace.
+        // 2. {@code '/'} (47) is a comment character. '//', '/*', '*/' are also allowed.
+        // 3. Single quote ({@code '\u005C''}, 39) and double quote ({@code '"'}, 34) are considered to be quote.
+        // 4. Ends of lines are treated as white space, not as separate tokens.
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
         tokenizer.resetSyntax();
-        tokenizer.wordChars(32, 128); //
+        tokenizer.wordChars(32, 128);
         tokenizer.wordChars(128 + 32, 255);
         tokenizer.ordinaryChar(';');
         tokenizer.ordinaryChar('=');

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
@@ -57,17 +57,15 @@ class JaasConfig extends Configuration {
         // 3. Single quote ({@code '\u005C''}, 39) and double quote ({@code '"'}, 34) are considered to be quote.
         // 4. Ends of lines are treated as white space, not as separate tokens.
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
-        tokenizer.resetSyntax();            // Reset the default configuration.
-        tokenizer.wordChars(32, 128);       // All characters in [32, 128] are allowed.
-        tokenizer.wordChars(128 + 32, 255); // All characters in [160, 255] are allowed.
-        tokenizer.ordinaryChar(';');        // ';' is treated as a reserved word.
-        tokenizer.ordinaryChar('=');        // '=' is treated as a reserved word.
-        tokenizer.whitespaceChars(0, ' ');  // All characters in [0, 32] (including ' ') are treated as space character.
-        tokenizer.commentChar('/');         // '/' is treated as a comment character.
-        tokenizer.quoteChar('"');           // '"' is treated as a quote.
-        tokenizer.quoteChar('\'');          // ''' is treated as a quote.
+        tokenizer.quoteChar('"');       // '"' is treated as a quote.
+        tokenizer.wordChars('$', '$');  // '$' symbol is allowed.
+        tokenizer.wordChars('_', '_');  // '_' symbol is allowed.
+        tokenizer.wordChars('-', '-');  // '-' symbol is allowed.
+        tokenizer.wordChars('*', '*');  // '*' symbol is allowed.
+        tokenizer.lowerCaseMode(false);
         tokenizer.slashSlashComments(true); // Allow '//' comments.
         tokenizer.slashStarComments(true);  // Allow '/*', '*/' comments.
+        tokenizer.eolIsSignificant(true);
 
         try {
             configEntries = new ArrayList<>();

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java
@@ -50,18 +50,24 @@ class JaasConfig extends Configuration {
     private final List<AppConfigurationEntry> configEntries;
 
     public JaasConfig(String loginContextName, String jaasConfigParams) {
-        // A-Z, a-z, -, _, $ are considered to be alphabetic.
+        // All characters except space, comment, quote, equal and semicolon are considered to be alphabetic.
+        // That is, numbers or symbols like '@' now can be a part of a word.
         // All bytes from 0 to ' ' {@code ' '} are considered to be whitespace.
         // '/' {@code '/'} is a comment character. '//', '/*', '*/' are also allowed.
         // Single quote {@code '\u005C''} and double quote {@code '"'} are considered to be quote.
-        // Numbered are parsed, but can't be a part of alphabetic string.
         // Ends of lines are treated as white space, not as separate tokens.
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
+        tokenizer.resetSyntax();
+        tokenizer.wordChars(32, 128); //
+        tokenizer.wordChars(128 + 32, 255);
+        tokenizer.ordinaryChar(';');
+        tokenizer.ordinaryChar('=');
+        tokenizer.whitespaceChars(0, ' ');
+        tokenizer.commentChar('/');
+        tokenizer.quoteChar('"');
+        tokenizer.quoteChar('\'');
         tokenizer.slashSlashComments(true);
         tokenizer.slashStarComments(true);
-        tokenizer.wordChars('-', '-');
-        tokenizer.wordChars('_', '_');
-        tokenizer.wordChars('$', '$');
 
         try {
             configEntries = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -181,6 +181,16 @@ public class JaasContextTest {
     }
 
     @Test
+    public void testNumericWord() throws Exception {
+        checkInvalidConfiguration("test.testInvalidControlFlag required password=k3fka;");  // should be a valid config.
+    }
+
+    @Test
+    public void testSymbolicWord() throws Exception {
+        checkInvalidConfiguration("test.testInvalidControlFlag required password=kafk@;");  // should be a valid config.
+    }
+
+    @Test
     public void testNumericOptionWithQuotes() throws Exception {
         Map<String, Object> options = new HashMap<>();
         options.put("option1", "3");

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -188,6 +188,20 @@ public class JaasContextTest {
     }
 
     @Test
+    public void testNumericWordStart() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("password", "1afka");
+        checkConfiguration("test.testNumericWordStart required password=\"1afka\";", "test.testNumericWordStart", LoginModuleControlFlag.REQUIRED, options);
+    }
+
+    @Test
+    public void testSymbolicWordStart() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("password", "#afka");
+        checkConfiguration("test.testSymbolicWordStart required password=\"#afka\";", "test.testSymbolicWordStart", LoginModuleControlFlag.REQUIRED, options);
+    }
+
+    @Test
     public void testNumericWord() throws Exception {
         Map<String, Object> options = new HashMap<>();
         options.put("password", "k3fka");
@@ -202,10 +216,10 @@ public class JaasContextTest {
     }
 
     @Test
-    public void testNumericCanBePartOfAWord() throws Exception {
+    public void testNumericAndSymbolicAWord() throws Exception {
         Map<String, Object> options = new HashMap<>();
         options.put("option1", "k2fk@");
-        checkConfiguration("test.testNumericCanBePartOfAWord required option1=\"k2fk@\";", "test.testNumericCanBePartOfAWord", LoginModuleControlFlag.REQUIRED, options);
+        checkConfiguration("test.testNumericAndSymbolicAWord required option1=\"k2fk@\";", "test.testNumericAndSymbolicAWord", LoginModuleControlFlag.REQUIRED, options);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -172,7 +172,14 @@ public class JaasContextTest {
 
     @Test
     public void testNumericOptionWithoutQuotes() throws Exception {
-        checkInvalidConfiguration("test.testNumericOptionWithoutQuotes required option1=3;");
+        try {
+            Map<String, Object> options = new HashMap<>();
+            options.put("option", "3");
+            checkConfiguration("test.testNumericOptionWithoutQuotes required option=3;", "test.testNumericOptionWithoutQuotes", LoginModuleControlFlag.REQUIRED, options);
+            fail("Given Jaas config is parsed properly but sun.security.provider.ConfigFile$Spi.<init> throws a IOException wrapped with a SecurityException.");
+        } catch (SecurityException e) {
+            assertEquals(IOException.class, e.getCause().getClass());
+        }
     }
 
     @Test
@@ -182,12 +189,23 @@ public class JaasContextTest {
 
     @Test
     public void testNumericWord() throws Exception {
-        checkInvalidConfiguration("test.testInvalidControlFlag required password=k3fka;");  // should be a valid config.
+        Map<String, Object> options = new HashMap<>();
+        options.put("password", "k3fka");
+        checkConfiguration("test.testNumericWord required password=\"k3fka\";", "test.testNumericWord", LoginModuleControlFlag.REQUIRED, options);
     }
 
     @Test
     public void testSymbolicWord() throws Exception {
-        checkInvalidConfiguration("test.testInvalidControlFlag required password=kafk@;");  // should be a valid config.
+        Map<String, Object> options = new HashMap<>();
+        options.put("password", "kafk@");
+        checkConfiguration("test.testSymbolicWord required password=\"kafk@\";", "test.testSymbolicWord", LoginModuleControlFlag.REQUIRED, options);
+    }
+
+    @Test
+    public void testNumericCanBePartOfAWord() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("option1", "k2fk@");
+        checkConfiguration("test.testNumericCanBePartOfAWord required option1=\"k2fk@\";", "test.testNumericCanBePartOfAWord", LoginModuleControlFlag.REQUIRED, options);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -172,19 +172,19 @@ public class JaasContextTest {
 
     @Test
     public void testNumericOptionWithoutQuotes() throws Exception {
-        try {
-            Map<String, Object> options = new HashMap<>();
-            options.put("option", "3");
-            checkConfiguration("test.testNumericOptionWithoutQuotes required option=3;", "test.testNumericOptionWithoutQuotes", LoginModuleControlFlag.REQUIRED, options);
-            fail("Given Jaas config is parsed properly but sun.security.provider.ConfigFile$Spi.<init> throws a IOException wrapped with a SecurityException.");
-        } catch (SecurityException e) {
-            assertEquals(IOException.class, e.getCause().getClass());
-        }
+        checkInvalidConfiguration("test.testNumericOptionWithoutQuotes required option1=3;");
     }
 
     @Test
     public void testInvalidControlFlag() throws Exception {
         checkInvalidConfiguration("test.testInvalidControlFlag { option1=3;");
+    }
+
+    @Test
+    public void testAsterisk() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("option", "*");
+        checkConfiguration("test.testAsterisk required option=*;", "test.testAsterisk", LoginModuleControlFlag.REQUIRED, options);
     }
 
     @Test


### PR DESCRIPTION
As I left in the comments, the `StreamTokenizer` used by `org.apache.kafka.common.security.JaasConfig` recognizes alphabetical characters, dash, underscore, and dollar sign as a 'word' only. (see [here](https://github.com/AdoptOpenJDK/openjdk-jdk9u/blob/master/jdk/src/java.base/share/classes/java/io/StreamTokenizer.java#L188)) Because of that, a string that contains a number or a symbol like '^' (which are so common in the password) raises an error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
