### PR TITLE
KAFKA-13544: fix FinalizedFeatureChangeListener deadlock

### DIFF
--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -242,7 +242,6 @@ class FinalizedFeatureChangeListener(private val finalizedFeatureCache: Finalize
     zkClient.unregisterZNodeChangeHandler(FeatureZNodeChangeHandler.path)
     queue.clear()
     thread.shutdown()
-    thread.join()
   }
 
   // For testing only.


### PR DESCRIPTION
[KAFKA-13544](https://issues.apache.org/jira/browse/KAFKA-13544?jql=project%20%3D%20KAFKA%20AND%20status%20%3D%20Open%20AND%20assignee%20in%20(EMPTY))
 
kafka broker server shutdown hook cause deadlock. 


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
