### PR TITLE
MINOR: replace Thread.isAlive by Thread.is_alive for Python code

### DIFF
--- a/tests/kafkatest/services/monitor/http.py
+++ b/tests/kafkatest/services/monitor/http.py
@@ -188,7 +188,7 @@ class _ReverseForwarder(object):
     def stop(self):
         self._stopping = True
         self._accept_thread.join(30)
-        if self._accept_thread.isAlive():
+        if self._accept_thread.is_alive():
             raise RuntimeError("Failed to stop reverse forwarder on %s", self._node)
         self._transport.cancel_port_forward('', self._remote_port)
 


### PR DESCRIPTION
`Thread.isAlive` was removed from python 3.9 (see https://bugs.python.org/issue37804), and the default version of python 3 in `openjdk:8` image is `3.9.2`. Hence, the following error is produced when running system tests.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 133, in run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 190, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.9/dist-packages/ducktape/mark/_mark.py", line 429, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/quota_test.py", line 157, in test_quota
    producer.run()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/services/service.py", line 318, in run
    self.stop()
  File "/opt/kafka-dev/tests/kafkatest/services/monitor/http.py", line 97, in stop
    super(HttpMetricsCollector, self).stop()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/services/background_thread.py", line 84, in stop
    super(BackgroundThreadService, self).stop()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/services/service.py", line 281, in stop
    self.stop_node(node)
  File "/opt/kafka-dev/tests/kafkatest/services/monitor/http.py", line 109, in stop_node
    self._forwarders[idx].stop()
  File "/opt/kafka-dev/tests/kafkatest/services/monitor/http.py", line 191, in stop
    if self._accept_thread.isAlive():
AttributeError: 'Thread' object has no attribute 'isAlive'
```

The replacement is `Thread.is_alive`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
