### PR TITLE
KAFKA-13512: topicIdsToNames and topicNamesToIds allocate unnecessary maps

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -182,11 +182,11 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
   }
 
   def topicNamesToIds(): util.Map[String, Uuid] = {
-    new util.HashMap(metadataSnapshot.topicIds.asJava)
+    Collections.unmodifiableMap(metadataSnapshot.topicIds.asJava)
   }
 
   def topicIdsToNames(): util.Map[Uuid, String] = {
-    new util.HashMap(metadataSnapshot.topicNames.asJava)
+    Collections.unmodifiableMap(metadataSnapshot.topicNames.asJava)
   }
 
   /**
@@ -194,7 +194,7 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
    */
   def topicIdInfo(): (util.Map[String, Uuid], util.Map[Uuid, String]) = {
     val snapshot = metadataSnapshot
-    (new util.HashMap(snapshot.topicIds.asJava), new util.HashMap(snapshot.topicNames.asJava))
+    (Collections.unmodifiableMap(snapshot.topicIds.asJava), Collections.unmodifiableMap(snapshot.topicNames.asJava))
   }
 
   override def getAllTopics(): Set[String] = {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -224,4 +224,9 @@ public class MetadataRequestBenchmark {
     public String testRequestToJson() {
         return RequestConvertToJson.requestDesc(allTopicMetadataRequest.header(), allTopicMetadataRequest.requestLog(), allTopicMetadataRequest.isForwarded()).toString();
     }
+
+    @Benchmark
+    public void testTopicIdInfo() {
+        metadataCache.topicIdInfo();
+    }
 }


### PR DESCRIPTION
We are creating a new map unnecessarily for these methods. Remove the extra map creation and simply wrap in unmodifiable map. 

I've also added a benchmark for the map method. 
Here are some results when I limited partitions to 20 only. 

Before change:
```
Benchmark                                 (partitionCount)  (topicCount)  Mode  Cnt   Score   Error  Units
MetadataRequestBenchmark.testTopicIdInfo                20           500  avgt   15  16.942 ± 0.306  ns/op
MetadataRequestBenchmark.testTopicIdInfo                20          1000  avgt   15  19.476 ± 0.339  ns/op
MetadataRequestBenchmark.testTopicIdInfo                20          5000  avgt   15  18.989 ± 0.482  ns/op
```

After change:
```
Benchmark                                 (partitionCount)  (topicCount)  Mode  Cnt   Score   Error  Units
MetadataRequestBenchmark.testTopicIdInfo                20           500  avgt   15  11.120 ± 0.336  ns/op
MetadataRequestBenchmark.testTopicIdInfo                20          1000  avgt   15  11.173 ± 0.489  ns/op
MetadataRequestBenchmark.testTopicIdInfo                20          5000  avgt   15  11.003 ± 0.042  ns/op
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
