### PR TITLE
KAFKA-13442: REST API endpoint for fetching a connector's config def

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSinkConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSinkConnector.java
@@ -37,6 +37,7 @@ public class FileStreamSinkConnector extends SinkConnector {
 
     public static final String FILE_CONFIG = "file";
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
+        .define("password", Type.PASSWORD, "alma", Importance.LOW, "Just testing the password config type")
         .define(FILE_CONFIG, Type.STRING, null, Importance.HIGH, "Destination filename. If not specified, the standard output will be used");
 
     private String filename;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
@@ -200,6 +201,13 @@ public interface Herder {
     default void validateConnectorConfig(Map<String, String> connectorConfig, Callback<ConfigInfos> callback, boolean doLog) {
         validateConnectorConfig(connectorConfig, callback);
     }
+
+    /**
+     * Fetches the config definition of a given connector type.
+     * @param connectorClass is the class name of the connector type we want to fetch.
+     * @return the config definition of the connector.
+     */
+    ConfigKeyInfos getConfigKeyInfos(String connectorClass);
 
     /**
      * Restart the task with the given id.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConfigKeyInfos.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConfigKeyInfos.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.runtime.rest.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class ConfigKeyInfos {
+
+    @JsonProperty("name")
+    private final String name;
+
+    @JsonProperty("groups")
+    private final List<String> groups;
+
+    @JsonProperty("configKeys")
+    private final List<ConfigKeyInfo> configKeys;
+
+    @JsonCreator
+    public ConfigKeyInfos(@JsonProperty("name") String name,
+                       @JsonProperty("groups") List<String> groups,
+                       @JsonProperty("configKeys") List<ConfigKeyInfo> configKeys) {
+        this.name = name;
+        this.groups = groups;
+        this.configKeys = configKeys;
+    }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigKeyInfos that = (ConfigKeyInfos) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(groups, that.groups) &&
+            Objects.equals(configKeys, that.configKeys);
+    }
+
+    public List<ConfigKeyInfo> configKeys() {
+        return Collections.unmodifiableList(configKeys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, groups, configKeys);
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("[")
+            .append(name)
+            .append(",")
+            .append(groups)
+            .append(",")
+            .append(configKeys)
+            .append("]");
+        return sb.toString();
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.tools.MockConnector;
@@ -74,6 +75,9 @@ public class ConnectorPluginsResource {
         final @PathParam("connectorType") String connType,
         final Map<String, String> connectorConfig
     ) throws Throwable {
+        if (connectorConfig == null) {
+            throw new IllegalArgumentException("A valid connector config must be provided as the body of the request");
+        }
         String includedConnType = connectorConfig.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
         if (includedConnType != null
             && !normalizedPluginName(includedConnType).endsWith(normalizedPluginName(connType))) {
@@ -115,6 +119,16 @@ public class ConnectorPluginsResource {
         }
 
         return Collections.unmodifiableList(connectorPlugins);
+    }
+
+    @GET
+    @Path("/{connectorClass}/config")
+    public ConfigKeyInfos listConfigInfos(final @PathParam("connectorClass") String connectorClass) {
+        if (connectorClass == null || connectorClass.isEmpty()) {
+            throw new IllegalArgumentException("A valid connector class name must be provided as the body of the request");
+        }
+
+        return herder.getConfigKeyInfos(connectorClass);
     }
 
     private String normalizedPluginName(String pluginName) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigValueInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
@@ -369,6 +370,20 @@ public class AbstractHerderTest {
         assertTrue(restartPlan.taskIdsToRestart().isEmpty());
 
         PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testGetConfigKeyInfos() {
+        TestSourceConnector connector = new TestSourceConnector();
+        AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy, 0);
+        EasyMock.expect(plugins.newConnector(TestSourceConnector.class.getName())).andReturn(connector);
+        replayAll();
+
+        ConfigKeyInfos configKeyInfos = herder.getConfigKeyInfos(TestSourceConnector.class.getName());
+        int expectedSize = SourceConnectorConfig.configDef().configKeys().size() + connector.config().configKeys().size();
+        assertEquals(expectedSize, configKeyInfos.configKeys().size());
+
+        verifyAll();
     }
 
     @Test


### PR DESCRIPTION
This PR implements a new Connect REST endpoint to fetch the config definition of a connector. This new API uses the HTTP GET method and is under the /connector-plugins/{connector-type}/config path.
The motivation of this is that some UI management tools could benefit from fetching the config definitions to help the user with a sample connector configuration. Using the config definition of the connector for sample generation is an easy way to solve this problem.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)