### PR TITLE
KAFKA-12959: Distribute standby and active tasks across threads to better balance load between threads

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -784,20 +784,32 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final ClientMetadata clientMetadata = clientEntry.getValue();
             final ClientState state = clientMetadata.state;
             final SortedSet<String> consumers = clientMetadata.consumers;
+            final Map<String, Integer> threadTaskCounts = new HashMap<>();
 
-            final Map<String, List<TaskId>> activeTaskAssignment = assignTasksToThreads(
+            final Map<String, List<TaskId>> activeTaskStatefulAssignment = assignStatefulTasksToThreads(
                 state.statefulActiveTasks(),
+                consumers,
+                state,
+                threadTaskCounts
+            );
+
+            final Map<String, List<TaskId>> standbyTaskAssignment = assignStatefulTasksToThreads(
+                state.standbyTasks(),
+                consumers,
+                state,
+                threadTaskCounts
+            );
+
+            final Map<String, List<TaskId>> activeTaskStatelessAssignment = assignStatelessTasksToThreads(
                 state.statelessActiveTasks(),
                 consumers,
-                state
+                threadTaskCounts
             );
 
-            final Map<String, List<TaskId>> standbyTaskAssignment = assignTasksToThreads(
-                state.standbyTasks(),
-                Collections.emptySet(),
-                consumers,
-                state
-            );
+            final Map<String, List<TaskId>> activeTaskAssignment = activeTaskStatefulAssignment;
+            for (final Map.Entry<String, List<TaskId>> threadEntry : activeTaskStatelessAssignment.entrySet()) {
+                activeTaskAssignment.get(threadEntry.getKey()).addAll(threadEntry.getValue());
+            }
 
             // Arbitrarily choose the leader's client to be responsible for triggering the probing rebalance,
             // note once we pick the first consumer within the process to trigger probing rebalance, other consumer
@@ -1029,60 +1041,65 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     /**
      * Generate an assignment that tries to preserve thread-level stickiness of stateful tasks without violating
-     * balance. The stateful and total task load are both balanced across threads. Tasks without previous owners
-     * will be interleaved by group id to spread subtopologies across threads and further balance the workload.
+     * balance. The tasks are balanced across threads. Tasks without previous owners will be interleaved by
+     * group id to spread subtopologies across threads and further balance the workload.
+     * threadLoad is a map that keeps track of task load per thread across multiple calls so actives and standbys
+     * are evenly distributed
      */
-    static Map<String, List<TaskId>> assignTasksToThreads(final Collection<TaskId> statefulTasksToAssign,
-                                                          final Collection<TaskId> statelessTasksToAssign,
-                                                          final SortedSet<String> consumers,
-                                                          final ClientState state) {
+    static Map<String, List<TaskId>> assignStatefulTasksToThreads(final Collection<TaskId> tasksToAssign,
+                                                                  final SortedSet<String> consumers,
+                                                                  final ClientState state,
+                                                                  final Map<String, Integer> threadLoad) {
         final Map<String, List<TaskId>> assignment = new HashMap<>();
         for (final String consumer : consumers) {
             assignment.put(consumer, new ArrayList<>());
         }
 
-        final List<TaskId> unassignedStatelessTasks = new ArrayList<>(statelessTasksToAssign);
-        Collections.sort(unassignedStatelessTasks);
+        int totalTasks = tasksToAssign.size();
+        for (final Integer threadTaskCount : threadLoad.values()) {
+            totalTasks += threadTaskCount;
+        }
 
-        final Iterator<TaskId> unassignedStatelessTasksIter = unassignedStatelessTasks.iterator();
-
-        final int minStatefulTasksPerThread = (int) Math.floor(((double) statefulTasksToAssign.size()) / consumers.size());
-        final PriorityQueue<TaskId> unassignedStatefulTasks = new PriorityQueue<>(statefulTasksToAssign);
+        final int minTasksPerThread = (int) Math.floor(((double) totalTasks) / consumers.size());
+        final PriorityQueue<TaskId> unassignedTasks = new PriorityQueue<>(tasksToAssign);
 
         final Queue<String> consumersToFill = new LinkedList<>();
         // keep track of tasks that we have to skip during the first pass in case we can reassign them later
         // using tree-map to make sure the iteration ordering over keys are preserved
         final Map<TaskId, String> unassignedTaskToPreviousOwner = new TreeMap<>();
 
-        if (!unassignedStatefulTasks.isEmpty()) {
-            // First assign stateful tasks to previous owner, up to the min expected tasks/thread
+        if (!unassignedTasks.isEmpty()) {
+            // First assign tasks to previous owner, up to the min expected tasks/thread
             for (final String consumer : consumers) {
                 final List<TaskId> threadAssignment = assignment.get(consumer);
 
                 for (final TaskId task : state.prevTasksByLag(consumer)) {
-                    if (unassignedStatefulTasks.contains(task)) {
-                        if (threadAssignment.size() < minStatefulTasksPerThread) {
+                    if (unassignedTasks.contains(task)) {
+                        final int threadTaskCount = threadAssignment.size() + threadLoad.getOrDefault(consumer, 0);
+                        if (threadTaskCount < minTasksPerThread) {
                             threadAssignment.add(task);
-                            unassignedStatefulTasks.remove(task);
+                            unassignedTasks.remove(task);
                         } else {
                             unassignedTaskToPreviousOwner.put(task, consumer);
                         }
                     }
                 }
 
-                if (threadAssignment.size() < minStatefulTasksPerThread) {
+                final int threadTaskCount = threadAssignment.size() + threadLoad.getOrDefault(consumer, 0);
+                if (threadTaskCount < minTasksPerThread) {
                     consumersToFill.offer(consumer);
                 }
             }
 
             // Next interleave remaining unassigned tasks amongst unfilled consumers
             while (!consumersToFill.isEmpty()) {
-                final TaskId task = unassignedStatefulTasks.poll();
+                final TaskId task = unassignedTasks.poll();
                 if (task != null) {
                     final String consumer = consumersToFill.poll();
                     final List<TaskId> threadAssignment = assignment.get(consumer);
                     threadAssignment.add(task);
-                    if (threadAssignment.size() < minStatefulTasksPerThread) {
+                    final int threadTaskCount = threadAssignment.size() + threadLoad.getOrDefault(consumer, 0);
+                    if (threadTaskCount < minTasksPerThread) {
                         consumersToFill.offer(consumer);
                     }
                 } else {
@@ -1090,43 +1107,82 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 }
             }
 
-            // At this point all consumers are at the min capacity, so there may be up to N - 1 unassigned
-            // stateful tasks still remaining that should now be distributed over the consumers
-            if (!unassignedStatefulTasks.isEmpty()) {
-                consumersToFill.addAll(consumers);
+            // At this point all consumers are at the min or min + 1 capacity,
+            // the tasks still remaining that should now be distributed over the consumers that are still
+            // at min capacity
+            if (!unassignedTasks.isEmpty()) {
+                for (final String consumer : consumers) {
+                    final int taskCount = assignment.get(consumer).size() + threadLoad.getOrDefault(consumer, 0);
+                    if (taskCount == minTasksPerThread) {
+                        consumersToFill.add(consumer);
+                    }
+                }
 
                 // Go over the tasks we skipped earlier and assign them to their previous owner when possible
                 for (final Map.Entry<TaskId, String> taskEntry : unassignedTaskToPreviousOwner.entrySet()) {
                     final TaskId task = taskEntry.getKey();
                     final String consumer = taskEntry.getValue();
-                    if (consumersToFill.contains(consumer) && unassignedStatefulTasks.contains(task)) {
+                    if (consumersToFill.contains(consumer) && unassignedTasks.contains(task)) {
                         assignment.get(consumer).add(task);
-                        unassignedStatefulTasks.remove(task);
+                        unassignedTasks.remove(task);
                         // Remove this consumer since we know it is now at minCapacity + 1
                         consumersToFill.remove(consumer);
                     }
                 }
 
                 // Now just distribute the remaining unassigned stateful tasks over the consumers still at min capacity
-                for (final TaskId task : unassignedStatefulTasks) {
+                for (final TaskId task : unassignedTasks) {
                     final String consumer = consumersToFill.poll();
                     final List<TaskId> threadAssignment = assignment.get(consumer);
                     threadAssignment.add(task);
                 }
+            }
+        }
+        // Update threadLoad
+        for (final Map.Entry<String, List<TaskId>> taskEntry : assignment.entrySet()) {
+            final String consumer = taskEntry.getKey();
+            final int totalCount = threadLoad.getOrDefault(consumer, 0) + taskEntry.getValue().size();
+            threadLoad.put(consumer, totalCount);
+        }
 
+        return assignment;
+    }
 
-                // There must be at least one consumer still at min capacity while all the others are at min
-                // capacity + 1, so start distributing stateless tasks to get all consumers back to the same count
-                while (unassignedStatelessTasksIter.hasNext()) {
-                    final String consumer = consumersToFill.poll();
-                    if (consumer != null) {
-                        final TaskId task = unassignedStatelessTasksIter.next();
-                        unassignedStatelessTasksIter.remove();
-                        assignment.get(consumer).add(task);
-                    } else {
-                        break;
-                    }
-                }
+    static Map<String, List<TaskId>> assignStatelessTasksToThreads(final Collection<TaskId> statelessTasksToAssign,
+                                                                  final SortedSet<String> consumers,
+                                                                  final Map<String, Integer> threadLoad) {
+        final List<TaskId> tasksToAssign = new ArrayList<>(statelessTasksToAssign);
+        Collections.sort(tasksToAssign);
+        final Map<String, List<TaskId>> assignment = new HashMap<>();
+        for (final String consumer : consumers) {
+            assignment.put(consumer, new ArrayList<>());
+        }
+
+        int maxThreadLoad = 0;
+        for (final int load : threadLoad.values()) {
+            maxThreadLoad = Integer.max(maxThreadLoad, load);
+        }
+
+        final Queue<String> consumersToFill = new LinkedList<>();
+
+        for (final String consumer : consumers) {
+            if (threadLoad.getOrDefault(consumer, 0) < maxThreadLoad) {
+                consumersToFill.offer(consumer);
+            }
+        }
+
+        final Iterator<TaskId> unassignedStatelessTasksIter = tasksToAssign.iterator();
+
+        // There must be at least one consumer still at min capacity while all the others are at min
+        // capacity + 1, so start distributing stateless tasks to get all consumers back to the same count
+        while (unassignedStatelessTasksIter.hasNext()) {
+            final String consumer = consumersToFill.poll();
+            if (consumer != null) {
+                final TaskId task = unassignedStatelessTasksIter.next();
+                unassignedStatelessTasksIter.remove();
+                assignment.get(consumer).add(task);
+            } else {
+                break;
             }
         }
 
@@ -1138,6 +1194,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final String consumer = consumersToFill.poll();
             assignment.get(consumer).add(task);
             consumersToFill.offer(consumer);
+        }
+
+        // Update threadLoad
+        for (final Map.Entry<String, List<TaskId>> taskEntry : assignment.entrySet()) {
+            final String consumer = taskEntry.getKey();
+            final int totalCount = threadLoad.getOrDefault(consumer, 0) + taskEntry.getValue().size();
+            threadLoad.put(consumer, totalCount);
         }
 
         return assignment;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1079,8 +1079,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
                 for (final TaskId task : state.prevTasksByLag(consumer)) {
                     if (unassignedTasks.contains(task)) {
-                        final int threadTaskCount = threadAssignment.size();
-                        if (threadTaskCount < tasksTargetCount) {
+                        if (threadAssignment.size() < tasksTargetCount) {
                             threadAssignment.add(task);
                             unassignedTasks.remove(task);
                         } else {
@@ -1089,8 +1088,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                     }
                 }
 
-                final int threadTaskCount = threadAssignment.size();
-                if (threadTaskCount < tasksTargetCount) {
+                if (threadAssignment.size() < tasksTargetCount) {
                     consumersToFill.offer(consumer);
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1049,7 +1049,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      * balance. The tasks are balanced across threads. Stateful tasks without previous owners will be interleaved by
      * group id to spread subtopologies across threads and further balance the workload.
      * Stateless tasks are simply spread across threads without taking into account previous ownership.
-     * threadLoad is a map that keeps track of task load per thread across multiple calls so actives and standbys
+     * threadLoad is a map that keeps track of task load per thread across multiple calls so active and standby
      * tasks are evenly distributed
      */
     static Map<String, List<TaskId>> assignTasksToThreads(final Collection<TaskId> tasksToAssign,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -103,7 +103,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
-import static org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assignStatefulTasksToThreads;
+import static org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assignTasksToThreads;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CHANGELOG_END_OFFSETS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
@@ -317,8 +317,9 @@ public class StreamsPartitionAssignorTest {
 
         assertEquivalentAssignment(
             previousAssignment,
-            assignStatefulTasksToThreads(
+            assignTasksToThreads(
                 allTasks,
+                true,
                 consumers,
                 state,
                 new HashMap<>()
@@ -351,8 +352,9 @@ public class StreamsPartitionAssignorTest {
         state.assignActiveTasks(allTasks);
 
         final Map<String, List<TaskId>> newAssignment =
-            assignStatefulTasksToThreads(
+            assignTasksToThreads(
                 allTasks,
+                true,
                 consumers,
                 state,
                 new HashMap<>()
@@ -384,8 +386,9 @@ public class StreamsPartitionAssignorTest {
         // Consumer 3 leaves the group
         consumers.remove(CONSUMER_3);
 
-        final Map<String, List<TaskId>> assignment = assignStatefulTasksToThreads(
+        final Map<String, List<TaskId>> assignment = assignTasksToThreads(
             allTasks,
+            true,
             consumers,
             state,
             new HashMap<>()
@@ -424,8 +427,9 @@ public class StreamsPartitionAssignorTest {
         state.initializePrevTasks(emptyMap());
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
-        final Map<String, List<TaskId>> assignment = assignStatefulTasksToThreads(
+        final Map<String, List<TaskId>> assignment = assignTasksToThreads(
             allTasks,
+            true,
             consumers,
             state,
             new HashMap<>()
@@ -464,8 +468,9 @@ public class StreamsPartitionAssignorTest {
         Collections.shuffle(allTasks);
 
         final Map<String, List<TaskId>> interleavedTaskIds =
-            assignStatefulTasksToThreads(
+            assignTasksToThreads(
                 allTasks,
+                true,
                 consumers,
                 state,
                 new HashMap<>()

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1098,10 +1098,12 @@ public class StreamsPartitionAssignorTest {
     public void testAssignWithStandbyReplicasBalanceWithStatelessTasks() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addProcessor("processor_with_state", new MockApiProcessorSupplier<>(), "source1");
-        builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor_with_state");
 
-        final List<String> topics = asList("topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
+        builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source2");
+
+        final List<String> topics = asList("topic1", "topic2");
 
         createMockTaskManager(EMPTY_TASKS, EMPTY_TASKS);
         adminClient = createMockAdminClientForAssignor(getTopicPartitionOffsetsMap(


### PR DESCRIPTION
Kafka Streams - Currently while distributing the standby tasks streams does not check if there are threads without any tasks or with less number of tasks. This can lead to few threads getting assigned both active and standby tasks when are threads within the same instance without any tasks assigned.

This PR takes into account active task assignment when assigning standbys to threads to achieve a better balance of tasks across threads

### Committer Checklist (excluded from commit message)
* [ ]  Verify design and implementation
* [ ]  Verify test coverage and CI build status
* [ ]  Verify documentation (including upgrade notes)