### PR TITLE
fix: add command options to fix error

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -90,7 +90,7 @@ $ bin/kafka-server-start.sh config/server.properties</code></pre>
             So before you can write your first events, you must create a topic.  Open another terminal session and run:
         </p>
 
-        <pre class="line-numbers"><code class="language-bash">$ bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092</code></pre>
+        <pre class="line-numbers"><code class="language-bash">$ bin/kafka-topics.sh --create --topic quickstart-events --partitions 3 --replication-factor 1 --bootstrap-server localhost:9092</code></pre>
 
         <p>
             All of Kafka's command line tools have additional options: run the <code>kafka-topics.sh</code> command without any


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

I'm following the quick start section in the documentation.
When I run the command in the quickstart to create topic with the kafka_2.13-3.0.0, I've got error message `Missing required argument "[partitions]"`.

The latest Kafka requires a partition option and replication factor option, so I added the options to the command.
The 3 for the partitions and 1 for the replication factor I've added is just an example works fine for me.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
