### PR TITLE
assign only one time for size()

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/StripedReplicaPlacer.java
@@ -184,14 +184,15 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
          *                  returned in this epoch.
          */
         int next(int epoch) {
-            if (brokers.size() == 0) return -1;
+            final int brokersSize = brokers.size();
+            if (brokersSize == 0) return -1;
             if (this.epoch != epoch) {
                 this.epoch = epoch;
                 this.index = 0;
                 this.offset = (offset + 1) % brokers.size();
             }
-            if (index >= brokers.size()) return -1;
-            int broker = brokers.get((index + offset) % brokers.size());
+            if (index >= brokersSize) return -1;
+            int broker = brokers.get((index + offset) % brokersSize);
             index++;
             return broker;
         }


### PR DESCRIPTION
_(This is my first PR for Kafka as junior engineer. This suggestion might be silly)_

If `.size()` is called when it is needed, JVM has to calculate all the time. Maybe this is not good for performance.
Hence what about assigning it one time and use many times? 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
