### PR TITLE
KAFKA-13242: Ensure UpdateFeatures is properly handled in KRaft

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesResponse.java
@@ -92,8 +92,7 @@ public class UpdateFeaturesResponse extends AbstractResponse {
             .setThrottleTimeMs(throttleTimeMs)
             .setErrorCode(topLevelError.error().code())
             .setErrorMessage(topLevelError.message())
-            .setResults(results)
-            .setThrottleTimeMs(throttleTimeMs);
+            .setResults(results);
         return new UpdateFeaturesResponse(responseData);
     }
 }

--- a/clients/src/main/resources/common/message/UpdateFeaturesRequest.json
+++ b/clients/src/main/resources/common/message/UpdateFeaturesRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 57,
   "type": "request",
-  "listeners": ["zkBroker", "broker"],
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "UpdateFeaturesRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -781,14 +781,13 @@ class ControllerApis(val requestChannel: RequestChannel,
   def handleUpdateFeatures(request: RequestChannel.Request): Unit = {
     val updateFeaturesRequest = request.body[UpdateFeaturesRequest]
     authHelper.authorizeClusterOperation(request, ALTER)
-    controller.updateFeatures(updateFeaturesRequest.data())
-      .whenComplete((results, exception) => {
+    controller.updateFeatures(updateFeaturesRequest.data)
+      .whenComplete((response, exception) => {
         if (exception != null) {
           requestHelper.handleError(request, exception)
         } else {
           requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => {
-            results.setThrottleTimeMs(requestThrottleMs)
-            new UpdateFeaturesResponse(results)
+            new UpdateFeaturesResponse(response.setThrottleTimeMs(requestThrottleMs))
           })
         }
       })

--- a/core/src/test/java/kafka/test/MockController.java
+++ b/core/src/test/java/kafka/test/MockController.java
@@ -39,6 +39,8 @@ import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.UpdateFeaturesRequestData;
+import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -305,6 +307,11 @@ public class MockController implements Controller {
 
     @Override
     public CompletableFuture<AllocateProducerIdsResponseData> allocateProducerIds(AllocateProducerIdsRequestData request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<UpdateFeaturesResponseData> updateFeatures(UpdateFeaturesRequestData request) {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -487,6 +487,14 @@ class ControllerApisTest {
   }
 
   @Test
+  def testUnauthorizedHandleUpdateFeatures(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+      handleUpdateFeatures(buildRequest(new UpdateFeaturesRequest.Builder(
+        new UpdateFeaturesRequestData()).build())))
+  }
+
+  @Test
   def testCreateTopics(): Unit = {
     val controller = new MockController.Builder().build()
     val controllerApis = createControllerApis(None, controller)

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -36,6 +36,8 @@ import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.UpdateFeaturesRequestData;
+import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.requests.ApiError;
@@ -232,6 +234,15 @@ public interface Controller extends AutoCloseable {
      */
     CompletableFuture<AllocateProducerIdsResponseData> allocateProducerIds(
         AllocateProducerIdsRequestData request
+    );
+
+    /**
+     * Perform some features changes
+     *
+     * @return A future which yields feature update results as a response
+     */
+    CompletableFuture<UpdateFeaturesResponseData> updateFeatures(
+        UpdateFeaturesRequestData request
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerResult.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerResult.java
@@ -54,7 +54,8 @@ class ControllerResult<T> {
         if (o == null || (!o.getClass().equals(getClass()))) {
             return false;
         }
-        ControllerResult other = (ControllerResult) o;
+        @SuppressWarnings("unchecked")
+        ControllerResult<T> other = (ControllerResult<T>) o;
         return records.equals(other.records) &&
             Objects.equals(response, other.response) &&
             Objects.equals(isAtomic, other.isAtomic);

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -23,6 +23,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.kafka.common.message.UpdateFeaturesRequestData.FeatureUpdateKeyCollection;
+import org.apache.kafka.common.message.UpdateFeaturesRequestData.FeatureUpdateKey;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
@@ -41,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(value = 40)
 public class FeatureControlManagerTest {
-    @SuppressWarnings("unchecked")
+
     private static Map<String, VersionRange> rangeMap(Object... args) {
         Map<String, VersionRange> result = new HashMap<>();
         for (int i = 0; i < args.length; i += 3) {
@@ -49,6 +52,20 @@ public class FeatureControlManagerTest {
             Integer low = (Integer) args[i + 1];
             Integer high = (Integer) args[i + 2];
             result.put(feature, new VersionRange(low.shortValue(), high.shortValue()));
+        }
+        return result;
+    }
+
+    private static FeatureUpdateKeyCollection featureUpdateKeys(Object... args) {
+        FeatureUpdateKeyCollection result = new FeatureUpdateKeyCollection();
+        for (int i = 0; i < args.length; i += 3) {
+            String feature = (String) args[i];
+            Integer max = (Integer) args[i + 1];
+            Boolean downgradable = (Boolean) args[i + 2];
+            result.add(new FeatureUpdateKey()
+                .setFeature(feature)
+                .setMaxVersionLevel(max.shortValue())
+                .setAllowDowngrade(downgradable));
         }
         return result;
     }
@@ -64,12 +81,10 @@ public class FeatureControlManagerTest {
         assertEquals(ControllerResult.atomicOf(Collections.emptyList(), Collections.
                 singletonMap("foo", new ApiError(Errors.INVALID_UPDATE_VERSION,
                     "The controller does not support the given feature range."))),
-            manager.updateFeatures(rangeMap("foo", 1, 3),
-                Collections.singleton("foo"),
+            manager.updateFeatures(featureUpdateKeys("foo", 3, false),
                 Collections.emptyMap()));
         ControllerResult<Map<String, ApiError>> result = manager.updateFeatures(
-            rangeMap("foo", 1, 2, "bar", 1, 1), Collections.emptySet(),
-                Collections.emptyMap());
+            featureUpdateKeys("foo", 2, false, "bar", 1, false), Collections.emptyMap());
         Map<String, ApiError> expectedMap = new HashMap<>();
         expectedMap.put("foo", ApiError.NONE);
         expectedMap.put("bar", new ApiError(Errors.INVALID_UPDATE_VERSION,
@@ -106,6 +121,23 @@ public class FeatureControlManagerTest {
             ControllerResult.atomicOf(
                 Collections.emptyList(),
                 Collections.singletonMap(
+                    "",
+                    new ApiError(
+                        Errors.INVALID_REQUEST,
+                        "Feature name can not be empty."
+                    )
+                )
+            ),
+            manager.updateFeatures(
+                featureUpdateKeys("", 3, true),
+                Collections.singletonMap(5, rangeMap())
+            )
+        );
+
+        assertEquals(
+            ControllerResult.atomicOf(
+                Collections.emptyList(),
+                Collections.singletonMap(
                     "foo",
                     new ApiError(
                         Errors.INVALID_UPDATE_VERSION,
@@ -114,14 +146,13 @@ public class FeatureControlManagerTest {
                 )
             ),
             manager.updateFeatures(
-                rangeMap("foo", 1, 3),
-                Collections.singleton("foo"),
+                featureUpdateKeys("foo", 3, false),
                 Collections.singletonMap(5, rangeMap())
             )
         );
 
         ControllerResult<Map<String, ApiError>> result = manager.updateFeatures(
-            rangeMap("foo", 1, 3), Collections.emptySet(), Collections.emptyMap());
+            featureUpdateKeys("foo", 3, false), Collections.emptyMap());
         assertEquals(Collections.singletonMap("foo", ApiError.NONE), result.response());
         manager.replay((FeatureLevelRecord) result.records().get(0).message());
         snapshotRegistry.getOrCreateSnapshot(3);
@@ -130,8 +161,8 @@ public class FeatureControlManagerTest {
                 singletonMap("foo", new ApiError(Errors.INVALID_UPDATE_VERSION,
                     "Can't downgrade the maximum version of this feature without " +
                     "setting downgradable to true."))),
-            manager.updateFeatures(rangeMap("foo", 1, 2),
-                Collections.emptySet(), Collections.emptyMap()));
+            manager.updateFeatures(featureUpdateKeys("foo", 2, false),
+                Collections.emptyMap()));
 
         assertEquals(
             ControllerResult.atomicOf(
@@ -147,8 +178,7 @@ public class FeatureControlManagerTest {
                 Collections.singletonMap("foo", ApiError.NONE)
             ),
             manager.updateFeatures(
-                rangeMap("foo", 1, 2),
-                Collections.singleton("foo"),
+                featureUpdateKeys("foo", 2, true),
                 Collections.emptyMap()
             )
         );
@@ -160,8 +190,8 @@ public class FeatureControlManagerTest {
         FeatureControlManager manager = new FeatureControlManager(
             rangeMap("foo", 1, 5, "bar", 1, 2), snapshotRegistry);
         ControllerResult<Map<String, ApiError>> result = manager.
-            updateFeatures(rangeMap("foo", 1, 5, "bar", 1, 1),
-                Collections.emptySet(), Collections.emptyMap());
+            updateFeatures(featureUpdateKeys("foo", 5, false, "bar", 1, false),
+                Collections.emptyMap());
         RecordTestUtils.replayAll(manager, result.records());
         RecordTestUtils.assertBatchIteratorContains(Arrays.asList(
             Arrays.asList(new ApiMessageAndVersion(new FeatureLevelRecord().


### PR DESCRIPTION
*More detailed description of your change*
This patch fixes several problems with the UpdateFeatures API in KRaft:

KafkaApis did not properly forward this request type to the controller.
ControllerApis did not handle the request type.
Some other small fixes.

*Summary of testing strategy (including rationale)*
1. unit test in FeatureControlManagerTest
2. I tried to converted UpdateFeaturesTest to use KRaft, but I encountered some problems, for example, we use totally different class in KRaft and zk mode, and we can overwrite data in zk path but we can't overwrite data in KRaft metadata topic, so I decided to handle this in a future PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
