### PR TITLE
MINOR: MetadataShell should handle ProducerIdsRecord

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -46,7 +46,6 @@ import org.apache.kafka.raft.BatchReader;
 import org.apache.kafka.raft.LeaderAndEpoch;
 import org.apache.kafka.raft.RaftClient;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
-import org.apache.kafka.server.common.ProducerIdsBlock;
 import org.apache.kafka.shell.MetadataNode.DirectoryNode;
 import org.apache.kafka.shell.MetadataNode.FileNode;
 import org.apache.kafka.snapshot.SnapshotReader;
@@ -322,12 +321,11 @@ public final class MetadataNodeManager implements AutoCloseable {
             }
             case PRODUCER_IDS_RECORD: {
                 ProducerIdsRecord record = (ProducerIdsRecord) message;
-                DirectoryNode lastBlockNode = data.root.mkdirs("lastProducerIdBlock");
-                lastBlockNode.create("assignedBrokerId").setContents(record.brokerId() + "");
-                lastBlockNode.create("assignedBrokerEpoch").setContents(record.brokerEpoch() + "");
+                DirectoryNode producerIds = data.root.mkdirs("producerIds");
+                producerIds.create("lastBlockBrokerId").setContents(record.brokerId() + "");
+                producerIds.create("lastBlockBrokerEpoch").setContents(record.brokerEpoch() + "");
 
-                DirectoryNode producerIdsNode = data.root.mkdirs("nextProducerIdBlock");
-                producerIdsNode.create("firstProducerId").setContents(record.producerIdsEnd() + "");
+                producerIds.create("nextBlockStartId").setContents(record.producerIdsEnd() + "");
                 break;
             }
             default:

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -322,12 +322,12 @@ public final class MetadataNodeManager implements AutoCloseable {
             }
             case PRODUCER_IDS_RECORD: {
                 ProducerIdsRecord record = (ProducerIdsRecord) message;
-                DirectoryNode producerIdNode = data.root.mkdirs("lastProducerIdBlock");
-                producerIdNode.create("assignedBrokerId").setContents(record.brokerId() + "");
-                producerIdNode.create("assignedBrokerEpoch").setContents(record.brokerEpoch() + "");
-                producerIdNode.create("blockStart")
-                    .setContents(record.producerIdsEnd() - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "");
-                producerIdNode.create("blockEnd").setContents(record.producerIdsEnd() - 1 + "");
+                DirectoryNode lastBlockNode = data.root.mkdirs("lastProducerIdBlock");
+                lastBlockNode.create("assignedBrokerId").setContents(record.brokerId() + "");
+                lastBlockNode.create("assignedBrokerEpoch").setContents(record.brokerEpoch() + "");
+
+                DirectoryNode producerIdsNode = data.root.mkdirs("nextProducerIdBlock");
+                producerIdsNode.create("firstProducerId").setContents(record.producerIdsEnd() + "");
                 break;
             }
             default:

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -322,8 +322,9 @@ public final class MetadataNodeManager implements AutoCloseable {
             }
             case PRODUCER_IDS_RECORD: {
                 ProducerIdsRecord record = (ProducerIdsRecord) message;
-                DirectoryNode producerIdNode = data.root.mkdirs("producerIds");
-                producerIdNode.create("broker").setContents(record.brokerId() + "");
+                DirectoryNode producerIdNode = data.root.mkdirs("lastProducerIdBlock");
+                producerIdNode.create("assignedBrokerId").setContents(record.brokerId() + "");
+                producerIdNode.create("assignedBrokerEpoch").setContents(record.brokerEpoch() + "");
                 producerIdNode.create("blockStart")
                     .setContents(record.producerIdsEnd() - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "");
                 producerIdNode.create("blockEnd").setContents(record.producerIdsEnd() - 1 + "");

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -325,7 +325,7 @@ public final class MetadataNodeManager implements AutoCloseable {
                 producerIds.create("lastBlockBrokerId").setContents(record.brokerId() + "");
                 producerIds.create("lastBlockBrokerEpoch").setContents(record.brokerEpoch() + "");
 
-                producerIds.create("nextBlockStartId").setContents(record.producerIdsEnd() + "");
+                producerIds.create("nextBlockStartId").setContents(record.nextProducerId() + "");
                 break;
             }
             default:

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metadata.MetadataRecordType;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.PartitionRecordJsonConverter;
+import org.apache.kafka.common.metadata.ProducerIdsRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
@@ -45,6 +46,7 @@ import org.apache.kafka.raft.BatchReader;
 import org.apache.kafka.raft.LeaderAndEpoch;
 import org.apache.kafka.raft.RaftClient;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.ProducerIdsBlock;
 import org.apache.kafka.shell.MetadataNode.DirectoryNode;
 import org.apache.kafka.shell.MetadataNode.FileNode;
 import org.apache.kafka.snapshot.SnapshotReader;
@@ -316,6 +318,15 @@ public final class MetadataNodeManager implements AutoCloseable {
                     node.rmrf(record.key());
                 else
                     node.create(record.key()).setContents(record.value() + "");
+                break;
+            }
+            case PRODUCER_IDS_RECORD: {
+                ProducerIdsRecord record = (ProducerIdsRecord) message;
+                DirectoryNode producerIdNode = data.root.mkdirs("producerIds");
+                producerIdNode.create("broker").setContents(record.brokerId() + "");
+                producerIdNode.create("blockStart")
+                    .setContents(record.producerIdsEnd() - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "");
+                producerIdNode.create("blockEnd").setContents(record.producerIdsEnd() - 1 + "");
                 break;
             }
             default:

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -310,13 +310,10 @@ public class MetadataNodeManagerTest {
             "1",
             metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerEpoch").contents());
         assertEquals(
-            10000 - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockStart").contents());
-        assertEquals(
-            "9999",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockEnd").contents());
+            10000 + "",
+            metadataNodeManager.getData().root().directory("nextProducerIdBlock").file("firstProducerId").contents());
 
-        // generate another brokerId
+        // generate another producerId record
         ProducerIdsRecord record2 = new ProducerIdsRecord()
             .setBrokerId(1)
             .setBrokerEpoch(2)
@@ -330,10 +327,7 @@ public class MetadataNodeManagerTest {
             "2",
             metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerEpoch").contents());
         assertEquals(
-            11000 - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockStart").contents());
-        assertEquals(
-            "10999",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockEnd").contents());
+            11000 + "",
+            metadataNodeManager.getData().root().directory("nextProducerIdBlock").file("firstProducerId").contents());
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
 import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
-import org.apache.kafka.server.common.ProducerIdsBlock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -25,16 +25,19 @@ import org.apache.kafka.common.metadata.FenceBrokerRecord;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.PartitionRecordJsonConverter;
+import org.apache.kafka.common.metadata.ProducerIdsRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
 import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
+import org.apache.kafka.server.common.ProducerIdsBlock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -276,7 +279,7 @@ public class MetadataNodeManagerTest {
                 "user", "kraft").children().containsKey("producer_byte_rate"));
 
         record = new ClientQuotaRecord()
-            .setEntity(Arrays.asList(
+            .setEntity(Collections.singletonList(
                 new ClientQuotaRecord.EntityData()
                     .setEntityType("user")
                     .setEntityName(null)
@@ -289,5 +292,42 @@ public class MetadataNodeManagerTest {
         assertEquals("2000.0",
             metadataNodeManager.getData().root().directory("client-quotas",
                 "user", "<default>").file("producer_byte_rate").contents());
+    }
+
+    @Test
+    public void testProducerIdsRecord() {
+        // generate brokerId
+        ProducerIdsRecord record1 = new ProducerIdsRecord()
+            .setBrokerId(0)
+            .setBrokerEpoch(1)
+            .setProducerIdsEnd(10000);
+        metadataNodeManager.handleMessage(record1);
+
+        assertEquals(
+            "0",
+            metadataNodeManager.getData().root().directory("producerIds").file("broker").contents());
+        assertEquals(
+            10000 - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "",
+            metadataNodeManager.getData().root().directory("producerIds").file("blockStart").contents());
+        assertEquals(
+            "9999",
+            metadataNodeManager.getData().root().directory("producerIds").file("blockEnd").contents());
+
+        // generate brokerId again
+        ProducerIdsRecord record2 = new ProducerIdsRecord()
+            .setBrokerId(1)
+            .setBrokerEpoch(2)
+            .setProducerIdsEnd(11000);
+        metadataNodeManager.handleMessage(record2);
+
+        assertEquals(
+            "1",
+            metadataNodeManager.getData().root().directory("producerIds").file("broker").contents());
+        assertEquals(
+            11000 - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "",
+            metadataNodeManager.getData().root().directory("producerIds").file("blockStart").contents());
+        assertEquals(
+            "10999",
+            metadataNodeManager.getData().root().directory("producerIds").file("blockEnd").contents());
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -305,13 +305,16 @@ public class MetadataNodeManagerTest {
 
         assertEquals(
             "0",
-            metadataNodeManager.getData().root().directory("producerIds").file("broker").contents());
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerId").contents());
+        assertEquals(
+            "1",
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerEpoch").contents());
         assertEquals(
             10000 - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "",
-            metadataNodeManager.getData().root().directory("producerIds").file("blockStart").contents());
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockStart").contents());
         assertEquals(
             "9999",
-            metadataNodeManager.getData().root().directory("producerIds").file("blockEnd").contents());
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockEnd").contents());
 
         // generate another brokerId
         ProducerIdsRecord record2 = new ProducerIdsRecord()
@@ -322,12 +325,15 @@ public class MetadataNodeManagerTest {
 
         assertEquals(
             "1",
-            metadataNodeManager.getData().root().directory("producerIds").file("broker").contents());
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerId").contents());
+        assertEquals(
+            "2",
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerEpoch").contents());
         assertEquals(
             11000 - ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE + "",
-            metadataNodeManager.getData().root().directory("producerIds").file("blockStart").contents());
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockStart").contents());
         assertEquals(
             "10999",
-            metadataNodeManager.getData().root().directory("producerIds").file("blockEnd").contents());
+            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("blockEnd").contents());
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -305,13 +305,13 @@ public class MetadataNodeManagerTest {
 
         assertEquals(
             "0",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerId").contents());
+            metadataNodeManager.getData().root().directory("producerIds").file("lastBlockBrokerId").contents());
         assertEquals(
             "1",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerEpoch").contents());
+            metadataNodeManager.getData().root().directory("producerIds").file("lastBlockBrokerEpoch").contents());
         assertEquals(
             10000 + "",
-            metadataNodeManager.getData().root().directory("nextProducerIdBlock").file("firstProducerId").contents());
+            metadataNodeManager.getData().root().directory("producerIds").file("nextBlockStartId").contents());
 
         // generate another producerId record
         ProducerIdsRecord record2 = new ProducerIdsRecord()
@@ -322,12 +322,12 @@ public class MetadataNodeManagerTest {
 
         assertEquals(
             "1",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerId").contents());
+            metadataNodeManager.getData().root().directory("producerIds").file("lastBlockBrokerId").contents());
         assertEquals(
             "2",
-            metadataNodeManager.getData().root().directory("lastProducerIdBlock").file("assignedBrokerEpoch").contents());
+            metadataNodeManager.getData().root().directory("producerIds").file("lastBlockBrokerEpoch").contents());
         assertEquals(
             11000 + "",
-            metadataNodeManager.getData().root().directory("nextProducerIdBlock").file("firstProducerId").contents());
+            metadataNodeManager.getData().root().directory("producerIds").file("nextBlockStartId").contents());
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -300,7 +300,7 @@ public class MetadataNodeManagerTest {
         ProducerIdsRecord record1 = new ProducerIdsRecord()
             .setBrokerId(0)
             .setBrokerEpoch(1)
-            .setProducerIdsEnd(10000);
+            .setNextProducerId(10000);
         metadataNodeManager.handleMessage(record1);
 
         assertEquals(
@@ -317,7 +317,7 @@ public class MetadataNodeManagerTest {
         ProducerIdsRecord record2 = new ProducerIdsRecord()
             .setBrokerId(1)
             .setBrokerEpoch(2)
-            .setProducerIdsEnd(11000);
+            .setNextProducerId(11000);
         metadataNodeManager.handleMessage(record2);
 
         assertEquals(

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -296,7 +296,7 @@ public class MetadataNodeManagerTest {
 
     @Test
     public void testProducerIdsRecord() {
-        // generate brokerId
+        // generate a producerId record
         ProducerIdsRecord record1 = new ProducerIdsRecord()
             .setBrokerId(0)
             .setBrokerEpoch(1)
@@ -313,7 +313,7 @@ public class MetadataNodeManagerTest {
             "9999",
             metadataNodeManager.getData().root().directory("producerIds").file("blockEnd").contents());
 
-        // generate brokerId again
+        // generate another brokerId
         ProducerIdsRecord record2 = new ProducerIdsRecord()
             .setBrokerId(1)
             .setBrokerEpoch(2)


### PR DESCRIPTION
*More detailed description of your change*
We store producer IDs in broker snapshots in #11527, I think we could also add the ability to inspect it using MetadataShell.

*Summary of testing strategy (including rationale)*
I tested this locally:
```
[ Kafka Metadata Shell ]
>> cat /producerIds/broker
1
>> cat /producerIds/blockStart
0
>> cat /producerIds/blockEnd
999
>> 
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
