### PR TITLE
MINOR: Update error log in `DefaultSslEngineFactory#createTrustStoreFromPem`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -480,7 +480,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
             } catch (InvalidConfigurationException e) {
                 throw e;
             } catch (Exception e) {
-                throw new InvalidConfigurationException("Invalid PEM keystore configs", e);
+                throw new InvalidConfigurationException("Invalid PEM truststore configs", e);
             }
         }
 


### PR DESCRIPTION
fix log message to match correctly indicate truststore instead of keystore.

