### PR TITLE
MINOR: replace lastOption call in LocalLog#flush() to prevent NoSuchElementException

### DIFF
--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -171,7 +171,8 @@ class LocalLog(@volatile private var _dir: File,
     val segmentsToFlush = segments.values(recoveryPoint, offset)
     segmentsToFlush.foreach(_.flush())
     // If there are any new segments, we need to flush the parent directory for crash consistency.
-    segmentsToFlush.lastOption.filter(_.baseOffset >= this.recoveryPoint).foreach(_ => Utils.flushDir(dir.toPath))
+    if (segmentsToFlush.exists(_.baseOffset >= this.recoveryPoint))
+      Utils.flushDir(dir.toPath)
   }
 
   /**


### PR DESCRIPTION
This PR fixed the iterator access issue during segment flush where a NoSuchElementException may be thrown. This can particularly happen if the Iterable[LogSegment] is accessed by 2 threads in parallel. A particular case is when retention periodic work empties segments from the segments map, while concurrently the async flush operation tries to access the very last segment from the same map. Since Iterable[T].lastOption is not thread-safe, the parallel access sometimes fails with a NoSuchElementException.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
