### PR TITLE
KAFKA-12648: fix IllegalStateException in ClientState after removing topologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -680,7 +680,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         for (final Map.Entry<UUID, ClientMetadata> entry : clientMetadataMap.entrySet()) {
             final UUID uuid = entry.getKey();
             final ClientState state = entry.getValue().state;
-            state.initializePrevTasks(taskForPartition);
+            state.initializePrevTasks(taskForPartition, taskManager.topologyMetadata().hasNamedTopologies());
 
             state.computeTaskLags(uuid, allTaskEndOffsetSums);
             clientStates.put(uuid, state);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -153,7 +153,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * @throws TopologyException        if this topology subscribes to any input topics or pattern already in use
      */
     public AddNamedTopologyResult addNamedTopology(final NamedTopology newTopology) {
-        log.debug("Adding topology: {}", newTopology.name());
+        log.info("Adding topology: {}", newTopology.name());
         if (hasStartedOrFinishedShuttingDown()) {
             throw new IllegalStateException("Cannot add a NamedTopology while the state is " + super.state);
         } else if (getTopologyByName(newTopology.name()).isPresent()) {
@@ -179,7 +179,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * @throws TopologyException        if this topology subscribes to any input topics or pattern already in use
      */
     public RemoveNamedTopologyResult removeNamedTopology(final String topologyToRemove, final boolean resetOffsets) {
-        log.debug("Removing topology: {}", topologyToRemove);
+        log.info("Removing topology: {}", topologyToRemove);
         if (!isRunningOrRebalancing()) {
             throw new IllegalStateException("Cannot remove a NamedTopology while the state is " + super.state);
         } else if (!getTopologyByName(topologyToRemove).isPresent()) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -312,7 +312,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
-        state.initializePrevTasks(emptyMap());
+        state.initializePrevTasks(emptyMap(), false);
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
         assertEquivalentAssignment(
@@ -342,7 +342,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
-        state.initializePrevTasks(emptyMap());
+        state.initializePrevTasks(emptyMap(), false);
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
         // We should be able to add a new task without sacrificing stickiness
@@ -378,7 +378,7 @@ public class StreamsPartitionAssignorTest {
         state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
-        state.initializePrevTasks(emptyMap());
+        state.initializePrevTasks(emptyMap(), false);
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
         // Consumer 3 leaves the group
@@ -421,7 +421,7 @@ public class StreamsPartitionAssignorTest {
         consumers.add(CONSUMER_4);
         state.addPreviousTasksAndOffsetSums(CONSUMER_4, getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS));
 
-        state.initializePrevTasks(emptyMap());
+        state.initializePrevTasks(emptyMap(), false);
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
         final Map<String, List<TaskId>> assignment = assignTasksToThreads(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -323,22 +322,20 @@ public class ClientStateTest {
     @Test
     public void shouldThrowWhenSomeOwnedPartitionsAreNotRecognizedWhenInitializingPrevActiveTasks() {
         final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
-        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, Task.LATEST_OFFSET);
-        client.addOwnedPartitions(mkSet(TP_0_0, TP_0_1), "c1");
-        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
-        assertThrows(IllegalStateException.class,() -> client.initializePrevTasks(taskForPartitionMap, false));
+        client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
+        client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
+        assertThrows(IllegalStateException.class, () -> client.initializePrevTasks(taskForPartitionMap, false));
     }
 
     @Test
     public void shouldFilterOutUnrecognizedPartitionsAndInitializePrevActiveTasksWhenUsingNamedTopologies() {
         final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
-        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, Task.LATEST_OFFSET);
-        client.addOwnedPartitions(mkSet(TP_0_0, TP_0_1), "c1");
-        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
+        client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
+        client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
         client.initializePrevTasks(taskForPartitionMap, true);
-        assertThat(client.prevActiveTasks(), equalTo(Collections.singleton(TASK_0_1)));
-        assertThat(client.previousAssignedTasks(), equalTo(Collections.singleton(TASK_0_1)));
-        assertTrue(client.prevStandbyTasks().isEmpty());
+        assertThat(client.prevActiveTasks().isEmpty(), is(true));
+        assertThat(client.previousAssignedTasks().isEmpty(), is(true));
+        assertThat(client.prevStandbyTasks().isEmpty(), is(true));
     }
 
     @Test
@@ -440,22 +437,20 @@ public class ClientStateTest {
     @Test
     public void shouldThrowWhenSomeOwnedPartitionsAreNotRecognizedWhenInitializingPrevStandbyTasks() {
         final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
-        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, 100L);
-        client.addOwnedPartitions(mkSet(TP_0_0, TP_0_1), "c1");
-        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
-        assertThrows(IllegalStateException.class,() -> client.initializePrevTasks(taskForPartitionMap, false));
+        client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
+        client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
+        assertThrows(IllegalStateException.class, () -> client.initializePrevTasks(taskForPartitionMap, false));
     }
 
     @Test
     public void shouldFilterOutUnrecognizedPartitionsAndInitializePrevStandbyTasksWhenUsingNamedTopologies() {
         final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
-        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, 100L);
-        client.addOwnedPartitions(mkSet(TP_0_0, TP_0_1), "c1");
-        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
+        client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
+        client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
         client.initializePrevTasks(taskForPartitionMap, true);
-        assertThat(client.prevActiveTasks(), equalTo(Collections.singleton(TASK_0_1)));
-        assertThat(client.previousAssignedTasks(), equalTo(Collections.singleton(TASK_0_1)));
-        assertTrue(client.prevStandbyTasks().isEmpty());
+        assertThat(client.prevActiveTasks().isEmpty(), is(true));
+        assertThat(client.previousAssignedTasks().isEmpty(), is(true));
+        assertThat(client.prevStandbyTasks().isEmpty(), is(true));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -320,7 +320,7 @@ public class ClientStateTest {
     }
 
     @Test
-    public void shouldThrowWhenSomeOwnedPartitionsAreNotRecognizedWhenInitializingPrevActiveTasks() {
+    public void shouldThrowWhenSomeOwnedPartitionsAreNotRecognizedWhenInitializingPrevTasks() {
         final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
         client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
         client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
@@ -328,7 +328,7 @@ public class ClientStateTest {
     }
 
     @Test
-    public void shouldFilterOutUnrecognizedPartitionsAndInitializePrevActiveTasksWhenUsingNamedTopologies() {
+    public void shouldFilterOutUnrecognizedPartitionsAndInitializePrevTasksWhenUsingNamedTopologies() {
         final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
         client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
         client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
@@ -432,25 +432,6 @@ public class ClientStateTest {
         assertThat(client.prevStandbyTasks(), equalTo(mkSet(TASK_0_1, TASK_0_2)));
         assertThat(client.previousAssignedTasks(), equalTo(mkSet(TASK_0_1, TASK_0_2)));
         assertTrue(client.prevActiveTasks().isEmpty());
-    }
-
-    @Test
-    public void shouldThrowWhenSomeOwnedPartitionsAreNotRecognizedWhenInitializingPrevStandbyTasks() {
-        final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
-        client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
-        client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
-        assertThrows(IllegalStateException.class, () -> client.initializePrevTasks(taskForPartitionMap, false));
-    }
-
-    @Test
-    public void shouldFilterOutUnrecognizedPartitionsAndInitializePrevStandbyTasksWhenUsingNamedTopologies() {
-        final Map<TopicPartition, TaskId> taskForPartitionMap = Collections.singletonMap(TP_0_1, TASK_0_1);
-        client.addOwnedPartitions(Collections.singleton(TP_0_0), "c1");
-        client.addPreviousTasksAndOffsetSums("c1", Collections.emptyMap());
-        client.initializePrevTasks(taskForPartitionMap, true);
-        assertThat(client.prevActiveTasks().isEmpty(), is(true));
-        assertThat(client.previousAssignedTasks().isEmpty(), is(true));
-        assertThat(client.prevStandbyTasks().isEmpty(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Fix for one of the causes of failure in the NamedTopologyIntegrationTest: `org.apache.kafka.streams.errors.StreamsException: java.lang.IllegalStateException: Must initialize prevActiveTasks from ownedPartitions before initializing remaining tasks.`

This exception could occur if a member sent in a subscription where all of its `ownedPartitions` were from a named topology that is no longer recognized by the group leader, eg because it was just removed from the client. We should filter each ClientState based on the current topology only so the assignor only processes the partitions/tasks it can identify. The member with the out-of-date tasks will eventually clean them up when the `#removeNamedTopology` API is invoked on them