### PR TITLE
MINOR: Correct usage of ConfigException in file and directory config providers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/provider/DirectoryConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/DirectoryConfigProvider.java
@@ -89,7 +89,8 @@ public class DirectoryConfigProvider implements ConfigProvider {
                             p -> p.getFileName().toString(),
                             p -> read(p)));
                 } catch (IOException e) {
-                    throw new ConfigException("Could not list directory " + dir, e);
+                    log.error("Could not list directory {}", dir, e);
+                    throw new ConfigException("Could not list directory " + dir);
                 }
             }
         }
@@ -100,7 +101,8 @@ public class DirectoryConfigProvider implements ConfigProvider {
         try {
             return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
         } catch (IOException e) {
-            throw new ConfigException("Could not read file " + path + " for property " + path.getFileName(), e);
+            log.error("Could not read file {} for property {}", path, path.getFileName(), e);
+            throw new ConfigException("Could not read file " + path + " for property " + path.getFileName());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/provider/FileConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/FileConfigProvider.java
@@ -18,6 +18,8 @@ package org.apache.kafka.common.config.provider;
 
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -34,6 +36,8 @@ import java.util.Set;
  * All property keys and values are stored as cleartext.
  */
 public class FileConfigProvider implements ConfigProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(FileConfigProvider.class);
 
     public void configure(Map<String, ?> configs) {
     }
@@ -62,7 +66,8 @@ public class FileConfigProvider implements ConfigProvider {
             }
             return new ConfigData(data);
         } catch (IOException e) {
-            throw new ConfigException("Could not read properties from file " + path, e);
+            log.error("Could not read properties from file {}", path, e);
+            throw new ConfigException("Could not read properties from file " + path);
         }
     }
 
@@ -89,7 +94,8 @@ public class FileConfigProvider implements ConfigProvider {
             }
             return new ConfigData(data);
         } catch (IOException e) {
-            throw new ConfigException("Could not read properties from file " + path, e);
+            log.error("Could not read properties from file {}", path, e);
+            throw new ConfigException("Could not read properties from file " + path);
         }
     }
 


### PR DESCRIPTION
The two-arg variant is intended to take a property name and value, not an exception message and a cause.

As-is, this leads to confusing log messages like:

```
org.apache.kafka.common.config.ConfigException: Invalid value java.nio.file.NoSuchFileException: /my/missing/secrets.properties for configuration Could not read properties from file /my/missing/secrets.properties
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
