### PR TITLE
KAFKA-13436: Omitted BrokerTopicMetrics metrics in the documentation

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1438,10 +1438,30 @@ $ bin/kafka-acls.sh \
         <td></td>
       </tr>
       <tr>
+        <td>Produce request rate</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Fetch request rate</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec</td>
+        <td></td>
+      </tr>
+      <tr>
         <td>Error rate</td>
         <td>kafka.network:type=RequestMetrics,name=ErrorsPerSec,request=([-.\w]+),error=([-.\w]+)</td>
         <td>Number of errors in responses counted per-request-type, per-error-code. If a response contains
             multiple errors, all are counted. error=NONE indicates successful responses.</td>
+      </tr>
+      <tr>
+        <td>Failed produce request rate</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Failed fetch request rate</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec</td>
+        <td></td>
       </tr>
       <tr>
         <td>Request size in bytes</td>
@@ -1476,6 +1496,11 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Byte out rate to other brokers</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Rejected byte out rate due to the record batch size is greater than max.message.bytes configuration</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec</td>
         <td></td>
       </tr>
       <tr>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1506,22 +1506,22 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message validation failure rate due to no key specified for compacted topic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=NoKeyCompactedTopicRecordsPerSec</td>
-        <td></td>
+        <td>0</td>
       </tr>
       <tr>
         <td>Message validation failure rate due to invalid magic number</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMagicNumberRecordsPerSec</td>
-        <td></td>
+        <td>0</td>
       </tr>
       <tr>
         <td>Message validation failure rate due to incorrect crc checksum</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMessageCrcRecordsPerSec</td>
-        <td></td>
+        <td>0</td>
       </tr>
       <tr>
         <td>Message validation failure rate due to non-continuous offset or sequence number in batch</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=InvalidOffsetOrSequenceRecordsPerSec</td>
-        <td></td>
+        <td>0</td>
       </tr>
       <tr>
         <td>Log flush rate and time</td>
@@ -1765,12 +1765,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Outgoing byte rate of reassignment traffic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec</td>
-        <td></td>
+        <td>0; non-zero when the partition reassignment is in progress.</td>
       </tr>
       <tr>
         <td>Incoming byte rate of reassignment traffic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec</td>
-        <td></td>
+        <td>0; non-zero when the partition reassignment is in progress.</td>
       </tr>
       <tr>
         <td>Size of a partition on disk (in bytes)</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1402,17 +1402,17 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message in rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Incoming message rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Byte in rate from clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Byte in (from the clients) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Byte in rate from other brokers</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Byte in (from the other brokers) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Controller Request rate from Broker</td>
@@ -1446,22 +1446,22 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Produce request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Produce request rate per topic.</td>
+        <td>Produce request rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Fetch request (from client or follower) rate per topic.</td>
+        <td>Fetch request (from client or follower) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Failed produce request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Failed Produce request rate per topic.</td>
+        <td>Failed Produce request rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Failed fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Failed Fetch request (from client or follower) rate per topic.</td>
+        <td>Failed Fetch request (from client or follower) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Request size in bytes</td>
@@ -1481,7 +1481,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message conversion rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)</td>
-        <td>Number of records which required message format conversion.</td>
+        <td>Message format conversion rate, by Produce or Fetch request, per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Request Queue Size</td>
@@ -1491,36 +1491,36 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Byte out rate to clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Byte out (to the clients) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Byte out rate to other brokers</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Byte out (to the other brokers) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Rejected byte rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec,topic=([-.\w]+)</td>
-        <td>Rejected byte out rate per topic, due to the record batch size is greater than max.message.bytes configuration.</td>
+        <td>Rejected byte rate per topic, due to the record batch size is greater than max.message.bytes configuration. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Message validation failure rate due to no key specified for compacted topic</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=NoKeyCompactedTopicRecordsPerSec,topic=([-.\w]+)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=NoKeyCompactedTopicRecordsPerSec</td>
         <td></td>
       </tr>
       <tr>
         <td>Message validation failure rate due to invalid magic number</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMagicNumberRecordsPerSec,topic=([-.\w]+)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMagicNumberRecordsPerSec</td>
         <td></td>
       </tr>
       <tr>
         <td>Message validation failure rate due to incorrect crc checksum</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMessageCrcRecordsPerSec,topic=([-.\w]+)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMessageCrcRecordsPerSec</td>
         <td></td>
       </tr>
       <tr>
         <td>Message validation failure rate due to non-continuous offset or sequence number in batch</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidOffsetOrSequenceRecordsPerSec,topic=([-.\w]+)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidOffsetOrSequenceRecordsPerSec</td>
         <td></td>
       </tr>
       <tr>
@@ -1764,12 +1764,12 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Outgoing byte rate of reassignment traffic</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec,topic=([-.\w]+)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec</td>
         <td></td>
       </tr>
       <tr>
         <td>Incoming byte rate of reassignment traffic</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec,topic=([-.\w]+)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec</td>
         <td></td>
       </tr>
       <tr>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1438,30 +1438,30 @@ $ bin/kafka-acls.sh \
         <td></td>
       </tr>
       <tr>
+        <td>Error rate</td>
+        <td>kafka.network:type=RequestMetrics,name=ErrorsPerSec,request=([-.\w]+),error=([-.\w]+)</td>
+        <td>Number of errors in responses counted per-request-type, per-error-code. If a response contains
+          multiple errors, all are counted. error=NONE indicates successful responses.</td>
+      </tr>
+      <tr>
         <td>Produce request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Produce request rate per topic.</td>
       </tr>
       <tr>
         <td>Fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Error rate</td>
-        <td>kafka.network:type=RequestMetrics,name=ErrorsPerSec,request=([-.\w]+),error=([-.\w]+)</td>
-        <td>Number of errors in responses counted per-request-type, per-error-code. If a response contains
-            multiple errors, all are counted. error=NONE indicates successful responses.</td>
+        <td>Fetch request (from client or follower) rate per topic.</td>
       </tr>
       <tr>
         <td>Failed produce request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Failed Produce request rate per topic.</td>
       </tr>
       <tr>
         <td>Failed fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Failed Fetch request (from client or follower) rate per topic.</td>
       </tr>
       <tr>
         <td>Request size in bytes</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1401,18 +1401,18 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Message in rate</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=([-.\w]+)</td>
+        <td>Number of incoming messages per topic.</td>
       </tr>
       <tr>
         <td>Byte in rate from clients</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=([-.\w]+)</td>
+        <td>Number of incoming bytes per topic, from clients.</td>
       </tr>
       <tr>
         <td>Byte in rate from other brokers</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec,topic=([-.\w]+)</td>
+        <td>Number of incoming bytes per topic, from other brokers.</td>
       </tr>
       <tr>
         <td>Controller Request rate from Broker</td>
@@ -1439,13 +1439,13 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Produce request rate</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec,topic=([-.\w]+)</td>
+        <td>Number of produce requests per topic.</td>
       </tr>
       <tr>
         <td>Fetch request rate</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec,topic=([-.\w]+)</td>
+        <td>Number of fetch requests per topic.</td>
       </tr>
       <tr>
         <td>Error rate</td>
@@ -1455,13 +1455,13 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Failed produce request rate</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec,topic=([-.\w]+)</td>
+        <td>Number of failed produce requests per topic.</td>
       </tr>
       <tr>
         <td>Failed fetch request rate</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec,topic=([-.\w]+)</td>
+        <td>Number of failed fetch requests per topic.</td>
       </tr>
       <tr>
         <td>Request size in bytes</td>
@@ -1481,7 +1481,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message conversion rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)</td>
-        <td>Number of records which required message format conversion.</td>
+        <td>Number of records which required message format conversion, per topic.</td>
       </tr>
       <tr>
         <td>Request Queue Size</td>
@@ -1490,38 +1490,38 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Byte out rate to clients</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=([-.\w]+)</td>
+        <td>Number of outgoing bytes per topic, to clients.</td>
       </tr>
       <tr>
         <td>Byte out rate to other brokers</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec,topic=([-.\w]+)</td>
+        <td>Number of outgoing bytes per topic, to other brokers.</td>
       </tr>
       <tr>
-        <td>Rejected byte out rate due to the record batch size is greater than max.message.bytes configuration</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec</td>
-        <td></td>
+        <td>Rejected byte rate</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec,topic=([-.\w]+)</td>
+        <td>Rejected byte out rate per topic, due to the record batch size is greater than max.message.bytes configuration.</td>
       </tr>
       <tr>
-        <td>Message validation failure rate due to no key specified for compacted topic</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=NoKeyCompactedTopicRecordsPerSec</td>
-        <td></td>
+        <td>Message validation failure rate (compacted topic, no key)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=NoKeyCompactedTopicRecordsPerSec,topic=([-.\w]+)</td>
+        <td>Message validation failure per topic, due to no key specified for compacted topic.</td>
       </tr>
       <tr>
-        <td>Message validation failure rate due to invalid magic number</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMagicNumberRecordsPerSec</td>
-        <td></td>
+        <td>Message validation failure rate (invalid magic number)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMagicNumberRecordsPerSec,topic=([-.\w]+)</td>
+        <td>Message validation failure per topic, due to invalid magic number.</td>
       </tr>
       <tr>
-        <td>Message validation failure rate due to incorrect crc checksum</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMessageCrcRecordsPerSec</td>
-        <td></td>
+        <td>Message validation failure rate (incorrect crc checksum)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMessageCrcRecordsPerSec,topic=([-.\w]+)</td>
+        <td>Message validation failure per topic, due to incorrect crc checksum.</td>
       </tr>
       <tr>
-        <td>Message validation failure rate due to non-continuous offset or sequence number in batch</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidOffsetOrSequenceRecordsPerSec</td>
-        <td></td>
+        <td>Message validation failure rate (non-continuous offset or sequence number in batch)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=InvalidOffsetOrSequenceRecordsPerSec,topic=([-.\w]+)</td>
+        <td>Message validation failure per topic, due to non-continuous offset or sequence number in batch.</td>
       </tr>
       <tr>
         <td>Log flush rate and time</td>
@@ -1764,13 +1764,13 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Outgoing byte rate of reassignment traffic</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec,topic=([-.\w]+)</td>
+        <td>Number of outgoing bytes per topic, due to reassignment traffic.</td>
       </tr>
       <tr>
         <td>Incoming byte rate of reassignment traffic</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec</td>
-        <td></td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec,topic=([-.\w]+)</td>
+        <td>Number of incoming bytes per topic, due to reassignment traffic.</td>
       </tr>
       <tr>
         <td>Size of a partition on disk (in bytes)</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1481,7 +1481,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message conversion rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)</td>
-        <td></td>
+        <td>Number of records which required message format conversion.</td>
       </tr>
       <tr>
         <td>Request Queue Size</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1402,17 +1402,17 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message in rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=([-.\w]+)</td>
-        <td>Number of incoming messages per topic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Byte in rate from clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=([-.\w]+)</td>
-        <td>Number of incoming bytes per topic, from clients.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Byte in rate from other brokers</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec,topic=([-.\w]+)</td>
-        <td>Number of incoming bytes per topic, from other brokers.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Controller Request rate from Broker</td>
@@ -1440,12 +1440,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Produce request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Number of produce requests per topic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Number of fetch requests per topic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Error rate</td>
@@ -1456,12 +1456,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Failed produce request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Number of failed produce requests per topic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Failed fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Number of failed fetch requests per topic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Request size in bytes</td>
@@ -1481,7 +1481,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message conversion rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)</td>
-        <td>Number of records which required message format conversion, per topic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Request Queue Size</td>
@@ -1491,12 +1491,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Byte out rate to clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=([-.\w]+)</td>
-        <td>Number of outgoing bytes per topic, to clients.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Byte out rate to other brokers</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec,topic=([-.\w]+)</td>
-        <td>Number of outgoing bytes per topic, to other brokers.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Rejected byte rate</td>
@@ -1504,24 +1504,24 @@ $ bin/kafka-acls.sh \
         <td>Rejected byte out rate per topic, due to the record batch size is greater than max.message.bytes configuration.</td>
       </tr>
       <tr>
-        <td>Message validation failure rate (compacted topic, no key)</td>
+        <td>Message validation failure rate due to no key specified for compacted topic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=NoKeyCompactedTopicRecordsPerSec,topic=([-.\w]+)</td>
-        <td>Message validation failure per topic, due to no key specified for compacted topic.</td>
+        <td></td>
       </tr>
       <tr>
-        <td>Message validation failure rate (invalid magic number)</td>
+        <td>Message validation failure rate due to invalid magic number</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMagicNumberRecordsPerSec,topic=([-.\w]+)</td>
-        <td>Message validation failure per topic, due to invalid magic number.</td>
+        <td></td>
       </tr>
       <tr>
-        <td>Message validation failure rate (incorrect crc checksum)</td>
+        <td>Message validation failure rate due to incorrect crc checksum</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=InvalidMessageCrcRecordsPerSec,topic=([-.\w]+)</td>
-        <td>Message validation failure per topic, due to incorrect crc checksum.</td>
+        <td></td>
       </tr>
       <tr>
-        <td>Message validation failure rate (non-continuous offset or sequence number in batch)</td>
+        <td>Message validation failure rate due to non-continuous offset or sequence number in batch</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=InvalidOffsetOrSequenceRecordsPerSec,topic=([-.\w]+)</td>
-        <td>Message validation failure per topic, due to non-continuous offset or sequence number in batch.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Log flush rate and time</td>
@@ -1765,12 +1765,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Outgoing byte rate of reassignment traffic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec,topic=([-.\w]+)</td>
-        <td>Number of outgoing bytes per topic, due to reassignment traffic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Incoming byte rate of reassignment traffic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec,topic=([-.\w]+)</td>
-        <td>Number of incoming bytes per topic, due to reassignment traffic.</td>
+        <td></td>
       </tr>
       <tr>
         <td>Size of a partition on disk (in bytes)</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1451,7 +1451,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Fetch request (from client or follower) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
+        <td>Fetch request (from clients or followers) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Failed produce request rate</td>
@@ -1461,7 +1461,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Failed fetch request rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec,topic=([-.\w]+)</td>
-        <td>Failed Fetch request (from client or follower) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
+        <td>Failed Fetch request (from clients or followers) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Request size in bytes</td>
@@ -1481,7 +1481,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Message conversion rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)</td>
-        <td>Message format conversion rate, by Produce or Fetch request, per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
+        <td>Message format conversion rate, for Produce or Fetch requests, per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Request Queue Size</td>
@@ -1501,7 +1501,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Rejected byte rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec,topic=([-.\w]+)</td>
-        <td>Rejected byte rate per topic, due to the record batch size is greater than max.message.bytes configuration. Omitting 'topic=(...)' will yield the all-topic rate.</td>
+        <td>Rejected byte rate per topic, due to the record batch size being greater than max.message.bytes configuration. Omitting 'topic=(...)' will yield the all-topic rate.</td>
       </tr>
       <tr>
         <td>Message validation failure rate due to no key specified for compacted topic</td>
@@ -1765,12 +1765,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Outgoing byte rate of reassignment traffic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesOutPerSec</td>
-        <td>0; non-zero when the partition reassignment is in progress.</td>
+        <td>0; non-zero when a partition reassignment is in progress.</td>
       </tr>
       <tr>
         <td>Incoming byte rate of reassignment traffic</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=ReassignmentBytesInPerSec</td>
-        <td>0; non-zero when the partition reassignment is in progress.</td>
+        <td>0; non-zero when a partition reassignment is in progress.</td>
       </tr>
       <tr>
         <td>Size of a partition on disk (in bytes)</td>


### PR DESCRIPTION
I found this issue while working on [KAFKA-13354](https://issues.apache.org/jira/browse/KAFKA-13354).

As soon as this PR is approved, I will open a PR on the kafka-site also.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
