### PR TITLE
KAFKA-13517. Add ConfigurationKeys to ConfigResource class

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2359,7 +2359,7 @@ public class KafkaAdminClient extends AdminClient {
                                 new DescribeConfigsRequestData.DescribeConfigsResource()
                                     .setResourceName(config.name())
                                     .setResourceType(config.type().id())
-                                    .setConfigurationKeys(null))
+                                    .setConfigurationKeys(config.configurationKeys().isEmpty() ? null : config.configurationKeys()))
                             .collect(Collectors.toList()))
                         .setIncludeSynonyms(options.includeSynonyms())
                         .setIncludeDocumentation(options.includeDocumentation()));

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.config;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -56,6 +57,7 @@ public final class ConfigResource {
 
     private final Type type;
     private final String name;
+    private final List<String> configurationKeys;
 
     /**
      * Create an instance of this class with the provided parameters.
@@ -64,10 +66,17 @@ public final class ConfigResource {
      * @param name a non-null resource name
      */
     public ConfigResource(Type type, String name) {
+        this(type, name, Collections.emptyList());
+    }
+
+    public ConfigResource(Type type, String name, List<String> configurationKeys) {
         Objects.requireNonNull(type, "type should not be null");
         Objects.requireNonNull(name, "name should not be null");
+        Objects.requireNonNull(configurationKeys, "List of configuration keys should not be null");
+
         this.type = type;
         this.name = name;
+        this.configurationKeys = configurationKeys;
     }
 
     /**
@@ -82,6 +91,13 @@ public final class ConfigResource {
      */
     public String name() {
         return name;
+    }
+
+    /**
+     * Return list of configuration keys to fetch.
+     */
+    public List<String> configurationKeys() {
+        return configurationKeys;
     }
 
     /**
@@ -113,6 +129,6 @@ public final class ConfigResource {
 
     @Override
     public String toString() {
-        return "ConfigResource(type=" + type + ", name='" + name + "')";
+        return "ConfigResource(type=" + type + ", name='" + name + "', configuration keys=" + configurationKeys + ")";
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1513,7 +1513,8 @@ public class KafkaAdminClientTest {
     @Test
     public void testDescribeBrokerConfigs() throws Exception {
         ConfigResource broker0Resource = new ConfigResource(ConfigResource.Type.BROKER, "0");
-        ConfigResource broker1Resource = new ConfigResource(ConfigResource.Type.BROKER, "1");
+        ConfigResource broker1Resource = new ConfigResource(ConfigResource.Type.BROKER, "1",
+                Collections.singletonList("broker.id"));
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponseFrom(new DescribeConfigsResponse(
@@ -1556,7 +1557,7 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testDescribeConfigsPartialResponse() throws Exception {
+    public void testDescribeConfigsPartialResponse() {
         ConfigResource topic = new ConfigResource(ConfigResource.Type.TOPIC, "topic");
         ConfigResource topic2 = new ConfigResource(ConfigResource.Type.TOPIC, "topic2");
         try (AdminClientUnitTestEnv env = mockClientEnv()) {


### PR DESCRIPTION
A list of `ConfigResource` class is passed as argument to
`AdminClient::describeConfigs` api to indicate configuration of the
entities to fetch. The `ConfigResource` class is made up of two fields,
name and type of entity. Kafka returns all configurations for the
entities provided to the admin client api.

This admin api in turn uses `DescribeConfigsRequest` kafka api to get the
configuration for the entities in question. In addition to name and type
of entity whose configuration to get, Kafka `DescribeConfigsResource`
structure also lets users provide `ConfigurationKeys` list, which allows
users to fetch only the configurations that are needed.

However, this field isn't exposed in the `ConfigResource` class that is
used by `AdminClient`, so users of `AdminClient` have no way to ask for
specific configuration. The API always returns all configurations. Then
the user of the `AdminClient::describeConfigs` go over the returned list
and filter out the config keys that they are interested in.

This results in boilerplate code for all users of
`AdminClient::describeConfigs` api, in addition to  being wasteful use of
resource. It becomes painful in large cluster case where to fetch one
configuration of all topics, we need to fetch all configuration of all
topics, which can be huge in size.

Creating this Jira to add same field (i.e. `ConfigurationKeys`) to the
`ConfigResource` structure to bring it to parity to
`DescribeConfigsResource` Kafka API structure. There should be no backward
compatibility issue as the field will be optional and will behave same
way if it is not specified (i.e. by passing null to backend kafka api)

Added unit and integration test to test the behavior.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
