### PR TITLE
KAFKA-13457: SocketChannel in Acceptor#accept is not closed upon IOException

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -735,8 +735,8 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
         throttledSockets += DelayedCloseSocket(socketChannel, endThrottleTimeMs)
         None
       case e: IOException =>
-        info(s"Encounter IOException", e)
-        closeSocket(socketChannel)
+        info(s"Encountered IOException, closing connection", e)
+        close(endPoint.listenerName, socketChannel)
         None
     }
   }

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -734,6 +734,10 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
         val endThrottleTimeMs = e.startThrottleTimeMs + e.throttleTimeMs
         throttledSockets += DelayedCloseSocket(socketChannel, endThrottleTimeMs)
         None
+      case e: IOException =>
+        info(s"Encounter IOException", e)
+        closeSocket(socketChannel)
+        None
     }
   }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -733,7 +733,7 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
         throttledSockets += DelayedCloseSocket(socketChannel, endThrottleTimeMs)
         None
       case e: IOException =>
-        info(s"Encountered IOException, closing connection", e)
+        error(s"Encountered an error while configuring the connection, closing it.", e)
         close(endPoint.listenerName, socketChannel)
         None
     }

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -870,9 +870,7 @@ class SocketServerTest {
 
   @Test
   def testExceptionInAcceptor(): Unit = {
-    val overrideNum = server.config.maxConnectionsPerIp + 1
     val overrideProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
-    overrideProps.put(KafkaConfig.MaxConnectionsPerIpOverridesProp, s"localhost:$overrideNum")
     val serverMetrics = new Metrics()
 
     val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), serverMetrics,


### PR DESCRIPTION
A patch for [KAFKA-13457](https://issues.apache.org/jira/browse/KAFKA-13457)
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)