### PR TITLE
MINOR: Add anchor to Kafka Streams page for use cases

### DIFF
--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -83,7 +83,7 @@
            </div>
        </div>
        <hr class="separator" id="streams-use-cases">
-        <h3 class="stream__text">Kafka Streams use cases</h3>
+       <h3 class="anchor-heading"><a id="streams_use_cases" class="anchor-link"></a><a href="#streams_use_cases">Kafka Streams use cases</a></h3>
          <div class="customers__grid">
            <div class="customer__grid">
              <div class="customer__item streams_logo_grid streams__ny__grid">


### PR DESCRIPTION
Add an anchor to the **Kafka Streams use cases** section of the [Streams Overview](https://kafka.apache.org/30/documentation/streams/), to enable linking directly to this section from external content.