### PR TITLE
KAFKA-13552: Fix BROKER and BROKER_LOGGER in KRaft

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
@@ -80,7 +80,7 @@ public class IncrementalAlterConfigsRequest extends AbstractRequest {
     private final IncrementalAlterConfigsRequestData data;
     private final short version;
 
-    private IncrementalAlterConfigsRequest(IncrementalAlterConfigsRequestData data, short version) {
+    public IncrementalAlterConfigsRequest(IncrementalAlterConfigsRequestData data, short version) {
         super(ApiKeys.INCREMENTAL_ALTER_CONFIGS, version);
         this.data = data;
         this.version = version;

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -200,7 +200,7 @@ class ConfigAdminManager(nodeId: Int,
       conf.dynamicConfig.validate(props, !configResource.name().isEmpty)
     } catch {
       case e: ApiException => throw e
-      // TODO: InvalidRequestException is not really the right exception here if the
+      //KAFKA-13609: InvalidRequestException is not really the right exception here if the
       // configuration fails validation. The configuration is still well-formed, but just
       // can't be applied. It should probably throw InvalidConfigurationException. However,
       // we should probably only change this in a KIP since it has compatibility implications.
@@ -276,7 +276,7 @@ class ConfigAdminManager(nodeId: Int,
   ): Unit = {
     val props = new Properties()
     resource.configs().forEach {
-      config => props.put(config.name(), config.value())
+      config => props.setProperty(config.name(), config.value())
     }
     validateBrokerConfigChange(props, configResource)
   }

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -1,0 +1,373 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package kafka.server
+
+import java.util
+import java.util.Properties
+
+import kafka.log.LogConfig
+import kafka.server.DynamicConfigManager.prepareIncrementalConfigs
+import kafka.utils.Log4jController
+import kafka.utils._
+import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType
+import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER, TOPIC}
+import org.apache.kafka.common.config.{ConfigResource, LogLevelConfig}
+import org.apache.kafka.common.errors.{ClusterAuthorizationException, InvalidConfigurationException, InvalidRequestException}
+import org.apache.kafka.common.message.{AlterConfigsRequestData, AlterConfigsResponseData, IncrementalAlterConfigsRequestData, IncrementalAlterConfigsResponseData}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterConfigsResource => LAlterConfigsResource}
+import org.apache.kafka.common.message.AlterConfigsResponseData.{AlterConfigsResourceResponse => LAlterConfigsResourceResponse}
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterConfigsResource => IAlterConfigsResource, AlterableConfig => IAlterableConfig}
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.{AlterConfigsResourceResponse => IAlterConfigsResourceResponse}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.protocol.Errors.{INVALID_REQUEST, UNKNOWN_SERVER_ERROR}
+import org.apache.kafka.common.requests.ApiError
+import org.apache.kafka.common.resource.{Resource, ResourceType}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Manages dynamic configuration operations on the broker.
+ *
+ * There are two RPCs that alter KIP-226 dynamic configurations: alterConfigs, and
+ * incrementalAlterConfigs. The main difference between the two is that alterConfigs sets
+ * all configurations related to a specific config resource, whereas
+ * incrementalAlterConfigs makes only designated changes.
+ *
+ * The original, non-incremental AlterConfigs is deprecated because there are inherent
+ * race conditions when multiple clients use it. It deletes any resource configuration
+ * keys that are not specified. This leads to clients trying to do read-modify-write
+ * cycles when they only want to change one config key. (But even read-modify-write doesn't
+ * work correctly, since "sensitive" configurations are omitted when read.)
+ *
+ * KIP-412 added support for changing log4j log levels via IncrementalAlterConfigs, but
+ * not via the original AlterConfigs. In retrospect, this would have been better off as a
+ * separate RPC, since the semantics are quite different. In particular, KIP-226 configs
+ * are stored durably (in ZK or KRaft) and persist across broker restarts, but KIP-412
+ * log4j levels do not. However, we have to handle it here now in order to maintain
+ * compatibility.
+ *
+ * Configuration processing is split into two parts.
+ * - The first step, called "preprocessing," handles setting KIP-412 log levels, validating
+ * BROKER configurations. We also filter out some other things here like UNKNOWN resource
+ * types, etc.
+ * - The second step is "persistence," and handles storing the configurations durably to our
+ * metadata store.
+ *
+ * When KIP-590 forwarding is active (such as in KRaft mode), preprocessing will happen
+ * on the broker, while persistence will happen on the active controller. (If KIP-590
+ * forwarding is not active, then both steps are done on the same broker.)
+ *
+ * In KRaft mode, the active controller performs its own configuration validation step in
+ * {@link kafka.server.ControllerConfigurationValidator}. This is mainly important for
+ * TOPIC resources, since we already validated changes to BROKER resources on the
+ * forwarding broker. The KRaft controller is also responsible for enforcing the configured
+ * {@link org.apache.kafka.server.policy.AlterConfigPolicy}.
+ */
+class ConfigAdminManager(nodeId: Int,
+                         conf: KafkaConfig,
+                         getResourceConfig: ConfigResource => Properties) extends Logging {
+  this.logIdent = "[ConfigAdminManager[nodeId=" + nodeId + "]: "
+
+  /**
+   * Preprocess an incremental configuration operation on the broker.
+   *
+   * @param request     The request data.
+   * @param authorize   A callback which is invoked when we need to authorize an operation.
+   *                    Currently, we only use this for log4j operations. Other types of
+   *                    operations are authorized in the persistence step.
+   * @return
+   */
+  def preprocess(
+    request: IncrementalAlterConfigsRequestData,
+    authorize: (ResourceType, String) => Boolean
+  ): util.IdentityHashMap[IAlterConfigsResource, ApiError] = {
+    val results = new util.IdentityHashMap[IAlterConfigsResource, ApiError]()
+    val resourceIds = new util.HashMap[(Byte, String), IAlterConfigsResource]
+    request.resources().forEach(resource => {
+      val preexisting = resourceIds.put((resource.resourceType(), resource.resourceName()), resource)
+      if (preexisting != null) {
+        Seq(preexisting, resource).foreach(
+          r => results.put(r, new ApiError(INVALID_REQUEST, "Each resource must appear at most once.")))
+      }
+    })
+    request.resources().forEach(resource => {
+      if (!results.containsKey(resource)) {
+        val resourceType = ConfigResource.Type.forId(resource.resourceType())
+        val configResource = new ConfigResource(resourceType, resource.resourceName())
+        try {
+          val nullUpdates = new util.ArrayList[String]()
+          resource.configs().forEach { config =>
+            if (config.configOperation() != AlterConfigOp.OpType.DELETE.id() &&
+              config.value() == null) {
+              nullUpdates.add(config.name())
+            }
+          }
+          if (!nullUpdates.isEmpty()) {
+            throw new InvalidRequestException("Null value not supported for : " +
+              String.join(", ", nullUpdates))
+          }
+          resourceType match {
+            case BROKER_LOGGER =>
+              if (!authorize(ResourceType.CLUSTER, Resource.CLUSTER_NAME)) {
+                throw new ClusterAuthorizationException(Errors.CLUSTER_AUTHORIZATION_FAILED.message())
+              }
+              validateResourceNameIsCurrentNodeId(resource.resourceName())
+              validateLogLevelConfigs(resource.configs())
+              if (!request.validateOnly()) {
+                alterLogLevelConfigs(resource.configs())
+              }
+              results.put(resource, ApiError.NONE)
+            case BROKER =>
+              // The resource name must be either blank (if setting a cluster config) or
+              // the ID of this specific broker.
+              if (!configResource.name().isEmpty) {
+                validateResourceNameIsCurrentNodeId(resource.resourceName())
+              }
+              validateBrokerConfigChange(resource, configResource)
+            case TOPIC =>
+            // Nothing to do.
+            case _ =>
+              throw new InvalidRequestException(s"Unknown resource type ${resource.resourceType().toInt}")
+          }
+        } catch {
+          case t: Throwable => {
+            val err = ApiError.fromThrowable(t)
+            info(s"Error preprocessing incrementalAlterConfigs request on ${configResource}", t)
+            results.put(resource, err)
+          }
+        }
+      }
+    })
+    results
+  }
+
+  def validateBrokerConfigChange(
+    resource: IAlterConfigsResource,
+    configResource: ConfigResource
+  ): Unit = {
+    val props = getResourceConfig(configResource)
+    val alterConfigOps = resource.configs().asScala.map {
+      case config =>
+        val opType = AlterConfigOp.OpType.forId(config.configOperation())
+        if (opType == null) {
+          throw new InvalidRequestException(s"Unknown operations type ${config.configOperation}")
+        }
+        new AlterConfigOp(new ConfigEntry(config.name(), config.value()), opType)
+    }.toSeq
+    prepareIncrementalConfigs(alterConfigOps, props, LogConfig.configKeys)
+    conf.dynamicConfig.validate(props, !configResource.name().isEmpty)
+  }
+
+  /**
+   * Preprocess a legacy configuration operation on the broker.
+   *
+   * @param request     The request data.
+   *
+   * @return
+   */
+  def preprocess(
+    request: AlterConfigsRequestData,
+  ): util.IdentityHashMap[LAlterConfigsResource, ApiError] = {
+    val results = new util.IdentityHashMap[LAlterConfigsResource, ApiError]()
+    val resourceIds = new util.HashMap[(Byte, String), LAlterConfigsResource]
+    request.resources().forEach(resource => {
+      val preexisting = resourceIds.put((resource.resourceType(), resource.resourceName()), resource)
+      if (preexisting != null) {
+        Seq(preexisting, resource).foreach(
+          r => results.put(r, new ApiError(INVALID_REQUEST, "Each resource must appear at most once.")))
+      }
+    })
+    request.resources().forEach(resource => {
+      if (!results.containsKey(resource)) {
+        val resourceType = ConfigResource.Type.forId(resource.resourceType())
+        val configResource = new ConfigResource(resourceType, resource.resourceName())
+        try {
+          resourceType match {
+            case BROKER =>
+              validateResourceNameIsCurrentNodeId(resource.resourceName())
+            case TOPIC =>
+            // Nothing to do.
+            case _ =>
+              // Since legacy AlterConfigs does not support BROKER_LOGGER, any attempt to use it
+              // gets caught by this clause.
+              throw new InvalidRequestException(s"Unknown resource type ${resource.resourceType().toInt}")
+          }
+          val nullUpdates = new util.ArrayList[String]()
+          resource.configs().forEach { config =>
+            if (config.value() == null) {
+              nullUpdates.add(config.name())
+            }
+          }
+          if (!nullUpdates.isEmpty()) {
+            throw new InvalidRequestException("Null value not supported for : " +
+              String.join(", ", nullUpdates))
+          }
+        } catch {
+          case t: Throwable => {
+            val err = ApiError.fromThrowable(t)
+            info(s"Error preprocessing alterConfigs request on ${configResource}: ${err}")
+            results.put(resource, err)
+          }
+        }
+      }
+    })
+    results
+  }
+
+  def validateResourceNameIsCurrentNodeId(name: String): Unit = {
+    val id = try name.toInt catch {
+      case _: NumberFormatException =>
+        throw new InvalidRequestException(s"Node id must be an integer, but it is: $name")
+    }
+    if (id != nodeId) {
+      throw new InvalidRequestException(s"Unexpected broker id, expected ${nodeId}, but received ${name}")
+    }
+  }
+
+  def validateLogLevelConfigs(ops: util.Collection[IAlterableConfig]): Unit = {
+    def validateLoggerNameExists(loggerName: String): Unit = {
+      if (!Log4jController.loggerExists(loggerName)) {
+        throw new InvalidConfigurationException(s"Logger $loggerName does not exist!")
+      }
+    }
+    ops.forEach { op =>
+      val loggerName = op.name
+      OpType.forId(op.configOperation()) match {
+        case OpType.SET =>
+          validateLoggerNameExists(loggerName)
+          val logLevel = op.value()
+          if (!LogLevelConfig.VALID_LOG_LEVELS.contains(logLevel)) {
+            val validLevelsStr = LogLevelConfig.VALID_LOG_LEVELS.asScala.mkString(", ")
+            throw new InvalidConfigurationException(
+              s"Cannot set the log level of $loggerName to $logLevel as it is not a supported log level. " +
+                s"Valid log levels are $validLevelsStr"
+            )
+          }
+        case OpType.DELETE =>
+          validateLoggerNameExists(loggerName)
+          if (loggerName == Log4jController.ROOT_LOGGER)
+            throw new InvalidRequestException(s"Removing the log level of the ${Log4jController.ROOT_LOGGER} logger is not allowed")
+        case OpType.APPEND => throw new InvalidRequestException(s"${OpType.APPEND} " +
+          s"operation is not allowed for the ${BROKER_LOGGER} resource")
+        case OpType.SUBTRACT => throw new InvalidRequestException(s"${OpType.SUBTRACT} " +
+          s"operation is not allowed for the ${BROKER_LOGGER} resource")
+        case _ => throw new InvalidRequestException(s"Unknown operation type ${op.configOperation()} " +
+          s"is not allowed for the ${BROKER_LOGGER} resource")
+      }
+    }
+  }
+
+  def alterLogLevelConfigs(ops: util.Collection[IAlterableConfig]): Unit = {
+    ops.forEach { op =>
+      val loggerName = op.name()
+      val logLevel = op.value()
+      OpType.forId(op.configOperation()) match {
+        case OpType.SET =>
+          info(s"Updating the log level of $loggerName to $logLevel")
+          Log4jController.logLevel(loggerName, logLevel)
+        case OpType.DELETE =>
+          info(s"Unset the log level of $loggerName")
+          Log4jController.unsetLogLevel(loggerName)
+        case _ => throw new IllegalArgumentException(
+          s"Invalid log4j configOperation: ${op.configOperation()}")
+      }
+    }
+  }
+}
+
+object ConfigAdminManager {
+  def copyWithoutPreprocessed(
+    request: IncrementalAlterConfigsRequestData,
+    processed: util.IdentityHashMap[IAlterConfigsResource, ApiError]
+  ): IncrementalAlterConfigsRequestData = {
+    val copy = new IncrementalAlterConfigsRequestData().
+      setValidateOnly(request.validateOnly())
+    request.resources().forEach(resource => {
+      if (!processed.containsKey(resource)) {
+        copy.resources().mustAdd(resource.duplicate())
+      }
+    })
+    copy
+  }
+
+  def copyWithoutPreprocessed(
+    request: AlterConfigsRequestData,
+    processed: util.IdentityHashMap[LAlterConfigsResource, ApiError]
+  ): AlterConfigsRequestData = {
+    val copy = new AlterConfigsRequestData().
+      setValidateOnly(request.validateOnly())
+    request.resources().forEach(resource => {
+      if (!processed.containsKey(resource)) {
+        copy.resources().mustAdd(resource.duplicate())
+      }
+    })
+    copy
+  }
+
+  def reassembleIncrementalResponse(
+    original: IncrementalAlterConfigsRequestData,
+    preprocessingResponses: util.IdentityHashMap[IAlterConfigsResource, ApiError],
+    persistentResponses: IncrementalAlterConfigsResponseData
+  ): IncrementalAlterConfigsResponseData = {
+    val response = new IncrementalAlterConfigsResponseData()
+    val iterator = persistentResponses.responses().iterator()
+    original.resources().forEach(resource => {
+      val error = Option(preprocessingResponses.get(resource)) match {
+        case None => if (!iterator.hasNext) {
+          new ApiError(UNKNOWN_SERVER_ERROR)
+        } else {
+          val resourceResponse = iterator.next()
+          new ApiError(Errors.forCode(resourceResponse.errorCode()), resourceResponse.errorMessage())
+        }
+        case Some(error) => error
+      }
+      response.responses().add(new IAlterConfigsResourceResponse().
+        setResourceName(resource.resourceName()).
+        setResourceType(resource.resourceType()).
+        setErrorCode(error.error().code()).
+        setErrorMessage(error.message()))
+    })
+    response
+  }
+
+  def reassembleLegacyResponse(
+    original: AlterConfigsRequestData,
+    preprocessingResponses: util.IdentityHashMap[LAlterConfigsResource, ApiError],
+    persistentResponses: AlterConfigsResponseData
+  ): AlterConfigsResponseData = {
+    val response = new AlterConfigsResponseData()
+    val iterator = persistentResponses.responses().iterator()
+    original.resources().forEach(resource => {
+      val error = Option(preprocessingResponses.get(resource)) match {
+        case None => if (!iterator.hasNext) {
+          new ApiError(UNKNOWN_SERVER_ERROR)
+        } else {
+          val resourceResponse = iterator.next()
+          new ApiError(Errors.forCode(resourceResponse.errorCode()), resourceResponse.errorMessage())
+        }
+        case Some(error) => error
+      }
+      response.responses().add(new LAlterConfigsResourceResponse().
+        setResourceName(resource.resourceName()).
+        setResourceType(resource.resourceType()).
+        setErrorCode(error.error().code()).
+        setErrorMessage(error.message()))
+    })
+    response
+  }
+}

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -42,7 +42,7 @@ import scala.collection.Seq
 import scala.util.Try
 
 /**
-  * The ConfigHandler is used to process config change notifications received by the DynamicConfigManager
+  * The ConfigHandler is used to process broker configuration change notifications.
   */
 trait ConfigHandler {
   def processConfigChanges(entityName: String, value: Properties): Unit

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -112,8 +112,12 @@ class ControllerApis(val requestChannel: RequestChannel,
       }
     } catch {
       case e: FatalExitError => throw e
-      case e: ExecutionException => requestHelper.handleError(request, e.getCause)
-      case e: Throwable => requestHelper.handleError(request, e)
+      case e: Throwable => {
+        val t = if (e.isInstanceOf[ExecutionException]) e.getCause() else e
+        error(s"Unexpected error handling request ${request.requestDesc(true)} " +
+          s"with context ${request.context}", t)
+        requestHelper.handleError(request, t)
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -29,6 +29,20 @@ import org.apache.kafka.common.internals.Topic
 
 import scala.collection.mutable
 
+/**
+ * The validator that the controller uses for dynamic configuration changes.
+ * It performs the generic validation, which can't be bypassed. If an AlterConfigPolicy
+ * is configured, the controller will check that after verifying that this passes.
+ *
+ * For changes to BROKER resources, the forwarding broker performs an extra validation step
+ * in {@link kafka.server.ConfigAdminManager#preprocess()} before sending the change to
+ * the controller. Therefore, the validation here is just a kind of sanity check, which
+ * should never fail under normal conditions.
+ *
+ * This validator does not handle changes to BROKER_LOGGER resources. Despite being bundled
+ * in the same RPC, BROKER_LOGGER is not really a dynamic configuration in the same sense
+ * as the others. It is not persisted to the metadata log (or to ZK, when we're in that mode).
+ */
 class ControllerConfigurationValidator extends ConfigurationValidator {
   override def validate(resource: ConfigResource, config: util.Map[String, String]): Unit = {
     resource.`type`() match {

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -252,8 +252,6 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
     addReconfigurable(new DynamicClientQuotaCallback(kafkaConfig.brokerId, kafkaServer))
 
     addBrokerReconfigurable(new DynamicThreadPool(kafkaServer))
-    if (kafkaServer.logManager.cleaner != null)
-      addBrokerReconfigurable(kafkaServer.logManager.cleaner)
     addBrokerReconfigurable(new DynamicLogConfig(kafkaServer.logManager, kafkaServer))
     addBrokerReconfigurable(new DynamicListenerConfig(kafkaServer))
     addBrokerReconfigurable(kafkaServer.socketServer)

--- a/core/src/main/scala/kafka/server/DynamicConfigManager.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfigManager.scala
@@ -18,12 +18,18 @@
 package kafka.server
 
 import java.nio.charset.StandardCharsets
+import java.util.Properties
 
 import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
 import kafka.utils.{Json, Logging}
 import kafka.utils.json.JsonObject
 import kafka.zk.{AdminZkClient, ConfigEntityChangeNotificationSequenceZNode, ConfigEntityChangeNotificationZNode, KafkaZkClient}
+import org.apache.kafka.clients.admin.AlterConfigOp
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType
+import org.apache.kafka.common.config.ConfigDef.ConfigKey
+import org.apache.kafka.common.config.{ConfigDef, ConfigResource}
 import org.apache.kafka.common.config.types.Password
+import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.utils.Time
 
@@ -180,5 +186,54 @@ class DynamicConfigManager(private val zkClient: KafkaZkClient,
 
   def shutdown(): Unit = {
     configChangeListener.close()
+  }
+}
+
+object DynamicConfigManager {
+  def toLoggableProps(resource: ConfigResource, configProps: Properties): Map[String, String] = {
+    configProps.asScala.map {
+      case (key, value) => (key, KafkaConfig.loggableValue(resource.`type`, key, value))
+    }
+  }
+
+  def prepareIncrementalConfigs(
+    alterConfigOps: Seq[AlterConfigOp],
+    configProps: Properties,
+    configKeys: Map[String, ConfigKey]
+  ): Unit = {
+    def listType(configName: String, configKeys: Map[String, ConfigKey]): Boolean = {
+      val configKey = configKeys(configName)
+      if (configKey == null)
+        throw new InvalidConfigurationException(s"Unknown topic config name: $configName")
+      configKey.`type` == ConfigDef.Type.LIST
+    }
+
+    alterConfigOps.foreach { alterConfigOp =>
+      val configPropName = alterConfigOp.configEntry.name
+      alterConfigOp.opType() match {
+        case OpType.SET => configProps.setProperty(alterConfigOp.configEntry.name, alterConfigOp.configEntry.value)
+        case OpType.DELETE => configProps.remove(alterConfigOp.configEntry.name)
+        case OpType.APPEND => {
+          if (!listType(alterConfigOp.configEntry.name, configKeys))
+            throw new InvalidRequestException(s"Config value append is not allowed for config key: ${alterConfigOp.configEntry.name}")
+          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry.name))
+            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
+            .getOrElse("")
+            .split(",").toList
+          val newValueList = oldValueList ::: alterConfigOp.configEntry.value.split(",").toList
+          configProps.setProperty(alterConfigOp.configEntry.name, newValueList.mkString(","))
+        }
+        case OpType.SUBTRACT => {
+          if (!listType(alterConfigOp.configEntry.name, configKeys))
+            throw new InvalidRequestException(s"Config value subtract is not allowed for config key: ${alterConfigOp.configEntry.name}")
+          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry.name))
+            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
+            .getOrElse("")
+            .split(",").toList
+          val newValueList = oldValueList.diff(alterConfigOp.configEntry.value.split(",").toList)
+          configProps.setProperty(alterConfigOp.configEntry.name, newValueList.mkString(","))
+        }
+      }
+    }
   }
 }

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -30,7 +30,36 @@ import scala.compat.java8.OptionConverters._
 
 trait ForwardingManager {
   def forwardRequest(
-    request: RequestChannel.Request,
+    originalRequest: RequestChannel.Request,
+    responseCallback: Option[AbstractResponse] => Unit
+  ): Unit = {
+    val buffer = originalRequest.buffer.duplicate()
+    buffer.flip()
+    forwardRequest(originalRequest.context,
+      buffer,
+      originalRequest.body[AbstractRequest],
+      () => originalRequest.toString(),
+      responseCallback)
+  }
+
+  def forwardRequest(
+    originalRequest: RequestChannel.Request,
+    newRequestBody: AbstractRequest,
+    responseCallback: Option[AbstractResponse] => Unit
+  ): Unit = {
+    val buffer = newRequestBody.serializeWithHeader(originalRequest.header)
+    forwardRequest(originalRequest.context,
+      buffer,
+      newRequestBody,
+      () => originalRequest.toString(),
+      responseCallback)
+  }
+
+  def forwardRequest(
+    requestContext: RequestContext,
+    requestBufferCopy: ByteBuffer,
+    requestBody: AbstractRequest,
+    requestToString: () => String,
     responseCallback: Option[AbstractResponse] => Unit
   ): Unit
 
@@ -66,29 +95,36 @@ class ForwardingManagerImpl(
   /**
    * Forward given request to the active controller.
    *
-   * @param request request to be forwarded
-   * @param responseCallback callback which takes in an `Option[AbstractResponse]`, where
-   *                         None is indicating that controller doesn't support the request
-   *                         version.
+   * @param requestContext      The request context of the original envelope request.
+   * @param requestBufferCopy   The request buffer we want to send. This should not be the original
+   *                            byte buffer from the envelope request, since we will be mutating
+   *                            the position and limit fields. It should be a copy.
+   * @param requestBody         The AbstractRequest we are sending.
+   * @param requestToString     A callback which can be invoked to produce a human-readable decription
+   *                            of the request.
+   * @param responseCallback    A callback which takes in an `Option[AbstractResponse]`.
+   *                            We will call this function with Some(x) after the controller responds with x.
+   *                            Or, if the controller doesn't support the request version, we will complete
+   *                            the callback with None.
    */
   override def forwardRequest(
-    request: RequestChannel.Request,
+    requestContext: RequestContext,
+    requestBufferCopy: ByteBuffer,
+    requestBody: AbstractRequest,
+    requestToString: () => String,
     responseCallback: Option[AbstractResponse] => Unit
   ): Unit = {
-    val requestBuffer = request.buffer.duplicate()
-    requestBuffer.flip()
-    val envelopeRequest = ForwardingManager.buildEnvelopeRequest(request.context, requestBuffer)
+    val envelopeRequest = ForwardingManager.buildEnvelopeRequest(requestContext, requestBufferCopy)
 
     class ForwardingResponseHandler extends ControllerRequestCompletionHandler {
       override def onComplete(clientResponse: ClientResponse): Unit = {
-        val requestBody = request.body[AbstractRequest]
 
         if (clientResponse.versionMismatch != null) {
-          debug(s"Returning `UNKNOWN_SERVER_ERROR` in response to request $requestBody " +
+          debug(s"Returning `UNKNOWN_SERVER_ERROR` in response to ${requestToString()} " +
             s"due to unexpected version error", clientResponse.versionMismatch)
           responseCallback(Some(requestBody.getErrorResponse(Errors.UNKNOWN_SERVER_ERROR.exception)))
         } else if (clientResponse.authenticationException != null) {
-          debug(s"Returning `UNKNOWN_SERVER_ERROR` in response to request $requestBody " +
+          debug(s"Returning `UNKNOWN_SERVER_ERROR` in response to ${requestToString()} " +
             s"due to authentication error", clientResponse.authenticationException)
           responseCallback(Some(requestBody.getErrorResponse(Errors.UNKNOWN_SERVER_ERROR.exception)))
         } else {
@@ -108,10 +144,10 @@ class ForwardingManagerImpl(
               // the error directly to the client since it would not be expected. Instead we
               // return `UNKNOWN_SERVER_ERROR` so that the user knows that there is a problem
               // on the broker.
-              debug(s"Forwarded request $request failed with an error in the envelope response $envelopeError")
+              debug(s"Forwarded request ${requestToString()} failed with an error in the envelope response $envelopeError")
               requestBody.getErrorResponse(Errors.UNKNOWN_SERVER_ERROR.exception)
             } else {
-              parseResponse(envelopeResponse.responseData, requestBody, request.header)
+              parseResponse(envelopeResponse.responseData, requestBody, requestContext.header)
             }
             responseCallback(Option(response))
           }
@@ -119,8 +155,8 @@ class ForwardingManagerImpl(
       }
 
       override def onTimeout(): Unit = {
-        debug(s"Forwarding of the request $request failed due to timeout exception")
-        val response = request.body[AbstractRequest].getErrorResponse(new TimeoutException())
+        debug(s"Forwarding of the request ${requestToString()} failed due to timeout exception")
+        val response = requestBody.getErrorResponse(new TimeoutException())
         responseCallback(Option(response))
       }
     }

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -38,7 +38,7 @@ trait ForwardingManager {
     forwardRequest(originalRequest.context,
       buffer,
       originalRequest.body[AbstractRequest],
-      () => originalRequest.toString(),
+      () => originalRequest.toString,
       responseCallback)
   }
 
@@ -51,10 +51,25 @@ trait ForwardingManager {
     forwardRequest(originalRequest.context,
       buffer,
       newRequestBody,
-      () => originalRequest.toString(),
+      () => originalRequest.toString,
       responseCallback)
   }
 
+  /**
+   * Forward given request to the active controller.
+   *
+   * @param requestContext      The request context of the original envelope request.
+   * @param requestBufferCopy   The request buffer we want to send. This should not be the original
+   *                            byte buffer from the envelope request, since we will be mutating
+   *                            the position and limit fields. It should be a copy.
+   * @param requestBody         The AbstractRequest we are sending.
+   * @param requestToString     A callback which can be invoked to produce a human-readable decription
+   *                            of the request.
+   * @param responseCallback    A callback which takes in an `Option[AbstractResponse]`.
+   *                            We will call this function with Some(x) after the controller responds with x.
+   *                            Or, if the controller doesn't support the request version, we will complete
+   *                            the callback with None.
+   */
   def forwardRequest(
     requestContext: RequestContext,
     requestBufferCopy: ByteBuffer,
@@ -92,21 +107,6 @@ class ForwardingManagerImpl(
   channelManager: BrokerToControllerChannelManager
 ) extends ForwardingManager with Logging {
 
-  /**
-   * Forward given request to the active controller.
-   *
-   * @param requestContext      The request context of the original envelope request.
-   * @param requestBufferCopy   The request buffer we want to send. This should not be the original
-   *                            byte buffer from the envelope request, since we will be mutating
-   *                            the position and limit fields. It should be a copy.
-   * @param requestBody         The AbstractRequest we are sending.
-   * @param requestToString     A callback which can be invoked to produce a human-readable decription
-   *                            of the request.
-   * @param responseCallback    A callback which takes in an `Option[AbstractResponse]`.
-   *                            We will call this function with Some(x) after the controller responds with x.
-   *                            Or, if the controller doesn't support the request version, we will complete
-   *                            the callback with None.
-   */
   override def forwardRequest(
     requestContext: RequestContext,
     requestBufferCopy: ByteBuffer,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -113,7 +113,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   val authHelper = new AuthHelper(authorizer)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)
   val aclApis = new AclApis(authHelper, authorizer, requestHelper, "broker", config)
-  val configManager = new ConfigAdminManager(brokerId, config, metadataSupport.getResourceConfig)
+  val configManager = new ConfigAdminManager(brokerId, config, configRepository)
 
   def close(): Unit = {
     aclApis.close()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -56,7 +56,7 @@ import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.{EpochEn
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.{ListenerName, Send}
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
@@ -113,6 +113,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   val authHelper = new AuthHelper(authorizer)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)
   val aclApis = new AclApis(authHelper, authorizer, requestHelper, "broker", config)
+  val configManager = new ConfigAdminManager(brokerId, config, metadataSupport.getResourceConfig)
 
   def close(): Unit = {
     aclApis.close()
@@ -130,15 +131,17 @@ class KafkaApis(val requestChannel: RequestChannel,
     def responseCallback(responseOpt: Option[AbstractResponse]): Unit = {
       responseOpt match {
         case Some(response) => requestHelper.sendForwardedResponse(request, response)
-        case None =>
-          info(s"The client connection will be closed due to controller responded " +
-            s"unsupported version exception during $request forwarding. " +
-            s"This could happen when the controller changed after the connection was established.")
-          requestChannel.closeConnection(request, Collections.emptyMap())
+        case None => handleInvalidVersionsDuringForwarding(request)
       }
     }
-
     metadataSupport.maybeForward(request, handler, responseCallback)
+  }
+
+  private def handleInvalidVersionsDuringForwarding(request: RequestChannel.Request): Unit = {
+    info(s"The client connection will be closed due to controller responded " +
+      s"unsupported version exception during $request forwarding. " +
+      s"This could happen when the controller changed after the connection was established.")
+    requestChannel.closeConnection(request, Collections.emptyMap())
   }
 
   private def forwardToControllerOrFail(
@@ -198,7 +201,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.DESCRIBE_ACLS => handleDescribeAcls(request)
         case ApiKeys.CREATE_ACLS => maybeForwardToController(request, handleCreateAcls)
         case ApiKeys.DELETE_ACLS => maybeForwardToController(request, handleDeleteAcls)
-        case ApiKeys.ALTER_CONFIGS => maybeForwardToController(request, handleAlterConfigsRequest)
+        case ApiKeys.ALTER_CONFIGS => handleAlterConfigsRequest(request)
         case ApiKeys.DESCRIBE_CONFIGS => handleDescribeConfigsRequest(request)
         case ApiKeys.ALTER_REPLICA_LOG_DIRS => handleAlterReplicaLogDirsRequest(request)
         case ApiKeys.DESCRIBE_LOG_DIRS => handleDescribeLogDirsRequest(request)
@@ -210,7 +213,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.DESCRIBE_DELEGATION_TOKEN => handleDescribeTokensRequest(request)
         case ApiKeys.DELETE_GROUPS => handleDeleteGroupsRequest(request, requestLocal)
         case ApiKeys.ELECT_LEADERS => maybeForwardToController(request, handleElectLeaders)
-        case ApiKeys.INCREMENTAL_ALTER_CONFIGS => maybeForwardToController(request, handleIncrementalAlterConfigsRequest)
+        case ApiKeys.INCREMENTAL_ALTER_CONFIGS => handleIncrementalAlterConfigsRequest(request)
         case ApiKeys.ALTER_PARTITION_REASSIGNMENTS => maybeForwardToController(request, handleAlterPartitionReassignmentsRequest)
         case ApiKeys.LIST_PARTITION_REASSIGNMENTS => maybeForwardToController(request, handleListPartitionReassignmentsRequest)
         case ApiKeys.OFFSET_DELETE => handleOffsetDeleteRequest(request, requestLocal)
@@ -1301,7 +1304,7 @@ class KafkaApis(val requestChannel: RequestChannel,
          requestThrottleMs,
          brokers.toList.asJava,
          clusterId,
-         metadataSupport.controllerId.getOrElse(MetadataResponse.NO_CONTROLLER_ID),
+         metadataCache.getControllerId.getOrElse(MetadataResponse.NO_CONTROLLER_ID),
          completeTopicMetadata.asJava,
          clusterAuthorizedOperations
       ))
@@ -2621,16 +2624,45 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleAlterConfigsRequest(request: RequestChannel.Request): Unit = {
-    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(request))
-    val alterConfigsRequest = request.body[AlterConfigsRequest]
+    val original = request.body[AlterConfigsRequest]
+    val preprocessingResponses = configManager.preprocess(original.data())
+    val remaining = ConfigAdminManager.copyWithoutPreprocessed(original.data(), preprocessingResponses)
+    def sendResponse(secondPart: Option[ApiMessage]): Unit = {
+      secondPart match {
+        case Some(result: AlterConfigsResponseData) =>
+          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+            new AlterConfigsResponse(ConfigAdminManager.reassembleLegacyResponse(
+              original.data(),
+              preprocessingResponses,
+              result).setThrottleTimeMs(requestThrottleMs)))
+        case _ => handleInvalidVersionsDuringForwarding(request)
+      }
+    }
+    if (remaining.resources().isEmpty) {
+      sendResponse(Some(new AlterConfigsResponseData()))
+    } else if ((!request.isForwarded) && metadataSupport.canForward()) {
+      metadataSupport.forwardingManager.get.forwardRequest(request,
+        new AlterConfigsRequest(remaining, request.header.apiVersion()),
+        response => sendResponse(response.map(_.data())))
+    } else {
+      sendResponse(Some(processLegacyAlterConfigsRequest(request, remaining)))
+    }
+  }
+
+  def processLegacyAlterConfigsRequest(
+    originalRequest: RequestChannel.Request,
+    data: AlterConfigsRequestData
+  ): AlterConfigsResponseData = {
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(originalRequest))
+    val alterConfigsRequest = new AlterConfigsRequest(data, originalRequest.header.apiVersion())
     val (authorizedResources, unauthorizedResources) = alterConfigsRequest.configs.asScala.toMap.partition { case (resource, _) =>
       resource.`type` match {
         case ConfigResource.Type.BROKER_LOGGER =>
           throw new InvalidRequestException(s"AlterConfigs is deprecated and does not support the resource type ${ConfigResource.Type.BROKER_LOGGER}")
         case ConfigResource.Type.BROKER =>
-          authHelper.authorize(request.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)
+          authHelper.authorize(originalRequest.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)
         case ConfigResource.Type.TOPIC =>
-          authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, resource.name)
+          authHelper.authorize(originalRequest.context, ALTER_CONFIGS, TOPIC, resource.name)
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt")
       }
     }
@@ -2638,19 +2670,15 @@ class KafkaApis(val requestChannel: RequestChannel,
     val unauthorizedResult = unauthorizedResources.keys.map { resource =>
       resource -> configsAuthorizationApiError(resource)
     }
-    def responseCallback(requestThrottleMs: Int): AlterConfigsResponse = {
-      val data = new AlterConfigsResponseData()
-        .setThrottleTimeMs(requestThrottleMs)
-      (authorizedResult ++ unauthorizedResult).foreach{ case (resource, error) =>
-        data.responses().add(new AlterConfigsResourceResponse()
-          .setErrorCode(error.error.code)
-          .setErrorMessage(error.message)
-          .setResourceName(resource.name)
-          .setResourceType(resource.`type`.id))
-      }
-      new AlterConfigsResponse(data)
+    val response = new AlterConfigsResponseData()
+    (authorizedResult ++ unauthorizedResult).foreach { case (resource, error) =>
+      response.responses().add(new AlterConfigsResourceResponse()
+        .setErrorCode(error.error.code)
+        .setErrorMessage(error.message)
+        .setResourceName(resource.name)
+        .setResourceType(resource.`type`.id))
     }
-    requestHelper.sendResponseMaybeThrottle(request, responseCallback)
+    response
   }
 
   def handleAlterPartitionReassignmentsRequest(request: RequestChannel.Request): Unit = {
@@ -2750,10 +2778,40 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleIncrementalAlterConfigsRequest(request: RequestChannel.Request): Unit = {
-    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(request))
-    val alterConfigsRequest = request.body[IncrementalAlterConfigsRequest]
+    val original = request.body[IncrementalAlterConfigsRequest]
+    val preprocessingResponses = configManager.preprocess(original.data(),
+      (rType, rName) => authHelper.authorize(request.context, ALTER_CONFIGS, rType, rName))
+    val remaining = ConfigAdminManager.copyWithoutPreprocessed(original.data(), preprocessingResponses)
 
-    val configs = alterConfigsRequest.data.resources.iterator.asScala.map { alterConfigResource =>
+    def sendResponse(secondPart: Option[ApiMessage]): Unit = {
+      secondPart match {
+        case Some(result: IncrementalAlterConfigsResponseData) =>
+          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+            new IncrementalAlterConfigsResponse(ConfigAdminManager.reassembleIncrementalResponse(
+              original.data(),
+              preprocessingResponses,
+              result).setThrottleTimeMs(requestThrottleMs)))
+        case _ => handleInvalidVersionsDuringForwarding(request)
+      }
+    }
+
+    if (remaining.resources().isEmpty) {
+      sendResponse(Some(new IncrementalAlterConfigsResponseData()))
+    } else if ((!request.isForwarded) && metadataSupport.canForward()) {
+      metadataSupport.forwardingManager.get.forwardRequest(request,
+        new IncrementalAlterConfigsRequest(remaining, request.header.apiVersion()),
+        response => sendResponse(response.map(_.data())))
+    } else {
+      sendResponse(Some(processIncrementalAlterConfigsRequest(request, remaining)))
+    }
+  }
+
+  def processIncrementalAlterConfigsRequest(
+    originalRequest: RequestChannel.Request,
+    data: IncrementalAlterConfigsRequestData
+  ): IncrementalAlterConfigsResponseData = {
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(originalRequest))
+    val configs = data.resources.iterator.asScala.map { alterConfigResource =>
       val configResource = new ConfigResource(ConfigResource.Type.forId(alterConfigResource.resourceType),
         alterConfigResource.resourceName)
       configResource -> alterConfigResource.configs.iterator.asScala.map {
@@ -2765,20 +2823,18 @@ class KafkaApis(val requestChannel: RequestChannel,
     val (authorizedResources, unauthorizedResources) = configs.partition { case (resource, _) =>
       resource.`type` match {
         case ConfigResource.Type.BROKER | ConfigResource.Type.BROKER_LOGGER =>
-          authHelper.authorize(request.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)
+          authHelper.authorize(originalRequest.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)
         case ConfigResource.Type.TOPIC =>
-          authHelper.authorize(request.context, ALTER_CONFIGS, TOPIC, resource.name)
+          authHelper.authorize(originalRequest.context, ALTER_CONFIGS, TOPIC, resource.name)
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt")
       }
     }
 
-    val authorizedResult = zkSupport.adminManager.incrementalAlterConfigs(authorizedResources, alterConfigsRequest.data.validateOnly)
+    val authorizedResult = zkSupport.adminManager.incrementalAlterConfigs(authorizedResources, data.validateOnly)
     val unauthorizedResult = unauthorizedResources.keys.map { resource =>
       resource -> configsAuthorizationApiError(resource)
     }
-
-    requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => new IncrementalAlterConfigsResponse(
-      requestThrottleMs, (authorizedResult ++ unauthorizedResult).asJava))
+    new IncrementalAlterConfigsResponse(0, (authorizedResult ++ unauthorizedResult).asJava).data()
   }
 
   def handleDescribeConfigsRequest(request: RequestChannel.Request): Unit = {
@@ -3287,7 +3343,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     val brokers = metadataCache.getAliveBrokerNodes(request.context.listenerName)
-    val controllerId = metadataSupport.controllerId.getOrElse(MetadataResponse.NO_CONTROLLER_ID)
+    val controllerId = metadataCache.getControllerId.getOrElse(MetadataResponse.NO_CONTROLLER_ID)
 
     requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => {
       val data = new DescribeClusterResponseData()

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -22,18 +22,16 @@ import java.util.Properties
 import kafka.admin.{AdminOperationException, AdminUtils}
 import kafka.common.TopicAlreadyMarkedForDeletionException
 import kafka.log.LogConfig
-import kafka.utils.Log4jController
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.DynamicConfig.QuotaConfigs
+import kafka.server.DynamicConfigManager.{prepareIncrementalConfigs, toLoggableProps}
 import kafka.server.metadata.ZkConfigRepository
 import kafka.utils._
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ScramMechanism}
-import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.common.Uuid
-import org.apache.kafka.common.config.ConfigDef.ConfigKey
-import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource, LogLevelConfig}
+import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource}
 import org.apache.kafka.common.errors.ThrottlingQuotaExceededException
 import org.apache.kafka.common.errors.{ApiException, InvalidConfigurationException, InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidRequestException, ReassignmentInProgressException, TopicExistsException, UnknownTopicOrPartitionException, UnsupportedVersionException}
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData.AlterUserScramCredentialsResult
@@ -388,14 +386,10 @@ class ZkAdminManager(val config: KafkaConfig,
     }
   }
 
-    def alterConfigs(configs: Map[ConfigResource, AlterConfigsRequest.Config], validateOnly: Boolean): Map[ConfigResource, ApiError] = {
+  def alterConfigs(configs: Map[ConfigResource, AlterConfigsRequest.Config], validateOnly: Boolean): Map[ConfigResource, ApiError] = {
     configs.map { case (resource, config) =>
 
       try {
-        val nullUpdates = config.entries.asScala.filter(_.value == null).map(_.name)
-        if (nullUpdates.nonEmpty)
-          throw new InvalidRequestException(s"Null value not supported for : ${nullUpdates.mkString(",")}")
-
         val configEntriesMap = config.entries.asScala.map(entry => (entry.name, entry.value)).toMap
 
         val configProps = new Properties
@@ -468,29 +462,6 @@ class ZkAdminManager(val config: KafkaConfig,
     resource -> ApiError.NONE
   }
 
-  private def toLoggableProps(resource: ConfigResource, configProps: Properties): Map[String, String] = {
-    configProps.asScala.map {
-      case (key, value) => (key, KafkaConfig.loggableValue(resource.`type`, key, value))
-    }
-  }
-
-  private def alterLogLevelConfigs(alterConfigOps: Seq[AlterConfigOp]): Unit = {
-    alterConfigOps.foreach { alterConfigOp =>
-      val loggerName = alterConfigOp.configEntry().name()
-      val logLevel = alterConfigOp.configEntry().value()
-      alterConfigOp.opType() match {
-        case OpType.SET =>
-          info(s"Updating the log level of $loggerName to $logLevel")
-          Log4jController.logLevel(loggerName, logLevel)
-        case OpType.DELETE =>
-          info(s"Unset the log level of $loggerName")
-          Log4jController.unsetLogLevel(loggerName)
-        case _ => throw new IllegalArgumentException(
-          s"Log level cannot be changed for OpType: ${alterConfigOp.opType()}")
-      }
-    }
-  }
-
   private def getBrokerId(resource: ConfigResource) = {
     if (resource.name == null || resource.name.isEmpty)
       None
@@ -514,18 +485,6 @@ class ZkAdminManager(val config: KafkaConfig,
   def incrementalAlterConfigs(configs: Map[ConfigResource, Seq[AlterConfigOp]], validateOnly: Boolean): Map[ConfigResource, ApiError] = {
     configs.map { case (resource, alterConfigOps) =>
       try {
-        // throw InvalidRequestException if any duplicate keys
-        val duplicateKeys = alterConfigOps.groupBy(config => config.configEntry.name).filter { case (_, v) =>
-          v.size > 1
-        }.keySet
-        if (duplicateKeys.nonEmpty)
-          throw new InvalidRequestException(s"Error due to duplicate config keys : ${duplicateKeys.mkString(",")}")
-        val nullUpdates = alterConfigOps
-          .filter(entry => entry.configEntry.value == null && entry.opType() != OpType.DELETE)
-          .map(entry => s"${entry.opType}:${entry.configEntry.name}")
-        if (nullUpdates.nonEmpty)
-          throw new InvalidRequestException(s"Null value not supported for : ${nullUpdates.mkString(",")}")
-
         val configEntriesMap = alterConfigOps.map(entry => (entry.configEntry.name, entry.configEntry.value)).toMap
 
         resource.`type` match {
@@ -545,13 +504,6 @@ class ZkAdminManager(val config: KafkaConfig,
             prepareIncrementalConfigs(alterConfigOps, configProps, KafkaConfig.configKeys)
             alterBrokerConfigs(resource, validateOnly, configProps, configEntriesMap)
 
-          case ConfigResource.Type.BROKER_LOGGER =>
-            getBrokerId(resource)
-            validateLogLevelConfigs(alterConfigOps)
-
-            if (!validateOnly)
-              alterLogLevelConfigs(alterConfigOps)
-            resource -> ApiError.NONE
           case resourceType =>
             throw new InvalidRequestException(s"AlterConfigs is only supported for topics and brokers, but resource type is $resourceType")
         }
@@ -570,73 +522,6 @@ class ZkAdminManager(val config: KafkaConfig,
           resource -> ApiError.fromThrowable(e)
       }
     }.toMap
-  }
-
-  private def validateLogLevelConfigs(alterConfigOps: Seq[AlterConfigOp]): Unit = {
-    def validateLoggerNameExists(loggerName: String): Unit = {
-      if (!Log4jController.loggerExists(loggerName))
-        throw new ConfigException(s"Logger $loggerName does not exist!")
-    }
-
-    alterConfigOps.foreach { alterConfigOp =>
-      val loggerName = alterConfigOp.configEntry.name
-      alterConfigOp.opType() match {
-        case OpType.SET =>
-          validateLoggerNameExists(loggerName)
-          val logLevel = alterConfigOp.configEntry.value
-          if (!LogLevelConfig.VALID_LOG_LEVELS.contains(logLevel)) {
-            val validLevelsStr = LogLevelConfig.VALID_LOG_LEVELS.asScala.mkString(", ")
-            throw new ConfigException(
-              s"Cannot set the log level of $loggerName to $logLevel as it is not a supported log level. " +
-              s"Valid log levels are $validLevelsStr"
-            )
-          }
-        case OpType.DELETE =>
-          validateLoggerNameExists(loggerName)
-          if (loggerName == Log4jController.ROOT_LOGGER)
-            throw new InvalidRequestException(s"Removing the log level of the ${Log4jController.ROOT_LOGGER} logger is not allowed")
-        case OpType.APPEND => throw new InvalidRequestException(s"${OpType.APPEND} operation is not allowed for the ${ConfigResource.Type.BROKER_LOGGER} resource")
-        case OpType.SUBTRACT => throw new InvalidRequestException(s"${OpType.SUBTRACT} operation is not allowed for the ${ConfigResource.Type.BROKER_LOGGER} resource")
-      }
-    }
-  }
-
-  private def prepareIncrementalConfigs(alterConfigOps: Seq[AlterConfigOp], configProps: Properties, configKeys: Map[String, ConfigKey]): Unit = {
-
-    def listType(configName: String, configKeys: Map[String, ConfigKey]): Boolean = {
-      val configKey = configKeys(configName)
-      if (configKey == null)
-        throw new InvalidConfigurationException(s"Unknown topic config name: $configName")
-      configKey.`type` == ConfigDef.Type.LIST
-    }
-
-    alterConfigOps.foreach { alterConfigOp =>
-      val configPropName = alterConfigOp.configEntry.name
-      alterConfigOp.opType() match {
-        case OpType.SET => configProps.setProperty(alterConfigOp.configEntry.name, alterConfigOp.configEntry.value)
-        case OpType.DELETE => configProps.remove(alterConfigOp.configEntry.name)
-        case OpType.APPEND => {
-          if (!listType(alterConfigOp.configEntry.name, configKeys))
-            throw new InvalidRequestException(s"Config value append is not allowed for config key: ${alterConfigOp.configEntry.name}")
-          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry.name))
-            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
-            .getOrElse("")
-            .split(",").toList
-          val newValueList = oldValueList ::: alterConfigOp.configEntry.value.split(",").toList
-          configProps.setProperty(alterConfigOp.configEntry.name, newValueList.mkString(","))
-        }
-        case OpType.SUBTRACT => {
-          if (!listType(alterConfigOp.configEntry.name, configKeys))
-            throw new InvalidRequestException(s"Config value subtract is not allowed for config key: ${alterConfigOp.configEntry.name}")
-          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry.name))
-            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
-            .getOrElse("")
-            .split(",").toList
-          val newValueList = oldValueList.diff(alterConfigOp.configEntry.value.split(",").toList)
-          configProps.setProperty(alterConfigOp.configEntry.name, newValueList.mkString(","))
-        }
-      }
-    }
   }
 
   def shutdown(): Unit = {

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -23,8 +23,8 @@ import kafka.admin.{AdminOperationException, AdminUtils}
 import kafka.common.TopicAlreadyMarkedForDeletionException
 import kafka.log.LogConfig
 import kafka.metrics.KafkaMetricsGroup
+import kafka.server.ConfigAdminManager.{prepareIncrementalConfigs, toLoggableProps}
 import kafka.server.DynamicConfig.QuotaConfigs
-import kafka.server.DynamicConfigManager.{prepareIncrementalConfigs, toLoggableProps}
 import kafka.server.metadata.ZkConfigRepository
 import kafka.utils._
 import kafka.utils.Implicits._

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -252,6 +252,9 @@ class BrokerMetadataListener(
     val delta = _delta
     _image = _delta.apply()
     _delta = new MetadataDelta(_image)
+    if (isDebugEnabled) {
+      debug(s"Publishing new metadata delta ${delta} at offset ${_image.highestOffsetAndEpoch().offset}.")
+    }
     publisher.publish(delta, _image)
   }
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -272,11 +272,7 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
 
     // Make the LogCleaner available for reconfiguration. We can't do this prior to this
     // point because LogManager#startup creates the LogCleaner object, if
-    // log.cleaner.enable is true.
-    //
-    // TODO: it would probably be better to make log.cleaner.enable dynamically
-    // configurable as well. It would also be cleaner to unconditionally create the log
-    // cleaner object in the LogManager constructor even if we never start it.
+    // log.cleaner.enable is true. TODO: improve this (see KAFKA-13610)
     Option(logManager.cleaner).foreach(conf.dynamicConfig.addBrokerReconfigurable)
 
     // Start the replica manager.

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -19,12 +19,12 @@ package kafka.server.metadata
 
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
-import kafka.log.{UnifiedLog, LogManager}
-import kafka.server.ConfigType
-import kafka.server.{ConfigEntityName, ConfigHandler, FinalizedFeatureCache, KafkaConfig, ReplicaManager, RequestLocal}
+import kafka.log.{LogManager, UnifiedLog}
+import kafka.server.DynamicConfigManager.toLoggableProps
+import kafka.server.{ConfigEntityName, ConfigHandler, ConfigType, FinalizedFeatureCache, KafkaConfig, ReplicaManager, RequestLocal}
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, TOPIC}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, TopicDelta, TopicsImage}
 
@@ -175,19 +175,31 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
 
       // Apply configuration deltas.
       Option(delta.configsDelta()).foreach { configsDelta =>
-        configsDelta.changes().keySet().forEach { configResource =>
-          val tag = configResource.`type`() match {
-            case ConfigResource.Type.TOPIC => Some(ConfigType.Topic)
-            case ConfigResource.Type.BROKER => Some(ConfigType.Broker)
-            case _ => None
-          }
-          tag.foreach { t =>
-            val newProperties = newImage.configs().configProperties(configResource)
-            val maybeDefaultName = configResource.name() match {
-              case "" => ConfigEntityName.Default
-              case k => k
+        configsDelta.changes().keySet().forEach { resource =>
+          val props = newImage.configs().configProperties(resource)
+          resource.`type`() match {
+            case TOPIC =>
+              // Apply changes to a topic's dynamic configuration.
+              info(s"Updating topic ${resource.name()} with new configuration : " +
+                toLoggableProps(resource, props).mkString(","))
+              dynamicConfigHandlers(ConfigType.Topic).
+                processConfigChanges(resource.name(), props)
+              conf.dynamicConfig.reloadUpdatedFilesWithoutConfigChange(props)
+            case BROKER => if (resource.name().isEmpty) {
+              // Apply changes to "cluster configs" (also known as default BROKER configs).
+              // These are stored in KRaft with an empty name field.
+              info(s"Updating brokers with new configuration : " +
+                toLoggableProps(resource, props).mkString(","))
+              dynamicConfigHandlers(ConfigType.Broker).
+                processConfigChanges(ConfigEntityName.Default, props)
+            } else if (resource.name().equals(brokerId.toString)) {
+              // Apply changes to this broker's dynamic configuration.
+              info(s"Updating broker ${brokerId} with new configuration : " +
+                toLoggableProps(resource, props).mkString(","))
+              dynamicConfigHandlers(ConfigType.Broker).
+                processConfigChanges(resource.name(), props)
             }
-            dynamicConfigHandlers(t).processConfigChanges(maybeDefaultName, newProperties)
+            case _ => // nothing to do
           }
         }
       }

--- a/core/src/main/scala/kafka/server/metadata/ZkConfigRepository.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkConfigRepository.scala
@@ -19,7 +19,7 @@ package kafka.server.metadata
 
 import java.util.Properties
 
-import kafka.server.ConfigType
+import kafka.server.{ConfigEntityName, ConfigType}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type
@@ -37,6 +37,13 @@ class ZkConfigRepository(adminZkClient: AdminZkClient) extends ConfigRepository 
       case Type.BROKER => ConfigType.Broker
       case tpe => throw new IllegalArgumentException(s"Unsupported config type: $tpe")
     }
-    adminZkClient.fetchEntityConfig(configTypeForZk, configResource.name)
+    // ZK stores cluster configs under "<default>".
+    val effectiveName = if (configResource.`type`.equals(Type.BROKER) &&
+        configResource.name.isEmpty()) {
+      ConfigEntityName.Default
+    } else {
+      configResource.name
+    }
+    adminZkClient.fetchEntityConfig(configTypeForZk, effectiveName)
   }
 }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -26,19 +26,20 @@ import java.time.Duration
 import java.util
 import java.util.{Collections, Properties}
 import java.util.concurrent._
+
 import javax.management.ObjectName
 import com.yammer.metrics.core.MetricName
 import kafka.admin.ConfigCommand
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.controller.{ControllerBrokerStateInfo, ControllerChannelManager}
-import kafka.log.LogConfig
+import kafka.log.{CleanerConfig, LogConfig}
 import kafka.message.ProducerCompressionCodec
 import kafka.metrics.KafkaYammerMetrics
 import kafka.network.{Processor, RequestChannel}
 import kafka.server.QuorumTestHarness
 import kafka.utils._
 import kafka.utils.Implicits._
-import kafka.zk.{ConfigEntityChangeNotificationZNode}
+import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.ConfigEntry.{ConfigSource, ConfigSynonym}
@@ -477,14 +478,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     verifyThreads("kafka-log-cleaner-thread-", countPerBroker = 1)
 
-    TestUtils.retry(60000) {
-      servers.foreach {
-        case server => if (server.logManager.cleaner == null) {
-          throw new RuntimeException("waiting for log cleaner to be initialized.")
-        }
-      }
-    }
-
     val props = new Properties
     props.put(KafkaConfig.LogCleanerThreadsProp, "2")
     props.put(KafkaConfig.LogCleanerDedupeBufferSizeProp, "20000000")
@@ -493,12 +486,15 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     props.put(KafkaConfig.MessageMaxBytesProp, "40000")
     props.put(KafkaConfig.LogCleanerIoMaxBytesPerSecondProp, "50000000")
     props.put(KafkaConfig.LogCleanerBackoffMsProp, "6000")
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogCleanerThreadsProp, "2"))
 
     // Verify cleaner config was updated. Wait for one of the configs to be updated and verify
     // that all other others were updated at the same time since they are reconfigured together
-    val newCleanerConfig = servers.head.logManager.cleaner.currentConfig
-    TestUtils.waitUntilTrue(() => newCleanerConfig.numThreads == 2, "Log cleaner not reconfigured")
+    var newCleanerConfig: CleanerConfig = null
+    TestUtils.waitUntilTrue(() => {
+      reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogCleanerThreadsProp, "2"))
+      newCleanerConfig = servers.head.logManager.cleaner.currentConfig
+      newCleanerConfig.numThreads == 2
+    }, "Log cleaner not reconfigured", 60000)
     assertEquals(20000000, newCleanerConfig.dedupeBufferSize)
     assertEquals(0.8, newCleanerConfig.dedupeBufferLoadFactor, 0.001)
     assertEquals(300000, newCleanerConfig.ioBufferSize)

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -1426,7 +1426,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
         Seq(new ConfigResource(ConfigResource.Type.BROKER, ""))
       brokerResources.foreach { brokerResource =>
         val exception = assertThrows(classOf[ExecutionException], () => alterResult.values.get(brokerResource).get)
-        assertTrue(exception.getCause.isInstanceOf[InvalidRequestException])
+        assertEquals(classOf[InvalidRequestException], exception.getCause().getClass())
       }
       servers.foreach { server =>
         assertEquals(oldProps, server.config.values.asScala.filter { case (k, _) => newProps.containsKey(k) })

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -477,6 +477,14 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     verifyThreads("kafka-log-cleaner-thread-", countPerBroker = 1)
 
+    TestUtils.retry(60000) {
+      servers.foreach {
+        case server => if (server.logManager.cleaner == null) {
+          throw new RuntimeException("waiting for log cleaner to be initialized.")
+        }
+      }
+    }
+
     val props = new Properties
     props.put(KafkaConfig.LogCleanerThreadsProp, "2")
     props.put(KafkaConfig.LogCleanerDedupeBufferSizeProp, "20000000")

--- a/core/src/test/scala/unit/kafka/server/ConfigAdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConfigAdminManagerTest.scala
@@ -1,0 +1,456 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util
+import java.util.{Collections, Properties}
+
+import kafka.utils.{Log4jController, TestUtils}
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType
+import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, BROKER_LOGGER, TOPIC, UNKNOWN}
+import org.apache.kafka.common.config.LogLevelConfig.VALID_LOG_LEVELS
+import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException}
+import org.apache.kafka.common.message.{AlterConfigsRequestData, AlterConfigsResponseData, IncrementalAlterConfigsRequestData, IncrementalAlterConfigsResponseData}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterConfigsResource => LAlterConfigsResource}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterConfigsResourceCollection => LAlterConfigsResourceCollection}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterableConfigCollection => LAlterableConfigCollection}
+import org.apache.kafka.common.message.AlterConfigsResponseData.{AlterConfigsResourceResponse => LAlterConfigsResourceResponse}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterableConfig => LAlterableConfig}
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterConfigsResource => IAlterConfigsResource}
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterConfigsResourceCollection => IAlterConfigsResourceCollection}
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterableConfig => IAlterableConfig}
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterableConfigCollection => IAlterableConfigCollection}
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.{AlterConfigsResourceResponse => IAlterConfigsResourceResponse}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.protocol.Errors.{INVALID_REQUEST, NONE}
+import org.apache.kafka.common.requests.ApiError
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{Assertions, Test}
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters._
+
+class ConfigAdminManagerTest {
+  val logger = LoggerFactory.getLogger(classOf[ConfigAdminManagerTest])
+
+  def newConfigAdminManager(brokerId: Integer): ConfigAdminManager = {
+    val config = TestUtils.createBrokerConfig(nodeId = brokerId, zkConnect = null)
+    new ConfigAdminManager(brokerId, new KafkaConfig(config), _ => new Properties())
+  }
+
+  def broker0Incremental(): IAlterConfigsResource = new IAlterConfigsResource().
+    setResourceName("0").
+    setResourceType(BROKER.id()).
+    setConfigs(new IAlterableConfigCollection(
+      util.Arrays.asList(new IAlterableConfig().setName("foo").
+        setValue("bar").
+        setConfigOperation(OpType.SET.id())).iterator()))
+
+  def topicAIncremental(): IAlterConfigsResource = new IAlterConfigsResource().
+    setResourceName("a").
+    setResourceType(TOPIC.id()).
+    setConfigs(new IAlterableConfigCollection(
+      util.Arrays.asList(new IAlterableConfig().setName("foo").
+        setValue("bar").
+        setConfigOperation(OpType.SET.id())).iterator()))
+
+  def broker0Legacy(): LAlterConfigsResource = new LAlterConfigsResource().
+    setResourceName("0").
+    setResourceType(BROKER.id()).
+    setConfigs(new LAlterableConfigCollection(
+      util.Arrays.asList(new LAlterableConfig().setName("foo").
+        setValue("bar")).iterator()))
+
+  def topicALegacy(): LAlterConfigsResource = new LAlterConfigsResource().
+    setResourceName("a").
+    setResourceType(TOPIC.id()).
+    setConfigs(new LAlterableConfigCollection(
+      util.Arrays.asList(new LAlterableConfig().setName("foo").
+        setValue("bar")).iterator()))
+
+  val invalidRequestError = new ApiError(INVALID_REQUEST)
+
+  @Test
+  def testCopyWithoutPreprocessedForIncremental(): Unit = {
+    val broker0 = broker0Incremental()
+    val topicA = topicAIncremental()
+    val request = new IncrementalAlterConfigsRequestData().setValidateOnly(true).
+      setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+        broker0, topicA).iterator()))
+    val processed1 = new util.IdentityHashMap[IAlterConfigsResource, ApiError]()
+    processed1.put(broker0, ApiError.NONE)
+    assertEquals(new IncrementalAlterConfigsRequestData().setValidateOnly(true).
+      setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+        topicA.duplicate()).iterator())),
+        ConfigAdminManager.copyWithoutPreprocessed(request, processed1))
+    val processed2 = new util.IdentityHashMap[IAlterConfigsResource, ApiError]()
+    assertEquals(new IncrementalAlterConfigsRequestData().setValidateOnly(true).
+      setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+        broker0.duplicate(), topicA.duplicate()).iterator())),
+      ConfigAdminManager.copyWithoutPreprocessed(request, processed2))
+    val processed3 = new util.IdentityHashMap[IAlterConfigsResource, ApiError]()
+    processed3.put(broker0, ApiError.NONE)
+    processed3.put(topicA, ApiError.NONE)
+    assertEquals(new IncrementalAlterConfigsRequestData().setValidateOnly(true),
+      ConfigAdminManager.copyWithoutPreprocessed(request, processed3))
+  }
+
+  @Test
+  def testCopyWithoutPreprocessedForLegacy(): Unit = {
+    val broker0 = broker0Legacy()
+    val topicA = topicALegacy()
+    val request = new AlterConfigsRequestData().setValidateOnly(true).
+      setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+        broker0, topicA).iterator()))
+    val processed1 = new util.IdentityHashMap[LAlterConfigsResource, ApiError]()
+    processed1.put(broker0, ApiError.NONE)
+    assertEquals(new AlterConfigsRequestData().setValidateOnly(true).
+      setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+        topicA.duplicate()).iterator())),
+      ConfigAdminManager.copyWithoutPreprocessed(request, processed1))
+    val processed2 = new util.IdentityHashMap[LAlterConfigsResource, ApiError]()
+    assertEquals(new AlterConfigsRequestData().setValidateOnly(true).
+      setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+        broker0.duplicate(), topicA.duplicate()).iterator())),
+      ConfigAdminManager.copyWithoutPreprocessed(request, processed2))
+    val processed3 = new util.IdentityHashMap[LAlterConfigsResource, ApiError]()
+    processed3.put(broker0, ApiError.NONE)
+    processed3.put(topicA, ApiError.NONE)
+    assertEquals(new AlterConfigsRequestData().setValidateOnly(true),
+      ConfigAdminManager.copyWithoutPreprocessed(request, processed3))
+  }
+
+  @Test
+  def testReassembleIncrementalResponse(): Unit = {
+    val broker0 = broker0Incremental()
+    val topicA = topicAIncremental()
+    val original = new IncrementalAlterConfigsRequestData().
+      setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+        broker0, topicA).iterator()))
+    val preprocessed1 = new util.IdentityHashMap[IAlterConfigsResource, ApiError]()
+    preprocessed1.put(broker0, invalidRequestError)
+    val persistentResponses1 = new IncrementalAlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new IAlterConfigsResourceResponse().
+        setResourceName("a").
+        setResourceType(TOPIC.id()).
+        setErrorCode(NONE.code()).
+        setErrorMessage(null)))
+    assertEquals(new IncrementalAlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new IAlterConfigsResourceResponse().
+        setResourceName("0").
+        setResourceType(BROKER.id()).
+        setErrorCode(INVALID_REQUEST.code()).
+        setErrorMessage(INVALID_REQUEST.message()),
+        new IAlterConfigsResourceResponse().
+          setResourceName("a").
+          setResourceType(TOPIC.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null))),
+      ConfigAdminManager.reassembleIncrementalResponse(original, preprocessed1, persistentResponses1))
+    val preprocessed2 = new util.IdentityHashMap[IAlterConfigsResource, ApiError]()
+    val persistentResponses2 = new IncrementalAlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new IAlterConfigsResourceResponse().
+          setResourceName("0").
+          setResourceType(BROKER.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null),
+        new IAlterConfigsResourceResponse().
+          setResourceName("a").
+          setResourceType(TOPIC.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null),
+      ))
+    assertEquals(new IncrementalAlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new IAlterConfigsResourceResponse().
+          setResourceName("0").
+          setResourceType(BROKER.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null),
+        new IAlterConfigsResourceResponse().
+          setResourceName("a").
+          setResourceType(TOPIC.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null))),
+      ConfigAdminManager.reassembleIncrementalResponse(original, preprocessed2, persistentResponses2))
+  }
+
+  @Test
+  def testReassembleLegacyResponse(): Unit = {
+    val broker0 = broker0Legacy()
+    val topicA = topicALegacy()
+    val original = new AlterConfigsRequestData().
+      setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+        broker0, topicA).iterator()))
+    val preprocessed1 = new util.IdentityHashMap[LAlterConfigsResource, ApiError]()
+    preprocessed1.put(broker0, invalidRequestError)
+    val persistentResponses1 = new AlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new LAlterConfigsResourceResponse().
+        setResourceName("a").
+        setResourceType(TOPIC.id()).
+        setErrorCode(NONE.code()).
+        setErrorMessage(null)))
+    assertEquals(new AlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new LAlterConfigsResourceResponse().
+        setResourceName("0").
+        setResourceType(BROKER.id()).
+        setErrorCode(INVALID_REQUEST.code()).
+        setErrorMessage(INVALID_REQUEST.message()),
+        new LAlterConfigsResourceResponse().
+          setResourceName("a").
+          setResourceType(TOPIC.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null))),
+      ConfigAdminManager.reassembleLegacyResponse(original, preprocessed1, persistentResponses1))
+    val preprocessed2 = new util.IdentityHashMap[LAlterConfigsResource, ApiError]()
+    val persistentResponses2 = new AlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new LAlterConfigsResourceResponse().
+        setResourceName("0").
+        setResourceType(BROKER.id()).
+        setErrorCode(NONE.code()).
+        setErrorMessage(null),
+        new LAlterConfigsResourceResponse().
+          setResourceName("a").
+          setResourceType(TOPIC.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null),
+      ))
+    assertEquals(new AlterConfigsResponseData().setResponses(
+      util.Arrays.asList(new LAlterConfigsResourceResponse().
+        setResourceName("0").
+        setResourceType(BROKER.id()).
+        setErrorCode(NONE.code()).
+        setErrorMessage(null),
+        new LAlterConfigsResourceResponse().
+          setResourceName("a").
+          setResourceType(TOPIC.id()).
+          setErrorCode(NONE.code()).
+          setErrorMessage(null))),
+      ConfigAdminManager.reassembleLegacyResponse(original, preprocessed2, persistentResponses2))
+  }
+
+  @Test
+  def testValidateResourceNameIsCurrentNodeId(): Unit = {
+    val manager = newConfigAdminManager(5)
+    manager.validateResourceNameIsCurrentNodeId("5")
+    assertEquals("Node id must be an integer, but it is: ",
+      Assertions.assertThrows(classOf[InvalidRequestException],
+        () => manager.validateResourceNameIsCurrentNodeId("")).getMessage())
+    assertEquals("Unexpected broker id, expected 5, but received 3",
+      Assertions.assertThrows(classOf[InvalidRequestException],
+        () => manager.validateResourceNameIsCurrentNodeId("3")).getMessage())
+    assertEquals("Node id must be an integer, but it is: e",
+      Assertions.assertThrows(classOf[InvalidRequestException],
+        () => manager.validateResourceNameIsCurrentNodeId("e")).getMessage())
+  }
+
+  @Test
+  def testValidateLogLevelConfigs(): Unit = {
+    val manager = newConfigAdminManager(5)
+    manager.validateLogLevelConfigs(util.Arrays.asList(new IAlterableConfig().
+      setName(logger.getName).
+      setConfigOperation(OpType.SET.id()).
+      setValue("TRACE")))
+    manager.validateLogLevelConfigs(util.Arrays.asList(new IAlterableConfig().
+      setName(logger.getName).
+      setConfigOperation(OpType.DELETE.id()).
+      setValue("")))
+    assertEquals("APPEND operation is not allowed for the BROKER_LOGGER resource",
+      Assertions.assertThrows(classOf[InvalidRequestException],
+        () => manager.validateLogLevelConfigs(util.Arrays.asList(new IAlterableConfig().
+          setName(logger.getName).
+          setConfigOperation(OpType.APPEND.id()).
+          setValue("TRACE")))).getMessage())
+    assertEquals(s"Cannot set the log level of ${logger.getName} to BOGUS as it is not " +
+      s"a supported log level. Valid log levels are ${VALID_LOG_LEVELS.asScala.mkString(", ")}",
+      Assertions.assertThrows(classOf[InvalidConfigurationException],
+        () => manager.validateLogLevelConfigs(util.Arrays.asList(new IAlterableConfig().
+          setName(logger.getName).
+          setConfigOperation(OpType.SET.id()).
+          setValue("BOGUS")))).getMessage())
+  }
+
+  @Test
+  def testValidateRootLogLevelConfigs(): Unit = {
+    val manager = newConfigAdminManager(5)
+    manager.validateLogLevelConfigs(util.Arrays.asList(new IAlterableConfig().
+      setName(Log4jController.ROOT_LOGGER).
+      setConfigOperation(OpType.SET.id()).
+      setValue("TRACE")))
+    assertEquals(s"Removing the log level of the ${Log4jController.ROOT_LOGGER} logger is not allowed",
+      Assertions.assertThrows(classOf[InvalidRequestException],
+        () => manager.validateLogLevelConfigs(util.Arrays.asList(new IAlterableConfig().
+          setName(Log4jController.ROOT_LOGGER).
+          setConfigOperation(OpType.DELETE.id()).
+          setValue("")))).getMessage())
+  }
+
+  def brokerLogger1Incremental(): IAlterConfigsResource = new IAlterConfigsResource().
+    setResourceName("1").
+    setResourceType(BROKER_LOGGER.id).
+    setConfigs(new IAlterableConfigCollection(
+      util.Arrays.asList(new IAlterableConfig().setName(logger.getName).
+        setValue("INFO").
+        setConfigOperation(OpType.SET.id())).iterator()))
+
+  def brokerLogger2Incremental(): IAlterConfigsResource = new IAlterConfigsResource().
+    setResourceName("2").
+    setResourceType(BROKER_LOGGER.id).
+    setConfigs(new IAlterableConfigCollection(
+      util.Arrays.asList(new IAlterableConfig().setName(logger.getName).
+        setValue(null).
+        setConfigOperation(OpType.SET.id())).iterator()))
+
+  @Test
+  def testPreprocessIncrementalWithUnauthorizedBrokerLoggerChanges(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val brokerLogger1 = brokerLogger1Incremental()
+    assertEquals(Collections.singletonMap(brokerLogger1,
+        new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED, null)),
+      manager.preprocess(new IncrementalAlterConfigsRequestData().
+        setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+          brokerLogger1).iterator())),
+          (_, _) => false))
+  }
+
+  @Test
+  def testPreprocessIncrementalWithNulls(): Unit = {
+    val manager = newConfigAdminManager(2)
+    val brokerLogger2 = brokerLogger2Incremental()
+    assertEquals(Collections.singletonMap(brokerLogger2,
+      new ApiError(INVALID_REQUEST, s"Null value not supported for : ${logger.getName}")),
+      manager.preprocess(new IncrementalAlterConfigsRequestData().
+        setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+          brokerLogger2).iterator())),
+        (_, _) => true))
+  }
+
+  @Test
+  def testPreprocessIncrementalWithLoggerChanges(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val brokerLogger1 = brokerLogger1Incremental()
+    assertEquals(Collections.singletonMap(brokerLogger1,
+      new ApiError(Errors.NONE, null)),
+      manager.preprocess(new IncrementalAlterConfigsRequestData().
+        setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+          brokerLogger1).iterator())),
+        (_, _) => true))
+  }
+
+  @Test
+  def testPreprocessIncrementalWithDuplicates(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val brokerLogger1a = brokerLogger1Incremental()
+    val brokerLogger1b = brokerLogger1Incremental()
+    val output = manager.preprocess(new IncrementalAlterConfigsRequestData().
+        setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+          brokerLogger1a, brokerLogger1b).iterator())),
+        (_, _) => true)
+    assertEquals(2, output.size())
+    Seq(brokerLogger1a, brokerLogger1b).foreach(r =>
+      assertEquals(new ApiError(INVALID_REQUEST, "Each resource must appear at most once."),
+        output.get(r)))
+  }
+
+  def brokerLogger1Legacy(): LAlterConfigsResource = new LAlterConfigsResource().
+    setResourceName("1").
+    setResourceType(BROKER_LOGGER.id).
+    setConfigs(new LAlterableConfigCollection(
+      util.Arrays.asList(new LAlterableConfig().setName(logger.getName).
+        setValue("INFO")).iterator()))
+
+  def broker2Legacy(): LAlterConfigsResource = new LAlterConfigsResource().
+    setResourceName("2").
+    setResourceType(BROKER.id).
+    setConfigs(new LAlterableConfigCollection(
+      util.Arrays.asList(new LAlterableConfig().setName(logger.getName).
+        setValue(null)).iterator()))
+
+  @Test
+  def testPreprocessLegacyWithBrokerLoggerChanges(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val brokerLogger1 = brokerLogger1Legacy()
+    assertEquals(Collections.singletonMap(brokerLogger1,
+      new ApiError(INVALID_REQUEST, "Unknown resource type 8")),
+      manager.preprocess(new AlterConfigsRequestData().
+        setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+          brokerLogger1).iterator()))))
+  }
+
+  @Test
+  def testPreprocessLegacyWithNulls(): Unit = {
+    val manager = newConfigAdminManager(2)
+    val brokerLogger2 = broker2Legacy()
+    assertEquals(Collections.singletonMap(brokerLogger2,
+      new ApiError(INVALID_REQUEST, s"Null value not supported for : ${logger.getName}")),
+      manager.preprocess(new AlterConfigsRequestData().
+        setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+          brokerLogger2).iterator()))))
+  }
+
+  @Test
+  def testPreprocessLegacyWithDuplicates(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val brokerLogger1a = brokerLogger1Legacy()
+    val brokerLogger1b = brokerLogger1Legacy()
+    val output = manager.preprocess(new AlterConfigsRequestData().
+      setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+        brokerLogger1a, brokerLogger1b).iterator())))
+    assertEquals(2, output.size())
+    Seq(brokerLogger1a, brokerLogger1b).foreach(r =>
+      assertEquals(new ApiError(INVALID_REQUEST, "Each resource must appear at most once."),
+        output.get(r)))
+  }
+
+  def unknownIncremental(): IAlterConfigsResource = new IAlterConfigsResource().
+    setResourceName("unknown").
+    setResourceType(UNKNOWN.id).
+    setConfigs(new IAlterableConfigCollection(
+      util.Arrays.asList(new IAlterableConfig().setName("foo").
+        setValue("bar").
+        setConfigOperation(OpType.SET.id())).iterator()))
+
+  def unknownLegacy(): LAlterConfigsResource = new LAlterConfigsResource().
+    setResourceName("unknown").
+    setResourceType(UNKNOWN.id).
+    setConfigs(new LAlterableConfigCollection(
+      util.Arrays.asList(new LAlterableConfig().setName("foo").
+        setValue("bar")).iterator()))
+
+  @Test
+  def testPreprocessIncrementalWithUnknownResource(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val unknown = unknownIncremental()
+    assertEquals(Collections.singletonMap(unknown,
+      new ApiError(INVALID_REQUEST, "Unknown resource type 0")),
+        manager.preprocess(new IncrementalAlterConfigsRequestData().
+        setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
+          unknown).iterator())),
+        (_, _) => false))
+  }
+
+  @Test
+  def testPreprocessLegacyWithUnknownResource(): Unit = {
+    val manager = newConfigAdminManager(1)
+    val unknown = unknownLegacy()
+    assertEquals(Collections.singletonMap(unknown,
+      new ApiError(INVALID_REQUEST, "Unknown resource type 0")),
+      manager.preprocess(new AlterConfigsRequestData().
+        setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
+          unknown).iterator()))))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -412,7 +412,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     EasyMock.expectLastCall().once()
     EasyMock.replay(handler)
 
-    val configManager = new DynamicConfigManager(zkClient, Map(ConfigType.Topic -> handler))
+    val configManager = new ZkConfigManager(zkClient, Map(ConfigType.Topic -> handler))
     // Notifications created using the old TopicConfigManager are ignored.
     configManager.ConfigChangedNotificationHandler.processNotification("not json".getBytes(StandardCharsets.UTF_8))
 


### PR DESCRIPTION
Currently, KRaft does not support setting BROKER_LOGGER configs (it always fails.) Additionally, there are several bugs in the handling of BROKER configs. They are not properly validated on the forwarding broker, and the way we apply them is buggy as well. This PR fixes those issues.

KafkaApis: add support for doing validation and log4j processing on the forwarding broker. This involves breaking the config request apart and forwarding only part of it. Adjust KafkaApisTest to test the new behavior, rather than expecting forwarding of the full request.

MetadataSupport: remove MetadataSupport#controllerId since it duplicates the functionality of MetadataCache#controllerId. Add support for getResourceConfig and maybeForward.

ControllerApis: log an error message if the handler throws an exception, just like we do in KafkaApis.

ControllerConfigurationValidator: add JavaDoc.

Move some functions that don't involve ZK from ZkAdminManager to DynamicConfigManager. Move some validation out of ZkAdminManager and into a new class, ConfigAdminManager, which is not tied to ZK.

ForwardingManager: add support for sending new requests, rather than just forwarding existing requests.

BrokerMetadataPublisher: do not try to apply dynamic configurations for brokers other than the current one. Log an INFO message when applying a new dynamic config, like we do in ZK mode. Also, invoke reloadUpdatedFilesWithoutConfigChange when applying a new non-default BROKER config.

QuorumController: fix a bug in ConfigResourceExistenceChecker which prevented cluster configs from being set. Add a test for this class.

Rename DynamicConfigManager to ZkConfigManager, since it is responsible for managing configurations in ZK.

Fix the handling of cluster configs in ZkConfigRepository.

Fix the a bug which prevented dynamically reconfiguring the log cleaner in KRaft mode. We were checking whether the cleaner was null prior to invoking LogManager#startup, which caused the cleaner to always be null.