### PR TITLE
KAFKA-8396: Clean up Transformer API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -4933,7 +4933,11 @@ public interface KStream<K, V> {
      * @see #foreach(ForeachAction)
      * @see #transform(TransformerSupplier, String...)
      */
-    void process(final ProcessorSupplier<? super K, ? super V, Void, Void> processorSupplier,
+    <KR, VR> KStream<KR, VR> process(final ProcessorSupplier<? super K, ? super V, ? extends KR, ? extends VR> processorSupplier,
                  final Named named,
                  final String... stateStoreNames);
+
+    <VR> KStream<K, VR> processValues(final ProcessorSupplier<? super K, ? super V, ? extends K, ? extends VR> processorSupplier,
+        final Named named,
+        final String... stateStoreNames);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -4937,7 +4937,7 @@ public interface KStream<K, V> {
                  final Named named,
                  final String... stateStoreNames);
 
-    <VR> KStream<K, VR> processValues(final ProcessorSupplier<? super K, ? super V, ? extends K, ? extends VR> processorSupplier,
+    <VR> KStream<K, VR> processValues(final ProcessorSupplier<K, V, K, VR> processorSupplier,
         final Named named,
         final String... stateStoreNames);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -796,6 +797,9 @@ public interface KTable<K, V> {
     <VR> KTable<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> transformerSupplier,
                                        final String... stateStoreNames);
 
+    <VR> KTable<K, VR> processValues(final ProcessorSupplier<K, V, K, VR> processorSupplier,
+        final String... stateStoreNames);
+
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
      * (with possibly a new type), with default serializers, deserializers, and state store.
@@ -871,6 +875,10 @@ public interface KTable<K, V> {
                                        final Named named,
                                        final String... stateStoreNames);
 
+    <VR> KTable<K, VR> processValues(final ProcessorSupplier<K, V, K, VR> processorSupplier,
+        final Named named,
+        final String... stateStoreNames);
+
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
      * (with possibly a new type), with the {@link Serde key serde}, {@link Serde value serde}, and the underlying
@@ -949,6 +957,10 @@ public interface KTable<K, V> {
     <VR> KTable<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> transformerSupplier,
                                        final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized,
                                        final String... stateStoreNames);
+
+    <VR> KTable<K, VR> processValues(final ProcessorSupplier<K, V, K, VR> processorSupplier,
+        final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized,
+        final String... stateStoreNames);
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
@@ -1030,6 +1042,11 @@ public interface KTable<K, V> {
                                        final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized,
                                        final Named named,
                                        final String... stateStoreNames);
+
+    <VR> KTable<K, VR> processValues(final ProcessorSupplier<K, V, K, VR> processorSupplier,
+        final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized,
+        final Named named,
+        final String... stateStoreNames);
 
     /**
      * Re-groups the records of this {@code KTable} using the provided {@link KeyValueMapper} and default serializers

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.StoreBuilder;
 
@@ -109,6 +110,12 @@ public abstract class AbstractStream<K, V> {
     static <K, V, VR> ValueMapperWithKey<K, V, VR> withKey(final ValueMapper<V, VR> valueMapper) {
         Objects.requireNonNull(valueMapper, "valueMapper can't be null");
         return (readOnlyKey, value) -> valueMapper.apply(value);
+    }
+
+    static <K, V, VR> ProcessorSupplier<K, V, K, VR> toValueProcessor(
+        final ProcessorSupplier<K, V, K, VR> processorSupplier
+    ) {
+        return new ValueProcessorSupplier<>(processorSupplier);
     }
 
     static <K, V, VR> ValueTransformerWithKeySupplier<K, V, VR> toValueTransformerWithKeySupplier(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1512,7 +1512,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     @Override
     public <VR> KStream<K, VR> processValues(
-        ProcessorSupplier<? super K, ? super V, ? extends K, ? extends VR> processorSupplier, Named named,
+        ProcessorSupplier<K, V, K, VR> processorSupplier, Named named,
         String... stateStoreNames) {
         Objects.requireNonNull(processorSupplier, "processorSupplier can't be null");
         Objects.requireNonNull(named, "named can't be null");
@@ -1525,7 +1525,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final String name = new NamedInternal(named).name();
         final StatefulProcessorNode<? super K, ? super V> processNode = new StatefulProcessorNode<>(
             name,
-            new ProcessorParameters<>(new ValueProcessorSupplier<>((ProcessorSupplier<K, V, K, VR>) processorSupplier), name),
+            new ProcessorParameters<>(new ValueProcessorSupplier<>(processorSupplier), name),
             stateStoreNames);
 
         builder.addGraphNode(graphNode, processNode);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
@@ -135,7 +135,7 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
 
     private class KTableTransformValuesGetter implements KTableValueGetter<K, VOut> {
         private final KTableValueGetter<K, V> parentGetter;
-        private InternalProcessorContext internalProcessorContext;
+        private InternalProcessorContext<?, ?> internalProcessorContext;
         private final ValueTransformerWithKey<? super K, ? super V, ? extends VOut> valueTransformer;
 
         KTableTransformValuesGetter(final KTableValueGetter<K, V> parentGetter,
@@ -146,7 +146,7 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
 
         @Override
         public void init(final ProcessorContext<?, ?> context) {
-            internalProcessorContext = (InternalProcessorContext) context;
+            internalProcessorContext = (InternalProcessorContext<?, ?>) context;
             parentGetter.init(context);
             valueTransformer.init(new ForwardingDisabledProcessorContext(internalProcessorContext));
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ValueProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ValueProcessorSupplier.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import java.util.Set;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.ValueProcessorContext;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class ValueProcessorSupplier<KIn, VIn, VOut> implements ProcessorSupplier<KIn, VIn, KIn, VOut> {
+
+    private final ProcessorSupplier<KIn, VIn, KIn, VOut> transformerSupplier;
+
+    public ValueProcessorSupplier(
+        ProcessorSupplier<KIn, VIn, KIn, VOut> transformerSupplier) {
+        this.transformerSupplier = transformerSupplier;
+    }
+
+    @Override
+    public Processor<KIn, VIn, KIn, VOut> get() {
+        return new KStreamValueProcessor<>(transformerSupplier.get());
+    }
+
+    @Override
+    public Set<StoreBuilder<?>> stores() {
+        return transformerSupplier.stores();
+    }
+
+    public static class KStreamValueProcessor<KIn, VIn, VOut> extends ContextualProcessor<KIn, VIn, KIn, VOut> {
+
+        private final Processor<KIn, VIn, KIn, VOut> processor;
+
+        private ValueProcessorContext<KIn, VOut> processorContext;
+
+        public KStreamValueProcessor(Processor<KIn, VIn, KIn, VOut> transformer) {
+            this.processor = transformer;
+        }
+
+        @Override
+        public void init(final ProcessorContext<KIn, VOut> context) {
+            super.init(context);
+            this.processorContext = new ValueProcessorContext<>(context);
+            processor.init(processorContext);
+        }
+
+        @Override
+        public void process(final Record<KIn, VIn> record) {
+            processorContext.setInitialKey(record.key());
+            processor.process(record);
+            processorContext.unsetInitialKey();
+        }
+
+        @Override
+        public void close() {
+            processor.close();
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ValueProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ValueProcessorSupplier.java
@@ -27,31 +27,30 @@ import org.apache.kafka.streams.state.StoreBuilder;
 
 public class ValueProcessorSupplier<KIn, VIn, VOut> implements ProcessorSupplier<KIn, VIn, KIn, VOut> {
 
-    private final ProcessorSupplier<KIn, VIn, KIn, VOut> transformerSupplier;
+    private final ProcessorSupplier<KIn, VIn, KIn, VOut> processorSupplier;
 
-    public ValueProcessorSupplier(
-        ProcessorSupplier<KIn, VIn, KIn, VOut> transformerSupplier) {
-        this.transformerSupplier = transformerSupplier;
+    public ValueProcessorSupplier(ProcessorSupplier<KIn, VIn, KIn, VOut> processorSupplier) {
+        this.processorSupplier = processorSupplier;
     }
 
     @Override
     public Processor<KIn, VIn, KIn, VOut> get() {
-        return new KStreamValueProcessor<>(transformerSupplier.get());
+        return new ValueProcessor<>(processorSupplier.get());
     }
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return transformerSupplier.stores();
+        return processorSupplier.stores();
     }
 
-    public static class KStreamValueProcessor<KIn, VIn, VOut> extends ContextualProcessor<KIn, VIn, KIn, VOut> {
+    public static class ValueProcessor<KIn, VIn, VOut> extends ContextualProcessor<KIn, VIn, KIn, VOut> {
 
         private final Processor<KIn, VIn, KIn, VOut> processor;
 
         private ValueProcessorContext<KIn, VOut> processorContext;
 
-        public KStreamValueProcessor(Processor<KIn, VIn, KIn, VOut> transformer) {
-            this.processor = transformer;
+        public ValueProcessor(Processor<KIn, VIn, KIn, VOut> processor) {
+            this.processor = processor;
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ValueProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ValueProcessorContext.java
@@ -1,0 +1,112 @@
+package org.apache.kafka.streams.processor.internals;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.processor.Cancellable;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
+
+public class ValueProcessorContext<KForward, VForward> implements ProcessorContext<KForward, VForward> {
+
+    final ProcessorContext<KForward, VForward> delegate;
+
+    private KForward key;
+
+    public ValueProcessorContext(ProcessorContext<KForward, VForward> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String applicationId() {
+        return null;
+    }
+
+    @Override
+    public TaskId taskId() {
+        return null;
+    }
+
+    @Override
+    public Optional<RecordMetadata> recordMetadata() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Serde<?> keySerde() {
+        return null;
+    }
+
+    @Override
+    public Serde<?> valueSerde() {
+        return null;
+    }
+
+    @Override
+    public File stateDir() {
+        return null;
+    }
+
+    @Override
+    public StreamsMetrics metrics() {
+        return null;
+    }
+
+    @Override
+    public <S extends StateStore> S getStateStore(String name) {
+        return null;
+    }
+
+    @Override
+    public Cancellable schedule(Duration interval, PunctuationType type,
+        Punctuator callback) {
+        return null;
+    }
+
+    public void setInitialKey(KForward initialKey) {
+        this.key = initialKey;
+    }
+
+    public void unsetInitialKey() {
+        this.key = null;
+    }
+
+    @Override
+    public <K extends KForward, V extends VForward> void forward(Record<K, V> record) {
+        if (key != null) {
+            if (!record.key().equals(key)) {
+                throw new IllegalArgumentException("Key has changed, and repartition is required.");
+            }
+        }
+        delegate.forward(record);
+    }
+
+    @Override
+    public <K extends KForward, V extends VForward> void forward(Record<K, V> record,
+        String childName) {
+
+    }
+
+    @Override
+    public void commit() {
+
+    }
+
+    @Override
+    public Map<String, Object> appConfigs() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> appConfigsWithPrefix(String prefix) {
+        return null;
+    }
+}


### PR DESCRIPTION
(Requires KIP)

Introduces a internal `ValueProcessor` and `ValueProcessorContext` to validate keys do not change between processing and forwarding values to child processors.

This validation only applies when processing, and not when adding punctuators to the topology.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
