### PR TITLE
MINOR: Fix confusion between EventQueueProcessingTimeMs and EventQueueTimeMs

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -135,7 +135,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
 
     @Override
     public void updateEventQueueProcessingTime(long durationMs) {
-        eventQueueTime.update(durationMs);
+        eventQueueProcessingTime.update(durationMs);
     }
 
     @Override


### PR DESCRIPTION
Make sure that the event queue processing time histogram gets updated
and add tests that verify that the update methods modify the correct
histogram.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
