### PR TITLE
KAFKA-13469: Block for in-flight record delivery before end-of-life source task offset commit

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -26,6 +26,10 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Used to track source records that have been (or are about to be) dispatched to a producer and their accompanying
@@ -42,9 +46,12 @@ class SubmittedRecords {
 
     // Visible for testing
     final Map<Map<String, Object>, Deque<SubmittedRecord>> records;
+    private AtomicInteger numUnackedMessages;
+    private CountDownLatch messageDrainLatch;
 
     public SubmittedRecords() {
         this.records = new HashMap<>();
+        this.numUnackedMessages = new AtomicInteger(0);
     }
 
     /**
@@ -68,6 +75,9 @@ class SubmittedRecords {
         SubmittedRecord result = new SubmittedRecord(partition, offset);
         records.computeIfAbsent(result.partition(), p -> new LinkedList<>())
                 .add(result);
+        synchronized (this) {
+            numUnackedMessages.incrementAndGet();
+        }
         return result;
     }
 
@@ -89,7 +99,9 @@ class SubmittedRecords {
         if (deque.isEmpty()) {
             records.remove(record.partition());
         }
-        if (!result) {
+        if (result) {
+            messageAcked();
+        } else {
             log.warn("Attempted to remove record from submitted queue for partition {}, but the record has not been submitted or has already been removed", record.partition());
         }
         return result;
@@ -132,6 +144,27 @@ class SubmittedRecords {
         return new CommittableOffsets(offsets, totalCommittableMessages, totalUncommittableMessages, records.size(), largestDequeSize, largestDequePartition);
     }
 
+    /**
+     * Wait for all currently in-flight messages to be acknowledged, up to the requested timeout.
+     * @param timeout the maximum time to wait
+     * @param timeUnit the time unit of the timeout argument
+     * @return whether all in-flight messages were acknowledged before the timeout elapsed
+     */
+    public boolean awaitAllMessages(long timeout, TimeUnit timeUnit) {
+        // Create a new message drain latch as a local variable to avoid SpotBugs warnings about inconsistent synchronization
+        // on an instance variable when invoking CountDownLatch::await outside a synchronized block
+        CountDownLatch messageDrainLatch;
+        synchronized (this) {
+            messageDrainLatch = new CountDownLatch(numUnackedMessages.get());
+            this.messageDrainLatch = messageDrainLatch;
+        }
+        try {
+            return messageDrainLatch.await(timeout, timeUnit);
+        } catch (InterruptedException e) {
+            return false;
+        }
+    }
+
     // Note that this will return null if either there are no committable offsets for the given deque, or the latest
     // committable offset is itself null. The caller is responsible for distinguishing between the two cases.
     private Map<String, Object> committableOffset(Deque<SubmittedRecord> queuedRecords) {
@@ -146,15 +179,22 @@ class SubmittedRecords {
         return queuedRecords.peek() != null && queuedRecords.peek().acked();
     }
 
-    static class SubmittedRecord {
+    private synchronized void messageAcked() {
+        numUnackedMessages.decrementAndGet();
+        if (messageDrainLatch != null) {
+            messageDrainLatch.countDown();
+        }
+    }
+
+    class SubmittedRecord {
         private final Map<String, Object> partition;
         private final Map<String, Object> offset;
-        private volatile boolean acked;
+        private final AtomicBoolean acked;
 
         public SubmittedRecord(Map<String, Object> partition, Map<String, Object> offset) {
             this.partition = partition;
             this.offset = offset;
-            this.acked = false;
+            this.acked = new AtomicBoolean(false);
         }
 
         /**
@@ -162,11 +202,13 @@ class SubmittedRecords {
          * This is safe to be called from a different thread than what called {@link SubmittedRecords#submit(SourceRecord)}.
          */
         public void ack() {
-            this.acked = true;
+            if (this.acked.compareAndSet(false, true)) {
+                messageAcked();
+            }
         }
 
         private boolean acked() {
-            return acked;
+            return acked.get();
         }
 
         private Map<String, Object> partition() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -146,6 +146,7 @@ class SubmittedRecords {
 
     /**
      * Wait for all currently in-flight messages to be acknowledged, up to the requested timeout.
+     * This method is expected to be called from the same thread that calls {@link #committableOffsets()}.
      * @param timeout the maximum time to wait
      * @param timeUnit the time unit of the timeout argument
      * @return whether all in-flight messages were acknowledged before the timeout elapsed

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -36,6 +36,7 @@ import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.SubmittedRecords.SubmittedRecord;
 import org.apache.kafka.connect.runtime.distributed.ClusterConfigState;
 import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator;
 import org.apache.kafka.connect.runtime.errors.Stage;
@@ -359,7 +360,7 @@ class WorkerSourceTask extends WorkerTask {
             }
 
             log.trace("{} Appending record to the topic {} with key {}, value {}", this, record.topic(), record.key(), record.value());
-            SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(record);
+            SubmittedRecord submittedRecord = submittedRecords.submit(record);
             try {
                 maybeCreateTopic(record.topic());
                 final String topic = producerRecord.topic();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SubmittedRecordsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.connect.runtime.SubmittedRecords.SubmittedRecord;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,7 +89,7 @@ public class SubmittedRecordsTest {
     public void testSingleAck() {
         Map<String, Object> offset = newOffset();
 
-        SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, offset);
+        SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, offset);
         CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         // Record has been submitted but not yet acked; cannot commit offsets for it yet
         assertFalse(committableOffsets.isEmpty());
@@ -119,10 +120,10 @@ public class SubmittedRecordsTest {
         Map<String, Object> partition2Offset1 = newOffset();
         Map<String, Object> partition2Offset2 = newOffset();
 
-        SubmittedRecords.SubmittedRecord partition1Record1 = submittedRecords.submit(PARTITION1, partition1Offset1);
-        SubmittedRecords.SubmittedRecord partition1Record2 = submittedRecords.submit(PARTITION1, partition1Offset2);
-        SubmittedRecords.SubmittedRecord partition2Record1 = submittedRecords.submit(PARTITION2, partition2Offset1);
-        SubmittedRecords.SubmittedRecord partition2Record2 = submittedRecords.submit(PARTITION2, partition2Offset2);
+        SubmittedRecord partition1Record1 = submittedRecords.submit(PARTITION1, partition1Offset1);
+        SubmittedRecord partition1Record2 = submittedRecords.submit(PARTITION1, partition1Offset2);
+        SubmittedRecord partition2Record1 = submittedRecords.submit(PARTITION2, partition2Offset1);
+        SubmittedRecord partition2Record2 = submittedRecords.submit(PARTITION2, partition2Offset2);
 
         CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         // No records ack'd yet; can't commit any offsets
@@ -171,7 +172,7 @@ public class SubmittedRecordsTest {
 
     @Test
     public void testRemoveLastSubmittedRecord() {
-        SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, newOffset());
+        SubmittedRecord submittedRecord = submittedRecords.submit(PARTITION1, newOffset());
 
         CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertEquals(Collections.emptyMap(), committableOffsets.offsets());
@@ -195,8 +196,8 @@ public class SubmittedRecordsTest {
         Map<String, Object> partition1Offset = newOffset();
         Map<String, Object> partition2Offset = newOffset();
 
-        SubmittedRecords.SubmittedRecord recordToRemove = submittedRecords.submit(PARTITION1, partition1Offset);
-        SubmittedRecords.SubmittedRecord lastSubmittedRecord = submittedRecords.submit(PARTITION2, partition2Offset);
+        SubmittedRecord recordToRemove = submittedRecords.submit(PARTITION1, partition1Offset);
+        SubmittedRecord lastSubmittedRecord = submittedRecords.submit(PARTITION2, partition2Offset);
 
         CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertMetadata(committableOffsets, 0, 2, 2, 1, PARTITION1, PARTITION2);
@@ -234,7 +235,7 @@ public class SubmittedRecordsTest {
 
     @Test
     public void testNullPartitionAndOffset() {
-        SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(null, null);
+        SubmittedRecord submittedRecord = submittedRecords.submit(null, null);
         CommittableOffsets committableOffsets = submittedRecords.committableOffsets();
         assertMetadata(committableOffsets, 0, 1, 1, 1, (Map<String, Object>) null);
 
@@ -253,7 +254,7 @@ public class SubmittedRecordsTest {
 
     @Test
     public void testAwaitMessagesAfterAllAcknowledged() {
-        SubmittedRecords.SubmittedRecord recordToAck = submittedRecords.submit(PARTITION1, newOffset());
+        SubmittedRecord recordToAck = submittedRecords.submit(PARTITION1, newOffset());
         assertFalse(submittedRecords.awaitAllMessages(0, TimeUnit.MILLISECONDS));
         recordToAck.ack();
         assertTrue(submittedRecords.awaitAllMessages(0, TimeUnit.MILLISECONDS));
@@ -261,8 +262,8 @@ public class SubmittedRecordsTest {
 
     @Test
     public void testAwaitMessagesAfterAllRemoved() {
-        SubmittedRecords.SubmittedRecord recordToRemove1 = submittedRecords.submit(PARTITION1, newOffset());
-        SubmittedRecords.SubmittedRecord recordToRemove2 = submittedRecords.submit(PARTITION1, newOffset());
+        SubmittedRecord recordToRemove1 = submittedRecords.submit(PARTITION1, newOffset());
+        SubmittedRecord recordToRemove2 = submittedRecords.submit(PARTITION1, newOffset());
         assertFalse(
                 "Await should fail since neither of the in-flight records has been removed so far",
                 submittedRecords.awaitAllMessages(0, TimeUnit.MILLISECONDS)
@@ -296,8 +297,8 @@ public class SubmittedRecordsTest {
 
     @Test
     public void testAwaitMessagesReturnsAfterAsynchronousAck() throws Exception {
-        SubmittedRecords.SubmittedRecord inFlightRecord1 = submittedRecords.submit(PARTITION1, newOffset());
-        SubmittedRecords.SubmittedRecord inFlightRecord2 = submittedRecords.submit(PARTITION2, newOffset());
+        SubmittedRecord inFlightRecord1 = submittedRecords.submit(PARTITION1, newOffset());
+        SubmittedRecord inFlightRecord2 = submittedRecords.submit(PARTITION2, newOffset());
 
         AtomicBoolean awaitResult = new AtomicBoolean();
         CountDownLatch awaitComplete = new CountDownLatch(1);


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13469)

Although committing source task offsets without blocking on the delivery of all in-flight records is beneficial most of the time, it can lead to duplicate record delivery if there are in-flight records at the time of the task's end-of-life offset commit.

A best-effort attempt is made here to wait for any such in-flight records to be delivered before proceeding with the end-of-life offset commit for source tasks. Connect will block for up to `offset.flush.timeout.ms` milliseconds before calculating the latest committable offsets for the task and flushing those to the persistent offset store.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
