### PR TITLE
MINOR: retry when deleting offsets for named topologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -224,6 +224,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                             } else {
                                 future.completeExceptionally(ex);
                             }
+                            deleteOffsetsResult = null;
                         }
                         try {
                             Thread.sleep(100);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -215,9 +215,6 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                         } catch (final InterruptedException ex) {
                             ex.printStackTrace();
                             break;
-                        } catch (final GroupIdNotFoundException e) {
-                          log.debug("The offsets have been reset and it retied again, no longer retrying.");
-                          break;
                         } catch (final ExecutionException ex) {
                             if (ex.getCause() != null &&
                                 ex.getCause() instanceof GroupSubscribedToTopicException &&
@@ -225,6 +222,10 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                                     .getMessage()
                                     .equals("Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it.")) {
                                 ex.printStackTrace();
+                            } else if (ex.getCause() != null &&
+                                ex.getCause() instanceof GroupIdNotFoundException) {
+                                log.debug("The offsets have been reset and it retied again, no longer retrying.");
+                                break;
                             } else {
                                 future.completeExceptionally(ex);
                             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -216,7 +216,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                             ex.printStackTrace();
                             break;
                         } catch (final GroupIdNotFoundException e) {
-                          log.debug("The offsets have been reset and it retied again no longer retrying");
+                          log.debug("The offsets have been reset and it retied again, no longer retrying.");
                           break;
                         } catch (final ExecutionException ex) {
                             if (ex.getCause() != null &&

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -224,7 +224,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                                 ex.printStackTrace();
                             } else if (ex.getCause() != null &&
                                 ex.getCause() instanceof GroupIdNotFoundException) {
-                                log.debug("The offsets have been reset and it retied again, no longer retrying.");
+                                log.debug("The offsets have been reset by another client or the group has been deleted, no need to retry further.");
                                 break;
                             } else {
                                 future.completeExceptionally(ex);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
@@ -214,6 +215,9 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                         } catch (final InterruptedException ex) {
                             ex.printStackTrace();
                             break;
+                        } catch (final GroupIdNotFoundException e) {
+                          log.debug("The offsets have been reset and it retied again no longer retrying");
+                          break;
                         } catch (final ExecutionException ex) {
                             if (ex.getCause() != null &&
                                 ex.getCause() instanceof GroupSubscribedToTopicException &&


### PR DESCRIPTION
When this was made I didn't expect deleteOffsetsResult to be set if an exception was thrown. But it is and to retry we need to reset it to null. Changing the KafkaStreamsNamedTopokogyWrapper for remove topology when resetting offsets

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
