### PR TITLE
KAFKA-13501: Avoid state restore via rebalance if standbys are enabled

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -228,8 +228,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         if (state() == State.CREATED) {
             recordCollector.initialize();
 
-            StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
+            mainConsumer.enforceRebalance();
 
+            StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
             // without EOS the checkpoint file would not be deleted after loading, and
             // with EOS we would not checkpoint ever during running state anyways.
             // therefore we can initialize the snapshot as empty so that we would checkpoint right after loading


### PR DESCRIPTION
There are certain scenario in which Kafka Streams wipes out local state and rebuilt it from scratch. This is a thread local cleanup, ie, no rebalance is triggered, and we end up with an offline task until state restoration finished.

If standby tasks are enable, it might actually make sense to trigger a rebalance instead, to get the task re-assigned to the instance hosting the standby so get the task active again quickly.

