### PR TITLE
KAFKA-13295: Avoiding Transation timeouts arising due to long restora…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -347,7 +347,7 @@ public class TaskManager {
         // to avoid potential long restoration times.
         if (processingMode == EXACTLY_ONCE_V2 && threadProducer().transactionInFlight() && !newActiveTasks.isEmpty()) {
             log.info("New active tasks were added and there is an inflight transaction. Attempting to commit tasks.");
-            int numCommitted = commitTasksAndMaybeUpdateCommittableOffsets(newActiveTasks, new HashMap<>());
+            final int numCommitted = commitTasksAndMaybeUpdateCommittableOffsets(newActiveTasks, new HashMap<>());
             if (numCommitted == -1) {
                 log.info("Couldn't commit any tasks since a rebalance is in progress");
             } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -298,54 +298,6 @@ public class TaskManager {
         }
     }
 
-    private void commitActiveTasks(final Map<TaskId, Set<TopicPartition>> activeTasks, final AtomicReference<RuntimeException> activeTasksCommitException) {
-        final Set<Task> activeTasksNeedCommit = new HashSet<>();
-        final Set<Task> activeTasksNeedRestore = new HashSet<>();
-        for (final Task task : tasks.allTasks()) {
-            if (activeTasks.containsKey(task.id()) && task.isActive() && task.commitNeeded()) {
-                activeTasksNeedCommit.add(task);
-            } else if (activeTasks.containsKey(task.id()) && task.isActive() && task.state() == State.RESTORING) {
-                activeTasksNeedRestore.add(task);
-            }
-        }
-
-        // If there are no active tasks to restore, then we don't need to commit any offsets or transactions.
-        if (activeTasksNeedRestore.size() == 0)
-            return;
-
-        final Map<Task, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsPerTask = new HashMap<>();
-        prepareCommitAndAddOffsetsToMap(activeTasksNeedCommit, consumedOffsetsPerTask);
-
-        final Set<Task> dirtyTasks = new HashSet<>();
-        try {
-            commitOffsetsOrTransaction(consumedOffsetsPerTask);
-        } catch (final TaskCorruptedException e) {
-            log.warn("Some tasks were corrupted when trying to commit offsets, these will be cleaned and revived: {}",
-                    e.corruptedTasks());
-
-            // If we hit a TaskCorruptedException it must be EOS, just handle the cleanup for those corrupted tasks right here
-            dirtyTasks.addAll(tasks.tasks(e.corruptedTasks()));
-            closeDirtyAndRevive(dirtyTasks, true);
-        } catch (final RuntimeException e) {
-            log.error("Exception caught while committing active tasks " + activeTasksNeedCommit, e);
-            activeTasksCommitException.compareAndSet(null, e);
-            dirtyTasks.addAll(consumedOffsetsPerTask.keySet());
-        }
-
-        // we enforce checkpointing upon suspending a task: if it is resumed later we just proceed normally, if it is
-        // going to be closed we would checkpoint by then
-        for (final Task task : activeTasksNeedCommit) {
-            if (!dirtyTasks.contains(task)) {
-                try {
-                    task.postCommit(true);
-                } catch (final RuntimeException e) {
-                    log.error("Exception caught while post-committing task " + task.id(), e);
-                    maybeWrapAndSetFirstException(activeTasksCommitException, e, task.id());
-                }
-            }
-        }
-    }
-
     /**
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
      * @throws StreamsException fatal error while creating / initializing the task
@@ -360,13 +312,6 @@ public class TaskManager {
                      "\tExisting active tasks: {}\n" +
                      "\tExisting standby tasks: {}",
                  activeTasks.keySet(), standbyTasks.keySet(), activeTaskIds(), standbyTaskIds());
-
-        final AtomicReference<RuntimeException> activeTasksCommitException = new AtomicReference<>(null);
-        commitActiveTasks(activeTasks, activeTasksCommitException);
-
-        if (activeTasksCommitException.get() != null) {
-            throw activeTasksCommitException.get();
-        }
 
         topologyMetadata.addSubscribedTopicsFromAssignment(
             activeTasks.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1291,7 +1291,6 @@ public class IntegrationTestUtils {
                                                                  final int maxMessages) {
         final List<ConsumerRecord<K, V>> consumerRecords;
         consumer.subscribe(singletonList(topic));
-        System.out.println("Got assignment:" + consumer.assignment());
         final int pollIntervalMs = 100;
         consumerRecords = new ArrayList<>();
         int totalPollTimeMs = 0;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1632,9 +1632,10 @@ public class StreamThreadTest {
 
         final StreamsProducer threadProducer = EasyMock.createNiceMock(StreamsProducer.class);
 
+        final ActiveTaskCreator activeTaskCreator = mock(ActiveTaskCreator.class);
         final Tasks tasks = EasyMock.createNiceMock(Tasks.class);
-        EasyMock.expect(tasks.threadProducer()).andReturn(threadProducer);
-        EasyMock.expect(tasks.allTasks()).andReturn(Arrays.asList(task1, task2));
+        EasyMock.expect(activeTaskCreator.threadProducer()).andReturn(threadProducer);
+        EasyMock.expect(tasks.allTasks()).andReturn(mkSet(task1, task2));
         replay(tasks);
 
         thread.taskManager().handleAssignment(activeTasks, emptyMap());
@@ -1672,9 +1673,10 @@ public class StreamThreadTest {
 
         final StreamsProducer threadProducer = EasyMock.createNiceMock(StreamsProducer.class);
 
+        final ActiveTaskCreator activeTaskCreator = mock(ActiveTaskCreator.class);
         final Tasks tasks = EasyMock.createNiceMock(Tasks.class);
-        EasyMock.expect(tasks.threadProducer()).andReturn(threadProducer);
-        EasyMock.expect(tasks.allTasks()).andReturn(Arrays.asList(task1, task2));
+        EasyMock.expect(activeTaskCreator.threadProducer()).andReturn(threadProducer);
+        EasyMock.expect(tasks.allTasks()).andReturn(mkSet(task1, task2));
         replay(tasks);
 
         thread.taskManager().handleAssignment(activeTasks, emptyMap());
@@ -1711,10 +1713,12 @@ public class StreamThreadTest {
         EasyMock.expect(task1.state()).andReturn(Task.State.RESTORING);
 
         final StreamsProducer threadProducer = EasyMock.createNiceMock(StreamsProducer.class);
+        final ActiveTaskCreator activeTaskCreator = mock(ActiveTaskCreator.class);
+
 
         final Tasks tasks = EasyMock.createNiceMock(Tasks.class);
-        EasyMock.expect(tasks.threadProducer()).andReturn(threadProducer);
-        EasyMock.expect(tasks.allTasks()).andReturn(Arrays.asList(task1, task2));
+        EasyMock.expect(activeTaskCreator.threadProducer()).andReturn(threadProducer);
+        EasyMock.expect(tasks.allTasks()).andReturn(mkSet(task1, task2));
         replay(tasks);
 
         thread.taskManager().handleAssignment(activeTasks, emptyMap());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2498,7 +2498,7 @@ public class TaskManagerTest {
             );
 
         expect(consumer.groupMetadata()).andReturn(groupMetadata);
-        Set<TopicPartition> assignments = union(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions);
+        final Set<TopicPartition> assignments = union(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions);
         expect(consumer.assignment()).andStubReturn(assignments);
         consumer.resume(assignments);
         expectLastCall();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2458,7 +2458,6 @@ public class TaskManagerTest {
     @Test
     public void shouldCloseAndReviveUncorruptedTasksWhenTimeoutExceptionThrownFromCommitDuringRevocationWithEOS() {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_V2, false);
-        final ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("appId");
         final StreamsProducer producer = mock(StreamsProducer.class);
         expect(activeTaskCreator.threadProducer()).andStubReturn(producer);
         final ProcessorStateManager stateManager = EasyMock.createMock(ProcessorStateManager.class);
@@ -2488,8 +2487,6 @@ public class TaskManagerTest {
 
         stateManager.markChangelogAsCorrupted(taskId00ChangelogPartitions);
         stateManager.markChangelogAsCorrupted(taskId01ChangelogPartitions);
-        stateManager.markChangelogAsCorrupted(mkSet());
-        stateManager.markChangelogAsCorrupted(mkSet());
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
             mkEntry(taskId00, taskId00Partitions),
@@ -2497,11 +2494,6 @@ public class TaskManagerTest {
             mkEntry(taskId02, taskId02Partitions)
             );
 
-        expect(consumer.groupMetadata()).andReturn(groupMetadata);
-        final Set<TopicPartition> assignments = union(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions);
-        expect(consumer.assignment()).andStubReturn(assignments);
-        consumer.resume(assignments);
-        expectLastCall();
         expectRestoreToBeCompleted(consumer, changeLogReader);
 
         expect(activeTaskCreator.createTasks(anyObject(), eq(assignmentActive))).andReturn(asList(revokedActiveTask, unrevokedActiveTask, unrevokedActiveTaskWithoutCommitNeeded));
@@ -2509,8 +2501,12 @@ public class TaskManagerTest {
         activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(taskId00);
         expectLastCall();
 
+        final ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("appId");
+        expect(consumer.groupMetadata()).andReturn(groupMetadata);
 
         doThrow(new TimeoutException()).when(producer).commitTransaction(expectedCommittedOffsets, groupMetadata);
+
+        expect(consumer.assignment()).andStubReturn(union(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions));
 
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader, stateManager);
 
@@ -2529,7 +2525,7 @@ public class TaskManagerTest {
 
         assertThat(unrevokedTaskChangelogMarkedAsCorrupted.get(), is(true));
         assertThat(revokedActiveTask.state(), is(State.SUSPENDED));
-        assertThat(unrevokedActiveTask.state(), is(State.RUNNING));
+        assertThat(unrevokedActiveTask.state(), is(State.CREATED));
         assertThat(unrevokedActiveTaskWithoutCommitNeeded.state(), is(State.RUNNING));
     }
 
@@ -2788,8 +2784,6 @@ public class TaskManagerTest {
         final Map<TaskId, Set<TopicPartition>> assignmentStandby = mkMap(
             mkEntry(taskId10, taskId10Partitions)
         );
-        final ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("appId");
-        expect(consumer.groupMetadata()).andReturn(groupMetadata);
         expectRestoreToBeCompleted(consumer, changeLogReader);
 
         expect(activeTaskCreator.createTasks(anyObject(), eq(assignmentActive)))
@@ -2800,6 +2794,8 @@ public class TaskManagerTest {
         expect(standbyTaskCreator.createTasks(eq(assignmentStandby)))
             .andReturn(singletonList(task10));
 
+        final ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("appId");
+        expect(consumer.groupMetadata()).andReturn(groupMetadata);
         producer.commitTransaction(expectedCommittedOffsets, groupMetadata);
         expectLastCall();
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2795,7 +2795,7 @@ public class TaskManagerTest {
         expect(activeTaskCreator.createTasks(anyObject(), eq(assignmentActive)))
             .andReturn(asList(task00, task01, task02));
 
-        expect(activeTaskCreator.threadProducer()).andReturn(producer);
+        expect(activeTaskCreator.threadProducer()).andReturn(producer).times(2);
         activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(taskId00);
         expect(standbyTaskCreator.createTasks(eq(assignmentStandby)))
             .andReturn(singletonList(task10));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2681,7 +2681,7 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldNotCompleteRestorationIfTaskCannotCompleteRestoration() {
+    public void shouldNotCompleteRestorationAndCommitTaskIfTaskCannotCompleteRestoration() {
         final Map<TaskId, Set<TopicPartition>> assignment = mkMap(
             mkEntry(taskId00, taskId00Partitions)
         );
@@ -2715,6 +2715,16 @@ public class TaskManagerTest {
             taskManager.activeTaskMap(),
             Matchers.equalTo(mkMap(mkEntry(taskId00, task00)))
         );
+
+        final StreamsProducer threadProducer = EasyMock.createNiceMock(StreamsProducer.class);
+
+        final Tasks tasks = EasyMock.createNiceMock(Tasks.class);
+        EasyMock.expect(tasks.threadProducer()).andReturn(threadProducer);
+        EasyMock.expect(tasks.allTasks()).andReturn(singletonList(task00));
+        replay(tasks);
+        threadProducer.commitTransaction(anyObject(), anyObject());
+        EasyMock.expectLastCall().times(1);
+
         assertThat(taskManager.standbyTaskMap(), Matchers.anEmptyMap());
         verify(activeTaskCreator);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2502,7 +2502,7 @@ public class TaskManagerTest {
         expectLastCall();
 
         final ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("appId");
-        expect(consumer.groupMetadata()).andReturn(groupMetadata);
+        expect(consumer.groupMetadata()).andStubReturn(groupMetadata);
 
         doThrow(new TimeoutException()).when(producer).commitTransaction(expectedCommittedOffsets, groupMetadata);
 
@@ -2719,8 +2719,7 @@ public class TaskManagerTest {
         final StreamsProducer threadProducer = EasyMock.createNiceMock(StreamsProducer.class);
 
         final Tasks tasks = EasyMock.createNiceMock(Tasks.class);
-        EasyMock.expect(tasks.threadProducer()).andReturn(threadProducer);
-        EasyMock.expect(tasks.allTasks()).andReturn(singletonList(task00));
+        EasyMock.expect(tasks.allTasks()).andReturn(singleton(task00));
         replay(tasks);
         threadProducer.commitTransaction(anyObject(), anyObject());
         EasyMock.expectLastCall().times(1);
@@ -2796,7 +2795,7 @@ public class TaskManagerTest {
             .andReturn(singletonList(task10));
 
         final ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("appId");
-        expect(consumer.groupMetadata()).andReturn(groupMetadata);
+        expect(consumer.groupMetadata()).andStubReturn(groupMetadata);
         producer.commitTransaction(expectedCommittedOffsets, groupMetadata);
         expectLastCall();
 
@@ -4649,6 +4648,7 @@ public class TaskManagerTest {
         expect(activeTask.inputPartitions()).andStubReturn(taskId00Partitions);
         expect(activeTask.isActive()).andStubReturn(true);
         expect(activeTask.prepareCommit()).andStubReturn(Collections.emptyMap());
+        expect(activeTask.commitNeeded()).andStubReturn(false);
 
         final StandbyTask standbyTask = EasyMock.mock(StandbyTask.class);
         expect(standbyTask.id()).andStubReturn(taskId00);


### PR DESCRIPTION
…tion times in EOS

The PR aims to avoid transaction timeouts arising due to long restoration times of new tasks. In particular, during assignment of active tasks, if there are any open transactions that need commit, this change would ensure those are done.