### PR TITLE
Add recordMetadata() to StateStoreContext

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateStoreContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateStoreContext.java
@@ -19,9 +19,11 @@ package org.apache.kafka.streams.processor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * State store context interface.
@@ -41,6 +43,18 @@ public interface StateStoreContext {
      * @return the task id
      */
     TaskId taskId();
+
+    /**
+     * Return the metadata of the current topic/partition/offset if available.
+     * This is defined as the metadata of the record that is currently been
+     * processed by the StreamTask that holds the store.
+     * <p>
+     * Note that the metadata is not defined during all store interactions, for
+     * example, while the StreamTask is running a punctuation.
+     *
+     * @return metadata of the current record
+     */
+    Optional<RecordMetadata> recordMetadata();
 
     /**
      * Returns the default key serde.

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -460,6 +460,11 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
             }
 
             @Override
+            public Optional<RecordMetadata> recordMetadata() {
+                return MockProcessorContext.this.recordMetadata();
+            }
+
+            @Override
             public Serde<?> keySerde() {
                 return MockProcessorContext.this.keySerde();
             }


### PR DESCRIPTION
Implementation of KIP-791: 
https://cwiki.apache.org/confluence/display/KAFKA/KIP-791%3A+Add+Record+Metadata+to+State+Store+Context