### PR TITLE
MINOR: Pass along compression type to snapshot writer

### DIFF
--- a/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotWriter.java
@@ -125,7 +125,7 @@ final public class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
                     memoryPool,
                     snapshotTime,
                     lastContainedLogTimestamp,
-                    CompressionType.NONE,
+                    compressionType,
                     serde);
             writer.initializeSnapshotWithHeader();
 


### PR DESCRIPTION
Make sure that the compression type is passed along to the
RecordsSnapshotWriter constructor when creating the snapshot writer
using the static createWithHeader method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
