### PR TITLE
KAFKA-13452: MM2 shouldn't checkpoint when offset mapping is unavailable

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -49,6 +49,10 @@ class OffsetSyncStore implements AutoCloseable {
 
     long translateDownstream(TopicPartition sourceTopicPartition, long upstreamOffset) {
         OffsetSync offsetSync = latestOffsetSync(sourceTopicPartition);
+        if (offsetSync == null) {
+            // Offset mapping is not available for the topic partition
+            return -1;
+        }
         if (offsetSync.upstreamOffset() > upstreamOffset) {
             // Offset is too far in the past to translate accurately
             return -1;
@@ -78,7 +82,6 @@ class OffsetSyncStore implements AutoCloseable {
     }
 
     private OffsetSync latestOffsetSync(TopicPartition topicPartition) {
-        return offsetSyncs.computeIfAbsent(topicPartition, x -> new OffsetSync(topicPartition,
-            -1, -1));
+        return offsetSyncs.get(topicPartition);
     }
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskTest.java
@@ -38,7 +38,7 @@ public class MirrorCheckpointTaskTest {
         assertEquals(new TopicPartition("source1.topic3", 4),
             mirrorCheckpointTask.renameTopicPartition(new TopicPartition("topic3", 4)),
                 "Renaming source1.topic3 failed");
-        assertEquals(new TopicPartition("topic3", 5),
+        assertEquals(new TopicPartition("source1.target2.topic3", 5),
             mirrorCheckpointTask.renameTopicPartition(new TopicPartition("target2.topic3", 5)),
                 "Renaming target2.topic3 failed");
         assertEquals(new TopicPartition("source1.source6.topic7", 8),
@@ -52,7 +52,6 @@ public class MirrorCheckpointTaskTest {
         MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source1", "target2",
             new DefaultReplicationPolicy(), offsetSyncStore, Collections.emptyMap(), Collections.emptyMap());
         offsetSyncStore.sync(new TopicPartition("topic1", 2), 3L, 4L);
-        offsetSyncStore.sync(new TopicPartition("target2.topic5", 6), 7L, 8L);
         Checkpoint checkpoint1 = mirrorCheckpointTask.checkpoint("group9", new TopicPartition("topic1", 2),
             new OffsetAndMetadata(10, null));
         SourceRecord sourceRecord1 = mirrorCheckpointTask.checkpointRecord(checkpoint1, 123L);
@@ -71,7 +70,7 @@ public class MirrorCheckpointTaskTest {
         Checkpoint checkpoint2 = mirrorCheckpointTask.checkpoint("group11", new TopicPartition("target2.topic5", 6),
             new OffsetAndMetadata(12, null));
         SourceRecord sourceRecord2 = mirrorCheckpointTask.checkpointRecord(checkpoint2, 234L);
-        assertEquals(new TopicPartition("topic5", 6), checkpoint2.topicPartition(),
+        assertEquals(new TopicPartition("source1.target2.topic5", 6), checkpoint2.topicPartition(),
                 "checkpoint group11 topic5 failed");
         assertEquals("group11", checkpoint2.consumerGroupId(),
                 "checkpoint group11 consumerGroupId failed");
@@ -79,7 +78,7 @@ public class MirrorCheckpointTaskTest {
                 "checkpoint group11 sourcePartition failed");
         assertEquals(12, checkpoint2.upstreamOffset(),
                 "checkpoint group11 upstreamOffset failed");
-        assertEquals(13, checkpoint2.downstreamOffset(),
+        assertEquals(12, checkpoint2.downstreamOffset(),
                 "checkpoint group11 downstreamOffset failed");
         assertEquals(234L, sourceRecord2.timestamp().longValue(),
                     "checkpoint group11 timestamp failed");

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -320,7 +320,7 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
             Duration.ofMillis(CHECKPOINT_DURATION_MS)).containsKey(new TopicPartition("backup.test-topic-1", 0)), CHECKPOINT_DURATION_MS, "Offsets not translated downstream to primary cluster.");
 
         waitForCondition(() -> primaryClient.remoteConsumerOffsets(consumerGroupName, BACKUP_CLUSTER_ALIAS,
-            Duration.ofMillis(CHECKPOINT_DURATION_MS)).containsKey(new TopicPartition("test-topic-1", 0)), CHECKPOINT_DURATION_MS, "Offsets not translated upstream to primary cluster.");
+            Duration.ofMillis(CHECKPOINT_DURATION_MS)).containsKey(new TopicPartition("backup.primary.test-topic-1", 0)), CHECKPOINT_DURATION_MS, "Offsets not translated upstream to primary cluster.");
 
         Map<TopicPartition, OffsetAndMetadata> primaryOffsets = primaryClient.remoteConsumerOffsets(consumerGroupName, BACKUP_CLUSTER_ALIAS,
                 Duration.ofMillis(CHECKPOINT_DURATION_MS));
@@ -335,10 +335,10 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
             backupConsumer.poll(CONSUMER_POLL_TIMEOUT_MS);
             backupConsumer.commitAsync();
         
-            assertTrue(backupConsumer.position(new TopicPartition("test-topic-1", 0)) > 0, "Consumer failedback to zero upstream offset.");
+            assertTrue(backupConsumer.position(new TopicPartition("backup.primary.test-topic-1", 0)) > 0, "Consumer failedback to zero upstream offset.");
             assertTrue(backupConsumer.position(new TopicPartition("backup.test-topic-1", 0)) > 0, "Consumer failedback to zero downstream offset.");
             assertTrue(backupConsumer.position(
-                new TopicPartition("test-topic-1", 0)) <= NUM_RECORDS_PRODUCED, "Consumer failedback beyond expected upstream offset.");
+                new TopicPartition("backup.primary.test-topic-1", 0)) <= NUM_RECORDS_PRODUCED, "Consumer failedback beyond expected upstream offset.");
             assertTrue(backupConsumer.position(
                 new TopicPartition("backup.test-topic-1", 0)) <= NUM_RECORDS_PRODUCED, "Consumer failedback beyond expected downstream offset.");
         }


### PR DESCRIPTION
MM2 checkpointing reads the offset-syncs topic to create offset mappings for committed consumer group offsets. In some corner cases, it is possible that a mapping is not available in offset-syncs - in that case, MM2 simply copies the source offset, which might not be a valid offset in the replica topic at all. This can cause issues when auto offset sync is also turned on.
Updated checkpointing logic to not create checkpoints for topic partitions without a valid offset mapping.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
