### PR TITLE
KAFKA-13711: Minor fixes for input topic management

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1383,7 +1383,19 @@ public class InternalTopologyBuilder {
         return !nodeToSourcePatterns.isEmpty();
     }
 
+    /**
+     * NOTE: this should not be invoked until the topology has been built via
+     * {@link #buildTopology()}, otherwise the collection will be uninitialized
+     *
+     * @return all user and internal source topics in this topology,
+     *         or {@code null} if uninitialized because {@link #buildTopology()} hs not been called yet
+     */
     synchronized Collection<String> sourceTopicCollection() {
+        if (sourceTopicCollection == null) {
+            if (usesPatternSubscription()) {
+                throw new IllegalStateException("Should not ")
+            }
+        }
         return sourceTopicCollection;
     }
 
@@ -2100,6 +2112,8 @@ public class InternalTopologyBuilder {
     }
 
     /**
+     * NOTE: this
+     *
      * @return a copy of all source topic names, including the application id and named topology prefix if applicable
      */
     public synchronized List<String> fullSourceTopicNames() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1345,10 +1345,6 @@ public class InternalTopologyBuilder {
         }
     }
 
-    void initializeSubscription() {
-
-    }
-
     private String buildSourceTopicsPatternString() {
         final List<String> allSourceTopics = maybeDecorateInternalSourceTopics(sourceTopicNames);
         Collections.sort(allSourceTopics);
@@ -1379,11 +1375,7 @@ public class InternalTopologyBuilder {
     }
 
     /**
-     * NOTE: this should not be invoked until the topology has been built via
-     * {@link #buildTopology()}, otherwise the collection will be uninitialized
-     *
-     * @return all user and internal source topics in this topology,
-     *         or {@code null} if uninitialized because {@link #buildTopology()} hs not been called yet
+     * @return full names of all user and internal source topics in this topology, including prefix for internal topics
      */
     public synchronized List<String> sourceTopicCollection() {
         if (sourceTopicCollection == null) {
@@ -2074,7 +2066,7 @@ public class InternalTopologyBuilder {
     }
 
     /**
-     * @return the set of topics that were newly
+     * @return the set of topics that are newly added to the subscription based on the assigned tasks
      */
     synchronized Set<String> addSubscribedTopicsFromAssignment(final Set<String> topics, final String logPrefix) {
         if (usesPatternSubscription()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -724,7 +724,7 @@ public class StreamThread extends Thread {
         if (topologyMetadata.usesPatternSubscription()) {
             mainConsumer.subscribe(topologyMetadata.sourceTopicPattern(), rebalanceListener);
         } else {
-            mainConsumer.subscribe(topologyMetadata.sourceTopicCollection(), rebalanceListener);
+            mainConsumer.subscribe(topologyMetadata.allFullSourceTopicNames(), rebalanceListener);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -297,7 +297,7 @@ public class StreamsMetadataState {
 
     private Set<String> getStoresOnHost(final Map<String, List<String>> storeToSourceTopics,
         final Set<TopicPartition> sourceTopicPartitions, final String topologyName) {
-        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForNamedTopology(topologyName);
+        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForTopology(topologyName);
         final Set<String> sourceTopicNames = builder.sourceTopicNames();
 
         final Set<String> storesOnHost = new HashSet<>();
@@ -458,7 +458,7 @@ public class StreamsMetadataState {
     }
 
     private SourceTopicsInfo getSourceTopicsInfo(final String storeName, final String topologyName) {
-        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForNamedTopology(topologyName);
+        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForTopology(topologyName);
         final List<String> sourceTopics = new ArrayList<>(builder.sourceTopicsForStore(storeName));
 
         if (sourceTopics.isEmpty()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -280,10 +280,7 @@ public class TaskManager {
                      "\tExisting standby tasks: {}",
                  activeTasks.keySet(), standbyTasks.keySet(), activeTaskIds(), standbyTaskIds());
 
-        topologyMetadata.addSubscribedTopicsFromAssignment(
-            activeTasks.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
-            logPrefix
-        );
+        topologyMetadata.addSubscribedTopicsFromAssignment(activeTasks, logPrefix);
 
         final LinkedHashMap<TaskId, RuntimeException> taskCloseExceptions = new LinkedHashMap<>();
         final Map<TaskId, Set<TopicPartition>> activeTasksToCreate = new HashMap<>(activeTasks);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -442,6 +442,10 @@ public class TopologyMetadata {
         return sourceTopics;
     }
 
+    private String getTopologyNameOrElseUnnamed(final String topologyName) {
+        return topologyName == null ? UNNAMED_TOPOLOGY : topologyName;
+    }
+
     public Map<Subtopology, TopicsInfo> topicGroups() {
         final Map<Subtopology, TopicsInfo> topicGroups = new HashMap<>();
         applyToEachBuilder(b -> topicGroups.putAll(b.topicGroups()));
@@ -526,10 +530,6 @@ public class TopologyMetadata {
             assignedTopics.getValue().retainAll(newTopics);
         }
         updateAndVerifyNewInputTopics(assignedTopicsByTopology);
-    }
-
-    private String getTopologyNameOrElseUnnamed(final String topologyName) {
-        return topologyName == null ? UNNAMED_TOPOLOGY : topologyName;
     }
 
     private void updateAndVerifyNewInputTopics(final Map<String, Set<String>> newTopicsByTopology) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -356,8 +356,8 @@ public class TopologyMetadata {
      * {@link #buildAndVerifyTopology(InternalTopologyBuilder)}, otherwise the
      * {@link InternalTopologyBuilder#sourceTopicCollection()}
      */
-    public Collection<String> sourceTopicCollection() {
-        final List<String> sourceTopics = new ArrayList<>();
+    public Set<String> sourceTopicCollection() {
+        final Set<String> sourceTopics = new HashSet<>();
         applyToEachBuilder(b -> sourceTopics.addAll(b.sourceTopicCollection()));
         return sourceTopics;
     }
@@ -498,7 +498,7 @@ public class TopologyMetadata {
         } else {
             if (!topics.equals(sourceTopicCollection())) {
                 log.error("{}Consumer's subscription does not match the known source topics.\n" +
-                        "consumer subscription: {}/n" +
+                        "consumer subscription: {}\n" +
                         "topics in topology metadata: {}",
                     logPrefix, topics, sourceTopicCollection());
                 throw new IllegalStateException("Consumer subscribed topics and topology's known topics do not match.");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -126,7 +126,7 @@ public class TopologyMetadata {
     }
 
     public Collection<String> sourceTopicsForTopology(final String name) {
-        return builders.get(name).sourceTopicCollection();
+        return builders.get(name).fullSourceTopicNames();
     }
 
     public boolean needsUpdate(final String threadName) {
@@ -220,7 +220,7 @@ public class TopologyMetadata {
             log.info("Removing NamedTopology {}, latest topology version is {}", topologyName, version.topologyVersion.get());
             version.activeTopologyWaiters.add(new TopologyVersionWaiters(topologyVersion(), future));
             final InternalTopologyBuilder removedBuilder = builders.remove(topologyName);
-            removedBuilder.sourceTopicCollection().forEach(allInputTopics::remove);
+            removedBuilder.fullSourceTopicNames().forEach(allInputTopics::remove);
             removedBuilder.allSourcePatternStrings().forEach(allInputTopics::remove);
         } finally {
             unlock();
@@ -243,7 +243,7 @@ public class TopologyMetadata {
 
         // As we go, check each topology for overlap in the set of input topics/patterns
         final int numInputTopics = allInputTopics.size();
-        final List<String> inputTopics = builder.sourceTopicCollection();
+        final List<String> inputTopics = builder.fullSourceTopicNames();
         final Collection<String> inputPatterns = builder.allSourcePatternStrings();
 
         final int numNewInputTopics = inputTopics.size() + inputPatterns.size();
@@ -354,11 +354,11 @@ public class TopologyMetadata {
     /**
      * NOTE: this should not be invoked until all topologies have been built via
      * {@link #buildAndVerifyTopology(InternalTopologyBuilder)}, otherwise the
-     * {@link InternalTopologyBuilder#sourceTopicCollection()}
+     * {@link InternalTopologyBuilder#fullSourceTopicNames()}
      */
     public Set<String> sourceTopicCollection() {
         final Set<String> sourceTopics = new HashSet<>();
-        applyToEachBuilder(b -> sourceTopics.addAll(b.sourceTopicCollection()));
+        applyToEachBuilder(b -> sourceTopics.addAll(b.fullSourceTopicNames()));
         return sourceTopics;
     }
 
@@ -464,7 +464,7 @@ public class TopologyMetadata {
             for (final String topic : topics) {
                 final Set<String> subscribingTopologies = new HashSet<>();
                 applyToEachBuilder(b -> {
-                    if (b.sourceTopicCollection().contains(topic) || b.matchesSubscribedPattern(topic)) {
+                    if (b.fullSourceTopicNames().contains(topic) || b.matchesSubscribedPattern(topic)) {
                         subscribingTopologies.add(getTopologyNameOrElseUnnamed(b.topologyName()));
                     }
                 });

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -139,7 +139,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * @return the NamedTopology for the specific name, or Optional.empty() if the application has no NamedTopology of that name
      */
     public Optional<NamedTopology> getTopologyByName(final String name) {
-        return Optional.ofNullable(topologyMetadata.lookupBuilderForNamedTopology(name)).map(InternalTopologyBuilder::namedTopology);
+        return Optional.ofNullable(topologyMetadata.lookupBuilderForTopology(name)).map(InternalTopologyBuilder::namedTopology);
     }
 
     /**
@@ -280,7 +280,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
     }
 
     private void verifyTopologyStateStore(final String topologyName, final String storeName) {
-        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForNamedTopology(topologyName);
+        final InternalTopologyBuilder builder = topologyMetadata.lookupBuilderForTopology(topologyName);
         if (builder == null) {
             throw new UnknownStateStoreException(
                 "Cannot get state store " + storeName + " from NamedTopology " + topologyName +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopology.java
@@ -38,7 +38,7 @@ public class NamedTopology extends Topology {
      * @return the list of all source topics this topology is subscribed to
      */
     public List<String> sourceTopics() {
-        return super.internalTopologyBuilder.fullSourceTopicNames();
+        return super.internalTopologyBuilder.sourceTopicCollection();
     }
 
     InternalTopologyBuilder internalTopologyBuilder() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopology.java
@@ -38,7 +38,7 @@ public class NamedTopology extends Topology {
      * @return the list of all source topics this topology is subscribed to
      */
     public List<String> sourceTopics() {
-        return super.internalTopologyBuilder.sourceTopicCollection();
+        return super.internalTopologyBuilder.fullSourceTopicNames();
     }
 
     InternalTopologyBuilder internalTopologyBuilder() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -89,7 +89,6 @@ public class InternalTopologyBuilderTest {
 
         builder.addSource(Topology.AutoOffsetReset.EARLIEST, "source", null, null, null, earliestTopic);
         builder.addSource(Topology.AutoOffsetReset.LATEST, "source2", null, null, null, latestTopic);
-        builder.initializeSubscription();
 
         assertThat(builder.offsetResetStrategy(earliestTopic), equalTo(OffsetResetStrategy.EARLIEST));
         assertThat(builder.offsetResetStrategy(latestTopic), equalTo(OffsetResetStrategy.LATEST));
@@ -102,7 +101,6 @@ public class InternalTopologyBuilderTest {
 
         builder.addSource(Topology.AutoOffsetReset.EARLIEST, "source", null, null, null, Pattern.compile(earliestTopicPattern));
         builder.addSource(Topology.AutoOffsetReset.LATEST, "source2", null, null, null,  Pattern.compile(latestTopicPattern));
-        builder.initializeSubscription();
 
         assertThat(builder.offsetResetStrategy("earliestTestTopic"), equalTo(OffsetResetStrategy.EARLIEST));
         assertThat(builder.offsetResetStrategy("latestTestTopic"), equalTo(OffsetResetStrategy.LATEST));
@@ -111,7 +109,6 @@ public class InternalTopologyBuilderTest {
     @Test
     public void shouldAddSourceWithoutOffsetReset() {
         builder.addSource(null, "source", null, stringSerde.deserializer(), stringSerde.deserializer(), "test-topic");
-        builder.initializeSubscription();
 
         assertEquals(Collections.singletonList("test-topic"), builder.sourceTopicCollection());
 
@@ -123,7 +120,6 @@ public class InternalTopologyBuilderTest {
         final Pattern expectedPattern = Pattern.compile("test-.*");
 
         builder.addSource(null, "source", null, stringSerde.deserializer(), stringSerde.deserializer(), Pattern.compile("test-.*"));
-        builder.initializeSubscription();
 
         assertThat(expectedPattern.pattern(), builder.sourceTopicsPatternString(), equalTo("test-.*"));
 
@@ -287,7 +283,6 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-2", null, null, null, "topic-2");
         builder.addSource(null, "source-3", null, null, null, "topic-3");
         builder.addInternalTopic("topic-3", InternalTopicProperties.empty());
-        builder.initializeSubscription();
 
         assertFalse(builder.usesPatternSubscription());
         assertEquals(Arrays.asList("X-topic-3", "topic-1", "topic-2"), builder.sourceTopicCollection());
@@ -304,7 +299,6 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-4", null, null, null, sourcePattern);
 
         builder.addInternalTopic("topic-3", InternalTopicProperties.empty());
-        builder.initializeSubscription();
 
         final Pattern expectedPattern = Pattern.compile("X-topic-3|topic-1|topic-2|topic-4|topic-5");
         final String patternString = builder.sourceTopicsPatternString();
@@ -327,7 +321,6 @@ public class InternalTopologyBuilderTest {
             "global-processor",
             new MockApiProcessorSupplier<>()
         );
-        builder.initializeSubscription();
 
         final Pattern expectedPattern = Pattern.compile("topic-1|topic-2");
 
@@ -351,7 +344,6 @@ public class InternalTopologyBuilderTest {
             "global-processor",
             new MockApiProcessorSupplier<>()
         );
-        builder.initializeSubscription();
 
         assertThat(builder.sourceTopicCollection(), equalTo(asList("topic-1", "topic-2")));
     }
@@ -360,7 +352,6 @@ public class InternalTopologyBuilderTest {
     public void testPatternSourceTopic() {
         final Pattern expectedPattern = Pattern.compile("topic-\\d");
         builder.addSource(null, "source-1", null, null, null, expectedPattern);
-        builder.initializeSubscription();
         final String patternString = builder.sourceTopicsPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
@@ -371,7 +362,6 @@ public class InternalTopologyBuilderTest {
         final Pattern expectedPattern = Pattern.compile("topics[A-Z]|.*-\\d");
         builder.addSource(null, "source-1", null, null, null, Pattern.compile("topics[A-Z]"));
         builder.addSource(null, "source-2", null, null, null, Pattern.compile(".*-\\d"));
-        builder.initializeSubscription();
         final String patternString = builder.sourceTopicsPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
@@ -382,7 +372,6 @@ public class InternalTopologyBuilderTest {
         final Pattern expectedPattern = Pattern.compile("topic-bar|topic-foo|.*-\\d");
         builder.addSource(null, "source-1", null, null, null, "topic-foo", "topic-bar");
         builder.addSource(null, "source-2", null, null, null, Pattern.compile(".*-\\d"));
-        builder.initializeSubscription();
         final String patternString = builder.sourceTopicsPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
@@ -1231,7 +1220,6 @@ public class InternalTopologyBuilderTest {
             "global-processor",
             new MockApiProcessorSupplier<>()
         );
-        builder.initializeSubscription();
 
         builder.rewriteTopology(new StreamsConfig(mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "asdf"),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -110,7 +110,7 @@ public class InternalTopologyBuilderTest {
     public void shouldAddSourceWithoutOffsetReset() {
         builder.addSource(null, "source", null, stringSerde.deserializer(), stringSerde.deserializer(), "test-topic");
 
-        assertEquals(Collections.singletonList("test-topic"), builder.sourceTopicCollection());
+        assertEquals(Collections.singletonList("test-topic"), builder.fullSourceTopicNames());
 
         assertThat(builder.offsetResetStrategy("test-topic"), equalTo(OffsetResetStrategy.NONE));
     }
@@ -285,7 +285,7 @@ public class InternalTopologyBuilderTest {
         builder.addInternalTopic("topic-3", InternalTopicProperties.empty());
 
         assertFalse(builder.usesPatternSubscription());
-        assertEquals(Arrays.asList("X-topic-3", "topic-1", "topic-2"), builder.sourceTopicCollection());
+        assertEquals(Arrays.asList("X-topic-3", "topic-1", "topic-2"), builder.fullSourceTopicNames());
     }
 
     @Test
@@ -345,7 +345,7 @@ public class InternalTopologyBuilderTest {
             new MockApiProcessorSupplier<>()
         );
 
-        assertThat(builder.sourceTopicCollection(), equalTo(asList("topic-1", "topic-2")));
+        assertThat(builder.fullSourceTopicNames(), equalTo(asList("topic-1", "topic-2")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.Topi
 import org.apache.kafka.streams.processor.internals.assignment.CopartitionedTopicsEnforcer;
 import org.apache.kafka.streams.processor.internals.testutil.DummyStreamsConfig;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -100,9 +101,14 @@ public class RepartitionTopicsTest {
     final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer = mock(CopartitionedTopicsEnforcer.class);
     final Cluster clusterMetadata = niceMock(Cluster.class);
 
+    @Before
+    public void setup() {
+        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
+        expect(internalTopologyBuilder.topologyName()).andStubReturn(null);
+    }
+
     @Test
     public void shouldSetupRepartitionTopics() {
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1), mkEntry(SUBTOPOLOGY_1, TOPICS_INFO2)));
         final Set<String> coPartitionGroup1 = mkSet(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2);
@@ -142,7 +148,6 @@ public class RepartitionTopicsTest {
 
     @Test
     public void shouldThrowMissingSourceTopicException() {
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1), mkEntry(SUBTOPOLOGY_1, TOPICS_INFO2)));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptyList());
@@ -169,7 +174,6 @@ public class RepartitionTopicsTest {
     public void shouldThrowTaskAssignmentExceptionIfPartitionCountCannotBeComputedForAllRepartitionTopics() {
         final RepartitionTopicConfig repartitionTopicConfigWithoutPartitionCount =
             new RepartitionTopicConfig(REPARTITION_WITHOUT_PARTITION_COUNT, TOPIC_CONFIG5);
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
                 mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1),
@@ -208,7 +212,6 @@ public class RepartitionTopicsTest {
             ),
             Collections.emptyMap()
         );
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
                 mkEntry(SUBTOPOLOGY_0, topicsInfo),
@@ -252,7 +255,6 @@ public class RepartitionTopicsTest {
             ),
             Collections.emptyMap()
         );
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
                 mkEntry(SUBTOPOLOGY_0, topicsInfo),
@@ -307,7 +309,6 @@ public class RepartitionTopicsTest {
             ),
             Collections.emptyMap()
         );
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
                 mkEntry(SUBTOPOLOGY_0, topicsInfo),
@@ -357,7 +358,6 @@ public class RepartitionTopicsTest {
             Collections.emptyMap(),
             Collections.emptyMap()
         );
-        expect(internalTopologyBuilder.hasNamedTopology()).andStubReturn(false);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(mkEntry(SUBTOPOLOGY_0, topicsInfo)));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptySet());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1178,7 +1178,7 @@ public class StreamThreadTest {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
         expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final InternalTopologyBuilder internalTopologyBuilder = EasyMock.createNiceMock(InternalTopologyBuilder.class);
-        expect(internalTopologyBuilder.sourceTopicCollection()).andReturn(Collections.singletonList(topic1)).times(2);
+        expect(internalTopologyBuilder.fullSourceTopicNames()).andReturn(Collections.singletonList(topic1)).times(2);
 
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -210,7 +210,7 @@ public class TaskManagerTest {
 
         expect(activeTaskCreator.createTasks(anyObject(), eq(assignment))).andStubReturn(emptyList());
 
-        topologyBuilder.addSubscribedTopicsFromAssignment(eq(asList(t1p1, newTopicPartition)), anyString());
+        topologyBuilder.addSubscribedTopicsFromAssignment(eq(mkSet(t1p1.topic(), newTopicPartition.topic())), anyString());
         expectLastCall();
 
         replay(activeTaskCreator, topologyBuilder);


### PR DESCRIPTION
While working on [#11600](https://github.com/apache/kafka/pull/11600) I noticed a few issues with how we manage topics in the TopologyMetadata, particularly surrounding the code to update and track input topics. This PR cleans that up and adds some further verification when processing possible updates from the subscription metadata or assignment