### PR TITLE
KAFKA-13395: Emit Client Quota Values as Metric

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -24,39 +24,46 @@ import kafka.network.RequestChannel
 import kafka.network.RequestChannel._
 import kafka.server.ClientQuotaManager._
 import kafka.utils.{Logging, QuotaUtils, ShutdownableThread}
-import org.apache.kafka.common.{Cluster, MetricName}
-import org.apache.kafka.common.metrics._
-import org.apache.kafka.common.metrics.Metrics
-import org.apache.kafka.common.metrics.stats.{Avg, CumulativeSum, Rate}
+import org.apache.kafka.common.metrics.stats.{Avg, CumulativeSum, Rate, Value}
+import org.apache.kafka.common.metrics.{Metrics, _}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{Sanitizer, Time}
+import org.apache.kafka.common.{Cluster, MetricName}
 import org.apache.kafka.server.quota.{ClientQuotaCallback, ClientQuotaEntity, ClientQuotaType}
 
 import scala.jdk.CollectionConverters._
 
 /**
  * Represents the sensors aggregated per client
- * @param metricTags Quota metric tags for the client
- * @param quotaSensor @Sensor that tracks the quota
+ * @param metricTags         Quota metric tags for the client
+ * @param quotaSensor        @Sensor that tracks the quota
  * @param throttleTimeSensor @Sensor that tracks the throttle time
+ * @param quotaValueSensor   @Option[Sensor] that tracks the quota value
  */
-case class ClientSensors(metricTags: Map[String, String], quotaSensor: Sensor, throttleTimeSensor: Sensor)
+case class ClientSensors(metricTags: Map[String, String],
+                         quotaSensor: Sensor,
+                         throttleTimeSensor: Sensor,
+                         quotaValueSensor: Option[Sensor])
 
 /**
  * Configuration settings for quota management
  * @param numQuotaSamples The number of samples to retain in memory
  * @param quotaWindowSizeSeconds The time span of each sample
- *
+ * @param quotaValueMetricEnable Boolean flag for if the client quota value should be reported as a metric
  */
 case class ClientQuotaManagerConfig(numQuotaSamples: Int =
                                         ClientQuotaManagerConfig.DefaultNumQuotaSamples,
                                     quotaWindowSizeSeconds: Int =
-                                        ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds)
+                                        ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds,
+                                    quotaValueMetricEnable: Boolean =
+                                        ClientQuotaManagerConfig.DefaultQuotaValueMetricEnable
+                                   )
 
 object ClientQuotaManagerConfig {
   // Always have 10 whole windows + 1 current window
   val DefaultNumQuotaSamples = 11
   val DefaultQuotaWindowSizeSeconds = 1
+  val DefaultQuotaValueMetricEnable = false
 }
 
 object QuotaTypes {
@@ -269,6 +276,12 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   def recordAndGetThrottleTimeMs(session: Session, clientId: String, value: Double, timeMs: Long): Int = {
     val clientSensors = getOrCreateQuotaSensors(session, clientId)
     try {
+
+      clientSensors.quotaValueSensor.foreach(s =>
+        Option(quotaCallback.quotaLimit(clientQuotaType, clientSensors.metricTags.asJava)).foreach(
+          q => s.record(q.toDouble, timeMs, false))
+      )
+
       clientSensors.quotaSensor.record(value, timeMs, true)
       0
     } catch {
@@ -395,10 +408,18 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
         registerQuotaMetrics(metricTags)
       ),
       sensorAccessor.getOrCreate(
-        getThrottleTimeSensorName(metricTags),
+        getQuotaSensorName(metricTags, "ThrottleTime"),
         ClientQuotaManager.InactiveSensorExpirationTimeSeconds,
         sensor => sensor.add(throttleMetricName(metricTags), new Avg)
-      )
+      ),
+      if (config.quotaValueMetricEnable) {
+        Some(sensorAccessor.getOrCreate(
+          getQuotaSensorName(metricTags, "Value"),
+          ClientQuotaManager.InactiveSensorExpirationTimeSeconds,
+          sensor => sensor.add(quotaValueMetricName(metricTags), new Value)
+        ))
+      }
+      else None
     )
     if (quotaCallback.quotaResetRequired(clientQuotaType))
       updateQuotaMetricConfigs()
@@ -416,11 +437,8 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   private def metricTagsToSensorSuffix(metricTags: Map[String, String]): String =
     metricTags.values.mkString(":")
 
-  private def getThrottleTimeSensorName(metricTags: Map[String, String]): String =
-    s"${quotaType}ThrottleTime-${metricTagsToSensorSuffix(metricTags)}"
-
-  private def getQuotaSensorName(metricTags: Map[String, String]): String =
-    s"$quotaType-${metricTagsToSensorSuffix(metricTags)}"
+  private def getQuotaSensorName(metricTags: Map[String, String], infix: String = ""): String =
+    s"${quotaType}${infix}-${metricTagsToSensorSuffix(metricTags)}"
 
   protected def getQuotaMetricConfig(metricTags: Map[String, String]): MetricConfig = {
     getQuotaMetricConfig(quotaLimit(metricTags.asJava))
@@ -552,6 +570,13 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   protected def clientQuotaMetricName(quotaMetricTags: Map[String, String]): MetricName = {
     metrics.metricName("byte-rate", quotaType.toString,
       "Tracking byte-rate per user/client-id",
+      quotaMetricTags.asJava)
+  }
+
+  protected def quotaValueMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+    metrics.metricName("byte-quota-value",
+      quotaType.toString,
+      "Tracking the byte-rate quota value per user/client-id",
       quotaMetricTags.asJava)
   }
 

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -85,6 +85,11 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
       quotaMetricTags.asJava)
   }
 
+  override protected def quotaValueMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+    metrics.metricName("request-quota-value", QuotaType.Request.toString,
+      "Tracking request-time quota per user/client-id", quotaMetricTags.asJava)
+  }
+
   private def nanosToPercentage(nanos: Long): Double =
     nanos * ClientRequestQuotaManager.NanosToPercentagePerSecond
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -219,6 +219,7 @@ object Defaults {
   val AlterLogDirsReplicationQuotaWindowSizeSeconds: Int = ReplicationQuotaManagerConfig.DefaultQuotaWindowSizeSeconds
   val NumControllerQuotaSamples: Int = ClientQuotaManagerConfig.DefaultNumQuotaSamples
   val ControllerQuotaWindowSizeSeconds: Int = ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds
+  val ClientQuotaValueMetricEnable: Boolean = ClientQuotaManagerConfig.DefaultQuotaValueMetricEnable
 
   /** ********* Transaction Configuration ***********/
   val TransactionalIdExpirationMsDefault = 604800000
@@ -532,6 +533,7 @@ object KafkaConfig {
   val AlterLogDirsReplicationQuotaWindowSizeSecondsProp = "alter.log.dirs.replication.quota.window.size.seconds"
   val ControllerQuotaWindowSizeSecondsProp = "controller.quota.window.size.seconds"
   val ClientQuotaCallbackClassProp = "client.quota.callback.class"
+  val ClientQuotaValueMetricEnableProp = "client.quota.value.metric.enable"
 
   val DeleteTopicEnableProp = "delete.topic.enable"
   val CompressionTypeProp = "compression.type"
@@ -935,6 +937,9 @@ object KafkaConfig {
     "quotas stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal " +
     "of the session and the client-id of the request is applied."
 
+  val ClientQuotaValueMetricEnableDoc = "Flag to enable emitting the quota value for each client-id/user metric " +
+    "if dynamic quota values are applied."
+
   val DeleteTopicEnableDoc = "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off"
   val CompressionTypeDoc = "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs " +
   "('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and " +
@@ -1246,6 +1251,7 @@ object KafkaConfig {
       .define(AlterLogDirsReplicationQuotaWindowSizeSecondsProp, INT, Defaults.AlterLogDirsReplicationQuotaWindowSizeSeconds, atLeast(1), LOW, AlterLogDirsReplicationQuotaWindowSizeSecondsDoc)
       .define(ControllerQuotaWindowSizeSecondsProp, INT, Defaults.ControllerQuotaWindowSizeSeconds, atLeast(1), LOW, ControllerQuotaWindowSizeSecondsDoc)
       .define(ClientQuotaCallbackClassProp, CLASS, null, LOW, ClientQuotaCallbackClassDoc)
+      .define(ClientQuotaValueMetricEnableProp, BOOLEAN, Defaults.ClientQuotaValueMetricEnable, LOW, ClientQuotaValueMetricEnableDoc)
 
       /** ********* General Security Configuration ****************/
       .define(ConnectionsMaxReauthMsProp, LONG, Defaults.ConnectionsMaxReauthMsDefault, MEDIUM, ConnectionsMaxReauthMsDoc)
@@ -1776,6 +1782,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val alterLogDirsReplicationQuotaWindowSizeSeconds = getInt(KafkaConfig.AlterLogDirsReplicationQuotaWindowSizeSecondsProp)
   val numControllerQuotaSamples = getInt(KafkaConfig.NumControllerQuotaSamplesProp)
   val controllerQuotaWindowSizeSeconds = getInt(KafkaConfig.ControllerQuotaWindowSizeSecondsProp)
+  val clientQuotaMetricValueEnable = getBoolean(KafkaConfig.ClientQuotaValueMetricEnableProp)
 
   /** ********* Fetch Configuration **************/
   val maxIncrementalFetchSessionCacheSlots = getInt(KafkaConfig.MaxIncrementalFetchSessionCacheSlots)

--- a/core/src/main/scala/kafka/server/QuotaFactory.scala
+++ b/core/src/main/scala/kafka/server/QuotaFactory.scala
@@ -91,7 +91,8 @@ object QuotaFactory extends Logging {
   def clientConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
     ClientQuotaManagerConfig(
       numQuotaSamples = cfg.numQuotaSamples,
-      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds
+      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds,
+      quotaValueMetricEnable = cfg.clientQuotaMetricValueEnable
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -718,6 +718,7 @@ class KafkaConfigTest {
         case KafkaConfig.TransactionsTopicReplicationFactorProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0", "-2")
         case KafkaConfig.NumQuotaSamplesProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.QuotaWindowSizeSecondsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
+        case KafkaConfig.ClientQuotaValueMetricEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
         case KafkaConfig.DeleteTopicEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
 
         case KafkaConfig.MetricNumSamplesProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -82,6 +82,7 @@ class RequestQuotaTest extends BaseRequestTest {
     properties.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
     properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[RequestQuotaTest.TestAuthorizer].getName)
     properties.put(KafkaConfig.PrincipalBuilderClassProp, classOf[RequestQuotaTest.TestPrincipalBuilder].getName)
+    properties.put(KafkaConfig.ClientQuotaValueMetricEnableProp, "true")
   }
 
   @BeforeEach
@@ -133,6 +134,18 @@ class RequestQuotaTest extends BaseRequestTest {
     for (apiKey <- RequestQuotaTest.ClientActions ++ RequestQuotaTest.ClusterActionsWithThrottle)
       submitTest(apiKey, () => checkRequestThrottleTime(apiKey))
 
+    waitAndCheckResults()
+  }
+
+  @Test
+  def testProduceAndRequestQuotaMetricValueWhenOverrideSet(): Unit = {
+    submitTest(ApiKeys.PRODUCE, () => checkSmallQuotaProducerQuotaMetric())
+    waitAndCheckResults()
+  }
+
+  @Test
+  def testConsumerAndRequestQuotaMetricValueWhenOverrideSet(): Unit = {
+    submitTest(ApiKeys.FETCH, () => checkSmallQuotaConsumerQuotaMetric())
     waitAndCheckResults()
   }
 
@@ -190,6 +203,33 @@ class RequestQuotaTest extends BaseRequestTest {
       clientId).throttleTimeSensor
     metricValue(leaderNode.metrics.metrics.get(metricName), sensor)
   }
+
+  private def byteQuotaMetricValue(clientId: String, quotaType: QuotaType): Double = {
+    val metricName = leaderNode.metrics.metricName("byte-quota-value",
+      quotaType.toString, "", "user", "", "client-id", clientId)
+
+    val sensor = if (quotaType == QuotaType.Fetch) {
+      leaderNode.quotaManagers.fetch.getOrCreateQuotaSensors(session("ANONYMOUS"),
+        clientId).quotaValueSensor
+    }
+    else {
+      leaderNode.quotaManagers.produce.getOrCreateQuotaSensors(session("ANONYMOUS"),
+        clientId).quotaValueSensor
+    }
+
+    metricValue(leaderNode.metrics.metrics.get(metricName), sensor.orNull)
+  }
+
+  private def requestQuotaMetricValue(clientId: String): Double = {
+    val metricName = leaderNode.metrics.metricName("request-quota-value",
+      QuotaType.Request.toString, "", "user", "", "client-id", clientId)
+
+    val sensor = leaderNode.quotaManagers.request.getOrCreateQuotaSensors(session("ANONYMOUS"),
+      clientId).quotaValueSensor
+
+    metricValue(leaderNode.metrics.metrics.get(metricName), sensor.orNull)
+  }
+
 
   private def requestTimeMetricValue(clientId: String): Double = {
     val metricName = leaderNode.metrics.metricName("request-time", QuotaType.Request.toString,
@@ -758,6 +798,42 @@ class RequestQuotaTest extends BaseRequestTest {
     val client = Client(clientId, apiKey)
     val throttled = client.runUntil(_ => throttleTimeMetricValue(clientId) > 0.0)
     assertTrue(throttled, s"Unauthorized client should have been throttled: $client")
+  }
+
+
+  private def checkSmallQuotaConsumerQuotaMetric(): Unit = {
+    val smallQuotaConsumerClient = Client(smallQuotaConsumerClientId, ApiKeys.FETCH)
+    val updated = smallQuotaConsumerClient.runUntil(_ =>
+      requestQuotaMetricValue(smallQuotaConsumerClientId) > 0)
+
+    val consumeQuotaManager = servers.head.dataPlaneRequestProcessor.quotas.fetch
+    val requestQuotaManager = servers.head.dataPlaneRequestProcessor.quotas.request
+
+    assertTrue(updated, s"Quota metric value should be updated: $updated")
+    assertEquals(Quota.upperBound(byteQuotaMetricValue(smallQuotaConsumerClientId, QuotaType.Fetch)),
+      consumeQuotaManager.quota("some-user", smallQuotaConsumerClientId),
+      s"Byte-rate consume quota metric value should be updated")
+    assertEquals(Quota.upperBound(requestQuotaMetricValue(smallQuotaConsumerClientId)),
+      requestQuotaManager.quota("some-user", smallQuotaConsumerClientId),
+      s"Request-time quota metric value should be updated")
+  }
+
+  private def checkSmallQuotaProducerQuotaMetric(): Unit = {
+    val smallQuotaProducerClient = Client(smallQuotaProducerClientId, ApiKeys.PRODUCE)
+    val updated = smallQuotaProducerClient.runUntil(_ =>
+      byteQuotaMetricValue(smallQuotaProducerClientId, QuotaType.Produce) > 0)
+
+    val produceQuotaManager = servers.head.dataPlaneRequestProcessor.quotas.produce
+    val requestQuotaManager = servers.head.dataPlaneRequestProcessor.quotas.request
+
+    assertTrue(updated, s"Quota metric value should be updated: $updated")
+    assertEquals(
+      Quota.upperBound(byteQuotaMetricValue(smallQuotaProducerClientId, QuotaType.Produce)),
+      produceQuotaManager.quota("some-user", smallQuotaProducerClientId),
+      s"Byte-rate produce quota value should be updated:")
+    assertEquals(Quota.upperBound(requestQuotaMetricValue(smallQuotaProducerClientId)),
+      requestQuotaManager.quota("some-user", smallQuotaProducerClientId),
+      s"Request-time quota metric value should be updated")
   }
 }
 


### PR DESCRIPTION
Implementation of proposed changes outlined in KIP 786.

- Optionally emits client quota values attached to the `byte-rate` and
  `throttle-time` under the `kafka.server` MBean.
  - This is done by the creation of new attributes `byte-quota-value`
    and `request-quota-value` respectively.
- Enabling the additional metrics is done through the boolean broker
  config `client.quota.value.metric.value`

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
