### PR TITLE
KAFKA-13557: Remove swapResult from the public API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/InternalQueryResultUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/InternalQueryResultUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.query;
+
+import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
+
+import java.util.List;
+
+/**
+ * This utility class is an internal API, but it must be located in the same package as
+ * {@link QueryResult} so that it can access the package-private constructor
+ * {@link QueryResult#QueryResult(Object, List, Position)}
+ */
+@Unstable
+public final class InternalQueryResultUtil {
+    // uninstantiable utility class
+    public InternalQueryResultUtil() {}
+
+    public static <R> QueryResult<R> copyAndSubstituteDeserializedResult(
+        final QueryResult<?> rawResult,
+        final R deserializedResult) {
+
+        if (rawResult.isFailure()) {
+            throw new IllegalArgumentException(
+                "Callers must avoid calling this method on a failed result."
+            );
+        } else {
+            return new QueryResult<>(
+                deserializedResult,
+                rawResult.getExecutionInfo(),
+                rawResult.getPosition()
+            );
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
@@ -41,6 +41,17 @@ public final class QueryResult<R> {
         this.failure = null;
     }
 
+    /**
+     * package-private constructor used in {@link InternalQueryResultUtil}.
+     */
+    QueryResult(final R result, final List<String> executionInfo, final Position position) {
+        this.result = result;
+        this.failureReason = null;
+        this.failure = null;
+        this.executionInfo = executionInfo;
+        this.position = position;
+    }
+
     private QueryResult(final FailureReason failureReason, final String failure) {
         this.result = null;
         this.failureReason = failureReason;
@@ -195,19 +206,6 @@ public final class QueryResult<R> {
                     + failure);
         }
         return result;
-    }
-
-    public <V> QueryResult<V> swapResult(final V value) {
-        if (isFailure()) {
-            throw new IllegalArgumentException(
-                "Callers must avoid calling this method on a failed result."
-            );
-        } else {
-            final QueryResult<V> result = new QueryResult<>(value);
-            result.executionInfo = executionInfo;
-            result.position = position;
-            return result;
-        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/AbstractQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/AbstractQueryResult.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.query.internals;
+
+
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Container for a single partition's result when executing a {@link StateQueryRequest}.
+ *
+ * @param <R> The result type of the query.
+ */
+public abstract class AbstractQueryResult<R> implements QueryResult<R> {
+
+    private List<String> executionInfo = new LinkedList<>();
+    private Position position;
+
+    public AbstractQueryResult() {
+
+    }
+
+    public AbstractQueryResult(final List<String> executionInfo, final Position position) {
+        this.executionInfo = executionInfo;
+        this.position = position;
+    }
+
+    /**
+     * Used by stores to add detailed execution information (if requested) during query execution.
+     */
+    public void addExecutionInfo(final String message) {
+        executionInfo.add(message);
+    }
+
+    /**
+     * Used by stores to report what exact position in the store's history it was at when it
+     * executed the query.
+     */
+    public void setPosition(final Position position) {
+        this.position = position;
+    }
+
+    /**
+     * If detailed execution information was requested in {@link StateQueryRequest#enableExecutionInfo()},
+     * this method returned the execution details for this partition's result.
+     */
+    public List<String> getExecutionInfo() {
+        return executionInfo;
+    }
+
+    /**
+     * This state partition's exact position in its history when this query was executed. Can be
+     * used in conjunction with subsequent queries via {@link StateQueryRequest#withPositionBound(PositionBound)}.
+     * <p>
+     * Note: stores are encouraged, but not required to set this property.
+     */
+    public Position getPosition() {
+        return position;
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/FailedQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/FailedQueryResult.java
@@ -18,44 +18,24 @@ package org.apache.kafka.streams.query.internals;
 
 
 import org.apache.kafka.streams.query.FailureReason;
-import org.apache.kafka.streams.query.Position;
-import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
-
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Container for a single partition's result when executing a {@link StateQueryRequest}.
  *
  * @param <R> The result type of the query.
  */
-public final class FailedQueryResult<R> implements QueryResult<R> {
+public final class FailedQueryResult<R>
+    extends AbstractQueryResult<R>
+    implements QueryResult<R> {
 
     private final FailureReason failureReason;
     private final String failure;
-    private final List<String> executionInfo = new LinkedList<>();
-    private Position position;
 
     public FailedQueryResult(final FailureReason failureReason, final String failure) {
         this.failureReason = failureReason;
         this.failure = failure;
-    }
-
-    /**
-     * Used by stores to add detailed execution information (if requested) during query execution.
-     */
-    public void addExecutionInfo(final String message) {
-        executionInfo.add(message);
-    }
-
-    /**
-     * Used by stores to report what exact position in the store's history it was at when it
-     * executed the query.
-     */
-    public void setPosition(final Position position) {
-        this.position = position;
     }
 
     /**
@@ -73,24 +53,6 @@ public final class FailedQueryResult<R> implements QueryResult<R> {
      */
     public boolean isFailure() {
         return true;
-    }
-
-    /**
-     * If detailed execution information was requested in {@link StateQueryRequest#enableExecutionInfo()},
-     * this method returned the execution details for this partition's result.
-     */
-    public List<String> getExecutionInfo() {
-        return executionInfo;
-    }
-
-    /**
-     * This state partition's exact position in its history when this query was executed. Can be
-     * used in conjunction with subsequent queries via {@link StateQueryRequest#withPositionBound(PositionBound)}.
-     * <p>
-     * Note: stores are encouraged, but not required to set this property.
-     */
-    public Position getPosition() {
-        return position;
     }
 
     /**
@@ -123,15 +85,5 @@ public final class FailedQueryResult<R> implements QueryResult<R> {
         throw new IllegalArgumentException(
             "Cannot get result for failed query. Failure is " + failureReason.name() + ": "
                 + failure);
-    }
-
-    @Override
-    public String toString() {
-        return "FailedQueryResult{" +
-            "executionInfo=" + executionInfo +
-            ", failureReason=" + failureReason +
-            ", failure='" + failure + '\'' +
-            ", position=" + position +
-            '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/InternalQueryResultUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/InternalQueryResultUtil.java
@@ -17,15 +17,11 @@
 package org.apache.kafka.streams.query.internals;
 
 import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
-import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.QueryResult;
 
-import java.util.List;
-
 /**
- * This utility class is an internal API, but it must be located in the same package as
- * {@link QueryResult} so that it can access the package-private constructor
- * {@link SucceededQueryResult (Object, List, Position )}
+ * Internal utility class to support operations the Kafka Streams framework needs to
+ * perform on {@link QueryResult}s.
  */
 @Unstable
 public final class InternalQueryResultUtil {

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/InternalQueryResultUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/InternalQueryResultUtil.java
@@ -14,22 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.query;
+package org.apache.kafka.streams.query.internals;
 
 import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.QueryResult;
 
 import java.util.List;
 
 /**
  * This utility class is an internal API, but it must be located in the same package as
  * {@link QueryResult} so that it can access the package-private constructor
- * {@link QueryResult#QueryResult(Object, List, Position)}
+ * {@link SucceededQueryResult (Object, List, Position )}
  */
 @Unstable
 public final class InternalQueryResultUtil {
     // uninstantiable utility class
     public InternalQueryResultUtil() {}
 
+    /**
+     * Creates a new `QueryResult` preserving the execution info
+     * and position of the provided result.
+     */
     public static <R> QueryResult<R> copyAndSubstituteDeserializedResult(
         final QueryResult<?> rawResult,
         final R deserializedResult) {
@@ -39,7 +45,7 @@ public final class InternalQueryResultUtil {
                 "Callers must avoid calling this method on a failed result."
             );
         } else {
-            return new QueryResult<>(
+            return new SucceededQueryResult<>(
                 deserializedResult,
                 rawResult.getExecutionInfo(),
                 rawResult.getPosition()

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
@@ -22,7 +22,6 @@ import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
-import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
@@ -19,11 +19,9 @@ package org.apache.kafka.streams.query.internals;
 
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.Position;
-import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
 
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -31,11 +29,11 @@ import java.util.List;
  *
  * @param <R> The result type of the query.
  */
-public final class SucceededQueryResult<R> implements QueryResult<R> {
+public final class SucceededQueryResult<R>
+    extends AbstractQueryResult<R>
+    implements QueryResult<R> {
 
     private final R result;
-    private List<String> executionInfo = new LinkedList<>();
-    private Position position;
 
     public SucceededQueryResult(final R result) {
         this.result = result;
@@ -47,24 +45,8 @@ public final class SucceededQueryResult<R> implements QueryResult<R> {
     SucceededQueryResult(final R result,
                          final List<String> executionInfo,
                          final Position position) {
+        super(executionInfo, position);
         this.result = result;
-        this.executionInfo = executionInfo;
-        this.position = position;
-    }
-
-    /**
-     * Used by stores to add detailed execution information (if requested) during query execution.
-     */
-    public void addExecutionInfo(final String message) {
-        executionInfo.add(message);
-    }
-
-    /**
-     * Used by stores to report what exact position in the store's history it was at when it
-     * executed the query.
-     */
-    public void setPosition(final Position position) {
-        this.position = position;
     }
 
     /**
@@ -82,24 +64,6 @@ public final class SucceededQueryResult<R> implements QueryResult<R> {
      */
     public boolean isFailure() {
         return false;
-    }
-
-    /**
-     * If detailed execution information was requested in {@link StateQueryRequest#enableExecutionInfo()},
-     * this method returned the execution details for this partition's result.
-     */
-    public List<String> getExecutionInfo() {
-        return executionInfo;
-    }
-
-    /**
-     * This state partition's exact position in its history when this query was executed. Can be
-     * used in conjunction with subsequent queries via {@link StateQueryRequest#withPositionBound(PositionBound)}.
-     * <p>
-     * Note: stores are encouraged, but not required to set this property.
-     */
-    public Position getPosition() {
-        return position;
     }
 
     /**
@@ -134,14 +98,5 @@ public final class SucceededQueryResult<R> implements QueryResult<R> {
      */
     public R getResult() {
         return result;
-    }
-
-    @Override
-    public String toString() {
-        return "QueryResult{" +
-            "executionInfo=" + executionInfo +
-            ", result=" + result +
-            ", position=" + position +
-            '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
@@ -14,13 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.query;
+package org.apache.kafka.streams.query.internals;
 
 
-import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.query.internals.FailedQueryResult;
-import org.apache.kafka.streams.query.internals.SucceededQueryResult;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -28,91 +32,66 @@ import java.util.List;
  *
  * @param <R> The result type of the query.
  */
-public interface QueryResult<R> {
-    /**
-     * Static factory method to create a result object for a successful query. Used by StateStores
-     * to respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
-     */
-    static <R> QueryResult<R> forResult(final R result) {
-        return new SucceededQueryResult<>(result);
+public final class SucceededQueryResult<R> implements QueryResult<R> {
+
+    private final R result;
+    private List<String> executionInfo = new LinkedList<>();
+    private Position position;
+
+    public SucceededQueryResult(final R result) {
+        this.result = result;
     }
 
     /**
-     * Static factory method to create a result object for a failed query. Used by StateStores to
-     * respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
+     * Special constructor used in {@link InternalQueryResultUtil}.
      */
-    static <R> QueryResult<R> forFailure(
-        final FailureReason failureReason,
-        final String failureMessage) {
-
-        return new FailedQueryResult<>(failureReason, failureMessage);
-    }
-
-    /**
-     * Static factory method to create a failed query result object to indicate that the store does
-     * not know how to handle the query.
-     * <p>
-     * Used by StateStores to respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
-     */
-    static <R> QueryResult<R> forUnknownQueryType(
-        final Query<R> query,
-        final StateStore store) {
-
-        return new FailedQueryResult<>(
-            FailureReason.UNKNOWN_QUERY_TYPE,
-            "This store (" + store.getClass() + ") doesn't know how to execute "
-                + "the given query (" + query + ")." +
-                " Contact the store maintainer if you need support for a new query type.");
-    }
-
-    /**
-     * Static factory method to create a failed query result object to indicate that the store has
-     * not yet caught up to the requested position bound.
-     * <p>
-     * Used by StateStores to respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
-     */
-    static <R> QueryResult<R> notUpToBound(
-        final Position currentPosition,
-        final PositionBound positionBound,
-        final int partition) {
-
-        return new FailedQueryResult<>(
-            FailureReason.NOT_UP_TO_BOUND,
-            "For store partition " + partition + ", the current position "
-                + currentPosition + " is not yet up to the bound "
-                + positionBound
-        );
+    SucceededQueryResult(final R result,
+                         final List<String> executionInfo,
+                         final Position position) {
+        this.result = result;
+        this.executionInfo = executionInfo;
+        this.position = position;
     }
 
     /**
      * Used by stores to add detailed execution information (if requested) during query execution.
      */
-    void addExecutionInfo(final String message);
+    public void addExecutionInfo(final String message) {
+        executionInfo.add(message);
+    }
 
     /**
      * Used by stores to report what exact position in the store's history it was at when it
      * executed the query.
      */
-    void setPosition(final Position position);
+    public void setPosition(final Position position) {
+        this.position = position;
+    }
 
     /**
      * True iff the query was successfully executed. The response is available in {@link
      * this#getResult()}.
      */
-    boolean isSuccess();
+    public boolean isSuccess() {
+        return true;
+    }
 
 
     /**
      * True iff the query execution failed. More information about the failure is available in
      * {@link this#getFailureReason()} and {@link this#getFailureMessage()}.
      */
-    boolean isFailure();
+    public boolean isFailure() {
+        return false;
+    }
 
     /**
      * If detailed execution information was requested in {@link StateQueryRequest#enableExecutionInfo()},
      * this method returned the execution details for this partition's result.
      */
-    List<String> getExecutionInfo();
+    public List<String> getExecutionInfo() {
+        return executionInfo;
+    }
 
     /**
      * This state partition's exact position in its history when this query was executed. Can be
@@ -120,21 +99,31 @@ public interface QueryResult<R> {
      * <p>
      * Note: stores are encouraged, but not required to set this property.
      */
-    Position getPosition();
+    public Position getPosition() {
+        return position;
+    }
 
     /**
      * If this partition failed to execute the query, returns the reason.
      *
      * @throws IllegalArgumentException if this is not a failed result.
      */
-    FailureReason getFailureReason();
+    public FailureReason getFailureReason() {
+        throw new IllegalArgumentException(
+            "Cannot get failure reason because this query did not fail."
+        );
+    }
 
     /**
      * If this partition failed to execute the query, returns the failure message.
      *
      * @throws IllegalArgumentException if this is not a failed result.
      */
-    String getFailureMessage();
+    public String getFailureMessage() {
+        throw new IllegalArgumentException(
+            "Cannot get failure message because this query did not fail."
+        );
+    }
 
     /**
      * Returns the result of executing the query on one partition. The result type is determined by
@@ -144,5 +133,16 @@ public interface QueryResult<R> {
      *
      * @throws IllegalArgumentException if this is not a successful query.
      */
-    R getResult();
+    public R getResult() {
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryResult{" +
+            "executionInfo=" + executionInfo +
+            ", result=" + result +
+            ", position=" + position +
+            '}';
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.query.InternalQueryResultUtil;
+import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -35,6 +35,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.query.InternalQueryResultUtil;
 import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
@@ -270,9 +271,11 @@ public class MeteredKeyValueStore<K, V>
                 getSensor,
                 getValueDeserializer()
             );
-            final QueryResult<KeyValueIterator<K, V>> typedQueryResult = rawResult.swapResult(
-                resultIterator
-            );
+            final QueryResult<KeyValueIterator<K, V>> typedQueryResult =
+                InternalQueryResultUtil.copyAndSubstituteDeserializedResult(
+                    rawResult,
+                    resultIterator
+                );
             result = (QueryResult<R>) typedQueryResult;
         } else {
             // the generic type doesn't matter, since failed queries have no result set.
@@ -296,7 +299,7 @@ public class MeteredKeyValueStore<K, V>
             final Deserializer<V> deserializer = getValueDeserializer();
             final V value = deserializer.deserialize(serdes.topic(), rawResult.getResult());
             final QueryResult<V> typedQueryResult =
-                rawResult.swapResult(value);
+                InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, value);
             result = (QueryResult<R>) typedQueryResult;
         } else {
             // the generic type doesn't matter, since failed queries have no result set.


### PR DESCRIPTION
Follow-on from https://github.com/apache/kafka/pull/11582 .
Removes a public API method in favor of an internal utility method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
