### PR TITLE
KAFKA-13553: add PAPI KV store tests for IQv2

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -155,7 +155,7 @@
 
     <!-- Streams -->
     <suppress checks="ClassFanOutComplexity"
-              files="(KafkaStreams|KStreamImpl|KTableImpl|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread).java"/>
+              files="(KafkaStreams|KStreamImpl|KTableImpl|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread|IQv2StoreIntegrationTest).java"/>
 
     <suppress checks="MethodLength"
               files="KTableImpl.java"/>

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -36,6 +36,9 @@ import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.Position;
@@ -52,8 +55,10 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.StoreSupplier;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
@@ -62,12 +67,15 @@ import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -80,8 +88,10 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -105,6 +115,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @RunWith(value = Parameterized.class)
 public class IQv2StoreIntegrationTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(IQv2StoreIntegrationTest.class);
+
+    private static final long SEED = new Random().nextLong();
+    private static final Random RANDOM = new Random(SEED);
+
     private static final int NUM_BROKERS = 1;
     public static final Duration WINDOW_SIZE = Duration.ofMinutes(5);
     private static int port = 0;
@@ -119,6 +134,7 @@ public class IQv2StoreIntegrationTest {
     public static class UnknownQuery implements Query<Void> { }
 
     private final StoresToTest storeToTest;
+    private final String kind;
     private final boolean cache;
     private final boolean log;
 
@@ -247,7 +263,8 @@ public class IQv2StoreIntegrationTest {
             @Override
             public StoreSupplier<?> supplier() {
                 return Stores.inMemoryWindowStore(STORE_NAME, Duration.ofDays(1), WINDOW_SIZE,
-                    false);
+                                                  false
+                );
             }
 
             @Override
@@ -259,7 +276,8 @@ public class IQv2StoreIntegrationTest {
             @Override
             public StoreSupplier<?> supplier() {
                 return Stores.persistentWindowStore(STORE_NAME, Duration.ofDays(1), WINDOW_SIZE,
-                    false);
+                                                    false
+                );
             }
 
             @Override
@@ -276,7 +294,8 @@ public class IQv2StoreIntegrationTest {
             @Override
             public StoreSupplier<?> supplier() {
                 return Stores.persistentTimestampedWindowStore(STORE_NAME, Duration.ofDays(1),
-                    WINDOW_SIZE, false);
+                                                               WINDOW_SIZE, false
+                );
             }
 
             @Override
@@ -330,31 +349,42 @@ public class IQv2StoreIntegrationTest {
         }
     }
 
-    @Parameterized.Parameters(name = "cache={0}, log={1}, supplier={2}")
+    @Parameterized.Parameters(name = "cache={0}, log={1}, supplier={2}, kind={3}")
     public static Collection<Object[]> data() {
+        LOG.info("Generating test cases according to random seed: {}", SEED);
         final List<Object[]> values = new ArrayList<>();
         for (final boolean cacheEnabled : Arrays.asList(true, false)) {
             for (final boolean logEnabled : Arrays.asList(true, false)) {
                 for (final StoresToTest toTest : StoresToTest.values()) {
-                    values.add(new Object[]{cacheEnabled, logEnabled, toTest.name()});
+                    for (final String kind : Arrays.asList("DSL", "PAPI")) {
+                        values.add(new Object[]{cacheEnabled, logEnabled, toTest.name(), kind});
+                    }
                 }
             }
         }
+        // Randomizing the test cases in case some orderings interfere with each other.
+        // If you wish to reproduce a randomized order, copy the logged SEED and substitute
+        // it for the constant at the top of the file. This will cause exactly the same sequence
+        // of pseudorandom values to be generated.
+        Collections.shuffle(values, RANDOM);
         return values;
     }
 
     public IQv2StoreIntegrationTest(
         final boolean cache,
         final boolean log,
-        final String storeToTest) {
+        final String storeToTest,
+        final String kind) {
         this.cache = cache;
         this.log = log;
         this.storeToTest = StoresToTest.valueOf(storeToTest);
+        this.kind = kind;
     }
 
     @BeforeClass
     public static void before()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
+
         CLUSTER.start();
         CLUSTER.deleteAllTopicsAndWait(60 * 1000L);
         final int partitions = 2;
@@ -408,90 +438,23 @@ public class IQv2StoreIntegrationTest {
         final Properties streamsConfig = streamsConfiguration(
             cache,
             log,
-            storeToTest.name()
+            storeToTest.name(),
+            kind
         );
 
         final StreamsBuilder builder = new StreamsBuilder();
-        if (supplier instanceof KeyValueBytesStoreSupplier) {
-            final Materialized<Integer, Integer, KeyValueStore<Bytes, byte[]>> materialized =
-                Materialized.as((KeyValueBytesStoreSupplier) supplier);
-
-            if (cache) {
-                materialized.withCachingEnabled();
-            } else {
-                materialized.withCachingDisabled();
-            }
-
-            if (log) {
-                materialized.withLoggingEnabled(Collections.emptyMap());
-            } else {
-                materialized.withCachingDisabled();
-            }
-
-            if (storeToTest.global()) {
-                builder.globalTable(
-                    INPUT_TOPIC_NAME,
-                    Consumed.with(Serdes.Integer(), Serdes.Integer()),
-                    materialized
-                );
-            } else {
-                builder.table(
-                    INPUT_TOPIC_NAME,
-                    Consumed.with(Serdes.Integer(), Serdes.Integer()),
-                    materialized
-                );
-            }
-        } else if (supplier instanceof WindowBytesStoreSupplier) {
-            final Materialized<Integer, Integer, WindowStore<Bytes, byte[]>> materialized =
-                Materialized.as((WindowBytesStoreSupplier) supplier);
-
-            if (cache) {
-                materialized.withCachingEnabled();
-            } else {
-                materialized.withCachingDisabled();
-            }
-
-            if (log) {
-                materialized.withLoggingEnabled(Collections.emptyMap());
-            } else {
-                materialized.withCachingDisabled();
-            }
-
-            builder
-                .stream(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()))
-                .groupByKey()
-                .windowedBy(TimeWindows.ofSizeWithNoGrace(WINDOW_SIZE))
-                .aggregate(
-                    () -> 0,
-                    (key, value, aggregate) -> aggregate + value,
-                    materialized
-                );
-        } else if (supplier instanceof SessionBytesStoreSupplier) {
-            final Materialized<Integer, Integer, SessionStore<Bytes, byte[]>> materialized =
-                Materialized.as((SessionBytesStoreSupplier) supplier);
-
-            if (cache) {
-                materialized.withCachingEnabled();
-            } else {
-                materialized.withCachingDisabled();
-            }
-
-            if (log) {
-                materialized.withLoggingEnabled(Collections.emptyMap());
-            } else {
-                materialized.withCachingDisabled();
-            }
-
-            builder
-                .stream(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()))
-                .groupByKey()
-                .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(WINDOW_SIZE))
-                .aggregate(
-                    () -> 0,
-                    (key, value, aggregate) -> aggregate + value,
-                    (aggKey, aggOne, aggTwo) -> aggOne + aggTwo,
-                    materialized
-                );
+        if (Objects.equals(kind, "DSL") && supplier instanceof KeyValueBytesStoreSupplier) {
+            setUpKeyValueDSLTopology((KeyValueBytesStoreSupplier) supplier, builder);
+        } else if (Objects.equals(kind, "PAPI") && supplier instanceof KeyValueBytesStoreSupplier) {
+            setUpKeyValuePAPITopology((KeyValueBytesStoreSupplier) supplier, builder);
+        } else if (Objects.equals(kind, "DSL") && supplier instanceof WindowBytesStoreSupplier) {
+            setUpWindowDSLTopology((WindowBytesStoreSupplier) supplier, builder);
+        } else if (Objects.equals(kind, "PAPI") && supplier instanceof WindowBytesStoreSupplier) {
+            throw new AssumptionViolatedException("Case not implemented yet");
+        } else if (Objects.equals(kind, "DSL") && supplier instanceof SessionBytesStoreSupplier) {
+            setUpSessionDSLTopology((SessionBytesStoreSupplier) supplier, builder);
+        } else if (Objects.equals(kind, "PAPI") && supplier instanceof SessionBytesStoreSupplier) {
+            throw new AssumptionViolatedException("Case not implemented yet");
         } else {
             throw new AssertionError("Store supplier is an unrecognized type.");
         }
@@ -507,10 +470,168 @@ public class IQv2StoreIntegrationTest {
             );
     }
 
+    private void setUpSessionDSLTopology(final SessionBytesStoreSupplier supplier,
+                                         final StreamsBuilder builder) {
+        final Materialized<Integer, Integer, SessionStore<Bytes, byte[]>> materialized =
+            Materialized.as(supplier);
+
+        if (cache) {
+            materialized.withCachingEnabled();
+        } else {
+            materialized.withCachingDisabled();
+        }
+
+        if (log) {
+            materialized.withLoggingEnabled(Collections.emptyMap());
+        } else {
+            materialized.withCachingDisabled();
+        }
+
+        builder
+            .stream(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()))
+            .groupByKey()
+            .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(WINDOW_SIZE))
+            .aggregate(
+                () -> 0,
+                (key, value, aggregate) -> aggregate + value,
+                (aggKey, aggOne, aggTwo) -> aggOne + aggTwo,
+                materialized
+            );
+    }
+
+    private void setUpWindowDSLTopology(final WindowBytesStoreSupplier supplier,
+                                        final StreamsBuilder builder) {
+        final Materialized<Integer, Integer, WindowStore<Bytes, byte[]>> materialized =
+            Materialized.as(supplier);
+
+        if (cache) {
+            materialized.withCachingEnabled();
+        } else {
+            materialized.withCachingDisabled();
+        }
+
+        if (log) {
+            materialized.withLoggingEnabled(Collections.emptyMap());
+        } else {
+            materialized.withCachingDisabled();
+        }
+
+        builder
+            .stream(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()))
+            .groupByKey()
+            .windowedBy(TimeWindows.ofSizeWithNoGrace(WINDOW_SIZE))
+            .aggregate(
+                () -> 0,
+                (key, value, aggregate) -> aggregate + value,
+                materialized
+            );
+    }
+
+    private void setUpKeyValueDSLTopology(final KeyValueBytesStoreSupplier supplier,
+                                          final StreamsBuilder builder) {
+        final Materialized<Integer, Integer, KeyValueStore<Bytes, byte[]>> materialized =
+            Materialized.as(supplier);
+
+        if (cache) {
+            materialized.withCachingEnabled();
+        } else {
+            materialized.withCachingDisabled();
+        }
+
+        if (log) {
+            materialized.withLoggingEnabled(Collections.emptyMap());
+        } else {
+            materialized.withCachingDisabled();
+        }
+
+        if (storeToTest.global()) {
+            builder.globalTable(
+                INPUT_TOPIC_NAME,
+                Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                materialized
+            );
+        } else {
+            builder.table(
+                INPUT_TOPIC_NAME,
+                Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                materialized
+            );
+        }
+    }
+
+    private void setUpKeyValuePAPITopology(final KeyValueBytesStoreSupplier supplier,
+                                           final StreamsBuilder builder) {
+        final StoreBuilder<?> keyValueStoreStoreBuilder;
+        final ProcessorSupplier<Integer, Integer, Void, Void> processorSupplier;
+        if (storeToTest.timestamped()) {
+            keyValueStoreStoreBuilder = Stores.timestampedKeyValueStoreBuilder(
+                supplier,
+                Serdes.Integer(),
+                Serdes.Integer()
+            );
+            processorSupplier = () -> new ContextualProcessor<Integer, Integer, Void, Void>() {
+                @Override
+                public void process(final Record<Integer, Integer> record) {
+                    final TimestampedKeyValueStore<Integer, Integer> stateStore =
+                        context().getStateStore(keyValueStoreStoreBuilder.name());
+                    stateStore.put(
+                        record.key(),
+                        ValueAndTimestamp.make(
+                            record.value(), record.timestamp()
+                        )
+                    );
+                }
+            };
+        } else {
+            keyValueStoreStoreBuilder = Stores.keyValueStoreBuilder(
+                supplier,
+                Serdes.Integer(),
+                Serdes.Integer()
+            );
+            processorSupplier =
+                () -> new ContextualProcessor<Integer, Integer, Void, Void>() {
+                    @Override
+                    public void process(final Record<Integer, Integer> record) {
+                        final KeyValueStore<Integer, Integer> stateStore =
+                            context().getStateStore(keyValueStoreStoreBuilder.name());
+                        stateStore.put(record.key(), record.value());
+                    }
+                };
+        }
+        if (cache) {
+            keyValueStoreStoreBuilder.withCachingEnabled();
+        } else {
+            keyValueStoreStoreBuilder.withCachingDisabled();
+        }
+        if (log) {
+            keyValueStoreStoreBuilder.withLoggingEnabled(Collections.emptyMap());
+        } else {
+            keyValueStoreStoreBuilder.withCachingDisabled();
+        }
+        if (storeToTest.global()) {
+            builder.addGlobalStore(
+                keyValueStoreStoreBuilder,
+                INPUT_TOPIC_NAME,
+                Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                processorSupplier
+            );
+        } else {
+            builder.addStateStore(keyValueStoreStoreBuilder);
+            builder
+                .stream(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()))
+                .process(processorSupplier, keyValueStoreStoreBuilder.name());
+        }
+
+    }
+
+
     @After
     public void afterTest() {
-        kafkaStreams.close();
-        kafkaStreams.cleanUp();
+        // only needed because some of the PAPI cases aren't added yet.
+        if (kafkaStreams != null) {
+            kafkaStreams.close();
+            kafkaStreams.cleanUp();
+        }
     }
 
     @AfterClass
@@ -755,11 +876,15 @@ public class IQv2StoreIntegrationTest {
         final StateQueryResult<ValueAndTimestamp<Integer>> result = kafkaStreams.query(request);
 
         assertThat(result.getGlobalResult().isFailure(), is(true));
-        assertThat(result.getGlobalResult().getFailureReason(),
-            is(FailureReason.UNKNOWN_QUERY_TYPE));
-        assertThat(result.getGlobalResult().getFailureMessage(),
+        assertThat(
+            result.getGlobalResult().getFailureReason(),
+            is(FailureReason.UNKNOWN_QUERY_TYPE)
+        );
+        assertThat(
+            result.getGlobalResult().getFailureMessage(),
             is("Global stores do not yet support the KafkaStreams#query API."
-                + " Use KafkaStreams#store instead."));
+                   + " Use KafkaStreams#store instead.")
+        );
     }
 
     public void shouldRejectUnknownQuery() {
@@ -777,9 +902,12 @@ public class IQv2StoreIntegrationTest {
             queryResult -> {
                 assertThat(queryResult.isFailure(), is(true));
                 assertThat(queryResult.isSuccess(), is(false));
-                assertThat(queryResult.getFailureReason(),
-                    is(FailureReason.UNKNOWN_QUERY_TYPE));
-                assertThat(queryResult.getFailureMessage(),
+                assertThat(
+                    queryResult.getFailureReason(),
+                    is(FailureReason.UNKNOWN_QUERY_TYPE)
+                );
+                assertThat(
+                    queryResult.getFailureMessage(),
                     matchesPattern(
                         "This store (.*)"
                             + " doesn't know how to execute the given query"
@@ -1099,9 +1227,10 @@ public class IQv2StoreIntegrationTest {
     }
 
     private static Properties streamsConfiguration(final boolean cache, final boolean log,
-        final String supplier) {
+                                                   final String supplier, final String kind) {
         final String safeTestName =
-            IQv2StoreIntegrationTest.class.getName() + "-" + cache + "-" + log + "-" + supplier;
+            IQv2StoreIntegrationTest.class.getName() + "-" + cache + "-" + log + "-" + supplier
+                + "-" + kind;
         final Properties config = new Properties();
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -608,7 +608,7 @@ public class IQv2StoreIntegrationTest {
         if (log) {
             keyValueStoreStoreBuilder.withLoggingEnabled(Collections.emptyMap());
         } else {
-            keyValueStoreStoreBuilder.withCachingDisabled();
+            keyValueStoreStoreBuilder.withLoggingDisabled();
         }
         if (storeToTest.global()) {
             builder.addGlobalStore(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -128,6 +128,8 @@ public class IQv2StoreIntegrationTest {
     private static final String STORE_NAME = "kv-store";
 
     private static final long RECORD_TIME = System.currentTimeMillis();
+    private static final long WINDOW_START =
+        (RECORD_TIME / WINDOW_SIZE.toMillis()) * WINDOW_SIZE.toMillis();
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
@@ -484,7 +486,7 @@ public class IQv2StoreIntegrationTest {
         if (log) {
             materialized.withLoggingEnabled(Collections.emptyMap());
         } else {
-            materialized.withCachingDisabled();
+            materialized.withLoggingDisabled();
         }
 
         builder
@@ -513,7 +515,7 @@ public class IQv2StoreIntegrationTest {
         if (log) {
             materialized.withLoggingEnabled(Collections.emptyMap());
         } else {
-            materialized.withCachingDisabled();
+            materialized.withLoggingDisabled();
         }
 
         builder
@@ -541,7 +543,7 @@ public class IQv2StoreIntegrationTest {
         if (log) {
             materialized.withLoggingEnabled(Collections.emptyMap());
         } else {
-            materialized.withCachingDisabled();
+            materialized.withLoggingDisabled();
         }
 
         if (storeToTest.global()) {
@@ -717,14 +719,11 @@ public class IQv2StoreIntegrationTest {
 
     private <T> void shouldHandleWindowKeyQueries(final Function<T, Integer> extractor) {
 
-        final long windowSize = WINDOW_SIZE.toMillis();
-        final long windowStart = (RECORD_TIME / windowSize) * windowSize;
-
         // tightest possible start range
         shouldHandleWindowKeyQuery(
             2,
-            Instant.ofEpochMilli(windowStart),
-            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
             extractor,
             mkSet(2)
         );
@@ -732,8 +731,8 @@ public class IQv2StoreIntegrationTest {
         // miss the window start range
         shouldHandleWindowKeyQuery(
             2,
-            Instant.ofEpochMilli(windowStart - 1),
-            Instant.ofEpochMilli(windowStart - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
             extractor,
             mkSet()
         );
@@ -741,8 +740,8 @@ public class IQv2StoreIntegrationTest {
         // miss the key
         shouldHandleWindowKeyQuery(
             999,
-            Instant.ofEpochMilli(windowStart),
-            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
             extractor,
             mkSet()
         );
@@ -750,8 +749,8 @@ public class IQv2StoreIntegrationTest {
         // miss both
         shouldHandleWindowKeyQuery(
             999,
-            Instant.ofEpochMilli(windowStart - 1),
-            Instant.ofEpochMilli(windowStart - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
             extractor,
             mkSet()
         );


### PR DESCRIPTION
During some recent reviews, @mjsax pointed out that StateStore layers
are constructed differently the stores are added via the PAPI vs. the DSL.

This PR adds PAPI construction to the IQv2StoreIntegrationTest so that
we can ensure IQv2 works on every possible state store.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
