### PR TITLE
MINOR: Brokers in KRaft don't need controller listener

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -84,14 +84,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   private def insertControllerListenersIfNeeded(props: Seq[Properties]): Unit = {
     if (isKRaftTest()) {
       props.foreach { config =>
-        // Add the CONTROLLER listener to "listeners" if it is not already there.
-        // But do not add it to advertised.listeners.
-        val listeners = config.getProperty(KafkaConfig.ListenersProp, "").split(",")
-        val listenerNames = listeners.map(_.replaceFirst(":.*", ""))
-        if (!listenerNames.contains("CONTROLLER")) {
-          config.setProperty(KafkaConfig.ListenersProp,
-            (listeners ++ Seq("CONTROLLER://localhost:0")).mkString(","))
-        }
         // Add a security protocol for the CONTROLLER endpoint, if one is not already set.
         val securityPairs = config.getProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "").split(",")
         if (!securityPairs.exists(_.startsWith("CONTROLLER:"))) {

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -62,7 +62,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
       trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties, logDirCount = logDirCount)
     configureListeners(cfgs)
     modifyConfigs(cfgs)
-    insertControllerListenersIfNeeded(cfgs)
     cfgs.map(KafkaConfig.fromProps)
   }
 
@@ -78,19 +77,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
       config.setProperty(KafkaConfig.ListenersProp, listeners)
       config.setProperty(KafkaConfig.AdvertisedListenersProp, listeners)
       config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, listenerSecurityMap)
-    }
-  }
-
-  private def insertControllerListenersIfNeeded(props: Seq[Properties]): Unit = {
-    if (isKRaftTest()) {
-      props.foreach { config =>
-        // Add a security protocol for the CONTROLLER endpoint, if one is not already set.
-        val securityPairs = config.getProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "").split(",")
-        if (!securityPairs.exists(_.startsWith("CONTROLLER:"))) {
-          config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp,
-            (securityPairs ++ Seq(s"CONTROLLER:${controllerListenerSecurityProtocol.toString}")).mkString(","))
-        }
-      }
     }
   }
 

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -103,10 +103,9 @@ abstract class QuorumTestHarness extends Logging {
   protected def zkAclsEnabled: Option[Boolean] = None
 
   /**
-   * When in KRaft mode, the security protocol to use for the controller listener.
-   * Can be overridden by subclasses.
+   * When in KRaft mode, this test harness only support PLAINTEXT
    */
-  protected def controllerListenerSecurityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT
+  private val controllerListenerSecurityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT
 
   protected def kraftControllerConfigs(): Seq[Properties] = {
     Seq(new Properties())

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -297,7 +297,7 @@ object TestUtils extends Logging {
       props.put(KafkaConfig.NodeIdProp, nodeId.toString)
       props.put(KafkaConfig.BrokerIdProp, nodeId.toString)
       props.put(KafkaConfig.AdvertisedListenersProp, listeners)
-      props.put(KafkaConfig.ListenersProp, listeners + ",CONTROLLER://localhost:0")
+      props.put(KafkaConfig.ListenersProp, listeners)
       props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
       props.put(KafkaConfig.ListenerSecurityProtocolMapProp, protocolAndPorts.
         map(p => "%s:%s".format(p._1, p._1)).mkString(",") + ",CONTROLLER:PLAINTEXT")


### PR DESCRIPTION
The KRaft brokers should not list the names in `controller.listener.names` in `listeners` because brokers do not bind to those endpoints. This commit also removes the extra changes to the security protocol map because the `PLAINTEXT` protocol doesn't require additional configuration.

To fully support all of the security protocol configuration additional changes to `QuorumTestHarness` are needed. Those changes can be made when migrating integration tests that need this functionality.

### committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
