### PR TITLE
KAFKA-13411: This code enforces the creation of the correct sasl client (OAuthBear…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -53,6 +53,9 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
+import javax.security.auth.callback.CallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClient;
+
 import javax.security.auth.Subject;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -53,7 +53,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
-import javax.security.auth.callback.CallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClient;
 
 import javax.security.auth.Subject;
@@ -220,13 +219,11 @@ public class SaslClientAuthenticator implements Authenticator {
                 log.debug("Creating SaslClient: client={};service={};serviceHostname={};mechs={}",
                     clientPrincipalName, servicePrincipal, host, Arrays.toString(mechs));
                 SaslClient retvalSaslClient = null;
-                if("OAUTHBEARER".equalsIgnoreCase(mechanism))
-                {
-	                OAuthBearerSaslClient.OAuthBearerSaslClientFactory ofactory = new OAuthBearerSaslClient.OAuthBearerSaslClientFactory();
-	                retvalSaslClient = ofactory.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
-                }else
-                {              
-                	retvalSaslClient = Sasl.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
+                if ("OAUTHBEARER".equalsIgnoreCase(mechanism)) {
+                    OAuthBearerSaslClient.OAuthBearerSaslClientFactory ofactory = new OAuthBearerSaslClient.OAuthBearerSaslClientFactory();
+                    retvalSaslClient = ofactory.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
+                } else {              
+                    retvalSaslClient = Sasl.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
                 }
 
                 if (retvalSaslClient == null) {

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -216,7 +216,16 @@ public class SaslClientAuthenticator implements Authenticator {
                 String[] mechs = {mechanism};
                 log.debug("Creating SaslClient: client={};service={};serviceHostname={};mechs={}",
                     clientPrincipalName, servicePrincipal, host, Arrays.toString(mechs));
-                SaslClient retvalSaslClient = Sasl.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
+                SaslClient retvalSaslClient = null;
+                if("OAUTHBEARER".equalsIgnoreCase(mechanism))
+                {
+	                OAuthBearerSaslClient.OAuthBearerSaslClientFactory ofactory = new OAuthBearerSaslClient.OAuthBearerSaslClientFactory();
+	                retvalSaslClient = ofactory.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
+                }else
+                {              
+                	retvalSaslClient = Sasl.createSaslClient(mechs, clientPrincipalName, servicePrincipal, host, configs, callbackHandler);
+                }
+
                 if (retvalSaslClient == null) {
                     throw new SaslAuthenticationException("Failed to create SaslClient with mechanism " + mechanism);
                 }


### PR DESCRIPTION
…erSaslClient) when the mechanism is OAUTHBEARER. There were issues when the client was loaded from different contexts which contains other sasl client implementations also for the OAUTHBEARER mechanism (example running in a wildfly context)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
