### PR TITLE
KAFKA-12648: Wait for all threads to be on an empty topology before unsubscribing

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -910,11 +910,12 @@ public class StreamThread extends Thread {
         if (topologyMetadata.isEmpty() || topologyMetadata.needsUpdate(getName())) {
             taskManager.handleTopologyUpdates();
             log.info("StreamThread has detected an update to the topology, triggering a rebalance to refresh the assignment");
-            topologyMetadata.maybeNotifyTopologyVersionWaiters(getName());
 
             if (topologyMetadata.isEmpty()) {
+                topologyMetadata.allThreadsHaveReachedThisVersion(getName());
                 mainConsumer.unsubscribe();
             }
+            topologyMetadata.maybeNotifyTopologyVersionWaiters(getName());
             topologyMetadata.maybeWaitForNonEmptyTopology(() -> state);
 
             subscribeConsumer();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -910,11 +910,11 @@ public class StreamThread extends Thread {
         if (topologyMetadata.isEmpty() || topologyMetadata.needsUpdate(getName())) {
             taskManager.handleTopologyUpdates();
             log.info("StreamThread has detected an update to the topology, triggering a rebalance to refresh the assignment");
+            topologyMetadata.maybeNotifyTopologyVersionWaiters(getName());
+
             if (topologyMetadata.isEmpty()) {
                 mainConsumer.unsubscribe();
             }
-            topologyMetadata.maybeNotifyTopologyVersionWaiters(getName());
-
             topologyMetadata.maybeWaitForNonEmptyTopology(() -> state);
 
             subscribeConsumer();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -48,6 +48,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,6 +160,17 @@ public class TopologyMetadata {
             }
         } finally {
             unlock();
+        }
+    }
+
+    public void allThreadsHaveReachedThisVersion(final String threadName) {
+        threadVersions.put(threadName, topologyVersion());
+        while (new HashSet<>(threadVersions.values()).size() != 1) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -48,8 +48,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,7 +166,7 @@ public class TopologyMetadata {
         while (new HashSet<>(threadVersions.values()).size() != 1) {
             try {
                 Thread.sleep(100);
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
                 e.printStackTrace();
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -206,10 +207,8 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                             break;
                         } catch (final ExecutionException ex) {
                             if (ex.getCause() != null &&
-                                ex.getCause() instanceof GroupSubscribedToTopicException &&
-                                ex.getCause()
-                                    .getMessage()
-                                    .equals("Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it.")) {
+                                ex.getCause() instanceof GroupSubscribedToTopicException ||
+                                ex.getCause() instanceof GroupIdNotFoundException) {
                                 ex.printStackTrace();
                                 deleteOffsetsResult = null;
                             } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -209,8 +209,8 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                             if (ex.getCause() != null &&
                                 ex.getCause() instanceof GroupSubscribedToTopicException ||
                                 ex.getCause() instanceof GroupIdNotFoundException) {
-                                ex.printStackTrace();
                                 deleteOffsetsResult = null;
+                                log.trace("waiting for the group to be unsubscribed from");
                             } else {
                                 future.completeExceptionally(ex);
                             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -211,6 +211,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                                     .getMessage()
                                     .equals("Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it.")) {
                                 ex.printStackTrace();
+                                deleteOffsetsResult = null;
                             } else {
                                 future.completeExceptionally(ex);
                             }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -535,7 +535,6 @@ public class NamedTopologyIntegrationTest {
     }
 
     @Test
-    @Ignore
     public void shouldAddToEmptyInitialTopologyRemoveResetOffsetsThenAddSameNamedTopologyWithRepartitioning() throws Exception {
         CLUSTER.createTopics(SUM_OUTPUT, COUNT_OUTPUT);
         // Build up named topology with two stateful subtopologies
@@ -553,7 +552,7 @@ public class NamedTopologyIntegrationTest {
 
         CLUSTER.getAllTopicsInCluster().stream().filter(t -> t.contains("-changelog") || t.contains("-repartition")).forEach(t -> {
             try {
-                CLUSTER.deleteTopicsAndWait(t);
+                CLUSTER.deleteTopicAndWait(t);
             } catch (final InterruptedException e) {
                 e.printStackTrace();
             }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -220,7 +220,7 @@ public class NamedTopologyIntegrationTest {
             streams2.close(Duration.ofSeconds(30));
         }
 
-        CLUSTER.getAllTopicsInCluster().stream().filter(t -> t.contains("-changelog")).forEach(t -> {
+        CLUSTER.getAllTopicsInCluster().stream().filter(t -> t.contains("-changelog") || t.contains("-repartition")).forEach(t -> {
             try {
                 CLUSTER.deleteTopicsAndWait(t);
             } catch (final InterruptedException e) {


### PR DESCRIPTION
Wait for all threads to be on an empty topology before unsubscribing this prevents and exception for "Must initialize prevActiveTasks from ownedPartitions before initializing remaining tasks."

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
