### PR TITLE
KAFKA-13431: Sink Connectors: Add support for topic-mutating SMTs to async users

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.Header;
@@ -32,18 +33,18 @@ public class InternalSinkRecord extends SinkRecord {
 
     private final ConsumerRecord<byte[], byte[]> originalRecord;
 
-    public InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, SinkRecord record) {
+    public InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, TopicPartition originalTopicPartition, SinkRecord record) {
         super(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
             record.valueSchema(), record.value(), record.kafkaOffset(), record.timestamp(),
-            record.timestampType(), record.headers());
+            record.timestampType(), record.headers(), originalTopicPartition);
         this.originalRecord = originalRecord;
     }
 
-    protected InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, String topic,
+    protected InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, TopicPartition originalTopicPartition, String topic,
                                  int partition, Schema keySchema, Object key, Schema valueSchema,
                                  Object value, long kafkaOffset, Long timestamp,
                                  TimestampType timestampType, Iterable<Header> headers) {
-        super(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers);
+        super(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers, originalTopicPartition);
         this.originalRecord = originalRecord;
     }
 
@@ -51,7 +52,7 @@ public class InternalSinkRecord extends SinkRecord {
     public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key,
                                 Schema valueSchema, Object value, Long timestamp,
                                 Iterable<Header> headers) {
-        return new InternalSinkRecord(originalRecord, topic, kafkaPartition, keySchema, key,
+        return new InternalSinkRecord(originalRecord, originalTopicPartition(), topic, kafkaPartition, keySchema, key,
             valueSchema, value, kafkaOffset(), timestamp, timestampType(), headers());
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -503,6 +503,7 @@ class WorkerSinkTask extends WorkerTask {
             return null;
         }
 
+        TopicPartition originalTopicPartition = new TopicPartition(msg.topic(), msg.partition());
         Long timestamp = ConnectUtils.checkAndConvertTimestamp(msg.timestamp());
         SinkRecord origRecord = new SinkRecord(msg.topic(), msg.partition(),
                 keyAndSchema.schema(), keyAndSchema.value(),
@@ -510,7 +511,9 @@ class WorkerSinkTask extends WorkerTask {
                 msg.offset(),
                 timestamp,
                 msg.timestampType(),
-                headers);
+                headers,
+                originalTopicPartition);
+
         log.trace("{} Applying transformations to record in topic '{}' partition {} at offset {} and timestamp {} with key {} and value {}",
                 this, msg.topic(), msg.partition(), msg.offset(), timestamp, keyAndSchema.value(), valueAndSchema.value());
         if (isTopicTrackingEnabled) {
@@ -523,7 +526,7 @@ class WorkerSinkTask extends WorkerTask {
             return null;
         }
         // Error reporting will need to correlate each sink record with the original consumer record
-        return new InternalSinkRecord(msg, transformedRecord);
+        return new InternalSinkRecord(msg, originalTopicPartition, transformedRecord);
     }
 
     private Headers convertHeadersFor(ConsumerRecord<byte[], byte[]> record) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSinkTask.java
@@ -72,7 +72,10 @@ public class VerifiableSinkTask extends SinkTask {
             data.put("topic", record.topic());
             data.put("time_ms", nowMs);
             data.put("seqno", record.value());
+            data.put("partition", record.kafkaPartition());
             data.put("offset", record.kafkaOffset());
+            data.put("originalTopic", record.originalTopicPartition().topic());
+            data.put("originalPartition", record.originalTopicPartition().partition());
             String dataJson;
             try {
                 dataJson = JSON_SERDE.writeValueAsString(data);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrantRecordSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrantRecordSinkConnector.java
@@ -17,13 +17,10 @@
 
 package org.apache.kafka.connect.integration;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 public class ErrantRecordSinkConnector extends MonitorableSinkConnector {
@@ -47,15 +44,10 @@ public class ErrantRecordSinkConnector extends MonitorableSinkConnector {
         }
 
         @Override
-        public void put(Collection<SinkRecord> records) {
-            for (SinkRecord rec : records) {
-                taskHandle.record();
-                TopicPartition tp = cachedTopicPartitions
-                    .computeIfAbsent(rec.topic(), v -> new HashMap<>())
-                    .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));
-                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0L) + 1);
-                reporter.report(rec, new Throwable());
-            }
+        protected void processRecord(SinkRecord rec) {
+            super.processRecord(rec);
+            reporter.report(rec, new Throwable());
         }
+
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.runtime;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -849,11 +848,11 @@ public class WorkerSinkTaskTest {
         workerTask.iteration(); // iter 1 -- initial assignment
         workerTask.iteration(); // iter 2 -- deliver 2 records
 
-        assertEquals(ImmutableList.of(TOPIC, TOPIC), recordsCapture.getValue().stream()
+        assertEquals(Arrays.asList(TOPIC, TOPIC), recordsCapture.getValue().stream()
                 .map(sr -> sr.originalTopicPartition().topic())
                 .collect(toList()));
 
-        assertEquals(ImmutableList.of(testPrefix + TOPIC, testPrefix + TOPIC), recordsCapture.getValue().stream()
+        assertEquals(Arrays.asList(testPrefix + TOPIC, testPrefix + TOPIC), recordsCapture.getValue().stream()
                 .map(SinkRecord::topic)
                 .collect(toList()));
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -184,7 +184,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
                 SinkRecord referenceSinkRecord
                         = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY, VALUE_SCHEMA, VALUE, FIRST_OFFSET + offset, TIMESTAMP, TIMESTAMP_TYPE);
                 InternalSinkRecord referenceInternalSinkRecord =
-                    new InternalSinkRecord(null, referenceSinkRecord);
+                    new InternalSinkRecord(null, new TopicPartition(TOPIC, PARTITION), referenceSinkRecord);
                 assertEquals(referenceInternalSinkRecord, rec);
                 offset++;
             }


### PR DESCRIPTION
Implementation for proposal described in [KIP-793](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=191336830).

It mainly consists of adding a new method in SinkRecord to get the original topic and partition, before applying transformations.

Unit and integration tests are included.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
