### PR TITLE
MINOR: Update javadoc of `SnapshotWriter.createWithHeader`

### DIFF
--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -113,10 +113,8 @@ final public class SnapshotWriter<T> implements AutoCloseable {
      * Create an instance of this class and initialize
      * the underlying snapshot with {@link SnapshotHeaderRecord}
      *
-     * @param snapshot a lambda to create the low level snapshot writer
      * @param maxBatchSize the maximum size in byte for a batch
      * @param memoryPool the memory pool for buffer allocation
-     * @param time the clock implementation
      * @param lastContainedLogTimestamp The append time of the highest record contained in this snapshot
      * @param compressionType the compression algorithm to use
      * @param serde the record serialization and deserialization implementation

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -113,8 +113,10 @@ final public class SnapshotWriter<T> implements AutoCloseable {
      * Create an instance of this class and initialize
      * the underlying snapshot with {@link SnapshotHeaderRecord}
      *
+     * @param supplier a lambda to create the low level snapshot writer
      * @param maxBatchSize the maximum size in byte for a batch
      * @param memoryPool the memory pool for buffer allocation
+     * @param snapshotTime the clock implementation
      * @param lastContainedLogTimestamp The append time of the highest record contained in this snapshot
      * @param compressionType the compression algorithm to use
      * @param serde the record serialization and deserialization implementation


### PR DESCRIPTION
Rename unnecessary comment information：SnapshotWriter.createWithHeader()


