### PR TITLE
KAFKA-13585; Fix flaky test `ReplicaManagerTest.testReplicaAlterLogDirsWithAndWithoutIds`

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -3540,7 +3540,6 @@ class ReplicaManagerTest {
   def testReplicaAlterLogDirsWithAndWithoutIds(usesTopicIds: Boolean): Unit = {
     val version = if (usesTopicIds) LeaderAndIsrRequestData.HIGHEST_SUPPORTED_VERSION else 4.toShort
     val topicId = if (usesTopicIds) this.topicId else Uuid.ZERO_UUID
-    val topicIdOpt = if (usesTopicIds) Some(topicId) else None
     val replicaManager = setupReplicaManagerWithMockedPurgatories(new MockTimer(time))
     try {
       val topicPartition = new TopicPartition(topic, 0)
@@ -3568,8 +3567,6 @@ class ReplicaManagerTest {
       val newReplicaFolder = replicaManager.logManager.liveLogDirs.filterNot(_ == partition.log.get.dir.getParentFile).head
       assertEquals(0, replicaManager.replicaAlterLogDirsManager.fetcherThreadMap.size)
       replicaManager.alterReplicaLogDirs(Map(topicPartition -> newReplicaFolder.getAbsolutePath))
-
-      assertFetcherHasTopicId(replicaManager.replicaAlterLogDirsManager, partition.topicPartition, topicIdOpt)
 
       // Make sure the future log is created.
       replicaManager.futureLocalLogOrException(topicPartition)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.stream.IntStream
 import java.util.{Collections, Optional, Properties}
-
 import kafka.api._
 import kafka.cluster.{BrokerEndPoint, Partition}
 import kafka.log._
@@ -2010,7 +2009,8 @@ class ReplicaManagerTest {
     brokerId: Int = 0,
     aliveBrokerIds: Seq[Int] = Seq(0, 1),
     propsModifier: Properties => Unit = _ => {},
-    mockReplicaFetcherManager: Option[ReplicaFetcherManager] = None
+    mockReplicaFetcherManager: Option[ReplicaFetcherManager] = None,
+    mockReplicaAlterLogDirsManager: Option[ReplicaAlterLogDirsManager] = None
   ): ReplicaManager = {
     val props = TestUtils.createBrokerConfig(brokerId, TestUtils.MockZkConnect)
     props.put("log.dirs", TestUtils.tempRelativeDir("data").getAbsolutePath + "," + TestUtils.tempRelativeDir("data2").getAbsolutePath)
@@ -2062,6 +2062,18 @@ class ReplicaManagerTest {
             time,
             threadNamePrefix,
             quotaManager
+          )
+        }
+      }
+
+      override def createReplicaAlterLogDirsManager(
+        quotaManager: ReplicationQuotaManager,
+        brokerTopicStats: BrokerTopicStats
+      ): ReplicaAlterLogDirsManager = {
+        mockReplicaAlterLogDirsManager.getOrElse {
+          super.createReplicaAlterLogDirsManager(
+            quotaManager,
+            brokerTopicStats
           )
         }
       }
@@ -2815,7 +2827,7 @@ class ReplicaManagerTest {
       // Delete the data directory to trigger a storage exception
       Utils.delete(dataDir)
 
-      val request = leaderAndIsrRequest(
+      val request = makeLeaderAndIsrRequest(
         topicId = Uuid.randomUuid(),
         topicPartition = topicPartition,
         replicas = Seq(0, 1),
@@ -2831,7 +2843,7 @@ class ReplicaManagerTest {
     }
   }
 
-  private def leaderAndIsrRequest(
+  private def makeLeaderAndIsrRequest(
     topicId: Uuid,
     topicPartition: TopicPartition,
     replicas: Seq[Int],
@@ -2888,7 +2900,7 @@ class ReplicaManagerTest {
       // This API is supported by both leaders and followers
 
       val barPartition = new TopicPartition("bar", 0)
-      val barLeaderAndIsrRequest = leaderAndIsrRequest(
+      val barLeaderAndIsrRequest = makeLeaderAndIsrRequest(
         topicId = Uuid.randomUuid(),
         topicPartition = barPartition,
         replicas = Seq(brokerId),
@@ -2900,7 +2912,7 @@ class ReplicaManagerTest {
 
       val otherBrokerId = 1
       val bazPartition = new TopicPartition("baz", 0)
-      val bazLeaderAndIsrRequest = leaderAndIsrRequest(
+      val bazLeaderAndIsrRequest = makeLeaderAndIsrRequest(
         topicId = Uuid.randomUuid(),
         topicPartition = bazPartition,
         replicas = Seq(brokerId, otherBrokerId),
@@ -3517,7 +3529,7 @@ class ReplicaManagerTest {
       // or does not start with a topic ID in the PartitionFetchState and adds one on the next request (!startsWithTopicId)
       val startingId = if (startsWithTopicId) topicId else Uuid.ZERO_UUID
       val startingIdOpt = if (startsWithTopicId) Some(topicId) else None
-      val leaderAndIsrRequest1 = leaderAndIsrRequest(startingId, tp, aliveBrokersIds, leaderAndIsr)
+      val leaderAndIsrRequest1 = makeLeaderAndIsrRequest(startingId, tp, aliveBrokersIds, leaderAndIsr)
       val leaderAndIsrResponse1 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest1, (_, _) => ())
       assertEquals(Errors.NONE, leaderAndIsrResponse1.error)
 
@@ -3525,7 +3537,7 @@ class ReplicaManagerTest {
 
       val endingId = if (!startsWithTopicId) topicId else Uuid.ZERO_UUID
       val endingIdOpt = if (!startsWithTopicId) Some(topicId) else None
-      val leaderAndIsrRequest2 = leaderAndIsrRequest(endingId, tp, aliveBrokersIds, leaderAndIsr)
+      val leaderAndIsrRequest2 = makeLeaderAndIsrRequest(endingId, tp, aliveBrokersIds, leaderAndIsr)
       val leaderAndIsrResponse2 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest2, (_, _) => ())
       assertEquals(Errors.NONE, leaderAndIsrResponse2.error)
 
@@ -3538,56 +3550,51 @@ class ReplicaManagerTest {
   @ParameterizedTest
   @ValueSource(booleans = Array(true, false))
   def testReplicaAlterLogDirsWithAndWithoutIds(usesTopicIds: Boolean): Unit = {
+    val tp = new TopicPartition(topic, 0)
     val version = if (usesTopicIds) LeaderAndIsrRequestData.HIGHEST_SUPPORTED_VERSION else 4.toShort
     val topicId = if (usesTopicIds) this.topicId else Uuid.ZERO_UUID
     val topicIdOpt = if (usesTopicIds) Some(topicId) else None
 
-    // We use a low `replica.fetch.max.bytes` in order to have multiple fetch
-    // requests issued by the ReplicaAlterLogDirsThread.
+    val mockReplicaAlterLogDirsManager = Mockito.mock(classOf[ReplicaAlterLogDirsManager])
     val replicaManager = setupReplicaManagerWithMockedPurgatories(
-      new MockTimer(time),
-      propsModifier = props => props.put(KafkaConfig.ReplicaFetchMaxBytesProp, "1")
+      timer = new MockTimer(time),
+      mockReplicaAlterLogDirsManager = Some(mockReplicaAlterLogDirsManager)
     )
 
     try {
-      val topicPartition = new TopicPartition(topic, 0)
-      val aliveBrokersIds = Seq(0, 1)
-      replicaManager.createPartition(topicPartition)
-        .createLogIfNotExists(isNew = false, isFutureReplica = false,
-          new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints), None)
-      val tp = new TopicPartition(topic, 0)
-      val leaderAndIsr = new LeaderAndIsr(0, 0, aliveBrokersIds.toList, 0)
+      replicaManager.createPartition(tp).createLogIfNotExists(
+        isNew = false,
+        isFutureReplica = false,
+        offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints),
+        topicId = None
+      )
 
-      val leaderAndIsrRequest1 = leaderAndIsrRequest(topicId, tp, aliveBrokersIds, leaderAndIsr, version = version)
-      replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest1, (_, _) => ())
+      val leaderAndIsrRequest = makeLeaderAndIsrRequest(
+        topicId = topicId,
+        topicPartition = tp,
+        replicas = Seq(0, 1),
+        leaderAndIsr = LeaderAndIsr(0, List(0, 1)),
+        version = version
+      )
+      replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest, (_, _) => ())
+
+      // Move the replica to the second log directory.
       val partition = replicaManager.getPartitionOrException(tp)
-      assertEquals(1, replicaManager.logManager.liveLogDirs.filterNot(_ == partition.log.get.dir.getParentFile).size)
-
-      // Append a couple of messages.
-      for (i <- 1 to 500) {
-        val records = TestUtils.singletonRecords(s"message $i".getBytes)
-        appendRecords(replicaManager, tp, records).onFire { response =>
-          assertEquals(Errors.NONE, response.error)
-        }
-      }
-
-      // Find the live and different folder.
       val newReplicaFolder = replicaManager.logManager.liveLogDirs.filterNot(_ == partition.log.get.dir.getParentFile).head
-      assertEquals(0, replicaManager.replicaAlterLogDirsManager.fetcherThreadMap.size)
-      replicaManager.alterReplicaLogDirs(Map(topicPartition -> newReplicaFolder.getAbsolutePath))
+      replicaManager.alterReplicaLogDirs(Map(tp -> newReplicaFolder.getAbsolutePath))
 
-      // Make sure the future log is created.
-      replicaManager.futureLocalLogOrException(topicPartition)
-      assertEquals(1, replicaManager.replicaAlterLogDirsManager.fetcherThreadMap.size)
+      // Make sure the future log is created with the correct topic ID.
+      val futureLog = replicaManager.futureLocalLogOrException(tp)
+      assertEquals(topicIdOpt, futureLog.topicId)
 
-      // Verify that the fetcher has the correct topic id.
-      assertFetcherHasTopicId(replicaManager.replicaAlterLogDirsManager, partition.topicPartition, topicIdOpt)
-
-      // Wait for the ReplicaAlterLogDirsThread to complete.
-      TestUtils.waitUntilTrue(() => {
-        replicaManager.replicaAlterLogDirsManager.shutdownIdleFetcherThreads()
-        replicaManager.replicaAlterLogDirsManager.fetcherThreadMap.isEmpty
-      }, s"ReplicaAlterLogDirsThread should be gone")
+      // Verify that addFetcherForPartitions was called with the correct topic ID.
+      Mockito.verify(mockReplicaAlterLogDirsManager, Mockito.times(1))
+        .addFetcherForPartitions(Map(tp -> InitialFetchState(
+          topicId = topicIdOpt,
+          leader = BrokerEndPoint(0, "localhost", -1),
+          currentLeaderEpoch = 0,
+          initOffset = 0
+        )))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }


### PR DESCRIPTION
`ReplicaManagerTest.testReplicaAlterLogDirsWithAndWithoutIds` fails regularly because `assertFetcherHasTopicId` can't validate the topic id in the fetch state. The issue is quite subtile. Under the hood, `assertFetcherHasTopicId` acquires the `partitionMapLock` in the fetcher thread. `partitionMapLock` is also acquired by the the `processFetchRequest` method. If `processFetchRequest` acquires it before `assertFetcherHasTopicId` can check the fetch state, `assertFetcherHasTopicId` has not chance to verify the state anymore because `processFetchRequest` will remove the fetch state before releasing the lock.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
