### PR TITLE
KAFKA-13423: GlobalThread should not log ERROR on clean shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -670,9 +670,6 @@ public class KafkaStreams implements AutoCloseable {
 
                     if (newState == GlobalStreamThread.State.RUNNING) {
                         maybeSetRunning();
-                    } else if (newState == GlobalStreamThread.State.DEAD && oldState != GlobalStreamThread.State.PENDING_SHUTDOWN) {
-                        log.error("Global thread has died. The streams application or client will now close to ERROR.");
-                        closeToError();
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -57,7 +57,6 @@ import org.apache.kafka.streams.processor.internals.ClientUtils;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread.State;
-import org.apache.kafka.streams.processor.internals.TopologyMetadata;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
@@ -669,8 +668,11 @@ public class KafkaStreams implements AutoCloseable {
 
                     if (newState == GlobalStreamThread.State.RUNNING) {
                         maybeSetRunning();
-                    } if (newState == GlobalStreamThread.State.PENDING_SHUTDOWN) {
-                        setState(State.PENDING_SHUTDOWN);
+                    } else if (newState == GlobalStreamThread.State.DEAD) {
+                        if (state != State.PENDING_SHUTDOWN) {
+                            log.error("Global thread has died. The streams application or client will now close to ERROR.");
+                            closeToError();
+                        }
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -666,7 +666,6 @@ public class KafkaStreams implements AutoCloseable {
                     // global stream thread has different invariants
                     final GlobalStreamThread.State newState = (GlobalStreamThread.State) abstractNewState;
                     globalThreadState = newState;
-                    final GlobalStreamThread.State oldState = (GlobalStreamThread.State) abstractOldState;
 
                     if (newState == GlobalStreamThread.State.RUNNING) {
                         maybeSetRunning();

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -56,6 +56,8 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ClientUtils;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread;
+import org.apache.kafka.streams.processor.internals.GlobalStreamThread.State;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
@@ -664,10 +666,11 @@ public class KafkaStreams implements AutoCloseable {
                     // global stream thread has different invariants
                     final GlobalStreamThread.State newState = (GlobalStreamThread.State) abstractNewState;
                     globalThreadState = newState;
+                    final GlobalStreamThread.State oldState = (GlobalStreamThread.State) abstractOldState;
 
                     if (newState == GlobalStreamThread.State.RUNNING) {
                         maybeSetRunning();
-                    } else if (newState == GlobalStreamThread.State.DEAD) {
+                    } else if (newState == GlobalStreamThread.State.DEAD && oldState != GlobalStreamThread.State.PENDING_SHUTDOWN) {
                         log.error("Global thread has died. The streams application or client will now close to ERROR.");
                         closeToError();
                     }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -669,6 +669,8 @@ public class KafkaStreams implements AutoCloseable {
 
                     if (newState == GlobalStreamThread.State.RUNNING) {
                         maybeSetRunning();
+                    } if (newState == GlobalStreamThread.State.PENDING_SHUTDOWN) {
+                        setState(State.PENDING_SHUTDOWN);
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -294,7 +294,7 @@ public class GlobalStreamThread extends Thread {
             setState(State.PENDING_SHUTDOWN);
             setState(State.DEAD);
 
-            log.warn("Error happened during initialization of the global state store; this thread has shutdown");
+            log.error("Error happened during initialization of the global state store; this thread has shutdown.");
             streamsMetrics.removeAllThreadLevelSensors(getName());
             streamsMetrics.removeAllThreadLevelMetrics(getName());
 
@@ -323,6 +323,7 @@ public class GlobalStreamThread extends Thread {
             );
             this.streamsUncaughtExceptionHandler.accept(e);
         } catch (final Exception e) {
+            log.error("Error happened while maintaining global state store. The streams application or client will now close to ERROR.", e);
             this.streamsUncaughtExceptionHandler.accept(e);
         } finally {
             // set the state to pending shutdown first as it may be called due to error;

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -529,6 +529,8 @@ public class KafkaStreamsTest {
                 () -> globalStreamThread.state() == DEAD,
                 "Thread never stopped.");
             globalStreamThread.join();
+
+            // shutting down the global thread from "external" will yield an error in KafkaStreams
             waitForCondition(
                 () -> streams.state() == KafkaStreams.State.PENDING_ERROR,
                 "Thread never stopped."

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -176,7 +177,9 @@ public class GlobalKTableIntegrationTest {
         TestUtils.waitForCondition(
             () -> {
                 globalState.clear();
-                replicatedStore.all().forEachRemaining(pair -> globalState.put(pair.key, pair.value));
+                try (final KeyValueIterator<Long, String> it = replicatedStore.all()) {
+                    it.forEachRemaining(pair -> globalState.put(pair.key, pair.value));
+                }
                 return globalState.equals(expectedState);
             },
             30000,
@@ -259,7 +262,9 @@ public class GlobalKTableIntegrationTest {
         TestUtils.waitForCondition(
             () -> {
                 globalState.clear();
-                replicatedStore.all().forEachRemaining(pair -> globalState.put(pair.key, pair.value));
+                try (final KeyValueIterator<Long, String> it = replicatedStore.all()) {
+                    it.forEachRemaining(pair -> globalState.put(pair.key, pair.value));
+                }
                 return globalState.equals(expectedState);
             },
             30000,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import kafka.utils.MockTime;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongSerializer;
@@ -37,7 +35,6 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.ValueJoiner;
-import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -67,7 +64,6 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.sa
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForApplicationState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
@@ -341,18 +337,7 @@ public class GlobalKTableIntegrationTest {
         startStreams();
         waitForApplicationState(singletonList(kafkaStreams), State.RUNNING, Duration.ofSeconds(30));
 
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
-            kafkaStreams.close();
-
-            final List<String> logs =
-                appender.getMessages().stream()
-                    .map(line -> line.split("] ")[1])
-                    .collect(Collectors.toList());
-            assertFalse(
-                logs.contains("Error happened while maintaining global state store. The streams application or client will now close to ERROR.")
-            );
-
-        }
+        kafkaStreams.close();
     }
 
     private void createTopics() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -344,7 +344,7 @@ public class GlobalKTableIntegrationTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
             kafkaStreams.close();
 
-            List<String> logs =
+            final List<String> logs =
                 appender.getMessages().stream()
                     .map(line -> line.split("] ")[1])
                     .collect(Collectors.toList());


### PR DESCRIPTION
Call for review @cadonna 