### PR TITLE
MINOR: Replace if/else with match in KafkaZkClient#getPartitionAssignmentForTopics

### DIFF
--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -682,13 +682,12 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     val getDataResponses = retryRequestsUntilConnected(getDataRequests.toSeq)
     getDataResponses.flatMap { getDataResponse =>
       val topic = getDataResponse.ctx.get.asInstanceOf[String]
-      if (getDataResponse.resultCode == Code.OK) {
-        val partitionMap = TopicZNode.decode(topic, getDataResponse.data).assignment.map { case (k, v) => (k.partition, v) }
-        Map(topic -> partitionMap)
-      } else if (getDataResponse.resultCode == Code.NONODE) {
-        Map.empty[String, Map[Int, ReplicaAssignment]]
-      } else {
-        throw getDataResponse.resultException.get
+      getDataResponse.resultCode match {
+        case Code.OK =>
+          val partitionMap = TopicZNode.decode(topic, getDataResponse.data).assignment.map { case (k, v) => (k.partition, v) }
+          Map(topic -> partitionMap)
+        case Code.NONODE => Map.empty[String, Map[Int, ReplicaAssignment]]
+        case _ => throw getDataResponse.resultException.get
       }
     }.toMap
   }


### PR DESCRIPTION
The PR apache#4196 (commit f300480f) replaced `if/else` with `case-match` in `KafkaZkClient`.
The method`getPartitionAssignmentForTopics` seems to be missed in the patch, while similar ones like `getFullReplicaAssignmentForTopics`, `getReplicaAssignmentAndTopicIdForTopics`, etc. adopted the `case-match` style.

This PR changes it to make the code style more consistent.
