### PR TITLE
POC of passing serdes around in IQv2

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1768,22 +1768,7 @@ public class KafkaStreams implements AutoCloseable {
 
         final Map<String, StateStore> globalStateStores = topologyMetadata.globalStateStores();
         if (globalStateStores.containsKey(storeName)) {
-            // Global stores pose one significant problem
-            // for IQv2: when they start up, they skip the regular
-            // ingest pipeline and instead use the "restoration" pipeline
-            // to read up until the current end offset. Then, they switch
-            // over to the regular ingest pipeline.
-            //
-            // IQv2 position tracking expects to track the position of each
-            // record from the input topic through the ingest pipeline and then
-            // get the position headers through the restoration pipeline via the
-            // changelog topic. The fact that global stores "restore" the input topic
-            // instead of ingesting it violates our expectations.
-            //
-            // It has also caused other problems, so we may want to consider
-            // switching the global store processing to use the normal paradigm
-            // rather than adding special-case logic to track positions in global
-            // stores.
+            // See KAFKA-13523
             result.setGlobalResult(
                 QueryResult.forFailure(
                     FailureReason.UNKNOWN_QUERY_TYPE,

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1809,7 +1809,8 @@ public class KafkaStreams implements AutoCloseable {
                                     request.isRequireActive()
                                         ? PositionBound.unbounded()
                                         : request.getPositionBound(),
-                                    request.executionInfoEnabled()
+                                    request.executionInfoEnabled(),
+                                    null
                                 );
                                 result.addResult(partition, r);
                             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.StateSerdes;
 
 /**
  * A storage engine for managing state maintained by a stream processor.
@@ -148,7 +149,8 @@ public interface StateStore {
     default <R> QueryResult<R> query(
         Query<R> query,
         PositionBound positionBound,
-        boolean collectExecutionInfo) {
+        boolean collectExecutionInfo,
+        StateSerdes<Object, Object> querySerdes) {
         // If a store doesn't implement a query handler, then all queries are unknown.
         return QueryResult.forUnknownQueryType(query, this);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/query/FailureReason.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/FailureReason.java
@@ -52,5 +52,12 @@ public enum FailureReason {
      * The requested store partition does not exist at all. For example, partition 4 was requested,
      * but the store in question only has 4 partitions (0 through 3).
      */
-    DOES_NOT_EXIST;
+    DOES_NOT_EXIST,
+
+    /**
+     * The store that handled the query got an exception during query execution. The message
+     * will contain the exception details. Depending on the nature of the exception, the caller
+     * may be able to retry this instance or may need to try a different instance.
+     */
+    STORE_EXCEPTION;
 }

--- a/streams/src/main/java/org/apache/kafka/streams/query/KeyQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/KeyQuery.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.query;
+
+import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
+
+@Evolving
+public class KeyQuery<K, V> implements Query<V> {
+
+    private final K key;
+
+    private KeyQuery(final K key) {
+        this.key = key;
+    }
+
+    public static <K, V> KeyQuery<K, V> withKey(final K key) {
+        return new KeyQuery<>(key);
+    }
+
+    public K getKey() {
+        return key;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
@@ -29,10 +29,10 @@ import java.util.List;
  */
 public final class QueryResult<R> {
 
-    private final List<String> executionInfo = new LinkedList<>();
     private final FailureReason failureReason;
     private final String failure;
     private final R result;
+    private List<String> executionInfo = new LinkedList<>();
     private Position position;
 
     private QueryResult(final R result) {
@@ -195,6 +195,18 @@ public final class QueryResult<R> {
                     + failure);
         }
         return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> QueryResult<V> swapResult(final V value) {
+        if (isFailure()) {
+            return (QueryResult<V>) this;
+        } else {
+            final QueryResult<V> result = new QueryResult<>(value);
+            result.executionInfo = executionInfo;
+            result.position = position;
+            return result;
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/query/RawKeyQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/RawKeyQuery.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.query;
+
+import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
+import org.apache.kafka.common.utils.Bytes;
+
+@Evolving
+public class RawKeyQuery implements Query<byte[]> {
+
+    private final Bytes key;
+
+    private RawKeyQuery(final Bytes key) {
+        this.key = key;
+    }
+
+    public static RawKeyQuery withKey(final Bytes key) {
+        return new RawKeyQuery(key);
+    }
+
+    public static RawKeyQuery withKey(final byte[] key) {
+        return new RawKeyQuery(Bytes.wrap(key));
+    }
+
+    public Bytes getKey() {
+        return key;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
@@ -97,11 +97,15 @@ public class StateQueryResult<R> {
      * prior observations.
      */
     public Position getPosition() {
-        Position position = Position.emptyPosition();
-        for (final QueryResult<R> r : partitionResults.values()) {
-            position = position.merge(r.getPosition());
+        if (globalResult != null) {
+            return globalResult.getPosition();
+        } else {
+            final Position position = Position.emptyPosition();
+            for (final QueryResult<R> r : partitionResults.values()) {
+                position.merge(r.getPosition());
+            }
+            return position;
         }
-        return position;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -107,10 +107,10 @@ public class CachingKeyValueStore
             // we can skip flushing to downstream as well as writing to underlying store
             if (rawNewValue != null || rawOldValue != null) {
                 // we need to get the old values if needed, and then put to store, and then flush
-                wrapped().put(entry.key(), entry.newValue());
-
                 final ProcessorRecordContext current = context.recordContext();
                 context.setRecordContext(entry.entry().context());
+                wrapped().put(entry.key(), entry.newValue());
+
                 try {
                     flushListener.apply(
                         new Record<>(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -45,13 +45,12 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     private final String name;
     private final NavigableMap<Bytes, byte[]> map = new TreeMap<>();
+    private final Position position = Position.emptyPosition();
     private volatile boolean open = false;
     private StateStoreContext context;
-    private Position position;
 
     public InMemoryKeyValueStore(final String name) {
         this.name = name;
-        this.position = Position.emptyPosition();
     }
 
     @Override
@@ -102,7 +101,9 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
             query,
             positionBound,
             collectExecutionInfo,
-            this
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,12 +96,14 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             collectExecutionInfo,
+            serdes,
             this,
             position,
             context.taskId().partition()

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -317,7 +317,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
         final boolean collectExecutionInfo) {
-        return StoreQueryUtils.handleBasicQueries(query, positionBound, collectExecutionInfo, this);
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            context.taskId().partition()
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -35,6 +35,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -316,11 +317,13 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             collectExecutionInfo,
+            serdes,
             this,
             position,
             context.taskId().partition()

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -357,7 +357,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
             query,
             positionBound,
             collectExecutionInfo,
-            this
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.slf4j.Logger;
@@ -352,11 +353,13 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             collectExecutionInfo,
+            serdes,
             this,
             position,
             context.taskId().partition()

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StateSerdes;
 
 import java.util.List;
 
@@ -122,11 +123,12 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
 
 
         final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-        final QueryResult<R> result = store.query(query, positionBound, collectExecutionInfo);
+        final QueryResult<R> result = store.query(query, positionBound, collectExecutionInfo, serdes);
         if (collectExecutionInfo) {
             final long end = System.nanoTime();
             result.addExecutionInfo(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -121,7 +121,9 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
             query,
             positionBound,
             collectExecutionInfo,
-            this
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,12 +116,14 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             collectExecutionInfo,
+            serdes,
             this,
             position,
             context.taskId().partition()

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -89,14 +89,6 @@ public class MeteredKeyValueStore<K, V>
     private StreamsMetricsImpl streamsMetrics;
     private TaskId taskId;
 
-    private  Map<Class, QueryHandler> queryHandlers =
-        mkMap(
-            mkEntry(
-                KeyQuery.class,
-                (query, positionBound, collectExecutionInfo, store) -> runKeyQuery(query, positionBound, collectExecutionInfo)
-            )
-        );
-
     MeteredKeyValueStore(final KeyValueStore<Bytes, byte[]> inner,
                          final String metricsScope,
                          final Time time,
@@ -206,62 +198,20 @@ public class MeteredKeyValueStore<K, V>
 
     @SuppressWarnings("unchecked")
     @Override
-    public <R> QueryResult<R> query(final Query<R> query,
+    public <R> QueryResult<R> query(
+        final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
-
-        final long start = System.nanoTime();
-        final QueryResult<R> result;
-
-        final QueryHandler handler = queryHandlers.get(query.getClass());
-        if (handler == null) {
-            result = wrapped().query(query, positionBound, collectExecutionInfo);
-            if (collectExecutionInfo) {
-                result.addExecutionInfo(
-                    "Handled in " + getClass() + " in " + (System.nanoTime() - start) + "ns");
-            }
-        } else {
-            result = (QueryResult<R>) handler.apply(
-                query,
-                positionBound,
-                collectExecutionInfo,
-                this
-            );
-            if (collectExecutionInfo) {
-                result.addExecutionInfo(
-                    "Handled in " + getClass() + " with serdes "
-                        + serdes + " in " + (System.nanoTime() - start) + "ns");
-            }
-        }
-        return result;
-    }
-
-    @SuppressWarnings("unchecked")
-    private <R> QueryResult<R> runKeyQuery(final Query query,
-        final PositionBound positionBound, final boolean collectExecutionInfo) {
-        final QueryResult<R> result;
-        final KeyQuery<K, V> typedQuery = (KeyQuery<K, V>) query;
-        final RawKeyQuery rawKeyQuery = RawKeyQuery.withKey(keyBytes(typedQuery.getKey()));
-        final QueryResult<byte[]> rawResult =
-            wrapped().query(rawKeyQuery, positionBound, collectExecutionInfo);
-        if (rawResult.isSuccess()) {
-            final boolean timestamped = WrappedStateStore.isTimestamped(wrapped());
-            final Serde<V> vSerde = serdes.valueSerde();
-            final Deserializer<V> deserializer;
-            if (!timestamped && vSerde instanceof ValueAndTimestampSerde) {
-                final ValueAndTimestampDeserializer valueAndTimestampDeserializer =
-                    (ValueAndTimestampDeserializer) ((ValueAndTimestampSerde) vSerde).deserializer();
-                deserializer = (Deserializer<V>) valueAndTimestampDeserializer.valueDeserializer;
-            } else {
-                deserializer = vSerde.deserializer();
-            }
-            final V value = deserializer.deserialize(serdes.topic(), rawResult.getResult());
-            final QueryResult<V> typedQueryResult =
-                rawResult.swapResult(value);
-            result = (QueryResult<R>) typedQueryResult;
-        } else {
-            // the generic type doesn't matter, since failed queries have no result set.
-            result = (QueryResult<R>) rawResult;
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes
+    ) {
+        final long start = collectExecutionInfo ? System.nanoTime() : -1L;
+        final QueryResult<R> result = wrapped().query(query, positionBound, collectExecutionInfo,
+            (StateSerdes<Object, Object>) this.serdes);
+        if (collectExecutionInfo) {
+            final long end = System.nanoTime();
+            result.addExecutionInfo(
+                "Handled in " + getClass() + " in " + (end - start)
+                    + "ns");
         }
         return result;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -53,7 +53,14 @@ public class RocksDBSessionStore
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
         final boolean collectExecutionInfo) {
-        return StoreQueryUtils.handleBasicQueries(query, positionBound, collectExecutionInfo, this);
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            stateStoreContext.taskId().partition()
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StateSerdes;
 
 
 public class RocksDBSessionStore
@@ -52,11 +53,13 @@ public class RocksDBSessionStore
 
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             collectExecutionInfo,
+            serdes,
             this,
             position,
             stateStoreContext.taskId().partition()

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -326,13 +326,18 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     }
 
     @Override
-    public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+    public <R> QueryResult<R> query(
+        final Query<R> query,
+        final PositionBound positionBound,
+        final boolean collectExecutionInfo) {
+
         return StoreQueryUtils.handleBasicQueries(
-                query,
-                positionBound,
-                collectExecutionInfo,
-                this
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            context.taskId().partition()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -21,7 +21,11 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -104,6 +108,20 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         noTimestampsIter.close();
     }
 
+    @Override
+    public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
+        final boolean collectExecutionInfo, final StateSerdes<Object, Object> serdes) {
+
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            serdes,
+            this,
+            position,
+            context.taskId().partition()
+        );
+    }
 
     private class DualColumnFamilyAccessor implements RocksDBAccessor {
         private final ColumnFamilyHandle oldColumnFamily;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -131,7 +131,14 @@ public class RocksDBWindowStore
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
         final boolean collectExecutionInfo) {
-        return StoreQueryUtils.handleBasicQueries(query, positionBound, collectExecutionInfo, this);
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            collectExecutionInfo,
+            this,
+            position,
+            stateStoreContext.taskId().partition()
+        );
     }
 
     private void maybeUpdateSeqnumForDups() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
@@ -130,11 +131,13 @@ public class RocksDBWindowStore
 
     @Override
     public <R> QueryResult<R> query(final Query<R> query, final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             collectExecutionInfo,
+            serdes,
             this,
             position,
             stateStoreContext.taskId().partition()

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 
 import java.util.Map;
-import java.util.Map.Entry;
 
 public final class StoreQueryUtils {
 
@@ -88,14 +87,10 @@ public final class StoreQueryUtils {
                 if (!partitionBounds.containsKey(partition)) {
                     // this topic isn't bounded for our partition, so just skip over it.
                 } else {
-                    if (seenPartitionBounds == null) {
-                        // we haven't seen a topic that is bounded for our partition
-                        return false;
-                    } else if (!seenPartitionBounds.containsKey(partition)) {
+                    if (!seenPartitionBounds.containsKey(partition)) {
                         // we haven't seen a partition that we have a bound for
                         return false;
-                    } else if (seenPartitionBounds.get(partition) < partitionBounds.get(
-                        partition)) {
+                    } else if (seenPartitionBounds.get(partition) < partitionBounds.get(partition)) {
                         // our current position is behind the bound
                         return false;
                     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -190,10 +191,11 @@ public class TimestampedKeyValueStoreBuilder<K, V>
         @Override
         public <R> QueryResult<R> query(final Query<R> query,
             final PositionBound positionBound,
-            final boolean collectExecutionInfo) {
+            final boolean collectExecutionInfo,
+            final StateSerdes<Object, Object> serdes) {
 
             final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-            final QueryResult<R> result = wrapped.query(query, positionBound, collectExecutionInfo);
+            final QueryResult<R> result = wrapped.query(query, positionBound, collectExecutionInfo, serdes);
             if (collectExecutionInfo) {
                 final long end = System.nanoTime();
                 result.addExecutionInfo("Handled in " + getClass() + " in " + (end - start) + "ns");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -208,10 +209,11 @@ public class TimestampedWindowStoreBuilder<K, V>
         @Override
         public <R> QueryResult<R> query(final Query<R> query,
             final PositionBound positionBound,
-            final boolean collectExecutionInfo) {
+            final boolean collectExecutionInfo,
+            final StateSerdes<Object, Object> serdes) {
 
             final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-            final QueryResult<R> result = wrapped.query(query, positionBound, collectExecutionInfo);
+            final QueryResult<R> result = wrapped.query(query, positionBound, collectExecutionInfo, serdes);
             if (collectExecutionInfo) {
                 final long end = System.nanoTime();
                 result.addExecutionInfo("Handled in " + getClass() + " in " + (end - start) + "ns");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
@@ -23,10 +23,17 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import static java.util.Objects.requireNonNull;
 
 public class ValueAndTimestampSerde<V> extends WrappingNullableSerde<ValueAndTimestamp<V>, Void, V> {
+    private final Serde<V> valueSerde;
+
     public ValueAndTimestampSerde(final Serde<V> valueSerde) {
         super(
             new ValueAndTimestampSerializer<>(requireNonNull(valueSerde, "valueSerde was null").serializer()),
             new ValueAndTimestampDeserializer<>(requireNonNull(valueSerde, "valueSerde was null").deserializer())
         );
+        this.valueSerde = valueSerde;
+    }
+
+    public Serde<V> getValueSerde() {
+        return valueSerde;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowToTimestampedWindowByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowToTimestampedWindowByteStoreAdapter.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
@@ -190,10 +191,11 @@ class WindowToTimestampedWindowByteStoreAdapter implements WindowStore<Bytes, by
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
 
         final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-        final QueryResult<R> result = store.query(query, positionBound, collectExecutionInfo);
+        final QueryResult<R> result = store.query(query, positionBound, collectExecutionInfo, serdes);
         if (collectExecutionInfo) {
             final long end = System.nanoTime();
             result.addExecutionInfo(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 
 /**
@@ -109,10 +110,11 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final boolean collectExecutionInfo,
+        final StateSerdes<Object, Object> serdes) {
 
         final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-        final QueryResult<R> result = wrapped().query(query, positionBound, collectExecutionInfo);
+        final QueryResult<R> result = wrapped().query(query, positionBound, collectExecutionInfo, serdes);
         if (collectExecutionInfo) {
             final long end = System.nanoTime();
             result.addExecutionInfo(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -419,6 +419,7 @@ public class IQv2StoreIntegrationTest {
     @Test
     public void verifyStore() {
         if (storeToTest.global()) {
+            // See KAFKA-13523
             globalShouldRejectAllQueries();
         } else {
             shouldRejectUnknownQuery();
@@ -429,6 +430,8 @@ public class IQv2StoreIntegrationTest {
     }
 
     private void globalShouldRejectAllQueries() {
+        // See KAFKA-13523
+
         final PingQuery query = new PingQuery();
         final StateQueryRequest<Boolean> request = inStore(STORE_NAME).withQuery(query);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
@@ -85,7 +86,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Category({IntegrationTest.class})
@@ -248,6 +248,7 @@ public class IQv2StoreIntegrationTest {
     public static void before()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
         CLUSTER.start();
+        CLUSTER.deleteAllTopicsAndWait(60 * 1000L);
         final int partitions = 2;
         CLUSTER.createTopic(INPUT_TOPIC_NAME, partitions, 1);
 
@@ -295,8 +296,14 @@ public class IQv2StoreIntegrationTest {
 
     @Before
     public void beforeTest() {
-        final StreamsBuilder builder = new StreamsBuilder();
         final StoreSupplier<?> supplier = storeToTest.supplier();
+        final Properties streamsConfig = streamsConfiguration(
+            cache,
+            log,
+            storeToTest.name()
+        );
+
+        final StreamsBuilder builder = new StreamsBuilder();
         if (supplier instanceof KeyValueBytesStoreSupplier) {
             final Materialized<Integer, Integer, KeyValueStore<Bytes, byte[]>> materialized =
                 Materialized.as((KeyValueBytesStoreSupplier) supplier);
@@ -389,13 +396,10 @@ public class IQv2StoreIntegrationTest {
 
         // Don't need to wait for running, since tests can use iqv2 to wait until they
         // get a valid response.
+
         kafkaStreams =
             IntegrationTestUtils.getStartedStreams(
-                streamsConfiguration(
-                    cache,
-                    log,
-                    supplier.getClass().getSimpleName()
-                ),
+                streamsConfig,
                 builder,
                 true
             );
@@ -414,10 +418,28 @@ public class IQv2StoreIntegrationTest {
 
     @Test
     public void verifyStore() {
-        shouldRejectUnknownQuery();
-        shouldHandlePingQuery();
-        shouldCollectExecutionInfo();
-        shouldCollectExecutionInfoUnderFailure();
+        if (storeToTest.global()) {
+            globalShouldRejectAllQueries();
+        } else {
+            shouldRejectUnknownQuery();
+            shouldHandlePingQuery();
+            shouldCollectExecutionInfo();
+            shouldCollectExecutionInfoUnderFailure();
+        }
+    }
+
+    private void globalShouldRejectAllQueries() {
+        final PingQuery query = new PingQuery();
+        final StateQueryRequest<Boolean> request = inStore(STORE_NAME).withQuery(query);
+
+        final StateQueryResult<Boolean> result = kafkaStreams.query(request);
+
+        assertThat(result.getGlobalResult().isFailure(), is(true));
+        assertThat(result.getGlobalResult().getFailureReason(),
+            is(FailureReason.UNKNOWN_QUERY_TYPE));
+        assertThat(result.getGlobalResult().getFailureMessage(),
+            is("Global stores do not yet support the KafkaStreams#query API."
+                + " Use KafkaStreams#store instead."));
     }
 
     public void shouldRejectUnknownQuery() {
@@ -435,7 +457,6 @@ public class IQv2StoreIntegrationTest {
             queryResult -> {
                 assertThat(queryResult.isFailure(), is(true));
                 assertThat(queryResult.isSuccess(), is(false));
-                assertThat(queryResult.getPosition(), is(nullValue()));
                 assertThat(queryResult.getFailureReason(),
                     is(FailureReason.UNKNOWN_QUERY_TYPE));
                 assertThat(queryResult.getFailureMessage(),
@@ -456,12 +477,18 @@ public class IQv2StoreIntegrationTest {
     public void shouldHandlePingQuery() {
 
         final PingQuery query = new PingQuery();
-        final StateQueryRequest<Boolean> request =
-            inStore(STORE_NAME).withQuery(query);
         final Set<Integer> partitions = mkSet(0, 1);
+        final StateQueryRequest<Boolean> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .withPartitions(partitions)
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
 
         final StateQueryResult<Boolean> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForResult(
+                kafkaStreams,
+                request
+            );
 
         makeAssertions(
             partitions,
@@ -473,9 +500,6 @@ public class IQv2StoreIntegrationTest {
                 }
                 assertThat(queryResult.isSuccess(), is(true));
 
-                // TODO: position not implemented
-                assertThat(queryResult.getPosition(), is(nullValue()));
-
                 assertThrows(IllegalArgumentException.class, queryResult::getFailureReason);
                 assertThrows(IllegalArgumentException.class, queryResult::getFailureMessage);
 
@@ -483,17 +507,25 @@ public class IQv2StoreIntegrationTest {
 
                 assertThat(queryResult.getExecutionInfo(), is(empty()));
             });
+        assertThat(result.getPosition(), is(INPUT_POSITION));
     }
 
     public void shouldCollectExecutionInfo() {
 
         final PingQuery query = new PingQuery();
-        final StateQueryRequest<Boolean> request =
-            inStore(STORE_NAME).withQuery(query).enableExecutionInfo();
         final Set<Integer> partitions = mkSet(0, 1);
+        final StateQueryRequest<Boolean> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .enableExecutionInfo()
+                .withPartitions(partitions)
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
 
         final StateQueryResult<Boolean> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForResult(
+                kafkaStreams,
+                request
+            );
 
         makeAssertions(
             partitions,
@@ -505,12 +537,19 @@ public class IQv2StoreIntegrationTest {
     public void shouldCollectExecutionInfoUnderFailure() {
 
         final UnknownQuery query = new UnknownQuery();
-        final StateQueryRequest<Void> request =
-            inStore(STORE_NAME).withQuery(query).enableExecutionInfo();
         final Set<Integer> partitions = mkSet(0, 1);
+        final StateQueryRequest<Void> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .enableExecutionInfo()
+                .withPartitions(partitions)
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
 
         final StateQueryResult<Void> result =
-            IntegrationTestUtils.iqv2WaitForPartitionsOrGlobal(kafkaStreams, request, partitions);
+            IntegrationTestUtils.iqv2WaitForResult(
+                kafkaStreams,
+                request
+            );
 
         makeAssertions(
             partitions,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -595,17 +595,17 @@ public class IQv2StoreIntegrationTest {
         final Function<V, Integer> valueExtactor,
         final Integer expectedValue) {
 
-        final KeyQuery<Integer, V> query = KeyQuery.withKey(key);
-        final StateQueryRequest<V> request =
+        final KeyQuery<Integer, byte[]> query = KeyQuery.withKey(key);
+        final StateQueryRequest<byte[]> request =
             inStore(STORE_NAME)
                 .withQuery(query)
                 .withPartitions(mkSet(0, 1))
                 .withPositionBound(PositionBound.at(INPUT_POSITION));
 
-        final StateQueryResult<V> result =
+        final StateQueryResult<byte[]> result =
             IntegrationTestUtils.iqv2WaitForResult(kafkaStreams, request);
 
-        final QueryResult<V> queryResult =
+        final QueryResult<byte[]> queryResult =
             result.getGlobalResult() != null
                 ? result.getGlobalResult()
                 : result.getOnlyPartitionResult();
@@ -619,8 +619,9 @@ public class IQv2StoreIntegrationTest {
         assertThrows(IllegalArgumentException.class,
             queryResult::getFailureMessage);
 
-        final V result1 = queryResult.getResult();
-        final Integer integer = valueExtactor.apply(result1);
+        final byte[] result1 = queryResult.getResult();
+        final V value = (V) queryResult.getSerdes().valueFrom(result1);
+        final Integer integer = valueExtactor.apply(value);
         assertThat(integer, is(expectedValue));
 
         assertThat(queryResult.getExecutionInfo(), is(empty()));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -51,6 +51,8 @@ import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.ThreadStateTransitionValidator;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentListener;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
 import org.apache.kafka.streams.query.StateQueryResult;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -91,6 +93,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.sleep;
 import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -139,6 +142,68 @@ public class IntegrationTestUtils {
         } while (System.currentTimeMillis() < deadline);
 
         throw new TimeoutException("The query never returned the desired partitions");
+    }
+
+    /**
+     * Repeatedly runs the query until the response is valid and then return the response.
+     * <p>
+     * Validity in this case means that the response position is up to the specified bound.
+     * <p>
+     * Once position bounding is generally supported, we should migrate tests to wait on the
+     * expected response position.
+     */
+    public static <R> StateQueryResult<R> iqv2WaitForResult(
+        final KafkaStreams kafkaStreams,
+        final StateQueryRequest<R> request) {
+
+        final long start = System.currentTimeMillis();
+        final long deadline = start + DEFAULT_TIMEOUT;
+
+        StateQueryResult<R> result;
+        do {
+            if (Thread.currentThread().isInterrupted()) {
+                fail("Test was interrupted.");
+            }
+
+            result = kafkaStreams.query(request);
+            final LinkedList<QueryResult<R>> allResults = getAllResults(result);
+
+            if (allResults.isEmpty()) {
+                sleep(100L);
+            } else {
+                final boolean needToWait = allResults
+                    .stream()
+                    .anyMatch(IntegrationTestUtils::needToWait);
+                if (needToWait) {
+                    sleep(100L);
+                } else {
+                    return result;
+                }
+            }
+        } while (System.currentTimeMillis() < deadline);
+
+        throw new TimeoutException(
+            "The query never returned within the bound. Last result: "
+            + result
+        );
+    }
+
+    private static <R> LinkedList<QueryResult<R>> getAllResults(
+        final StateQueryResult<R> result) {
+        final LinkedList<QueryResult<R>> allResults =
+            new LinkedList<>(result.getPartitionResults().values());
+        if (result.getGlobalResult() != null) {
+            allResults.add(result.getGlobalResult());
+        }
+        return allResults;
+    }
+
+    private static <R> boolean needToWait(final QueryResult<R> queryResult) {
+        return queryResult.isFailure()
+            && (
+            FailureReason.NOT_UP_TO_BOUND.equals(queryResult.getFailureReason())
+                || FailureReason.NOT_PRESENT.equals(queryResult.getFailureReason())
+        );
     }
 
     /*


### PR DESCRIPTION
Just experimenting with what would happen if we pass serdes around and just skip translating data in the Metered stores at all.

I think this winds up being a little messy because didn't want to build in `K` and `V` type bounds on the query, so there's no bound on the serde types either, which means that both the store's query handler and the user of IQ have to cast after de/serialization.

There also doesn't seem to be a way to generalize the notion of a "lazily deserialized result", since the object returned by a query may not be a plain value, but it might be an Iterator of values, or a Future value, etc.

I might have just wound up on the wrong track here, though, so I'm going to take a break and come back later to see if I have better ideas.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
