### PR TITLE
KAFKA-13510: Connect APIs to list all connector plugins and retrieve …

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -85,5 +86,13 @@ public interface Converter {
      */
     default SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
         return toConnectData(topic, value);
+    }
+
+    /**
+     * Configuration specification for this set of converters.
+     * @return the configuration specification; may not be null
+     */
+    default ConfigDef config() {
+        return new ConfigDef();
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
@@ -89,7 +89,7 @@ public interface Converter {
     }
 
     /**
-     * Configuration specification for this set of converters.
+     * Configuration specification for this converter.
      * @return the configuration specification; may not be null
      */
     default ConfigDef config() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -784,7 +784,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                     throw new BadRequestException("Invalid plugin type " + pluginType + ". Valid types are sink, source, converter, header_converter, transformation, predicate.");
             }
         } catch (ClassNotFoundException cnfe) {
-            throw new BadRequestException("Unknown plugin " + pluginName + ".");
+            throw new NotFoundException("Unknown plugin " + pluginName + ".");
         }
         for (ConfigDef.ConfigKey configKey : configDefs.configKeys().values()) {
             results.add(AbstractHerder.convertConfigKey(configKey));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import org.apache.kafka.connect.runtime.isolation.PluginType;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
@@ -260,7 +259,13 @@ public interface Herder {
      */
     String kafkaClusterId();
 
-    List<ConfigKeyInfo> connectorPluginConfig(PluginType pluginType, String pluginName);
+
+    /**
+     * Returns the configuration of a plugin
+     * @param pluginName the name of the plugin
+     * @return the list of ConfigKeyInfo of the plugin
+     */
+    List<ConfigKeyInfo> connectorPluginConfig(String pluginName);
 
     enum ConfigReloadAction {
         NONE,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -16,10 +16,12 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.connect.runtime.isolation.PluginType;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
@@ -257,6 +259,8 @@ public interface Herder {
      * @return the cluster ID of the Kafka cluster backing this connect cluster
      */
     String kafkaClusterId();
+
+    List<ConfigKeyInfo> connectorPluginConfig(PluginType pluginType, String pluginName);
 
     enum ConfigReloadAction {
         NONE,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
@@ -30,7 +30,7 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
  * {@link Predicate} is true (or false, according to {@code negate}).
  * @param <R>
  */
-class PredicatedTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
+public class PredicatedTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
 
     static final String PREDICATE_CONFIG = "predicate";
     static final String NEGATE_CONFIG = "negate";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -76,7 +76,7 @@ import java.util.stream.Collectors;
 public class DelegatingClassLoader extends URLClassLoader {
     private static final Logger log = LoggerFactory.getLogger(DelegatingClassLoader.class);
     private static final String CLASSPATH_NAME = "classpath";
-    private static final String UNDEFINED_VERSION = "undefined";
+    public static final String UNDEFINED_VERSION = "undefined";
 
     private final ConcurrentMap<String, SortedMap<PluginDesc<?>, ClassLoader>> pluginLoaders;
     private final ConcurrentMap<String, String> aliases;
@@ -254,7 +254,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         } catch (IOException e) {
             log.error("Could not get listing for plugin path: {}. Ignoring.", path, e);
         } catch (ReflectiveOperationException e) {
-            log.error("Could not instantiate plugins in: {}. Ignoring: {}", path, e);
+            log.error("Could not instantiate plugins in: {}. Ignoring.", path, e);
         }
     }
 
@@ -419,7 +419,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         return pluginImpl instanceof Versioned ? ((Versioned) pluginImpl).version() : UNDEFINED_VERSION;
     }
 
-    private static <T> String versionFor(Class<? extends T> pluginKlass) throws ReflectiveOperationException {
+    public static <T> String versionFor(Class<? extends T> pluginKlass) throws ReflectiveOperationException {
         // Temporary workaround until all the plugins are versioned.
         return Connector.class.isAssignableFrom(pluginKlass) ?
             versionFor(pluginKlass.getDeclaredConstructor().newInstance()) : UNDEFINED_VERSION;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -131,15 +131,10 @@ public class DelegatingClassLoader extends URLClassLoader {
         this(pluginPaths, DelegatingClassLoader.class.getClassLoader());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Set<PluginDesc<Connector>> connectors() {
-        Set<PluginDesc<Connector>> connectors = new TreeSet<>();
-        for (PluginDesc<SinkConnector> sinkConnector : sinkConnectors) {
-            connectors.add((PluginDesc<Connector>) (PluginDesc<? extends Connector>) sinkConnector);
-        }
-        for (PluginDesc<SourceConnector> sourceConnector : sourceConnectors) {
-            connectors.add((PluginDesc<Connector>) (PluginDesc<? extends Connector>) sourceConnector);
-        }
+        Set<PluginDesc<Connector>> connectors = new TreeSet<>((Set) sinkConnectors);
+        connectors.addAll((Set) sourceConnectors);
         return connectors;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
@@ -17,9 +17,10 @@
 package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.common.config.provider.ConfigProvider;
-import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
@@ -30,7 +31,8 @@ import java.util.Collection;
 import java.util.List;
 
 public class PluginScanResult {
-    private final Collection<PluginDesc<Connector>> connectors;
+    private final Collection<PluginDesc<SinkConnector>> sinkConnectors;
+    private final Collection<PluginDesc<SourceConnector>> sourceConnectors;
     private final Collection<PluginDesc<Converter>> converters;
     private final Collection<PluginDesc<HeaderConverter>> headerConverters;
     private final Collection<PluginDesc<Transformation<?>>> transformations;
@@ -42,7 +44,8 @@ public class PluginScanResult {
     private final List<Collection<?>> allPlugins;
 
     public PluginScanResult(
-            Collection<PluginDesc<Connector>> connectors,
+            Collection<PluginDesc<SinkConnector>> sinkConnectors,
+            Collection<PluginDesc<SourceConnector>> sourceConnectors,
             Collection<PluginDesc<Converter>> converters,
             Collection<PluginDesc<HeaderConverter>> headerConverters,
             Collection<PluginDesc<Transformation<?>>> transformations,
@@ -51,7 +54,8 @@ public class PluginScanResult {
             Collection<PluginDesc<ConnectRestExtension>> restExtensions,
             Collection<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies
     ) {
-        this.connectors = connectors;
+        this.sinkConnectors = sinkConnectors;
+        this.sourceConnectors = sourceConnectors;
         this.converters = converters;
         this.headerConverters = headerConverters;
         this.transformations = transformations;
@@ -60,12 +64,16 @@ public class PluginScanResult {
         this.restExtensions = restExtensions;
         this.connectorClientConfigPolicies = connectorClientConfigPolicies;
         this.allPlugins =
-            Arrays.asList(connectors, converters, headerConverters, transformations, configProviders,
+            Arrays.asList(sinkConnectors, sourceConnectors, converters, headerConverters, transformations, configProviders,
                           connectorClientConfigPolicies);
     }
 
-    public Collection<PluginDesc<Connector>> connectors() {
-        return connectors;
+    public Collection<PluginDesc<SinkConnector>> sinkConnectors() {
+        return sinkConnectors;
+    }
+
+    public Collection<PluginDesc<SourceConnector>> sourceConnectors() {
+        return sourceConnectors;
     }
 
     public Collection<PluginDesc<Converter>> converters() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginType.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginType.java
@@ -17,22 +17,24 @@
 package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.common.config.provider.ConfigProvider;
-import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 
 import java.util.Locale;
 
 public enum PluginType {
     SOURCE(SourceConnector.class),
     SINK(SinkConnector.class),
-    CONNECTOR(Connector.class),
     CONVERTER(Converter.class),
+    HEADER_CONVERTER(HeaderConverter.class),
     TRANSFORMATION(Transformation.class),
+    PREDICATE(Predicate.class),
     CONFIGPROVIDER(ConfigProvider.class),
     REST_EXTENSION(ConnectRestExtension.class),
     CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY(ConnectorClientConfigOverridePolicy.class),

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -319,7 +319,6 @@ public class PluginUtils {
         switch (plugin.type()) {
             case SOURCE:
             case SINK:
-            case CONNECTOR:
                 return prunePluginName(plugin, "Connector");
             default:
                 return prunePluginName(plugin, plugin.type().simpleName());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.provider.ConfigProvider;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -155,6 +156,10 @@ public class Plugins {
         return delegatingLoader.converters();
     }
 
+    public Set<PluginDesc<HeaderConverter>> headerConverters() {
+        return delegatingLoader.headerConverters();
+    }
+
     public Set<PluginDesc<Transformation<?>>> transformations() {
         return delegatingLoader.transformations();
     }
@@ -165,6 +170,44 @@ public class Plugins {
 
     public Connector newConnector(String connectorClassOrAlias) {
         Class<? extends Connector> klass = connectorClass(connectorClassOrAlias);
+        return newPlugin(klass);
+    }
+
+    public Converter newConverter(String className) throws ClassNotFoundException {
+        Class<? extends Converter> klass = pluginClass(
+                delegatingLoader,
+                className,
+                Converter.class
+        );
+        return newPlugin(klass);
+    }
+
+    public HeaderConverter newHeaderConverter(String className) throws ClassNotFoundException {
+        Class<? extends HeaderConverter> klass = pluginClass(
+                delegatingLoader,
+                className,
+                HeaderConverter.class
+        );
+        return newPlugin(klass);
+    }
+
+    @SuppressWarnings("rawtypes")
+    public Predicate newPredicate(String className) throws ClassNotFoundException {
+        Class<? extends Predicate> klass = pluginClass(
+                delegatingLoader,
+                className,
+                Predicate.class
+        );
+        return newPlugin(klass);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <R extends ConnectRecord<R>> Transformation<R> newTransformation(String className) throws ClassNotFoundException {
+        Class<? extends Transformation> klass = pluginClass(
+                delegatingLoader,
+                className,
+                Transformation.class
+        );
         return newPlugin(klass);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -174,7 +174,7 @@ public class Plugins {
     }
 
     public Object newPlugin(String classOrAlias) throws ClassNotFoundException {
-        Class<? extends Object> klass = pluginClass(delegatingLoader, classOrAlias, Object.class);
+        Class<?> klass = pluginClass(delegatingLoader, classOrAlias, Object.class);
         return newPlugin(klass);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -193,7 +193,7 @@ public class Plugins {
             );
         } catch (ClassNotFoundException e) {
             List<PluginDesc<? extends Connector>> matches = new ArrayList<>();
-            Set<PluginDesc<? extends Connector>> connectors = delegatingLoader.connectors();
+            Set<PluginDesc<Connector>> connectors = delegatingLoader.connectors();
             for (PluginDesc<? extends Connector> plugin : connectors) {
                 Class<?> pluginClass = plugin.pluginClass();
                 String simpleName = pluginClass.getSimpleName();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfo.java
@@ -17,21 +17,23 @@
 package org.apache.kafka.connect.runtime.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
+import org.apache.kafka.connect.runtime.isolation.PluginType;
 
 import java.util.Objects;
 
 public class ConnectorPluginInfo {
     private final String className;
-    private final ConnectorType type;
+    private final PluginType type;
     private final String version;
 
     @JsonCreator
     public ConnectorPluginInfo(
         @JsonProperty("class") String className,
-        @JsonProperty("type") ConnectorType type,
+        @JsonProperty("type") PluginType type,
         @JsonProperty("version") String version
     ) {
         this.className = className;
@@ -39,8 +41,8 @@ public class ConnectorPluginInfo {
         this.version = version;
     }
 
-    public ConnectorPluginInfo(PluginDesc<Connector> plugin) {
-        this(plugin.className(), ConnectorType.from(plugin.pluginClass()), plugin.version());
+    public ConnectorPluginInfo(PluginDesc<?> plugin, PluginType type) {
+        this(plugin.className(), type, plugin.version());
     }
 
     @JsonProperty("class")
@@ -49,11 +51,12 @@ public class ConnectorPluginInfo {
     }
 
     @JsonProperty("type")
-    public ConnectorType type() {
-        return type;
+    public String type() {
+        return type.toString();
     }
 
     @JsonProperty("version")
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NoVersionFilter.class)
     public String version() {
         return version;
     }
@@ -68,7 +71,7 @@ public class ConnectorPluginInfo {
         }
         ConnectorPluginInfo that = (ConnectorPluginInfo) o;
         return Objects.equals(className, that.className) &&
-               type == that.type &&
+               Objects.equals(type, that.type) &&
                Objects.equals(version, that.version);
     }
 
@@ -79,11 +82,21 @@ public class ConnectorPluginInfo {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ConnectorPluginInfo{");
-        sb.append("className='").append(className).append('\'');
-        sb.append(", type=").append(type);
-        sb.append(", version='").append(version).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "ConnectorPluginInfo{" + "className='" + className + '\'' +
+                ", type=" + type.toString() +
+                ", version='" + version + '\'' +
+                '}';
+    }
+
+    public static final class NoVersionFilter {
+        @Override
+        public boolean equals(Object obj) {
+            return DelegatingClassLoader.UNDEFINED_VERSION.equals(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return super.hashCode();
+        }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfo.java
@@ -41,8 +41,8 @@ public class ConnectorPluginInfo {
         this.version = version;
     }
 
-    public ConnectorPluginInfo(PluginDesc<?> plugin, PluginType type) {
-        this(plugin.className(), type, plugin.version());
+    public ConnectorPluginInfo(PluginDesc<?> plugin) {
+        this(plugin.className(), plugin.type(), plugin.version());
     }
 
     @JsonProperty("class")

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfo.java
@@ -89,11 +89,12 @@ public class ConnectorPluginInfo {
     }
 
     public static final class NoVersionFilter {
-        @Override
+        // This method is used by Jackson to filter the version field for plugins that don't have a version
         public boolean equals(Object obj) {
             return DelegatingClassLoader.UNDEFINED_VERSION.equals(obj);
         }
 
+        // Dummy hashCode method to not fail compilation because of equals() method
         @Override
         public int hashCode() {
             return super.hashCode();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/PluginInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/PluginInfo.java
@@ -25,13 +25,13 @@ import org.apache.kafka.connect.runtime.isolation.PluginType;
 
 import java.util.Objects;
 
-public class ConnectorPluginInfo {
+public class PluginInfo {
     private final String className;
     private final PluginType type;
     private final String version;
 
     @JsonCreator
-    public ConnectorPluginInfo(
+    public PluginInfo(
         @JsonProperty("class") String className,
         @JsonProperty("type") PluginType type,
         @JsonProperty("version") String version
@@ -41,7 +41,7 @@ public class ConnectorPluginInfo {
         this.version = version;
     }
 
-    public ConnectorPluginInfo(PluginDesc<?> plugin) {
+    public PluginInfo(PluginDesc<?> plugin) {
         this(plugin.className(), plugin.type(), plugin.version());
     }
 
@@ -69,7 +69,7 @@ public class ConnectorPluginInfo {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ConnectorPluginInfo that = (ConnectorPluginInfo) o;
+        PluginInfo that = (PluginInfo) o;
         return Objects.equals(className, that.className) &&
                Objects.equals(type, that.type) &&
                Objects.equals(version, that.version);
@@ -82,7 +82,7 @@ public class ConnectorPluginInfo {
 
     @Override
     public String toString() {
-        return "ConnectorPluginInfo{" + "className='" + className + '\'' +
+        return "PluginInfo{" + "className='" + className + '\'' +
                 ", type=" + type.toString() +
                 ", version='" + version + '\'' +
                 '}';

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -50,10 +50,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -138,8 +136,9 @@ public class ConnectorPluginsResource {
     public List<ConnectorPluginInfo> listConnectorPlugins(@DefaultValue("true") @QueryParam("connectorsOnly") boolean connectorsOnly) {
         synchronized (this) {
             if (connectorsOnly) {
-                Set<String> types = new HashSet<>(Arrays.asList(PluginType.SINK.toString(), PluginType.SOURCE.toString()));
-                return Collections.unmodifiableList(connectorPlugins.stream().filter(p -> types.contains(p.type())).collect(Collectors.toList()));
+                return Collections.unmodifiableList(connectorPlugins.stream()
+                        .filter(p -> PluginType.SINK.toString().equals(p.type()) || PluginType.SOURCE.toString().equals(p.type()))
+                        .collect(Collectors.toList()));
             } else {
                 return Collections.unmodifiableList(connectorPlugins);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -23,7 +23,7 @@ import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.PluginType;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
+import org.apache.kafka.connect.runtime.rest.entities.PluginInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.source.SourceConnector;
@@ -63,7 +63,7 @@ public class ConnectorPluginsResource {
 
     private static final String ALIAS_SUFFIX = "Connector";
     private final Herder herder;
-    private final List<ConnectorPluginInfo> connectorPlugins;
+    private final List<PluginInfo> connectorPlugins;
 
     static final List<Class<? extends SinkConnector>> SINK_CONNECTOR_EXCLUDES = Arrays.asList(
             VerifiableSinkConnector.class,
@@ -97,7 +97,7 @@ public class ConnectorPluginsResource {
     private <T> void addConnectorPlugins(Collection<PluginDesc<T>> plugins, Collection<Class<? extends T>> excludes) {
         plugins.stream()
                 .filter(p -> !excludes.contains(p.pluginClass()))
-                .map(ConnectorPluginInfo::new)
+                .map(PluginInfo::new)
                 .forEach(connectorPlugins::add);
     }
 
@@ -133,7 +133,7 @@ public class ConnectorPluginsResource {
 
     @GET
     @Path("/")
-    public List<ConnectorPluginInfo> listConnectorPlugins(@DefaultValue("true") @QueryParam("connectorsOnly") boolean connectorsOnly) {
+    public List<PluginInfo> listConnectorPlugins(@DefaultValue("true") @QueryParam("connectorsOnly") boolean connectorsOnly) {
         synchronized (this) {
             if (connectorsOnly) {
                 return Collections.unmodifiableList(connectorPlugins.stream()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSinkConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSinkConnector.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.tools;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.sink.SinkConnector;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * @see VerifiableSinkTask
  */
-public class VerifiableSinkConnector extends SourceConnector {
+public class VerifiableSinkConnector extends SinkConnector {
     private Map<String, String> config;
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.runtime.TestSinkConnector;
+import org.apache.kafka.connect.runtime.SampleSinkConnector;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -39,7 +39,7 @@ import java.util.Map;
  * which are initiated by the embedded connector, and wait for them to consume a desired number of
  * messages.
  */
-public class MonitorableSinkConnector extends TestSinkConnector {
+public class MonitorableSinkConnector extends SampleSinkConnector {
 
     private static final Logger log = LoggerFactory.getLogger(MonitorableSinkConnector.class);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -21,7 +21,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.runtime.TestSourceConnector;
+import org.apache.kafka.connect.runtime.SampleSourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.tools.ThroughputThrottler;
@@ -43,7 +43,7 @@ import java.util.stream.LongStream;
  * that generates records of a fixed structure. The rate of record production can be adjusted
  * through the configs 'throughput' and 'messages.per.poll'
  */
-public class MonitorableSourceConnector extends TestSourceConnector {
+public class MonitorableSourceConnector extends SampleSourceConnector {
     private static final Logger log = LoggerFactory.getLogger(MonitorableSourceConnector.class);
 
     public static final String TOPIC_CONFIG = "topic";

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/PredicatedTransformationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/PredicatedTransformationTest.java
@@ -16,12 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import java.util.Map;
-
-import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.transforms.Transformation;
-import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.junit.Test;
 
 import static java.util.Collections.singletonMap;
@@ -43,75 +38,9 @@ public class PredicatedTransformationTest {
 
     private void applyAndAssert(boolean predicateResult, boolean negate,
                                 SourceRecord expectedResult) {
-        class TestTransformation implements Transformation<SourceRecord> {
 
-            private boolean closed = false;
-            private SourceRecord transformedRecord;
-
-            private TestTransformation(SourceRecord transformedRecord) {
-                this.transformedRecord = transformedRecord;
-            }
-
-            @Override
-            public SourceRecord apply(SourceRecord record) {
-                return transformedRecord;
-            }
-
-            @Override
-            public ConfigDef config() {
-                return null;
-            }
-
-            @Override
-            public void close() {
-                closed = true;
-            }
-
-            @Override
-            public void configure(Map<String, ?> configs) {
-
-            }
-
-            private void assertClosed() {
-                assertTrue("Transformer should be closed", closed);
-            }
-        }
-
-        class TestPredicate implements Predicate<SourceRecord> {
-
-            private boolean testResult;
-            private boolean closed = false;
-
-            private TestPredicate(boolean testResult) {
-                this.testResult = testResult;
-            }
-
-            @Override
-            public ConfigDef config() {
-                return null;
-            }
-
-            @Override
-            public boolean test(SourceRecord record) {
-                return testResult;
-            }
-
-            @Override
-            public void close() {
-                closed = true;
-            }
-
-            @Override
-            public void configure(Map<String, ?> configs) {
-
-            }
-
-            private void assertClosed() {
-                assertTrue("Predicate should be closed", closed);
-            }
-        }
-        TestPredicate predicate = new TestPredicate(predicateResult);
-        TestTransformation predicatedTransform = new TestTransformation(transformed);
+        SamplePredicate predicate = new SamplePredicate(predicateResult);
+        SampleTransformation<SourceRecord> predicatedTransform = new SampleTransformation<>(transformed);
         PredicatedTransformation<SourceRecord> pt = new PredicatedTransformation<>(
                 predicate,
                 negate,
@@ -120,7 +49,7 @@ public class PredicatedTransformationTest {
         assertEquals(expectedResult, pt.apply(initial));
 
         pt.close();
-        predicate.assertClosed();
-        predicatedTransform.assertClosed();
+        assertTrue(predicate.closed);
+        assertTrue(predicatedTransform.closed);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleConverterWithHeaders.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleConverterWithHeaders.java
@@ -28,7 +28,7 @@ import org.apache.kafka.connect.storage.Converter;
 /**
  * This is a simple Converter implementation that uses "encoding" header to encode/decode strings via provided charset name
  */
-public class TestConverterWithHeaders implements Converter {
+public class SampleConverterWithHeaders implements Converter {
     private static final String HEADER_ENCODING = "encoding";
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleHeaderConverter.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleHeaderConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.storage.HeaderConverter;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class SampleHeaderConverter implements HeaderConverter {
+    @Override
+    public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+        return null;
+    }
+
+    @Override
+    public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+        return new byte[0];
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef()
+                .define("converterconfig", ConfigDef.Type.STRING, "default", ConfigDef.Importance.LOW, "docs");
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SamplePredicate.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SamplePredicate.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+
+import java.util.Map;
+
+public class SamplePredicate implements Predicate<SourceRecord> {
+
+    private boolean testResult;
+    boolean closed = false;
+
+    public SamplePredicate() { }
+
+    public SamplePredicate(boolean testResult) {
+        this.testResult = testResult;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef()
+                .define("predconfig", ConfigDef.Type.STRING, "default", ConfigDef.Importance.LOW, "docs");
+    }
+
+    @Override
+    public boolean test(SourceRecord record) {
+        return testResult;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) { }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSinkConnector.java
@@ -18,14 +18,14 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.sink.SinkConnector;
 
 import java.util.List;
 import java.util.Map;
 
-public class TestSourceConnector extends SourceConnector {
+public class SampleSinkConnector extends SinkConnector {
 
-    public static final String VERSION = "an entirely different version";
+    public static final String VERSION = "some great version";
 
     @Override
     public String version() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleSourceConnector.java
@@ -18,14 +18,14 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.source.SourceConnector;
 
 import java.util.List;
 import java.util.Map;
 
-public class TestSinkConnector extends SinkConnector {
+public class SampleSourceConnector extends SourceConnector {
 
-    public static final String VERSION = "some great version";
+    public static final String VERSION = "an entirely different version";
 
     @Override
     public String version() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleTransformation.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SampleTransformation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.util.Map;
+
+public class SampleTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    boolean closed = false;
+    private R transformedRecord;
+
+    public SampleTransformation() { }
+
+    public SampleTransformation(R transformedRecord) {
+        this.transformedRecord = transformedRecord;
+    }
+
+    @Override
+    public R apply(R record) {
+        return transformedRecord;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef()
+                .define("subconfig", ConfigDef.Type.STRING, "default", ConfigDef.Importance.LOW, "docs");
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) { }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -1790,7 +1790,7 @@ public class WorkerSinkTaskTest {
     @Test
     public void testHeadersWithCustomConverter() throws Exception {
         StringConverter stringConverter = new StringConverter();
-        TestConverterWithHeaders testConverter = new TestConverterWithHeaders();
+        SampleConverterWithHeaders testConverter = new SampleConverterWithHeaders();
 
         createTask(initialState, stringConverter, testConverter, stringConverter);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -996,7 +996,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     @Test
     public void testHeadersWithCustomConverter() throws Exception {
         StringConverter stringConverter = new StringConverter();
-        TestConverterWithHeaders testConverter = new TestConverterWithHeaders();
+        SampleConverterWithHeaders testConverter = new SampleConverterWithHeaders();
 
         createWorkerTask(TargetState.STARTED, stringConverter, testConverter, stringConverter);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfoTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorPluginInfoTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest.entities;
+
+import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConnectorPluginInfoTest {
+
+    @Test
+    public void testNoVersionFilter() {
+        ConnectorPluginInfo.NoVersionFilter filter = new ConnectorPluginInfo.NoVersionFilter();
+        assertFalse(filter.equals("1.0"));
+        assertFalse(filter.equals(new Object()));
+        assertFalse(filter.equals(null));
+        assertTrue(filter.equals(DelegatingClassLoader.UNDEFINED_VERSION));
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/PluginInfoTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/PluginInfoTest.java
@@ -22,11 +22,11 @@ import org.junit.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ConnectorPluginInfoTest {
+public class PluginInfoTest {
 
     @Test
     public void testNoVersionFilter() {
-        ConnectorPluginInfo.NoVersionFilter filter = new ConnectorPluginInfo.NoVersionFilter();
+        PluginInfo.NoVersionFilter filter = new PluginInfo.NoVersionFilter();
         assertFalse(filter.equals("1.0"));
         assertFalse(filter.equals(new Object()));
         assertFalse(filter.equals(null));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -399,13 +399,15 @@ public class ConnectorPluginsResourceTest {
     }
 
     @Test
-    public void testConnectorPluginsIncludesTypeAndVersionInformation() throws Exception {
+    public void testConnectorPluginsIncludesClassTypeAndVersionInformation() throws Exception {
         ConnectorPluginInfo sinkInfo = newInfo(SampleSinkConnector.class);
         ConnectorPluginInfo sourceInfo = newInfo(SampleSourceConnector.class);
         assertEquals(PluginType.SINK.toString(), sinkInfo.type());
         assertEquals(PluginType.SOURCE.toString(), sourceInfo.type());
         assertEquals(SampleSinkConnector.VERSION, sinkInfo.version());
         assertEquals(SampleSourceConnector.VERSION, sourceInfo.version());
+        assertEquals(SampleSinkConnector.class.getName(), sinkInfo.className());
+        assertEquals(SampleSourceConnector.class.getName(), sourceInfo.className());
 
         final ObjectMapper objectMapper = new ObjectMapper();
         String serializedSink = objectMapper.writeValueAsString(ConnectorType.SINK);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -42,7 +42,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigValueInfo;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
+import org.apache.kafka.connect.runtime.rest.entities.PluginInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.storage.StringConverter;
@@ -341,20 +341,20 @@ public class ConnectorPluginsResourceTest {
         Set<Class<?>> excludes = Stream.of(ConnectorPluginsResource.SINK_CONNECTOR_EXCLUDES, ConnectorPluginsResource.SOURCE_CONNECTOR_EXCLUDES)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
-        Set<ConnectorPluginInfo> expectedConnectorPlugins = Stream.of(SINK_CONNECTOR_PLUGINS, SOURCE_CONNECTOR_PLUGINS)
+        Set<PluginInfo> expectedConnectorPlugins = Stream.of(SINK_CONNECTOR_PLUGINS, SOURCE_CONNECTOR_PLUGINS)
                 .flatMap(Collection::stream)
                 .filter(p -> !excludes.contains(p.pluginClass()))
                 .map(ConnectorPluginsResourceTest::newInfo)
                 .collect(Collectors.toSet());
-        Set<ConnectorPluginInfo> actualConnectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins(true));
+        Set<PluginInfo> actualConnectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins(true));
         assertEquals(expectedConnectorPlugins, actualConnectorPlugins);
         verify(herder, atLeastOnce()).plugins();
     }
 
     @Test
     public void testConnectorPluginsIncludesClassTypeAndVersionInformation() throws Exception {
-        ConnectorPluginInfo sinkInfo = newInfo(SampleSinkConnector.class);
-        ConnectorPluginInfo sourceInfo = newInfo(SampleSourceConnector.class);
+        PluginInfo sinkInfo = newInfo(SampleSinkConnector.class);
+        PluginInfo sourceInfo = newInfo(SampleSourceConnector.class);
         assertEquals(PluginType.SINK.toString(), sinkInfo.type());
         assertEquals(PluginType.SOURCE.toString(), sourceInfo.type());
         assertEquals(SampleSinkConnector.VERSION, sinkInfo.version());
@@ -391,7 +391,7 @@ public class ConnectorPluginsResourceTest {
                         ConnectorPluginsResource.TRANSFORM_EXCLUDES
                 ).flatMap(Collection::stream)
                 .collect(Collectors.toSet());
-        Set<ConnectorPluginInfo> expectedConnectorPlugins = Stream.of(
+        Set<PluginInfo> expectedConnectorPlugins = Stream.of(
                         SINK_CONNECTOR_PLUGINS,
                         SOURCE_CONNECTOR_PLUGINS,
                         CONVERTER_PLUGINS,
@@ -402,7 +402,7 @@ public class ConnectorPluginsResourceTest {
                 .filter(p -> !excludes.contains(p.pluginClass()))
                 .map(ConnectorPluginsResourceTest::newInfo)
                 .collect(Collectors.toSet());
-        Set<ConnectorPluginInfo> actualConnectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins(false));
+        Set<PluginInfo> actualConnectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins(false));
         assertEquals(expectedConnectorPlugins, actualConnectorPlugins);
         verify(herder, atLeastOnce()).plugins();
     }
@@ -425,13 +425,13 @@ public class ConnectorPluginsResourceTest {
         }
     }
 
-    protected static ConnectorPluginInfo newInfo(PluginDesc<?> pluginDesc) {
-        return new ConnectorPluginInfo(new MockConnectorPluginDesc<>(pluginDesc.pluginClass(), pluginDesc.version()));
+    protected static PluginInfo newInfo(PluginDesc<?> pluginDesc) {
+        return new PluginInfo(new MockConnectorPluginDesc<>(pluginDesc.pluginClass(), pluginDesc.version()));
     }
 
-    protected static ConnectorPluginInfo newInfo(Class<?> klass)
+    protected static PluginInfo newInfo(Class<?> klass)
             throws Exception {
-        return new ConnectorPluginInfo(new MockConnectorPluginDesc<>(klass));
+        return new PluginInfo(new MockConnectorPluginDesc<>(klass));
     }
 
     public static class MockPluginClassLoader extends PluginClassLoader {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -16,9 +16,7 @@
  */
 package org.apache.kafka.connect.runtime.rest.resources;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javax.ws.rs.core.HttpHeaders;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -28,51 +26,55 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.converters.LongConverter;
 import org.apache.kafka.connect.runtime.AbstractHerder;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
-import org.apache.kafka.connect.runtime.TestSinkConnector;
-import org.apache.kafka.connect.runtime.TestSourceConnector;
-import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.SampleSinkConnector;
+import org.apache.kafka.connect.runtime.SampleSourceConnector;
+import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
+import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
+import org.apache.kafka.connect.runtime.isolation.PluginType;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
-import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigValueInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
-import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.tools.MockConnector;
 import org.apache.kafka.connect.tools.MockSinkConnector;
 import org.apache.kafka.connect.tools.MockSourceConnector;
 import org.apache.kafka.connect.tools.SchemaSourceConnector;
 import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
+import org.apache.kafka.connect.transforms.RegexRouter;
+import org.apache.kafka.connect.transforms.TimestampConverter;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.HasHeaderKey;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+import org.apache.kafka.connect.transforms.predicates.RecordIsTombstone;
 import org.apache.kafka.connect.util.Callback;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.api.easymock.annotation.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.ArgumentCaptor;
 
 import javax.ws.rs.BadRequestException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -81,38 +83,80 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(RestClient.class)
-@PowerMockIgnore("javax.management.*")
 public class ConnectorPluginsResourceTest {
 
-    private static Map<String, String> props;
-    private static Map<String, String> partialProps = new HashMap<>();
+    private static final Map<String, String> PROPS;
+    private static final Map<String, String> PARTIAL_PROPS = new HashMap<>();
     static {
-        partialProps.put("name", "test");
-        partialProps.put("test.string.config", "testString");
-        partialProps.put("test.int.config", "1");
-        partialProps.put("test.list.config", "a,b");
+        PARTIAL_PROPS.put("name", "test");
+        PARTIAL_PROPS.put("test.string.config", "testString");
+        PARTIAL_PROPS.put("test.int.config", "1");
+        PARTIAL_PROPS.put("test.list.config", "a,b");
 
-        props = new HashMap<>(partialProps);
-        props.put("connector.class", ConnectorPluginsResourceTestConnector.class.getSimpleName());
-        props.put("plugin.path", "test.path");
+        PROPS = new HashMap<>(PARTIAL_PROPS);
+        PROPS.put("connector.class", ConnectorPluginsResourceTestConnector.class.getSimpleName());
+        PROPS.put("plugin.path", null);
     }
 
     private static final ConfigInfos CONFIG_INFOS;
     private static final ConfigInfos PARTIAL_CONFIG_INFOS;
     private static final int ERROR_COUNT = 0;
     private static final int PARTIAL_CONFIG_ERROR_COUNT = 1;
-    private static final Set<PluginDesc<Connector>> CONNECTOR_PLUGINS = new TreeSet<>();
+    private static final Set<MockConnectorPluginDesc<?>> CONNECTOR_PLUGINS = new TreeSet<>();
+    private static final Set<MockConnectorPluginDesc<?>> CONVERTER_PLUGINS = new TreeSet<>();
+    private static final Set<MockConnectorPluginDesc<?>> HEADER_CONVERTER_PLUGINS = new TreeSet<>();
+    private static final Set<MockConnectorPluginDesc<?>> TRANSFORMATION_PLUGINS = new TreeSet<>();
+    private static final Set<MockConnectorPluginDesc<?>> PREDICATE_PLUGINS = new TreeSet<>();
+
+    private final List<Class<? extends Connector>> connectorClasses = asList(
+            VerifiableSourceConnector.class,
+            VerifiableSinkConnector.class,
+            MockSourceConnector.class,
+            MockSinkConnector.class,
+            MockConnector.class,
+            SchemaSourceConnector.class,
+            ConnectorPluginsResourceTestConnector.class
+    );
+
+    private final List<Class<? extends Converter>> converterClasses = asList(
+            StringConverter.class,
+            LongConverter.class
+    );
+
+    private final List<Class<? extends HeaderConverter>> headerConverterClasses = asList(
+            StringConverter.class,
+            LongConverter.class
+    );
+
+    @SuppressWarnings("rawtypes")
+    private final List<Class<? extends Transformation>> transformationClasses = asList(
+            RegexRouter.class,
+            TimestampConverter.Value.class
+    );
+
+    @SuppressWarnings("rawtypes")
+    private final List<Class<? extends Predicate>> predicateClasses = asList(
+            HasHeaderKey.class,
+            RecordIsTombstone.class
+    );
 
     static {
         List<ConfigInfo> configs = new LinkedList<>();
         List<ConfigInfo> partialConfigs = new LinkedList<>();
 
         ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-        List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
-        List<ConfigValue> partialConnectorConfigValues = connectorConfigDef.validate(partialProps);
+        List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(PROPS);
+        List<ConfigValue> partialConnectorConfigValues = connectorConfigDef.validate(PARTIAL_PROPS);
         ConfigInfos result = AbstractHerder.generateResult(ConnectorPluginsResourceTestConnector.class.getName(), connectorConfigDef.configKeys(), connectorConfigValues, Collections.emptyList());
         ConfigInfos partialResult = AbstractHerder.generateResult(ConnectorPluginsResourceTestConnector.class.getName(), connectorConfigDef.configKeys(), partialConnectorConfigValues, Collections.emptyList());
         configs.addAll(result.values());
@@ -144,70 +188,72 @@ public class ConnectorPluginsResourceTest {
 
         CONFIG_INFOS = new ConfigInfos(ConnectorPluginsResourceTestConnector.class.getName(), ERROR_COUNT, Collections.singletonList("Test"), configs);
         PARTIAL_CONFIG_INFOS = new ConfigInfos(ConnectorPluginsResourceTestConnector.class.getName(), PARTIAL_CONFIG_ERROR_COUNT, Collections.singletonList("Test"), partialConfigs);
+    }
 
-        List<Class<? extends Connector>> abstractConnectorClasses = asList(
-            Connector.class,
-            SourceConnector.class,
-            SinkConnector.class
-        );
+    private final Herder herder = mock(DistributedHerder.class);
+    private final Plugins plugins = mock(Plugins.class);
+    private ConnectorPluginsResource connectorPluginsResource;
 
-        List<Class<? extends Connector>> connectorClasses = asList(
-            VerifiableSourceConnector.class,
-            VerifiableSinkConnector.class,
-            MockSourceConnector.class,
-            MockSinkConnector.class,
-            MockConnector.class,
-            SchemaSourceConnector.class,
-            ConnectorPluginsResourceTestConnector.class
-        );
-
+    @SuppressWarnings("rawtypes")
+    @Before
+    public void setUp() throws Exception {
         try {
-            for (Class<? extends Connector> klass : abstractConnectorClasses) {
-                MockConnectorPluginDesc pluginDesc = new MockConnectorPluginDesc(klass, "0.0.0");
+            for (Class<? extends Connector> klass : connectorClasses) {
+                MockConnectorPluginDesc<? extends Connector> pluginDesc = new MockConnectorPluginDesc<>(klass);
                 CONNECTOR_PLUGINS.add(pluginDesc);
             }
-            for (Class<? extends Connector> klass : connectorClasses) {
-                MockConnectorPluginDesc pluginDesc = new MockConnectorPluginDesc(klass);
-                CONNECTOR_PLUGINS.add(pluginDesc);
+            for (Class<? extends Converter> klass : converterClasses) {
+                MockConnectorPluginDesc<? extends Converter> pluginDesc = new MockConnectorPluginDesc<>(klass);
+                CONVERTER_PLUGINS.add(pluginDesc);
+            }
+            for (Class<? extends HeaderConverter> klass : headerConverterClasses) {
+                MockConnectorPluginDesc<? extends HeaderConverter> pluginDesc = new MockConnectorPluginDesc<>(klass);
+                HEADER_CONVERTER_PLUGINS.add(pluginDesc);
+            }
+            for (Class<? extends Transformation> klass : transformationClasses) {
+                MockConnectorPluginDesc<? extends Transformation> pluginDesc = new MockConnectorPluginDesc<>(klass);
+                TRANSFORMATION_PLUGINS.add(pluginDesc);
+            }
+            for (Class<? extends Predicate> klass : predicateClasses) {
+                MockConnectorPluginDesc<? extends Predicate> pluginDesc = new MockConnectorPluginDesc<>(klass);
+                PREDICATE_PLUGINS.add(pluginDesc);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Mock
-    private Herder herder;
-    @Mock
-    private Plugins plugins;
-    private ConnectorPluginsResource connectorPluginsResource;
-
-    @Before
-    public void setUp() throws Exception {
-        PowerMock.mockStatic(RestClient.class,
-                RestClient.class.getMethod("httpRequest", String.class, String.class, HttpHeaders.class, Object.class, TypeReference.class, WorkerConfig.class));
-
-        plugins = PowerMock.createMock(Plugins.class);
-        herder = PowerMock.createMock(AbstractHerder.class);
+        doReturn(plugins).when(herder).plugins();
+        doReturn(CONNECTOR_PLUGINS).when(plugins).connectors();
+        doReturn(CONVERTER_PLUGINS).when(plugins).converters();
+        doReturn(HEADER_CONVERTER_PLUGINS).when(plugins).headerConverters();
+        doReturn(TRANSFORMATION_PLUGINS).when(plugins).transformations();
+        doReturn(PREDICATE_PLUGINS).when(plugins).predicates();
         connectorPluginsResource = new ConnectorPluginsResource(herder);
     }
 
-    private void expectPlugins() {
-        EasyMock.expect(herder.plugins()).andReturn(plugins);
-        EasyMock.expect(plugins.connectors()).andReturn(CONNECTOR_PLUGINS);
-        PowerMock.replayAll();
+    @Test
+    public void testGetAlias() {
+        assertEquals("FileStreamSink", connectorPluginsResource.getAlias("org.apache.kafka.connect.file.FileStreamSinkConnector"));
+        assertEquals("FileStreamSink", connectorPluginsResource.getAlias("FileStreamSinkConnector"));
+        assertEquals("FileStreamSink", connectorPluginsResource.getAlias("FileStreamSink"));
+        assertEquals("SomeConverter", connectorPluginsResource.getAlias("SomeConverter"));
+        assertEquals("SomeHeaderConverter", connectorPluginsResource.getAlias("SomeHeaderConverter"));
+        assertEquals("Predicate", connectorPluginsResource.getAlias("org.apache.Predicate"));
+        assertEquals("MyTransformation", connectorPluginsResource.getAlias(".MyTransformation"));
+
+        assertEquals("", connectorPluginsResource.getAlias("org.apache."));
+        assertEquals("", connectorPluginsResource.getAlias("org.apache.Connector"));
     }
 
     @Test
     public void testValidateConfigWithSingleErrorDueToMissingConnectorClassname() throws Throwable {
-        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
-        herder.validateConnectorConfig(EasyMock.eq(partialProps), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
-
-        PowerMock.expectLastCall().andAnswer((IAnswer<Void>) () -> {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Callback<ConfigInfos>> configInfosCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(partialProps);
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(PARTIAL_PROPS);
 
             Connector connector = new ConnectorPluginsResourceTestConnector();
-            Config config = connector.validate(partialProps);
+            Config config = connector.validate(PARTIAL_PROPS);
             ConfigDef configDef = connector.config();
             Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
             List<ConfigValue> configValues = config.configValues();
@@ -224,15 +270,13 @@ public class ConnectorPluginsResourceTest {
             );
             configInfosCallback.getValue().onCompletion(null, configInfos);
             return null;
-        });
-
-        PowerMock.replayAll();
+        }).when(herder).validateConnectorConfig(eq(PARTIAL_PROPS), configInfosCallback.capture(), anyBoolean());
 
         // This call to validateConfigs does not throw a BadRequestException because we've mocked
         // validateConnectorConfig.
         ConfigInfos configInfos = connectorPluginsResource.validateConfigs(
             ConnectorPluginsResourceTestConnector.class.getSimpleName(),
-            partialProps
+            PARTIAL_PROPS
         );
         assertEquals(PARTIAL_CONFIG_INFOS.name(), configInfos.name());
         assertEquals(PARTIAL_CONFIG_INFOS.errorCount(), configInfos.errorCount());
@@ -241,21 +285,19 @@ public class ConnectorPluginsResourceTest {
             new HashSet<>(PARTIAL_CONFIG_INFOS.values()),
             new HashSet<>(configInfos.values())
         );
-
-        PowerMock.verifyAll();
+        verify(herder).validateConnectorConfig(eq(PARTIAL_PROPS), any(), anyBoolean());
     }
 
     @Test
     public void testValidateConfigWithSimpleName() throws Throwable {
-        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
-
-        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Callback<ConfigInfos>> configInfosCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(PROPS);
 
             Connector connector = new ConnectorPluginsResourceTestConnector();
-            Config config = connector.validate(props);
+            Config config = connector.validate(PROPS);
             ConfigDef configDef = connector.config();
             Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
             List<ConfigValue> configValues = config.configValues();
@@ -272,34 +314,30 @@ public class ConnectorPluginsResourceTest {
             );
             configInfosCallback.getValue().onCompletion(null, configInfos);
             return null;
-        });
-
-        PowerMock.replayAll();
+        }).when(herder).validateConnectorConfig(eq(PROPS), configInfosCallback.capture(), anyBoolean());
 
         // make a request to connector-plugins resource using just the simple class name.
         ConfigInfos configInfos = connectorPluginsResource.validateConfigs(
             ConnectorPluginsResourceTestConnector.class.getSimpleName(),
-            props
+            PROPS
         );
         assertEquals(CONFIG_INFOS.name(), configInfos.name());
         assertEquals(0, configInfos.errorCount());
         assertEquals(CONFIG_INFOS.groups(), configInfos.groups());
         assertEquals(new HashSet<>(CONFIG_INFOS.values()), new HashSet<>(configInfos.values()));
-
-        PowerMock.verifyAll();
+        verify(herder).validateConnectorConfig(eq(PROPS), any(), anyBoolean());
     }
 
     @Test
     public void testValidateConfigWithAlias() throws Throwable {
-        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
-
-        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Callback<ConfigInfos>> configInfosCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(PROPS);
 
             Connector connector = new ConnectorPluginsResourceTestConnector();
-            Config config = connector.validate(props);
+            Config config = connector.validate(PROPS);
             ConfigDef configDef = connector.config();
             Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
             List<ConfigValue> configValues = config.configValues();
@@ -316,21 +354,18 @@ public class ConnectorPluginsResourceTest {
             );
             configInfosCallback.getValue().onCompletion(null, configInfos);
             return null;
-        });
-
-        PowerMock.replayAll();
+        }).when(herder).validateConnectorConfig(eq(PROPS), configInfosCallback.capture(), anyBoolean());
 
         // make a request to connector-plugins resource using a valid alias.
         ConfigInfos configInfos = connectorPluginsResource.validateConfigs(
             "ConnectorPluginsResourceTest",
-            props
+            PROPS
         );
         assertEquals(CONFIG_INFOS.name(), configInfos.name());
         assertEquals(0, configInfos.errorCount());
         assertEquals(CONFIG_INFOS.groups(), configInfos.groups());
         assertEquals(new HashSet<>(CONFIG_INFOS.values()), new HashSet<>(configInfos.values()));
-
-        PowerMock.verifyAll();
+        verify(herder).validateConnectorConfig(eq(PROPS), any(), anyBoolean());
     }
 
     @Test
@@ -339,44 +374,40 @@ public class ConnectorPluginsResourceTest {
         // simple name but different package.
         String customClassname = "com.custom.package."
             + ConnectorPluginsResourceTestConnector.class.getSimpleName();
-        assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs(customClassname, props));
+        assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs(customClassname, PROPS));
     }
 
     @Test
     public void testValidateConfigWithNonExistentAlias() {
-        assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs("ConnectorPluginsTest", props));
+        assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs("ConnectorPluginsTest", PROPS));
     }
 
     @Test
-    public void testListConnectorPlugins() throws Exception {
-        expectPlugins();
-        Set<ConnectorPluginInfo> connectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins());
-        assertFalse(connectorPlugins.contains(newInfo(Connector.class, "0.0")));
-        assertFalse(connectorPlugins.contains(newInfo(SourceConnector.class, "0.0")));
-        assertFalse(connectorPlugins.contains(newInfo(SinkConnector.class, "0.0")));
-        assertFalse(connectorPlugins.contains(newInfo(VerifiableSourceConnector.class)));
-        assertFalse(connectorPlugins.contains(newInfo(VerifiableSinkConnector.class)));
-        assertFalse(connectorPlugins.contains(newInfo(MockSourceConnector.class)));
-        assertFalse(connectorPlugins.contains(newInfo(MockSinkConnector.class)));
-        assertFalse(connectorPlugins.contains(newInfo(MockConnector.class)));
-        assertFalse(connectorPlugins.contains(newInfo(SchemaSourceConnector.class)));
-        assertTrue(connectorPlugins.contains(newInfo(ConnectorPluginsResourceTestConnector.class)));
-        PowerMock.verifyAll();
+    public void testListConnectorPlugins() {
+        Set<ConnectorPluginInfo> connectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins(true));
+
+        for (MockConnectorPluginDesc<?> plugin : CONNECTOR_PLUGINS) {
+            boolean contained = connectorPlugins.contains(newInfo(plugin.pluginClass(), plugin.version(), plugin.type()));
+            System.out.println(plugin.className());
+            System.out.println(contained);
+            if ((plugin.type() != PluginType.SOURCE && plugin.type() != PluginType.SINK) ||
+                (ConnectorPluginsResource.CONNECTOR_EXCLUDES.contains(plugin.pluginClass()))) {
+                assertFalse(contained);
+            } else {
+                assertTrue(contained);
+            }
+        }
+        verify(herder, atLeastOnce()).plugins();
     }
 
     @Test
     public void testConnectorPluginsIncludesTypeAndVersionInformation() throws Exception {
-        expectPlugins();
-        ConnectorPluginInfo sinkInfo = newInfo(TestSinkConnector.class);
-        ConnectorPluginInfo sourceInfo =
-                newInfo(TestSourceConnector.class);
-        ConnectorPluginInfo unknownInfo =
-            newInfo(ConnectorPluginsResourceTestConnector.class);
-        assertEquals(ConnectorType.SINK, sinkInfo.type());
-        assertEquals(ConnectorType.SOURCE, sourceInfo.type());
-        assertEquals(ConnectorType.UNKNOWN, unknownInfo.type());
-        assertEquals(TestSinkConnector.VERSION, sinkInfo.version());
-        assertEquals(TestSourceConnector.VERSION, sourceInfo.version());
+        ConnectorPluginInfo sinkInfo = newInfo(SampleSinkConnector.class, PluginType.SINK);
+        ConnectorPluginInfo sourceInfo = newInfo(SampleSourceConnector.class, PluginType.SOURCE);
+        assertEquals(PluginType.SINK.toString(), sinkInfo.type());
+        assertEquals(PluginType.SOURCE.toString(), sourceInfo.type());
+        assertEquals(SampleSinkConnector.VERSION, sinkInfo.version());
+        assertEquals(SampleSourceConnector.VERSION, sourceInfo.version());
 
         final ObjectMapper objectMapper = new ObjectMapper();
         String serializedSink = objectMapper.writeValueAsString(ConnectorType.SINK);
@@ -399,19 +430,57 @@ public class ConnectorPluginsResourceTest {
         );
     }
 
-    protected static ConnectorPluginInfo newInfo(Class<? extends Connector> klass, String version) {
-        return new ConnectorPluginInfo(new MockConnectorPluginDesc(klass, version));
+    @Test
+    public void testListAllPlugins() {
+        Set<ConnectorPluginInfo> connectorPlugins = new HashSet<>(connectorPluginsResource.listConnectorPlugins(false));
+
+        for (MockConnectorPluginDesc<?> plugin : CONNECTOR_PLUGINS) {
+            boolean contained = connectorPlugins.contains(newInfo(plugin.pluginClass(), plugin.version(), plugin.type()));
+            if ((ConnectorPluginsResource.CONNECTOR_EXCLUDES.contains(plugin.pluginClass())) ||
+                (ConnectorPluginsResource.TRANSFORM_EXCLUDES.contains(plugin.pluginClass()))) {
+                assertFalse(contained);
+            } else {
+                assertTrue(contained);
+            }
+        }
+        verify(herder, atLeastOnce()).plugins();
     }
 
-    protected static ConnectorPluginInfo newInfo(Class<? extends Connector> klass)
+    @Test
+    public void testGetConnectorConfigDef() {
+        String connName = ConnectorPluginsResourceTestConnector.class.getName();
+        when(herder.connectorPluginConfig(eq(PluginType.SOURCE), eq(connName))).thenAnswer(answer -> {
+            List<ConfigKeyInfo> results = new ArrayList<>();
+            for (ConfigDef.ConfigKey configKey : ConnectorPluginsResourceTestConnector.CONFIG_DEF.configKeys().values()) {
+                results.add(AbstractHerder.convertConfigKey(configKey));
+            }
+            return results;
+        });
+        List<ConfigKeyInfo> connectorConfigDef = connectorPluginsResource.getConnectorConfigDef(connName);
+        assertEquals(ConnectorPluginsResourceTestConnector.CONFIG_DEF.names().size(), connectorConfigDef.size());
+        for (String config : ConnectorPluginsResourceTestConnector.CONFIG_DEF.names()) {
+            Optional<ConfigKeyInfo> cki = connectorConfigDef.stream().filter(c -> c.name().equals(config)).findFirst();
+            assertTrue(cki.isPresent());
+        }
+    }
+
+    @Test(expected = org.apache.kafka.connect.runtime.rest.errors.BadRequestException.class)
+    public void testGetConnectorConfigDefWithBadName() {
+        String connName = "AnotherPlugin";
+        when(herder.connectorPluginConfig(eq(PluginType.UNKNOWN), eq(connName))).thenCallRealMethod();
+        connectorPluginsResource.getConnectorConfigDef(connName);
+    }
+
+    protected static ConnectorPluginInfo newInfo(Class<?> klass, String version, PluginType type) {
+        return new ConnectorPluginInfo(new MockConnectorPluginDesc<>(klass, version), type);
+    }
+
+    protected static ConnectorPluginInfo newInfo(Class<?> klass, PluginType type)
             throws Exception {
-        return new ConnectorPluginInfo(new MockConnectorPluginDesc(klass));
+        return new ConnectorPluginInfo(new MockConnectorPluginDesc<>(klass), type);
     }
 
     public static class MockPluginClassLoader extends PluginClassLoader {
-        public MockPluginClassLoader(URL pluginLocation, URL[] urls, ClassLoader parent) {
-            super(pluginLocation, urls, parent);
-        }
 
         public MockPluginClassLoader(URL pluginLocation, URL[] urls) {
             super(pluginLocation, urls);
@@ -423,22 +492,22 @@ public class ConnectorPluginsResourceTest {
         }
     }
 
-    public static class MockConnectorPluginDesc extends PluginDesc<Connector> {
-        public MockConnectorPluginDesc(Class<? extends Connector> klass, String version) {
+    public static class MockConnectorPluginDesc<T> extends PluginDesc<T> {
+        public MockConnectorPluginDesc(Class<T> klass, String version) {
             super(klass, version, new MockPluginClassLoader(null, new URL[0]));
         }
 
-        public MockConnectorPluginDesc(Class<? extends Connector> klass) throws Exception {
+        public MockConnectorPluginDesc(Class<T> klass) throws Exception {
             super(
                     klass,
-                    klass.getConstructor().newInstance().version(),
+                    DelegatingClassLoader.versionFor(klass),
                     new MockPluginClassLoader(null, new URL[0])
             );
         }
     }
 
     /* Name here needs to be unique as we are testing the aliasing mechanism */
-    public static class ConnectorPluginsResourceTestConnector extends Connector {
+    public static class ConnectorPluginsResourceTestConnector extends SourceConnector {
 
         private static final String TEST_STRING_CONFIG = "test.string.config";
         private static final String TEST_INT_CONFIG = "test.int.config";

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -261,6 +261,14 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Suppress warning about missing reflexive and symmetric properties of equal.
+             This equals method is used as a value filter for Jackson. -->
+        <Class name="org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo$NoVersionFilter"/>
+        <Method name="equals"/>
+        <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS"/>
+    </Match>
+
+    <Match>
         <!-- Suppress some minor warnings about machine-generated code for benchmarking. -->
         <Package name="~org\.apache\.kafka\.jmh\..*\.jmh_generated"/>
     </Match>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -263,7 +263,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     <Match>
         <!-- Suppress warning about missing reflexive and symmetric properties of equal.
              This equals method is used as a value filter for Jackson. -->
-        <Class name="org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo$NoVersionFilter"/>
+        <Class name="org.apache.kafka.connect.runtime.rest.entities.PluginInfo$NoVersionFilter"/>
         <Method name="equals"/>
         <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS"/>
     </Match>


### PR DESCRIPTION
…their configdefs

Implements [KIP-769](https://cwiki.apache.org/confluence/display/KAFKA/KIP-769%3A+Connect+APIs+to+list+all+connector+plugins+and+retrieve+their+configuration+definitions)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
