### PR TITLE
MINOR: Adding a constant to denote UNKNOWN leader in LeaderAndEpoch

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2448,7 +2448,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     private final class ListenerContext implements CloseListener<BatchReader<T>> {
         private final RaftClient.Listener<T> listener;
         // This field is used only by the Raft IO thread
-        private LeaderAndEpoch lastFiredLeaderChange = new LeaderAndEpoch(OptionalInt.empty(), 0);
+        private LeaderAndEpoch lastFiredLeaderChange = LeaderAndEpoch.UNKNOWN;
 
         // These fields are visible to both the Raft IO thread and the listener
         // and are protected through synchronization on this ListenerContext instance

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderAndEpoch.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderAndEpoch.java
@@ -22,6 +22,7 @@ import java.util.OptionalInt;
 public class LeaderAndEpoch {
     private final OptionalInt leaderId;
     private final int epoch;
+    public static final LeaderAndEpoch UNKNOWN = new LeaderAndEpoch(OptionalInt.empty(), 0);
 
     public LeaderAndEpoch(OptionalInt leaderId, int epoch) {
         this.leaderId = Objects.requireNonNull(leaderId);


### PR DESCRIPTION
Verified that the KafkaRaftClientTest passes with the change.