### PR TITLE
Fix storage metadata comparison in storage tool

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -86,6 +86,13 @@ class RawMetaProperties(val props: Properties = new Properties()) {
     }
   }
 
+  override def equals(that: Any): Boolean = that match {
+    case other: RawMetaProperties => props.equals(other.props)
+    case _ => false
+  }
+
+  override def hashCode(): Int = props.hashCode
+
   override def toString: String = {
     "{" + props.keySet().asScala.toList.asInstanceOf[List[String]].sorted.map {
       key => key + "=" + props.get(key)


### PR DESCRIPTION
Reproduce current issue:

```shell
$ sed -i 's|log.dirs=/tmp/kraft-combined-logs|+log.dirs=/tmp/kraft-combined-logs,/tmp/kraft-combined-logs2' ./config/kraft/server.properties

$ ./bin/kafka-storage.sh format -t R19xNyxMQvqQRGlkGDi2cg -c ./config/kraft/server.properties
Formatting /tmp/kraft-combined-logs
Formatting /tmp/kraft-combined-logs2

$ ./bin/kafka-storage.sh info -c ./config/kraft/server.properties
Found log directories:
  /tmp/kraft-combined-logs
  /tmp/kraft-combined-logs2

Found metadata: {cluster.id=R19xNyxMQvqQRGlkGDi2cg, node.id=1, version=1}

Found problem:
  Metadata for /tmp/kraft-combined-logs2/meta.properties was {cluster.id=R19xNyxMQvqQRGlkGDi2cg, node.id=1, version=1}, but other directories featured {cluster.id=R19xNyxMQvqQRGlkGDi2cg, node.id=1, version=1}
```

It's reporting that same metadata are not the same...

With this fix:

```shell
$ ./bin/kafka-storage.sh info -c ./config/kraft/server.properties
Found log directories:
  /tmp/kraft-combined-logs
  /tmp/kraft-combined-logs2

Found metadata: {cluster.id=R19xNyxMQvqQRGlkGDi2cg, node.id=1, version=1}
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
