### PR TITLE
KAFKA-13485: Restart connectors after RetriableException raised from Task::start()

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Stage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Stage.java
@@ -22,6 +22,12 @@ package org.apache.kafka.connect.runtime.errors;
 public enum Stage {
 
     /**
+     * When calling the start() method on a connector
+     */
+    TASK_START,
+
+
+    /**
      * When calling the poll() method on a SourceConnector
      */
     TASK_POLL,


### PR DESCRIPTION
If a `RetriableException` is raised from `Task::start()`, this doesn't trigger an attempt to start that connector again. I.e. the restart functionality currently is only implemented for exceptions raised from `poll()/put()`. Triggering restarts also upon failures during `start()` would be desirable, so to circumvent temporary failure conditions like a network hickup which currrently require a manual restart of the affected tasks, if a connector for instance establishes a database connection during `start()`.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
