### PR TITLE
KAFKA-7589: Allow configuring network threads per listener

### DIFF
--- a/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
@@ -41,7 +41,7 @@ trait KafkaMetricsGroup extends Logging {
   }
 
 
-  protected def explicitMetricName(group: String, typeName: String, name: String,
+  def explicitMetricName(group: String, typeName: String, name: String,
                                    tags: scala.collection.Map[String, String]): MetricName = {
 
     val nameBuilder: StringBuilder = new StringBuilder
@@ -69,6 +69,9 @@ trait KafkaMetricsGroup extends Logging {
 
   def newMeter(name: String, eventType: String, timeUnit: TimeUnit, tags: scala.collection.Map[String, String] = Map.empty): Meter =
     KafkaYammerMetrics.defaultRegistry().newMeter(metricName(name, tags), eventType, timeUnit)
+
+  def newMeter(metricName: MetricName, eventType: String, timeUnit: TimeUnit): Meter =
+    KafkaYammerMetrics.defaultRegistry().newMeter(metricName, eventType, timeUnit)
 
   def newHistogram(name: String, biased: Boolean = true, tags: scala.collection.Map[String, String] = Map.empty): Histogram =
     KafkaYammerMetrics.defaultRegistry().newHistogram(metricName(name, tags), biased)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -52,7 +52,7 @@ import org.apache.kafka.common.{Endpoint, KafkaException, MetricName, Reconfigur
 import org.slf4j.event.Level
 
 import scala.collection._
-import scala.collection.mutable.{ArrayBuffer, Buffer}
+import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.control.ControlThrowable
 
@@ -95,19 +95,21 @@ class SocketServer(val config: KafkaConfig,
   memoryPoolSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
   private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolSensor) else MemoryPool.NONE
   // data-plane
-  private val dataPlaneProcessors = new ConcurrentHashMap[Int, Processor]()
-  private[network] val dataPlaneAcceptors = new ConcurrentHashMap[EndPoint, Acceptor]()
-  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneMetricPrefix, time, apiVersionManager.newRequestMetrics)
+  private[network] val dataPlaneAcceptors = new ConcurrentHashMap[EndPoint, DataPlaneAcceptor]()
+  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneAcceptor.MetricPrefix, time, apiVersionManager.newRequestMetrics)
   // control-plane
-  private var controlPlaneProcessorOpt : Option[Processor] = None
-  private[network] var controlPlaneAcceptorOpt : Option[Acceptor] = None
+  private[network] var controlPlaneAcceptorOpt: Option[ControlPlaneAcceptor] = None
   val controlPlaneRequestChannelOpt: Option[RequestChannel] = config.controlPlaneListenerName.map(_ =>
-    new RequestChannel(20, ControlPlaneMetricPrefix, time, apiVersionManager.newRequestMetrics))
+    new RequestChannel(20, ControlPlaneAcceptor.MetricPrefix, time, apiVersionManager.newRequestMetrics))
 
-  private var nextProcessorId = 0
+  private val nextPId: AtomicInteger = new AtomicInteger(0)
   val connectionQuotas = new ConnectionQuotas(config, time, metrics)
   private var startedProcessingRequests = false
   private var stoppedProcessingRequests = false
+
+  def nextProcessorId(): Int = {
+    nextPId.getAndIncrement()
+  }
 
   /**
    * Starts the socket server and creates all the Acceptors and the Processors. The Acceptors
@@ -128,21 +130,23 @@ class SocketServer(val config: KafkaConfig,
               dataPlaneListeners: Seq[EndPoint] = config.dataPlaneListeners): Unit = {
     this.synchronized {
       createControlPlaneAcceptorAndProcessor(controlPlaneListener)
-      createDataPlaneAcceptorsAndProcessors(config.numNetworkThreads, dataPlaneListeners)
+      createDataPlaneAcceptorsAndProcessors(dataPlaneListeners)
       if (startProcessingRequests) {
         this.startProcessingRequests()
       }
     }
 
-    newGauge(s"${DataPlaneMetricPrefix}NetworkProcessorAvgIdlePercent", () => SocketServer.this.synchronized {
-      val ioWaitRatioMetricNames = dataPlaneProcessors.values.asScala.iterator.map { p =>
+    val dataPlaneProcessors = dataPlaneAcceptors.asScala.values.flatMap(a => a.processors)
+    val controlPlaneProcessorOpt = controlPlaneAcceptorOpt.map(a => a.processors(0))
+    newGauge(s"${DataPlaneAcceptor.MetricPrefix}NetworkProcessorAvgIdlePercent", () => SocketServer.this.synchronized {
+      val ioWaitRatioMetricNames = dataPlaneProcessors.map { p =>
         metrics.metricName("io-wait-ratio", MetricsGroup, p.metricTags)
       }
       ioWaitRatioMetricNames.map { metricName =>
         Option(metrics.metric(metricName)).fold(0.0)(m => Math.min(m.metricValue.asInstanceOf[Double], 1.0))
       }.sum / dataPlaneProcessors.size
     })
-    newGauge(s"${ControlPlaneMetricPrefix}NetworkProcessorAvgIdlePercent", () => SocketServer.this.synchronized {
+    newGauge(s"${ControlPlaneAcceptor.MetricPrefix}NetworkProcessorAvgIdlePercent", () => SocketServer.this.synchronized {
       val ioWaitRatioMetricName = controlPlaneProcessorOpt.map { p =>
         metrics.metricName("io-wait-ratio", MetricsGroup, p.metricTags)
       }
@@ -152,15 +156,15 @@ class SocketServer(val config: KafkaConfig,
     })
     newGauge("MemoryPoolAvailable", () => memoryPool.availableMemory)
     newGauge("MemoryPoolUsed", () => memoryPool.size() - memoryPool.availableMemory)
-    newGauge(s"${DataPlaneMetricPrefix}ExpiredConnectionsKilledCount", () => SocketServer.this.synchronized {
-      val expiredConnectionsKilledCountMetricNames = dataPlaneProcessors.values.asScala.iterator.map { p =>
+    newGauge(s"${DataPlaneAcceptor.MetricPrefix}ExpiredConnectionsKilledCount", () => SocketServer.this.synchronized {
+      val expiredConnectionsKilledCountMetricNames = dataPlaneProcessors.map { p =>
         metrics.metricName("expired-connections-killed-count", MetricsGroup, p.metricTags)
       }
       expiredConnectionsKilledCountMetricNames.map { metricName =>
         Option(metrics.metric(metricName)).fold(0.0)(m => m.metricValue.asInstanceOf[Double])
       }.sum
     })
-    newGauge(s"${ControlPlaneMetricPrefix}ExpiredConnectionsKilledCount", () => SocketServer.this.synchronized {
+    newGauge(s"${ControlPlaneAcceptor.MetricPrefix}ExpiredConnectionsKilledCount", () => SocketServer.this.synchronized {
       val expiredConnectionsKilledCountMetricNames = controlPlaneProcessorOpt.map { p =>
         metrics.metricName("expired-connections-killed-count", MetricsGroup, p.metricTags)
       }
@@ -203,23 +207,22 @@ class SocketServer(val config: KafkaConfig,
    * Before starting them, we ensure that authorizer has all the metadata to authorize
    * requests on that endpoint by waiting on the provided future.
    */
-  private def startAcceptorAndProcessors(threadPrefix: String,
-                                         endpoint: EndPoint,
+  private def startAcceptorAndProcessors(endpoint: EndPoint,
                                          acceptor: Acceptor,
                                          authorizerFutures: Map[Endpoint, CompletableFuture[Void]] = Map.empty): Unit = {
     debug(s"Wait for authorizer to complete start up on listener ${endpoint.listenerName}")
     waitForAuthorizerFuture(acceptor, authorizerFutures)
     debug(s"Start processors on listener ${endpoint.listenerName}")
-    acceptor.startProcessors(threadPrefix)
+    acceptor.startProcessors()
     debug(s"Start acceptor thread on listener ${endpoint.listenerName}")
     if (!acceptor.isStarted()) {
       KafkaThread.nonDaemon(
-        s"${threadPrefix}-kafka-socket-acceptor-${endpoint.listenerName}-${endpoint.securityProtocol}-${endpoint.port}",
+        s"${acceptor.threadPrefix()}-kafka-socket-acceptor-${endpoint.listenerName}-${endpoint.securityProtocol}-${endpoint.port}",
         acceptor
       ).start()
       acceptor.awaitStartup()
     }
-    info(s"Started $threadPrefix acceptor and processor(s) for endpoint : ${endpoint.listenerName}")
+    info(s"Started ${acceptor.threadPrefix()} acceptor and processor(s) for endpoint : ${endpoint.listenerName}")
   }
 
   /**
@@ -238,7 +241,7 @@ class SocketServer(val config: KafkaConfig,
     }
     orderedAcceptors.foreach { acceptor =>
       val endpoint = acceptor.endPoint
-      startAcceptorAndProcessors(DataPlaneThreadPrefix, endpoint, acceptor, authorizerFutures)
+      startAcceptorAndProcessors(endpoint, acceptor, authorizerFutures)
     }
   }
 
@@ -248,18 +251,22 @@ class SocketServer(val config: KafkaConfig,
   private def startControlPlaneProcessorAndAcceptor(authorizerFutures: Map[Endpoint, CompletableFuture[Void]]): Unit = {
     controlPlaneAcceptorOpt.foreach { controlPlaneAcceptor =>
       val endpoint = config.controlPlaneListener.get
-      startAcceptorAndProcessors(ControlPlaneThreadPrefix, endpoint, controlPlaneAcceptor, authorizerFutures)
+      startAcceptorAndProcessors(endpoint, controlPlaneAcceptor, authorizerFutures)
     }
   }
 
   private def endpoints = config.listeners.map(l => l.listenerName -> l).toMap
 
-  private def createDataPlaneAcceptorsAndProcessors(dataProcessorsPerListener: Int,
-                                                    endpoints: Seq[EndPoint]): Unit = {
+  def createDataPlaneAcceptorsAndProcessors(endpoints: Seq[EndPoint]): Unit = {
     endpoints.foreach { endpoint =>
+      val parsedConfigs = config.valuesFromThisConfigWithPrefixOverride(endpoint.listenerName.configPrefix)
       connectionQuotas.addListener(config, endpoint.listenerName)
-      val dataPlaneAcceptor = createAcceptor(endpoint, DataPlaneMetricPrefix)
-      addDataPlaneProcessors(dataPlaneAcceptor, endpoint, dataProcessorsPerListener)
+
+      val isPrivilegedListener = controlPlaneRequestChannelOpt.isEmpty && config.interBrokerListenerName == endpoint.listenerName
+
+      val dataPlaneAcceptor = createDataPlaneAcceptor(endpoint, isPrivilegedListener, dataPlaneRequestChannel)
+      config.addReconfigurable(dataPlaneAcceptor)
+      dataPlaneAcceptor.configure(parsedConfigs)
       dataPlaneAcceptors.put(endpoint, dataPlaneAcceptor)
       info(s"Created data-plane acceptor and processors for endpoint : ${endpoint.listenerName}")
     }
@@ -268,42 +275,20 @@ class SocketServer(val config: KafkaConfig,
   private def createControlPlaneAcceptorAndProcessor(endpointOpt: Option[EndPoint]): Unit = {
     endpointOpt.foreach { endpoint =>
       connectionQuotas.addListener(config, endpoint.listenerName)
-      val controlPlaneAcceptor = createAcceptor(endpoint, ControlPlaneMetricPrefix)
-      val controlPlaneProcessor = newProcessor(nextProcessorId, controlPlaneRequestChannelOpt.get,
-        connectionQuotas, endpoint.listenerName, endpoint.securityProtocol, memoryPool, isPrivilegedListener = true)
+      val controlPlaneAcceptor = createControlPlaneAcceptor(endpoint, controlPlaneRequestChannelOpt.get)
+      controlPlaneAcceptor.addProcessors(1)
       controlPlaneAcceptorOpt = Some(controlPlaneAcceptor)
-      controlPlaneProcessorOpt = Some(controlPlaneProcessor)
-      val listenerProcessors = new ArrayBuffer[Processor]()
-      listenerProcessors += controlPlaneProcessor
-      controlPlaneRequestChannelOpt.foreach(_.addProcessor(controlPlaneProcessor))
-      nextProcessorId += 1
-      controlPlaneAcceptor.addProcessors(listenerProcessors, ControlPlaneThreadPrefix)
       info(s"Created control-plane acceptor and processor for endpoint : ${endpoint.listenerName}")
     }
   }
 
-  protected def createAcceptor(endPoint: EndPoint, metricPrefix: String) : Acceptor = {
-    val sendBufferSize = config.socketSendBufferBytes
-    val recvBufferSize = config.socketReceiveBufferBytes
-    val listenBacklogSize = config.socketListenBacklogSize
-    new Acceptor(endPoint, sendBufferSize, recvBufferSize, listenBacklogSize, nodeId, connectionQuotas, metricPrefix, time)
+
+  protected def createDataPlaneAcceptor(endPoint: EndPoint, isPrivilegedListener: Boolean, requestChannel: RequestChannel): DataPlaneAcceptor = {
+    new DataPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, isPrivilegedListener, requestChannel, metrics, credentialProvider, logContext, memoryPool, apiVersionManager)
   }
 
-  private def addDataPlaneProcessors(acceptor: Acceptor, endpoint: EndPoint, newProcessorsPerListener: Int): Unit = {
-    val listenerName = endpoint.listenerName
-    val securityProtocol = endpoint.securityProtocol
-    val listenerProcessors = new ArrayBuffer[Processor]()
-    val isPrivilegedListener = controlPlaneRequestChannelOpt.isEmpty && config.interBrokerListenerName == listenerName
-
-    for (_ <- 0 until newProcessorsPerListener) {
-      val processor = newProcessor(nextProcessorId, dataPlaneRequestChannel, connectionQuotas,
-        listenerName, securityProtocol, memoryPool, isPrivilegedListener)
-      listenerProcessors += processor
-      dataPlaneRequestChannel.addProcessor(processor)
-      nextProcessorId += 1
-    }
-    listenerProcessors.foreach(p => dataPlaneProcessors.put(p.id, p))
-    acceptor.addProcessors(listenerProcessors, DataPlaneThreadPrefix)
+  private def createControlPlaneAcceptor(endPoint: EndPoint, requestChannel: RequestChannel): ControlPlaneAcceptor = {
+    new ControlPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, requestChannel, metrics, credentialProvider, logContext, memoryPool, apiVersionManager)
   }
 
   /**
@@ -321,16 +306,6 @@ class SocketServer(val config: KafkaConfig,
       stoppedProcessingRequests = true
     }
     info("Stopped socket server request processors")
-  }
-
-  def resizeThreadPool(oldNumNetworkThreads: Int, newNumNetworkThreads: Int): Unit = synchronized {
-    info(s"Resizing network thread pool size for each data-plane listener from $oldNumNetworkThreads to $newNumNetworkThreads")
-    if (newNumNetworkThreads > oldNumNetworkThreads) {
-      dataPlaneAcceptors.forEach { (endpoint, acceptor) =>
-        addDataPlaneProcessors(acceptor, endpoint, newNumNetworkThreads - oldNumNetworkThreads)
-      }
-    } else if (newNumNetworkThreads < oldNumNetworkThreads)
-      dataPlaneAcceptors.asScala.values.foreach(_.removeProcessors(oldNumNetworkThreads - newNumNetworkThreads, dataPlaneRequestChannel))
   }
 
   /**
@@ -355,7 +330,7 @@ class SocketServer(val config: KafkaConfig,
       if (acceptor != null) {
         acceptor.serverChannel.socket.getLocalPort
       } else {
-        controlPlaneAcceptorOpt.map (_.serverChannel.socket().getLocalPort).getOrElse(throw new KafkaException("Could not find listenerName : " + listenerName + " in data-plane or control-plane"))
+        controlPlaneAcceptorOpt.map(_.serverChannel.socket().getLocalPort).getOrElse(throw new KafkaException("Could not find listenerName : " + listenerName + " in data-plane or control-plane"))
       }
     } catch {
       case e: Exception =>
@@ -365,10 +340,10 @@ class SocketServer(val config: KafkaConfig,
 
   def addListeners(listenersAdded: Seq[EndPoint]): Unit = synchronized {
     info(s"Adding data-plane listeners for endpoints $listenersAdded")
-    createDataPlaneAcceptorsAndProcessors(config.numNetworkThreads, listenersAdded)
+    createDataPlaneAcceptorsAndProcessors(listenersAdded)
     listenersAdded.foreach { endpoint =>
       val acceptor = dataPlaneAcceptors.get(endpoint)
-      startAcceptorAndProcessors(DataPlaneThreadPrefix, endpoint, acceptor)
+      startAcceptorAndProcessors(endpoint, acceptor)
     }
   }
 
@@ -421,44 +396,22 @@ class SocketServer(val config: KafkaConfig,
     }
   }
 
-  // `protected` for test usage
-  protected[network] def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                      securityProtocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean): Processor = {
-    new Processor(id,
-      time,
-      config.socketRequestMaxBytes,
-      requestChannel,
-      connectionQuotas,
-      config.connectionsMaxIdleMs,
-      config.failedAuthenticationDelayMs,
-      listenerName,
-      securityProtocol,
-      config,
-      metrics,
-      credentialProvider,
-      memoryPool,
-      logContext,
-      Processor.ConnectionQueueSize,
-      isPrivilegedListener,
-      apiVersionManager
-    )
-  }
-
   // For test usage
   private[network] def connectionCount(address: InetAddress): Int =
     Option(connectionQuotas).fold(0)(_.get(address))
 
   // For test usage
-  private[network] def dataPlaneProcessor(index: Int): Processor = dataPlaneProcessors.get(index)
-
+  def dataPlaneAcceptor(listenerName: String): Option[DataPlaneAcceptor] = {
+    dataPlaneAcceptors.asScala.foreach { case (endPoint, acceptor) =>
+      if (endPoint.listenerName.value() == listenerName)
+        return Some(acceptor)
+    }
+    None
+  }
 }
 
 object SocketServer {
   val MetricsGroup = "socket-server-metrics"
-  val DataPlaneThreadPrefix = "data-plane"
-  val ControlPlaneThreadPrefix = "control-plane"
-  val DataPlaneMetricPrefix = ""
-  val ControlPlaneMetricPrefix = "ControlPlane"
 
   val ReconfigurableConfigs = Set(
     KafkaConfig.MaxConnectionsPerIpProp,
@@ -544,26 +497,188 @@ private[kafka] abstract class AbstractServerThread(connectionQuotas: ConnectionQ
   }
 }
 
+object DataPlaneAcceptor {
+  val ThreadPrefix = "data-plane"
+  val MetricPrefix = ""
+  val ListenerReconfigurableConfigs = Set(KafkaConfig.NumNetworkThreadsProp)
+}
+
+class DataPlaneAcceptor(socketServer: SocketServer,
+                        endPoint: EndPoint,
+                        config: KafkaConfig,
+                        nodeId: Int,
+                        connectionQuotas: ConnectionQuotas,
+                        time: Time,
+                        isPrivilegedListener: Boolean,
+                        requestChannel: RequestChannel,
+                        metrics: Metrics,
+                        credentialProvider: CredentialProvider,
+                        logContext: LogContext,
+                        memoryPool: MemoryPool,
+                        apiVersionManager: ApiVersionManager)
+  extends Acceptor(socketServer,
+                   endPoint,
+                   config,
+                   nodeId,
+                   connectionQuotas,
+                   time,
+                   isPrivilegedListener,
+                   requestChannel,
+                   metrics,
+                   credentialProvider,
+                   logContext,
+                   memoryPool,
+                   apiVersionManager) with ListenerReconfigurable {
+
+  override def metricPrefix(): String = DataPlaneAcceptor.MetricPrefix
+  override def threadPrefix(): String = DataPlaneAcceptor.ThreadPrefix
+
+  /**
+   * Returns the listener name associated with this reconfigurable. Listener-specific
+   * configs corresponding to this listener name are provided for reconfiguration.
+   */
+  override def listenerName(): ListenerName = endPoint.listenerName
+
+  /**
+   * Returns the names of configs that may be reconfigured.
+   */
+  override def reconfigurableConfigs(): util.Set[String] = DataPlaneAcceptor.ListenerReconfigurableConfigs.asJava
+
+
+  /**
+   * Validates the provided configuration. The provided map contains
+   * all configs including any reconfigurable configs that may be different
+   * from the initial configuration. Reconfiguration will be not performed
+   * if this method throws any exception.
+   *
+   * @throws ConfigException if the provided configs are not valid. The exception
+   *                         message from ConfigException will be returned to the client in
+   *                         the AlterConfigs response.
+   */
+  override def validateReconfiguration(configs: util.Map[String, _]): Unit = {
+    configs.forEach { (k, v) =>
+      if (reconfigurableConfigs.contains(k)) {
+        val newValue = v.asInstanceOf[Int]
+        val oldValue = processors.length
+        if (newValue != oldValue) {
+          val errorMsg = s"Dynamic thread count update validation failed for $k=$v"
+          if (newValue <= 0)
+            throw new ConfigException(s"$errorMsg, value should be at least 1")
+          if (newValue < oldValue / 2)
+            throw new ConfigException(s"$errorMsg, value should be at least half the current value $oldValue")
+          if (newValue > oldValue * 2)
+            throw new ConfigException(s"$errorMsg, value should not be greater than double the current value $oldValue")
+        }
+      }
+    }
+  }
+
+  /**
+   * Reconfigures this instance with the given key-value pairs. The provided
+   * map contains all configs including any reconfigurable configs that
+   * may have changed since the object was initially configured using
+   * {@link Configurable# configure ( Map )}. This method will only be invoked if
+   * the configs have passed validation using {@link #validateReconfiguration ( Map )}.
+   */
+  override def reconfigure(configs: util.Map[String, _]): Unit = {
+    val newNumNetworkThreads = configs.get(KafkaConfig.NumNetworkThreadsProp).asInstanceOf[Int]
+
+    if (newNumNetworkThreads != processors.length) {
+      info(s"Resizing network thread pool size for ${endPoint.listenerName} listener from ${processors.length} to $newNumNetworkThreads")
+      if (newNumNetworkThreads > processors.length) {
+        addProcessors(newNumNetworkThreads - processors.length)
+      } else if (newNumNetworkThreads < processors.length) {
+        removeProcessors(processors.length - newNumNetworkThreads)
+      }
+    }
+  }
+
+  /**
+   * Configure this class with the given key-value pairs
+   */
+  override def configure(configs: util.Map[String, _]): Unit = {
+    addProcessors(configs.get(KafkaConfig.NumNetworkThreadsProp).asInstanceOf[Int])
+  }
+}
+
+object ControlPlaneAcceptor {
+  val ThreadPrefix = "control-plane"
+  val MetricPrefix = "ControlPlane"
+}
+
+class ControlPlaneAcceptor(socketServer: SocketServer,
+                           endPoint: EndPoint,
+                           config: KafkaConfig,
+                           nodeId: Int,
+                           connectionQuotas: ConnectionQuotas,
+                           time: Time,
+                           requestChannel: RequestChannel,
+                           metrics: Metrics,
+                           credentialProvider: CredentialProvider,
+                           logContext: LogContext,
+                           memoryPool: MemoryPool,
+                           apiVersionManager: ApiVersionManager)
+  extends Acceptor(socketServer,
+                   endPoint,
+                   config,
+                   nodeId,
+                   connectionQuotas,
+                   time,
+                   true,
+                   requestChannel,
+                   metrics,
+                   credentialProvider,
+                   logContext,
+                   memoryPool,
+                   apiVersionManager) {
+
+  override def metricPrefix(): String = ControlPlaneAcceptor.MetricPrefix
+  override def threadPrefix(): String = ControlPlaneAcceptor.ThreadPrefix
+
+  def processorOpt(): Option[Processor] = {
+    if (processors.isEmpty)
+      None
+    else
+      Some(processors.apply(0))
+  }
+}
+
 /**
  * Thread that accepts and configures new connections. There is one of these per endpoint.
  */
-private[kafka] class Acceptor(val endPoint: EndPoint,
-                              val sendBufferSize: Int,
-                              val recvBufferSize: Int,
-                              val listenBacklogSize: Int,
-                              nodeId: Int,
-                              connectionQuotas: ConnectionQuotas,
-                              metricPrefix: String,
-                              time: Time,
-                              logPrefix: String = "") extends AbstractServerThread(connectionQuotas) with KafkaMetricsGroup {
+private[kafka] abstract class Acceptor(val socketServer: SocketServer,
+                                       val endPoint: EndPoint,
+                                       var config: KafkaConfig,
+                                       nodeId: Int,
+                                       connectionQuotas: ConnectionQuotas,
+                                       time: Time,
+                                       isPrivilegedListener: Boolean,
+                                       requestChannel: RequestChannel,
+                                       metrics: Metrics,
+                                       credentialProvider: CredentialProvider,
+                                       logContext: LogContext,
+                                       memoryPool: MemoryPool,
+                                       apiVersionManager: ApiVersionManager)
+  extends AbstractServerThread(connectionQuotas) with KafkaMetricsGroup {
 
-  this.logIdent = logPrefix
+  def metricPrefix(): String
+  def threadPrefix(): String
+
+  private val sendBufferSize = config.socketSendBufferBytes
+  private val recvBufferSize = config.socketReceiveBufferBytes
+  private val listenBacklogSize = config.socketListenBacklogSize
+
   private val nioSelector = NSelector.open()
-  val serverChannel = openServerSocket(endPoint.host, endPoint.port, listenBacklogSize)
-  private val processors = new ArrayBuffer[Processor]()
+  private[network] val serverChannel = openServerSocket(endPoint.host, endPoint.port, listenBacklogSize)
+  private[network] val processors = new ArrayBuffer[Processor]()
   private val processorsStarted = new AtomicBoolean
-  private val blockedPercentMeter = newMeter(s"${metricPrefix}AcceptorBlockedPercent",
-    "blocked time", TimeUnit.NANOSECONDS, Map(ListenerMetricTag -> endPoint.listenerName.value))
+  // Build the metric name explicitly in order to keep the existing name for compatibility
+  private val blockedPercentMeterMetricName = explicitMetricName(
+    "kafka.network",
+    "Acceptor",
+    s"${metricPrefix()}AcceptorBlockedPercent",
+    Map(ListenerMetricTag -> endPoint.listenerName.value))
+  private val blockedPercentMeter = newMeter(blockedPercentMeterMetricName,"blocked time", TimeUnit.NANOSECONDS)
   private var currentProcessorIndex = 0
   private[network] val throttledSockets = new mutable.PriorityQueue[DelayedCloseSocket]()
 
@@ -571,28 +686,22 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
     override def compare(that: DelayedCloseSocket): Int = endThrottleTimeMs compare that.endThrottleTimeMs
   }
 
-  private[network] def addProcessors(newProcessors: Buffer[Processor], processorThreadPrefix: String): Unit = synchronized {
-    processors ++= newProcessors
-    if (processorsStarted.get)
-      startProcessors(newProcessors, processorThreadPrefix)
-  }
-
-  private[network] def startProcessors(processorThreadPrefix: String): Unit = synchronized {
+  private[network] def startProcessors(): Unit = synchronized {
     if (!processorsStarted.getAndSet(true)) {
-      startProcessors(processors, processorThreadPrefix)
+      startProcessors(processors)
     }
   }
 
-  private def startProcessors(processors: Seq[Processor], processorThreadPrefix: String): Unit = synchronized {
+  private def startProcessors(processors: Seq[Processor]): Unit = synchronized {
     processors.foreach { processor =>
       KafkaThread.nonDaemon(
-        s"${processorThreadPrefix}-kafka-network-thread-$nodeId-${endPoint.listenerName}-${endPoint.securityProtocol}-${processor.id}",
+        s"${threadPrefix()}-kafka-network-thread-$nodeId-${endPoint.listenerName}-${endPoint.securityProtocol}-${processor.id}",
         processor
       ).start()
     }
   }
 
-  private[network] def removeProcessors(removeCount: Int, requestChannel: RequestChannel): Unit = synchronized {
+  private[network] def removeProcessors(removeCount: Int): Unit = synchronized {
     // Shutdown `removeCount` processors. Remove them from the processor list first so that no more
     // connections are assigned. Shutdown the removed processors, closing the selector and its connections.
     // The processors are then removed from `requestChannel` and any pending responses to these processors are dropped.
@@ -776,6 +885,42 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
   @Override
   def wakeup(): Unit = nioSelector.wakeup()
 
+  def addProcessors(toCreate: Int): Unit = {
+    val listenerName = endPoint.listenerName
+    val securityProtocol = endPoint.securityProtocol
+    val listenerProcessors = new ArrayBuffer[Processor]()
+
+    for (_ <- 0 until toCreate) {
+      val processor = newProcessor(socketServer.nextProcessorId(), listenerName, securityProtocol)
+      listenerProcessors += processor
+      requestChannel.addProcessor(processor)
+    }
+
+    processors ++= listenerProcessors
+    if (processorsStarted.get)
+      startProcessors(listenerProcessors)
+  }
+
+  def newProcessor(id: Int, listenerName: ListenerName, securityProtocol: SecurityProtocol): Processor = {
+    new Processor(id,
+                  time,
+                  config.socketRequestMaxBytes,
+                  requestChannel,
+                  connectionQuotas,
+                  config.connectionsMaxIdleMs,
+                  config.failedAuthenticationDelayMs,
+                  listenerName,
+                  securityProtocol,
+                  config,
+                  metrics,
+                  credentialProvider,
+                  memoryPool,
+                  logContext,
+                  Processor.ConnectionQueueSize,
+                  isPrivilegedListener,
+                  apiVersionManager)
+  }
+
 }
 
 private[kafka] object Processor {
@@ -850,7 +995,7 @@ private[kafka] class Processor(val id: Int,
   private val expiredConnectionsKilledCountMetricName = metrics.metricName("expired-connections-killed-count", MetricsGroup, metricTags)
   metrics.addMetric(expiredConnectionsKilledCountMetricName, expiredConnectionsKilledCount)
 
-  private val selector = createSelector(
+  private[network] val selector = createSelector(
     ChannelBuilders.serverChannelBuilder(
       listenerName,
       listenerName == config.interBrokerListenerName,
@@ -1239,7 +1384,7 @@ private[kafka] class Processor(val id: Int,
     openOrClosingChannel(connectionId).foreach(c => c.handleChannelMuteEvent(event))
   }
 
-  private def tryUnmuteChannel(connectionId: String) = {
+  private def tryUnmuteChannel(connectionId: String): Unit = {
     openOrClosingChannel(connectionId).foreach(c => selector.unmute(c.id))
   }
 
@@ -1250,7 +1395,7 @@ private[kafka] class Processor(val id: Int,
   /**
    * Wakeup the thread for selection.
    */
-  override def wakeup() = selector.wakeup()
+  override def wakeup(): Unit = selector.wakeup()
 
   override def initiateShutdown(): Unit = {
     super.initiateShutdown()

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -28,7 +28,7 @@ import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.{ProducerIdManager, TransactionCoordinator}
 import kafka.log.LogManager
 import kafka.metrics.KafkaYammerMetrics
-import kafka.network.SocketServer
+import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.RaftManager
 import kafka.security.CredentialProvider
 import kafka.server.KafkaRaftServer.ControllerRole
@@ -401,8 +401,8 @@ class BrokerServer(
 
       dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.nodeId,
         socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
-        config.numIoThreads, s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent",
-        SocketServer.DataPlaneThreadPrefix)
+        config.numIoThreads, s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent",
+        DataPlaneAcceptor.ThreadPrefix)
 
       // Block until we've caught up with the latest metadata from the controller quorum.
       lifecycleManager.initialCatchUpFuture.get()

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.{CompletableFuture, TimeUnit}
 import kafka.cluster.Broker.ServerInfo
 import kafka.log.LogConfig
 import kafka.metrics.{KafkaMetricsGroup, KafkaYammerMetrics, LinuxIoMetricsCollector}
-import kafka.network.SocketServer
+import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.RaftManager
 import kafka.security.CredentialProvider
 import kafka.server.KafkaConfig.{AlterConfigPolicyClassNameProp, CreateTopicPolicyClassNameProp}
@@ -194,8 +194,8 @@ class ControllerServer(
         controllerApis,
         time,
         config.numIoThreads,
-        s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent",
-        SocketServer.DataPlaneThreadPrefix)
+        s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent",
+        DataPlaneAcceptor.ThreadPrefix)
       socketServer.startProcessingRequests(authorizerFutures)
     } catch {
       case e: Throwable =>

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1506,7 +1506,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   //  During dynamic update, we use the values from this config, these are only used in DynamicBrokerConfig
   private[server] def originalsFromThisConfig: util.Map[String, AnyRef] = super.originals
   private[server] def valuesFromThisConfig: util.Map[String, _] = super.values
-  private[server] def valuesFromThisConfigWithPrefixOverride(prefix: String): util.Map[String, AnyRef] =
+  def valuesFromThisConfigWithPrefixOverride(prefix: String): util.Map[String, AnyRef] =
     super.valuesWithPrefixOverride(prefix)
 
   /** ********* Zookeeper Configuration ***********/

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -30,7 +30,7 @@ import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.{ProducerIdManager, TransactionCoordinator}
 import kafka.log.LogManager
 import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}
-import kafka.network.{RequestChannel, SocketServer}
+import kafka.network.{ControlPlaneAcceptor, DataPlaneAcceptor, RequestChannel, SocketServer}
 import kafka.security.CredentialProvider
 import kafka.server.metadata.{ZkConfigRepository, ZkMetadataCache}
 import kafka.utils._
@@ -416,12 +416,12 @@ class KafkaServer(
         dataPlaneRequestProcessor = createKafkaApis(socketServer.dataPlaneRequestChannel)
 
         dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.brokerId, socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
-          config.numIoThreads, s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent", SocketServer.DataPlaneThreadPrefix)
+          config.numIoThreads, s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent", DataPlaneAcceptor.ThreadPrefix)
 
         socketServer.controlPlaneRequestChannelOpt.foreach { controlPlaneRequestChannel =>
           controlPlaneRequestProcessor = createKafkaApis(controlPlaneRequestChannel)
           controlPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.brokerId, socketServer.controlPlaneRequestChannelOpt.get, controlPlaneRequestProcessor, time,
-            1, s"${SocketServer.ControlPlaneMetricPrefix}RequestHandlerAvgIdlePercent", SocketServer.ControlPlaneThreadPrefix)
+            1, s"${ControlPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent", ControlPlaneAcceptor.ThreadPrefix)
         }
 
         Mx4jLoader.maybeLoad()

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -20,7 +20,7 @@ package kafka.tools
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.concurrent.{CompletableFuture, CountDownLatch, LinkedBlockingDeque, TimeUnit}
 import joptsimple.OptionException
-import kafka.network.SocketServer
+import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.{KafkaRaftManager, RaftManager}
 import kafka.security.CredentialProvider
 import kafka.server.{KafkaConfig, KafkaRequestHandlerPool, MetaProperties, SimpleApiVersionManager}
@@ -113,8 +113,8 @@ class TestRaftServer(
       requestHandler,
       time,
       config.numIoThreads,
-      s"${SocketServer.DataPlaneMetricPrefix}RequestHandlerAvgIdlePercent",
-      SocketServer.DataPlaneThreadPrefix
+      s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent",
+      DataPlaneAcceptor.ThreadPrefix
     )
 
     workloadGenerator.start()

--- a/core/src/test/scala/integration/kafka/network/DynamicNumNetworkThreadsTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicNumNetworkThreadsTest.scala
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package integration.kafka.network
+
+import kafka.server.{BaseRequestTest, Defaults, KafkaConfig}
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
+import org.apache.kafka.common.network.ListenerName
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
+
+import java.util.Properties
+import scala.jdk.CollectionConverters._
+
+class DynamicNumNetworkThreadsTest extends BaseRequestTest {
+
+  override def brokerCount = 1
+
+  val internal = "PLAINTEXT"
+  val external = "EXTERNAL"
+
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.put(KafkaConfig.ListenersProp, s"$internal://localhost:0, $external://localhost:0")
+    properties.put(KafkaConfig.ListenerSecurityProtocolMapProp, s"$internal:PLAINTEXT, $external:PLAINTEXT")
+    properties.put(s"listener.name.${internal.toLowerCase}.${KafkaConfig.NumNetworkThreadsProp}", "2")
+  }
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    super.setUp(testInfo)
+    TestUtils.createTopic(zkClient, "test", brokerCount, brokerCount, servers)
+    assertEquals(2, getNumNetworkThreads(internal))
+    assertEquals(Defaults.NumNetworkThreads, getNumNetworkThreads(external))
+  }
+
+  def getNumNetworkThreads(listener: String): Int = {
+    brokers.head.metrics.metrics().keySet().asScala
+      .filter(_.name() == "request-rate")
+      .count(listener == _.tags().get("listener"))
+  }
+
+  @Test
+  def testDynamicNumNetworkThreads(): Unit = {
+    // Increase the base network thread count
+    val newBaseNetworkThreadsCount = Defaults.NumNetworkThreads + 1
+    var props = new Properties
+    props.put(KafkaConfig.NumNetworkThreadsProp, newBaseNetworkThreadsCount.toString)
+    reconfigureServers(props, (KafkaConfig.NumNetworkThreadsProp, newBaseNetworkThreadsCount.toString))
+
+    // Only the external listener is changed
+    assertEquals(2, getNumNetworkThreads(internal))
+    assertEquals(newBaseNetworkThreadsCount, getNumNetworkThreads(external))
+
+    // Increase the network thread count for internal
+    val newInternalNetworkThreadsCount = 3
+    props = new Properties
+    props.put(s"listener.name.${internal.toLowerCase}.${KafkaConfig.NumNetworkThreadsProp}", newInternalNetworkThreadsCount.toString)
+    reconfigureServers(props, (s"listener.name.${internal.toLowerCase}.${KafkaConfig.NumNetworkThreadsProp}", newInternalNetworkThreadsCount.toString))
+
+    // The internal listener is changed
+    assertEquals(newInternalNetworkThreadsCount, getNumNetworkThreads(internal))
+    assertEquals(newBaseNetworkThreadsCount, getNumNetworkThreads(external))
+  }
+
+  private def reconfigureServers(newProps: Properties, aPropToVerify: (String, String)): Unit = {
+    val adminClient = createAdminClient()
+    TestUtils.incrementalAlterConfigs(servers, adminClient, newProps, perBrokerConfig = false).all.get()
+    waitForConfigOnServer(aPropToVerify._1, aPropToVerify._2)
+    adminClient.close()
+  }
+
+  private def createAdminClient(): Admin = {
+    val bootstrapServers = TestUtils.bootstrapServers(servers, new ListenerName(securityProtocol.name))
+    val config = new Properties()
+    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    config.put(AdminClientConfig.METADATA_MAX_AGE_CONFIG, "10")
+    val adminClient = Admin.create(config)
+    adminClient
+  }
+
+  private def waitForConfigOnServer(propName: String, propValue: String, maxWaitMs: Long = 10000): Unit = {
+    TestUtils.retry(maxWaitMs) {
+      assertEquals(propValue, servers.head.config.originals.get(propName))
+    }
+  }
+
+}

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -823,8 +823,12 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     val kafkaMetrics = servers.head.metrics.metrics().keySet.asScala
       .filter(_.tags.containsKey(Processor.NetworkProcessorMetricTag))
-      .groupBy(_.tags.get(Processor.NetworkProcessorMetricTag))
-    assertEquals(numProcessors, kafkaMetrics.size)
+      .groupBy(_.tags.get(Processor.ListenerMetricTag))
+
+    assertEquals(2, kafkaMetrics.size) // 2 listeners
+    // 2 threads per listener
+    assertEquals(2, kafkaMetrics.get("INTERNAL").get.groupBy(_.tags().get(Processor.NetworkProcessorMetricTag)).size)
+    assertEquals(2, kafkaMetrics.get("EXTERNAL").get.groupBy(_.tags().get(Processor.NetworkProcessorMetricTag)).size)
 
     KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala
       .filter(isProcessorMetric)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -32,7 +32,7 @@ import javax.net.ssl._
 import kafka.cluster.EndPoint
 import kafka.metrics.KafkaYammerMetrics
 import kafka.security.CredentialProvider
-import kafka.server.{KafkaConfig, SimpleApiVersionManager, ThrottleCallback, ThrottledChannel}
+import kafka.server.{ApiVersionManager, KafkaConfig, SimpleApiVersionManager, ThrottleCallback, ThrottledChannel}
 import kafka.utils.Implicits._
 import kafka.utils.TestUtils
 import org.apache.kafka.common.memory.MemoryPool
@@ -82,6 +82,11 @@ class SocketServerTest {
 
   private val kafkaLogger = org.apache.log4j.LogManager.getLogger("kafka")
   private var logLevelToRestore: Level = _
+  def endpoint: EndPoint = {
+    KafkaConfig.fromProps(props, doLog = false).dataPlaneListeners.head
+  }
+  def listener: String = endpoint.listenerName.value
+  @volatile var uncaughtExceptions = 0
 
   @BeforeEach
   def setUp(): Unit = {
@@ -286,6 +291,7 @@ class SocketServerTest {
 
   @Test
   def testStagedListenerStartup(): Unit = {
+    shutdownServerAndMetrics(server)
     val testProps = new Properties
     testProps ++= props
     testProps.put("listeners", "EXTERNAL://localhost:0,INTERNAL://localhost:0,CONTROLLER://localhost:0")
@@ -344,6 +350,7 @@ class SocketServerTest {
 
   @Test
   def testStagedListenerShutdownWhenConnectionQueueIsFull(): Unit = {
+    shutdownServerAndMetrics(server)
     val testProps = new Properties
     testProps ++= props
     testProps.put("listeners", "EXTERNAL://localhost:0,INTERNAL://localhost:0,CONTROLLER://localhost:0")
@@ -399,7 +406,7 @@ class SocketServerTest {
       outgoing.flush()
       receiveResponse(socket)
     } catch {
-      case _: IOException => // thats fine
+      case _: IOException => // that's fine
     }
   }
 
@@ -502,47 +509,29 @@ class SocketServerTest {
   @Test
   def testConnectionIdReuse(): Unit = {
     val idleTimeMs = 60000
-    val time = new MockTime()
     props.put(KafkaConfig.ConnectionsMaxIdleMsProp, idleTimeMs.toString)
     props ++= sslServerProps
-    val serverMetrics = new Metrics
-    @volatile var selector: TestableSelector = null
     val overrideConnectionId = "127.0.0.1:1-127.0.0.1:2-0"
-    val overrideServer = new SocketServer(
-      KafkaConfig.fromProps(props), serverMetrics, time, credentialProvider, apiVersionManager
-    ) {
-      override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean): Processor = {
-        new Processor(id, time, config.socketRequestMaxBytes, dataPlaneRequestChannel, connectionQuotas,
-          config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics,
-          credentialProvider, memoryPool, new LogContext(), Processor.ConnectionQueueSize, isPrivilegedListener, apiVersionManager) {
-          override protected[network] def connectionId(socket: Socket): String = overrideConnectionId
-          override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
-            val testableSelector = new TestableSelector(config, channelBuilder, time, metrics)
-            selector = testableSelector
-            testableSelector
-          }
-        }
-      }
-    }
+    val overrideServer = new TestableSocketServer(KafkaConfig.fromProps(props))
 
-    def openChannel: Option[KafkaChannel] = overrideServer.dataPlaneProcessor(0).channel(overrideConnectionId)
-    def openOrClosingChannel: Option[KafkaChannel] = overrideServer.dataPlaneProcessor(0).openOrClosingChannel(overrideConnectionId)
+    def openChannel: Option[KafkaChannel] = overrideServer.dataPlaneAcceptor(listener).get.processors(0).channel(overrideConnectionId)
+    def openOrClosingChannel: Option[KafkaChannel] = overrideServer.dataPlaneAcceptor(listener).get.processors(0).openOrClosingChannel(overrideConnectionId)
     def connectionCount = overrideServer.connectionCount(InetAddress.getByName("127.0.0.1"))
 
     // Create a client connection and wait for server to register the connection with the selector. For
     // test scenarios below where `Selector.register` fails, the wait ensures that checks are performed
     // only after `register` is processed by the server.
     def connectAndWaitForConnectionRegister(): Socket = {
-      val connections = selector.operationCounts(SelectorOperation.Register)
+      val connections = overrideServer.testableSelector.operationCounts(SelectorOperation.Register)
       val socket = sslConnect(overrideServer)
       TestUtils.waitUntilTrue(() =>
-        selector.operationCounts(SelectorOperation.Register) == connections + 1, "Connection not registered")
+        overrideServer.testableSelector.operationCounts(SelectorOperation.Register) == connections + 1, "Connection not registered")
       socket
     }
 
     try {
       overrideServer.startup()
+      overrideServer.testableProcessor.setConnectionId(overrideConnectionId)
       val socket1 = connectAndWaitForConnectionRegister()
       TestUtils.waitUntilTrue(() => connectionCount == 1 && openChannel.isDefined, "Failed to create channel")
       val channel1 = openChannel.getOrElse(throw new RuntimeException("Channel not found"))
@@ -556,7 +545,7 @@ class SocketServerTest {
       TestUtils.waitUntilTrue(() => openChannel.isEmpty, "Channel not closed")
 
       // Create a channel with buffered receive and close remote connection
-      val request = makeChannelWithBufferedRequestsAndCloseRemote(overrideServer, selector)
+      val request = makeChannelWithBufferedRequestsAndCloseRemote(overrideServer, overrideServer.testableSelector)
       val channel2 = openChannel.getOrElse(throw new RuntimeException("Channel not found"))
 
       // Create new connection with same id when `channel2` is closing, but still in Selector.channels
@@ -592,7 +581,7 @@ class SocketServerTest {
     val request1 = receiveRequest(server.dataPlaneRequestChannel)
 
     val connectionId = request1.context.connectionId
-    val channel = server.dataPlaneProcessor(0).channel(connectionId).getOrElse(throw new IllegalStateException("Channel not found"))
+    val channel = server.dataPlaneAcceptor(listener).get.processors(0).channel(connectionId).getOrElse(throw new IllegalStateException("Channel not found"))
     val transportLayer: SslTransportLayer = JTestUtils.fieldValue(channel, classOf[KafkaChannel], "transportLayer")
     val netReadBuffer: ByteBuffer = JTestUtils.fieldValue(transportLayer, classOf[SslTransportLayer], "netReadBuffer")
 
@@ -611,8 +600,8 @@ class SocketServerTest {
    * The channel should remain open in SocketServer even if it detects that the peer has closed
    * the connection since there is pending data to be processed.
    */
-  private def makeChannelWithBufferedRequestsAndCloseRemote(server: SocketServer,
-                                                            serverSelector: Selector,
+  private def makeChannelWithBufferedRequestsAndCloseRemote(server: TestableSocketServer,
+                                                            serverSelector: TestableSelector,
                                                             makeClosing: Boolean = false): RequestChannel.Request = {
 
     val proxyServer = new ProxyServer(server)
@@ -626,7 +615,7 @@ class SocketServerTest {
       processRequestNoOpResponse(server.dataPlaneRequestChannel, request1)
       val channel = openOrClosingChannel(request1, server).getOrElse(throw new IllegalStateException("Channel closed too early"))
       if (makeClosing)
-        serverSelector.asInstanceOf[TestableSelector].pendingClosingChannels.add(channel)
+        serverSelector.pendingClosingChannels.add(channel)
 
       receiveRequest(server.dataPlaneRequestChannel, timeout = 10000)
     } finally {
@@ -646,13 +635,13 @@ class SocketServerTest {
       try {
         Some(receiveRequest(server.dataPlaneRequestChannel, timeout = 1000))
       } catch {
-        case e: Exception => None
+        case _: Exception => None
       }
     }
 
     def closedChannelWithPendingRequest(): Option[RequestChannel.Request] = {
       val socket = createSocket.apply()
-      val req1 = sendRequestsReceiveOne(server, socket, producerRequestBytes(ack = 0), numRequests = 100)
+      val req1 = sendRequestsReceiveOne(server, socket, producerRequestBytes(), numRequests = 100)
       processRequestNoOpResponse(server.dataPlaneRequestChannel, req1)
       // Set SoLinger to 0 to force a hard disconnect via TCP RST
       socket.setSoLinger(true, 0)
@@ -693,7 +682,7 @@ class SocketServerTest {
         new RequestChannel.NoOpResponse(request)
     server.dataPlaneRequestChannel.sendResponse(response)
 
-    // Quota manager would call notifyThrottlingDone() on throttling completion. Simulate it if throttleingInProgress is
+    // Quota manager would call notifyThrottlingDone() on throttling completion. Simulate it if throttlingInProgress is
     // false.
     if (!throttlingInProgress)
       throttledChannel.notifyThrottlingDone()
@@ -702,23 +691,23 @@ class SocketServerTest {
   }
 
   def openChannel(request: RequestChannel.Request, server: SocketServer = this.server): Option[KafkaChannel] =
-    server.dataPlaneProcessor(0).channel(request.context.connectionId)
+    server.dataPlaneAcceptor(listener).get.processors(0).channel(request.context.connectionId)
 
   def openOrClosingChannel(request: RequestChannel.Request, server: SocketServer = this.server): Option[KafkaChannel] =
-    server.dataPlaneProcessor(0).openOrClosingChannel(request.context.connectionId)
+    server.dataPlaneAcceptor(listener).get.processors(0).openOrClosingChannel(request.context.connectionId)
 
   @Test
   def testSendActionResponseWithThrottledChannelWhereThrottlingInProgress(): Unit = {
     val socket = connect()
     val serializedBytes = producerRequestBytes()
     // SendAction with throttling in progress
-    val request = throttledChannelTestSetUp(socket, serializedBytes, false, true)
+    val request = throttledChannelTestSetUp(socket, serializedBytes, noOpResponse = false, throttlingInProgress = true)
 
     // receive response
     assertEquals(serializedBytes.toSeq, receiveResponse(socket).toSeq)
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.MUTED_AND_THROTTLED), "fail")
     // Channel should still be muted.
-    assertTrue(openOrClosingChannel(request).exists(c => c.isMuted()))
+    assertTrue(openOrClosingChannel(request).exists(c => c.isMuted))
   }
 
   @Test
@@ -726,14 +715,14 @@ class SocketServerTest {
     val socket = connect()
     val serializedBytes = producerRequestBytes()
     // SendAction with throttling in progress
-    val request = throttledChannelTestSetUp(socket, serializedBytes, false, false)
+    val request = throttledChannelTestSetUp(socket, serializedBytes, noOpResponse = false, throttlingInProgress = false)
 
     // receive response
     assertEquals(serializedBytes.toSeq, receiveResponse(socket).toSeq)
     // Since throttling is already done, the channel can be unmuted after sending out the response.
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.NOT_MUTED), "fail")
     // Channel is now unmuted.
-    assertFalse(openOrClosingChannel(request).exists(c => c.isMuted()))
+    assertFalse(openOrClosingChannel(request).exists(c => c.isMuted))
   }
 
   @Test
@@ -741,11 +730,11 @@ class SocketServerTest {
     val socket = connect()
     val serializedBytes = producerRequestBytes()
     // SendAction with throttling in progress
-    val request = throttledChannelTestSetUp(socket, serializedBytes, true, true)
+    val request = throttledChannelTestSetUp(socket, serializedBytes, noOpResponse = true, throttlingInProgress = true)
 
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.MUTED_AND_THROTTLED), "fail")
     // Channel should still be muted.
-    assertTrue(openOrClosingChannel(request).exists(c => c.isMuted()))
+    assertTrue(openOrClosingChannel(request).exists(c => c.isMuted))
   }
 
   @Test
@@ -753,12 +742,12 @@ class SocketServerTest {
     val socket = connect()
     val serializedBytes = producerRequestBytes()
     // SendAction with throttling in progress
-    val request = throttledChannelTestSetUp(socket, serializedBytes, true, false)
+    val request = throttledChannelTestSetUp(socket, serializedBytes, noOpResponse = true, throttlingInProgress = false)
 
     // Since throttling is already done, the channel can be unmuted.
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.NOT_MUTED), "fail")
     // Channel is now unmuted.
-    assertFalse(openOrClosingChannel(request).exists(c => c.isMuted()))
+    assertFalse(openOrClosingChannel(request).exists(c => c.isMuted))
   }
 
   @Test
@@ -870,19 +859,16 @@ class SocketServerTest {
 
   @Test
   def testExceptionInAcceptor(): Unit = {
-    val overrideProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
     val serverMetrics = new Metrics()
 
-    val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), serverMetrics,
+    val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics,
       Time.SYSTEM, credentialProvider, apiVersionManager) {
 
       // same as SocketServer.createAcceptor,
       // except the Acceptor overriding a method to inject the exception
-      override protected def createAcceptor(endPoint: EndPoint, metricPrefix: String): Acceptor = {
-        val sendBufferSize = config.socketSendBufferBytes
-        val recvBufferSize = config.socketReceiveBufferBytes
-        val listenBacklogSize = config.socketListenBacklogSize
-        new Acceptor(endPoint, sendBufferSize, recvBufferSize, listenBacklogSize, nodeId, connectionQuotas, metricPrefix, time) {
+      override protected def createDataPlaneAcceptor(endPoint: EndPoint, isPrivilegedListener: Boolean, requestChannel: RequestChannel): DataPlaneAcceptor = {
+
+        new DataPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, false, requestChannel, serverMetrics, credentialProvider, new LogContext(), MemoryPool.NONE, apiVersionManager) {
           override protected def configureAcceptedSocketChannel(socketChannel: SocketChannel): Unit = {
             assertEquals(1, connectionQuotas.get(socketChannel.socket.getInetAddress))
             throw new IOException("test injected IOException")
@@ -1032,18 +1018,17 @@ class SocketServerTest {
     val username = "admin"
     val password = "admin-secret"
     val reauthMs = 1500
-    val brokerProps = new Properties
-    brokerProps.setProperty("listeners", "SASL_PLAINTEXT://localhost:0")
-    brokerProps.setProperty("security.inter.broker.protocol", "SASL_PLAINTEXT")
-    brokerProps.setProperty("listener.name.sasl_plaintext.plain.sasl.jaas.config",
+    props.setProperty("listeners", "SASL_PLAINTEXT://localhost:0")
+    props.setProperty("security.inter.broker.protocol", "SASL_PLAINTEXT")
+    props.setProperty("listener.name.sasl_plaintext.plain.sasl.jaas.config",
       "org.apache.kafka.common.security.plain.PlainLoginModule required " +
         "username=\"%s\" password=\"%s\" user_%s=\"%s\";".format(username, password, username, password))
-    brokerProps.setProperty("sasl.mechanism.inter.broker.protocol", "PLAIN")
-    brokerProps.setProperty("listener.name.sasl_plaintext.sasl.enabled.mechanisms", "PLAIN")
-    brokerProps.setProperty("num.network.threads", "1")
-    brokerProps.setProperty("connections.max.reauth.ms", reauthMs.toString)
+    props.setProperty("sasl.mechanism.inter.broker.protocol", "PLAIN")
+    props.setProperty("listener.name.sasl_plaintext.sasl.enabled.mechanisms", "PLAIN")
+    props.setProperty("num.network.threads", "1")
+    props.setProperty("connections.max.reauth.ms", reauthMs.toString)
     val overrideProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect,
-      saslProperties = Some(brokerProps), enableSaslPlaintext = true)
+      saslProperties = Some(props), enableSaslPlaintext = true)
     val time = new MockTime()
     val overrideServer = new TestableSocketServer(KafkaConfig.fromProps(overrideProps), time = time)
     try {
@@ -1093,7 +1078,7 @@ class SocketServerTest {
       // wait a little bit for the server-side disconnection to occur since it happens asynchronously
       try {
         TestUtils.waitUntilTrue(() => overrideServer.testableSelector.channels.isEmpty,
-          "Expired connection was not closed", 1000, 100)
+          "Expired connection was not closed", 1000)
       } finally {
         socket.close()
       }
@@ -1113,6 +1098,7 @@ class SocketServerTest {
   /* Test that we update request metrics if the client closes the connection while the broker response is in flight. */
   @Test
   def testClientDisconnectionUpdatesRequestMetrics(): Unit = {
+    shutdownServerAndMetrics(server)
     // The way we detect a connection close from the client depends on the response size. If it's small, an
     // IOException ("Connection reset by peer") is thrown when the Selector reads from the socket. If
     // it's large, an IOException ("Broken pipe") is thrown when the Selector writes to the socket. We test
@@ -1123,26 +1109,12 @@ class SocketServerTest {
 
   private def checkClientDisconnectionUpdatesRequestMetrics(responseBufferSize: Int): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
-    val serverMetrics = new Metrics
-    var conn: Socket = null
-    val overrideServer = new SocketServer(
-      KafkaConfig.fromProps(props), serverMetrics, Time.SYSTEM, credentialProvider, apiVersionManager
-    ) {
-      override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false): Processor = {
-        new Processor(id, time, config.socketRequestMaxBytes, dataPlaneRequestChannel, connectionQuotas,
-          config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics,
-          credentialProvider, MemoryPool.NONE, new LogContext(), Processor.ConnectionQueueSize, isPrivilegedListener, apiVersionManager) {
-          override protected[network] def sendResponse(response: RequestChannel.Response, responseSend: Send): Unit = {
-            conn.close()
-            super.sendResponse(response, responseSend)
-          }
-        }
-      }
-    }
+    val overrideServer = new TestableSocketServer(KafkaConfig.fromProps(props))
+
     try {
       overrideServer.startup()
-      conn = connect(overrideServer)
+      val conn: Socket = connect(overrideServer)
+      overrideServer.testableProcessor.closeSocketOnSendResponse(conn)
       val serializedBytes = producerRequestBytes()
       sendRequest(conn, serializedBytes)
 
@@ -1167,27 +1139,13 @@ class SocketServerTest {
 
   @Test
   def testClientDisconnectionWithOutstandingReceivesProcessedUntilFailedSend(): Unit = {
+    shutdownServerAndMetrics(server)
     val serverMetrics = new Metrics
-    @volatile var selector: TestableSelector = null
-    val overrideServer = new SocketServer(
-      KafkaConfig.fromProps(props), serverMetrics, Time.SYSTEM, credentialProvider, apiVersionManager
-    ) {
-      override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean): Processor = {
-        new Processor(id, time, config.socketRequestMaxBytes, dataPlaneRequestChannel, connectionQuotas,
-          config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics,
-          credentialProvider, memoryPool, new LogContext(), Processor.ConnectionQueueSize, isPrivilegedListener, apiVersionManager) {
-          override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
-            val testableSelector = new TestableSelector(config, channelBuilder, time, metrics)
-            selector = testableSelector
-            testableSelector
-          }
-        }
-      }
-    }
+    val overrideServer = new TestableSocketServer(KafkaConfig.fromProps(props))
 
     try {
       overrideServer.startup()
+      val selector = overrideServer.testableSelector
 
       // Create a channel, send some requests and close socket. Receive one pending request after socket was closed.
       val request = closeSocketWithPendingRequest(overrideServer, () => connect(overrideServer))
@@ -1208,7 +1166,6 @@ class SocketServerTest {
    */
   @Test
   def testBrokerSendAfterChannelClosedUpdatesRequestMetrics(): Unit = {
-    val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
     props.setProperty(KafkaConfig.ConnectionsMaxIdleMsProp, "110")
     val serverMetrics = new Metrics
     var conn: Socket = null
@@ -1222,7 +1179,7 @@ class SocketServerTest {
       val channel = overrideServer.dataPlaneRequestChannel
       val request = receiveRequest(channel)
 
-      TestUtils.waitUntilTrue(() => overrideServer.dataPlaneProcessor(request.processor).channel(request.context.connectionId).isEmpty,
+      TestUtils.waitUntilTrue(() => overrideServer.dataPlaneAcceptor(listener).get.processors(request.processor).channel(request.context.connectionId).isEmpty,
         s"Idle connection `${request.context.connectionId}` was not closed by selector")
 
       val requestMetrics = channel.metrics(request.header.apiKey.name)
@@ -1264,7 +1221,7 @@ class SocketServerTest {
 
   @Test
   def testMetricCollectionAfterShutdown(): Unit = {
-    server.shutdown()
+    shutdownServerAndMetrics(server)
 
     val nonZeroMetricNamesAndValues = KafkaYammerMetrics
       .defaultRegistry
@@ -1278,7 +1235,7 @@ class SocketServerTest {
 
   @Test
   def testProcessorMetricsTags(): Unit = {
-    val kafkaMetricNames = metrics.metrics.keySet.asScala.filter(_.tags.asScala.get("listener").nonEmpty)
+    val kafkaMetricNames = metrics.metrics.keySet.asScala.filter(_.tags.asScala.contains("listener"))
     assertFalse(kafkaMetricNames.isEmpty)
 
     val expectedListeners = Set("PLAINTEXT")
@@ -1309,6 +1266,7 @@ class SocketServerTest {
    */
   @Test
   def configureNewConnectionException(): Unit = {
+    shutdownServerAndMetrics(server)
     withTestableServer (testWithServer = { testableServer =>
       val testableSelector = testableServer.testableSelector
 
@@ -1334,6 +1292,7 @@ class SocketServerTest {
    */
   @Test
   def processNewResponseException(): Unit = {
+    shutdownServerAndMetrics(server)
     withTestableServer (testWithServer = { testableServer =>
       val testableSelector = testableServer.testableSelector
       testableSelector.updateMinWakeup(2)
@@ -1477,7 +1436,7 @@ class SocketServerTest {
    */
   @Test
   def closingChannelWithCompleteAndIncompleteBufferedReceives(): Unit = {
-    verifyRemoteCloseWithBufferedReceives(numComplete = 3, hasIncomplete = true, makeClosing = false)
+    verifyRemoteCloseWithBufferedReceives(numComplete = 3, hasIncomplete = true)
   }
 
   /**
@@ -1486,7 +1445,7 @@ class SocketServerTest {
    */
   @Test
   def closingChannelWithBufferedReceivesFailedSend(): Unit = {
-    verifyRemoteCloseWithBufferedReceives(numComplete = 3, hasIncomplete = false, responseRequiredIndex = 1, makeClosing = false)
+    verifyRemoteCloseWithBufferedReceives(numComplete = 3, hasIncomplete = false, responseRequiredIndex = 1)
   }
 
   /**
@@ -1504,6 +1463,7 @@ class SocketServerTest {
                                                     hasIncomplete: Boolean,
                                                     responseRequiredIndex: Int = -1,
                                                     makeClosing: Boolean = false): Unit = {
+    shutdownServerAndMetrics(server)
     props ++= sslServerProps
 
     // Truncates the last request in the SSL buffers by directly updating the buffers to simulate partial buffered request
@@ -1583,6 +1543,7 @@ class SocketServerTest {
    */
   @Test
   def idleExpiryWithBufferedReceives(): Unit = {
+    shutdownServerAndMetrics(server)
     val idleTimeMs = 60000
     val time = new MockTime()
     props.put(KafkaConfig.ConnectionsMaxIdleMsProp, idleTimeMs.toString)
@@ -1599,7 +1560,7 @@ class SocketServerTest {
 
       val sleepTimeMs = idleTimeMs / 2 + 1
       val (socket, request) = makeSocketWithBufferedRequests(testableServer, testableSelector, proxyServer)
-      // advance mock time in increments to verify that muted sockets with buffered data dont have their idle time updated
+      // advance mock time in increments to verify that muted sockets with buffered data don't have their idle time updated
       // additional calls to poll() should not update the channel last idle time
       for (_ <- 0 to 3) {
         time.sleep(sleepTimeMs)
@@ -1620,6 +1581,7 @@ class SocketServerTest {
 
   @Test
   def testUnmuteChannelWithBufferedReceives(): Unit = {
+    shutdownServerAndMetrics(server)
     val time = new MockTime()
     props ++= sslServerProps
     val testableServer = new TestableSocketServer(time = time)
@@ -1682,6 +1644,7 @@ class SocketServerTest {
    */
   @Test
   def processCompletedSendException(): Unit = {
+    shutdownServerAndMetrics(server)
     withTestableServer (testWithServer = { testableServer =>
       val testableSelector = testableServer.testableSelector
       val sockets = (1 to 2).map(_ => connect(testableServer))
@@ -1728,6 +1691,7 @@ class SocketServerTest {
    */
   @Test
   def pollException(): Unit = {
+    shutdownServerAndMetrics(server)
     withTestableServer (testWithServer = { testableServer =>
       val (socket, _) = connectAndProcessRequest(testableServer)
       val testableSelector = testableServer.testableSelector
@@ -1745,6 +1709,7 @@ class SocketServerTest {
    */
   @Test
   def controlThrowable(): Unit = {
+    shutdownServerAndMetrics(server)
     withTestableServer (testWithServer = { testableServer =>
       connectAndProcessRequest(testableServer)
       val testableSelector = testableServer.testableSelector
@@ -1755,8 +1720,8 @@ class SocketServerTest {
       testableSelector.waitForOperations(SelectorOperation.Poll, 1)
 
       testableSelector.waitForOperations(SelectorOperation.CloseSelector, 1)
-      assertEquals(1, testableServer.uncaughtExceptions)
-      testableServer.uncaughtExceptions = 0
+      assertEquals(1, uncaughtExceptions)
+      uncaughtExceptions = 0
     })
   }
 
@@ -1916,13 +1881,14 @@ class SocketServerTest {
   private def withTestableServer(config : KafkaConfig = KafkaConfig.fromProps(props),
                                  testWithServer: TestableSocketServer => Unit,
                                  startProcessingRequests: Boolean = true): Unit = {
+    shutdownServerAndMetrics(server)
     val testableServer = new TestableSocketServer(config)
     testableServer.startup(startProcessingRequests = startProcessingRequests)
     try {
       testWithServer(testableServer)
     } finally {
       shutdownServerAndMetrics(testableServer)
-      assertEquals(0, testableServer.uncaughtExceptions)
+      assertEquals(0, uncaughtExceptions)
     }
   }
 
@@ -1958,7 +1924,7 @@ class SocketServerTest {
     connectionId.contains(s":${socket.getLocalPort}-")
 
   private def verifyAcceptorBlockedPercent(listenerName: String, expectBlocked: Boolean): Unit = {
-    val blockedPercentMetricMBeanName = "kafka.network:type=Acceptor,name=AcceptorBlockedPercent,listener=PLAINTEXT"
+    val blockedPercentMetricMBeanName = s"kafka.network:type=Acceptor,name=AcceptorBlockedPercent,listener=$listenerName"
     val blockedPercentMetrics = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.filter { case (k, _) =>
       k.getMBeanName == blockedPercentMetricMBeanName
     }.values
@@ -1973,6 +1939,87 @@ class SocketServerTest {
     }
   }
 
+  class TestableAcceptor(socketServer: SocketServer,
+                         endPoint: EndPoint,
+                         cfg: KafkaConfig,
+                         nodeId: Int,
+                         connectionQuotas: ConnectionQuotas,
+                         time: Time,
+                         isPrivilegedListener: Boolean,
+                         requestChannel: RequestChannel,
+                         metrics: Metrics,
+                         credentialProvider: CredentialProvider,
+                         logContext: LogContext,
+                         memoryPool: MemoryPool,
+                         apiVersionManager: ApiVersionManager,
+                         connectionQueueSize: Int) extends DataPlaneAcceptor(socketServer,
+                                                                             endPoint,
+                                                                             cfg,
+                                                                             nodeId,
+                                                                             connectionQuotas,
+                                                                             time,
+                                                                             isPrivilegedListener,
+                                                                             requestChannel,
+                                                                             metrics,
+                                                                             credentialProvider,
+                                                                             logContext,
+                                                                             memoryPool,
+                                                                             apiVersionManager) {
+
+    override def newProcessor(id: Int, listenerName: ListenerName, securityProtocol: SecurityProtocol): Processor = {
+      new TestableProcessor(id, time, requestChannel, listenerName, securityProtocol, cfg, connectionQuotas, connectionQueueSize, isPrivilegedListener)
+    }
+  }
+
+  class TestableProcessor(id: Int, time: Time, requestChannel: RequestChannel, listenerName: ListenerName, securityProtocol: SecurityProtocol, config: KafkaConfig, connectionQuotas: ConnectionQuotas, connectionQueueSize: Int, isPrivilegedListener: Boolean)
+  extends Processor(id,
+                    time,
+                    10000,
+                    requestChannel,
+                    connectionQuotas,
+                    300000L,
+                    0,
+                    listenerName,
+                    securityProtocol,
+                    config,
+                    new Metrics(),
+                    credentialProvider,
+                    MemoryPool.NONE,
+                    new LogContext(),
+                    connectionQueueSize,
+                    isPrivilegedListener,
+                    apiVersionManager) {
+    private var connectionId: Option[String] = None
+    private var conn: Option[Socket] = None
+
+    override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
+      new TestableSelector(config, channelBuilder, time, metrics, metricTags.asScala)
+    }
+
+    override private[network] def processException(errorMessage: String, throwable: Throwable): Unit = {
+      if (errorMessage.contains("uncaught exception"))
+        uncaughtExceptions += 1
+      super.processException(errorMessage, throwable)
+    }
+
+    def setConnectionId(connectionId: String): Unit = {
+      this.connectionId = Some(connectionId)
+    }
+
+    override protected[network] def connectionId(socket: Socket): String = {
+      this.connectionId.getOrElse(super.connectionId(socket))
+    }
+
+    def closeSocketOnSendResponse(conn: Socket): Unit = {
+      this.conn = Some(conn)
+    }
+
+    override protected[network] def sendResponse(response: RequestChannel.Response, responseSend: Send): Unit = {
+      this.conn.foreach(_.close())
+      super.sendResponse(response, responseSend)
+    }
+  }
+
   class TestableSocketServer(
     config : KafkaConfig = KafkaConfig.fromProps(props),
     connectionQueueSize: Int = 20,
@@ -1981,31 +2028,15 @@ class SocketServerTest {
     config, new Metrics, time, credentialProvider, apiVersionManager,
   ) {
 
-    @volatile var selector: Option[TestableSelector] = None
-    @volatile var uncaughtExceptions = 0
-
-    override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                              protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false): Processor = {
-      new Processor(id, time, config.socketRequestMaxBytes, requestChannel, connectionQuotas, config.connectionsMaxIdleMs,
-        config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics, credentialProvider,
-        memoryPool, new LogContext(), connectionQueueSize, isPrivilegedListener, apiVersionManager) {
-
-        override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
-          val testableSelector = new TestableSelector(config, channelBuilder, time, metrics, metricTags.asScala)
-          selector = Some(testableSelector)
-          testableSelector
-        }
-
-        override private[network] def processException(errorMessage: String, throwable: Throwable): Unit = {
-          if (errorMessage.contains("uncaught exception"))
-            uncaughtExceptions += 1
-          super.processException(errorMessage, throwable)
-        }
-      }
+    override def createDataPlaneAcceptor(endPoint: EndPoint, isPrivilegedListener: Boolean, requestChannel: RequestChannel) : DataPlaneAcceptor = {
+      new TestableAcceptor(this, endPoint, config, 0, connectionQuotas, time, isPrivilegedListener, requestChannel, metrics, credentialProvider, new LogContext, MemoryPool.NONE, apiVersionManager, connectionQueueSize)
     }
 
     def testableSelector: TestableSelector =
-      selector.getOrElse(throw new IllegalStateException("Selector not created"))
+      dataPlaneAcceptors.get(endpoint).processors(0).selector.asInstanceOf[TestableSelector]
+
+    def testableProcessor: TestableProcessor =
+      dataPlaneAcceptors.get(endpoint).processors(0).asInstanceOf[TestableProcessor]
 
     def waitForChannelClose(connectionId: String, locallyClosed: Boolean): Unit = {
       val selector = testableSelector
@@ -2021,7 +2052,7 @@ class SocketServerTest {
       val openCount = selector.allChannels.size - 1 // minus one for the channel just closed above
       TestUtils.waitUntilTrue(() => connectionCount(localAddress) == openCount, "Connection count not decremented")
       TestUtils.waitUntilTrue(() =>
-        dataPlaneProcessor(0).inflightResponseCount == 0, "Inflight responses not cleared")
+        dataPlaneAcceptor(listener).get.processors(0).inflightResponseCount == 0, "Inflight responses not cleared")
       assertNull(selector.channel(connectionId), "Channel not removed")
       assertNull(selector.closingChannel(connectionId), "Closing channel not removed")
     }


### PR DESCRIPTION
Implements [KIP-788](https://cwiki.apache.org/confluence/display/KAFKA/KIP-788%3A+Allow+configuring+num.network.threads+per+listener). The number of network threads can be set per listener using the following syntax:
`listener.name.<listener>.num.network.threads=<num>`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
