### PR TITLE
KAFKA-13488: Producer fails to recover if topic gets deleted midway

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -394,9 +394,12 @@ public class Metadata implements Closeable {
         if (hasReliableLeaderEpoch && partitionMetadata.leaderEpoch.isPresent()) {
             int newEpoch = partitionMetadata.leaderEpoch.get();
             Integer currentEpoch = lastSeenLeaderEpochs.get(tp);
-            // oldTopicId can be null (when metadata is fetched during topic recreation), update the metadata in that case as well.
+            // Between the time that a topic is deleted and re-created, the client may lose
+            // track of the corresponding topicId (i.e. `oldTopicId` will be null). In this case,
+            // when we discover the new topicId, we allow the corresponding leader epoch
+            // to override the last seen value.
             if (topicId != null && !topicId.equals(oldTopicId)) {
-                // If both topic IDs were valid and the topic ID changed, update the metadata
+                // If the new topic ID is valid and different from the last seen topic ID, update the metadata
                 log.info("Resetting the last seen epoch of partition {} to {} since the associated topicId changed from {} to {}",
                          tp, newEpoch, oldTopicId, topicId);
                 lastSeenLeaderEpochs.put(tp, newEpoch);

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -394,7 +394,8 @@ public class Metadata implements Closeable {
         if (hasReliableLeaderEpoch && partitionMetadata.leaderEpoch.isPresent()) {
             int newEpoch = partitionMetadata.leaderEpoch.get();
             Integer currentEpoch = lastSeenLeaderEpochs.get(tp);
-            if (topicId != null && oldTopicId != null && !topicId.equals(oldTopicId)) {
+            // oldTopicId can be null (when metadata is fetched during topic recreation), update the metadata in that case as well.
+            if (topicId != null && !topicId.equals(oldTopicId)) {
                 // If both topic IDs were valid and the topic ID changed, update the metadata
                 log.info("Resetting the last seen epoch of partition {} to {} since the associated topicId changed from {} to {}",
                          tp, newEpoch, oldTopicId, topicId);

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -394,12 +394,11 @@ public class Metadata implements Closeable {
         if (hasReliableLeaderEpoch && partitionMetadata.leaderEpoch.isPresent()) {
             int newEpoch = partitionMetadata.leaderEpoch.get();
             Integer currentEpoch = lastSeenLeaderEpochs.get(tp);
-            // Between the time that a topic is deleted and re-created, the client may lose
-            // track of the corresponding topicId (i.e. `oldTopicId` will be null). In this case,
-            // when we discover the new topicId, we allow the corresponding leader epoch
-            // to override the last seen value.
             if (topicId != null && !topicId.equals(oldTopicId)) {
-                // If the new topic ID is valid and different from the last seen topic ID, update the metadata
+                // If the new topic ID is valid and different from the last seen topic ID, update the metadata.
+                // Between the time that a topic is deleted and re-created, the client may lose track of the
+                // corresponding topicId (i.e. `oldTopicId` will be null). In this case, when we discover the new
+                // topicId, we allow the corresponding leader epoch to override the last seen value.
                 log.info("Resetting the last seen epoch of partition {} to {} since the associated topicId changed from {} to {}",
                          tp, newEpoch, oldTopicId, topicId);
                 lastSeenLeaderEpochs.put(tp, newEpoch);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -375,22 +375,21 @@ public class MetadataTest {
     @Test
     public void testEpochUpdateAfterTopicDeletion() {
         TopicPartition tp = new TopicPartition("topic-1", 0);
-        Map<String, Uuid> topicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
 
         MetadataResponse metadataResponse = emptyMetadataResponse();
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
 
-        // Start with a topic A with a topic ID foo
+        Map<String, Uuid> topicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
         metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10, topicIds);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
         assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
 
-        // Topic A is now deleted so Response contains an Error. LeaderEpoch should still return maintain Old value
-        metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.singletonMap("topic-1", Errors.UNKNOWN_TOPIC_OR_PARTITION), new HashMap<>());
+        // Topic topic-1 is now deleted so Response contains an Error. LeaderEpoch should still maintain Old value
+        metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.singletonMap("topic-1", Errors.UNKNOWN_TOPIC_OR_PARTITION), Collections.emptyMap());
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
         assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
 
-        // Create topic A again but this time with a topic ID bar. LeaderEpoch should be updated to new even if lower.
+        // Create topic-1 again but this time with a topic ID bar. LeaderEpoch should be updated to new even if lower.
         Map<String, Uuid> newTopicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
         metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 5, newTopicIds);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -381,13 +381,12 @@ public class MetadataTest {
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
 
         // Start with a topic with no topic ID
-        metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10);
+        metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 100);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
-        assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
+        assertEquals(Optional.of(100), metadata.lastSeenLeaderEpoch(tp));
 
-        // We should treat an added topic ID as though it is the same topic. Handle only when epoch increases.
-        // Don't update to an older one
-        metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 1, topicIds);
+        // If the Older topic Id is null, we should go with the new TopicId as the leader Epoch
+        metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10, topicIds);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 2L);
         assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
 

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -379,6 +379,7 @@ public class MetadataTest {
         MetadataResponse metadataResponse = emptyMetadataResponse();
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
 
+        // Start with a Topic topic-1 with a random topic ID
         Map<String, Uuid> topicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
         metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10, topicIds);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
@@ -389,7 +390,7 @@ public class MetadataTest {
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
         assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
 
-        // Create topic-1 again but this time with a topic ID bar. LeaderEpoch should be updated to new even if lower.
+        // Create topic-1 again but this time with a different topic ID. LeaderEpoch should be updated to new even if lower.
         Map<String, Uuid> newTopicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
         metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 5, newTopicIds);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
@@ -409,7 +410,7 @@ public class MetadataTest {
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
         assertEquals(Optional.of(100), metadata.lastSeenLeaderEpoch(tp));
 
-        // If the Older topic Id is null, we should go with the new TopicId as the leader Epoch
+        // If the older topic ID is null, we should go with the new topic ID as the leader epoch
         metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10, topicIds);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 2L);
         assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -373,6 +373,31 @@ public class MetadataTest {
     }
 
     @Test
+    public void testEpochUpdateAfterTopicDeletion() {
+        TopicPartition tp = new TopicPartition("topic-1", 0);
+        Map<String, Uuid> topicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
+
+        MetadataResponse metadataResponse = emptyMetadataResponse();
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
+
+        // Start with a topic A with a topic ID foo
+        metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10, topicIds);
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
+        assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
+
+        // Topic A is now deleted so Response contains an Error. LeaderEpoch should still return maintain Old value
+        metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.singletonMap("topic-1", Errors.UNKNOWN_TOPIC_OR_PARTITION), new HashMap<>());
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
+        assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));
+
+        // Create topic A again but this time with a topic ID bar. LeaderEpoch should be updated to new even if lower.
+        Map<String, Uuid> newTopicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());
+        metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 5, newTopicIds);
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
+        assertEquals(Optional.of(5), metadata.lastSeenLeaderEpoch(tp));
+    }
+
+    @Test
     public void testEpochUpdateOnChangedTopicIds() {
         TopicPartition tp = new TopicPartition("topic-1", 0);
         Map<String, Uuid> topicIds = Collections.singletonMap("topic-1", Uuid.randomUuid());

--- a/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
@@ -50,7 +50,7 @@ class ProducerSendWhileDeletionTest extends IntegrationTestHarness {
         val numRecords = 10
         val topic = "topic"
 
-        // create topic with leader as 0 for the 2 partitions.
+        // Create topic with leader as 0 for the 2 partitions.
         createTopic(topic, Map(0 -> Seq(0, 1), 1 -> Seq(0, 1)))
 
         val reassignment = Map(
@@ -70,7 +70,7 @@ class ProducerSendWhileDeletionTest extends IntegrationTestHarness {
             assertEquals(topic, resp.topic())
         }
 
-        // start topic deletion
+        // Start topic deletion
         adminZkClient.deleteTopic(topic)
 
         // Verify that the topic is deleted when no metadata request comes in

--- a/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
@@ -35,9 +35,9 @@ class ProducerSendWhileDeletionTest extends IntegrationTestHarness {
     serverConfig.put(KafkaConfig.DefaultReplicationFactorProp, 2.toString)
     serverConfig.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
 
-    producerConfig.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5 * 1000L)
-    producerConfig.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10 * 1000)
-    producerConfig.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10 * 1000)
+    producerConfig.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000L.toString)
+    producerConfig.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000.toString)
+    producerConfig.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10000.toString)
 
     /**
      * Tests that Producer gets self-recovered when a topic is deleted mid-way of produce.

--- a/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
@@ -1,0 +1,86 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.api
+
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.producer.ProducerRecord
+
+import java.util.Properties
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+
+
+class ProducerSendWhileDeletionTest extends BaseProducerSendTest {
+
+
+    override def generateConfigs = {
+        val overridingProps = new Properties()
+        val numServers = 2
+        overridingProps.put(KafkaConfig.NumPartitionsProp, 2.toString)
+        overridingProps.put(KafkaConfig.DefaultReplicationFactorProp, 2.toString)
+        overridingProps.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
+        TestUtils.createBrokerConfigs(numServers, zkConnect, false, interBrokerSecurityProtocol = Some(securityProtocol),
+                trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties).map(KafkaConfig.fromProps(_, overridingProps))
+    }
+
+    /**
+     * Tests that Producer gets self-recovered when a topic is deleted mid-way of produce.
+     *
+     * Producer will attempt to send messages to the partition specified in each record, and should
+     * succeed as long as the partition is included in the metadata.
+     */
+    @Test
+    def testSendWithTopicDeletionMidWay(): Unit = {
+        val numRecords = 10
+
+        // create topic with leader as 0 for the 2 partitions.
+        createTopic(topic, Map(0 -> Seq(0, 1), 1 -> Seq(0, 1)))
+
+        val reassignment = Map(
+            new TopicPartition(topic, 0) -> Seq(1, 0),
+            new TopicPartition(topic, 1) -> Seq(1, 0)
+        )
+
+        // Change leader to 1 for both the partitions to increase leader Epoch from 0 -> 1
+        zkClient.createPartitionReassignment(reassignment)
+        TestUtils.waitUntilTrue(() => !zkClient.reassignPartitionsInProgress,
+            "failed to remove reassign partitions path after completion")
+
+        val producer = createProducer(brokerList, maxBlockMs = 5 * 1000L, deliveryTimeoutMs = 20 * 1000)
+
+        (1 to numRecords).map { i =>
+            val resp = producer.send(new ProducerRecord(topic, null, ("value" + i).getBytes(StandardCharsets.UTF_8))).get
+            assertEquals(topic, resp.topic())
+        }
+
+        // start topic deletion
+        adminZkClient.deleteTopic(topic)
+
+        // Verify that the topic is deleted when no metadata request comes in
+        TestUtils.verifyTopicDeletion(zkClient, topic, 2, servers)
+
+        // Producer should be able to send messages even after topic gets deleted and auto-created
+        assertEquals(topic, producer.send(new ProducerRecord(topic, null, ("value").getBytes(StandardCharsets.UTF_8))).get.topic())
+    }
+
+
+}

--- a/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
@@ -58,7 +58,7 @@ class ProducerSendWhileDeletionTest extends IntegrationTestHarness {
             new TopicPartition(topic, 1) -> Seq(1, 0)
         )
 
-        // Change leader to 1 for both the partitions to increase leader Epoch from 0 -> 1
+        // Change leader to 1 for both the partitions to increase leader epoch from 0 -> 1
         zkClient.createPartitionReassignment(reassignment)
         TestUtils.waitUntilTrue(() => !zkClient.reassignPartitionsInProgress,
             "failed to remove reassign partitions path after completion")


### PR DESCRIPTION
Allow LeaderEpoch to be re-assigned to the new value from the Metadata Response if oldTopicId is not present in the cache. This is needed because oldTopicId is removed from the cache if the topic gets deleted but the LeaderEpoch is not removed. Hence, metadata for the newly recreated topic won't be accepted unless we allow oldTopicId to be null.

This is a fix on top of earlier made #10952 and #11004 PRs but still don't solve the bug mentioned in KAFKA-13488. This is now fixed in this PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
