### PR TITLE
KAFKA-13476: Increase resilience timestamp decoding Kafka Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1108,7 +1108,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                             LATEST_MAGIC_BYTE, version);
                     return RecordQueue.UNKNOWN;
             }
-        } catch (final IllegalArgumentException argumentException) {
+        } catch (final Exception exception) {
             log.warn("Unsupported offset metadata found");
             return RecordQueue.UNKNOWN;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1109,7 +1109,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     return RecordQueue.UNKNOWN;
             }
         } catch (final IllegalArgumentException argumentException) {
-            log.warn("Unsupported offset metadata found {}", encryptedString);
+            log.warn("Unsupported offset metadata found");
             return RecordQueue.UNKNOWN;
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1097,15 +1097,20 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         if (encryptedString.isEmpty()) {
             return RecordQueue.UNKNOWN;
         }
-        final ByteBuffer buffer = ByteBuffer.wrap(Base64.getDecoder().decode(encryptedString));
-        final byte version = buffer.get();
-        switch (version) {
-            case LATEST_MAGIC_BYTE:
-                return buffer.getLong();
-            default:
-                log.warn("Unsupported offset metadata version found. Supported version {}. Found version {}.",
-                         LATEST_MAGIC_BYTE, version);
-                return RecordQueue.UNKNOWN;
+        try {
+            final ByteBuffer buffer = ByteBuffer.wrap(Base64.getDecoder().decode(encryptedString));
+            final byte version = buffer.get();
+            switch (version) {
+                case LATEST_MAGIC_BYTE:
+                    return buffer.getLong();
+                default:
+                    log.warn("Unsupported offset metadata version found. Supported version {}. Found version {}.",
+                            LATEST_MAGIC_BYTE, version);
+                    return RecordQueue.UNKNOWN;
+            }
+        } catch (final IllegalArgumentException argumentException) {
+            log.warn("Unsupported offset metadata found {}", encryptedString);
+            return RecordQueue.UNKNOWN;
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1184,6 +1184,13 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldReturnUnknownTimestampIfInvalidMetadata() {
+        task = createStatelessTask(createConfig("100"));
+        final String invalidBase64String = "{}";
+        assertEquals(RecordQueue.UNKNOWN, task.decodeTimestamp(invalidBase64String));
+    }
+
+    @Test
     public void shouldBeProcessableIfAllPartitionsBuffered() {
         task = createStatelessTask(createConfig("100"));
         task.initializeIfNeeded();


### PR DESCRIPTION
Kafka Streams decodes the Offset Metadata to extract timestamps.
If this metadata is not in Base64 the application fails, with no way to recover except creating a new custom offset commit.
The change is to catch the IllegalArgumentException that the Base64 Decoder throws, log that an exception occurred and return the UNKNOWN value instead.

As this is a smaller change I've only updated the decode Timestamp unit tests to test this scenario.

This is my first contribution, so I probably need to take some more actions to get this accepted, any help is appreciated.