### PR TITLE
KAFKA-13399 towards scala3

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -238,14 +238,14 @@ object ReassignPartitionsCommand extends Logging {
       executeAssignment(adminClient,
         opts.options.has(opts.additionalOpt),
         Utils.readFileAsString(opts.options.valueOf(opts.reassignmentJsonFileOpt)),
-        opts.options.valueOf(opts.interBrokerThrottleOpt),
-        opts.options.valueOf(opts.replicaAlterLogDirsThrottleOpt),
-        opts.options.valueOf(opts.timeoutOpt))
+        opts.options.valueOf(opts.interBrokerThrottleOpt).longValue(),
+        opts.options.valueOf(opts.replicaAlterLogDirsThrottleOpt).longValue(),
+        opts.options.valueOf(opts.timeoutOpt).longValue())
     } else if (opts.options.has(opts.cancelOpt)) {
       cancelAssignment(adminClient,
         Utils.readFileAsString(opts.options.valueOf(opts.reassignmentJsonFileOpt)),
         opts.options.has(opts.preserveThrottlesOpt),
-        opts.options.valueOf(opts.timeoutOpt))
+        opts.options.valueOf(opts.timeoutOpt).longValue())
     } else if (opts.options.has(opts.listOpt)) {
       listReassignments(adminClient)
     } else {

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -22,7 +22,7 @@ import java.util.{Collections, Properties}
 import joptsimple._
 import kafka.common.AdminCommandFailedException
 import kafka.log.LogConfig
-import kafka.utils._
+import kafka.utils.{immutable=> _, _}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.CreatePartitionsOptions
 import org.apache.kafka.clients.admin.CreateTopicsOptions

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -485,7 +485,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
     } else {
       val (logConfigs, failed) = zkClient.getLogConfigs(
         partitionsWithNoLiveInSyncReplicas.iterator.map { case (partition, _) => partition.topic }.toSet,
-        config.originals()
+        config.originals
       )
 
       partitionsWithNoLiveInSyncReplicas.map { case (partition, leaderAndIsr) =>

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -34,7 +34,7 @@ import kafka.metrics.KafkaMetricsGroup
 import kafka.server.{FetchLogEnd, ReplicaManager, RequestLocal}
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Implicits._
-import kafka.utils._
+import kafka.utils.{immutable=> _, _}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.internals.Topic

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -175,7 +175,7 @@ case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] 
   }
 
   def overriddenConfigsAsLoggableString: String = {
-    val overriddenTopicProps = props.asScala.collect {
+    val overriddenTopicProps: Map[String, Object] = props.asScala.collect {
       case (k: String, v) if overriddenConfigs.contains(k) => (k, v.asInstanceOf[AnyRef])
     }
     ConfigUtils.configMapToRedactedString(overriddenTopicProps.asJava, configDef)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -355,7 +355,7 @@ class LogManager(logDirs: Seq[File],
               s"$logDirAbsolutePath, resetting to the base offset of the first segment", e)
         }
 
-        val logsToLoad = Option(dir.listFiles).getOrElse(Array.empty).filter(logDir =>
+        val logsToLoad = Option(dir.listFiles).getOrElse(Array.empty[File]).filter(logDir =>
           logDir.isDirectory && UnifiedLog.parseTopicPartitionName(logDir).topic != KafkaRaftServer.MetadataTopic)
         val numLogsLoaded = new AtomicInteger(0)
         numTotalLogs += logsToLoad.length

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -42,11 +42,11 @@ final class KafkaMetadataLog private (
   // Access to this object needs to be synchronized because it is used by the snapshotting thread to notify the
   // polling thread when snapshots are created. This object is also used to store any opened snapshot reader.
   snapshots: mutable.TreeMap[OffsetAndEpoch, Option[FileRawSnapshotReader]],
-  topicPartition: TopicPartition,
+  topicPartitionArg: TopicPartition,
   config: MetadataLogConfig
 ) extends ReplicatedLog with Logging {
 
-  this.logIdent = s"[MetadataLog partition=$topicPartition, nodeId=${config.nodeId}] "
+  this.logIdent = s"[MetadataLog partition=$topicPartitionArg, nodeId=${config.nodeId}] "
 
   override def read(startOffset: Long, readIsolation: Isolation): LogFetchInfo = {
     val isolation = readIsolation match {
@@ -223,7 +223,7 @@ final class KafkaMetadataLog private (
    * Return the topic partition associated with the log.
    */
   override def topicPartition(): TopicPartition = {
-    topicPartition
+    topicPartitionArg
   }
 
   /**

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -150,7 +150,7 @@ class KafkaNetworkChannel(
           request.createdTimeMs,
           destination = node,
           request = buildRequest(request.data),
-          handler = onComplete
+          handler = onComplete(_)
         ))
 
       case None =>

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -427,7 +427,7 @@ class BrokerServer(
       metadataListener.startPublishing(metadataPublisher).get()
 
       // Log static broker configurations.
-      new KafkaConfig(config.originals(), true)
+      new KafkaConfig(config.originals, true)
 
       // Enable inbound TCP connections.
       socketServer.startProcessingRequests(authorizerFutures)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1980,7 +1980,7 @@ class ReplicaManager(val config: KafkaConfig,
   protected def createReplicaSelector(): Option[ReplicaSelector] = {
     config.replicaSelectorClassName.map { className =>
       val tmpReplicaSelector: ReplicaSelector = CoreUtils.createObject[ReplicaSelector](className)
-      tmpReplicaSelector.configure(config.originals())
+      tmpReplicaSelector.configure(config.originals)
       tmpReplicaSelector
     }
   }

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -759,7 +759,7 @@ class ZkAdminManager(val config: KafkaConfig,
                 props.setProperty(op.key, value.toString)
               case ConfigDef.Type.LONG | ConfigDef.Type.INT =>
                 val epsilon = 1e-6
-                val intValue = if (key.`type` == ConfigDef.Type.LONG)
+                val intValue: Long = if (key.`type` == ConfigDef.Type.LONG)
                   (value + epsilon).toLong
                 else
                   (value + epsilon).toInt

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -26,7 +26,7 @@ import kafka.metrics.KafkaMetricsGroup
 import kafka.server.ConfigAdminManager.{prepareIncrementalConfigs, toLoggableProps}
 import kafka.server.DynamicConfig.QuotaConfigs
 import kafka.server.metadata.ZkConfigRepository
-import kafka.utils._
+import kafka.utils.{immutable => _, _}
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ScramMechanism}
@@ -51,7 +51,7 @@ import org.apache.kafka.common.requests.{AlterConfigsRequest, ApiError}
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter}
 import org.apache.kafka.common.utils.Sanitizer
 
-import scala.collection.{Map, mutable, _}
+import scala.collection.{Map, _}
 import scala.jdk.CollectionConverters._
 
 class ZkAdminManager(val config: KafkaConfig,

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -27,7 +27,7 @@ import com.typesafe.scalalogging.LazyLogging
 import joptsimple._
 import kafka.utils.Implicits._
 import kafka.utils.{Exit, _}
-import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig => ClientConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.{MessageFormatter, TopicPartition}
 import org.apache.kafka.common.errors.{AuthenticationException, TimeoutException, WakeupException}
 import org.apache.kafka.common.record.TimestampType
@@ -148,11 +148,11 @@ object ConsoleConsumer extends Logging {
     props ++= config.consumerProps
     props ++= config.extraConsumerProps
     setAutoOffsetResetValue(config, props)
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
-    if (props.getProperty(ConsumerConfig.CLIENT_ID_CONFIG) == null)
-      props.put(ConsumerConfig.CLIENT_ID_CONFIG, "console-consumer")
+    props.put(ClientConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
+    if (props.getProperty(ClientConsumerConfig.CLIENT_ID_CONFIG) == null)
+      props.put(ClientConsumerConfig.CLIENT_ID_CONFIG, "console-consumer")
     CommandLineUtils.maybeMergeOptions(
-      props, ConsumerConfig.ISOLATION_LEVEL_CONFIG, config.options, config.isolationLevelOpt)
+      props, ClientConsumerConfig.ISOLATION_LEVEL_CONFIG, config.options, config.isolationLevelOpt)
     props
   }
 
@@ -170,9 +170,9 @@ object ConsoleConsumer extends Logging {
   def setAutoOffsetResetValue(config: ConsumerConfig, props: Properties): Unit = {
     val (earliestConfigValue, latestConfigValue) = ("earliest", "latest")
 
-    if (props.containsKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) {
+    if (props.containsKey(ClientConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) {
       // auto.offset.reset parameter was specified on the command line
-      val autoResetOption = props.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+      val autoResetOption = props.getProperty(ClientConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
       if (config.options.has(config.resetBeginningOpt) && earliestConfigValue != autoResetOption) {
         // conflicting options - latest und earliest, throw an error
         System.err.println(s"Can't simultaneously specify --from-beginning and 'auto.offset.reset=$autoResetOption', " +
@@ -185,7 +185,7 @@ object ConsoleConsumer extends Logging {
       // no explicit value for auto.offset.reset was specified
       // if --from-beginning was specified use earliest, otherwise default to latest
       val autoResetOption = if (config.options.has(config.resetBeginningOpt)) earliestConfigValue else latestConfigValue
-      props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoResetOption)
+      props.put(ClientConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoResetOption)
     }
   }
 
@@ -316,10 +316,10 @@ object ConsoleConsumer extends Logging {
     val formatter: MessageFormatter = messageFormatterClass.getDeclaredConstructor().newInstance().asInstanceOf[MessageFormatter]
 
     if (keyDeserializer != null && keyDeserializer.nonEmpty) {
-      formatterArgs.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer)
+      formatterArgs.setProperty(ClientConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer)
     }
     if (valueDeserializer != null && valueDeserializer.nonEmpty) {
-      formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer)
+      formatterArgs.setProperty(ClientConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer)
     }
 
     formatter.configure(formatterArgs.asScala.asJava)
@@ -372,8 +372,8 @@ object ConsoleConsumer extends Logging {
     // if the group id is provided in more than place (through different means) all values must be the same
     val groupIdsProvided = Set(
       Option(options.valueOf(groupIdOpt)), // via --group
-      Option(consumerProps.get(ConsumerConfig.GROUP_ID_CONFIG)), // via --consumer-property
-      Option(extraConsumerProps.get(ConsumerConfig.GROUP_ID_CONFIG)) // via --consumer.config
+      Option(consumerProps.get(ClientConsumerConfig.GROUP_ID_CONFIG)), // via --consumer-property
+      Option(extraConsumerProps.get(ClientConsumerConfig.GROUP_ID_CONFIG)) // via --consumer.config
     ).flatten
 
     if (groupIdsProvided.size > 1) {
@@ -384,13 +384,13 @@ object ConsoleConsumer extends Logging {
 
     groupIdsProvided.headOption match {
       case Some(group) =>
-        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, group)
+        consumerProps.put(ClientConsumerConfig.GROUP_ID_CONFIG, group)
       case None =>
-        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, s"console-consumer-${new Random().nextInt(100000)}")
+        consumerProps.put(ClientConsumerConfig.GROUP_ID_CONFIG, s"console-consumer-${new Random().nextInt(100000)}")
         // By default, avoid unnecessary expansion of the coordinator cache since
         // the auto-generated group and its offsets is not intended to be used again
-        if (!consumerProps.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
-          consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+        if (!consumerProps.containsKey(ClientConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
+          consumerProps.put(ClientConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
         groupIdPassed = false
     }
 

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -27,7 +27,7 @@ import kafka.message._
 import kafka.utils.Implicits._
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, ToolsUtils}
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig => ClientProducerConfig, ProducerRecord}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.utils.Utils
 import scala.jdk.CollectionConverters._
@@ -86,39 +86,39 @@ object ConsoleProducer {
     props ++= config.extraProducerProps
 
     if (config.bootstrapServer != null)
-      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
+      props.put(ClientProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
     else
-      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokerList)
+      props.put(ClientProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokerList)
 
-    props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec)
-    if (props.getProperty(ProducerConfig.CLIENT_ID_CONFIG) == null)
-      props.put(ProducerConfig.CLIENT_ID_CONFIG, "console-producer")
-    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
+    props.put(ClientProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec)
+    if (props.getProperty(ClientProducerConfig.CLIENT_ID_CONFIG) == null)
+      props.put(ClientProducerConfig.CLIENT_ID_CONFIG, "console-producer")
+    props.put(ClientProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
+    props.put(ClientProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
 
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.LINGER_MS_CONFIG, config.options, config.sendTimeoutOpt)
+      props, ClientProducerConfig.LINGER_MS_CONFIG, config.options, config.sendTimeoutOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.ACKS_CONFIG, config.options, config.requestRequiredAcksOpt)
+      props, ClientProducerConfig.ACKS_CONFIG, config.options, config.requestRequiredAcksOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, config.options, config.requestTimeoutMsOpt)
+      props, ClientProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, config.options, config.requestTimeoutMsOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.RETRIES_CONFIG, config.options, config.messageSendMaxRetriesOpt)
+      props, ClientProducerConfig.RETRIES_CONFIG, config.options, config.messageSendMaxRetriesOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.RETRY_BACKOFF_MS_CONFIG, config.options, config.retryBackoffMsOpt)
+      props, ClientProducerConfig.RETRY_BACKOFF_MS_CONFIG, config.options, config.retryBackoffMsOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.SEND_BUFFER_CONFIG, config.options, config.socketBufferSizeOpt)
+      props, ClientProducerConfig.SEND_BUFFER_CONFIG, config.options, config.socketBufferSizeOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.BUFFER_MEMORY_CONFIG, config.options, config.maxMemoryBytesOpt)
+      props, ClientProducerConfig.BUFFER_MEMORY_CONFIG, config.options, config.maxMemoryBytesOpt)
     // We currently have 2 options to set the batch.size value. We'll deprecate/remove one of them in KIP-717.
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.BATCH_SIZE_CONFIG, config.options, config.batchSizeOpt)
+      props, ClientProducerConfig.BATCH_SIZE_CONFIG, config.options, config.batchSizeOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.BATCH_SIZE_CONFIG, config.options, config.maxPartitionMemoryBytesOpt)
+      props, ClientProducerConfig.BATCH_SIZE_CONFIG, config.options, config.maxPartitionMemoryBytesOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.METADATA_MAX_AGE_CONFIG, config.options, config.metadataExpiryMsOpt)
+      props, ClientProducerConfig.METADATA_MAX_AGE_CONFIG, config.options, config.metadataExpiryMsOpt)
     CommandLineUtils.maybeMergeOptions(
-      props, ProducerConfig.MAX_BLOCK_MS_CONFIG, config.options, config.maxBlockMsOpt)
+      props, ClientProducerConfig.MAX_BLOCK_MS_CONFIG, config.options, config.maxBlockMsOpt)
 
     props
   }

--- a/core/src/main/scala/kafka/utils/json/DecodeJson.scala
+++ b/core/src/main/scala/kafka/utils/json/DecodeJson.scala
@@ -85,13 +85,13 @@ object DecodeJson {
     else decodeJson.decodeEither(node).map(Some(_))
   }
 
-  implicit def decodeSeq[E, S[+T] <: Seq[E]](implicit decodeJson: DecodeJson[E], factory: Factory[E, S[E]]): DecodeJson[S[E]] = (node: JsonNode) => {
+  implicit def decodeSeq[E, S[E] <: Seq[E]](implicit decodeJson: DecodeJson[E], factory: Factory[E, S[E]]): DecodeJson[S[E]] = (node: JsonNode) => {
     if (node.isArray)
       decodeIterator(node.elements.asScala)(decodeJson.decodeEither)
     else Left(s"Expected JSON array, received $node")
   }
 
-  implicit def decodeMap[V, M[K, +V] <: Map[K, V]](implicit decodeJson: DecodeJson[V], factory: Factory[(String, V), M[String, V]]): DecodeJson[M[String, V]] = (node: JsonNode) => {
+  implicit def decodeMap[V, M[K, V] <: Map[K, V]](implicit decodeJson: DecodeJson[V], factory: Factory[(String, V), M[String, V]]): DecodeJson[M[String, V]] = (node: JsonNode) => {
     if (node.isObject)
       decodeIterator(node.fields.asScala)(e => decodeJson.decodeEither(e.getValue).map(v => (e.getKey, v)))
     else Left(s"Expected JSON object, received $node")

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -2425,7 +2425,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def testDescribeClusterClusterAuthorizedOperationsWithoutDescribeCluster(quorum: String): Unit = {
     removeAllClientAcls()
 
-    for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion to ApiKeys.DESCRIBE_CLUSTER.latestVersion) {
+    for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion.toInt to ApiKeys.DESCRIBE_CLUSTER.latestVersion.toInt) {
       testDescribeClusterClusterAuthorizedOperations(version.toShort, 0)
     }
   }
@@ -2445,7 +2445,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val expectedClusterAuthorizedOperations = Utils.to32BitField(
       acls.map(_.operation.code.asInstanceOf[JByte]).asJava)
 
-    for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion to ApiKeys.DESCRIBE_CLUSTER.latestVersion) {
+    for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion.toInt to ApiKeys.DESCRIBE_CLUSTER.latestVersion.toInt) {
       testDescribeClusterClusterAuthorizedOperations(version.toShort, expectedClusterAuthorizedOperations)
     }
   }

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.{Cluster, Reconfigurable}
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth._
-import org.apache.kafka.server.quota._
+import org.apache.kafka.server.quota.{ClientQuotaCallback, ClientQuotaType, ClientQuotaEntity}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 

--- a/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
@@ -91,7 +91,7 @@ class DescribeAuthorizedOperationsTest extends IntegrationTestHarness with SaslS
     val topicResource = new ResourcePattern(ResourceType.TOPIC, AclEntry.WildcardResource, PatternType.LITERAL)
 
     try {
-      authorizer.configure(this.configs.head.originals())
+      authorizer.configure(this.configs.head.originals)
       val result = authorizer.createAcls(null, List(
         new AclBinding(clusterResource, accessControlEntry(
           JaasTestUtils.KafkaServerPrincipalUnqualifiedName, CLUSTER_ACTION)),

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -486,8 +486,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try a newCount which would be a decrease
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(1)).asJava, option)
-      
-      var e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      var e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidPartitionsException when newCount is a decrease")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
       assertEquals("Topic currently has 3 partitions, which is higher than the requested 1.", e.getCause.getMessage, desc)
@@ -496,7 +498,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try a newCount which would be a noop (without assignment)
       alterResult = client.createPartitions(Map(topic2 ->
         NewPartitions.increaseTo(3)).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic2).get
+        ()
+      },
         () => s"$desc: Expect InvalidPartitionsException when requesting a noop")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
       assertEquals("Topic already has 3 partitions.", e.getCause.getMessage, desc)
@@ -522,7 +527,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val unknownTopic = "an-unknown-topic"
       alterResult = client.createPartitions(Map(unknownTopic ->
         NewPartitions.increaseTo(2)).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(unknownTopic).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(unknownTopic).get
+        ()
+      },
         () => s"$desc: Expect InvalidTopicException when using an unknown topic")
       assertTrue(e.getCause.isInstanceOf[UnknownTopicOrPartitionException], desc)
       assertEquals("The topic 'an-unknown-topic' does not exist.", e.getCause.getMessage, desc)
@@ -530,7 +538,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try an invalid newCount
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(-22)).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidPartitionsException when newCount is invalid")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
       assertEquals("Topic currently has 3 partitions, which is higher than the requested -22.", e.getCause.getMessage,
@@ -540,7 +551,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try assignments where the number of brokers != replication factor
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(4, asList(asList(1, 2)))).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidPartitionsException when #brokers != replication factor")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Inconsistent replication factor between partitions, partition 0 has 1 " +
@@ -551,7 +565,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try #assignments < with the increase
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(6, asList(asList(1)))).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidReplicaAssignmentException when #assignments != newCount - oldCount")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Increasing the number of partitions by 3 but 1 assignments provided.", e.getCause.getMessage, desc)
@@ -560,7 +577,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try #assignments > with the increase
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(4, asList(asList(1), asList(2)))).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidReplicaAssignmentException when #assignments != newCount - oldCount")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Increasing the number of partitions by 1 but 2 assignments provided.", e.getCause.getMessage, desc)
@@ -569,7 +589,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try with duplicate brokers in assignments
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(4, asList(asList(1, 1)))).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments has duplicate brokers")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Duplicate brokers not allowed in replica assignment: 1, 1 for partition id 3.",
@@ -579,7 +602,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try assignments with differently sized inner lists
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(5, asList(asList(1), asList(1, 0)))).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments have differently sized inner lists")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Inconsistent replication factor between partitions, partition 0 has 1 " +
@@ -589,7 +615,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try assignments with unknown brokers
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(4, asList(asList(12)))).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments contains an unknown broker")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Unknown broker(s) in replica assignment: 12.", e.getCause.getMessage, desc)
@@ -598,7 +627,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       // try with empty assignments
       alterResult = client.createPartitions(Map(topic1 ->
         NewPartitions.increaseTo(4, Collections.emptyList())).asJava, option)
-      e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+      e = assertThrows(classOf[ExecutionException], () => {
+        alterResult.values.get(topic1).get
+        ()
+      },
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments is empty")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
       assertEquals("Increasing the number of partitions by 1 but 0 assignments provided.", e.getCause.getMessage, desc)
@@ -622,7 +654,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     deleteResult.topicNameValues.get(topic1).get
     alterResult = client.createPartitions(Map(topic1 ->
       NewPartitions.increaseTo(4)).asJava, validateOnly)
-    e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
+    e = assertThrows(classOf[ExecutionException], () => {
+      alterResult.values.get(topic1).get
+      ()
+    },
       () => "Expect InvalidTopicException when the topic is queued for deletion")
     assertTrue(e.getCause.isInstanceOf[InvalidTopicException])
     assertEquals("The topic is queued for deletion.", e.getCause.getMessage)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -1038,7 +1038,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(numRecords, MockProducerInterceptor.ONSEND_COUNT.intValue)
     assertEquals(numRecords, MockProducerInterceptor.ON_SUCCESS_COUNT.intValue)
     // send invalid record
-    assertThrows(classOf[Throwable], () => testProducer.send(null), () => "Should not allow sending a null record")
+    assertThrows(classOf[Throwable], () => {
+      testProducer.send(null)
+      ()
+    }, () => "Should not allow sending a null record")
     assertEquals(1, MockProducerInterceptor.ON_ERROR_COUNT.intValue, "Interceptor should be notified about exception")
     assertEquals(0, MockProducerInterceptor.ON_ERROR_WITH_METADATA_COUNT.intValue(), "Interceptor should not receive metadata with an exception when record is null")
 

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -483,7 +483,7 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
     def initializeAcls(): Unit = {
       val authorizer = CoreUtils.createObject[Authorizer](authorizerForInitClass.getName)
       try {
-        authorizer.configure(configs.head.originals())
+        authorizer.configure(configs.head.originals)
         val ace = new AccessControlEntry(WildcardPrincipalString, WildcardHost, ALL, ALLOW)
         authorizer.createAcls(null, List(new AclBinding(new ResourcePattern(TOPIC, "*", LITERAL), ace)).asJava)
         authorizer.createAcls(null, List(new AclBinding(new ResourcePattern(GROUP, "*", LITERAL), ace)).asJava)

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -300,8 +300,8 @@ object ReplicationQuotasTestRig {
         s"<p>- BrokerCount: ${config.brokers}" +
         s"<p>- PartitionCount: ${config.partitions}" +
         f"<p>- Throttle: ${config.throttle.toDouble}%,.0f MB/s" +
-        f"<p>- MsgCount: ${config.msgsPerPartition}%,.0f " +
-        f"<p>- MsgSize: ${config.msgSize}%,.0f" +
+        f"<p>- MsgCount: ${config.msgsPerPartition.toDouble}%,.0f " +
+        f"<p>- MsgSize: ${config.msgSize.toDouble}%,.0f" +
         s"<p>- TargetBytesPerBrokerMB: ${config.targetBytesPerBrokerMB}<p>"
       append(message)
     }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
@@ -260,7 +260,10 @@ class ReassignPartitionsCommandArgsTest {
   }
 
   def shouldFailWith(msg: String, args: Array[String]): Unit = {
-    val e = assertThrows(classOf[Exception], () => ReassignPartitionsCommand.validateAndParseArgs(args),
+    val e = assertThrows(classOf[Exception], () => {
+      ReassignPartitionsCommand.validateAndParseArgs(args)
+      ()
+    },
       () => s"Should have failed with [$msg] but no failure occurred.")
     assertTrue(e.getMessage.startsWith(msg), s"Expected exception with message:\n[$msg]\nbut was\n[${e.getMessage}]")
   }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
@@ -252,19 +252,28 @@ class ReassignPartitionsUnitTest {
   @Test
   def testParseGenerateAssignmentArgs(): Unit = {
     assertStartsWith("Broker list contains duplicate entries",
-      assertThrows(classOf[AdminCommandFailedException], () => parseGenerateAssignmentArgs(
-          """{"topics": [{"topic": "foo"}], "version":1}""", "1,1,2"),
+      assertThrows(classOf[AdminCommandFailedException], () => {
+        parseGenerateAssignmentArgs(
+          """{"topics": [{"topic": "foo"}], "version":1}""", "1,1,2")
+        ()
+      },
         () => "Expected to detect duplicate broker list entries").getMessage)
     assertStartsWith("Broker list contains duplicate entries",
-      assertThrows(classOf[AdminCommandFailedException], () => parseGenerateAssignmentArgs(
-          """{"topics": [{"topic": "foo"}], "version":1}""", "5,2,3,4,5"),
+      assertThrows(classOf[AdminCommandFailedException], () => {
+        parseGenerateAssignmentArgs(
+          """{"topics": [{"topic": "foo"}], "version":1}""", "5,2,3,4,5")
+        ()
+      },
         () => "Expected to detect duplicate broker list entries").getMessage)
     assertEquals((Seq(5,2,3,4),Seq("foo")),
       parseGenerateAssignmentArgs("""{"topics": [{"topic": "foo"}], "version":1}""",
         "5,2,3,4"))
     assertStartsWith("List of topics to reassign contains duplicate entries",
-      assertThrows(classOf[AdminCommandFailedException], () => parseGenerateAssignmentArgs(
-          """{"topics": [{"topic": "foo"},{"topic": "foo"}], "version":1}""", "5,2,3,4"),
+      assertThrows(classOf[AdminCommandFailedException], () => {
+        parseGenerateAssignmentArgs(
+          """{"topics": [{"topic": "foo"},{"topic": "foo"}], "version":1}""", "5,2,3,4")
+        ()
+      },
         () => "Expected to detect duplicate topic entries").getMessage)
     assertEquals((Seq(5,3,4),Seq("foo","bar")),
       parseGenerateAssignmentArgs(
@@ -279,7 +288,10 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Replication factor: 3 larger than available brokers: 2",
         assertThrows(classOf[InvalidReplicationFactorException],
-          () => generateAssignment(adminClient, """{"topics":[{"topic":"foo"},{"topic":"bar"}]}""", "0,1", false),
+          () => {
+            generateAssignment(adminClient, """{"topics":[{"topic":"foo"},{"topic":"bar"}]}""", "0,1", false)
+            ()
+          },
           () => "Expected generateAssignment to fail").getMessage)
     } finally {
       adminClient.close()
@@ -293,7 +305,10 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Topic quux not found",
         assertThrows(classOf[ExecutionException],
-          () => generateAssignment(adminClient, """{"topics":[{"topic":"foo"},{"topic":"quux"}]}""", "0,1", false),
+          () => {
+            generateAssignment(adminClient, """{"topics":[{"topic":"foo"},{"topic":"quux"}]}""", "0,1", false)
+            ()
+          },
           () => "Expected generateAssignment to fail").getCause.getMessage)
     } finally {
       adminClient.close()
@@ -315,7 +330,10 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Not all brokers have rack information.",
         assertThrows(classOf[AdminOperationException],
-          () => generateAssignment(adminClient, """{"topics":[{"topic":"foo"}]}""", "0,1,2,3", true),
+          () => {
+            generateAssignment(adminClient, """{"topics":[{"topic":"foo"}]}""", "0,1,2,3", true)
+            ()
+          },
           () => "Expected generateAssignment to fail").getMessage)
       // It should succeed when --disable-rack-aware is used.
       val (_, current) = generateAssignment(adminClient,
@@ -450,26 +468,38 @@ class ReassignPartitionsUnitTest {
   def testParseExecuteAssignmentArgs(): Unit = {
     assertStartsWith("Partition reassignment list cannot be empty",
       assertThrows(classOf[AdminCommandFailedException],
-        () => parseExecuteAssignmentArgs("""{"version":1,"partitions":[]}"""),
+        () => {
+          parseExecuteAssignmentArgs("""{"version":1,"partitions":[]}""")
+          ()
+        },
         () => "Expected to detect empty partition reassignment list").getMessage)
     assertStartsWith("Partition reassignment contains duplicate topic partitions",
-      assertThrows(classOf[AdminCommandFailedException], () => parseExecuteAssignmentArgs(
+      assertThrows(classOf[AdminCommandFailedException], () => {
+        parseExecuteAssignmentArgs(
           """{"version":1,"partitions":""" +
             """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
             """{"topic":"foo","partition":0,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
-            """]}"""), () => "Expected to detect a partition list with duplicate entries").getMessage)
+            """]}""")
+        ()
+      }, () => "Expected to detect a partition list with duplicate entries").getMessage)
     assertStartsWith("Partition reassignment contains duplicate topic partitions",
-      assertThrows(classOf[AdminCommandFailedException], () => parseExecuteAssignmentArgs(
+      assertThrows(classOf[AdminCommandFailedException], () => {
+        parseExecuteAssignmentArgs(
           """{"version":1,"partitions":""" +
             """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["/abc","/def"]},""" +
             """{"topic":"foo","partition":0,"replicas":[2,3],"log_dirs":["/abc","/def"]}""" +
-            """]}"""), () => "Expected to detect a partition replica list with duplicate entries").getMessage)
+            """]}""")
+        ()
+      }, () => "Expected to detect a partition replica list with duplicate entries").getMessage)
     assertStartsWith("Partition replica lists may not contain duplicate entries",
-      assertThrows(classOf[AdminCommandFailedException], () => parseExecuteAssignmentArgs(
+      assertThrows(classOf[AdminCommandFailedException], () => {
+        parseExecuteAssignmentArgs(
           """{"version":1,"partitions":""" +
             """[{"topic":"foo","partition":0,"replicas":[0,0],"log_dirs":["/abc","/def"]},""" +
             """{"topic":"foo","partition":1,"replicas":[2,3],"log_dirs":["/abc","/def"]}""" +
-            """]}"""), () => "Expected to detect a partition replica list with duplicate entries").getMessage)
+            """]}""")
+        ()
+      }, () => "Expected to detect a partition replica list with duplicate entries").getMessage)
     assertEquals((Map(
         new TopicPartition("foo", 0) -> Seq(1, 2, 3),
         new TopicPartition("foo", 1) -> Seq(3, 4, 5),

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -257,7 +257,7 @@ class PartitionStateMachineTest {
       .thenReturn(Seq(GetDataResponse(Code.OK, null, Some(partition),
         TopicPartitionStateZNode.encode(leaderIsrAndControllerEpoch), stat, ResponseMetadata(0, 0))))
 
-    when(mockZkClient.getLogConfigs(Set.empty, config.originals()))
+    when(mockZkClient.getLogConfigs(Set.empty, config.originals))
       .thenReturn((Map(partition.topic -> LogConfig()), Map.empty[String, Exception]))
     val leaderAndIsrAfterElection = leaderAndIsr.newLeader(brokerId)
     val updatedLeaderAndIsr = leaderAndIsrAfterElection.withZkVersion(2)
@@ -433,7 +433,7 @@ class PartitionStateMachineTest {
     }
     prepareMockToGetTopicPartitionsStatesRaw()
     def prepareMockToGetLogConfigs(): Unit = {
-      when(mockZkClient.getLogConfigs(Set.empty, config.originals())).thenReturn((Map.empty[String, LogConfig], Map.empty[String, Exception]))
+      when(mockZkClient.getLogConfigs(Set.empty, config.originals)).thenReturn((Map.empty[String, LogConfig], Map.empty[String, Exception]))
     }
     prepareMockToGetLogConfigs()
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -3637,7 +3637,10 @@ class GroupCoordinatorTest {
   }
 
   private def verifyDelayedTaskNotCompleted(firstJoinFuture: Future[JoinGroupResult]) = {
-    assertThrows(classOf[TimeoutException], () => await(firstJoinFuture, 1),
+    assertThrows(classOf[TimeoutException], () => {
+      await(firstJoinFuture, 1)
+      ()
+    },
       () => "should have timed out as rebalance delay not expired")
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -2374,7 +2374,7 @@ class GroupMetadataManagerTest {
       minOneMessage = ArgumentMatchers.eq(true)))
       .thenReturn(FetchDataInfo(LogOffsetMetadata(startOffset), mockRecords))
     when(replicaManager.getLog(groupMetadataTopicPartition)).thenReturn(Some(logMock))
-    when(replicaManager.getLogEndOffset(groupMetadataTopicPartition)).thenReturn(Some[Long](18))
+    when(replicaManager.getLogEndOffset(groupMetadataTopicPartition)).thenReturn(Some[Long](18L))
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, groupEpoch, _ => (), 0L)
 
     // Empty control batch should not have caused the load to fail

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -514,14 +514,20 @@ class LocalLogTest {
   @Test
   def testParseTopicPartitionNameForEmptyName(): Unit = {
     val dir = new File("")
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir.getCanonicalPath)
   }
 
   @Test
   def testParseTopicPartitionNameForNull(): Unit = {
     val dir: File = null
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir)
   }
 
@@ -530,11 +536,17 @@ class LocalLogTest {
     val topic = "test_topic"
     val partition = "1999"
     val dir = new File(logDir, topic + partition)
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir.getCanonicalPath)
     // also test the "-delete" marker case
     val deleteMarkerDir = new File(logDir, topic + partition + "." + LocalLog.DeleteDirSuffix)
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(deleteMarkerDir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(deleteMarkerDir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
   }
 
@@ -543,13 +555,19 @@ class LocalLogTest {
     val topic = ""
     val partition = "1999"
     val dir = new File(logDir, topicPartitionName(topic, partition))
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir.getCanonicalPath)
 
     // also test the "-delete" marker case
     val deleteMarkerDir = new File(logDir, LocalLog.logDeleteDirName(new TopicPartition(topic, partition.toInt)))
 
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(deleteMarkerDir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(deleteMarkerDir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
   }
 
@@ -558,12 +576,18 @@ class LocalLogTest {
     val topic = "test_topic"
     val partition = ""
     val dir = new File(logDir.getPath + topicPartitionName(topic, partition))
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir.getCanonicalPath)
 
     // also test the "-delete" marker case
     val deleteMarkerDir = new File(logDir, topicPartitionName(topic, partition) + "." + LocalLog.DeleteDirSuffix)
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(deleteMarkerDir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(deleteMarkerDir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
   }
 
@@ -572,22 +596,34 @@ class LocalLogTest {
     val topic = "test_topic"
     val partition = "1999a"
     val dir = new File(logDir, topicPartitionName(topic, partition))
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir.getCanonicalPath)
 
     // also test the "-delete" marker case
     val deleteMarkerDir = new File(logDir, topic + partition + "." + LocalLog.DeleteDirSuffix)
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(deleteMarkerDir),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(deleteMarkerDir)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
   }
 
   @Test
   def testParseTopicPartitionNameForExistingInvalidDir(): Unit = {
     val dir1 = new File(logDir.getPath + "/non_kafka_dir")
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir1),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir1)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir1.getCanonicalPath)
     val dir2 = new File(logDir.getPath + "/non_kafka_dir-delete")
-    assertThrows(classOf[KafkaException], () => LocalLog.parseTopicPartitionName(dir2),
+    assertThrows(classOf[KafkaException], () => {
+      LocalLog.parseTopicPartitionName(dir2)
+      ()
+    },
       () => "KafkaException should have been thrown for dir: " + dir2.getCanonicalPath)
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import kafka.common._
 import kafka.server.{BrokerTopicStats, LogDirFailureChannel}
-import kafka.utils._
+import kafka.utils.{immutable => _, _}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.CorruptRecordException
 import org.apache.kafka.common.record._

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -234,7 +234,10 @@ class LogManagerTest {
     assertEquals(log.numberOfSegments * 4 + 1, log.dir.list.length, "Files should have been deleted")
     assertEquals(0, readLog(log, offset + 1).records.sizeInBytes, "Should get empty fetch off new log.")
 
-    assertThrows(classOf[OffsetOutOfRangeException], () => readLog(log, 0), () => "Should get exception from fetching earlier.")
+    assertThrows(classOf[OffsetOutOfRangeException], () => {
+      readLog(log, 0)
+      ()
+    }, () => "Should get exception from fetching earlier.")
     // log should still be appendable
     log.appendAsLeader(TestUtils.singletonRecords("test".getBytes()), leaderEpoch = 0)
   }

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -1232,7 +1232,10 @@ class UnifiedLogTest {
         new SimpleRecord(mockTime.milliseconds, s"key-$seq".getBytes, s"value-$seq".getBytes),
         new SimpleRecord(mockTime.milliseconds, s"key-$seq".getBytes, s"value-$seq".getBytes)),
       producerId = pid, producerEpoch = epoch, sequence = seq - 2)
-    assertThrows(classOf[OutOfOrderSequenceException], () => log.appendAsLeader(records, leaderEpoch = 0),
+    assertThrows(classOf[OutOfOrderSequenceException], () => {
+      log.appendAsLeader(records, leaderEpoch = 0)
+      ()
+    },
       () => "Should have received an OutOfOrderSequenceException since we attempted to append a duplicate of a records in the middle of the log.")
 
     // Append a duplicate of the batch which is 4th from the tail. This should succeed without error since we
@@ -1245,7 +1248,10 @@ class UnifiedLogTest {
     records = TestUtils.records(
       List(new SimpleRecord(mockTime.milliseconds, s"key-1".getBytes, s"value-1".getBytes)),
       producerId = pid, producerEpoch = epoch, sequence = 1)
-    assertThrows(classOf[OutOfOrderSequenceException], () => log.appendAsLeader(records, leaderEpoch = 0),
+    assertThrows(classOf[OutOfOrderSequenceException], () => {
+      log.appendAsLeader(records, leaderEpoch = 0)
+      ()
+    },
       () => "Should have received an OutOfOrderSequenceException since we attempted to append a duplicate of a batch which is older than the last 5 appended batches.")
 
     // Append a duplicate entry with a single records at the tail of the log. This should return the appendInfo of the original entry.
@@ -1827,7 +1833,10 @@ class UnifiedLogTest {
     // should be able to append the small message
     log.appendAsLeader(first, leaderEpoch = 0)
 
-    assertThrows(classOf[RecordTooLargeException], () => log.appendAsLeader(second, leaderEpoch = 0),
+    assertThrows(classOf[RecordTooLargeException], () => {
+      log.appendAsLeader(second, leaderEpoch = 0)
+      ()
+    },
       () => "Second message set should throw MessageSizeTooLargeException.")
   }
 
@@ -2192,7 +2201,10 @@ class UnifiedLogTest {
     for (magic <- magicVals; compression <- compressionTypes) {
       val invalidRecord = MemoryRecords.withRecords(magic, compression, new SimpleRecord(1.toString.getBytes))
       assertThrows(classOf[UnexpectedAppendOffsetException],
-        () => log.appendAsFollower(invalidRecord),
+        () => {
+          log.appendAsFollower(invalidRecord)
+          ()
+        },
         () => s"Magic=$magic, compressionType=$compression")
     }
   }

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -119,7 +119,7 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
         val replication = if (!topic.assignments().isEmpty)
           topic.assignments().iterator().next().brokerIds().size()
         else
-          topic.replicationFactor
+          topic.replicationFactor.toInt
 
         if (request.data.validateOnly) {
           assertNotNull(metadataForTopic)

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
@@ -162,7 +162,7 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
   def testCreateTopicsRequestVersions(quorum: String): Unit = {
     // Note: we don't run this test when in KRaft mode, because kraft does not yet support returning topic
     // configs from CreateTopics.
-    for (version <- ApiKeys.CREATE_TOPICS.oldestVersion to ApiKeys.CREATE_TOPICS.latestVersion) {
+    for (version <- ApiKeys.CREATE_TOPICS.oldestVersion.toInt to ApiKeys.CREATE_TOPICS.latestVersion.toInt) {
       val topic = s"topic_$version"
       val data = new CreateTopicsRequestData()
       data.setTimeoutMs(10000)

--- a/core/src/test/scala/unit/kafka/server/DescribeClusterRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeClusterRequestTest.scala
@@ -74,7 +74,7 @@ class DescribeClusterRequestTest extends BaseRequestTest {
       Int.MinValue
     }
 
-    for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion to ApiKeys.DESCRIBE_CLUSTER.latestVersion) {
+    for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion.toInt to ApiKeys.DESCRIBE_CLUSTER.latestVersion.toInt) {
       val describeClusterRequest = new DescribeClusterRequest.Builder(new DescribeClusterRequestData()
         .setIncludeClusterAuthorizedOperations(includeClusterAuthorizedOperations))
         .build(version.toShort)

--- a/core/src/test/scala/unit/kafka/server/FinalizedFeatureChangeListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FinalizedFeatureChangeListenerTest.scala
@@ -240,10 +240,11 @@ class FinalizedFeatureChangeListenerTest extends QuorumTestHarness {
 
     val exitLatch = new CountDownLatch(1)
     Exit.setExitProcedure((_, _) => exitLatch.countDown())
+    val feature1: SupportedVersionRange = brokerFeatures.supportedFeatures.get("feature_1")
     val incompatibleFinalizedFeaturesMap = Map[String, FinalizedVersionRange](
       "feature_1" -> new FinalizedVersionRange(
-        brokerFeatures.supportedFeatures.get("feature_1").min(),
-        (brokerFeatures.supportedFeatures.get("feature_1").max() + 1).asInstanceOf[Short]))
+        feature1.min(),
+        (feature1.max() + 1).asInstanceOf[Short]))
     val incompatibleFinalizedFeatures = Features.finalizedFeatures(incompatibleFinalizedFeaturesMap.asJava)
     zkClient.updateFeatureZNode(FeatureZNode(FeatureZNodeStatus.Enabled, incompatibleFinalizedFeatures))
     val (mayBeFeatureZNodeIncompatibleBytes, updatedVersion) = zkClient.getDataAndVersion(FeatureZNode.path)

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -60,7 +60,7 @@ class IsrExpirationTest {
   @BeforeEach
   def setUp(): Unit = {
     val logManager: LogManager = mock(classOf[LogManager])
-    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
+    when(logManager.liveLogDirs).thenReturn(Seq.empty[File])
 
     alterIsrManager = TestUtils.createAlterIsrManager()
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1283,7 +1283,7 @@ class KafkaApisTest {
     val topic = "topic"
     addTopicToMetadataCache(topic, numPartitions = 2)
 
-    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion) {
+    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion.toInt to ApiKeys.TXN_OFFSET_COMMIT.latestVersion.toInt) {
       reset(replicaManager, clientRequestQuotaManager, requestChannel, groupCoordinator)
 
       val topicPartition = new TopicPartition(topic, 1)
@@ -1340,7 +1340,7 @@ class KafkaApisTest {
     val topic = "topic"
     addTopicToMetadataCache(topic, numPartitions = 2)
 
-    for (version <- ApiKeys.INIT_PRODUCER_ID.oldestVersion to ApiKeys.INIT_PRODUCER_ID.latestVersion) {
+    for (version <- ApiKeys.INIT_PRODUCER_ID.oldestVersion.toInt to ApiKeys.INIT_PRODUCER_ID.latestVersion.toInt) {
 
       reset(replicaManager, clientRequestQuotaManager, requestChannel, txnCoordinator)
 
@@ -1406,7 +1406,7 @@ class KafkaApisTest {
     val topic = "topic"
     addTopicToMetadataCache(topic, numPartitions = 2)
 
-    for (version <- ApiKeys.ADD_OFFSETS_TO_TXN.oldestVersion to ApiKeys.ADD_OFFSETS_TO_TXN.latestVersion) {
+    for (version <- ApiKeys.ADD_OFFSETS_TO_TXN.oldestVersion.toInt to ApiKeys.ADD_OFFSETS_TO_TXN.latestVersion.toInt) {
 
       reset(replicaManager, clientRequestQuotaManager, requestChannel, groupCoordinator, txnCoordinator)
 
@@ -1464,7 +1464,7 @@ class KafkaApisTest {
     val topic = "topic"
     addTopicToMetadataCache(topic, numPartitions = 2)
 
-    for (version <- ApiKeys.ADD_PARTITIONS_TO_TXN.oldestVersion to ApiKeys.ADD_PARTITIONS_TO_TXN.latestVersion) {
+    for (version <- ApiKeys.ADD_PARTITIONS_TO_TXN.oldestVersion.toInt to ApiKeys.ADD_PARTITIONS_TO_TXN.latestVersion.toInt) {
 
       reset(replicaManager, clientRequestQuotaManager, requestChannel, txnCoordinator)
 
@@ -1518,7 +1518,7 @@ class KafkaApisTest {
     val topic = "topic"
     addTopicToMetadataCache(topic, numPartitions = 2)
 
-    for (version <- ApiKeys.END_TXN.oldestVersion to ApiKeys.END_TXN.latestVersion) {
+    for (version <- ApiKeys.END_TXN.oldestVersion.toInt to ApiKeys.END_TXN.latestVersion.toInt) {
       reset(replicaManager, clientRequestQuotaManager, requestChannel, txnCoordinator)
 
       val capturedResponse: ArgumentCaptor[EndTxnResponse] = ArgumentCaptor.forClass(classOf[EndTxnResponse])
@@ -1569,7 +1569,7 @@ class KafkaApisTest {
     val topic = "topic"
     addTopicToMetadataCache(topic, numPartitions = 2)
 
-    for (version <- ApiKeys.PRODUCE.oldestVersion to ApiKeys.PRODUCE.latestVersion) {
+    for (version <- ApiKeys.PRODUCE.oldestVersion.toInt to ApiKeys.PRODUCE.latestVersion.toInt) {
 
       reset(replicaManager, clientQuotaManager, clientRequestQuotaManager, requestChannel, txnCoordinator)
 
@@ -2518,7 +2518,7 @@ class KafkaApisTest {
 
   @Test
   def testJoinGroupWhenAnErrorOccurs(): Unit = {
-    for (version <- ApiKeys.JOIN_GROUP.oldestVersion to ApiKeys.JOIN_GROUP.latestVersion) {
+    for (version <- ApiKeys.JOIN_GROUP.oldestVersion.toInt to ApiKeys.JOIN_GROUP.latestVersion.toInt) {
       testJoinGroupWhenAnErrorOccurs(version.asInstanceOf[Short])
     }
   }
@@ -2584,7 +2584,7 @@ class KafkaApisTest {
 
   @Test
   def testJoinGroupProtocolType(): Unit = {
-    for (version <- ApiKeys.JOIN_GROUP.oldestVersion to ApiKeys.JOIN_GROUP.latestVersion) {
+    for (version <- ApiKeys.JOIN_GROUP.oldestVersion.toInt to ApiKeys.JOIN_GROUP.latestVersion.toInt) {
       testJoinGroupProtocolType(version.asInstanceOf[Short])
     }
   }
@@ -2655,7 +2655,7 @@ class KafkaApisTest {
 
   @Test
   def testSyncGroupProtocolTypeAndName(): Unit = {
-    for (version <- ApiKeys.SYNC_GROUP.oldestVersion to ApiKeys.SYNC_GROUP.latestVersion) {
+    for (version <- ApiKeys.SYNC_GROUP.oldestVersion.toInt to ApiKeys.SYNC_GROUP.latestVersion.toInt) {
       testSyncGroupProtocolTypeAndName(version.asInstanceOf[Short])
     }
   }
@@ -2712,7 +2712,7 @@ class KafkaApisTest {
 
   @Test
   def testSyncGroupProtocolTypeAndNameAreMandatorySinceV5(): Unit = {
-    for (version <- ApiKeys.SYNC_GROUP.oldestVersion to ApiKeys.SYNC_GROUP.latestVersion) {
+    for (version <- ApiKeys.SYNC_GROUP.oldestVersion.toInt to ApiKeys.SYNC_GROUP.latestVersion.toInt) {
       testSyncGroupProtocolTypeAndNameAreMandatorySinceV5(version.asInstanceOf[Short])
     }
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1480,7 +1480,7 @@ class KafkaConfigTest {
     val config = KafkaConfig.fromProps(props)
     assertEquals(3, config.brokerId)
     assertEquals(3, config.nodeId)
-    val originals = config.originals()
+    val originals = config.originals
     assertEquals("3", originals.get(KafkaConfig.BrokerIdProp))
     assertEquals("3", originals.get(KafkaConfig.NodeIdProp))
   }
@@ -1495,7 +1495,7 @@ class KafkaConfigTest {
     val config = KafkaConfig.fromProps(props)
     assertEquals(3, config.brokerId)
     assertEquals(3, config.nodeId)
-    val originals = config.originals()
+    val originals = config.originals
     assertEquals("3", originals.get(KafkaConfig.BrokerIdProp))
     assertEquals("3", originals.get(KafkaConfig.NodeIdProp))
   }

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -210,7 +210,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     TestUtils.generateAndProduceMessages(servers, topic, 9)
     TestUtils.produceMessage(servers, topic, "test-10", System.currentTimeMillis() + 10L)
 
-    for (version <- ApiKeys.LIST_OFFSETS.oldestVersion to ApiKeys.LIST_OFFSETS.latestVersion) {
+    for (version <- ApiKeys.LIST_OFFSETS.oldestVersion.toInt to ApiKeys.LIST_OFFSETS.latestVersion.toInt) {
       if (version == 0) {
         assertEquals((-1L, -1), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))

--- a/core/src/test/scala/unit/kafka/server/MockBrokerToControllerChannelManager.scala
+++ b/core/src/test/scala/unit/kafka/server/MockBrokerToControllerChannelManager.scala
@@ -25,13 +25,13 @@ class MockBrokerToControllerChannelManager(
   val client: MockClient,
   time: MockTime,
   controllerNodeProvider: ControllerNodeProvider,
-  controllerApiVersions: NodeApiVersions = NodeApiVersions.create(),
+  controllerApiVersionsParam: NodeApiVersions = NodeApiVersions.create(),
   val retryTimeoutMs: Int = 60000,
   val requestTimeoutMs: Int = 30000
 ) extends BrokerToControllerChannelManager {
   private val unsentQueue = new java.util.ArrayDeque[BrokerToControllerQueueItem]()
 
-  client.setNodeApiVersions(controllerApiVersions)
+  client.setNodeApiVersions(controllerApiVersionsParam)
 
   override def start(): Unit = {}
 
@@ -49,7 +49,7 @@ class MockBrokerToControllerChannelManager(
   }
 
   override def controllerApiVersions(): Option[NodeApiVersions] = {
-    Some(controllerApiVersions)
+    Some(controllerApiVersionsParam)
   }
 
   private[server] def handleResponse(request: BrokerToControllerQueueItem)(response: ClientResponse): Unit = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -306,7 +306,7 @@ class ReplicaManagerQuotasTest {
 
     //Return the same log for each partition as it doesn't matter
     when(logManager.getLog(any[TopicPartition], anyBoolean)).thenReturn(Some(log))
-    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
+    when(logManager.liveLogDirs).thenReturn(Seq.empty[File])
 
     val alterIsrManager: AlterIsrManager = mock(classOf[AlterIsrManager])
 

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -185,7 +185,8 @@ class UpdateFeaturesTest extends BaseRequestTest {
     val validUpdates = new FeatureUpdateKeyCollection()
     val validUpdate = new UpdateFeaturesRequestData.FeatureUpdateKey();
     validUpdate.setFeature("feature_1");
-    validUpdate.setMaxVersionLevel(defaultSupportedFeatures().get("feature_1").max())
+    val feature1Range: SupportedVersionRange = defaultSupportedFeatures().get("feature_1")
+    validUpdate.setMaxVersionLevel(feature1Range.max())
     validUpdate.setAllowDowngrade(false)
     validUpdates.add(validUpdate)
 
@@ -210,7 +211,8 @@ class UpdateFeaturesTest extends BaseRequestTest {
    */
   @Test
   def testShouldFailRequestWhenDowngradeFlagIsNotSetDuringDowngrade(): Unit = {
-    val targetMaxVersionLevel = (defaultFinalizedFeatures().get("feature_1").max() - 1).asInstanceOf[Short]
+    val feature1Range: FinalizedVersionRange = defaultFinalizedFeatures().get("feature_1")
+    val targetMaxVersionLevel = (feature1Range.max() - 1).asInstanceOf[Short]
     testWithInvalidFeatureUpdate[InvalidRequestException](
       "feature_1",
       new FeatureUpdate(targetMaxVersionLevel,false),
@@ -223,7 +225,8 @@ class UpdateFeaturesTest extends BaseRequestTest {
    */
   @Test
   def testShouldFailRequestWhenDowngradeToHigherVersionLevelIsAttempted(): Unit = {
-    val targetMaxVersionLevel = (defaultFinalizedFeatures().get("feature_1").max() + 1).asInstanceOf[Short]
+    val feature1Range: FinalizedVersionRange = defaultFinalizedFeatures().get("feature_1")
+    val targetMaxVersionLevel = (feature1Range.max() + 1).asInstanceOf[Short]
     testWithInvalidFeatureUpdate[InvalidRequestException](
       "feature_1",
       new FeatureUpdate(targetMaxVersionLevel, true),
@@ -292,7 +295,8 @@ class UpdateFeaturesTest extends BaseRequestTest {
    */
   @Test
   def testShouldFailRequestWhenUpgradingToSameVersionLevel(): Unit = {
-    val targetMaxVersionLevel = defaultFinalizedFeatures().get("feature_1").max()
+    val feature1Range: FinalizedVersionRange = defaultFinalizedFeatures().get("feature_1")
+    val targetMaxVersionLevel = feature1Range.max()
     testWithInvalidFeatureUpdate[InvalidRequestException](
       "feature_1",
       new FeatureUpdate(targetMaxVersionLevel, false),
@@ -395,8 +399,10 @@ class UpdateFeaturesTest extends BaseRequestTest {
       Utils.mkMap(
         Utils.mkEntry("feature_1", new FinalizedVersionRange(1, 3)),
         Utils.mkEntry("feature_2", new FinalizedVersionRange(2, 3))))
-    val update1 = new FeatureUpdate(targetFinalizedFeatures.get("feature_1").max(), false)
-    val update2 = new FeatureUpdate(targetFinalizedFeatures.get("feature_2").max(), false)
+    val feature1Range: FinalizedVersionRange = targetFinalizedFeatures.get("feature_1")
+    val update1 = new FeatureUpdate(feature1Range.max(), false)
+    val feature2Range: FinalizedVersionRange = targetFinalizedFeatures.get("feature_2")
+    val update2 = new FeatureUpdate(feature2Range.max(), false)
 
     val adminClient = createAdminClient()
     adminClient.updateFeatures(
@@ -438,8 +444,10 @@ class UpdateFeaturesTest extends BaseRequestTest {
       Utils.mkMap(
         Utils.mkEntry("feature_1", new FinalizedVersionRange(1, 3)),
         Utils.mkEntry("feature_2", new FinalizedVersionRange(2, 3))))
-    val update1 = new FeatureUpdate(targetFinalizedFeatures.get("feature_1").max(), false)
-    val update2 = new FeatureUpdate(targetFinalizedFeatures.get("feature_2").max(), true)
+    val feature1Range: FinalizedVersionRange = targetFinalizedFeatures.get("feature_1")
+    val update1 = new FeatureUpdate(feature1Range.max(), false)
+    val feature2Range: FinalizedVersionRange = targetFinalizedFeatures.get("feature_2")
+    val update2 = new FeatureUpdate(feature2Range.max(), true)
 
     val adminClient = createAdminClient()
     adminClient.updateFeatures(
@@ -483,8 +491,10 @@ class UpdateFeaturesTest extends BaseRequestTest {
       Utils.mkMap(
         Utils.mkEntry("feature_1", new FinalizedVersionRange(1, 3)),
         Utils.mkEntry("feature_2", new FinalizedVersionRange(2, 3))))
-    val validUpdate = new FeatureUpdate(targetFinalizedFeatures.get("feature_1").max(), false)
-    val invalidUpdate = new FeatureUpdate(targetFinalizedFeatures.get("feature_2").max(), false)
+    val feature1Range: FinalizedVersionRange = targetFinalizedFeatures.get("feature_1")
+    val validUpdate = new FeatureUpdate(feature1Range.max(), false)
+    val feature2Range: FinalizedVersionRange = targetFinalizedFeatures.get("feature_2")
+    val invalidUpdate = new FeatureUpdate(feature2Range.max(), false)
 
     val adminClient = createAdminClient()
     val result = adminClient.updateFeatures(
@@ -551,8 +561,10 @@ class UpdateFeaturesTest extends BaseRequestTest {
       Utils.mkMap(
         Utils.mkEntry("feature_1", new FinalizedVersionRange(1, 3)),
         Utils.mkEntry("feature_2", new FinalizedVersionRange(2, 3))))
-    val invalidUpdate = new FeatureUpdate(targetFinalizedFeatures.get("feature_1").max(), false)
-    val validUpdate = new FeatureUpdate(targetFinalizedFeatures.get("feature_2").max(), true)
+    val targetFeature1: FinalizedVersionRange = targetFinalizedFeatures.get("feature_1")
+    val invalidUpdate = new FeatureUpdate(targetFeature1.max(), false)
+    val targetFeature2 = targetFinalizedFeatures.get("feature_2")
+    val validUpdate = new FeatureUpdate(targetFeature2.max(), true)
 
     val adminClient = createAdminClient()
     val result = adminClient.updateFeatures(

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -60,7 +60,7 @@ class OffsetsForLeaderEpochTest {
     val mockLog: UnifiedLog = mock(classOf[UnifiedLog])
     val logManager: LogManager = mock(classOf[LogManager])
     when(mockLog.endOffsetForEpoch(epochRequested)).thenReturn(Some(offsetAndEpoch))
-    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
+    when(logManager.liveLogDirs).thenReturn(Seq.empty[File])
 
     // create a replica manager with 1 partition that has 1 replica
     replicaManager = new ReplicaManager(
@@ -89,7 +89,7 @@ class OffsetsForLeaderEpochTest {
   @Test
   def shouldReturnNoLeaderForPartitionIfThrown(): Unit = {
     val logManager: LogManager = mock(classOf[LogManager])
-    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
+    when(logManager.liveLogDirs).thenReturn(Seq.empty[File])
 
     //create a replica manager with 1 partition that has 0 replica
     replicaManager = new ReplicaManager(
@@ -120,7 +120,7 @@ class OffsetsForLeaderEpochTest {
   @Test
   def shouldReturnUnknownTopicOrPartitionIfThrown(): Unit = {
     val logManager: LogManager = mock(classOf[LogManager])
-    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
+    when(logManager.liveLogDirs).thenReturn(Seq.empty[File])
 
     //create a replica manager with 0 partition
     replicaManager = new ReplicaManager(


### PR DESCRIPTION
This PR takes all changes in https://github.com/apache/kafka/pull/11350 that are needed for a Scala 3 compatibility except those with an open bug report or already solved one.

The PR is separated in 5 commits, one for each type of change performed:
- Avoid Shadowing: Scala 3 compiler is not so friendly with shadowing and reports errors where Scala 2 wasn't.
- Not rely on automatic widening in numeric types: Scala 3 doesn't automatically convert `Short` to `Int` or `Int` to `Long` at will as in Scala 2. Changes in here help the typer by manually forcing the conversions.
- Remove redundant parenthesis: Scala 2 was more lax about calling with empty parenthesis a method without parenthesis. This became stricter in Scala 3.
- Explicit type declaration: Scala 3 changed a bit in the area of type inference and in some cases it picks the most general type, causing in our case some trouble as this is not public but package protected.
In other cases, the typer wasn't able to infer the proper one, forcing it to be manually set.
- Workaround for SAM conversion with overloading: This is a reported bug that unfortunately can't be fixed easily without breakage on Scala's side. For further information check lampepfl/dotty#13549

The resulting code is still Scala 2 valid code and arguably more correct.

Instead of doing all the changes in an enormous PR with all the changes at once, we can already perform the changes we know for a fact that are going to be needed for Scala 3.

If desired I can provide 1 PR per commit.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
