### PR TITLE
KAFKA-13487:Create a topic partition directory based on the size of the directory

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -207,4 +207,11 @@ public class TopicConfig {
         "broker will not perform down-conversion for consumers expecting an older message format. The broker responds " +
         "with <code>UNSUPPORTED_VERSION</code> error for consume requests from such older clients. This configuration" +
         "does not apply to any message format conversion that might be required for replication to followers.";
+
+    public static final String LOG_DIRECTORY_SELECT_STRATEGY_CONFIG = "log.directory.select.strategy";
+    public static final String LOG_DIRECTORY_SELECT_STRATEGY_DOC = "This configuration controls the creation strategy " +
+            "of the partition directory, all directories under the Broker level configuration item `log.dirs` " +
+            "will be sorted. When set to <code>Partition</code>, the directory with the smallest number of " +
+            "partitions has priority allocation; When set to <code>Size</code> is sorted by directory size, " +
+            "the smallest directory has priority distribution ";
 }

--- a/core/src/main/java/kafka/record/LogDirSelectType.java
+++ b/core/src/main/java/kafka/record/LogDirSelectType.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.record;
+
+import java.util.NoSuchElementException;
+
+/**
+ * The log dir selector type of the records.
+ */
+public enum LogDirSelectType {
+    NO_LOG_DIR_SELECT_TYPE(-1, "NoTimestampType"), PARTITION(0, "Partition"), SIZE(1, "Size");
+
+    public final int id;
+    public final String name;
+
+    LogDirSelectType(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static LogDirSelectType forName(String name) {
+        for (LogDirSelectType t : values())
+            if (t.name.equals(name))
+                return t;
+        throw new NoSuchElementException("Invalid log dir selector type " + name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -20,6 +20,7 @@ package kafka.log
 import kafka.api.{ApiVersion, ApiVersionValidator, KAFKA_3_0_IV1}
 import kafka.log.LogConfig.configDef
 import kafka.message.BrokerCompressionCodec
+import kafka.record.LogDirSelectType
 import kafka.server.{KafkaConfig, ThrottledReplicaListValidator}
 import kafka.utils.Implicits._
 import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList, Validator}
@@ -68,6 +69,7 @@ object Defaults {
   val FollowerReplicationThrottledReplicas = Collections.emptyList[String]()
   val MaxIdMapSnapshots = kafka.server.Defaults.MaxIdMapSnapshots
   val MessageDownConversionEnable = kafka.server.Defaults.MessageDownConversionEnable
+  val LogDirectorySelectStrategy = kafka.server.Defaults.LogDirectorySelectStrategy
 }
 
 case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] = Set.empty)
@@ -107,6 +109,7 @@ case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] 
   val LeaderReplicationThrottledReplicas = getList(LogConfig.LeaderReplicationThrottledReplicasProp)
   val FollowerReplicationThrottledReplicas = getList(LogConfig.FollowerReplicationThrottledReplicasProp)
   val messageDownConversionEnable = getBoolean(LogConfig.MessageDownConversionEnableProp)
+  val logDirectorySelectStrategy = LogDirSelectType.forName(getString(LogConfig.LogDirectorySelectStrategyProp))
 
   class RemoteLogConfig {
     val remoteStorageEnable = getBoolean(LogConfig.RemoteLogStorageEnableProp)
@@ -217,6 +220,7 @@ object LogConfig {
   val MessageTimestampTypeProp = TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG
   val MessageTimestampDifferenceMaxMsProp = TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG
   val MessageDownConversionEnableProp = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_CONFIG
+  val LogDirectorySelectStrategyProp = TopicConfig.LOG_DIRECTORY_SELECT_STRATEGY_CONFIG
 
   // Leave these out of TopicConfig for now as they are replication quota configs
   val LeaderReplicationThrottledReplicasProp = "leader.replication.throttled.replicas"
@@ -253,6 +257,7 @@ object LogConfig {
   val MessageTimestampTypeDoc = TopicConfig.MESSAGE_TIMESTAMP_TYPE_DOC
   val MessageTimestampDifferenceMaxMsDoc = TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DOC
   val MessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC
+  val LogDirectorySelectStrategyDoc = TopicConfig.LOG_DIRECTORY_SELECT_STRATEGY_DOC
 
   val LeaderReplicationThrottledReplicasDoc = "A list of replicas for which log replication should be throttled on " +
     "the leader side. The list should describe a set of replicas in the form " +
@@ -376,7 +381,8 @@ object LogConfig {
         FollowerReplicationThrottledReplicasDoc, FollowerReplicationThrottledReplicasProp)
       .define(MessageDownConversionEnableProp, BOOLEAN, Defaults.MessageDownConversionEnable, LOW,
         MessageDownConversionEnableDoc, KafkaConfig.LogMessageDownConversionEnableProp)
-
+      .define(LogDirectorySelectStrategyProp, STRING, Defaults.LogDirectorySelectStrategy, in("Partition", "Size"),
+        MEDIUM, LogDirectorySelectStrategyDoc, KafkaConfig.LogDirectorySelectStrategyProp)
     // RemoteLogStorageEnableProp, LocalLogRetentionMsProp, LocalLogRetentionBytesProp do not have server default
     // config names.
     logConfigDef

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -148,6 +148,7 @@ object Defaults {
   val AutoCreateTopicsEnable = true
   val MinInSyncReplicas = 1
   val MessageDownConversionEnable = true
+  val LogDirectorySelectStrategy = "Partition"
 
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMs = RequestTimeoutMs
@@ -473,6 +474,7 @@ object KafkaConfig {
   val CreateTopicPolicyClassNameProp = "create.topic.policy.class.name"
   val AlterConfigPolicyClassNameProp = "alter.config.policy.class.name"
   val LogMessageDownConversionEnableProp = LogConfigPrefix + "message.downconversion.enable"
+  val LogDirectorySelectStrategyProp = LogConfigPrefix + "directory.select.strategy"
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsProp = "controller.socket.timeout.ms"
   val DefaultReplicationFactorProp = "default.replication.factor"
@@ -867,6 +869,7 @@ object KafkaConfig {
   val AlterConfigPolicyClassNameDoc = "The alter configs policy class that should be used for validation. The class should " +
     "implement the <code>org.apache.kafka.server.policy.AlterConfigPolicy</code> interface."
   val LogMessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC;
+  val LogDirectorySelectStrategyDoc = TopicConfig.LOG_DIRECTORY_SELECT_STRATEGY_DOC;
 
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsDoc = "The socket timeout for controller-to-broker channels"
@@ -1206,6 +1209,7 @@ object KafkaConfig {
       .define(CreateTopicPolicyClassNameProp, CLASS, null, LOW, CreateTopicPolicyClassNameDoc)
       .define(AlterConfigPolicyClassNameProp, CLASS, null, LOW, AlterConfigPolicyClassNameDoc)
       .define(LogMessageDownConversionEnableProp, BOOLEAN, Defaults.MessageDownConversionEnable, LOW, LogMessageDownConversionEnableDoc)
+      .define(LogDirectorySelectStrategyProp, STRING, Defaults.LogDirectorySelectStrategy, MEDIUM, LogDirectorySelectStrategyDoc)
 
       /** ********* Replication configuration ***********/
       .define(ControllerSocketTimeoutMsProp, INT, Defaults.ControllerSocketTimeoutMs, MEDIUM, ControllerSocketTimeoutMsDoc)
@@ -1998,7 +2002,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       if (voterIds.isEmpty) {
         throw new ConfigException(s"If using ${KafkaConfig.ProcessRolesProp}, ${KafkaConfig.QuorumVotersProp} must contain a parseable set of voters.")
       } else if (processRoles.contains(ControllerRole)) {
-        // Ensure that controllers use their node.id as a voter in controller.quorum.voters 
+        // Ensure that controllers use their node.id as a voter in controller.quorum.voters
         require(voterIds.contains(nodeId), s"If ${KafkaConfig.ProcessRolesProp} contains the 'controller' role, the node id $nodeId must be included in the set of voters ${KafkaConfig.QuorumVotersProp}=$voterIds")
       } else {
         // Ensure that the broker's node.id is not an id in controller.quorum.voters
@@ -2091,7 +2095,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
     val principalBuilderClass = getClass(KafkaConfig.PrincipalBuilderClassProp)
     require(principalBuilderClass != null, s"${KafkaConfig.PrincipalBuilderClassProp} must be non-null")
-    require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass), 
+    require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass),
       s"${KafkaConfig.PrincipalBuilderClassProp} must implement KafkaPrincipalSerde")
   }
 }

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -372,8 +372,6 @@ class LogManagerTest {
       TestUtils.tempDir(),
       TestUtils.tempDir())
     logManager.shutdown()
-//    val logProps = new Properties()
-//    logProps.put(LogConfig.LogDirectorySelectStrategyProp, LogDirSelectType.SIZE.name: java.lang.String)
 
     val properties = new Properties()
     properties.put(LogConfig.LogDirectorySelectStrategyProp, LogDirSelectType.SIZE.name: java.lang.String)
@@ -381,7 +379,6 @@ class LogManagerTest {
 
     logManager = createLogManager(logDirs = dirs, configRepository = configRepository)
 
-//    val logConfig = LogConfig(logProps)
     def createRecords = TestUtils.singletonRecords(value = "test".getBytes)
     val setSize = createRecords.sizeInBytes
     val msgPerSeg = 10

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -670,6 +670,7 @@ class KafkaConfigTest {
         case KafkaConfig.LogFlushSchedulerIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.LogFlushIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.LogMessageTimestampDifferenceMaxMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
+        case KafkaConfig.LogDirectorySelectStrategyProp => // ignore string
         case KafkaConfig.LogFlushStartOffsetCheckpointIntervalMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.NumRecoveryThreadsPerDataDirProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.AutoCreateTopicsEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")


### PR DESCRIPTION
issue:[KAFKA-13487](https://issues.apache.org/jira/browse/KAFKA-13487)

In the actual production environment, the file size generated by each subject partition is different. As a result, the disk usage of the base directory is unbalanced.It is not convenient to use the existing script to migrate the topic replica(such as kafka-reassign-partitions.sh)

Add Broker-level configuration items:**log.directory.select.strategy**, there are two values: **partition** and **size**
* **partition**: Sort by the number of directories under each base directory (log.dirs) (the current version of the new partition creation strategy)
* **size**: Sort by the size of each directory (log.dirs), the smallest directory has the highest allocation right

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
