### PR TITLE
HOTFIX: Bump version of grgit fro 4.1.0 to 4.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,7 +63,7 @@ versions += [
   commonsCli: "1.4",
   gradle: "6.8.1",
   gradleVersionsPlugin: "0.36.0",
-  grgit: "4.1.0",
+  grgit: "4.1.1",
   httpclient: "4.5.13",
   easymock: "4.2",
   jackson: "2.10.5",


### PR DESCRIPTION
grgit 4.1.0 caused the following error with gradle

> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.eclipse.jgit:org.eclipse.jgit:latest.release.
     Required by:
         project : > org.ajoberstar.grgit:grgit-core:4.1.0
...

making it impossible to build the branch. 

grgit 4.1.1 fixes this issue.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
