### PR TITLE
KAFKA-13522: add position tracking and bounding to IQv2

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1776,7 +1776,6 @@ public class KafkaStreams implements AutoCloseable {
                 )
             );
         } else {
-
             for (final StreamThread thread : threads) {
                 final Map<TaskId, Task> tasks = thread.allTasks();
                 for (final Entry<TaskId, Task> entry : tasks.entrySet()) {
@@ -1813,14 +1812,15 @@ public class KafkaStreams implements AutoCloseable {
                                 );
                                 result.addResult(partition, r);
                             }
-                        }
 
-                        // optimization: if we have handled all the requested partitions,
-                        // we can return right away.
-                        handledPartitions.add(partition);
-                        if (!request.isAllPartitions()
-                            && handledPartitions.containsAll(request.getPartitions())) {
-                            return result;
+
+                            // optimization: if we have handled all the requested partitions,
+                            // we can return right away.
+                            handledPartitions.add(partition);
+                            if (!request.isAllPartitions()
+                                && handledPartitions.containsAll(request.getPartitions())) {
+                                return result;
+                            }
                         }
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1768,22 +1768,7 @@ public class KafkaStreams implements AutoCloseable {
 
         final Map<String, StateStore> globalStateStores = topologyMetadata.globalStateStores();
         if (globalStateStores.containsKey(storeName)) {
-            // Global stores pose one significant problem
-            // for IQv2: when they start up, they skip the regular
-            // ingest pipeline and instead use the "restoration" pipeline
-            // to read up until the current end offset. Then, they switch
-            // over to the regular ingest pipeline.
-            //
-            // IQv2 position tracking expects to track the position of each
-            // record from the input topic through the ingest pipeline and then
-            // get the position headers through the restoration pipeline via the
-            // changelog topic. The fact that global stores "restore" the input topic
-            // instead of ingesting it violates our expectations.
-            //
-            // It has also caused other problems, so we may want to consider
-            // switching the global store processing to use the normal paradigm
-            // rather than adding special-case logic to track positions in global
-            // stores.
+            // See KAFKA-13523
             result.setGlobalResult(
                 QueryResult.forFailure(
                     FailureReason.UNKNOWN_QUERY_TYPE,

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1764,7 +1764,6 @@ public class KafkaStreams implements AutoCloseable {
             );
         }
         final StateQueryResult<R> result = new StateQueryResult<>();
-        final Set<Integer> handledPartitions = new HashSet<>();
 
         final Map<String, StateStore> globalStateStores = topologyMetadata.globalStateStores();
         if (globalStateStores.containsKey(storeName)) {
@@ -1816,9 +1815,8 @@ public class KafkaStreams implements AutoCloseable {
 
                             // optimization: if we have handled all the requested partitions,
                             // we can return right away.
-                            handledPartitions.add(partition);
                             if (!request.isAllPartitions()
-                                && handledPartitions.containsAll(request.getPartitions())) {
+                                && result.getPartitionResults().keySet().containsAll(request.getPartitions())) {
                                 return result;
                             }
                         }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1829,7 +1829,7 @@ public class KafkaStreams implements AutoCloseable {
 
         if (!request.isAllPartitions()) {
             for (final Integer partition : request.getPartitions()) {
-                if (!result.getPartitionResults().containsKey(partition)){
+                if (!result.getPartitionResults().containsKey(partition)) {
                     result.addResult(partition, QueryResult.forFailure(
                         FailureReason.NOT_PRESENT,
                         "The requested partition was not present at the time of the query."

--- a/streams/src/main/java/org/apache/kafka/streams/query/Position.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/Position.java
@@ -129,7 +129,7 @@ public class Position {
     /**
      * Return the partition -> offset mapping for a specific topic.
      */
-    public Map<Integer, Long> getBound(final String topic) {
+    public Map<Integer, Long> getPartitionPositions(final String topic) {
         final ConcurrentHashMap<Integer, Long> bound = position.get(topic);
         return bound == null ? Collections.emptyMap() : Collections.unmodifiableMap(bound);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/query/Position.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/Position.java
@@ -172,4 +172,8 @@ public class Position {
         throw new UnsupportedOperationException(
             "This mutable object is not suitable as a hash key");
     }
+
+    public boolean isEmpty() {
+        return position.isEmpty();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/query/PositionBound.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/PositionBound.java
@@ -30,63 +30,42 @@ import java.util.Objects;
 public class PositionBound {
 
     private final Position position;
-    private final boolean unbounded;
 
-    private PositionBound(final Position position, final boolean unbounded) {
-        if (unbounded && position != null) {
-            throw new IllegalArgumentException();
-        } else if (position != null) {
-            this.position = position.copy();
-            this.unbounded = false;
-        } else {
-            this.position = null;
-            this.unbounded = unbounded;
-        }
+    private PositionBound(final Position position) {
+        this.position = position.copy();
     }
 
     /**
      * Creates a new PositionBound representing "no bound"
      */
     public static PositionBound unbounded() {
-        return new PositionBound(null, true);
+        return new PositionBound(Position.emptyPosition());
     }
 
     /**
      * Creates a new PositionBound representing a specific position.
      */
     public static PositionBound at(final Position position) {
-        return new PositionBound(position, false);
+        return new PositionBound(position);
     }
 
     /**
      * Returns true iff this object specifies that there is no position bound.
      */
     public boolean isUnbounded() {
-        return unbounded;
+        return position.isEmpty();
     }
 
     /**
      * Returns the specific position of this bound.
-     *
-     * @throws IllegalArgumentException if this is an "unbounded" position.
      */
     public Position position() {
-        if (unbounded) {
-            throw new IllegalArgumentException(
-                "Cannot get the position of an unbounded PositionBound."
-            );
-        } else {
-            return position;
-        }
+        return position;
     }
 
     @Override
     public String toString() {
-        if (isUnbounded()) {
-            return "PositionBound{unbounded}";
-        } else {
-            return "PositionBound{position=" + position + '}';
-        }
+        return "PositionBound{position=" + position + '}';
     }
 
     @Override
@@ -98,7 +77,7 @@ public class PositionBound {
             return false;
         }
         final PositionBound that = (PositionBound) o;
-        return unbounded == that.unbounded && Objects.equals(position, that.position);
+        return Objects.equals(position, that.position);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
@@ -97,11 +97,15 @@ public class StateQueryResult<R> {
      * prior observations.
      */
     public Position getPosition() {
-        Position position = Position.emptyPosition();
-        for (final QueryResult<R> r : partitionResults.values()) {
-            position = position.merge(r.getPosition());
+        if (globalResult != null) {
+            return globalResult.getPosition();
+        } else {
+            final Position position = Position.emptyPosition();
+            for (final QueryResult<R> r : partitionResults.values()) {
+                position.merge(r.getPosition());
+            }
+            return position;
         }
-        return position;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -107,10 +107,10 @@ public class CachingKeyValueStore
             // we can skip flushing to downstream as well as writing to underlying store
             if (rawNewValue != null || rawOldValue != null) {
                 // we need to get the old values if needed, and then put to store, and then flush
-                wrapped().put(entry.key(), entry.newValue());
-
                 final ProcessorRecordContext current = context.recordContext();
                 context.setRecordContext(entry.entry().context());
+                wrapped().put(entry.key(), entry.newValue());
+
                 try {
                     flushListener.apply(
                         new Record<>(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -45,13 +45,12 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     private final String name;
     private final NavigableMap<Bytes, byte[]> map = new TreeMap<>();
+    private final Position position = Position.emptyPosition();
     private volatile boolean open = false;
     private StateStoreContext context;
-    private Position position;
 
     public InMemoryKeyValueStore(final String name) {
         this.name = name;
-        this.position = Position.emptyPosition();
     }
 
     @Override
@@ -102,7 +101,9 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
             query,
             positionBound,
             collectExecutionInfo,
-            this
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -317,7 +317,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
         final boolean collectExecutionInfo) {
-        return StoreQueryUtils.handleBasicQueries(query, positionBound, collectExecutionInfo, this);
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            context.taskId().partition()
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -357,7 +357,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
             query,
             positionBound,
             collectExecutionInfo,
-            this
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -121,7 +121,9 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
             query,
             positionBound,
             collectExecutionInfo,
-            this
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PositionSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PositionSerde.java
@@ -78,7 +78,7 @@ public final class PositionSerde {
             arraySize += Integer.SIZE; // topic name length
             arraySize += topicBytes.length; // topic name itself
 
-            final Map<Integer, Long> partitionOffsets = position.getBound(topic);
+            final Map<Integer, Long> partitionOffsets = position.getPartitionPositions(topic);
             arraySize += Integer.SIZE; // Number of PartitionOffset pairs
             arraySize += (Integer.SIZE + Long.SIZE)
                     * partitionOffsets.size(); // partitionOffsets themselves
@@ -93,7 +93,7 @@ public final class PositionSerde {
             buffer.put(topics[i]);
 
             final String topic = entries.get(i);
-            final Map<Integer, Long> partitionOffsets = position.getBound(topic);
+            final Map<Integer, Long> partitionOffsets = position.getPartitionPositions(topic);
             buffer.putInt(partitionOffsets.size());
             for (final Entry<Integer, Long> partitionOffset : partitionOffsets.entrySet()) {
                 buffer.putInt(partitionOffset.getKey());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -53,7 +53,14 @@ public class RocksDBSessionStore
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
         final boolean collectExecutionInfo) {
-        return StoreQueryUtils.handleBasicQueries(query, positionBound, collectExecutionInfo, this);
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            stateStoreContext.taskId().partition()
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -326,13 +326,18 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     }
 
     @Override
-    public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+    public <R> QueryResult<R> query(
+        final Query<R> query,
+        final PositionBound positionBound,
+        final boolean collectExecutionInfo) {
+
         return StoreQueryUtils.handleBasicQueries(
-                query,
-                positionBound,
-                collectExecutionInfo,
-                this
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -131,7 +131,14 @@ public class RocksDBWindowStore
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
         final boolean collectExecutionInfo) {
-        return StoreQueryUtils.handleBasicQueries(query, positionBound, collectExecutionInfo, this);
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            stateStoreContext.taskId().partition()
+        );
     }
 
     private void maybeUpdateSeqnumForDups() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 
 import java.util.Map;
-import java.util.Map.Entry;
 
 public final class StoreQueryUtils {
 
@@ -88,14 +87,10 @@ public final class StoreQueryUtils {
                 if (!partitionBounds.containsKey(partition)) {
                     // this topic isn't bounded for our partition, so just skip over it.
                 } else {
-                    if (seenPartitionBounds == null) {
-                        // we haven't seen a topic that is bounded for our partition
-                        return false;
-                    } else if (!seenPartitionBounds.containsKey(partition)) {
+                    if (!seenPartitionBounds.containsKey(partition)) {
                         // we haven't seen a partition that we have a bound for
                         return false;
-                    } else if (seenPartitionBounds.get(partition) < partitionBounds.get(
-                        partition)) {
+                    } else if (seenPartitionBounds.get(partition) < partitionBounds.get(partition)) {
                         // our current position is behind the bound
                         return false;
                     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -77,26 +77,22 @@ public final class StoreQueryUtils {
         final PositionBound positionBound,
         final int partition
     ) {
-        if (positionBound.isUnbounded()) {
-            return true;
-        } else {
-            final Position bound = positionBound.position();
-            for (final String topic : bound.getTopics()) {
-                final Map<Integer, Long> partitionBounds = bound.getBound(topic);
-                final Map<Integer, Long> seenPartitionBounds = position.getBound(topic);
-                if (!partitionBounds.containsKey(partition)) {
-                    // this topic isn't bounded for our partition, so just skip over it.
-                } else {
-                    if (!seenPartitionBounds.containsKey(partition)) {
-                        // we haven't seen a partition that we have a bound for
-                        return false;
-                    } else if (seenPartitionBounds.get(partition) < partitionBounds.get(partition)) {
-                        // our current position is behind the bound
-                        return false;
-                    }
+        final Position bound = positionBound.position();
+        for (final String topic : bound.getTopics()) {
+            final Map<Integer, Long> partitionBounds = bound.getBound(topic);
+            final Map<Integer, Long> seenPartitionBounds = position.getBound(topic);
+            if (!partitionBounds.containsKey(partition)) {
+                // this topic isn't bounded for our partition, so just skip over it.
+            } else {
+                if (!seenPartitionBounds.containsKey(partition)) {
+                    // we haven't seen a partition that we have a bound for
+                    return false;
+                } else if (seenPartitionBounds.get(partition) < partitionBounds.get(partition)) {
+                    // our current position is behind the bound
+                    return false;
                 }
             }
-            return true;
         }
+        return true;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -79,15 +79,15 @@ public final class StoreQueryUtils {
     ) {
         final Position bound = positionBound.position();
         for (final String topic : bound.getTopics()) {
-            final Map<Integer, Long> partitionBounds = bound.getBound(topic);
-            final Map<Integer, Long> seenPartitionBounds = position.getBound(topic);
+            final Map<Integer, Long> partitionBounds = bound.getPartitionPositions(topic);
+            final Map<Integer, Long> seenPartitionPositions = position.getPartitionPositions(topic);
             if (!partitionBounds.containsKey(partition)) {
                 // this topic isn't bounded for our partition, so just skip over it.
             } else {
-                if (!seenPartitionBounds.containsKey(partition)) {
+                if (!seenPartitionPositions.containsKey(partition)) {
                     // we haven't seen a partition that we have a bound for
                     return false;
-                } else if (seenPartitionBounds.get(partition) < partitionBounds.get(partition)) {
+                } else if (seenPartitionPositions.get(partition) < partitionBounds.get(partition)) {
                     // our current position is behind the bound
                     return false;
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -144,8 +144,8 @@ public class ConsistencyVectorIntegrationTest {
         for (final TestingRocksDBStore store : supplier.stores) {
             if (store.getDbDir() != null) {
                 assertThat(store.getDbDir().toString().contains("/0_0/"), is(true));
-                assertThat(store.getPosition().getBound(INPUT_TOPIC_NAME), notNullValue());
-                assertThat(store.getPosition().getBound(INPUT_TOPIC_NAME), hasEntry(0, 99L));
+                assertThat(store.getPosition().getPartitionPositions(INPUT_TOPIC_NAME), notNullValue());
+                assertThat(store.getPosition().getPartitionPositions(INPUT_TOPIC_NAME), hasEntry(0, 99L));
                 count.incrementAndGet();
             }
         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -419,6 +419,7 @@ public class IQv2StoreIntegrationTest {
     @Test
     public void verifyStore() {
         if (storeToTest.global()) {
+            // See KAFKA-13523
             globalShouldRejectAllQueries();
         } else {
             shouldRejectUnknownQuery();
@@ -429,6 +430,8 @@ public class IQv2StoreIntegrationTest {
     }
 
     private void globalShouldRejectAllQueries() {
+        // See KAFKA-13523
+
         final PingQuery query = new PingQuery();
         final StateQueryRequest<Boolean> request = inStore(STORE_NAME).withQuery(query);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -452,7 +452,7 @@ public class IQv2StoreIntegrationTest {
         final Set<Integer> partitions = mkSet(0, 1);
 
         final StateQueryResult<Void> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForPartitions(kafkaStreams, request, partitions);
 
         makeAssertions(
             partitions,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
@@ -85,7 +86,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Category({IntegrationTest.class})
@@ -248,6 +248,7 @@ public class IQv2StoreIntegrationTest {
     public static void before()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
         CLUSTER.start();
+        CLUSTER.deleteAllTopicsAndWait(60 * 1000L);
         final int partitions = 2;
         CLUSTER.createTopic(INPUT_TOPIC_NAME, partitions, 1);
 
@@ -295,8 +296,14 @@ public class IQv2StoreIntegrationTest {
 
     @Before
     public void beforeTest() {
-        final StreamsBuilder builder = new StreamsBuilder();
         final StoreSupplier<?> supplier = storeToTest.supplier();
+        final Properties streamsConfig = streamsConfiguration(
+            cache,
+            log,
+            storeToTest.name()
+        );
+
+        final StreamsBuilder builder = new StreamsBuilder();
         if (supplier instanceof KeyValueBytesStoreSupplier) {
             final Materialized<Integer, Integer, KeyValueStore<Bytes, byte[]>> materialized =
                 Materialized.as((KeyValueBytesStoreSupplier) supplier);
@@ -389,13 +396,10 @@ public class IQv2StoreIntegrationTest {
 
         // Don't need to wait for running, since tests can use iqv2 to wait until they
         // get a valid response.
+
         kafkaStreams =
             IntegrationTestUtils.getStartedStreams(
-                streamsConfiguration(
-                    cache,
-                    log,
-                    supplier.getClass().getSimpleName()
-                ),
+                streamsConfig,
                 builder,
                 true
             );
@@ -414,10 +418,28 @@ public class IQv2StoreIntegrationTest {
 
     @Test
     public void verifyStore() {
-        shouldRejectUnknownQuery();
-        shouldHandlePingQuery();
-        shouldCollectExecutionInfo();
-        shouldCollectExecutionInfoUnderFailure();
+        if (storeToTest.global()) {
+            globalShouldRejectAllQueries();
+        } else {
+            shouldRejectUnknownQuery();
+            shouldHandlePingQuery();
+            shouldCollectExecutionInfo();
+            shouldCollectExecutionInfoUnderFailure();
+        }
+    }
+
+    private void globalShouldRejectAllQueries() {
+        final PingQuery query = new PingQuery();
+        final StateQueryRequest<Boolean> request = inStore(STORE_NAME).withQuery(query);
+
+        final StateQueryResult<Boolean> result = kafkaStreams.query(request);
+
+        assertThat(result.getGlobalResult().isFailure(), is(true));
+        assertThat(result.getGlobalResult().getFailureReason(),
+            is(FailureReason.UNKNOWN_QUERY_TYPE));
+        assertThat(result.getGlobalResult().getFailureMessage(),
+            is("Global stores do not yet support the KafkaStreams#query API."
+                + " Use KafkaStreams#store instead."));
     }
 
     public void shouldRejectUnknownQuery() {
@@ -435,7 +457,6 @@ public class IQv2StoreIntegrationTest {
             queryResult -> {
                 assertThat(queryResult.isFailure(), is(true));
                 assertThat(queryResult.isSuccess(), is(false));
-                assertThat(queryResult.getPosition(), is(nullValue()));
                 assertThat(queryResult.getFailureReason(),
                     is(FailureReason.UNKNOWN_QUERY_TYPE));
                 assertThat(queryResult.getFailureMessage(),
@@ -456,12 +477,18 @@ public class IQv2StoreIntegrationTest {
     public void shouldHandlePingQuery() {
 
         final PingQuery query = new PingQuery();
-        final StateQueryRequest<Boolean> request =
-            inStore(STORE_NAME).withQuery(query);
         final Set<Integer> partitions = mkSet(0, 1);
+        final StateQueryRequest<Boolean> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .withPartitions(partitions)
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
 
         final StateQueryResult<Boolean> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForResult(
+                kafkaStreams,
+                request
+            );
 
         makeAssertions(
             partitions,
@@ -473,9 +500,6 @@ public class IQv2StoreIntegrationTest {
                 }
                 assertThat(queryResult.isSuccess(), is(true));
 
-                // TODO: position not implemented
-                assertThat(queryResult.getPosition(), is(nullValue()));
-
                 assertThrows(IllegalArgumentException.class, queryResult::getFailureReason);
                 assertThrows(IllegalArgumentException.class, queryResult::getFailureMessage);
 
@@ -483,17 +507,25 @@ public class IQv2StoreIntegrationTest {
 
                 assertThat(queryResult.getExecutionInfo(), is(empty()));
             });
+        assertThat(result.getPosition(), is(INPUT_POSITION));
     }
 
     public void shouldCollectExecutionInfo() {
 
         final PingQuery query = new PingQuery();
-        final StateQueryRequest<Boolean> request =
-            inStore(STORE_NAME).withQuery(query).enableExecutionInfo();
         final Set<Integer> partitions = mkSet(0, 1);
+        final StateQueryRequest<Boolean> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .enableExecutionInfo()
+                .withPartitions(partitions)
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
 
         final StateQueryResult<Boolean> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForResult(
+                kafkaStreams,
+                request
+            );
 
         makeAssertions(
             partitions,
@@ -505,12 +537,19 @@ public class IQv2StoreIntegrationTest {
     public void shouldCollectExecutionInfoUnderFailure() {
 
         final UnknownQuery query = new UnknownQuery();
-        final StateQueryRequest<Void> request =
-            inStore(STORE_NAME).withQuery(query).enableExecutionInfo();
         final Set<Integer> partitions = mkSet(0, 1);
+        final StateQueryRequest<Void> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .enableExecutionInfo()
+                .withPartitions(partitions)
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
 
         final StateQueryResult<Void> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForResult(
+                kafkaStreams,
+                request
+            );
 
         makeAssertions(
             partitions,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -51,6 +51,8 @@ import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.ThreadStateTransitionValidator;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentListener;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
 import org.apache.kafka.streams.query.StateQueryResult;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -91,6 +93,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.sleep;
 import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -139,6 +142,68 @@ public class IntegrationTestUtils {
         } while (System.currentTimeMillis() < deadline);
 
         throw new TimeoutException("The query never returned the desired partitions");
+    }
+
+    /**
+     * Repeatedly runs the query until the response is valid and then return the response.
+     * <p>
+     * Validity in this case means that the response position is up to the specified bound.
+     * <p>
+     * Once position bounding is generally supported, we should migrate tests to wait on the
+     * expected response position.
+     */
+    public static <R> StateQueryResult<R> iqv2WaitForResult(
+        final KafkaStreams kafkaStreams,
+        final StateQueryRequest<R> request) {
+
+        final long start = System.currentTimeMillis();
+        final long deadline = start + DEFAULT_TIMEOUT;
+
+        StateQueryResult<R> result;
+        do {
+            if (Thread.currentThread().isInterrupted()) {
+                fail("Test was interrupted.");
+            }
+
+            result = kafkaStreams.query(request);
+            final LinkedList<QueryResult<R>> allResults = getAllResults(result);
+
+            if (allResults.isEmpty()) {
+                sleep(100L);
+            } else {
+                final boolean needToWait = allResults
+                    .stream()
+                    .anyMatch(IntegrationTestUtils::needToWait);
+                if (needToWait) {
+                    sleep(100L);
+                } else {
+                    return result;
+                }
+            }
+        } while (System.currentTimeMillis() < deadline);
+
+        throw new TimeoutException(
+            "The query never returned within the bound. Last result: "
+            + result
+        );
+    }
+
+    private static <R> LinkedList<QueryResult<R>> getAllResults(
+        final StateQueryResult<R> result) {
+        final LinkedList<QueryResult<R>> allResults =
+            new LinkedList<>(result.getPartitionResults().values());
+        if (result.getGlobalResult() != null) {
+            allResults.add(result.getGlobalResult());
+        }
+        return allResults;
+    }
+
+    private static <R> boolean needToWait(final QueryResult<R> queryResult) {
+        return queryResult.isFailure()
+            && (
+            FailureReason.NOT_UP_TO_BOUND.equals(queryResult.getFailureReason())
+                || FailureReason.NOT_PRESENT.equals(queryResult.getFailureReason())
+        );
     }
 
     /*

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -119,7 +119,7 @@ public class IntegrationTestUtils {
      * Once position bounding is generally supported, we should migrate tests to wait on the
      * expected response position.
      */
-    public static <R> StateQueryResult<R> iqv2WaitForPartitionsOrGlobal(
+    public static <R> StateQueryResult<R> iqv2WaitForPartitions(
         final KafkaStreams kafkaStreams,
         final StateQueryRequest<R> request,
         final Set<Integer> partitions) {
@@ -128,16 +128,14 @@ public class IntegrationTestUtils {
         final long deadline = start + DEFAULT_TIMEOUT;
 
         do {
+            if (Thread.currentThread().isInterrupted()) {
+                fail("Test was interrupted.");
+            }
             final StateQueryResult<R> result = kafkaStreams.query(request);
-            if (result.getPartitionResults().keySet().containsAll(partitions)
-                || result.getGlobalResult() != null) {
+            if (result.getPartitionResults().keySet().containsAll(partitions)) {
                 return result;
             } else {
-                try {
-                    Thread.sleep(100L);
-                } catch (final InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                sleep(100L);
             }
         } while (System.currentTimeMillis() < deadline);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -202,8 +202,7 @@ public class IntegrationTestUtils {
         return queryResult.isFailure()
             && (
             FailureReason.NOT_UP_TO_BOUND.equals(queryResult.getFailureReason())
-                || FailureReason.NOT_PRESENT.equals(queryResult.getFailureReason())
-        );
+                || FailureReason.NOT_PRESENT.equals(queryResult.getFailureReason()));
     }
 
     /*

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
@@ -50,9 +50,9 @@ public class PositionBoundTest {
     }
 
     @Test
-    public void unboundedShouldThrowOnPosition() {
+    public void unboundedShouldReturnEmptyPosition() {
         final PositionBound bound = PositionBound.unbounded();
-        assertThrows(IllegalArgumentException.class, bound::position);
+        assertThat(bound.position(), equalTo(Position.emptyPosition()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
@@ -47,14 +47,14 @@ public class PositionTest {
 
         final Position position = Position.fromMap(map);
         assertThat(position.getTopics(), equalTo(mkSet("topic", "topic1")));
-        assertThat(position.getBound("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
 
         // Should be a copy of the constructor map
 
         map.get("topic1").put(99, 99L);
 
         // so the position is still the original one
-        assertThat(position.getBound("topic1"), equalTo(mkMap(
+        assertThat(position.getPartitionPositions("topic1"), equalTo(mkMap(
             mkEntry(0, 5L),
             mkEntry(7, 0L)
         )));
@@ -85,13 +85,13 @@ public class PositionTest {
         final Position merged = position.merge(position1);
 
         assertThat(merged.getTopics(), equalTo(mkSet("topic", "topic1", "topic2")));
-        assertThat(merged.getBound("topic"), equalTo(mkMap(mkEntry(0, 7L))));
-        assertThat(merged.getBound("topic1"), equalTo(mkMap(
+        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 7L))));
+        assertThat(merged.getPartitionPositions("topic1"), equalTo(mkMap(
             mkEntry(0, 5L),
             mkEntry(7, 0L),
             mkEntry(8, 1L)
         )));
-        assertThat(merged.getBound("topic2"), equalTo(mkMap(mkEntry(9, 5L))));
+        assertThat(merged.getPartitionPositions("topic2"), equalTo(mkMap(mkEntry(9, 5L))));
     }
 
     @Test
@@ -99,9 +99,9 @@ public class PositionTest {
         final Position position = Position.emptyPosition();
         position.withComponent("topic", 3, 5L);
         position.withComponent("topic", 3, 4L);
-        assertThat(position.getBound("topic").get(3), equalTo(5L));
+        assertThat(position.getPartitionPositions("topic").get(3), equalTo(5L));
         position.withComponent("topic", 3, 6L);
-        assertThat(position.getBound("topic").get(3), equalTo(6L));
+        assertThat(position.getPartitionPositions("topic").get(3), equalTo(6L));
     }
 
     @Test
@@ -123,21 +123,21 @@ public class PositionTest {
 
         // copy has not changed
         assertThat(copy.getTopics(), equalTo(mkSet("topic", "topic1")));
-        assertThat(copy.getBound("topic"), equalTo(mkMap(mkEntry(0, 5L))));
-        assertThat(copy.getBound("topic1"), equalTo(mkMap(
+        assertThat(copy.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertThat(copy.getPartitionPositions("topic1"), equalTo(mkMap(
             mkEntry(0, 5L),
             mkEntry(7, 0L)
         )));
 
         // original has changed
         assertThat(position.getTopics(), equalTo(mkSet("topic", "topic1", "topic2")));
-        assertThat(position.getBound("topic"), equalTo(mkMap(mkEntry(0, 6L))));
-        assertThat(position.getBound("topic1"), equalTo(mkMap(
+        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 6L))));
+        assertThat(position.getPartitionPositions("topic1"), equalTo(mkMap(
             mkEntry(0, 5L),
             mkEntry(7, 0L),
             mkEntry(8, 1L)
         )));
-        assertThat(position.getBound("topic2"), equalTo(mkMap(mkEntry(2, 4L))));
+        assertThat(position.getPartitionPositions("topic2"), equalTo(mkMap(mkEntry(2, 4L))));
     }
 
     @Test
@@ -153,8 +153,8 @@ public class PositionTest {
         final Position merged = position.merge(null);
 
         assertThat(merged.getTopics(), equalTo(mkSet("topic", "topic1")));
-        assertThat(merged.getBound("topic"), equalTo(mkMap(mkEntry(0, 5L))));
-        assertThat(merged.getBound("topic1"), equalTo(mkMap(
+        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertThat(merged.getPartitionPositions("topic1"), equalTo(mkMap(
             mkEntry(0, 5L),
             mkEntry(7, 0L)
         )));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -592,8 +592,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(expected, results);
         assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getBound(""), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getBound(""), hasEntry(0, 3L));
+        assertThat(bytesStore.getPosition().getPartitionPositions(""), Matchers.notNullValue());
+        assertThat(bytesStore.getPosition().getPartitionPositions(""), hasEntry(0, 3L));
     }
 
     @Test
@@ -629,10 +629,10 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(expected, results);
         assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getBound("A"), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getBound("A"), hasEntry(0, 3L));
-        assertThat(bytesStore.getPosition().getBound("B"), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getBound("B"), hasEntry(0, 2L));
+        assertThat(bytesStore.getPosition().getPartitionPositions("A"), Matchers.notNullValue());
+        assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 3L));
+        assertThat(bytesStore.getPosition().getPartitionPositions("B"), Matchers.notNullValue());
+        assertThat(bytesStore.getPosition().getPartitionPositions("B"), hasEntry(0, 2L));
     }
 
     @Test
@@ -665,7 +665,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(expected, results);
         assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getBound("A"), hasEntry(0, 2L));
+        assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 2L));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -270,8 +270,8 @@ public class ChangeLoggingKeyValueBytesStoreTest {
         final Header vectorHeader = collector.collected().get(0).headers().lastHeader(ChangelogRecordDeserializationHelper.CHANGELOG_POSITION_HEADER_KEY);
         assertThat(vectorHeader, is(notNullValue()));
         final Position position = PositionSerde.deserialize(ByteBuffer.wrap(vectorHeader.value()));
-        assertThat(position.getBound(INPUT_TOPIC_NAME), is(notNullValue()));
-        assertThat(position.getBound(INPUT_TOPIC_NAME), hasEntry(0, 100L));
+        assertThat(position.getPartitionPositions(INPUT_TOPIC_NAME), is(notNullValue()));
+        assertThat(position.getPartitionPositions(INPUT_TOPIC_NAME), hasEntry(0, 100L));
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1003,8 +1003,8 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                         rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))));
 
         assertThat(rocksDBStore.getPosition(), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getBound(""), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getBound(""), hasEntry(0, 3L));
+        assertThat(rocksDBStore.getPosition().getPartitionPositions(""), Matchers.notNullValue());
+        assertThat(rocksDBStore.getPosition().getPartitionPositions(""), hasEntry(0, 3L));
     }
 
     @Test
@@ -1040,10 +1040,10 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                         rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))));
 
         assertThat(rocksDBStore.getPosition(), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getBound("A"), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getBound("A"), hasEntry(0, 3L));
-        assertThat(rocksDBStore.getPosition().getBound("B"), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getBound("B"), hasEntry(0, 2L));
+        assertThat(rocksDBStore.getPosition().getPartitionPositions("A"), Matchers.notNullValue());
+        assertThat(rocksDBStore.getPosition().getPartitionPositions("A"), hasEntry(0, 3L));
+        assertThat(rocksDBStore.getPosition().getPartitionPositions("B"), Matchers.notNullValue());
+        assertThat(rocksDBStore.getPosition().getPartitionPositions("B"), hasEntry(0, 2L));
     }
 
     @Test
@@ -1067,7 +1067,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))));
 
         assertThat(rocksDBStore.getPosition(), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getBound("A"), hasEntry(0, 2L));
+        assertThat(rocksDBStore.getPosition().getPartitionPositions("A"), hasEntry(0, 2L));
     }
 
     @Test


### PR DESCRIPTION
* Fill in the Position response in the IQv2 result.
* Enforce PositionBound in IQv2 queries.
* Update integration testing approach to leverage consistent queries.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
