### PR TITLE
MINOR: Update docs for producer callbacks to reflect current behaviour

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -25,10 +25,12 @@ public interface Callback {
     /**
      * A callback method the user can implement to provide asynchronous handling of request completion. This method will
      * be called when the record sent to the server has been acknowledged. When exception is not null in the callback,
-     * metadata will contain the special -1 value for all fields except for topicPartition, which will be valid.
+     * and the exception is a subclass of ApiException, metadata will be null. For all other exceptions, metadata will
+     * contain the special -1 value for all fields except for topicPartition, which will be valid.
      *
-     * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
-     *                 with -1 value for all fields except for topicPartition will be returned if an error occurred.
+     * @param metadata The metadata for the record that was sent (i.e. the partition and offset). A null value or an
+     *                 empty metadata with -1 value for all fields except for topicPartition will be returned if an
+     *                 error occurred.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      *                  Possible thrown exceptions include:
      *


### PR DESCRIPTION
Originally, Callback would return a null metadata value when an error occurred.

This was partially changed by [KAFKA-3303](https://issues.apache.org/jira/browse/KAFKA-3303), where in some cases Callback would return an 'empty' metadata. In this empty metadata TopicPartition is set correctly but all other fields are set as `-1`.

The docs were later updated by [KAFKA-7412](https://issues.apache.org/jira/browse/KAFKA-7412), but it incorrectly states that Callback will always return this 'empty' metadata when an error occurs. However in the case of any exceptions that are a subclass of ApiException, Callback will still return a null value (see [here](https://github.com/apache/kafka/blob/3.1/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L1002)).

This change aims to clarify the docs to accurately reflect the behaviour of producer callbacks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)