### PR TITLE
KAFKA-13422: Add verification of duplicate configuration for each type of LoginModule in JaasConfigFile

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/JaasContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasContext.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -153,7 +153,13 @@ public class JaasContext {
         AppConfigurationEntry[] entries = configuration.getAppConfigurationEntry(name);
         if (entries == null)
             throw new IllegalArgumentException("Could not find a '" + name + "' entry in this JAAS configuration.");
-        this.configurationEntries = Collections.unmodifiableList(new ArrayList<>(Arrays.asList(entries)));
+        Map<String, AppConfigurationEntry> loginModuleEntries = new HashMap<>();
+        for (AppConfigurationEntry entry : entries) {
+            if (loginModuleEntries.containsKey(entry.getLoginModuleName()))
+                throw new IllegalArgumentException("The loginModule '" + entry.getLoginModuleName() + "' in the JAAS config property should only be configured once");
+            loginModuleEntries.put(entry.getLoginModuleName(), entry);
+        }
+        this.configurationEntries = Collections.unmodifiableList(new ArrayList<>(loginModuleEntries.values()));
         this.dynamicJaasConfig = dynamicJaasConfig;
     }
 


### PR DESCRIPTION
Add verification of duplicate configuration for each type of LoginModule in JaasConfigFile.

Story JIRA: https://issues.apache.org/jira/browse/KAFKA-13422

Author: RivenSun2 riven.sun@zoom.us
