### PR TITLE
KAFKA-13539: Improve propagation and processing of SSL handshake failures

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -601,7 +601,7 @@ public class Selector implements Selectable, AutoCloseable {
                     close(channel, CloseMode.GRACEFUL);
 
             } catch (Exception e) {
-                String desc = channel.socketDescription();
+                String desc = String.format("%s (channelId=%s)", channel.socketDescription(), channel.id());
                 if (e instanceof IOException) {
                     log.debug("Connection with {} disconnected", desc, e);
                 } else if (e instanceof AuthenticationException) {

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -96,10 +96,16 @@ public class NetworkTestUtils {
         assertTrue(selector.isChannelReady(node));
     }
 
-    public static ChannelState waitForChannelClose(Selector selector, String node, ChannelState.State channelState)
+    public static ChannelState waitForChannelClose(Selector selector, String node, ChannelState.State channelState) throws IOException {
+        return waitForChannelClose(selector, node, channelState, 0);
+    }
+
+    public static ChannelState waitForChannelClose(Selector selector, String node, ChannelState.State channelState, int delayBetweenPollMs)
             throws IOException {
         boolean closed = false;
         for (int i = 0; i < 300; i++) {
+            if (delayBetweenPollMs > 0)
+                Utils.sleep(delayBetweenPollMs);
             selector.poll(100L);
             if (selector.channel(node) == null && selector.closingChannel(node) == null) {
                 closed = true;


### PR DESCRIPTION
When server fails SSL handshake and closes its connection, we attempt to report this to clients on a best-effort basis. When IOException is detected in the client, we may proceed to close the connection before processing all the data from the server if we have data pending to be sent to the server. Server attempts to send any data that has been already wrapped, but may not wrap again after handshake failure, so error may not be propagated to clients. However, our tests assume that clients always detect  handshake failures. This PR attempts to wrap and send all data on the server-side after handshake failure and attempts to process all data on the client-side.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
