### PR TITLE
KAFKA-13394: Topic IDs should be removed from PartitionFetchState if they are no longer sent by the controller

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1401,6 +1401,12 @@ class ReplicaManager(val config: KafkaConfig,
                     if (partitionState.leader != localBrokerId)
                       topicIdUpdateFollowerPartitions.add(partition)
                     Errors.NONE
+                  case None if logTopicId.isDefined =>
+                    // If we have a topic ID in the log but not in the request, we must have previously had topic IDs but
+                    // are now downgrading. If we are a follower, remove the topic ID from the PartitionFetchState.
+                    if (partitionState.leader != localBrokerId)
+                      topicIdUpdateFollowerPartitions.add(partition)
+                    Errors.NONE
                   case _ =>
                     stateChangeLogger.info(s"Ignoring LeaderAndIsr request from " +
                       s"controller $controllerId with correlation id $correlationId " +

--- a/core/src/test/scala/integration/kafka/server/FetchRequestTestDowngrade.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchRequestTestDowngrade.scala
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.kafka.server
+
+import java.time.Duration
+import java.util.Arrays.asList
+
+import kafka.api.{ApiVersion, KAFKA_2_7_IV0, KAFKA_3_1_IV0}
+import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.utils.TestUtils
+import kafka.zk.ZkVersion
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import scala.collection.{Map, Seq}
+
+class FetchRequestTestDowngrade extends BaseRequestTest {
+
+    override def brokerCount: Int = 3
+    override def generateConfigs: Seq[KafkaConfig] = {
+        // Brokers should start with newer IBP and downgrade to the older one.
+        Seq(
+                createConfig(0, KAFKA_3_1_IV0),
+                createConfig(1, KAFKA_3_1_IV0),
+                createConfig(2, KAFKA_2_7_IV0)
+        )
+    }
+
+    @Test
+    def testTopicIdsInFetcherOldController(): Unit = {
+        val topic = "topic"
+        val producer = createProducer()
+        val consumer = createConsumer()
+
+        ensureControllerIn(Seq(0))
+        assertEquals(0, controllerSocketServer.config.brokerId)
+        val partitionLeaders = createTopic(topic,  Map(0 -> Seq(1, 0, 2), 1 -> Seq(0, 2, 1)))
+        TestUtils.waitForAllPartitionsMetadata(servers, topic, 2)
+        ensureControllerIn(Seq(2))
+        assertEquals(2, controllerSocketServer.config.brokerId)
+
+        assertEquals(1, partitionLeaders(0))
+        assertEquals(0, partitionLeaders(1))
+
+        val record1 = new ProducerRecord(topic, 0, null, "key".getBytes, "value".getBytes)
+        val record2 = new ProducerRecord(topic, 1, null, "key".getBytes, "value".getBytes)
+        producer.send(record1)
+        producer.send(record2)
+
+        consumer.assign(asList(new TopicPartition(topic, 0), new TopicPartition(topic, 1)))
+        val count = consumer.poll(Duration.ofMillis(5000)).count() + consumer.poll(Duration.ofMillis(5000)).count()
+        assertEquals(2, count)
+    }
+
+    private def ensureControllerIn(brokerIds: Seq[Int]): Unit = {
+        while (!brokerIds.contains(controllerSocketServer.config.brokerId)) {
+            zkClient.deleteController(ZkVersion.MatchAnyVersion)
+            TestUtils.waitUntilControllerElected(zkClient)
+        }
+    }
+
+    private def createConfig(nodeId: Int, interBrokerVersion: ApiVersion): KafkaConfig = {
+        val props = TestUtils.createBrokerConfig(nodeId, zkConnect)
+        props.put(KafkaConfig.InterBrokerProtocolVersionProp, interBrokerVersion.version)
+        KafkaConfig.fromProps(props)
+    }
+
+} 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -3537,7 +3537,7 @@ class ReplicaManagerTest {
       assertEquals(1, replicaManager.logManager.liveLogDirs.filterNot(_ == partition.log.get.dir.getParentFile).size)
 
       // Append a couple of messages.
-      for (i <- 1 to 40) {
+      for (i <- 1 to 500) {
         val records = TestUtils.singletonRecords(s"message $i".getBytes)
         appendRecords(replicaManager, tp, records).onFire { response =>
           assertEquals(Errors.NONE, response.error)


### PR DESCRIPTION
With KAFKA-13102, we added topic IDs to the InitialFetchState and the PartitionFetchState in order to send fetch requests using topic IDs when ibp is 3.1. 

However, there are some cases where we could initially send topic IDs from the controller and then no longer to do so (controller changes to an IBP < 2.8). If we do not remove from the PartitionFetchState and one broker is still IBP 3.1, it will try to send a version 13 fetch request to brokers that no longer have topic IDs in the metadata cache. This could leave the cluster in a state unable to fetch from these partitions.

This PR removes the topic IDs from the PartitionFetchState if the log contains a topic ID but the request does not. This means that we will always handle a leader and isr request if there is no ID in the request but an ID in the log. 
Such a state should be transient because we are either 
* upgrading the cluster and somehow switched between a new IBP controller and an old one --> and will eventually have all new IBP controllers/brokers.
* downgrading the cluster --> will eventually have all old IBP controllers/brokers and will restart the broker/delete the partition metadata file for them. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
