### PR TITLE
KAFKA-13351: Add possibility to write kafka headers in Kafka Console Producer

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -217,7 +217,7 @@ object ConsoleProducer {
         | headers.separator=,
         | headers.key.separator=:
         |Default parsing pattern when:
-        | parse.headers=true & parse.key=true:
+        | parse.headers=true and parse.key=true:
         |  "h1:v1,h2:v2...\tkey\tvalue"
         | parse.key=true:
         |  "key\tvalue"

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -17,6 +17,10 @@
 
 package kafka.tools
 
+import java.io._
+import java.nio.charset.StandardCharsets
+import java.util.Properties
+import java.util.regex.Pattern
 import joptsimple.{OptionException, OptionParser, OptionSet}
 import kafka.common._
 import kafka.message._
@@ -26,10 +30,6 @@ import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.utils.Utils
-import java.io._
-import java.nio.charset.StandardCharsets
-import java.util.Properties
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters._
 
 object ConsoleProducer {

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -349,13 +349,13 @@ object ConsoleProducer {
     }
 
     private def splitHeaders(headers: String): Array[(String, Array[Byte])] = {
-      headerSeparatorPattern.split(headers)
-        .map(pair =>
-          (pair.indexOf(headerKeySeparator), ignoreError) match {
-            case (-1, false) => throw new KafkaException(s"No header key separator found in pair '$pair' on line number $lineNumber")
-            case (-1, true) => (pair, null)
-            case (i, _) => (pair.substring(0, i), pair.substring(i + 1).getBytes(StandardCharsets.UTF_8))
-          })
+      headerSeparatorPattern.split(headers).map { pair =>
+        (pair.indexOf(headerKeySeparator), ignoreError) match {
+          case (-1, false) => throw new KafkaException(s"No header key separator found in pair '$pair' on line number $lineNumber")
+          case (-1, true) => (pair, null)
+          case (i, _) => (pair.substring(0, i), pair.substring(i + 1).getBytes(StandardCharsets.UTF_8))
+        }
+      }
     }
 
     private def offset(segment: String) = {

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.utils.Utils
-
 import java.io._
 import java.nio.charset.StandardCharsets
 import java.util.Properties
@@ -320,7 +319,6 @@ object ConsoleProducer {
       line match {
         case null => null
         case line =>
-
           val headers = parse(parseHeader, line, headersDelimiter, "headers delimiter")
           val key = parse(parseKey, line.substring(offset(headers)), keySeparator, "key separator")
           val value = line.substring(offset(headers) + offset(key))
@@ -331,7 +329,7 @@ object ConsoleProducer {
             if (value != null) value.getBytes(StandardCharsets.UTF_8) else null,
           )
 
-          if (headers != null){
+          if (headers != null) {
             splitHeaders(headers)
               .foreach(header => record.headers().add(header._1, header._2))
           }
@@ -360,10 +358,8 @@ object ConsoleProducer {
           })
     }
 
-    private def offset(headers: String) = {
-      if (headers == null) 0 else headers.length + 1
+    private def offset(segment: String) = {
+      if (segment == null) 0 else segment.length + 1
     }
   }
 }
-
-

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -308,6 +308,12 @@ object ConsoleProducer {
         headerKeySeparator = props.getProperty("headers.key.separator")
       if (props.containsKey("ignore.error"))
         ignoreError = props.getProperty("ignore.error").trim.equalsIgnoreCase("true")
+      if (headersDelimiter.equals(headersSeparator))
+        throw new KafkaException("headers.delimiter and headers.separator may not be equal")
+      if (headersDelimiter.equals(headerKeySeparator))
+        throw new KafkaException("headers.delimiter and headers.key.separator may not be equal")
+      if (headersSeparator.equals(headerKeySeparator))
+        throw new KafkaException("headers.separator and headers.key.separator may not be equal")
       reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
     }
 

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -328,7 +328,7 @@ object ConsoleProducer {
           case (line, false, false) => new ProducerRecord(topic, line.getBytes(StandardCharsets.UTF_8))
         }
       } catch {
-        case _: MatchError => onMatchError(line)
+        case _: Throwable => onMatchError(line)
       }
     }
 

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -320,8 +320,12 @@ object ConsoleProducer {
         case null => null
         case line =>
           val headers = parse(parseHeader, line, headersDelimiter, "headers delimiter")
-          val key = parse(parseKey, line.substring(offset(headers)), keySeparator, "key separator")
-          val value = line.substring(offset(headers) + offset(key))
+          val headerOffset = if (headers == null) 0 else headers.length + headersDelimiter.length
+
+          val key = parse(parseKey, line.substring(headerOffset), keySeparator, "key separator")
+          val keyOffset = if (key == null) 0 else key.length + keySeparator.length
+
+          val value = line.substring(headerOffset + keyOffset)
 
           val record = new ProducerRecord[Array[Byte], Array[Byte]](
             topic,
@@ -353,13 +357,9 @@ object ConsoleProducer {
         (pair.indexOf(headerKeySeparator), ignoreError) match {
           case (-1, false) => throw new KafkaException(s"No header key separator found in pair '$pair' on line number $lineNumber")
           case (-1, true) => (pair, null)
-          case (i, _) => (pair.substring(0, i), pair.substring(i + 1).getBytes(StandardCharsets.UTF_8))
+          case (i, _) => (pair.substring(0, i), pair.substring(i + headerKeySeparator.length).getBytes(StandardCharsets.UTF_8))
         }
       }
-    }
-
-    private def offset(segment: String) = {
-      if (segment == null) 0 else segment.length + 1
     }
   }
 }

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -211,23 +211,24 @@ object ConsoleProducer {
       .describedAs("size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1024*100)
-    val propertyOpt = parser.accepts("property", "A mechanism to pass user-defined properties in the form key=value to the message reader. " +
-      "This allows custom configuration for a user-defined message reader. Default properties include:\n" +
-      "\tparse.key=false\n" +
-      "\tparse.headers=false\n" +
-      "\tignore.error=false\n" +
-      "Default parsing pattern when:\n" +
-      "\tparse.headers=true & parse.key=true:\n" +
-      "\t \"h1:v1,h2...\\tkey\\tvalue\"\n" +
-      "\tparse.headers=false & parse.key=true:\n" +
-      "\t \"key\\tvalue\"\n" +
-      "\tparse.headers=true & parse.key=false:\n" +
-      "\t \"h1:v1,h2...\\tvalue\"\n" +
-      "Customize pattern via (defaults shown)\n" +
-      "\tkey.separator=\\t\n" +
-      "\theaders.delimiter=\\t\n" +
-      "\theaders.separator=,\n" +
-      "\theaders.key.separator=:"
+    val propertyOpt = parser.accepts("property",
+      """A mechanism to pass user-defined properties in the form key=value to the message reader. This allows custom configuration for a user-defined message reader.
+        |Default properties include:
+        | parse.key=false
+        | parse.headers=false
+        | ignore.error=false
+        | key.separator=\t
+        | headers.delimiter=\t
+        | headers.separator=,
+        | headers.key.separator=:
+        |Default parsing pattern when:
+        | parse.headers=true & parse.key=true:
+        |  "h1:v1,h2...\tkey\tvalue"
+        | parse.headers=false & parse.key=true:
+        |  "key\tvalue"
+        | parse.headers=true & parse.key=false:
+        |  "h1:v1,h2...\tvalue"
+      """.stripMargin
       )
       .withRequiredArg
       .describedAs("prop")

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -218,11 +218,11 @@ object ConsoleProducer {
         | headers.key.separator=:
         |Default parsing pattern when:
         | parse.headers=true & parse.key=true:
-        |  "h1:v1,h2...\tkey\tvalue"
+        |  "h1:v1,h2:v2...\tkey\tvalue"
         | parse.key=true:
         |  "key\tvalue"
         | parse.headers=true:
-        |  "h1:v1,h2...\tvalue"
+        |  "h1:v1,h2:v2...\tvalue"
       """.stripMargin
       )
       .withRequiredArg

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -319,10 +319,10 @@ object ConsoleProducer {
       line match {
         case null => null
         case line =>
-          val headers = parse(parseHeader, line, headersDelimiter, "headers delimiter")
+          val headers = parse(parseHeader, line, 0, headersDelimiter, "headers delimiter")
           val headerOffset = if (headers == null) 0 else headers.length + headersDelimiter.length
 
-          val key = parse(parseKey, line.substring(headerOffset), keySeparator, "key separator")
+          val key = parse(parseKey, line, headerOffset, keySeparator, "key separator")
           val keyOffset = if (key == null) 0 else key.length + keySeparator.length
 
           val value = line.substring(headerOffset + keyOffset)
@@ -342,13 +342,13 @@ object ConsoleProducer {
       }
     }
 
-    private def parse(enabled: Boolean, toParse: String, demarcation: String, demarcationName: String): String = {
-      (enabled, toParse.indexOf(demarcation)) match {
+    private def parse(enabled: Boolean, line: String, startIndex: Int, demarcation: String, demarcationName: String): String = {
+      (enabled, line.indexOf(demarcation, startIndex)) match {
         case (false, _) => null
         case (_, -1) =>
           if (ignoreError) null
-          else throw new KafkaException(s"No $demarcationName found in '$toParse' on line number $lineNumber")
-        case (_, index) => toParse.substring(0, index)
+          else throw new KafkaException(s"No $demarcationName found on line number $lineNumber: '$line'")
+        case (_, index) => line.substring(startIndex, index)
       }
     }
 

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -303,11 +303,11 @@ object ConsoleProducer {
         headerKeySeparator = props.getProperty("headers.key.separator")
       if (props.containsKey("ignore.error"))
         ignoreError = props.getProperty("ignore.error").trim.equalsIgnoreCase("true")
-      if (headersDelimiter.equals(headersSeparator))
+      if (headersDelimiter == headersSeparator)
         throw new KafkaException("headers.delimiter and headers.separator may not be equal")
-      if (headersDelimiter.equals(headerKeySeparator))
+      if (headersDelimiter == headerKeySeparator)
         throw new KafkaException("headers.delimiter and headers.key.separator may not be equal")
-      if (headersSeparator.equals(headerKeySeparator))
+      if (headersSeparator == headerKeySeparator)
         throw new KafkaException("headers.separator and headers.key.separator may not be equal")
       reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
     }
@@ -331,7 +331,7 @@ object ConsoleProducer {
 
           if (headers != null) {
             splitHeaders(headers)
-              .foreach(header => record.headers().add(header._1, header._2))
+              .foreach(header => record.headers.add(header._1, header._2))
           }
 
           record

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -105,6 +105,7 @@ class LineMessageReaderTest {
 
     lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
     lineReader.readMessage()
+
     val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
 
     assertEquals(
@@ -162,8 +163,8 @@ class LineMessageReaderTest {
   def testMalformedHeader(): Unit = {
     val lineReader = new LineMessageReader()
     val input = "key-val\tkey0\tvalue0\n"
-
     lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
+
     val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
 
     assertEquals(

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package unit.kafka.tools
+package kafka.tools
 
 import kafka.tools.ConsoleProducer.LineMessageReader
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -204,11 +204,11 @@ class LineMessageReaderTest {
   def runTest(props: Properties, input: String, expectedRecords: ProducerRecord[String, String]*): Unit = {
     val lineReader = new LineMessageReader
     lineReader.init(new ByteArrayInputStream(input.getBytes), props)
-    expectedRecords.foreach(r => assertEquality(r, lineReader.readMessage()))
+    expectedRecords.foreach(r => assertRecordEquals(r, lineReader.readMessage()))
   }
 
   //  The equality method of ProducerRecord compares memory references for the header iterator, this is why this custom equality check is used.
-  private def assertEquality[K, V](expected: ProducerRecord[K, V], actual: ProducerRecord[Array[Byte], Array[Byte]]): Unit = {
+  private def assertRecordEquals[K, V](expected: ProducerRecord[K, V], actual: ProducerRecord[Array[Byte], Array[Byte]]): Unit = {
     assertEquals(expected.key, if (actual.key == null) null else new String(actual.key))
     assertEquals(expected.value, if (actual.value == null) null else new String(actual.value))
     assertEquals(expected.headers.toArray.toList, actual.headers.toArray.toList)

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -140,6 +140,30 @@ class LineMessageReaderTest {
   }
 
   @Test
+  def testHeaderDemarcationCollision(): Unit ={
+    val props = defaultTestProps
+    props.put("headers.delimiter", "\t")
+    props.put("headers.separator", "\t")
+    props.put("headers.key.separator", "\t")
+
+    assertThrowsOnInvalidPatternConfig(props, "headers.delimiter and headers.separator may not be equal")
+
+    props.put("headers.separator", ",")
+    assertThrowsOnInvalidPatternConfig(props, "headers.delimiter and headers.key.separator may not be equal")
+
+    props.put("headers.key.separator", ",")
+    assertThrowsOnInvalidPatternConfig(props, "headers.separator and headers.key.separator may not be equal")
+  }
+
+  private def assertThrowsOnInvalidPatternConfig(props: Properties, expectedMessage: String): Unit = {
+    val exception = assertThrows(classOf[KafkaException], () => new LineMessageReader().init(null, props))
+    assertEquals(
+      expectedMessage,
+      exception.getMessage
+    )
+  }
+
+  @Test
   def testIgnoreErrorInInput(): Unit = {
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0\n" +

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package kafka.tools
+package unit.kafka.tools
 
 import kafka.tools.ConsoleProducer.LineMessageReader
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -54,8 +54,30 @@ class LineMessageReaderTest {
   }
 
   @Test
-  def minimalValidInputWithHeaderKeyAndValue(): Unit = {
+  def testMinimalValidInputWithHeaderKeyAndValue(): Unit = {
     runTest(defaultTestProps, ":\t\t", record("", "", List("" -> "")))
+  }
+
+  @Test
+  def testKeyMissingValue(): Unit = {
+    val props = defaultTestProps
+    props.put("parse.headers", "false")
+    runTest(props, "key\t", record("key", ""))
+  }
+
+  @Test
+  def testDemarcationsLongerThanOne(): Unit = {
+    val props = defaultTestProps
+    props.put("key.separator", "\t\t")
+    props.put("headers.delimiter", "\t\t")
+    props.put("headers.separator", "---")
+    props.put("headers.key.separator", "::::")
+
+    runTest(
+      props,
+      "headerKey0.0::::headerValue0.0---headerKey1.0::::\t\tkey\t\tvalue",
+      record("key", "value", List("headerKey0.0" -> "headerValue0.0", "headerKey1.0"-> ""))
+    )
   }
 
   @Test
@@ -81,7 +103,6 @@ class LineMessageReaderTest {
   def testParseHeaderEnabledWithCustomDelimiterAndVaryingNumberOfKeyValueHeaderPairs(): Unit = {
     val props = defaultTestProps
     props.put("key.separator", "#")
-    props.put("parse.headers", "true")
     props.put("headers.delimiter", "!")
     props.put("headers.separator", "&")
     props.put("headers.key.separator", ":")

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -75,7 +75,7 @@ class LineMessageReaderTest {
     props.put("parse.key", "false")
 
     val expectedHeaders: lang.Iterable[Header] = asList(new RecordHeader("headerKey", "headerValue".getBytes()))
-    runTest(defaultTestProps, input, record(null, "value", expectedHeaders))
+    runTest(props, input, record(null, "value", expectedHeaders))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.tools
+
+import org.apache.kafka.common.KafkaException
+import kafka.tools.ConsoleProducer.LineMessageReader
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
+import org.junit.jupiter.api.Test
+
+import java.io.ByteArrayInputStream
+import java.lang
+import java.util.Arrays.asList
+import java.util.Properties
+
+class LineMessageReaderTest {
+
+  private def defaultTestProps = {
+    val props = new Properties()
+    props.put("topic", "topic")
+    props.put("parse.key", "true")
+    props.put("parse.headers", "true")
+    props
+  }
+
+
+  @Test
+  def testLineReader(): Unit = {
+    val lineReader = new LineMessageReader();
+    val input =
+      "key0\tvalue0\n" +
+        "key1\tvalue1"
+
+    val props = defaultTestProps
+    props.put("parse.headers", "false")
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
+
+    val expected0 = producerRecord("key0", "value0")
+    val actual0 = lineReader.readMessage()
+    assertEquality(expected0, actual0)
+
+    val expected1 = producerRecord("key1", "value1")
+    val actual1 = lineReader.readMessage()
+    assertEquality(expected1, actual1)
+
+  }
+
+  @Test
+  def testLineReaderHeader(): Unit = {
+    val lineReader = new LineMessageReader();
+    val input = "headerKey0:headerValue0,headerKey1:headerValue1\tkey0\tvalue0\n"
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
+
+    val expectedHeaders: lang.Iterable[Header] = asList(
+      new RecordHeader("headerKey0", "headerValue0".getBytes()),
+      new RecordHeader("headerKey1", "headerValue1".getBytes())
+    )
+    val expected = producerRecord("key0", "value0", expectedHeaders)
+    val actual = lineReader.readMessage()
+
+    assertEquality(expected, actual)
+
+  }
+
+  @Test
+  def testLineReaderHeaderNoKey(): Unit = {
+    val lineReader = new LineMessageReader();
+    val input = "headerKey:headerValue\tvalue\n"
+
+    val props = defaultTestProps
+    props.put("parse.key", "false")
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
+
+    val expectedHeaders: lang.Iterable[Header] = asList(new RecordHeader("headerKey", "headerValue".getBytes()))
+    val expected = producerRecord(null, "value", expectedHeaders)
+    val actual = lineReader.readMessage()
+
+    assertEquality(expected, actual)
+  }
+
+  @Test
+  def testLineReaderOnlyValue(): Unit = {
+    val lineReader = new LineMessageReader();
+    val input = "value\n"
+
+    val props = defaultTestProps
+    props.put("parse.key", "false")
+    props.put("parse.headers", "false")
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
+
+    val expected = producerRecord(null, "value", null)
+    val actual = lineReader.readMessage()
+
+    assertEquality(expected, actual)
+  }
+
+  @Test
+  def testParseHeaderEnabledWithCustomDelimiterAndVaryingNumberOfKeyValueHeaderPairs(): Unit = {
+    val lineReader = new LineMessageReader();
+    val props = defaultTestProps
+    props.put("key.separator", "#")
+    props.put("parse.headers", "true")
+    props.put("headers.delimiter", "!")
+    props.put("headers.separator", "&")
+    props.put("headers.key.separator", ":")
+
+
+    val input =
+      "headerKey0.0:headerValue0.0&headerKey0.1:headerValue0.1!key0#value0\n" +
+        "headerKey1.0:headerValue1.0!key1#value1"
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
+
+    val headers: lang.Iterable[Header] = asList(
+      new RecordHeader("headerKey0.0", "headerValue0.0".getBytes()),
+      new RecordHeader("headerKey0.1", "headerValue0.1".getBytes())
+    )
+    val record0 = new ProducerRecord("topic", null, null, "key0", "value0", headers)
+    assertEquality(record0, lineReader.readMessage())
+
+    val headers1: lang.Iterable[Header] = asList(new RecordHeader("headerKey1.0", "headerValue1.0".getBytes()))
+    val record1 = new ProducerRecord("topic", null, null, "key1", "value1", headers1)
+    assertEquality(record1, lineReader.readMessage())
+
+  }
+
+  @Test
+  def testMissingHeaderSeparatorInInput(): Unit = {
+    val lineReader = new LineMessageReader();
+    val input =
+      "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1\tkey0\tvalue0\n" +
+        "headerKey1.0:headerValue1.0[MISSING-DELIMITER]key1\tvalue1"
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
+    lineReader.readMessage()
+    val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
+
+    assertEquals(
+      "Could not parse line 2, most likely line does not match pattern: headerKey0:headerValue0,...,headerKeyN:headerValueN\tkey\tvalue",
+      expectedException.getMessage
+    )
+  }
+
+  @Test
+  def testIgnoreErrorInInput(): Unit = {
+    val lineReader = new LineMessageReader();
+    val input =
+      "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0\n" +
+        "headerKey1.0:headerValue1.0\tkey1\tvalue1"
+
+    val props = defaultTestProps
+    props.put("ignore.error", "true")
+    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
+
+    val payLoadOnlyDueToError = new ProducerRecord("topic", null, "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0")
+    assertEquality(payLoadOnlyDueToError, lineReader.readMessage());
+
+    val headers: lang.Iterable[Header] = asList(new RecordHeader("headerKey1.0", "headerValue1.0".getBytes()))
+    val record1 = new ProducerRecord("topic", null, null, "key1", "value1", headers)
+
+    assertEquality(record1, lineReader.readMessage())
+
+  }
+
+  //  The equality method of ProducerRecord compares memory references for the header iterator, this is why this custom equality check is used.
+  private def assertEquality[K, V](expected: ProducerRecord[K, V], actual: ProducerRecord[Array[Byte], Array[Byte]]): Unit = {
+    assertEquals(expected.key(), if (actual.key() == null) null else new String(actual.key()))
+    assertEquals(expected.value(), if (actual.value() == null) null else new String(actual.value()))
+    assertEquals(expected.headers().toArray.toList, actual.headers().toArray.toList)
+  }
+
+  private def producerRecord[K, V](key: K, value: V, headers: lang.Iterable[Header]): ProducerRecord[K, V] = {
+    new ProducerRecord("topic", null, null, key, value, headers)
+  }
+
+  private def producerRecord[K, V](key: K, value: V): ProducerRecord[K, V] = {
+    new ProducerRecord("topic", key, value)
+  }
+
+
+}

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -130,7 +130,7 @@ class LineMessageReaderTest {
     val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
 
     assertEquals(
-      "No key separator found in 'key1[MISSING-DELIMITER]value1' on line number 2",
+      "No key separator found on line number 2: 'headerKey1.0:headerValue1.0\tkey1[MISSING-DELIMITER]value1'",
       expectedException.getMessage
     )
   }

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
+ * (the "License") you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -17,9 +17,9 @@
 
 package unit.kafka.tools
 
-import org.apache.kafka.common.KafkaException
 import kafka.tools.ConsoleProducer.LineMessageReader
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
@@ -40,84 +40,55 @@ class LineMessageReaderTest {
     props
   }
 
-
   @Test
   def testLineReader(): Unit = {
-    val lineReader = new LineMessageReader();
     val input =
-      "key0\tvalue0\n" +
-        "key1\tvalue1"
+    "key0\tvalue0\n" +
+    "key1\tvalue1"
 
     val props = defaultTestProps
     props.put("parse.headers", "false")
 
-    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
-
-    val expected0 = producerRecord("key0", "value0")
-    val actual0 = lineReader.readMessage()
-    assertEquality(expected0, actual0)
-
-    val expected1 = producerRecord("key1", "value1")
-    val actual1 = lineReader.readMessage()
-    assertEquality(expected1, actual1)
-
+    runTest(props, input, record("key0", "value0"), record("key1", "value1"))
   }
 
   @Test
   def testLineReaderHeader(): Unit = {
-    val lineReader = new LineMessageReader();
-    val input = "headerKey0:headerValue0,headerKey1:headerValue1\tkey0\tvalue0\n"
 
-    lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
+    val input = "headerKey0:headerValue0,headerKey1:headerValue1\tkey0\tvalue0\n"
 
     val expectedHeaders: lang.Iterable[Header] = asList(
       new RecordHeader("headerKey0", "headerValue0".getBytes()),
       new RecordHeader("headerKey1", "headerValue1".getBytes())
     )
-    val expected = producerRecord("key0", "value0", expectedHeaders)
-    val actual = lineReader.readMessage()
 
-    assertEquality(expected, actual)
+    val expected = record("key0", "value0", expectedHeaders)
 
+    runTest(defaultTestProps, input, expected)
   }
 
   @Test
   def testLineReaderHeaderNoKey(): Unit = {
-    val lineReader = new LineMessageReader();
     val input = "headerKey:headerValue\tvalue\n"
 
     val props = defaultTestProps
     props.put("parse.key", "false")
 
-    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
-
     val expectedHeaders: lang.Iterable[Header] = asList(new RecordHeader("headerKey", "headerValue".getBytes()))
-    val expected = producerRecord(null, "value", expectedHeaders)
-    val actual = lineReader.readMessage()
-
-    assertEquality(expected, actual)
+    runTest(defaultTestProps, input, record(null, "value", expectedHeaders))
   }
 
   @Test
   def testLineReaderOnlyValue(): Unit = {
-    val lineReader = new LineMessageReader();
-    val input = "value\n"
-
     val props = defaultTestProps
     props.put("parse.key", "false")
     props.put("parse.headers", "false")
 
-    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
-
-    val expected = producerRecord(null, "value", null)
-    val actual = lineReader.readMessage()
-
-    assertEquality(expected, actual)
+    runTest(props, "value\n", record(null, "value"))
   }
 
   @Test
   def testParseHeaderEnabledWithCustomDelimiterAndVaryingNumberOfKeyValueHeaderPairs(): Unit = {
-    val lineReader = new LineMessageReader();
     val props = defaultTestProps
     props.put("key.separator", "#")
     props.put("parse.headers", "true")
@@ -125,29 +96,27 @@ class LineMessageReaderTest {
     props.put("headers.separator", "&")
     props.put("headers.key.separator", ":")
 
-
     val input =
       "headerKey0.0:headerValue0.0&headerKey0.1:headerValue0.1!key0#value0\n" +
         "headerKey1.0:headerValue1.0!key1#value1"
-
-    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
 
     val headers: lang.Iterable[Header] = asList(
       new RecordHeader("headerKey0.0", "headerValue0.0".getBytes()),
       new RecordHeader("headerKey0.1", "headerValue0.1".getBytes())
     )
+
     val record0 = new ProducerRecord("topic", null, null, "key0", "value0", headers)
-    assertEquality(record0, lineReader.readMessage())
 
     val headers1: lang.Iterable[Header] = asList(new RecordHeader("headerKey1.0", "headerValue1.0".getBytes()))
     val record1 = new ProducerRecord("topic", null, null, "key1", "value1", headers1)
-    assertEquality(record1, lineReader.readMessage())
+
+    runTest(props, input, record0, record1)
 
   }
 
   @Test
-  def testMissingHeaderSeparatorInInput(): Unit = {
-    val lineReader = new LineMessageReader();
+  def testMissingHeaderSeparator(): Unit = {
+    val lineReader = new LineMessageReader()
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1\tkey0\tvalue0\n" +
         "headerKey1.0:headerValue1.0[MISSING-DELIMITER]key1\tvalue1"
@@ -164,23 +133,45 @@ class LineMessageReaderTest {
 
   @Test
   def testIgnoreErrorInInput(): Unit = {
-    val lineReader = new LineMessageReader();
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0\n" +
         "headerKey1.0:headerValue1.0\tkey1\tvalue1"
 
     val props = defaultTestProps
     props.put("ignore.error", "true")
-    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
 
-    val payLoadOnlyDueToError = new ProducerRecord("topic", null, "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0")
-    assertEquality(payLoadOnlyDueToError, lineReader.readMessage());
+    val payLoadOnlyDueToError: ProducerRecord[String, String] =
+      new ProducerRecord(
+        "topic",
+        null,
+        "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0"
+      )
 
     val headers: lang.Iterable[Header] = asList(new RecordHeader("headerKey1.0", "headerValue1.0".getBytes()))
-    val record1 = new ProducerRecord("topic", null, null, "key1", "value1", headers)
+    val validRecord = new ProducerRecord("topic", null, null, "key1", "value1", headers)
 
-    assertEquality(record1, lineReader.readMessage())
+    runTest(props, input, payLoadOnlyDueToError, validRecord)
+  }
 
+  @Test
+  def testMalformedHeader(): Unit = {
+    val lineReader = new LineMessageReader()
+    val input =
+      "headerKey0.0:,\tkey0\tvalue0\n"
+
+    lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
+    val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
+
+    assertEquals(
+      "Could not parse line 1, most likely line does not match pattern: headerKey0:headerValue0,...,headerKeyN:headerValueN\tkey\tvalue",
+      expectedException.getMessage
+    )
+  }
+
+  def runTest(props: Properties, input: String, expectedRecords: ProducerRecord[String, String]*): Unit = {
+    val lineReader = new LineMessageReader()
+    lineReader.init(new ByteArrayInputStream(input.getBytes), props)
+    expectedRecords.foreach(r => assertEquality(r, lineReader.readMessage()))
   }
 
   //  The equality method of ProducerRecord compares memory references for the header iterator, this is why this custom equality check is used.
@@ -190,11 +181,11 @@ class LineMessageReaderTest {
     assertEquals(expected.headers().toArray.toList, actual.headers().toArray.toList)
   }
 
-  private def producerRecord[K, V](key: K, value: V, headers: lang.Iterable[Header]): ProducerRecord[K, V] = {
+  private def record[K, V](key: K, value: V, headers: lang.Iterable[Header]): ProducerRecord[K, V] = {
     new ProducerRecord("topic", null, null, key, value, headers)
   }
 
-  private def producerRecord[K, V](key: K, value: V): ProducerRecord[K, V] = {
+  private def record[K, V](key: K, value: V): ProducerRecord[K, V] = {
     new ProducerRecord("topic", key, value)
   }
 

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package unit.kafka.tools
+package kafka.tools
 
 import kafka.tools.ConsoleProducer.LineMessageReader
 import org.apache.kafka.clients.producer.ProducerRecord

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -127,14 +127,14 @@ class LineMessageReaderTest {
     val lineReader = new LineMessageReader()
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1\tkey0\tvalue0\n" +
-      "headerKey1.0:headerValue1.0[MISSING-DELIMITER]key1\tvalue1"
+      "headerKey1.0:headerValue1.0\tkey1[MISSING-DELIMITER]value1"
 
     lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
     lineReader.readMessage()
     val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
 
     assertEquals(
-      "No key separator found on line 2: headerKey1.0:headerValue1.0[MISSING-DELIMITER]key1\tvalue1",
+      "No key separator found in 'key1[MISSING-DELIMITER]value1' on line number 2",
       expectedException.getMessage
     )
   }
@@ -178,7 +178,7 @@ class LineMessageReaderTest {
     val expectedException = assertThrows(classOf[KafkaException], () => lineReader.readMessage())
 
     assertEquals(
-      "No header key separator found on line 1 in pair key-val",
+      "No header key separator found in pair 'key-val' on line number 1",
       expectedException.getMessage
     )
   }
@@ -217,6 +217,4 @@ class LineMessageReaderTest {
   private def record[K, V](key: K, value: V): ProducerRecord[K, V] = {
     new ProducerRecord("topic", key, value)
   }
-
-
 }

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -29,7 +29,7 @@ import java.util.Properties
 class LineMessageReaderTest {
 
   private def defaultTestProps = {
-    val props = new Properties()
+    val props = new Properties
     props.put("topic", "topic")
     props.put("parse.key", "true")
     props.put("parse.headers", "true")
@@ -98,7 +98,7 @@ class LineMessageReaderTest {
 
   @Test
   def testMissingKeySeparator(): Unit = {
-    val lineReader = new LineMessageReader()
+    val lineReader = new LineMessageReader
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1\tkey0\tvalue0\n" +
       "headerKey1.0:headerValue1.0\tkey1[MISSING-DELIMITER]value1"
@@ -202,21 +202,21 @@ class LineMessageReaderTest {
   }
 
   def runTest(props: Properties, input: String, expectedRecords: ProducerRecord[String, String]*): Unit = {
-    val lineReader = new LineMessageReader()
+    val lineReader = new LineMessageReader
     lineReader.init(new ByteArrayInputStream(input.getBytes), props)
     expectedRecords.foreach(r => assertEquality(r, lineReader.readMessage()))
   }
 
   //  The equality method of ProducerRecord compares memory references for the header iterator, this is why this custom equality check is used.
   private def assertEquality[K, V](expected: ProducerRecord[K, V], actual: ProducerRecord[Array[Byte], Array[Byte]]): Unit = {
-    assertEquals(expected.key(), if (actual.key() == null) null else new String(actual.key()))
-    assertEquals(expected.value(), if (actual.value() == null) null else new String(actual.value()))
-    assertEquals(expected.headers().toArray.toList, actual.headers().toArray.toList)
+    assertEquals(expected.key, if (actual.key == null) null else new String(actual.key))
+    assertEquals(expected.value, if (actual.value == null) null else new String(actual.value))
+    assertEquals(expected.headers.toArray.toList, actual.headers.toArray.toList)
   }
 
   private def record[K, V](key: K, value: V, headers: List[(String, String)]): ProducerRecord[K, V] = {
     val record = new ProducerRecord("topic", key, value)
-    headers.foreach(h => record.headers().add(h._1, if (h._2 != null) h._2.getBytes() else null))
+    headers.foreach(h => record.headers.add(h._1, if (h._2 != null) h._2.getBytes else null))
     record
   }
 

--- a/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/LineMessageReaderTest.scala
@@ -88,7 +88,7 @@ class LineMessageReaderTest {
 
     val input =
       "headerKey0.0:headerValue0.0&headerKey0.1:headerValue0.1!key0#value0\n" +
-        "headerKey1.0:headerValue1.0!key1#value1"
+      "headerKey1.0:headerValue1.0!key1#value1"
 
     val record0 = record("key0", "value0", List("headerKey0.0" -> "headerValue0.0", "headerKey0.1" -> "headerValue0.1"))
     val record1 = record("key1", "value1", List("headerKey1.0" -> "headerValue1.0"))
@@ -101,7 +101,7 @@ class LineMessageReaderTest {
     val lineReader = new LineMessageReader()
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1\tkey0\tvalue0\n" +
-        "headerKey1.0:headerValue1.0\tkey1[MISSING-DELIMITER]value1"
+      "headerKey1.0:headerValue1.0\tkey1[MISSING-DELIMITER]value1"
 
     lineReader.init(new ByteArrayInputStream(input.getBytes), defaultTestProps)
     lineReader.readMessage()
@@ -141,7 +141,7 @@ class LineMessageReaderTest {
   def testIgnoreErrorInInput(): Unit = {
     val input =
       "headerKey0.0:headerValue0.0,headerKey0.1:headerValue0.1[MISSING-DELIMITER]key0\tvalue0\n" +
-        "headerKey1.0:headerValue1.0\tkey1\tvalue1"
+      "headerKey1.0:headerValue1.0\tkey1\tvalue1"
 
     val props = defaultTestProps
     props.put("ignore.error", "true")


### PR DESCRIPTION
Just like with the ConsoleConsumer, if headers and/or key enabled then the order is "headers key value".
The separator for the header and headerKey are configurable. The defaults are the same as in the ConsoleConsumer.

In short,

Default parsing pattern 

when:
parse.headers=true and parse.key=true:
    "h1:v1,h2...\tkey\tvalue"

when:
parse.headers=false and parse.key=true:
    "key\tvalue"

when:
parse.headers=true and parse.key=false:
    "h1:v1,h2...\tvalue" 

Testing strategy:
The testing is constrained to testing LineMessageReader as this is the only affected class.
Different combinations of parse.headers=true|false and parse.key=true|false are tested.
Different string patterns are tested. Including input that does not fit the expected Pattern.
LineMessageReaderTest.testLineReader suggests that the change is backward compatible.

This contribution is my original work and I license the work to the project under the project's open source license.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
