### PR TITLE
DOCS-9992: Fix method name in table-table FK left join example

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -2567,7 +2567,7 @@ Function&lt;Long, Long&gt; foreignKeyExtractor = (x) -&gt; x;
 Function&lt;Long, Long&gt; foreignKeyExtractor = (x) -&gt; x;
 
 // Java 8+ example, using lambda expressions
-                KTable&lt;String, String&gt; joined = left.join(right, foreignKeyExtractor,
+                KTable&lt;String, String&gt; joined = left.leftJoin(right, foreignKeyExtractor,
                     (leftValue, rightValue) -&gt; &quot;left=&quot; + leftValue + &quot;, right=&quot; + rightValue /* ValueJoiner */
                   );</code></pre>
                               <p>Detailed behavior:</p>


### PR DESCRIPTION
Fix the foreign-key left join example to use the `leftJoin` method.

cc @mikebin 