### PR TITLE
KAFKA-13577: Replace easymock with mockito in kafka:core - part 2

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
@@ -21,9 +21,9 @@ import java.io.File
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.utils.{Time, Utils}
-import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.Mockito.{mock, when}
 
 class LogSegmentsTest {
 
@@ -228,10 +228,9 @@ class LogSegmentsTest {
   @Test
   def testSizeForLargeLogs(): Unit = {
     val largeSize = Int.MaxValue.toLong * 2
-    val logSegment: LogSegment = EasyMock.createMock(classOf[LogSegment])
+    val logSegment: LogSegment = mock(classOf[LogSegment])
 
-    EasyMock.expect(logSegment.size).andReturn(Int.MaxValue).anyTimes
-    EasyMock.replay(logSegment)
+    when(logSegment.size).thenReturn(Int.MaxValue)
 
     assertEquals(Int.MaxValue, LogSegments.sizeInBytes(Seq(logSegment)))
     assertEquals(largeSize, LogSegments.sizeInBytes(Seq(logSegment, logSegment)))

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -31,9 +31,9 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.{MockTime, Utils}
-import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.Mockito.{mock, when}
 
 class ProducerStateManagerTest {
   private var logDir: File = null
@@ -960,10 +960,9 @@ class ProducerStateManagerTest {
     val producerId = 23423L
     val baseOffset = 15
 
-    val batch: RecordBatch = EasyMock.createMock(classOf[RecordBatch])
-    EasyMock.expect(batch.isControlBatch).andReturn(true).once
-    EasyMock.expect(batch.iterator).andReturn(Collections.emptyIterator[Record]).once
-    EasyMock.replay(batch)
+    val batch: RecordBatch = mock(classOf[RecordBatch])
+    when(batch.isControlBatch).thenReturn(true)
+    when(batch.iterator).thenReturn(Collections.emptyIterator[Record])
 
     // Appending the empty control batch should not throw and a new transaction shouldn't be started
     append(stateManager, producerId, baseOffset, batch, origin = AppendOrigin.Client)

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -38,9 +38,9 @@ import org.apache.kafka.common.requests.AlterConfigsRequest._
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
 import org.apache.kafka.common.utils.{SecurityUtils, Utils}
-import org.easymock.EasyMock._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api._
+import org.mockito.Mockito.mock
 import org.mockito.{ArgumentCaptor, Mockito}
 
 import scala.collection.{Map, Seq}
@@ -287,9 +287,9 @@ class RequestChannelTest {
     new network.RequestChannel.Request(processor = 1,
       requestContext,
       startTimeNanos = 0,
-      createNiceMock(classOf[MemoryPool]),
+      mock(classOf[MemoryPool]),
       buffer,
-      createNiceMock(classOf[RequestChannel.Metrics])
+      mock(classOf[RequestChannel.Metrics])
     )
   }
 

--- a/core/src/test/scala/unit/kafka/network/RequestConvertToJsonTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestConvertToJsonTest.scala
@@ -29,9 +29,9 @@ import org.apache.kafka.common.network.{ClientInformation, ListenerName, Network
 import org.apache.kafka.common.protocol.{ApiKeys, MessageUtil}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
-import org.easymock.EasyMock.createNiceMock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -89,7 +89,7 @@ class RequestConvertToJsonTest {
 
     val actualNode = RequestConvertToJson.requestHeaderNode(header)
 
-    assertEquals(expectedNode, actualNode);
+    assertEquals(expectedNode, actualNode)
   }
 
   @Test
@@ -168,9 +168,9 @@ class RequestConvertToJsonTest {
     new network.RequestChannel.Request(processor = 1,
       requestContext,
       startTimeNanos = 0,
-      createNiceMock(classOf[MemoryPool]),
+      mock(classOf[MemoryPool]),
       buffer,
-      createNiceMock(classOf[RequestChannel.Metrics])
+      mock(classOf[RequestChannel.Metrics])
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
@@ -31,8 +31,8 @@ import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.{AbstractRequest, FetchRequest, RequestContext, RequestHeader}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.MockTime
-import org.easymock.EasyMock
 import org.junit.jupiter.api.AfterEach
+import org.mockito.Mockito.mock
 
 class BaseClientQuotaManagerTest {
   protected val time = new MockTime
@@ -57,7 +57,7 @@ class BaseClientQuotaManagerTest {
 
     val request = builder.build()
     val buffer = request.serializeWithHeader(new RequestHeader(builder.apiKey, request.version, "", 0))
-    val requestChannelMetrics: RequestChannel.Metrics = EasyMock.createNiceMock(classOf[RequestChannel.Metrics])
+    val requestChannelMetrics: RequestChannel.Metrics = mock(classOf[RequestChannel.Metrics])
 
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -33,11 +33,11 @@ import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.config.{ConfigException, SslConfigs}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.server.authorizer._
-import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
+import org.mockito.Mockito.{mock, when}
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
@@ -330,7 +330,7 @@ class DynamicBrokerConfigTest {
     props.put(name, value)
     val oldValue = config.originals.get(name)
 
-    def updateConfig() = {
+    def updateConfig(): Unit = {
       if (perBrokerConfig)
         config.dynamicConfig.updateBrokerConfig(0, config.dynamicConfig.toPersistentProps(props, perBrokerConfig))
       else
@@ -381,7 +381,7 @@ class DynamicBrokerConfigTest {
     try {
       configWithoutSecret.dynamicConfig.toPersistentProps(dynamicProps, perBrokerConfig = true)
     } catch {
-      case e: ConfigException => // expected exception
+      case _: ConfigException => // expected exception
     }
     val persistedProps = configWithSecret.dynamicConfig.toPersistentProps(dynamicProps, perBrokerConfig = true)
     assertFalse(persistedProps.getProperty(KafkaConfig.SaslJaasConfigProp).contains("myLoginModule"),
@@ -430,9 +430,8 @@ class DynamicBrokerConfigTest {
   def testDynamicListenerConfig(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092)
     val oldConfig =  KafkaConfig.fromProps(props)
-    val kafkaServer: KafkaServer = EasyMock.createMock(classOf[kafka.server.KafkaServer])
-    EasyMock.expect(kafkaServer.config).andReturn(oldConfig).anyTimes()
-    EasyMock.replay(kafkaServer)
+    val kafkaServer: KafkaServer = mock(classOf[kafka.server.KafkaServer])
+    when(kafkaServer.config).thenReturn(oldConfig)
 
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
     new DynamicListenerConfig(kafkaServer).validateReconfiguration(KafkaConfig(props))
@@ -449,7 +448,7 @@ class DynamicBrokerConfigTest {
     val oldConfig =  KafkaConfig.fromProps(props)
     oldConfig.dynamicConfig.initialize(None)
 
-    val kafkaServer: KafkaServer = EasyMock.createMock(classOf[kafka.server.KafkaServer])
+    val kafkaServer: KafkaServer = mock(classOf[kafka.server.KafkaServer])
 
     class TestAuthorizer extends Authorizer with Reconfigurable {
       @volatile var superUsers = ""
@@ -468,9 +467,8 @@ class DynamicBrokerConfigTest {
     }
 
     val authorizer = new TestAuthorizer
-    EasyMock.expect(kafkaServer.config).andReturn(oldConfig).anyTimes()
-    EasyMock.expect(kafkaServer.authorizer).andReturn(Some(authorizer)).anyTimes()
-    EasyMock.replay(kafkaServer)
+    when(kafkaServer.config).thenReturn(oldConfig)
+    when(kafkaServer.authorizer).thenReturn(Some(authorizer))
     // We are only testing authorizer reconfiguration, ignore any exceptions due to incomplete mock
     assertThrows(classOf[Throwable], () => kafkaServer.config.dynamicConfig.addReconfigurables(kafkaServer))
     props.put("super.users", "User:admin")
@@ -492,9 +490,8 @@ class DynamicBrokerConfigTest {
 
   @Test
   def testDynamicConfigInitializationWithoutConfigsInZK(): Unit = {
-    val zkClient: KafkaZkClient = EasyMock.createMock(classOf[KafkaZkClient])
-    EasyMock.expect(zkClient.getEntityConfigs(EasyMock.anyString(), EasyMock.anyString())).andReturn(new java.util.Properties()).anyTimes()
-    EasyMock.replay(zkClient)
+    val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
+    when(zkClient.getEntityConfigs(anyString(), anyString())).thenReturn(new java.util.Properties())
 
     val oldConfig =  KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092))
     val dynamicBrokerConfig = new DynamicBrokerConfig(oldConfig)

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -42,11 +42,12 @@ import org.apache.kafka.common.quota.ClientQuotaEntity.{CLIENT_ID, IP, USER}
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.record.{CompressionType, RecordVersion}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito.{mock, verify}
 
 import scala.annotation.nowarn
 import scala.collection.{Map, Seq}
@@ -403,14 +404,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     props.put("a.b", "10")
 
     // Create a mock ConfigHandler to record config changes it is asked to process
-    val entityArgument = EasyMock.newCapture[String]
-    val propertiesArgument = EasyMock.newCapture[Properties]
-    val handler: ConfigHandler = EasyMock.createNiceMock(classOf[ConfigHandler])
-    handler.processConfigChanges(
-      EasyMock.and(EasyMock.capture(entityArgument), EasyMock.isA(classOf[String])),
-      EasyMock.and(EasyMock.capture(propertiesArgument), EasyMock.isA(classOf[Properties])))
-    EasyMock.expectLastCall().once()
-    EasyMock.replay(handler)
+    val handler: ConfigHandler = mock(classOf[ConfigHandler])
 
     val configManager = new ZkConfigManager(zkClient, Map(ConfigType.Topic -> handler))
     // Notifications created using the old TopicConfigManager are ignored.
@@ -433,7 +427,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     configManager.ConfigChangedNotificationHandler.processNotification(Json.encodeAsBytes(jsonMap.asJava))
 
     // Verify that processConfigChanges was only called once
-    EasyMock.verify(handler)
+    verify(handler).processConfigChanges(anyString, any[Properties])
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -160,7 +160,6 @@ class ReplicaManagerQuotasTest {
 
     val quota = mockQuota()
     when(quota.isQuotaExceeded).thenReturn(true)
-//    expect(quota.isQuotaExceeded).andReturn(true).once()
 
     val fetch = replicaManager.readFromLocalLog(
       replicaId = FetchRequest.CONSUMER_REPLICA_ID,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -27,10 +27,11 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.FetchRequest
-import org.easymock.EasyMock
-import org.easymock.EasyMock._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
+import org.mockito.{AdditionalMatchers, ArgumentMatchers}
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt, anyLong}
+import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 
@@ -56,10 +57,10 @@ class ReplicaManagerQuotasTest {
     setUpMocks(fetchInfo)
     val followerReplicaId = configs.last.brokerId
 
-    val quota = mockQuota(1000000)
-    expect(quota.isQuotaExceeded).andReturn(false).once()
-    expect(quota.isQuotaExceeded).andReturn(true).once()
-    replay(quota)
+    val quota = mockQuota()
+    when(quota.isQuotaExceeded)
+      .thenReturn(false)
+      .thenReturn(true)
 
     val fetch = replicaManager.readFromLocalLog(
       replicaId = followerReplicaId,
@@ -82,10 +83,10 @@ class ReplicaManagerQuotasTest {
     setUpMocks(fetchInfo)
     val followerReplicaId = configs.last.brokerId
 
-    val quota = mockQuota(1000000)
-    expect(quota.isQuotaExceeded).andReturn(true).once()
-    expect(quota.isQuotaExceeded).andReturn(true).once()
-    replay(quota)
+    val quota = mockQuota()
+    when(quota.isQuotaExceeded)
+      .thenReturn(true)
+      .thenReturn(true)
 
     val fetch = replicaManager.readFromLocalLog(
       replicaId = followerReplicaId,
@@ -107,10 +108,10 @@ class ReplicaManagerQuotasTest {
     setUpMocks(fetchInfo)
     val followerReplicaId = configs.last.brokerId
 
-    val quota = mockQuota(1000000)
-    expect(quota.isQuotaExceeded).andReturn(false).once()
-    expect(quota.isQuotaExceeded).andReturn(false).once()
-    replay(quota)
+    val quota = mockQuota()
+    when(quota.isQuotaExceeded)
+      .thenReturn(false)
+      .thenReturn(false)
 
     val fetch = replicaManager.readFromLocalLog(
       replicaId = followerReplicaId,
@@ -132,10 +133,10 @@ class ReplicaManagerQuotasTest {
     setUpMocks(fetchInfo, bothReplicasInSync = true)
     val followerReplicaId = configs.last.brokerId
 
-    val quota = mockQuota(1000000)
-    expect(quota.isQuotaExceeded).andReturn(false).once()
-    expect(quota.isQuotaExceeded).andReturn(true).once()
-    replay(quota)
+    val quota = mockQuota()
+    when(quota.isQuotaExceeded)
+      .thenReturn(false)
+      .thenReturn(true)
 
     val fetch = replicaManager.readFromLocalLog(
       replicaId = followerReplicaId,
@@ -157,10 +158,9 @@ class ReplicaManagerQuotasTest {
   def shouldIncludeThrottledReplicasForConsumerFetch(): Unit = {
     setUpMocks(fetchInfo)
 
-    val quota = mockQuota(1000000)
-    expect(quota.isQuotaExceeded).andReturn(true).once()
-    expect(quota.isQuotaExceeded).andReturn(true).once()
-    replay(quota)
+    val quota = mockQuota()
+    when(quota.isQuotaExceeded).thenReturn(true)
+//    expect(quota.isQuotaExceeded).andReturn(true).once()
 
     val fetch = replicaManager.readFromLocalLog(
       replicaId = FetchRequest.CONSUMER_REPLICA_ID,
@@ -184,24 +184,23 @@ class ReplicaManagerQuotasTest {
     // Set up DelayedFetch where there is data to return to a follower replica, either in-sync or out of sync
     def setupDelayedFetch(isReplicaInSync: Boolean): DelayedFetch = {
       val endOffsetMetadata = LogOffsetMetadata(messageOffset = 100L, segmentBaseOffset = 0L, relativePositionInSegment = 500)
-      val partition: Partition = EasyMock.createMock(classOf[Partition])
+      val partition: Partition = mock(classOf[Partition])
 
       val offsetSnapshot = LogOffsetSnapshot(
         logStartOffset = 0L,
         logEndOffset = endOffsetMetadata,
         highWatermark = endOffsetMetadata,
         lastStableOffset = endOffsetMetadata)
-      EasyMock.expect(partition.fetchOffsetSnapshot(Optional.empty(), fetchOnlyFromLeader = true))
-          .andReturn(offsetSnapshot)
+      when(partition.fetchOffsetSnapshot(Optional.empty(), fetchOnlyFromLeader = true))
+          .thenReturn(offsetSnapshot)
 
-      val replicaManager: ReplicaManager = EasyMock.createMock(classOf[ReplicaManager])
-      EasyMock.expect(replicaManager.getPartitionOrException(EasyMock.anyObject[TopicPartition]))
-        .andReturn(partition).anyTimes()
+      val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+      when(replicaManager.getPartitionOrException(any[TopicPartition]))
+        .thenReturn(partition)
 
-      EasyMock.expect(replicaManager.shouldLeaderThrottle(EasyMock.anyObject[ReplicaQuota], EasyMock.anyObject[Partition], EasyMock.anyObject[Int]))
-        .andReturn(!isReplicaInSync).anyTimes()
-      EasyMock.expect(partition.getReplica(1)).andReturn(None)
-      EasyMock.replay(replicaManager, partition)
+      when(replicaManager.shouldLeaderThrottle(any[ReplicaQuota], any[Partition], anyInt))
+        .thenReturn(!isReplicaInSync)
+      when(partition.getReplica(1)).thenReturn(None)
 
       val tp = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("t1", 0))
       val fetchPartitionStatus = FetchPartitionStatus(LogOffsetMetadata(messageOffset = 50L, segmentBaseOffset = 0L,
@@ -233,21 +232,19 @@ class ReplicaManagerQuotasTest {
         LogOffsetMetadata(messageOffset = 100L, segmentBaseOffset = 0L, relativePositionInSegment = 500)
       else
         LogOffsetMetadata(messageOffset = 150L, segmentBaseOffset = 50L, relativePositionInSegment = 500)
-      val partition: Partition = EasyMock.createMock(classOf[Partition])
+      val partition: Partition = mock(classOf[Partition])
 
       val offsetSnapshot = LogOffsetSnapshot(
         logStartOffset = 0L,
         logEndOffset = endOffsetMetadata,
         highWatermark = endOffsetMetadata,
         lastStableOffset = endOffsetMetadata)
-      EasyMock.expect(partition.fetchOffsetSnapshot(Optional.empty(), fetchOnlyFromLeader = true))
-        .andReturn(offsetSnapshot)
+      when(partition.fetchOffsetSnapshot(Optional.empty(), fetchOnlyFromLeader = true))
+        .thenReturn(offsetSnapshot)
 
-      val replicaManager: ReplicaManager = EasyMock.createMock(classOf[ReplicaManager])
-      EasyMock.expect(replicaManager.getPartitionOrException(EasyMock.anyObject[TopicPartition]))
-        .andReturn(partition).anyTimes()
-
-      EasyMock.replay(replicaManager, partition)
+      val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+      when(replicaManager.getPartitionOrException(any[TopicPartition]))
+        .thenReturn(partition)
 
       val tidp = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("t1", 0))
       val fetchPartitionStatus = FetchPartitionStatus(LogOffsetMetadata(messageOffset = 50L, segmentBaseOffset = 0L,
@@ -273,47 +270,45 @@ class ReplicaManagerQuotasTest {
 
   def setUpMocks(fetchInfo: Seq[(TopicIdPartition, PartitionData)], record: SimpleRecord = this.record,
                  bothReplicasInSync: Boolean = false): Unit = {
-    val scheduler: KafkaScheduler = createNiceMock(classOf[KafkaScheduler])
+    val scheduler: KafkaScheduler = mock(classOf[KafkaScheduler])
 
     //Create log which handles both a regular read and a 0 bytes read
-    val log: UnifiedLog = createNiceMock(classOf[UnifiedLog])
-    expect(log.logStartOffset).andReturn(0L).anyTimes()
-    expect(log.logEndOffset).andReturn(20L).anyTimes()
-    expect(log.highWatermark).andReturn(5).anyTimes()
-    expect(log.lastStableOffset).andReturn(5).anyTimes()
-    expect(log.logEndOffsetMetadata).andReturn(LogOffsetMetadata(20L)).anyTimes()
-    expect(log.topicId).andReturn(Some(topicId)).anyTimes()
+    val log: UnifiedLog = mock(classOf[UnifiedLog])
+    when(log.logStartOffset).thenReturn(0L)
+    when(log.logEndOffset).thenReturn(20L)
+    when(log.highWatermark).thenReturn(5)
+    when(log.lastStableOffset).thenReturn(5)
+    when(log.logEndOffsetMetadata).thenReturn(LogOffsetMetadata(20L))
+    when(log.topicId).thenReturn(Some(topicId))
 
     //if we ask for len 1 return a message
-    expect(log.read(anyObject(),
-      maxLength = geq(1),
-      isolation = anyObject(),
-      minOneMessage = anyBoolean())).andReturn(
+    when(log.read(anyLong,
+      maxLength = AdditionalMatchers.geq(1),
+      isolation = any[FetchIsolation],
+      minOneMessage = anyBoolean)).thenReturn(
       FetchDataInfo(
         LogOffsetMetadata(0L, 0L, 0),
         MemoryRecords.withRecords(CompressionType.NONE, record)
-      )).anyTimes()
+      ))
 
     //if we ask for len = 0, return 0 messages
-    expect(log.read(anyObject(),
-      maxLength = EasyMock.eq(0),
-      isolation = anyObject(),
-      minOneMessage = anyBoolean())).andReturn(
+    when(log.read(anyLong,
+      maxLength = ArgumentMatchers.eq(0),
+      isolation = any[FetchIsolation],
+      minOneMessage = anyBoolean)).thenReturn(
       FetchDataInfo(
         LogOffsetMetadata(0L, 0L, 0),
         MemoryRecords.EMPTY
-      )).anyTimes()
-    replay(log)
+      ))
 
     //Create log manager
-    val logManager: LogManager = createMock(classOf[LogManager])
+    val logManager: LogManager = mock(classOf[LogManager])
 
     //Return the same log for each partition as it doesn't matter
-    expect(logManager.getLog(anyObject(), anyBoolean())).andReturn(Some(log)).anyTimes()
-    expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
-    replay(logManager)
+    when(logManager.getLog(any[TopicPartition], anyBoolean)).thenReturn(Some(log))
+    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
 
-    val alterIsrManager: AlterIsrManager = createMock(classOf[AlterIsrManager])
+    val alterIsrManager: AlterIsrManager = mock(classOf[AlterIsrManager])
 
     val leaderBrokerId = configs.head.brokerId
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
@@ -351,9 +346,9 @@ class ReplicaManagerQuotasTest {
     metrics.close()
   }
 
-  def mockQuota(bound: Long): ReplicaQuota = {
-    val quota: ReplicaQuota = createMock(classOf[ReplicaQuota])
-    expect(quota.isThrottled(anyObject())).andReturn(true).anyTimes()
+  def mockQuota(): ReplicaQuota = {
+    val quota: ReplicaQuota = mock(classOf[ReplicaQuota])
+    when(quota.isThrottled(any[TopicPartition])).thenReturn(true)
     quota
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -53,14 +53,15 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.image.{ClientQuotasImage, ClusterImageTest, ConfigurationsImage, FeaturesImage, MetadataImage, ProducerIdsImage, TopicsDelta, TopicsImage}
 import org.apache.kafka.raft.{OffsetAndEpoch => RaftOffsetAndEpoch}
-import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.{ArgumentMatchers, Mockito}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.{any, anyInt}
+import org.mockito.Mockito.{mock, times, verify, when}
 
 import scala.collection.{Map, Seq, mutable}
 import scala.jdk.CollectionConverters._
@@ -88,7 +89,7 @@ class ReplicaManagerTest {
   def setUp(): Unit = {
     val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
     config = KafkaConfig.fromProps(props)
-    alterIsrManager = EasyMock.createMock(classOf[AlterIsrManager])
+    alterIsrManager = mock(classOf[AlterIsrManager])
     quotaManager = QuotaFactory.instantiate(config, metrics, time, "")
   }
 
@@ -165,7 +166,7 @@ class ReplicaManagerTest {
       alterIsrManager = alterIsrManager,
       threadNamePrefix = Option(this.getClass.getName))
     try {
-      def callback(responseStatus: Map[TopicPartition, PartitionResponse]) = {
+      def callback(responseStatus: Map[TopicPartition, PartitionResponse]): Unit = {
         assert(responseStatus.values.head.error == Errors.INVALID_REQUIRED_ACKS)
       }
       rm.appendRecords(
@@ -184,18 +185,18 @@ class ReplicaManagerTest {
   }
 
   private def mockGetAliveBrokerFunctions(cache: MetadataCache, aliveBrokers: Seq[Node]): Unit = {
-    Mockito.when(cache.hasAliveBroker(ArgumentMatchers.anyInt())).thenAnswer(new Answer[Boolean]() {
+    when(cache.hasAliveBroker(anyInt)).thenAnswer(new Answer[Boolean]() {
       override def answer(invocation: InvocationOnMock): Boolean = {
-        aliveBrokers.map(_.id()).contains(invocation.getArguments()(0).asInstanceOf[Int])
+        aliveBrokers.map(_.id()).contains(invocation.getArgument(0).asInstanceOf[Int])
       }
     })
-    Mockito.when(cache.getAliveBrokerNode(ArgumentMatchers.anyInt(), ArgumentMatchers.any[ListenerName])).
+    when(cache.getAliveBrokerNode(anyInt, any[ListenerName])).
       thenAnswer(new Answer[Option[Node]]() {
         override def answer(invocation: InvocationOnMock): Option[Node] = {
-          aliveBrokers.find(node => node.id == invocation.getArguments()(0).asInstanceOf[Integer])
+          aliveBrokers.find(node => node.id == invocation.getArgument(0).asInstanceOf[Integer])
         }
       })
-    Mockito.when(cache.getAliveBrokerNodes(ArgumentMatchers.any[ListenerName])).thenReturn(aliveBrokers)
+    when(cache.getAliveBrokerNodes(any[ListenerName])).thenReturn(aliveBrokers)
   }
 
   @Test
@@ -206,7 +207,7 @@ class ReplicaManagerTest {
     val logProps = new Properties()
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)), LogConfig(logProps))
     val aliveBrokers = Seq(new Node(0, "host0", 0), new Node(1, "host1", 1))
-    val metadataCache: MetadataCache = Mockito.mock(classOf[MetadataCache])
+    val metadataCache: MetadataCache = mock(classOf[MetadataCache])
     mockGetAliveBrokerFunctions(metadataCache, aliveBrokers)
     val rm = new ReplicaManager(
       metrics = metrics,
@@ -979,7 +980,7 @@ class ReplicaManagerTest {
       // Create 2 partitions, assign replica 0 as the leader for both a different follower (1 and 2) for each
       val tp0 = new TopicPartition(topic, 0)
       val tp1 = new TopicPartition(topic, 1)
-      val topicId = Uuid.randomUuid();
+      val topicId = Uuid.randomUuid()
       val tidp0 = new TopicIdPartition(topicId, tp0)
       val tidp1 = new TopicIdPartition(topicId, tp1)
       val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints)
@@ -1025,7 +1026,7 @@ class ReplicaManagerTest {
         }
       }
 
-      def fetchCallback(responseStatus: Seq[(TopicIdPartition, FetchPartitionData)]) = {
+      def fetchCallback(responseStatus: Seq[(TopicIdPartition, FetchPartitionData)]): Unit = {
         val responseStatusMap = responseStatus.toMap
         assertEquals(2, responseStatus.size)
         assertEquals(Set(tidp0, tidp1), responseStatusMap.keySet)
@@ -1104,11 +1105,12 @@ class ReplicaManagerTest {
     val leaderEpochIncrement = 2
     val aliveBrokerIds = Seq[Integer](followerBrokerId, leaderBrokerId)
     val countDownLatch = new CountDownLatch(1)
+    val offsetFromLeader = 5
 
     // Prepare the mocked components for the test
     val (replicaManager, mockLogMgr) = prepareReplicaManagerAndLogManager(new MockTimer(time),
       topicPartition, leaderEpoch + leaderEpochIncrement, followerBrokerId, leaderBrokerId, countDownLatch,
-      expectTruncation = expectTruncation, localLogOffset = Some(10), extraProps = extraProps, topicId = Some(topicId))
+      expectTruncation = expectTruncation, localLogOffset = Some(10), offsetFromLeader = offsetFromLeader, extraProps = extraProps, topicId = Some(topicId))
 
     try {
       // Initialize partition state to follower, with leader = 1, leaderEpoch = 1
@@ -1135,7 +1137,11 @@ class ReplicaManagerTest {
       assertTrue(countDownLatch.await(1000L, TimeUnit.MILLISECONDS))
 
       // Truncation should have happened once
-      EasyMock.verify(mockLogMgr)
+      if (expectTruncation) {
+        verify(mockLogMgr).truncateTo(Map(tp -> offsetFromLeader), isFuture = false)
+      }
+
+      verify(mockLogMgr).finishedInitializingLog(ArgumentMatchers.eq(tp), any())
     } finally {
       replicaManager.shutdown()
     }
@@ -1479,7 +1485,7 @@ class ReplicaManagerTest {
     val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100,
       Optional.empty())
 
-    val nonPurgatoryFetchResult = sendConsumerFetch(replicaManager, tidp0, partitionData, None, timeout = 0)
+    val nonPurgatoryFetchResult = sendConsumerFetch(replicaManager, tidp0, partitionData, None)
     assertNotNull(nonPurgatoryFetchResult.get)
     assertEquals(Errors.NONE, nonPurgatoryFetchResult.get.error)
     assertMetricCount(1)
@@ -1680,7 +1686,7 @@ class ReplicaManagerTest {
       Optional.of(1))
     val fetchResult = sendConsumerFetch(replicaManager, tidp0, partitionData, None, timeout = 10)
     assertNull(fetchResult.get)
-    Mockito.when(replicaManager.metadataCache.contains(ArgumentMatchers.eq(tp0))).thenReturn(true)
+    when(replicaManager.metadataCache.contains(tp0)).thenReturn(true)
 
     // We have a fetch in purgatory, now receive a stop replica request and
     // assert that the fetch returns with a NOT_LEADER error
@@ -1722,7 +1728,7 @@ class ReplicaManagerTest {
     val produceResult = sendProducerAppend(replicaManager, tp0, 3)
     assertNull(produceResult.get)
 
-    Mockito.when(replicaManager.metadataCache.contains(tp0)).thenReturn(true)
+    when(replicaManager.metadataCache.contains(tp0)).thenReturn(true)
 
     replicaManager.stopReplicas(2, 0, 0,
       mutable.Map(tp0 -> new StopReplicaPartitionState()
@@ -1864,29 +1870,18 @@ class ReplicaManagerTest {
 
     // Expect to call LogManager.truncateTo exactly once
     val topicPartitionObj = new TopicPartition(topic, topicPartition)
-    val mockLogMgr: LogManager = EasyMock.createMock(classOf[LogManager])
-    EasyMock.expect(mockLogMgr.liveLogDirs).andReturn(config.logDirs.map(new File(_).getAbsoluteFile)).anyTimes
-    EasyMock.expect(mockLogMgr.getOrCreateLog(EasyMock.eq(topicPartitionObj),
-      isNew = EasyMock.eq(false), isFuture = EasyMock.eq(false), EasyMock.anyObject())).andReturn(mockLog).anyTimes
-    if (expectTruncation) {
-      EasyMock.expect(mockLogMgr.truncateTo(Map(topicPartitionObj -> offsetFromLeader),
-        isFuture = false)).once
-    }
-    EasyMock.expect(mockLogMgr.initializingLog(topicPartitionObj)).anyTimes
-    EasyMock.expect(mockLogMgr.getLog(topicPartitionObj, isFuture = true)).andReturn(None)
-
-    EasyMock.expect(mockLogMgr.finishedInitializingLog(
-      EasyMock.eq(topicPartitionObj), EasyMock.anyObject())).anyTimes
-
-    EasyMock.replay(mockLogMgr)
+    val mockLogMgr: LogManager = mock(classOf[LogManager])
+    when(mockLogMgr.liveLogDirs).thenReturn(config.logDirs.map(new File(_).getAbsoluteFile))
+    when(mockLogMgr.getOrCreateLog(ArgumentMatchers.eq(topicPartitionObj), ArgumentMatchers.eq(false), ArgumentMatchers.eq(false), any())).thenReturn(mockLog)
+    when(mockLogMgr.getLog(topicPartitionObj, isFuture = true)).thenReturn(None)
 
     val aliveBrokerIds = Seq[Integer](followerBrokerId, leaderBrokerId)
     val aliveBrokers = aliveBrokerIds.map(brokerId => new Node(brokerId, s"host$brokerId", brokerId))
 
-    val metadataCache: MetadataCache = Mockito.mock(classOf[MetadataCache])
+    val metadataCache: MetadataCache = mock(classOf[MetadataCache])
     mockGetAliveBrokerFunctions(metadataCache, aliveBrokers)
-    Mockito.when(metadataCache.getPartitionReplicaEndpoints(
-      ArgumentMatchers.any[TopicPartition], ArgumentMatchers.any[ListenerName])).
+    when(metadataCache.getPartitionReplicaEndpoints(
+      any[TopicPartition], any[ListenerName])).
         thenReturn(Map(leaderBrokerId -> new Node(leaderBrokerId, "host1", 9092, "rack-a"),
           followerBrokerId -> new Node(followerBrokerId, "host2", 9092, "rack-b")).toMap)
 
@@ -1934,7 +1929,7 @@ class ReplicaManagerTest {
             new ReplicaFetcherThread(s"ReplicaFetcherThread-$fetcherId", fetcherId,
               sourceBroker, config, failedPartitions, replicaManager, metrics, time, quotaManager.follower, Some(blockingSend)) {
 
-              override def doWork() = {
+              override def doWork(): Unit = {
                 // In case the thread starts before the partition is added by AbstractFetcherManager,
                 // add it here (it's a no-op if already added)
                 val initialOffset = InitialFetchState(
@@ -2048,7 +2043,7 @@ class ReplicaManagerTest {
                             isolationLevel: IsolationLevel,
                             clientMetadata: Option[ClientMetadata]): CallbackResult[FetchPartitionData] = {
     val result = new CallbackResult[FetchPartitionData]()
-    def fetchCallback(responseStatus: Seq[(TopicIdPartition, FetchPartitionData)]) = {
+    def fetchCallback(responseStatus: Seq[(TopicIdPartition, FetchPartitionData)]): Unit = {
       assertEquals(1, responseStatus.size)
       val (topicPartition, fetchData) = responseStatus.head
       assertEquals(partition, topicPartition)
@@ -2087,10 +2082,10 @@ class ReplicaManagerTest {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)), LogConfig(logProps))
     val aliveBrokers = aliveBrokerIds.map(brokerId => new Node(brokerId, s"host$brokerId", brokerId))
 
-    val metadataCache: MetadataCache = Mockito.mock(classOf[MetadataCache])
-    Mockito.when(metadataCache.topicIdInfo()).thenReturn((topicIds.asJava, topicNames.asJava))
-    Mockito.when(metadataCache.topicNamesToIds()).thenReturn(topicIds.asJava)
-    Mockito.when(metadataCache.topicIdsToNames()).thenReturn(topicNames.asJava)
+    val metadataCache: MetadataCache = mock(classOf[MetadataCache])
+    when(metadataCache.topicIdInfo()).thenReturn((topicIds.asJava, topicNames.asJava))
+    when(metadataCache.topicNamesToIds()).thenReturn(topicIds.asJava)
+    when(metadataCache.topicIdsToNames()).thenReturn(topicNames.asJava)
     mockGetAliveBrokerFunctions(metadataCache, aliveBrokers)
     val mockProducePurgatory = new DelayedOperationPurgatory[DelayedProduce](
       purgatoryName = "Produce", timer, reaperEnabled = false)
@@ -2154,11 +2149,8 @@ class ReplicaManagerTest {
     val leaderEpochIncrement = 1
     val correlationId = 0
     val controllerId = 0
-    val mockTopicStats1: BrokerTopicStats = EasyMock.mock(classOf[BrokerTopicStats])
-    val (rm0, rm1) = prepareDifferentReplicaManagers(EasyMock.mock(classOf[BrokerTopicStats]), mockTopicStats1)
-
-    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(topic)).andVoid.once
-    EasyMock.replay(mockTopicStats1)
+    val mockTopicStats1: BrokerTopicStats = mock(classOf[BrokerTopicStats])
+    val (rm0, rm1) = prepareDifferentReplicaManagers(mock(classOf[BrokerTopicStats]), mockTopicStats1)
 
     try {
       // make broker 0 the leader of partition 0 and
@@ -2235,7 +2227,7 @@ class ReplicaManagerTest {
     }
 
     // verify that broker 1 did remove its metrics when no longer being the leader of partition 1
-    EasyMock.verify(mockTopicStats1)
+    verify(mockTopicStats1).removeOldLeaderMetrics(topic)
   }
 
   @Test
@@ -2245,12 +2237,8 @@ class ReplicaManagerTest {
     val leaderEpochIncrement = 1
     val correlationId = 0
     val controllerId = 0
-    val mockTopicStats1: BrokerTopicStats = EasyMock.mock(classOf[BrokerTopicStats])
-    val (rm0, rm1) = prepareDifferentReplicaManagers(EasyMock.mock(classOf[BrokerTopicStats]), mockTopicStats1)
-
-    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(topic)).andVoid.once
-    EasyMock.expect(mockTopicStats1.removeOldFollowerMetrics(topic)).andVoid.once
-    EasyMock.replay(mockTopicStats1)
+    val mockTopicStats1: BrokerTopicStats = mock(classOf[BrokerTopicStats])
+    val (rm0, rm1) = prepareDifferentReplicaManagers(mock(classOf[BrokerTopicStats]), mockTopicStats1)
 
     try {
       // make broker 0 the leader of partition 0 and
@@ -2327,7 +2315,8 @@ class ReplicaManagerTest {
     }
 
     // verify that broker 1 did remove its metrics when no longer being the leader of partition 1
-    EasyMock.verify(mockTopicStats1)
+    verify(mockTopicStats1).removeOldLeaderMetrics(topic)
+    verify(mockTopicStats1).removeOldFollowerMetrics(topic)
   }
 
   private def prepareDifferentReplicaManagers(brokerTopicStats1: BrokerTopicStats,
@@ -2344,8 +2333,8 @@ class ReplicaManagerTest {
     val mockLogMgr0 = TestUtils.createLogManager(config0.logDirs.map(new File(_)))
     val mockLogMgr1 = TestUtils.createLogManager(config1.logDirs.map(new File(_)))
 
-    val metadataCache0: MetadataCache = Mockito.mock(classOf[MetadataCache])
-    val metadataCache1: MetadataCache = Mockito.mock(classOf[MetadataCache])
+    val metadataCache0: MetadataCache = mock(classOf[MetadataCache])
+    val metadataCache1: MetadataCache = mock(classOf[MetadataCache])
     val aliveBrokers = Seq(new Node(0, "host0", 0), new Node(1, "host1", 1))
     mockGetAliveBrokerFunctions(metadataCache0, aliveBrokers)
     mockGetAliveBrokerFunctions(metadataCache1, aliveBrokers)
@@ -2898,8 +2887,7 @@ class ReplicaManagerTest {
         topicId = Uuid.randomUuid(),
         topicPartition = topicPartition,
         replicas = Seq(0, 1),
-        leaderAndIsr = LeaderAndIsr(if (becomeLeader) 0 else 1, List(0, 1)),
-        isNew = true
+        leaderAndIsr = LeaderAndIsr(if (becomeLeader) 0 else 1, List(0, 1))
       )
 
       replicaManager.becomeLeaderOrFollower(0, request, (_, _) => ())
@@ -2955,12 +2943,12 @@ class ReplicaManagerTest {
     val replicaManager = setupReplicaManagerWithMockedPurgatories(new MockTimer(time), brokerId)
     try {
       val fooPartition = new TopicPartition("foo", 0)
-      Mockito.when(replicaManager.metadataCache.contains(fooPartition)).thenReturn(false)
+      when(replicaManager.metadataCache.contains(fooPartition)).thenReturn(false)
       val fooProducerState = replicaManager.activeProducerState(fooPartition)
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.forCode(fooProducerState.errorCode))
 
       val oofPartition = new TopicPartition("oof", 0)
-      Mockito.when(replicaManager.metadataCache.contains(oofPartition)).thenReturn(true)
+      when(replicaManager.metadataCache.contains(oofPartition)).thenReturn(true)
       val oofProducerState = replicaManager.activeProducerState(oofPartition)
       assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, Errors.forCode(oofProducerState.errorCode))
 
@@ -3439,7 +3427,7 @@ class ReplicaManagerTest {
     val otherId = localId + 1
     val topicPartition = new TopicPartition("foo", 0)
 
-    val mockReplicaFetcherManager = Mockito.mock(classOf[ReplicaFetcherManager])
+    val mockReplicaFetcherManager = mock(classOf[ReplicaFetcherManager])
     val replicaManager = setupReplicaManagerWithMockedPurgatories(
       timer = new MockTimer(time),
       brokerId = localId,
@@ -3448,7 +3436,7 @@ class ReplicaManagerTest {
 
     try {
       // The first call to removeFetcherForPartitions should be ignored.
-      Mockito.when(mockReplicaFetcherManager.removeFetcherForPartitions(
+      when(mockReplicaFetcherManager.removeFetcherForPartitions(
         Set(topicPartition))
       ).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
 
@@ -3465,7 +3453,7 @@ class ReplicaManagerTest {
 
       // Verify that addFetcherForPartitions was called with the correct
       // init offset.
-      Mockito.verify(mockReplicaFetcherManager, Mockito.times(1))
+      verify(mockReplicaFetcherManager)
         .addFetcherForPartitions(
           Map(topicPartition -> InitialFetchState(
             topicId = Some(FOO_UUID),
@@ -3477,7 +3465,7 @@ class ReplicaManagerTest {
 
       // The second call to removeFetcherForPartitions simulate the case
       // where the fetcher write to the log before being shutdown.
-      Mockito.when(mockReplicaFetcherManager.removeFetcherForPartitions(
+      when(mockReplicaFetcherManager.removeFetcherForPartitions(
         Set(topicPartition))
       ).thenAnswer { _ =>
         replicaManager.getPartition(topicPartition) match {
@@ -3505,7 +3493,7 @@ class ReplicaManagerTest {
 
       // Verify that addFetcherForPartitions was called with the correct
       // init offset.
-      Mockito.verify(mockReplicaFetcherManager, Mockito.times(1))
+      verify(mockReplicaFetcherManager)
         .addFetcherForPartitions(
           Map(topicPartition -> InitialFetchState(
             topicId = Some(FOO_UUID),
@@ -3622,7 +3610,7 @@ class ReplicaManagerTest {
     val topicId = if (usesTopicIds) this.topicId else Uuid.ZERO_UUID
     val topicIdOpt = if (usesTopicIds) Some(topicId) else None
 
-    val mockReplicaAlterLogDirsManager = Mockito.mock(classOf[ReplicaAlterLogDirsManager])
+    val mockReplicaAlterLogDirsManager = mock(classOf[ReplicaAlterLogDirsManager])
     val replicaManager = setupReplicaManagerWithMockedPurgatories(
       timer = new MockTimer(time),
       mockReplicaAlterLogDirsManager = Some(mockReplicaAlterLogDirsManager)
@@ -3655,7 +3643,7 @@ class ReplicaManagerTest {
       assertEquals(topicIdOpt, futureLog.topicId)
 
       // Verify that addFetcherForPartitions was called with the correct topic ID.
-      Mockito.verify(mockReplicaAlterLogDirsManager, Mockito.times(1))
+      verify(mockReplicaAlterLogDirsManager, times(1))
         .addFetcherForPartitions(Map(tp -> InitialFetchState(
           topicId = topicIdOpt,
           leader = BrokerEndPoint(0, "localhost", -1),

--- a/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
@@ -17,10 +17,12 @@
 
 package kafka.server
 
+import java.util.Properties
+
+import kafka.server.metadata.ZkConfigRepository
+import kafka.utils.TestUtils
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.common.metrics.Metrics
-import org.easymock.EasyMock
-import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.message.DescribeConfigsRequestData
 import org.apache.kafka.common.message.DescribeConfigsResponseData
@@ -30,19 +32,17 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotEquals
-import java.util.Properties
-
-import kafka.server.metadata.ZkConfigRepository
+import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 
 class ZkAdminManagerTest {
 
-  private val zkClient: KafkaZkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
+  private val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
   private val metrics = new Metrics()
   private val brokerId = 1
   private val topic = "topic-1"
-  private val metadataCache: MetadataCache = EasyMock.createNiceMock(classOf[MetadataCache])
+  private val metadataCache: MetadataCache = mock(classOf[MetadataCache])
 
   @AfterEach
   def tearDown(): Unit = {
@@ -56,10 +56,8 @@ class ZkAdminManagerTest {
 
   @Test
   def testDescribeConfigsWithNullConfigurationKeys(): Unit = {
-    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
-    EasyMock.expect(metadataCache.contains(topic)).andReturn(true)
-
-    EasyMock.replay(zkClient, metadataCache)
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    when(metadataCache.contains(topic)).thenReturn(true)
 
     val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
       .setResourceName(topic)
@@ -73,10 +71,8 @@ class ZkAdminManagerTest {
 
   @Test
   def testDescribeConfigsWithEmptyConfigurationKeys(): Unit = {
-    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
-    EasyMock.expect(metadataCache.contains(topic)).andReturn(true)
-
-    EasyMock.replay(zkClient, metadataCache)
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    when(metadataCache.contains(topic)).thenReturn(true)
 
     val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
       .setResourceName(topic)
@@ -89,10 +85,8 @@ class ZkAdminManagerTest {
 
   @Test
   def testDescribeConfigsWithConfigurationKeys(): Unit = {
-    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
-    EasyMock.expect(metadataCache.contains(topic)).andReturn(true)
-
-    EasyMock.replay(zkClient, metadataCache)
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    when(metadataCache.contains(topic)).thenReturn(true)
 
     val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
       .setResourceName(topic)
@@ -108,10 +102,9 @@ class ZkAdminManagerTest {
 
   @Test
   def testDescribeConfigsWithDocumentation(): Unit = {
-    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(new Properties)
-    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Broker, brokerId.toString)).andReturn(new Properties)
-    EasyMock.expect(metadataCache.contains(topic)).andReturn(true)
-    EasyMock.replay(zkClient, metadataCache)
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(new Properties)
+    when(zkClient.getEntityConfigs(ConfigType.Broker, brokerId.toString)).thenReturn(new Properties)
+    when(metadataCache.contains(topic)).thenReturn(true)
 
     val configHelper = createConfigHelper(metadataCache, zkClient)
 

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -29,9 +29,9 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
-import org.easymock.EasyMock._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 
@@ -57,11 +57,10 @@ class OffsetsForLeaderEpochTest {
     val request = Seq(newOffsetForLeaderTopic(tp, RecordBatch.NO_PARTITION_LEADER_EPOCH, epochRequested))
 
     //Stubs
-    val mockLog: UnifiedLog = createNiceMock(classOf[UnifiedLog])
-    val logManager: LogManager = createNiceMock(classOf[LogManager])
-    expect(mockLog.endOffsetForEpoch(epochRequested)).andReturn(Some(offsetAndEpoch))
-    expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
-    replay(mockLog, logManager)
+    val mockLog: UnifiedLog = mock(classOf[UnifiedLog])
+    val logManager: LogManager = mock(classOf[LogManager])
+    when(mockLog.endOffsetForEpoch(epochRequested)).thenReturn(Some(offsetAndEpoch))
+    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
 
     // create a replica manager with 1 partition that has 1 replica
     replicaManager = new ReplicaManager(
@@ -89,9 +88,8 @@ class OffsetsForLeaderEpochTest {
 
   @Test
   def shouldReturnNoLeaderForPartitionIfThrown(): Unit = {
-    val logManager: LogManager = createNiceMock(classOf[LogManager])
-    expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
-    replay(logManager)
+    val logManager: LogManager = mock(classOf[LogManager])
+    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
 
     //create a replica manager with 1 partition that has 0 replica
     replicaManager = new ReplicaManager(
@@ -121,9 +119,8 @@ class OffsetsForLeaderEpochTest {
 
   @Test
   def shouldReturnUnknownTopicOrPartitionIfThrown(): Unit = {
-    val logManager: LogManager = createNiceMock(classOf[LogManager])
-    expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
-    replay(logManager)
+    val logManager: LogManager = mock(classOf[LogManager])
+    when(logManager.liveLogDirs).thenReturn(Array.empty[File])
 
     //create a replica manager with 0 partition
     replicaManager = new ReplicaManager(

--- a/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
@@ -33,9 +33,9 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.{InvalidReplicaAssignmentException, InvalidTopicException, TopicExistsException}
 import org.apache.kafka.common.metrics.Quota
 import org.apache.kafka.test.{TestUtils => JTestUtils}
-import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
+import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, immutable}
@@ -140,11 +140,10 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
 
   @Test
   def testMarkedDeletionTopicCreation(): Unit = {
-    val zkMock: KafkaZkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
+    val zkMock: KafkaZkClient = mock(classOf[KafkaZkClient])
     val topicPartition = new TopicPartition("test", 0)
     val topic = topicPartition.topic
-    EasyMock.expect(zkMock.isTopicMarkedForDeletion(topic)).andReturn(true);
-    EasyMock.replay(zkMock)
+    when(zkMock.isTopicMarkedForDeletion(topic)).thenReturn(true)
     val adminZkClient = new AdminZkClient(zkMock)
 
     assertThrows(classOf[TopicExistsException], () => adminZkClient.validateTopicCreate(topic, Map.empty, new Properties))
@@ -155,10 +154,9 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
     val topic = "test.topic"
 
     // simulate the ZK interactions that can happen when a topic is concurrently created by multiple processes
-    val zkMock: KafkaZkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
-    EasyMock.expect(zkMock.topicExists(topic)).andReturn(false)
-    EasyMock.expect(zkMock.getAllTopicsInCluster(false)).andReturn(Set("some.topic", topic, "some.other.topic"))
-    EasyMock.replay(zkMock)
+    val zkMock: KafkaZkClient = mock(classOf[KafkaZkClient])
+    when(zkMock.topicExists(topic)).thenReturn(false)
+    when(zkMock.getAllTopicsInCluster(false)).thenReturn(Set("some.topic", topic, "some.other.topic"))
     val adminZkClient = new AdminZkClient(zkMock)
 
     assertThrows(classOf[TopicExistsException], () => adminZkClient.validateTopicCreate(topic, Map.empty, new Properties))


### PR DESCRIPTION
Follow up from https://github.com/apache/kafka/pull/11672

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
