### PR TITLE
KAFKA-13514: Fix flakey testLargeAssignmentAndGroupWithNonEqualSubscription

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -589,13 +589,13 @@ public abstract class AbstractStickyAssignorTest {
         assignor.assign(partitionsPerTopic, subscriptions);
     }
 
-    @Timeout(60)
+    @Timeout(40)
     @Test
     public void testLargeAssignmentAndGroupWithNonEqualSubscription() {
         // 1 million partitions!
         int topicCount = 500;
         int partitionCount = 2_000;
-        int consumerCount = 2_000;
+        int consumerCount = 1_000;
 
         List<String> topics = new ArrayList<>();
         Map<String, Integer> partitionsPerTopic = new HashMap<>();


### PR DESCRIPTION
For one `StickyAssignorTest#testLargeAssignmentAndGroupWithNonEqualSubscription` takes 60s is too long. 

I think this test is trying to prove we can run large assignment with general sticky assignor. Using 1000 consumer with 1M partition should be able to verify it.

Reduce the timeout from 60s to 40s, and reduce the consumer count from 2000 -> 1000.
In local env, before change, the time took 44s, after change, time took 16s. 
If before change, in jenkins we took around 60s, we now, took around 20s.

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/43372967/145212950-c3b640a3-32a2-40d9-b0d7-3722f3738766.png">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
