### PR TITLE
KAFKA-13533: Clean up resources on failed connector and task startup

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -134,7 +134,7 @@
     <suppress checks="ParameterNumber"
               files="Worker(SinkTask|SourceTask|Coordinator).java"/>
     <suppress checks="ParameterNumber"
-              files="ConfigKeyInfo.java"/>
+              files="(ConfigKeyInfo|Worker).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(RestServer|AbstractHerder|DistributedHerder|Worker).java"/>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -298,7 +298,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
     }
 
     @Override
-    protected void close() {
+    protected void doClose() {
         if (started) {
             Utils.closeQuietly(task::stop, "source task");
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -164,7 +164,7 @@ class WorkerSinkTask extends WorkerTask {
     }
 
     @Override
-    protected void close() {
+    protected void doClose() {
         // FIXME Kafka needs to add a timeout parameter here for us to properly obey the timeout
         // passed in
         try {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
  * if the task fails at the same time. To protect from these cases, we synchronize status updates
  * using the WorkerTask's monitor.
  */
-abstract class WorkerTask implements Runnable {
+abstract class WorkerTask implements Runnable, AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(WorkerTask.class);
     private static final String THREAD_NAME_PREFIX = "task-thread-";
 
@@ -153,7 +153,7 @@ abstract class WorkerTask implements Runnable {
 
     protected abstract void execute();
 
-    protected abstract void close();
+    protected abstract void doClose();
 
     protected boolean isStopping() {
         return stopping;
@@ -163,9 +163,10 @@ abstract class WorkerTask implements Runnable {
         return cancelled;
     }
 
-    private void doClose() {
+    @Override
+    public void close() {
         try {
-            close();
+            doClose();
         } catch (Throwable t) {
             log.error("{} Task threw an uncaught and unrecoverable exception during shutdown", this, t);
             throw t;
@@ -197,7 +198,7 @@ abstract class WorkerTask implements Runnable {
                 throw t;
             }
         } finally {
-            doClose();
+            close();
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorHandlingMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorHandlingMetrics.java
@@ -23,15 +23,19 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.ConnectMetrics;
 import org.apache.kafka.connect.runtime.ConnectMetricsRegistry;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains various sensors used for monitoring errors.
  */
-public class ErrorHandlingMetrics {
+public class ErrorHandlingMetrics implements AutoCloseable {
 
     private final Time time = new SystemTime();
 
     private final ConnectMetrics.MetricGroup metricGroup;
+
+    private static final Logger log = LoggerFactory.getLogger(ErrorHandlingMetrics.class);
 
     // metrics
     private final Sensor recordProcessingFailures;
@@ -137,5 +141,14 @@ public class ErrorHandlingMetrics {
      */
     public ConnectMetrics.MetricGroup metricGroup() {
         return metricGroup;
+    }
+
+    /**
+     * Close the task Error metrics group when the task is closed
+     */
+    @Override
+    public void close() {
+        log.debug("Removing error handling metrics of group {}", metricGroup.groupId());
+        metricGroup.close();
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
  * An {@link OffsetBackingStore} with support for reading from and writing to a worker-global
  * offset backing store and/or a connector-specific offset backing store.
  */
-public class ConnectorOffsetBackingStore implements OffsetBackingStore {
+public class ConnectorOffsetBackingStore implements OffsetBackingStore, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(ConnectorOffsetBackingStore.class);
 
@@ -185,6 +185,14 @@ public class ConnectorOffsetBackingStore implements OffsetBackingStore {
         // Worker offset store should not be stopped as it may be used for multiple connectors
         connectorStore.ifPresent(OffsetBackingStore::stop);
         connectorStoreAdmin.ifPresent(TopicAdmin::close);
+    }
+
+    /**
+     * Synonym for {@link #stop()}, for use with try-with-resources blocks.
+     */
+    @Override
+    public void close() {
+        stop();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/Closeables.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/Closeables.java
@@ -23,7 +23,47 @@ import org.slf4j.LoggerFactory;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Objects;
 
+/**
+ * This class allows developers to easily track multiple {@link AutoCloseable} objects allocated
+ * at different times and, if necessary {@link AutoCloseable#close} them.
+ * <p>
+ * Users should create an instance in a try-with-resources block,
+ * {@link #register(AutoCloseable, String) register} resources that they allocate inside that
+ * block, and optionally {@link #clear() clear} those resources before exiting the block if they
+ * will be used outside it.
+ * <p>
+ * For example:
+ * <pre> {@code
+ * try (Closeables closeables = new Closeables()) {
+ *      // Switch to the connector's classloader if something goes wrong and we have to close the
+ *      // resources we've allocated for it
+ *      closeables.useLoader(connectorClassLoader);
+ *
+ *     Converter keyConverter = createConverter(KEY_CONVERTER_CONFIG, connectorConfig);
+ *     // Close the key converter if any of the next steps fails
+ *     closeables.register(keyConverter, "task key converter");
+ *
+ *     Converter valueConverter = createConverter(VALUE_CONVERTER_CONFIG, connectorConfig);
+ *     // Close the value converter if any of the next steps fails
+ *     closeables.register(valueConverter, "task value converter);
+ *
+ *     HeaderConverter headerConverter = createHeaderConverter(connectorConfig);
+ *     // Close the header converter if any of the next steps fails
+ *     closeables.register(headerConverter, "task header converter);
+ *
+ *     WorkerTask workerTask = createWorkerTask(keyConverter, valueConverter, headerConverter);
+ *
+ *     // We've successfully created our task; clear our closeables since we want to keep using
+ *     // these
+ *     closeables.clear();
+ * }
+ * }</pre>
+ *
+ * Thread safety: this class is not thread-safe and is only intended to be accessed from a single
+ * thread per instance.
+ */
 public class Closeables implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(Closeables.class);
@@ -35,23 +75,57 @@ public class Closeables implements AutoCloseable {
         closeables = new IdentityHashMap<>();
     }
 
+    /**
+     * Register a resource to be {@link AutoCloseable#close() closed} when this {@link Closeables}
+     * object is {@link #close() closed}.
+     * @param closeable the closeable resource to track; if null, will be silently ignored
+     * @param name a description of the closeable resource to use for logging; may not be null
+     */
     public void register(AutoCloseable closeable, String name) {
+        Objects.requireNonNull(name, "name may not be null");
         if (closeable == null) {
-            log.trace("Ignoring null closeable {}", name);
+            log.trace("Ignoring null closeable: {}", name);
         } else {
             log.trace("Registering closeable {}: {}", name, closeable);
             this.closeables.put(closeable, name);
         }
     }
 
+    /**
+     * Set a {@link ClassLoader} to switch to when {@link AutoCloseable#close() closing}
+     * resources that have been {@link #register(AutoCloseable, String) registered}.
+     * <p>
+     * May not be invoked more than once.
+     * @param loader the loader to use; may not be null
+     * @throws IllegalStateException if invoked more than once
+     */
     public void useLoader(ClassLoader loader) {
+        if (this.loader != null) {
+            throw new IllegalStateException("May only define classloader once");
+        }
+        Objects.requireNonNull(loader, "class loader may not be null");
         this.loader = loader;
     }
 
+    /**
+     * Forget any resources that have been {@link #register(AutoCloseable, String) registered}
+     * before this call. Note that if a {@link ClassLoader} has been set via
+     * {@link #useLoader(ClassLoader)}, it will remain set, and subsequent calls to
+     * {@link #useLoader(ClassLoader)} will still fail.
+     */
     public void clear() {
         closeables.clear();
     }
 
+    /**
+     * {@link AutoCloseable#close() Close} all resources that have been
+     * {@link #register(AutoCloseable, String) registered}, using the {@link ClassLoader} set via
+     * {@link #useLoader(ClassLoader)} (if one has been set), except those that have been forgotten
+     * by a call to {@link #clear()}.
+     * <p>
+     * If any call to {@link AutoCloseable#close()} fails, the exception is caught, logged, and not
+     * propagated to the caller.
+     */
     @Override
     public void close() {
         if (closeables.isEmpty())

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/Closeables.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/Closeables.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.runtime.isolation.LoaderSwap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+public class Closeables implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(Closeables.class);
+
+    private final Map<AutoCloseable, String> closeables;
+    private ClassLoader loader;
+
+    public Closeables() {
+        closeables = new IdentityHashMap<>();
+    }
+
+    public void register(AutoCloseable closeable, String name) {
+        if (closeable == null) {
+            log.trace("Ignoring null closeable {}", name);
+        } else {
+            log.trace("Registering closeable {}: {}", name, closeable);
+            this.closeables.put(closeable, name);
+        }
+    }
+
+    public void useLoader(ClassLoader loader) {
+        this.loader = loader;
+    }
+
+    public void clear() {
+        closeables.clear();
+    }
+
+    @Override
+    public void close() {
+        if (closeables.isEmpty())
+            return;
+
+        try (Utils.UncheckedCloseable loaderSwap = maybeSwapLoaders()) {
+            closeables.forEach(Utils::closeQuietly);
+            closeables.clear();
+        }
+    }
+
+    private Utils.UncheckedCloseable maybeSwapLoaders() {
+        if (loader != null) {
+            return new LoaderSwap(loader)::close;
+        } else {
+            return () -> { };
+        }
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -18,8 +18,8 @@ package org.apache.kafka.connect.util;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -248,7 +248,7 @@ public class ErrorHandlingTaskTest {
 
         workerSinkTask.initialize(TASK_CONFIG);
         workerSinkTask.initializeAndStart();
-        workerSinkTask.close();
+        workerSinkTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -271,7 +271,7 @@ public class ErrorHandlingTaskTest {
         PowerMock.replayAll();
 
         workerSourceTask.initialize(TASK_CONFIG);
-        workerSourceTask.close();
+        workerSourceTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -299,7 +299,7 @@ public class ErrorHandlingTaskTest {
         PowerMock.replayAll();
 
         workerSourceTask.initialize(TASK_CONFIG);
-        workerSourceTask.close();
+        workerSourceTask.doClose();
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TestCloseables.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TestCloseables.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.util.Closeables;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestCloseables extends Closeables {
+
+    private final Map<Class<? extends AutoCloseable>, Integer> registered;
+
+    private ClassLoader loader;
+    private boolean cleared;
+
+    public TestCloseables() {
+        super();
+        this.registered = new HashMap<>();
+    }
+
+    @Override
+    public void register(AutoCloseable closeable, String description) {
+        super.register(closeable, description);
+        this.registered.compute(closeable.getClass(), (c, numRegistered) -> numRegistered == null ? 1 : numRegistered + 1);
+    }
+
+    @Override
+    public void useLoader(ClassLoader loader) {
+        super.useLoader(loader);
+        this.loader = loader;
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        this.cleared = true;
+    }
+
+    public Map<Class<? extends AutoCloseable>, Integer> registered() {
+        return registered;
+    }
+
+    public boolean cleared() {
+        return cleared;
+    }
+
+    public ClassLoader loader() {
+        return loader;
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -356,7 +356,7 @@ public class WorkerSinkTaskTest {
         sinkTaskContext.getValue().requestCommit(); // Force an offset commit
         workerTask.iteration();
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -175,7 +175,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
             workerTask.iteration();
         }
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         // Verify contents match expected values, i.e. that they were translated properly. With max
         // batch size 1 and poll returns 1 message at a time, we should have a matching # of batches
@@ -224,7 +224,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         // Commit finishes synchronously for testing so we can check this immediately
         assertEquals(0, workerTask.commitFailures());
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         assertEquals(2, capturedRecords.getValues().size());
 
@@ -265,7 +265,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         assertEquals(1, workerTask.commitFailures());
         assertEquals(false, Whitebox.getInternalState(workerTask, "committing"));
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -307,7 +307,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         assertEquals(1, workerTask.commitFailures());
         assertEquals(false, Whitebox.getInternalState(workerTask, "committing"));
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -340,7 +340,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         assertEquals(1, workerTask.commitFailures());
         assertEquals(false, Whitebox.getInternalState(workerTask, "committing"));
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -377,7 +377,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         assertEquals(1, workerTask.commitFailures());
         assertEquals(false, Whitebox.getInternalState(workerTask, "committing"));
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -439,7 +439,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         workerTask.iteration();
         workerTask.iteration();
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -477,7 +477,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         workerTask.iteration();
         workerTask.iteration();
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }
@@ -503,7 +503,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         workerTask.iteration();
         workerTask.iteration();
         workerTask.stop();
-        workerTask.close();
+        workerTask.doClose();
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
@@ -94,7 +94,7 @@ public class WorkerTaskTest {
                 .addMockedMethod("initialize")
                 .addMockedMethod("initializeAndStart")
                 .addMockedMethod("execute")
-                .addMockedMethod("close")
+                .addMockedMethod("doClose")
                 .createStrictMock();
 
         workerTask.initialize(TASK_CONFIG);
@@ -109,7 +109,7 @@ public class WorkerTaskTest {
         statusListener.onStartup(taskId);
         expectLastCall();
 
-        workerTask.close();
+        workerTask.doClose();
         expectLastCall();
 
         statusListener.onShutdown(taskId);
@@ -144,13 +144,13 @@ public class WorkerTaskTest {
                         retryWithToleranceOperator, Time.SYSTEM, statusBackingStore)
                 .addMockedMethod("initialize")
                 .addMockedMethod("execute")
-                .addMockedMethod("close")
+                .addMockedMethod("doClose")
                 .createStrictMock();
 
         workerTask.initialize(TASK_CONFIG);
         EasyMock.expectLastCall();
 
-        workerTask.close();
+        workerTask.doClose();
         EasyMock.expectLastCall();
 
         replay(workerTask);
@@ -185,7 +185,7 @@ public class WorkerTaskTest {
                 .addMockedMethod("initialize")
                 .addMockedMethod("initializeAndStart")
                 .addMockedMethod("execute")
-                .addMockedMethod("close")
+                .addMockedMethod("doClose")
                 .createStrictMock();
 
         final CountDownLatch stopped = new CountDownLatch(1);
@@ -211,7 +211,7 @@ public class WorkerTaskTest {
         statusListener.onStartup(taskId);
         expectLastCall();
 
-        workerTask.close();
+        workerTask.doClose();
         expectLastCall();
 
         // there should be no call to onShutdown()


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13533)

Introduces and leverages a new `Closeables` utility class that can be used to track accrued `AutoCloseable` objects via a try-with-resources block. Also switches the `Worker` class over to use `Plugins::withClassLoader` wherever possible.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
