### PR TITLE
KAFKA-13445: Add ECDSA test for JWT validation

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/AccessTokenBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/AccessTokenBuilder.java
@@ -39,13 +39,13 @@ public class AccessTokenBuilder {
 
     private String subject = "jdoe";
 
-    private String subjectClaimName = ReservedClaimNames.SUBJECT;
+    private final String subjectClaimName = ReservedClaimNames.SUBJECT;
 
     private Object scope = "engineering";
 
-    private String scopeClaimName = "scope";
+    private final String scopeClaimName = "scope";
 
-    private Long issuedAtSeconds;
+    private final Long issuedAtSeconds;
 
     private Long expirationSeconds;
 
@@ -69,10 +69,6 @@ public class AccessTokenBuilder {
         return this;
     }
 
-    public String audience() {
-        return audience;
-    }
-
     public AccessTokenBuilder audience(String audience) {
         this.audience = audience;
         return this;
@@ -89,11 +85,6 @@ public class AccessTokenBuilder {
 
     public String subjectClaimName() {
         return subjectClaimName;
-    }
-
-    public AccessTokenBuilder subjectClaimName(String subjectClaimName) {
-        this.subjectClaimName = subjectClaimName;
-        return this;
     }
 
     public Object scope() {
@@ -120,18 +111,8 @@ public class AccessTokenBuilder {
         return scopeClaimName;
     }
 
-    public AccessTokenBuilder scopeClaimName(String scopeClaimName) {
-        this.scopeClaimName = scopeClaimName;
-        return this;
-    }
-
     public Long issuedAtSeconds() {
         return issuedAtSeconds;
-    }
-
-    public AccessTokenBuilder issuedAtSeconds(Long issuedAtSeconds) {
-        this.issuedAtSeconds = issuedAtSeconds;
-        return this;
     }
 
     public Long expirationSeconds() {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerLoginCallbackHandlerTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
 import org.apache.kafka.common.utils.Utils;
+import org.jose4j.jws.AlgorithmIdentifiers;
 import org.junit.jupiter.api.Test;
 
 public class OAuthBearerLoginCallbackHandlerTest extends OAuthBearerTest {
@@ -47,7 +48,9 @@ public class OAuthBearerLoginCallbackHandlerTest extends OAuthBearerTest {
     @Test
     public void testHandleTokenCallback() throws Exception {
         Map<String, ?> configs = getSaslConfigs();
-        AccessTokenBuilder builder = new AccessTokenBuilder();
+        AccessTokenBuilder builder = new AccessTokenBuilder()
+            .jwk(createRsaJwk())
+            .alg(AlgorithmIdentifiers.RSA_USING_SHA256);
         String accessToken = builder.build();
         AccessTokenRetriever accessTokenRetriever = () -> accessToken;
 

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerTest.java
@@ -45,6 +45,10 @@ import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.authenticator.TestJaasConfig;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.utils.Utils;
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.RsaJwkGenerator;
+import org.jose4j.lang.JoseException;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.function.Executable;
@@ -193,6 +197,26 @@ public abstract class OAuthBearerTest {
 
     protected Map<String, ?> getSaslConfigs() {
         return getSaslConfigs(Collections.emptyMap());
+    }
+
+    protected PublicJsonWebKey createRsaJwk() throws JoseException {
+        RsaJsonWebKey jwk = RsaJwkGenerator.generateJwk(2048);
+        jwk.setKeyId("key-1");
+        return jwk;
+    }
+
+    protected PublicJsonWebKey createEcJwk() throws JoseException {
+        PublicJsonWebKey jwk = PublicJsonWebKey.Factory.newPublicJwk("{" +
+            "  \"kty\": \"EC\"," +
+            "  \"d\": \"Tk7qzHNnSBMioAU7NwZ9JugFWmWbUCyzeBRjVcTp_so\"," +
+            "  \"use\": \"sig\"," +
+            "  \"crv\": \"P-256\"," +
+            "  \"kid\": \"key-1\"," +
+            "  \"x\": \"qqeGjWmYZU5M5bBrRw1zqZcbPunoFVxsfaa9JdA0R5I\"," +
+            "  \"y\": \"wnoj0YjheNP80XYh1SEvz1-wnKByEoHvb6KrDcjMuWc\"" +
+            "}");
+        jwk.setKeyId("key-1");
+        return jwk;
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerValidatorCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerValidatorCallbackHandlerTest.java
@@ -31,6 +31,7 @@ import javax.security.auth.callback.Callback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.apache.kafka.common.utils.Utils;
+import org.jose4j.jws.AlgorithmIdentifiers;
 import org.junit.jupiter.api.Test;
 
 public class OAuthBearerValidatorCallbackHandlerTest extends OAuthBearerTest {
@@ -39,7 +40,10 @@ public class OAuthBearerValidatorCallbackHandlerTest extends OAuthBearerTest {
     public void testBasic() throws Exception {
         String expectedAudience = "a";
         List<String> allAudiences = Arrays.asList(expectedAudience, "b", "c");
-        AccessTokenBuilder builder = new AccessTokenBuilder().audience(expectedAudience);
+        AccessTokenBuilder builder = new AccessTokenBuilder()
+            .audience(expectedAudience)
+            .jwk(createRsaJwk())
+            .alg(AlgorithmIdentifiers.RSA_USING_SHA256);
         String accessToken = builder.build();
 
         Map<String, ?> configs = getSaslConfigs(SASL_OAUTHBEARER_EXPECTED_AUDIENCE, allAudiences);
@@ -92,7 +96,7 @@ public class OAuthBearerValidatorCallbackHandlerTest extends OAuthBearerTest {
         AccessTokenBuilder builder) {
         OAuthBearerValidatorCallbackHandler handler = new OAuthBearerValidatorCallbackHandler();
         CloseableVerificationKeyResolver verificationKeyResolver = (jws, nestingContext) ->
-                builder.jwk().getRsaPublicKey();
+                builder.jwk().getPublicKey();
         AccessTokenValidator accessTokenValidator = AccessTokenValidatorFactory.create(options, verificationKeyResolver);
         handler.init(verificationKeyResolver, accessTokenValidator);
         return handler;

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidatorTest.java
@@ -19,8 +19,10 @@ package org.apache.kafka.common.security.oauthbearer.secured;
 
 import java.util.Collections;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.lang.InvalidAlgorithmException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,14 +40,35 @@ public class ValidatorAccessTokenValidatorTest extends AccessTokenValidatorTest 
     }
 
     @Test
-    public void testBasicEncryption() throws Exception {
-        AccessTokenBuilder builder = new AccessTokenBuilder();
+    public void testRsaEncryptionAlgorithm() throws Exception {
+        PublicJsonWebKey jwk = createRsaJwk();
+        testEncryptionAlgorithm(jwk, AlgorithmIdentifiers.RSA_USING_SHA256);
+    }
+
+    @Test
+    public void testEcdsaEncryptionAlgorithm() throws Exception {
+        PublicJsonWebKey jwk = createEcJwk();
+        testEncryptionAlgorithm(jwk, AlgorithmIdentifiers.ECDSA_USING_P256_CURVE_AND_SHA256);
+    }
+
+    @Test
+    public void testInvalidEncryptionAlgorithm() throws Exception {
+        PublicJsonWebKey jwk = createRsaJwk();
+
+        assertThrowsWithMessage(InvalidAlgorithmException.class,
+            () -> testEncryptionAlgorithm(jwk, "fake"),
+            "fake is an unknown, unsupported or unavailable alg algorithm");
+    }
+
+    private void testEncryptionAlgorithm(PublicJsonWebKey jwk, String alg) throws Exception {
+        AccessTokenBuilder builder = new AccessTokenBuilder().jwk(jwk).alg(alg);
         AccessTokenValidator validator = createAccessTokenValidator(builder);
 
         JsonWebSignature jws = new JsonWebSignature();
         jws.setKey(builder.jwk().getPrivateKey());
         jws.setKeyIdHeaderValue(builder.jwk().getKeyId());
-        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+        jws.setAlgorithmHeaderValue(alg);
+        jws.setPayload("{}");
         String accessToken = builder.build();
 
         OAuthBearerToken token = validator.validate(accessToken);

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidatorTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
-import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.lang.InvalidAlgorithmException;
 import org.junit.jupiter.api.Test;
 
@@ -63,14 +62,7 @@ public class ValidatorAccessTokenValidatorTest extends AccessTokenValidatorTest 
     private void testEncryptionAlgorithm(PublicJsonWebKey jwk, String alg) throws Exception {
         AccessTokenBuilder builder = new AccessTokenBuilder().jwk(jwk).alg(alg);
         AccessTokenValidator validator = createAccessTokenValidator(builder);
-
-        JsonWebSignature jws = new JsonWebSignature();
-        jws.setKey(builder.jwk().getPrivateKey());
-        jws.setKeyIdHeaderValue(builder.jwk().getKeyId());
-        jws.setAlgorithmHeaderValue(alg);
-        jws.setPayload("{}");
         String accessToken = builder.build();
-
         OAuthBearerToken token = validator.validate(accessToken);
 
         assertEquals(builder.subject(), token.principalName());


### PR DESCRIPTION
The tests for OAuth JWT validation all assume usage of RSA, but we need to have ECDSA support there too.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
