### PR TITLE
KAFKA-13446: Remove JWT access token from logs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/LoginAccessTokenValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/LoginAccessTokenValidator.java
@@ -84,7 +84,6 @@ public class LoginAccessTokenValidator implements AccessTokenValidator {
 
     @SuppressWarnings("unchecked")
     public OAuthBearerToken validate(String accessToken) throws ValidateException {
-        log.debug("validate - accessToken: {}", accessToken);
         SerializedJwt serializedJwt = new SerializedJwt(accessToken);
         Map<String, Object> payload;
 
@@ -120,8 +119,6 @@ public class LoginAccessTokenValidator implements AccessTokenValidator {
             expiration,
             subject,
             issuedAt);
-
-        log.debug("validate - token: {}", token);
 
         return token;
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerLoginCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerLoginCallbackHandler.java
@@ -241,13 +241,10 @@ public class OAuthBearerLoginCallbackHandler implements AuthenticateCallbackHand
 
     private void handleTokenCallback(OAuthBearerTokenCallback callback) throws IOException {
         checkInitialized();
-
         String accessToken = accessTokenRetriever.retrieve();
-        log.debug("handle - accessToken: {}", accessToken);
 
         try {
             OAuthBearerToken token = accessTokenValidator.validate(accessToken);
-            log.debug("handle - token: {}", token);
             callback.token(token);
         } catch (ValidateException e) {
             log.warn(e.getMessage(), e);

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerValidatorCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/OAuthBearerValidatorCallbackHandler.java
@@ -182,7 +182,6 @@ public class OAuthBearerValidatorCallbackHandler implements AuthenticateCallback
 
         try {
             token = accessTokenValidator.validate(callback.tokenValue());
-            log.debug("handle - token: {}", token);
             callback.token(token);
         } catch (ValidateException e) {
             log.warn(e.getMessage(), e);

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidator.java
@@ -149,7 +149,6 @@ public class ValidatorAccessTokenValidator implements AccessTokenValidator {
 
     @SuppressWarnings("unchecked")
     public OAuthBearerToken validate(String accessToken) throws ValidateException {
-        log.debug("validate - accessToken: {}", accessToken);
         SerializedJwt serializedJwt = new SerializedJwt(accessToken);
 
         JwtContext jwt;
@@ -188,8 +187,6 @@ public class ValidatorAccessTokenValidator implements AccessTokenValidator {
             expiration,
             sub,
             issuedAt);
-
-        log.debug("validate - token: {}", token);
 
         return token;
     }


### PR DESCRIPTION
The OAuth code logs the access token on both the client and the server, potentially exposing service account details. Remove all logging entries to prevent this from leaking.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
