### PR TITLE
KAFKA-13421; Reenable `testRollingBrokerRestartsWithSmallerMaxGroupSizeConfigDisruptsBigGroup`

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -299,7 +299,6 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
     * Then, 1 consumer should be left out of the group.
     */
   @Test
-  @Disabled // To be re-enabled once we fix KAFKA-13421
   def testRollingBrokerRestartsWithSmallerMaxGroupSizeConfigDisruptsBigGroup(): Unit = {
     val group = "group-max-size-test"
     val topic = "group-max-size-test"

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -55,7 +55,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
    */
   def servers: mutable.Buffer[KafkaServer] = {
     checkIsZKTest()
-    _brokers.map(_.asInstanceOf[KafkaServer])
+    _brokers.asInstanceOf[mutable.Buffer[KafkaServer]]
   }
 
   var brokerList: String = null
@@ -208,8 +208,9 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
           threadNamePrefix = None,
           enableForwarding
         )
+      } else {
+        brokers(i).startup()
       }
-      _brokers(i).startup()
       alive(i) = true
     }
   }


### PR DESCRIPTION
This test was disabled in https://github.com/apache/kafka/commit/af8100b94fda4a27511797233e9845078ae8a69f. The reason the test was failing is that it assumes that the reference to `servers` can be mutated directly. The implementation in `IntegrationTestHarness` is intended to allow this by returning a mutable buffer, but the implementation actually returns a copy of the underlying collection. This caused the test case to create multiple `KafkaServer` instances instead of one as intended because it was modifying the copy. This led to the broker registration failure.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
