### PR TITLE
KAFKA-13425:  Optimization of KafkaConsumer#pause semantics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2007,7 +2007,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Suspend fetching from the requested partitions. Future calls to {@link #poll(Duration)} will not return
      * any records from these partitions until they have been resumed using {@link #resume(Collection)}.
      * Note that this method does not affect partition subscription. In particular, it does not cause a group
-     * rebalance when automatic assignment is used. And groupRebalance does not preserve pause state.
+     * rebalance when automatic assignment is used.
+     *
+     * Note: Rebalance will not preserve the pause/resume state.
      * @param partitions The partitions which should be paused
      * @throws IllegalStateException if any of the provided partitions are not currently assigned to this consumer
      */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2007,7 +2007,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Suspend fetching from the requested partitions. Future calls to {@link #poll(Duration)} will not return
      * any records from these partitions until they have been resumed using {@link #resume(Collection)}.
      * Note that this method does not affect partition subscription. In particular, it does not cause a group
-     * rebalance when automatic assignment is used.
+     * rebalance when automatic assignment is used. And groupRebalance does not preserve pause state.
      * @param partitions The partitions which should be paused
      * @throws IllegalStateException if any of the provided partitions are not currently assigned to this consumer
      */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -307,6 +307,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
     private Exception invokePartitionsRevoked(final Set<TopicPartition> revokedPartitions) {
         log.info("Revoke previously assigned partitions {}", Utils.join(revokedPartitions, ", "));
+        Set<TopicPartition> revokePausedPartitions = subscriptions.pausedPartitions();
+        revokePausedPartitions.removeAll(revokedPartitions);
+        if (!revokePausedPartitions.isEmpty())
+            log.info("Revoke previously paused partitions {}", Utils.join(revokePausedPartitions, ", "));
 
         ConsumerRebalanceListener listener = subscriptions.rebalanceListener();
         try {
@@ -326,6 +330,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
     private Exception invokePartitionsLost(final Set<TopicPartition> lostPartitions) {
         log.info("Lost previously assigned partitions {}", Utils.join(lostPartitions, ", "));
+        Set<TopicPartition> lostPausedPartitions = subscriptions.pausedPartitions();
+        lostPausedPartitions.removeAll(lostPartitions);
+        if (!lostPausedPartitions.isEmpty())
+            log.info("Lost previously paused partitions {}", Utils.join(lostPausedPartitions, ", "));
 
         ConsumerRebalanceListener listener = subscriptions.rebalanceListener();
         try {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -310,7 +310,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         Set<TopicPartition> revokePausedPartitions = subscriptions.pausedPartitions();
         revokePausedPartitions.retainAll(revokedPartitions);
         if (!revokePausedPartitions.isEmpty())
-            log.info("Revoke previously paused partitions {}", Utils.join(revokePausedPartitions, ", "));
+            log.info("The pause flag in partitions [{}] will be removed due to revocation.", Utils.join(revokePausedPartitions, ", "));
 
         ConsumerRebalanceListener listener = subscriptions.rebalanceListener();
         try {
@@ -333,7 +333,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         Set<TopicPartition> lostPausedPartitions = subscriptions.pausedPartitions();
         lostPausedPartitions.retainAll(lostPartitions);
         if (!lostPausedPartitions.isEmpty())
-            log.info("Lost previously paused partitions {}", Utils.join(lostPausedPartitions, ", "));
+            log.info("The pause flag in partitions [{}] will be removed due to lost.", Utils.join(lostPausedPartitions, ", "));
 
         ConsumerRebalanceListener listener = subscriptions.rebalanceListener();
         try {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -308,7 +308,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     private Exception invokePartitionsRevoked(final Set<TopicPartition> revokedPartitions) {
         log.info("Revoke previously assigned partitions {}", Utils.join(revokedPartitions, ", "));
         Set<TopicPartition> revokePausedPartitions = subscriptions.pausedPartitions();
-        revokePausedPartitions.removeAll(revokedPartitions);
+        revokePausedPartitions.retainAll(revokedPartitions);
         if (!revokePausedPartitions.isEmpty())
             log.info("Revoke previously paused partitions {}", Utils.join(revokePausedPartitions, ", "));
 
@@ -331,7 +331,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     private Exception invokePartitionsLost(final Set<TopicPartition> lostPartitions) {
         log.info("Lost previously assigned partitions {}", Utils.join(lostPartitions, ", "));
         Set<TopicPartition> lostPausedPartitions = subscriptions.pausedPartitions();
-        lostPausedPartitions.removeAll(lostPartitions);
+        lostPausedPartitions.retainAll(lostPartitions);
         if (!lostPausedPartitions.isEmpty())
             log.info("Lost previously paused partitions {}", Utils.join(lostPausedPartitions, ", "));
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -333,7 +333,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         Set<TopicPartition> lostPausedPartitions = subscriptions.pausedPartitions();
         lostPausedPartitions.retainAll(lostPartitions);
         if (!lostPausedPartitions.isEmpty())
-            log.info("The pause flag in partitions [{}] will be removed due to lost.", Utils.join(lostPausedPartitions, ", "));
+            log.info("The pause flag in partitions [{}] will be removed due to partition lost.", Utils.join(lostPausedPartitions, ", "));
 
         ConsumerRebalanceListener listener = subscriptions.rebalanceListener();
         try {


### PR DESCRIPTION
1. Enhance the annotation of KafkaConsumer#pause(...) method
2. Add log output when clearing the paused mark of topicPartitions

Story JIRA: https://issues.apache.org/jira/browse/KAFKA-13425

Author: RivenSun2 <riven.sun@zoom.us>

Reviewers: Luke Chen <showuon@gmail.com>