### PR TITLE
KAFKA-13316; Enable KRaft mode in CreateTopics tests

### DIFF
--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData._
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNotNull, assertTrue}
 
 import scala.jdk.CollectionConverters._
 
@@ -122,8 +122,8 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
           topic.replicationFactor
 
         if (request.data.validateOnly) {
-          assertNotNull(metadataForTopic, s"Topic $topic should be created")
-          assertFalse(metadataForTopic.error == Errors.NONE, s"Error ${metadataForTopic.error} for topic $topic")
+          assertNotNull(metadataForTopic)
+          assertNotEquals(Errors.NONE, metadataForTopic.error, s"Topic $topic should not be created")
           assertTrue(metadataForTopic.partitionMetadata.isEmpty, "The topic should have no partitions")
         }
         else {

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithForwardingTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithForwardingTest.scala
@@ -19,7 +19,8 @@ package kafka.server
 
 import org.apache.kafka.common.protocol.Errors
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import scala.jdk.CollectionConverters._
 
@@ -27,8 +28,9 @@ class CreateTopicsRequestWithForwardingTest extends AbstractCreateTopicsRequestT
 
   override def enableForwarding: Boolean = true
 
-  @Test
-  def testForwardToController(): Unit = {
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testForwardToController(quorum: String): Unit = {
     val req = topicsReq(Seq(topicReq("topic1")))
     val response = sendCreateTopicRequest(req, notControllerSocketServer)
     // With forwarding enabled, request could be forwarded to the active controller.

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
@@ -25,7 +25,8 @@ import org.apache.kafka.common.errors.PolicyViolationException
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.server.policy.CreateTopicPolicy
 import org.apache.kafka.server.policy.CreateTopicPolicy.RequestMetadata
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import scala.jdk.CollectionConverters._
 
@@ -37,7 +38,8 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
     properties.put(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[Policy].getName)
   }
 
-  @Test
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
   def testValidCreateTopicsRequests(): Unit = {
     validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic1",
       numPartitions = 5))))
@@ -55,7 +57,8 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
       assignment = Map(0 -> List(1, 0), 1 -> List(0, 1))))))
   }
 
-  @Test
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
   def testErrorCreateTopicsRequests(): Unit = {
     val existingTopic = "existing-topic"
     createTopic(existingTopic, 1, 1)

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
@@ -19,9 +19,9 @@ package kafka.server
 
 import java.util
 import java.util.Properties
-
 import kafka.log.LogConfig
 import org.apache.kafka.common.errors.PolicyViolationException
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.server.policy.CreateTopicPolicy
 import org.apache.kafka.server.policy.CreateTopicPolicy.RequestMetadata
@@ -38,9 +38,15 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
     properties.put(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[Policy].getName)
   }
 
+  override def kraftControllerConfigs(): Seq[Properties] = {
+    val properties = new Properties()
+    properties.put(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[Policy].getName)
+    Seq(properties)
+  }
+
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
-  def testValidCreateTopicsRequests(): Unit = {
+  def testValidCreateTopicsRequests(quorum: String): Unit = {
     validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic1",
       numPartitions = 5))))
 
@@ -59,10 +65,7 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
-  def testErrorCreateTopicsRequests(): Unit = {
-    val existingTopic = "existing-topic"
-    createTopic(existingTopic, 1, 1)
-
+  def testErrorCreateTopicsRequests(quorum: String): Unit = {
     // Policy violations
     validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("policy-topic1",
       numPartitions = 4, replicationFactor = 1))),
@@ -90,26 +93,48 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
       Map("policy-topic5" -> error(Errors.POLICY_VIOLATION,
         Some("Topic partitions should have at least 2 partitions, received 1 for partition 0"))))
 
+    var errorMsg = if (isKRaftTest()) {
+      "Unable to replicate the partition 4 time(s): The target replication factor of 4 cannot be reached because only 3 broker(s) are registered."
+    } else {
+      "Replication factor: 4 larger than available brokers: 3."
+    }
+    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-replication",
+      numPartitions = 10, replicationFactor = brokerCount + 1)), validateOnly = true),
+      Map("error-replication" -> error(Errors.INVALID_REPLICATION_FACTOR,
+        Some(errorMsg))))
+
+    errorMsg = if (isKRaftTest()) {
+      "Replication factor must be larger than 0, or -1 to use the default value."
+    } else {
+      "Replication factor must be larger than 0."
+    }
+    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-replication2",
+      numPartitions = 10, replicationFactor = -2)), validateOnly = true),
+      Map("error-replication2" -> error(Errors.INVALID_REPLICATION_FACTOR,
+        Some(errorMsg))))
+
+    errorMsg = if (isKRaftTest()) {
+      "Number of partitions was set to an invalid non-positive value."
+    } else {
+      "Number of partitions must be larger than 0."
+    }
+    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-partitions",
+      numPartitions = -2, replicationFactor = 1)), validateOnly = true),
+      Map("error-partitions" -> error(Errors.INVALID_PARTITIONS,
+        Some(errorMsg))))
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk"))
+  def testErrorCreateExistingTopicsRequests(): Unit = {
+    val existingTopic = "existing-topic"
+    createTopic(existingTopic, 1, 1)
+
     // Check that basic errors still work
     validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq(existingTopic,
       numPartitions = 5, replicationFactor = 1))),
       Map(existingTopic -> error(Errors.TOPIC_ALREADY_EXISTS,
         Some("Topic 'existing-topic' already exists."))))
-
-    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-replication",
-      numPartitions = 10, replicationFactor = brokerCount + 1)), validateOnly = true),
-      Map("error-replication" -> error(Errors.INVALID_REPLICATION_FACTOR,
-        Some("Replication factor: 4 larger than available brokers: 3."))))
-
-    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-replication2",
-      numPartitions = 10, replicationFactor = -2)), validateOnly = true),
-      Map("error-replication2" -> error(Errors.INVALID_REPLICATION_FACTOR,
-        Some("Replication factor must be larger than 0."))))
-
-    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-partitions",
-      numPartitions = -2, replicationFactor = 1)), validateOnly = true),
-      Map("error-partitions" -> error(Errors.INVALID_PARTITIONS,
-        Some("Number of partitions must be larger than 0."))))
   }
 
 }
@@ -126,6 +151,10 @@ object CreateTopicsRequestWithPolicyTest {
     }
 
     def validate(requestMetadata: RequestMetadata): Unit = {
+      if (Topic.isInternal(requestMetadata.topic())) {
+        // Do not verify internal topics
+        return
+      }
       require(!closed, "Policy should not be closed")
       require(!configs.isEmpty, "configure should have been called with non empty configs")
 


### PR DESCRIPTION
*More detailed description of your change*
This PR follows #11629 to enable `CreateTopicsRequestWithForwardingTest` and `CreateTopicsRequestWithPolicyTest` in KRaft mode.

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
