### PR TITLE
KAFKA-12648: extend IQ APIs to work with named topologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -373,7 +373,7 @@ public class KafkaStreams implements AutoCloseable {
         }
     }
 
-    private void validateIsRunningOrRebalancing() {
+    protected void validateIsRunningOrRebalancing() {
         synchronized (stateLock) {
             if (state.hasNotStarted()) {
                 throw new StreamsNotStartedException("KafkaStreams has not been started, you can retry after calling start()");

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -164,7 +164,7 @@ public class KafkaStreams implements AutoCloseable {
     protected final StreamsConfig applicationConfigs;
     protected final List<StreamThread> threads;
     protected final StateDirectory stateDirectory;
-    private final StreamsMetadataState streamsMetadataState;
+    protected final StreamsMetadataState streamsMetadataState;
     private final ScheduledExecutorService stateDirCleaner;
     private final ScheduledExecutorService rocksDBMetricsRecordingService;
     protected final Admin adminClient;

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParameters.java
@@ -30,7 +30,7 @@ public class StoreQueryParameters<T> {
     private final String storeName;
     private final QueryableStoreType<T> queryableStoreType;
 
-    private StoreQueryParameters(final String storeName, final QueryableStoreType<T>  queryableStoreType, final Integer partition, final boolean staleStores) {
+    protected StoreQueryParameters(final String storeName, final QueryableStoreType<T>  queryableStoreType, final Integer partition, final boolean staleStores) {
         this.storeName = storeName;
         this.queryableStoreType = queryableStoreType;
         this.partition = partition;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -149,7 +149,7 @@ public class StreamsMetadataState {
         final ArrayList<StreamsMetadata> results = new ArrayList<>();
         for (final StreamsMetadata metadata : allMetadata) {
             if (metadata instanceof NamedTopologyStreamsMetadataImpl
-                && ((NamedTopologyStreamsMetadataImpl) metadata).getNamedTopologyToStoreNames().get(topologyName).contains(storeName)) {
+                && ((NamedTopologyStreamsMetadataImpl) metadata).namedTopologyToStoreNames().get(topologyName).contains(storeName)) {
                 results.add(metadata);
             }
         }
@@ -418,7 +418,7 @@ public class StreamsMetadataState {
         final Set<HostInfo> standbyHosts = new HashSet<>();
         for (final StreamsMetadata streamsMetadata : allMetadata) {
             if (streamsMetadata instanceof NamedTopologyStreamsMetadataImpl
-                && ((NamedTopologyStreamsMetadataImpl) streamsMetadata).getNamedTopologyToStoreNames().get(topologyName).contains(storeName)) {
+                && ((NamedTopologyStreamsMetadataImpl) streamsMetadata).namedTopologyToStoreNames().get(topologyName).contains(storeName)) {
                 final Set<String> activeStateStoreNames = streamsMetadata.stateStoreNames();
                 final Set<TopicPartition> topicPartitions = new HashSet<>(streamsMetadata.topicPartitions());
                 final Set<String> standbyStateStoreNames = streamsMetadata.standbyStateStoreNames();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1298,7 +1298,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         );
 
         final Cluster fakeCluster = Cluster.empty().withPartitions(topicToPartitionInfo);
-//        streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, fakeCluster);
+        streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, fakeCluster);
 
         // we do not capture any exceptions but just let the exception thrown from consumer.poll directly
         // since when stream thread captures it, either we close all tasks as dirty or we close thread

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1298,7 +1298,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         );
 
         final Cluster fakeCluster = Cluster.empty().withPartitions(topicToPartitionInfo);
-        streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, fakeCluster);
+//        streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, fakeCluster);
 
         // we do not capture any exceptions but just let the exception thrown from consumer.poll directly
         // since when stream thread captures it, either we close all tasks as dirty or we close thread

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -20,10 +20,12 @@ import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
@@ -300,8 +302,21 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
     /**
      * See {@link KafkaStreams#streamsMetadataForStore(String)}
      */
-    public Collection<StreamsMetadata> streamsMetadataForStore(final String storeName, final String topologyName) {
+    public Collection<StreamsMetadata> streamsMetadataForStore(final String storeName, final String topologyName) { // verify that it returns something
         verifyTopologyStateStore(topologyName, storeName);
+        validateIsRunningOrRebalancing();
         return streamsMetadataState.getAllMetadataForStore(storeName, topologyName);
+    }
+
+    /**
+     * See {@link KafkaStreams#queryMetadataForKey(String, Object, Serializer)}
+     */
+    public <K> KeyQueryMetadata queryMetadataForKey(final String storeName,
+                                                    final K key,
+                                                    final Serializer<K> keySerializer,
+                                                    final String topologyName) {
+        verifyTopologyStateStore(topologyName, storeName);
+        validateIsRunningOrRebalancing();
+        return streamsMetadataState.getKeyQueryMetadataForKey(storeName, key, keySerializer, topologyName);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -24,10 +24,12 @@ import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TaskMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.errors.UnknownStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
@@ -267,5 +269,26 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
 
     public String getFullTopologyDescription() {
         return topologyMetadata.topologyDescriptionString();
+    }
+
+    /**
+     * See {@link KafkaStreams#store(StoreQueryParameters)}
+     */
+    public <T> T store(final NamedTopologyStoreQueryParameters<T> storeQueryParameters) {
+        final String topologyName = storeQueryParameters.topologyName;
+        final String storeName = storeQueryParameters.storeName();
+        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForNamedTopology(topologyName);
+        if (builder == null) {
+            throw new UnknownStateStoreException(
+                "Cannot get state store " + storeName + " from NamedTopology " + topologyName +
+                    " because no such topology exists."
+            );
+        } else if (!builder.hasStore(storeName)) {
+            throw new UnknownStateStoreException(
+                "Cannot get state store " + storeName + " from NamedTopology " + topologyName +
+                    " because no such state store exists in this topology."
+            );
+        }
+        return super.store(storeQueryParameters);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -307,7 +307,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
     /**
      * See {@link KafkaStreams#streamsMetadataForStore(String)}
      */
-    public Collection<StreamsMetadata> streamsMetadataForStore(final String storeName, final String topologyName) { // verify that it returns something
+    public Collection<StreamsMetadata> streamsMetadataForStore(final String storeName, final String topologyName) {
         verifyTopologyStateStore(topologyName, storeName);
         validateIsRunningOrRebalancing();
         return streamsMetadataState.getAllMetadataForStore(storeName, topologyName);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.namedtopology;
+
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.state.QueryableStoreType;
+
+import java.util.Objects;
+
+public class NamedTopologyStoreQueryParameters<T> extends StoreQueryParameters<T> {
+
+    final String topologyName;
+
+    private NamedTopologyStoreQueryParameters(final String topologyName,
+                                              final String storeName,
+                                              final QueryableStoreType<T>  queryableStoreType,
+                                              final Integer partition,
+                                              final boolean staleStores) {
+        super(storeName, queryableStoreType, partition, staleStores);
+        this.topologyName = topologyName;
+    }
+
+    public static <T> NamedTopologyStoreQueryParameters<T> fromNamedTopologyAndStoreNameAndType(final String topologyName,
+                                                                                   final String storeName,
+                                                                                   final QueryableStoreType<T> queryableStoreType) {
+        return new NamedTopologyStoreQueryParameters<>(topologyName, storeName, queryableStoreType, null, false);
+    }
+
+    public String topologyName() {
+        return topologyName;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final NamedTopologyStoreQueryParameters<?> that = (NamedTopologyStoreQueryParameters<?>) o;
+
+        return Objects.equals(topologyName, that.topologyName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (topologyName != null ? topologyName.hashCode() : 0);
+        return result;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStoreQueryParameters.java
@@ -40,6 +40,10 @@ public class NamedTopologyStoreQueryParameters<T> extends StoreQueryParameters<T
         return new NamedTopologyStoreQueryParameters<>(topologyName, storeName, queryableStoreType, null, false);
     }
 
+    public NamedTopologyStoreQueryParameters<T> enableStaleStores() {
+        return new NamedTopologyStoreQueryParameters<>(topologyName, this.storeName(), this.queryableStoreType(), this.partition(), true);
+    }
+
     public String topologyName() {
         return topologyName;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals.namedtopology;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.state.HostInfo;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.streams.processor.internals.namedtopology;
 
 import java.util.Collection;
@@ -8,20 +24,24 @@ import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 public class NamedTopologyStreamsMetadataImpl extends StreamsMetadataImpl {
-  private final Map<String, Collection<String>> namedTopologyToStoreNames;
+    private final Map<String, Collection<String>> namedTopologyToStoreNames;
 
-  public NamedTopologyStreamsMetadataImpl(final HostInfo hostInfo,
-      final Set<String> stateStoreNames,
-      final Set<TopicPartition> topicPartitions,
-      final Set<String> standbyStateStoreNames,
-      final Set<TopicPartition> standbyTopicPartitions,
-      final Map<String, Collection<String>> namedTopologyToStoreNames) {
-    super(hostInfo, stateStoreNames, topicPartitions, standbyStateStoreNames,
-        standbyTopicPartitions);
-    this.namedTopologyToStoreNames = namedTopologyToStoreNames;
-  }
+    public NamedTopologyStreamsMetadataImpl(final HostInfo hostInfo,
+        final Set<String> stateStoreNames,
+        final Set<TopicPartition> topicPartitions,
+        final Set<String> standbyStateStoreNames,
+        final Set<TopicPartition> standbyTopicPartitions,
+        final Map<String, Collection<String>> namedTopologyToStoreNames
+    ) {
+        super(hostInfo,
+            stateStoreNames,
+            topicPartitions,
+            standbyStateStoreNames,
+            standbyTopicPartitions);
+        this.namedTopologyToStoreNames = namedTopologyToStoreNames;
+    }
 
-  public Map<String, Collection<String>> getNamedTopologyToStoreNames() {
-    return namedTopologyToStoreNames;
-  }
+    public Map<String, Collection<String>> getNamedTopologyToStoreNames() {
+        return namedTopologyToStoreNames;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
@@ -1,0 +1,27 @@
+package org.apache.kafka.streams.processor.internals.namedtopology;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
+
+public class NamedTopologyStreamsMetadataImpl extends StreamsMetadataImpl {
+  private final Map<String, Collection<String>> namedTopologyToStoreNames;
+
+  public NamedTopologyStreamsMetadataImpl(final HostInfo hostInfo,
+      final Set<String> stateStoreNames,
+      final Set<TopicPartition> topicPartitions,
+      final Set<String> standbyStateStoreNames,
+      final Set<TopicPartition> standbyTopicPartitions,
+      final Map<String, Collection<String>> namedTopologyToStoreNames) {
+    super(hostInfo, stateStoreNames, topicPartitions, standbyStateStoreNames,
+        standbyTopicPartitions);
+    this.namedTopologyToStoreNames = namedTopologyToStoreNames;
+  }
+
+  public Map<String, Collection<String>> getNamedTopologyToStoreNames() {
+    return namedTopologyToStoreNames;
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyStreamsMetadataImpl.java
@@ -41,7 +41,31 @@ public class NamedTopologyStreamsMetadataImpl extends StreamsMetadataImpl {
         this.namedTopologyToStoreNames = namedTopologyToStoreNames;
     }
 
-    public Map<String, Collection<String>> getNamedTopologyToStoreNames() {
+    public Map<String, Collection<String>> namedTopologyToStoreNames() {
         return namedTopologyToStoreNames;
+    }
+    
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final NamedTopologyStreamsMetadataImpl that = (NamedTopologyStreamsMetadataImpl) o;
+
+        return Objects.equals(namedTopologyToStoreNames, that.namedTopologyToStoreNames);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (namedTopologyToStoreNames() != null ? namedTopologyToStoreNames().hashCode() : 0);
+        return result;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStoreQueryParameters;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
@@ -42,12 +43,17 @@ public class StreamThreadStateStoreProvider {
 
     @SuppressWarnings("unchecked")
     public <T> List<T> stores(final StoreQueryParameters storeQueryParams) {
-        final String storeName = storeQueryParams.storeName();
-        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
-        if (streamThread.state() == StreamThread.State.DEAD) {
+        final StreamThread.State state = streamThread.state();
+        if (state == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }
-        final StreamThread.State state = streamThread.state();
+
+        final String storeName = storeQueryParams.storeName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
+        final String topologyName = storeQueryParams instanceof NamedTopologyStoreQueryParameters ?
+            ((NamedTopologyStoreQueryParameters) storeQueryParams).topologyName() :
+            null;
+
         if (storeQueryParams.staleStoresEnabled() ? state.isAlive() : state == StreamThread.State.RUNNING) {
             final Collection<Task> tasks = storeQueryParams.staleStoresEnabled() ?
                     streamThread.allTasks().values() : streamThread.activeTasks();
@@ -55,6 +61,7 @@ public class StreamThreadStateStoreProvider {
             if (storeQueryParams.partition() != null) {
                 for (final Task task : tasks) {
                     if (task.id().partition() == storeQueryParams.partition() &&
+                        (topologyName == null || topologyName.equals(task.id().topologyName())) &&
                         task.getStore(storeName) != null &&
                         storeName.equals(task.getStore(storeName).name())) {
                         final T typedStore = validateAndCastStores(task.getStore(storeName), queryableStoreType, storeName, task.id());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -38,8 +38,11 @@ import org.apache.kafka.streams.processor.internals.namedtopology.AddNamedTopolo
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStoreQueryParameters;
 import org.apache.kafka.streams.processor.internals.namedtopology.RemoveNamedTopologyResult;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.utils.UniqueTopicSerdeScope;
 import org.apache.kafka.test.TestUtils;
@@ -340,6 +343,10 @@ public class NamedTopologyIntegrationTest {
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
+
+        final ReadOnlyKeyValueStore<String, Long> store =
+            streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("topology-1", "store", QueryableStoreTypes.keyValueStore()));
+        assertThat(store.get("A"), equalTo(2L));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -347,6 +348,11 @@ public class NamedTopologyIntegrationTest {
         final ReadOnlyKeyValueStore<String, Long> store =
             streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("topology-1", "store", QueryableStoreTypes.keyValueStore()));
         assertThat(store.get("A"), equalTo(2L));
+
+//        Collection<StreamsMetadata> test1 = streams.streamsMetadataForStore("store");
+        Collection<StreamsMetadata> streamsMetadata = streams.streamsMetadataForStore("store", "topology-1");
+
+//        System.out.println(test1);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -323,6 +323,14 @@ public class NamedTopologyIntegrationTest {
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(singletonList(streams), Duration.ofSeconds(15));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
+
+
+        final ReadOnlyKeyValueStore<String, Long> store =
+            streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("topology-1", "store", QueryableStoreTypes.keyValueStore()));
+        assertThat(store.get("A"), equalTo(2L));
+
+        final Collection<StreamsMetadata> test1 = streams.streamsMetadataForStore("store");
+        final Collection<StreamsMetadata> streamsMetadata = streams.streamsMetadataForStore("store", "topology-1");
     }
     
     @Test
@@ -344,15 +352,6 @@ public class NamedTopologyIntegrationTest {
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
-
-        final ReadOnlyKeyValueStore<String, Long> store =
-            streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("topology-1", "store", QueryableStoreTypes.keyValueStore()));
-        assertThat(store.get("A"), equalTo(2L));
-
-//        Collection<StreamsMetadata> test1 = streams.streamsMetadataForStore("store");
-        Collection<StreamsMetadata> streamsMetadata = streams.streamsMetadataForStore("store", "topology-1");
-
-//        System.out.println(test1);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -107,7 +107,6 @@ public class NamedTopologyIntegrationTest {
     private final static String DELAYED_INPUT_STREAM_3 = "delayed-input-stream-3";
     private final static String DELAYED_INPUT_STREAM_4 = "delayed-input-stream-4";
 
-
     private final static Materialized<Object, Long, KeyValueStore<Bytes, byte[]>> IN_MEMORY_STORE = Materialized.as(Stores.inMemoryKeyValueStore("store"));
     private final static Materialized<Object, Long, KeyValueStore<Bytes, byte[]>> ROCKSDB_STORE = Materialized.as(Stores.persistentKeyValueStore("store"));
 
@@ -324,9 +323,12 @@ public class NamedTopologyIntegrationTest {
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
 
-
         final ReadOnlyKeyValueStore<String, Long> store =
-            streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("topology-1", "store", QueryableStoreTypes.keyValueStore()));
+            streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType(
+                "topology-1",
+                "store",
+                QueryableStoreTypes.keyValueStore())
+            );
         assertThat(store.get("A"), equalTo(2L));
 
         final Collection<StreamsMetadata> test1 = streams.streamsMetadataForStore("store");
@@ -583,7 +585,6 @@ public class NamedTopologyIntegrationTest {
 
         CLUSTER.deleteTopicsAndWait(SUM_OUTPUT, COUNT_OUTPUT);
     }
-
 
     private static void produceToInputTopics(final String topic, final Collection<KeyValue<String, Long>> records) {
         IntegrationTestUtils.produceKeyValuesSynchronously(


### PR DESCRIPTION
In the new NamedTopology API being worked on, state store names and their uniqueness requirement is going to be scoped only to the owning topology, rather than to the entire app. In other words, two different named topologies can have different state stores with the same name.

This is going to cause problems for some of the existing IQ APIs which require only a name to resolve the underlying state store. We're now going to need to take in the topology name in addition to the state store name to be able to locate the specific store a user wants to query

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
