### PR TITLE
KAFKA-13498: keeping track of latest seen position in different state stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -54,6 +54,7 @@ public class CachingKeyValueStore
     private InternalProcessorContext<?, ?> context;
     private Thread streamThread;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private Position position;
 
     CachingKeyValueStore(final KeyValueStore<Bytes, byte[]> underlying) {
         super(underlying);
@@ -80,8 +81,13 @@ public class CachingKeyValueStore
         streamThread = Thread.currentThread();
     }
 
+    Position getPosition() {
+        return position;
+    }
+
     private void initInternal(final InternalProcessorContext<?, ?> context) {
         this.context = context;
+        this.position = Position.emptyPosition();
 
         this.cacheName = ThreadCache.nameSpaceFromTaskIdAndStore(context.taskId().toString(), name());
         this.context.registerCacheFlushListener(cacheName, entries -> {
@@ -158,6 +164,8 @@ public class CachingKeyValueStore
                 context.timestamp(),
                 context.partition(),
                 context.topic()));
+
+        position = position.update(context.topic(), context.partition(), context.offset());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Position.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Position.java
@@ -44,10 +44,12 @@ public class Position {
     }
 
     public Position update(final String topic, final int partition, final long offset) {
-        position.computeIfAbsent(topic, k -> new ConcurrentHashMap<>());
-        final ConcurrentMap<Integer, AtomicLong> topicMap = position.get(topic);
-        topicMap.computeIfAbsent(partition, k -> new AtomicLong(0));
-        topicMap.get(partition).getAndAccumulate(offset, Math::max);
+        if (topic != null) {
+            position.computeIfAbsent(topic, k -> new ConcurrentHashMap<>());
+            final ConcurrentMap<Integer, AtomicLong> topicMap = position.get(topic);
+            topicMap.computeIfAbsent(partition, k -> new AtomicLong(0));
+            topicMap.get(partition).getAndAccumulate(offset, Math::max);
+        }
         return this;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractSessionBytesStoreTest {
 
     private MockRecordCollector recordCollector;
 
-    private InternalMockProcessorContext context;
+    InternalMockProcessorContext context;
 
     abstract <K, V> SessionStore<K, V> buildSessionStore(final long retentionPeriod,
                                                          final Serde<K> keySerde,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.ArrayList;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
@@ -32,6 +33,8 @@ import java.util.List;
 
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.toStoreKeyBinary;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -158,6 +161,34 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
         assertEquals(windowedPair(1, "five", RETENTION_PERIOD), iterator.next());
         assertEquals(windowedPair(1, "six", 5 * (RETENTION_PERIOD / 4)), iterator.next());
         assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void shouldMatchPositionAfterPut() {
+        final List<KeyValue<Integer, String>> entries = new ArrayList<>();
+        entries.add(new KeyValue<>(0, "v"));
+        entries.add(new KeyValue<>(1, "v"));
+        entries.add(new KeyValue<>(2, "v"));
+        entries.add(new KeyValue<>(3, "v"));
+        entries.add(new KeyValue<>(4, "v"));
+
+        final MonotonicProcessorRecordContext recordContext = new MonotonicProcessorRecordContext("input", 0);
+        context.setRecordContext(recordContext);
+
+        final Position expected = Position.emptyPosition();
+        long offset = 0;
+        for (final KeyValue<Integer, String> k : entries) {
+            windowStore.put(k.key, k.value, SEGMENT_INTERVAL);
+            expected.update("input", 0, offset);
+            offset++;
+        }
+
+        final MeteredWindowStore<Integer, String> meteredSessionStore = (MeteredWindowStore<Integer, String>) windowStore;
+        final ChangeLoggingWindowBytesStore changeLoggingSessionBytesStore = (ChangeLoggingWindowBytesStore) meteredSessionStore.wrapped();
+        final InMemoryWindowStore inMemoryWindowStore = (InMemoryWindowStore) changeLoggingSessionBytesStore.wrapped();
+
+        final Position actual = inMemoryWindowStore.getPosition();
+        assertThat(expected, is(actual));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MonotonicProcessorRecordContext.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MonotonicProcessorRecordContext.java
@@ -22,16 +22,30 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 
 public class MonotonicProcessorRecordContext extends ProcessorRecordContext {
     private long counter;
+    private final boolean automatic;
 
     public MonotonicProcessorRecordContext(final String topic, final int partition) {
+        this(topic, partition, true);
+    }
+
+    public MonotonicProcessorRecordContext(final String topic, final int partition, final boolean automatic) {
         super(0, 0, partition, topic, new RecordHeaders());
         this.counter = 0;
+        this.automatic = automatic;
     }
 
     @Override
     public long offset() {
         final long ret = counter;
-        counter++;
+        if (automatic) {
+            counter++;
+        }
         return ret;
+    }
+
+    public void kick() {
+        if (!automatic) {
+            counter++;
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -40,6 +40,8 @@ import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -635,6 +637,34 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
                 segments.segmentName(6L)),
             segmentDirs(baseDir)
         );
+    }
+
+    @Test
+    public void shouldMatchPositionAfterPut() {
+        final List<KeyValue<Integer, String>> entries = new ArrayList<>();
+        entries.add(new KeyValue<>(0, "v"));
+        entries.add(new KeyValue<>(1, "v"));
+        entries.add(new KeyValue<>(2, "v"));
+        entries.add(new KeyValue<>(3, "v"));
+        entries.add(new KeyValue<>(4, "v"));
+
+        final MonotonicProcessorRecordContext recordContext = new MonotonicProcessorRecordContext("input", 0);
+        context.setRecordContext(recordContext);
+
+        final Position expected = Position.emptyPosition();
+        long offset = 0;
+        for (final KeyValue<Integer, String> k : entries) {
+            windowStore.put(k.key, k.value, SEGMENT_INTERVAL);
+            expected.update("input", 0, offset);
+            offset++;
+        }
+
+        final MeteredWindowStore<Integer, String> meteredSessionStore = (MeteredWindowStore<Integer, String>) windowStore;
+        final ChangeLoggingWindowBytesStore changeLoggingSessionBytesStore = (ChangeLoggingWindowBytesStore) meteredSessionStore.wrapped();
+        final RocksDBWindowStore rocksDBWindowStore = (RocksDBWindowStore) changeLoggingSessionBytesStore.wrapped();
+
+        final Position actual = rocksDBWindowStore.getPosition();
+        assertThat(expected, is(actual));
     }
 
     private Set<String> segmentDirs(final File baseDir) {


### PR DESCRIPTION
Previously [KAFKA-13480](https://github.com/apache/kafka/pull/11514) was adding position tracking to the RocksDB and InMemory KV store. This PR adds other stores such as CachingKVStore, and all Session and Windowed variants.