### PR TITLE
KAFKA-13341: Quotas are not applied to requests with null clientId

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -576,8 +576,8 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     }
 
     override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.Map[String, String]): lang.Double = {
-      val sanitizedUser = metricTags.get(DefaultTags.User)
-      val clientId = metricTags.get(DefaultTags.ClientId)
+      val sanitizedUser = if (metricTags.get(DefaultTags.User) == "ANONYMOUS") "" else metricTags.get(DefaultTags.User)
+      val clientId = if (metricTags.get(DefaultTags.ClientId) == null) "" else metricTags.get(DefaultTags.ClientId)
       var quota: Quota = null
 
       if (sanitizedUser != null && clientId != null) {
@@ -612,8 +612,12 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
             // /config/clients/<default>
             quota = overriddenQuotas.get(DefaultClientIdQuotaEntity)
           }
+        } else {
+          // /config/clients/<default>
+          quota = overriddenQuotas.get(DefaultClientIdQuotaEntity)
         }
       }
+
       if (quota == null) null else quota.bound
     }
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -72,6 +72,32 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
       throttleTimeMs = maybeRecord(clientQuotaManager, client1.user, client1.clientId, 1000 * config.numQuotaSamples)
       assertEquals(0, throttleTimeMs, s"throttleTimeMs should be 0. was $throttleTimeMs")
 
+      // Case 5: test clients with null or empty client id.
+      if (defaultConfigClient.configUser.isEmpty) {
+        // should be 4000; default client (with null or empty client id) should follow the default, overridden value.
+        assertEquals(Long.MaxValue, clientQuotaManager.quota(defaultConfigClient.user, defaultConfigClient.clientId).bound, 0.0, "Should return the newly overridden value (4000)")
+        assertEquals(Long.MaxValue, clientQuotaManager.quota(defaultConfigClient.user, null).bound, 0.0, "Should return the newly overridden value (4000)")
+      }
+      if (client1.user == "ANONYMOUS") {
+        // should be 4000; default client (with null or empty client id) should follow the default, overridden value.
+        assertEquals(Long.MaxValue, clientQuotaManager.quota(client1.user, "").bound, 0.0, "Should return the overridden value (4000)")
+        assertEquals(Long.MaxValue, clientQuotaManager.quota(client1.user, null).bound, 0.0, "Should return the overridden value (4000)")
+      } else {
+        // client1.user (with null or empty client id) should follow the user quota. (if user is 'ANONYMOUS', it should follow the default, overridden value.)
+        clientQuotaManager.updateQuota(client1.configUser, None, None, Some(new Quota(2500, true)))
+        assertEquals(2500L, clientQuotaManager.quota(client1.user, "").bound, 0.0, "Should return the newly overridden value (2500)")
+        assertEquals(2500L, clientQuotaManager.quota(client1.user, null).bound, 0.0, "Should return the newly overridden value (2500)")
+      }
+      if (client2.user == "ANONYMOUS") {
+        // should be 4000; default client (with null or empty client id) should follow the default, overridden value.
+        assertEquals(Long.MaxValue, clientQuotaManager.quota(client2.user, "").bound, 0.0, "Should return the overridden value (4000)")
+        assertEquals(Long.MaxValue, clientQuotaManager.quota(client2.user, null).bound, 0.0, "Should return the overridden value (4000)")
+      } else {
+        // client2.user (with null or empty client id) should follow the user quota. (if user is 'ANONYMOUS', it should follow the default, overridden value.)
+        clientQuotaManager.updateQuota(client2.configUser, None, None, Some(new Quota(4500, true)))
+        assertEquals(4500L, clientQuotaManager.quota(client2.user, "").bound, 0.0, "Should return the overridden value (4500)")
+        assertEquals(4500L, clientQuotaManager.quota(client2.user, null).bound, 0.0, "Should return the overridden value (4500)")
+      }
     } finally {
       clientQuotaManager.shutdown()
     }

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -74,14 +74,14 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
 
       // Case 5: test clients with null or empty client id.
       if (defaultConfigClient.configUser.isEmpty) {
-        // should be 4000; default client (with null or empty client id) should follow the default, overridden value.
-        assertEquals(Long.MaxValue, clientQuotaManager.quota(defaultConfigClient.user, defaultConfigClient.clientId).bound, 0.0, "Should return the newly overridden value (4000)")
-        assertEquals(Long.MaxValue, clientQuotaManager.quota(defaultConfigClient.user, null).bound, 0.0, "Should return the newly overridden value (4000)")
+        // default client (with null or empty client id) should follow the default, overridden value.
+        assertEquals(4000L, clientQuotaManager.quota(defaultConfigClient.user, defaultConfigClient.clientId).bound, 0.0, "Should return the newly overridden value (4000)")
+        assertEquals(4000L, clientQuotaManager.quota(defaultConfigClient.user, null).bound, 0.0, "Should return the newly overridden value (4000)")
       }
       if (client1.user == "ANONYMOUS") {
-        // should be 4000; default client (with null or empty client id) should follow the default, overridden value.
-        assertEquals(Long.MaxValue, clientQuotaManager.quota(client1.user, "").bound, 0.0, "Should return the overridden value (4000)")
-        assertEquals(Long.MaxValue, clientQuotaManager.quota(client1.user, null).bound, 0.0, "Should return the overridden value (4000)")
+        // default client (with null or empty client id) should follow the default, overridden value.
+        assertEquals(4000L, clientQuotaManager.quota(client1.user, "").bound, 0.0, "Should return the overridden value (4000)")
+        assertEquals(4000L, clientQuotaManager.quota(client1.user, null).bound, 0.0, "Should return the overridden value (4000)")
       } else {
         // client1.user (with null or empty client id) should follow the user quota. (if user is 'ANONYMOUS', it should follow the default, overridden value.)
         clientQuotaManager.updateQuota(client1.configUser, None, None, Some(new Quota(2500, true)))
@@ -89,9 +89,9 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
         assertEquals(2500L, clientQuotaManager.quota(client1.user, null).bound, 0.0, "Should return the newly overridden value (2500)")
       }
       if (client2.user == "ANONYMOUS") {
-        // should be 4000; default client (with null or empty client id) should follow the default, overridden value.
-        assertEquals(Long.MaxValue, clientQuotaManager.quota(client2.user, "").bound, 0.0, "Should return the overridden value (4000)")
-        assertEquals(Long.MaxValue, clientQuotaManager.quota(client2.user, null).bound, 0.0, "Should return the overridden value (4000)")
+        // default client (with null or empty client id) should follow the default, overridden value.
+        assertEquals(4000L, clientQuotaManager.quota(client2.user, "").bound, 0.0, "Should return the overridden value (4000)")
+        assertEquals(4000L, clientQuotaManager.quota(client2.user, null).bound, 0.0, "Should return the overridden value (4000)")
       } else {
         // client2.user (with null or empty client id) should follow the user quota. (if user is 'ANONYMOUS', it should follow the default, overridden value.)
         clientQuotaManager.updateQuota(client2.configUser, None, None, Some(new Quota(4500, true)))


### PR DESCRIPTION
I inspected this issue a little bit.

As shown in the first, proof-of-problem commit, the quota limit does not work correctly when the user is `""` or `ANONYMOUS` and the client id is `""` or `null`. We can fix it by treating `ANONYMOUS` as a default user and using client quota (i.e., `/config/clients/<default>`) when the client id is `null`.

As far as I understood, this issue is just an edge case in the current implementation, not a regression.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
