### PR TITLE
KAFKA-13414: Replace Powermock/EasyMock by Mockito in connect.storage

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -18,27 +18,25 @@ package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.util.Callback;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(PowerMockRunner.class)
 public class FileOffsetBackingStoreTest {
 
     FileOffsetBackingStore store;
@@ -55,7 +53,6 @@ public class FileOffsetBackingStoreTest {
         firstSet.put(null, null);
     }
 
-    @SuppressWarnings("deprecation")
     @Before
     public void setup() throws IOException {
         store = new FileOffsetBackingStore();
@@ -77,21 +74,17 @@ public class FileOffsetBackingStoreTest {
     @Test
     public void testGetSet() throws Exception {
         Callback<Void> setCallback = expectSuccessfulSetCallback();
-        PowerMock.replayAll();
 
         store.set(firstSet, setCallback).get();
 
         Map<ByteBuffer, ByteBuffer> values = store.get(Arrays.asList(buffer("key"), buffer("bad"))).get();
         assertEquals(buffer("value"), values.get(buffer("key")));
         assertNull(values.get(buffer("bad")));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testSaveRestore() throws Exception {
         Callback<Void> setCallback = expectSuccessfulSetCallback();
-        PowerMock.replayAll();
 
         store.set(firstSet, setCallback).get();
         store.stop();
@@ -100,10 +93,8 @@ public class FileOffsetBackingStoreTest {
         FileOffsetBackingStore restore = new FileOffsetBackingStore();
         restore.configure(config);
         restore.start();
-        Map<ByteBuffer, ByteBuffer> values = restore.get(Arrays.asList(buffer("key"))).get();
+        Map<ByteBuffer, ByteBuffer> values = restore.get(Collections.singletonList(buffer("key"))).get();
         assertEquals(buffer("value"), values.get(buffer("key")));
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -118,9 +109,8 @@ public class FileOffsetBackingStoreTest {
 
     private Callback<Void> expectSuccessfulSetCallback() {
         @SuppressWarnings("unchecked")
-        Callback<Void> setCallback = PowerMock.createMock(Callback.class);
-        setCallback.onCompletion(EasyMock.isNull(Throwable.class), EasyMock.isNull(Void.class));
-        PowerMock.expectLastCall();
+        Callback<Void> setCallback = mock(Callback.class);
+        setCallback.onCompletion(isNull(), isNull());
         return setCallback;
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -73,18 +74,21 @@ public class FileOffsetBackingStoreTest {
 
     @Test
     public void testGetSet() throws Exception {
-        Callback<Void> setCallback = expectSuccessfulSetCallback();
+        @SuppressWarnings("unchecked")
+        Callback<Void> setCallback = mock(Callback.class);
 
         store.set(firstSet, setCallback).get();
 
         Map<ByteBuffer, ByteBuffer> values = store.get(Arrays.asList(buffer("key"), buffer("bad"))).get();
         assertEquals(buffer("value"), values.get(buffer("key")));
         assertNull(values.get(buffer("bad")));
+        verify(setCallback).onCompletion(isNull(), isNull());
     }
 
     @Test
     public void testSaveRestore() throws Exception {
-        Callback<Void> setCallback = expectSuccessfulSetCallback();
+        @SuppressWarnings("unchecked")
+        Callback<Void> setCallback = mock(Callback.class);
 
         store.set(firstSet, setCallback).get();
         store.stop();
@@ -95,6 +99,7 @@ public class FileOffsetBackingStoreTest {
         restore.start();
         Map<ByteBuffer, ByteBuffer> values = restore.get(Collections.singletonList(buffer("key"))).get();
         assertEquals(buffer("value"), values.get(buffer("key")));
+        verify(setCallback).onCompletion(isNull(), isNull());
     }
 
     @Test
@@ -107,10 +112,4 @@ public class FileOffsetBackingStoreTest {
         return ByteBuffer.wrap(v.getBytes());
     }
 
-    private Callback<Void> expectSuccessfulSetCallback() {
-        @SuppressWarnings("unchecked")
-        Callback<Void> setCallback = mock(Callback.class);
-        setCallback.onCompletion(isNull(), isNull());
-        return setCallback;
-    }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
@@ -26,13 +26,9 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.TopicStatus;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
-import org.easymock.Capture;
-import org.easymock.EasyMockSupport;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,17 +40,17 @@ import static org.apache.kafka.connect.storage.KafkaStatusBackingStore.CONNECTOR
 import static org.apache.kafka.connect.storage.KafkaStatusBackingStore.TASK_STATUS_PREFIX;
 import static org.apache.kafka.connect.storage.KafkaStatusBackingStore.TOPIC_STATUS_PREFIX;
 import static org.apache.kafka.connect.storage.KafkaStatusBackingStore.TOPIC_STATUS_SEPARATOR;
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.newCapture;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(PowerMockRunner.class)
-public class KafkaStatusBackingStoreFormatTest extends EasyMockSupport {
+@SuppressWarnings("unchecked")
+public class KafkaStatusBackingStoreFormatTest {
 
     private static final String STATUS_TOPIC = "status-topic";
     private static final String FOO_TOPIC = "foo-topic";
@@ -64,8 +60,8 @@ public class KafkaStatusBackingStoreFormatTest extends EasyMockSupport {
     private Time time;
     private KafkaStatusBackingStore store;
     private JsonConverter converter;
-    @Mock
-    private KafkaBasedLog<String, byte[]> kafkaBasedLog;
+
+    private KafkaBasedLog<String, byte[]> kafkaBasedLog = mock(KafkaBasedLog.class);
 
     @Before
     public void setup() {
@@ -185,82 +181,64 @@ public class KafkaStatusBackingStoreFormatTest extends EasyMockSupport {
     public void putTopicState() {
         TopicStatus topicStatus = new TopicStatus(FOO_TOPIC, new ConnectorTaskId(FOO_CONNECTOR, 0), time.milliseconds());
         String key = TOPIC_STATUS_PREFIX + FOO_TOPIC + TOPIC_STATUS_SEPARATOR + FOO_CONNECTOR;
-        Capture<byte[]> valueCapture = newCapture();
-        Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq(key), capture(valueCapture), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    return null;
-                });
-        replayAll();
+        ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            return null;
+        }).when(kafkaBasedLog).send(eq(key), valueCaptor.capture(), any(Callback.class));
 
         store.put(topicStatus);
         // check capture state
-        assertEquals(topicStatus, store.parseTopicStatus(valueCapture.getValue()));
+        assertEquals(topicStatus, store.parseTopicStatus(valueCaptor.getValue()));
         // state is not visible until read back from the log
         assertNull(store.getTopic(FOO_CONNECTOR, FOO_TOPIC));
 
-        ConsumerRecord<String, byte[]> statusRecord = new ConsumerRecord<>(STATUS_TOPIC, 0, 0, key, valueCapture.getValue());
+        ConsumerRecord<String, byte[]> statusRecord = new ConsumerRecord<>(STATUS_TOPIC, 0, 0, key, valueCaptor.getValue());
         store.read(statusRecord);
         assertEquals(topicStatus, store.getTopic(FOO_CONNECTOR, FOO_TOPIC));
-        assertEquals(new HashSet<>(Collections.singletonList(topicStatus)), new HashSet<>(store.getAllTopics(FOO_CONNECTOR)));
-
-        verifyAll();
+        assertEquals(Collections.singleton(topicStatus), new HashSet<>(store.getAllTopics(FOO_CONNECTOR)));
     }
 
     @Test
     public void putTopicStateRetriableFailure() {
         TopicStatus topicStatus = new TopicStatus(FOO_TOPIC, new ConnectorTaskId(FOO_CONNECTOR, 0), time.milliseconds());
         String key = TOPIC_STATUS_PREFIX + FOO_TOPIC + TOPIC_STATUS_SEPARATOR + FOO_CONNECTOR;
-        Capture<byte[]> valueCapture = newCapture();
-        Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq(key), capture(valueCapture), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, new TimeoutException());
-                    return null;
-                })
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    return null;
-                });
 
-        replayAll();
+        ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, new TimeoutException());
+            return null;
+        }).doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            return null;
+        }).when(kafkaBasedLog).send(eq(key), valueCaptor.capture(), any(Callback.class));
+
         store.put(topicStatus);
 
         // check capture state
-        assertEquals(topicStatus, store.parseTopicStatus(valueCapture.getValue()));
+        assertEquals(topicStatus, store.parseTopicStatus(valueCaptor.getValue()));
         // state is not visible until read back from the log
         assertNull(store.getTopic(FOO_CONNECTOR, FOO_TOPIC));
-
-        verifyAll();
     }
 
     @Test
     public void putTopicStateNonRetriableFailure() {
         TopicStatus topicStatus = new TopicStatus(FOO_TOPIC, new ConnectorTaskId(FOO_CONNECTOR, 0), time.milliseconds());
         String key = TOPIC_STATUS_PREFIX + FOO_TOPIC + TOPIC_STATUS_SEPARATOR + FOO_CONNECTOR;
-        Capture<byte[]> valueCapture = newCapture();
-        Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq(key), capture(valueCapture), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, new UnknownServerException());
-                    return null;
-                });
 
-        replayAll();
+        ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, new UnknownServerException());
+            return null;
+        }).when(kafkaBasedLog).send(eq(key), valueCaptor.capture(), any(Callback.class));
 
         // the error is logged and ignored
         store.put(topicStatus);
 
         // check capture state
-        assertEquals(topicStatus, store.parseTopicStatus(valueCapture.getValue()));
+        assertEquals(topicStatus, store.parseTopicStatus(valueCaptor.getValue()));
         // state is not visible until read back from the log
         assertNull(store.getTopic(FOO_CONNECTOR, FOO_TOPIC));
-
-        verifyAll();
     }
 
     @Test
@@ -272,18 +250,14 @@ public class KafkaStatusBackingStoreFormatTest extends EasyMockSupport {
                 0), time.milliseconds());
         String firstKey = TOPIC_STATUS_PREFIX + FOO_TOPIC + TOPIC_STATUS_SEPARATOR + FOO_CONNECTOR;
         String secondKey = TOPIC_STATUS_PREFIX + BAR_TOPIC + TOPIC_STATUS_SEPARATOR + FOO_CONNECTOR;
-        Capture<byte[]> valueCapture = newCapture();
-        Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq(secondKey), capture(valueCapture), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    // The second status record is read soon after it's persisted in the status topic
-                    ConsumerRecord<String, byte[]> statusRecord = new ConsumerRecord<>(STATUS_TOPIC, 0, 0, secondKey, valueCapture.getValue());
-                    store.read(statusRecord);
-                    return null;
-                });
-        replayAll();
+
+        ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            ConsumerRecord<String, byte[]> statusRecord = new ConsumerRecord<>(STATUS_TOPIC, 0, 0, secondKey, valueCaptor.getValue());
+            store.read(statusRecord);
+            return null;
+        }).when(kafkaBasedLog).send(eq(secondKey), valueCaptor.capture(), any(Callback.class));
 
         byte[] value = store.serializeTopicStatus(firstTopicStatus);
         ConsumerRecord<String, byte[]> statusRecord = new ConsumerRecord<>(STATUS_TOPIC, 0, 0, firstKey, value);
@@ -291,13 +265,10 @@ public class KafkaStatusBackingStoreFormatTest extends EasyMockSupport {
         store.put(secondTopicStatus);
 
         // check capture state
-        assertEquals(secondTopicStatus, store.parseTopicStatus(valueCapture.getValue()));
+        assertEquals(secondTopicStatus, store.parseTopicStatus(valueCaptor.getValue()));
         assertEquals(firstTopicStatus, store.getTopic(FOO_CONNECTOR, FOO_TOPIC));
         assertEquals(secondTopicStatus, store.getTopic(FOO_CONNECTOR, BAR_TOPIC));
-        assertEquals(new HashSet<>(Arrays.asList(firstTopicStatus, secondTopicStatus)),
-                new HashSet<>(store.getAllTopics(FOO_CONNECTOR)));
-
-        verifyAll();
+        assertEquals(new HashSet<>(Arrays.asList(firstTopicStatus, secondTopicStatus)), new HashSet<>(store.getAllTopics(FOO_CONNECTOR)));
     }
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreFormatTest.java
@@ -48,6 +48,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("unchecked")
 public class KafkaStatusBackingStoreFormatTest {
@@ -214,6 +216,7 @@ public class KafkaStatusBackingStoreFormatTest {
         }).when(kafkaBasedLog).send(eq(key), valueCaptor.capture(), any(Callback.class));
 
         store.put(topicStatus);
+        verify(kafkaBasedLog, times(2)).send(any(), any(), any());
 
         // check capture state
         assertEquals(topicStatus, store.parseTopicStatus(valueCaptor.getValue()));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
@@ -33,14 +33,9 @@ import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockSupport;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,20 +43,21 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.newCapture;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
-@RunWith(PowerMockRunner.class)
-public class KafkaStatusBackingStoreTest extends EasyMockSupport {
+public class KafkaStatusBackingStoreTest {
 
     private static final String STATUS_TOPIC = "status-topic";
     private static final String WORKER_ID = "localhost:8083";
@@ -69,12 +65,10 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
     private static final ConnectorTaskId TASK = new ConnectorTaskId(CONNECTOR, 0);
 
     private KafkaStatusBackingStore store;
-    @Mock
-    Converter converter;
-    @Mock
-    private KafkaBasedLog<String, byte[]> kafkaBasedLog;
-    @Mock
-    WorkerConfig workerConfig;
+    private final KafkaBasedLog<String, byte[]> kafkaBasedLog = mock(KafkaBasedLog.class);
+
+    Converter converter = mock(Converter.class);
+    WorkerConfig workerConfig = mock(WorkerConfig.class);
 
     @Before
     public void setup() {
@@ -83,83 +77,62 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
 
     @Test
     public void misconfigurationOfStatusBackingStore() {
-        expect(workerConfig.getString(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG)).andReturn(null);
-        expect(workerConfig.getString(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG)).andReturn("   ");
-        replayAll();
+        when(workerConfig.getString(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG)).thenReturn(null);
+        when(workerConfig.getString(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG)).thenReturn("   ");
 
         Exception e = assertThrows(ConfigException.class, () -> store.configure(workerConfig));
         assertEquals("Must specify topic for connector status.", e.getMessage());
         e = assertThrows(ConfigException.class, () -> store.configure(workerConfig));
         assertEquals("Must specify topic for connector status.", e.getMessage());
-        verifyAll();
     }
 
     @Test
     public void putConnectorState() {
         byte[] value = new byte[0];
-        expect(converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class)))
-                .andStubReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class))).thenReturn(value);
 
-        final Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq("status-connector-conn"), eq(value), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    return null;
-                });
-        replayAll();
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            return null;
+        }).when(kafkaBasedLog).send(eq("status-connector-conn"), eq(value), any(Callback.class));
 
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.RUNNING, WORKER_ID, 0);
         store.put(status);
 
         // state is not visible until read back from the log
         assertNull(store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
     public void putConnectorStateRetriableFailure() {
         byte[] value = new byte[0];
-        expect(converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class)))
-                .andStubReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class))).thenReturn(value);
 
-        final Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq("status-connector-conn"), eq(value), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, new TimeoutException());
-                    return null;
-                })
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    return null;
-                });
-        replayAll();
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, new TimeoutException());
+            return null;
+        }).doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            return null;
+        })
+        .when(kafkaBasedLog).send(eq("status-connector-conn"), eq(value), any(Callback.class));
 
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.RUNNING, WORKER_ID, 0);
         store.put(status);
 
         // state is not visible until read back from the log
         assertNull(store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
     public void putConnectorStateNonRetriableFailure() {
         byte[] value = new byte[0];
-        expect(converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class)))
-                .andStubReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class))).thenReturn(value);
 
-        final Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq("status-connector-conn"), eq(value), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, new UnknownServerException());
-                    return null;
-                });
-        replayAll();
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, new UnknownServerException());
+            return null;
+        }).when(kafkaBasedLog).send(eq("status-connector-conn"), eq(value), any(Callback.class));
 
         // the error is logged and ignored
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.RUNNING, WORKER_ID, 0);
@@ -167,8 +140,6 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
 
         // state is not visible until read back from the log
         assertNull(store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
@@ -182,43 +153,29 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         statusMap.put("state", "RUNNING");
         statusMap.put("generation", 1L);
 
-        expect(converter.toConnectData(STATUS_TOPIC, value))
-                .andReturn(new SchemaAndValue(null, statusMap));
-
-        // we're verifying that there is no call to KafkaBasedLog.send
-
-        replayAll();
+        when(converter.toConnectData(STATUS_TOPIC, value)).thenReturn(new SchemaAndValue(null, statusMap));
 
         store.read(consumerRecord(0, "status-connector-conn", value));
         store.putSafe(new ConnectorStatus(CONNECTOR, ConnectorStatus.State.UNASSIGNED, WORKER_ID, 0));
 
+        verify(kafkaBasedLog, never()).send(anyString(), any(), any(Callback.class));
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.RUNNING, otherWorkerId, 1);
         assertEquals(status, store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
     public void putSafeWithNoPreviousValueIsPropagated() {
         final byte[] value = new byte[0];
+        ArgumentCaptor<Struct> captor = ArgumentCaptor.forClass(Struct.class);
 
-        final Capture<Struct> statusValueStruct = newCapture();
-        converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), capture(statusValueStruct));
-        EasyMock.expectLastCall().andReturn(value);
-
-        kafkaBasedLog.send(eq("status-connector-" + CONNECTOR), eq(value), anyObject(Callback.class));
-        expectLastCall();
-
-        replayAll();
-
+        kafkaBasedLog.send(eq("status-connector-" + CONNECTOR), eq(value), any(Callback.class));
         final ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.FAILED, WORKER_ID, 0);
         store.putSafe(status);
 
-        verifyAll();
-
-        assertEquals(status.state().toString(), statusValueStruct.getValue().get(KafkaStatusBackingStore.STATE_KEY_NAME));
-        assertEquals(status.workerId(), statusValueStruct.getValue().get(KafkaStatusBackingStore.WORKER_ID_KEY_NAME));
-        assertEquals(status.generation(), statusValueStruct.getValue().get(KafkaStatusBackingStore.GENERATION_KEY_NAME));
+        verify(converter).fromConnectData(eq(STATUS_TOPIC), any(Schema.class), captor.capture());
+        assertEquals(status.state().toString(), captor.getValue().get(KafkaStatusBackingStore.STATE_KEY_NAME));
+        assertEquals(status.workerId(), captor.getValue().get(KafkaStatusBackingStore.WORKER_ID_KEY_NAME));
+        assertEquals(status.generation(), captor.getValue().get(KafkaStatusBackingStore.GENERATION_KEY_NAME));
     }
 
     @Test
@@ -236,31 +193,24 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         secondStatusRead.put("state", "UNASSIGNED");
         secondStatusRead.put("generation", 0L);
 
-        expect(converter.toConnectData(STATUS_TOPIC, value))
-                .andReturn(new SchemaAndValue(null, firstStatusRead))
-                .andReturn(new SchemaAndValue(null, secondStatusRead));
+        when(converter.toConnectData(STATUS_TOPIC, value))
+                .thenReturn(new SchemaAndValue(null, firstStatusRead))
+                .thenReturn(new SchemaAndValue(null, secondStatusRead));
 
-        expect(converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class)))
-                .andStubReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class)))
+                .thenReturn(value);
 
-        final Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq("status-connector-conn"), eq(value), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    store.read(consumerRecord(1, "status-connector-conn", value));
-                    return null;
-                });
-
-        replayAll();
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            store.read(consumerRecord(1, "status-connector-conn", value));
+            return null;
+        }).when(kafkaBasedLog).send(eq("status-connector-conn"), eq(value), any(Callback.class));
 
         store.read(consumerRecord(0, "status-connector-conn", value));
         store.putSafe(new ConnectorStatus(CONNECTOR, ConnectorStatus.State.UNASSIGNED, WORKER_ID, 0));
 
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.UNASSIGNED, WORKER_ID, 0);
         assertEquals(status, store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
@@ -279,30 +229,24 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         secondStatusRead.put("state", "UNASSIGNED");
         secondStatusRead.put("generation", 0L);
 
-        expect(converter.toConnectData(STATUS_TOPIC, value))
-                .andReturn(new SchemaAndValue(null, firstStatusRead))
-                .andReturn(new SchemaAndValue(null, secondStatusRead));
+        when(converter.toConnectData(STATUS_TOPIC, value))
+                .thenReturn(new SchemaAndValue(null, firstStatusRead))
+                .thenReturn(new SchemaAndValue(null, secondStatusRead));
 
-        expect(converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class)))
-                .andStubReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class)))
+                .thenReturn(value);
 
-        final Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq("status-connector-conn"), eq(value), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    store.read(consumerRecord(1, "status-connector-conn", value));
-                    return null;
-                });
-        replayAll();
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            store.read(consumerRecord(1, "status-connector-conn", value));
+            return null;
+        }).when(kafkaBasedLog).send(eq("status-connector-conn"), eq(value), any(Callback.class));
 
         store.read(consumerRecord(0, "status-connector-conn", value));
 
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.UNASSIGNED, WORKER_ID, 0);
         store.put(status);
         assertEquals(status, store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
@@ -314,41 +258,32 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         statusMap.put("state", "RUNNING");
         statusMap.put("generation", 0L);
 
-        expect(converter.toConnectData(STATUS_TOPIC, value))
-                .andReturn(new SchemaAndValue(null, statusMap));
-
-        replayAll();
+        when(converter.toConnectData(STATUS_TOPIC, value))
+                .thenReturn(new SchemaAndValue(null, statusMap));
 
         store.read(consumerRecord(0, "status-connector-conn", value));
 
         ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.RUNNING, WORKER_ID, 0);
         assertEquals(status, store.get(CONNECTOR));
-
-        verifyAll();
     }
 
     @Test
     public void putTaskState() {
         byte[] value = new byte[0];
-        expect(converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class)))
-                .andStubReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class)))
+                .thenReturn(value);
 
-        final Capture<Callback> callbackCapture = newCapture();
-        kafkaBasedLog.send(eq("status-task-conn-0"), eq(value), capture(callbackCapture));
-        expectLastCall()
-                .andAnswer(() -> {
-                    callbackCapture.getValue().onCompletion(null, null);
-                    return null;
-                });
-        replayAll();
+        doAnswer(invocation -> {
+            ((Callback) invocation.getArgument(2)).onCompletion(null, null);
+            store.read(consumerRecord(1, "status-connector-conn", value));
+            return null;
+        }).when(kafkaBasedLog).send(eq("status-task-conn-0"), eq(value), any(Callback.class));
 
         TaskStatus status = new TaskStatus(TASK, TaskStatus.State.RUNNING, WORKER_ID, 0);
         store.put(status);
 
         // state is not visible until read back from the log
         assertNull(store.get(TASK));
-
-        verifyAll();
     }
 
     @Test
@@ -360,17 +295,13 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         statusMap.put("state", "RUNNING");
         statusMap.put("generation", 0L);
 
-        expect(converter.toConnectData(STATUS_TOPIC, value))
-                .andReturn(new SchemaAndValue(null, statusMap));
-
-        replayAll();
+        when(converter.toConnectData(STATUS_TOPIC, value))
+                .thenReturn(new SchemaAndValue(null, statusMap));
 
         store.read(consumerRecord(0, "status-task-conn-0", value));
 
         TaskStatus status = new TaskStatus(TASK, TaskStatus.State.RUNNING, WORKER_ID, 0);
         assertEquals(status, store.get(TASK));
-
-        verifyAll();
     }
 
     @Test
@@ -381,19 +312,9 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         statusMap.put("state", "RUNNING");
         statusMap.put("generation", 0L);
 
-        converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class));
-        EasyMock.expectLastCall().andReturn(value);
-        kafkaBasedLog.send(eq("status-connector-" + CONNECTOR), eq(value), anyObject(Callback.class));
-        expectLastCall();
-
-        converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class));
-        EasyMock.expectLastCall().andReturn(value);
-        kafkaBasedLog.send(eq("status-task-conn-0"), eq(value), anyObject(Callback.class));
-        expectLastCall();
-
-        expect(converter.toConnectData(STATUS_TOPIC, value)).andReturn(new SchemaAndValue(null, statusMap));
-
-        replayAll();
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class))).thenReturn(value);
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class))).thenReturn(value);
+        when(converter.toConnectData(STATUS_TOPIC, value)).thenReturn(new SchemaAndValue(null, statusMap));
 
         ConnectorStatus connectorStatus = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.RUNNING, WORKER_ID, 0);
         store.put(connectorStatus);
@@ -401,12 +322,14 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         store.put(taskStatus);
         store.read(consumerRecord(0, "status-task-conn-0", value));
 
+        verify(kafkaBasedLog).send(eq("status-connector-" + CONNECTOR), eq(value), any(Callback.class));
+        verify(kafkaBasedLog).send(eq("status-task-conn-0"), eq(value), any(Callback.class));
+
         assertEquals(new HashSet<>(Collections.singletonList(CONNECTOR)), store.connectors());
         assertEquals(new HashSet<>(Collections.singletonList(taskStatus)), new HashSet<>(store.getAll(CONNECTOR)));
         store.read(consumerRecord(0, "status-connector-conn", null));
         assertTrue(store.connectors().isEmpty());
         assertTrue(store.getAll(CONNECTOR).isEmpty());
-        verifyAll();
     }
 
     @Test
@@ -417,23 +340,18 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         statusMap.put("state", "RUNNING");
         statusMap.put("generation", 0L);
 
-        converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), anyObject(Struct.class));
-        EasyMock.expectLastCall().andReturn(value);
-        kafkaBasedLog.send(eq("status-task-conn-0"), eq(value), anyObject(Callback.class));
-        expectLastCall();
-
-        expect(converter.toConnectData(STATUS_TOPIC, value)).andReturn(new SchemaAndValue(null, statusMap));
-
-        replayAll();
+        when(converter.fromConnectData(eq(STATUS_TOPIC), any(Schema.class), any(Struct.class))).thenReturn(value);
+        when(converter.toConnectData(STATUS_TOPIC, value)).thenReturn(new SchemaAndValue(null, statusMap));
 
         TaskStatus taskStatus = new TaskStatus(TASK, TaskStatus.State.RUNNING, WORKER_ID, 0);
         store.put(taskStatus);
         store.read(consumerRecord(0, "status-task-conn-0", value));
 
+        verify(kafkaBasedLog).send(eq("status-task-conn-0"), eq(value), any(Callback.class));
+
         assertEquals(new HashSet<>(Collections.singletonList(taskStatus)), new HashSet<>(store.getAll(CONNECTOR)));
         store.read(consumerRecord(0, "status-task-conn-0", null));
         assertTrue(store.getAll(CONNECTOR).isEmpty());
-        verifyAll();
     }
 
     private static ConsumerRecord<String, byte[]> consumerRecord(long offset, String key, byte[] value) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
@@ -18,15 +18,10 @@ package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.util.Callback;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.api.easymock.annotation.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.ArgumentCaptor;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -39,11 +34,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(PowerMockRunner.class)
 public class OffsetStorageWriterTest {
     private static final String NAMESPACE = "namespace";
     // Connect format - any types should be accepted here
@@ -54,12 +52,12 @@ public class OffsetStorageWriterTest {
     private static final byte[] OFFSET_KEY_SERIALIZED = "key-serialized".getBytes();
     private static final byte[] OFFSET_VALUE_SERIALIZED = "value-serialized".getBytes();
 
-    @Mock private OffsetBackingStore store;
-    @Mock private Converter keyConverter;
-    @Mock private Converter valueConverter;
-    private OffsetStorageWriter writer;
+    private static final Exception EXCEPTION = new RuntimeException("error");
 
-    private static Exception exception = new RuntimeException("error");
+    private final OffsetBackingStore store = mock(OffsetBackingStore.class);
+    private final Converter keyConverter = mock(Converter.class);
+    private final Converter valueConverter = mock(Converter.class);
+    private OffsetStorageWriter writer;
 
     private ExecutorService service;
 
@@ -77,34 +75,26 @@ public class OffsetStorageWriterTest {
     @Test
     public void testWriteFlush() throws Exception {
         @SuppressWarnings("unchecked")
-        Callback<Void> callback = PowerMock.createMock(Callback.class);
+        Callback<Void> callback = mock(Callback.class);
         expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, callback, false, null);
-
-        PowerMock.replayAll();
 
         writer.offset(OFFSET_KEY, OFFSET_VALUE);
 
         assertTrue(writer.beginFlush());
         writer.doFlush(callback).get(1000, TimeUnit.MILLISECONDS);
-
-        PowerMock.verifyAll();
     }
 
     // It should be possible to set offset values to null
     @Test
     public void testWriteNullValueFlush() throws Exception {
         @SuppressWarnings("unchecked")
-        Callback<Void> callback = PowerMock.createMock(Callback.class);
+        Callback<Void> callback = mock(Callback.class);
         expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, null, null, callback, false, null);
-
-        PowerMock.replayAll();
 
         writer.offset(OFFSET_KEY, null);
 
         assertTrue(writer.beginFlush());
         writer.doFlush(callback).get(1000, TimeUnit.MILLISECONDS);
-
-        PowerMock.verifyAll();
     }
 
     // It should be possible to use null keys. These aren't actually stored as null since the key is wrapped to include
@@ -112,30 +102,22 @@ public class OffsetStorageWriterTest {
     @Test
     public void testWriteNullKeyFlush() throws Exception {
         @SuppressWarnings("unchecked")
-        Callback<Void> callback = PowerMock.createMock(Callback.class);
+        Callback<Void> callback = mock(Callback.class);
         expectStore(null, null, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, callback, false, null);
-
-        PowerMock.replayAll();
 
         writer.offset(null, OFFSET_VALUE);
 
         assertTrue(writer.beginFlush());
         writer.doFlush(callback).get(1000, TimeUnit.MILLISECONDS);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testNoOffsetsToFlush() {
-        // If no offsets are flushed, we should finish immediately and not have made any calls to the
-        // underlying storage layer
-
-        PowerMock.replayAll();
-
-        // Should not return a future
         assertFalse(writer.beginFlush());
 
-        PowerMock.verifyAll();
+        // If no offsets are flushed, we should finish immediately and not have made any calls to the
+        // underlying storage layer
+        verifyNoInteractions(store);
     }
 
     @Test
@@ -144,64 +126,52 @@ public class OffsetStorageWriterTest {
         // such that a subsequent flush will write them.
 
         @SuppressWarnings("unchecked")
-        final Callback<Void> callback = PowerMock.createMock(Callback.class);
+        final Callback<Void> callback = mock(Callback.class);
         // First time the write fails
         expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, callback, true, null);
-        // Second time it succeeds
-        expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, callback, false, null);
-        // Third time it has no data to flush so we won't get past beginFlush()
 
-        PowerMock.replayAll();
+        // Third time it has no data to flush so we won't get past beginFlush()
 
         writer.offset(OFFSET_KEY, OFFSET_VALUE);
         assertTrue(writer.beginFlush());
         writer.doFlush(callback).get(1000, TimeUnit.MILLISECONDS);
+
+        // Second time it succeeds
+        expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, callback, false, null);
         assertTrue(writer.beginFlush());
         writer.doFlush(callback).get(1000, TimeUnit.MILLISECONDS);
         assertFalse(writer.beginFlush());
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testAlreadyFlushing() {
         @SuppressWarnings("unchecked")
-        final Callback<Void> callback = PowerMock.createMock(Callback.class);
+        final Callback<Void> callback = mock(Callback.class);
         // Trigger the send, but don't invoke the callback so we'll still be mid-flush
         CountDownLatch allowStoreCompleteCountdown = new CountDownLatch(1);
         expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, null, false, allowStoreCompleteCountdown);
-
-        PowerMock.replayAll();
 
         writer.offset(OFFSET_KEY, OFFSET_VALUE);
         assertTrue(writer.beginFlush());
         writer.doFlush(callback);
         assertThrows(ConnectException.class, writer::beginFlush);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCancelBeforeAwaitFlush() {
-        PowerMock.replayAll();
-
         writer.offset(OFFSET_KEY, OFFSET_VALUE);
         assertTrue(writer.beginFlush());
         writer.cancelFlush();
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCancelAfterAwaitFlush() throws Exception {
         @SuppressWarnings("unchecked")
-        Callback<Void> callback = PowerMock.createMock(Callback.class);
+        Callback<Void> callback = mock(Callback.class);
         CountDownLatch allowStoreCompleteCountdown = new CountDownLatch(1);
         // In this test, the write should be cancelled so the callback will not be invoked and is not
         // passed to the expectStore call
         expectStore(OFFSET_KEY, OFFSET_KEY_SERIALIZED, OFFSET_VALUE, OFFSET_VALUE_SERIALIZED, null, false, allowStoreCompleteCountdown);
-
-        PowerMock.replayAll();
 
         writer.offset(OFFSET_KEY, OFFSET_VALUE);
         assertTrue(writer.beginFlush());
@@ -210,8 +180,6 @@ public class OffsetStorageWriterTest {
         writer.cancelFlush();
         allowStoreCompleteCountdown.countDown();
         flushFuture.get(1000, TimeUnit.MILLISECONDS);
-
-        PowerMock.verifyAll();
     }
 
     /**
@@ -227,43 +195,43 @@ public class OffsetStorageWriterTest {
      * @param waitForCompletion if non-null, a CountDownLatch that should be awaited on before
      *                          invoking the callback. A (generous) timeout is still imposed to
      *                          ensure tests complete.
-     * @return the captured set of ByteBuffer key-value pairs passed to the storage layer
      */
+    @SuppressWarnings("unchecked")
     private void expectStore(Map<String, Object> key, byte[] keySerialized,
                              Map<String, Object> value, byte[] valueSerialized,
                              final Callback<Void> callback,
                              final boolean fail,
                              final CountDownLatch waitForCompletion) {
         List<Object> keyWrapped = Arrays.asList(NAMESPACE, key);
-        EasyMock.expect(keyConverter.fromConnectData(NAMESPACE, null, keyWrapped)).andReturn(keySerialized);
-        EasyMock.expect(valueConverter.fromConnectData(NAMESPACE, null, value)).andReturn(valueSerialized);
+        when(keyConverter.fromConnectData(NAMESPACE, null, keyWrapped)).thenReturn(keySerialized);
+        when(valueConverter.fromConnectData(NAMESPACE, null, value)).thenReturn(valueSerialized);
 
-        final Capture<Callback<Void>> storeCallback = Capture.newInstance();
+        final ArgumentCaptor<Callback<Void>> storeCallback = ArgumentCaptor.forClass(Callback.class);
         final Map<ByteBuffer, ByteBuffer> offsetsSerialized = Collections.singletonMap(
                 keySerialized == null ? null : ByteBuffer.wrap(keySerialized),
                 valueSerialized == null ? null : ByteBuffer.wrap(valueSerialized));
-        EasyMock.expect(store.set(EasyMock.eq(offsetsSerialized), EasyMock.capture(storeCallback)))
-            .andAnswer(() ->
-                service.submit(() -> {
-                    if (waitForCompletion != null)
-                        assertTrue(waitForCompletion.await(10000, TimeUnit.MILLISECONDS));
+        when(store.set(eq(offsetsSerialized), storeCallback.capture())).thenAnswer(invocation -> {
+            final Callback<Void> cb = storeCallback.getValue();
+            return service.submit(() -> {
+                if (waitForCompletion != null)
+                    assertTrue(waitForCompletion.await(10000, TimeUnit.MILLISECONDS));
 
-                    if (fail) {
-                        storeCallback.getValue().onCompletion(exception, null);
-                    } else {
-                        storeCallback.getValue().onCompletion(null, null);
-                    }
-                    return null;
-                })
-            );
+                if (fail) {
+                    cb.onCompletion(EXCEPTION, null);
+                } else {
+                    cb.onCompletion(null, null);
+                }
+                return null;
+            });
+        });
+
         if (callback != null) {
             if (fail) {
-                callback.onCompletion(EasyMock.eq(exception), EasyMock.eq(null));
+                callback.onCompletion(EXCEPTION, null);
             } else {
                 callback.onCompletion(null, null);
             }
         }
-        PowerMock.expectLastCall();
     }
 
 }


### PR DESCRIPTION
I've skipped the following classes as they use powermock to stub/access private and static fields/methods:
- KafkaConfigBackingStoreTest
- KafkaOffsetBackingStoreTest

Those will require some refactoring and will be updated in a separate PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
