### PR TITLE
MINOR: make JoinGroupRequest and LeaveGroupRequest 'Reason' field ignorable

### DIFF
--- a/clients/src/main/resources/common/message/JoinGroupRequest.json
+++ b/clients/src/main/resources/common/message/JoinGroupRequest.json
@@ -57,7 +57,7 @@
       { "name": "Metadata", "type": "bytes", "versions": "0+",
         "about": "The protocol metadata." }
     ]},
-    { "name": "Reason", "type": "string", "versions": "8+", "nullableVersions": "8+", "default": "null",
+    { "name": "Reason", "type": "string", "versions": "8+", "nullableVersions": "8+", "default": "null", "ignorable": true,
       "about": "The reason why the member (re-)joins the group." }
   ]
 }

--- a/clients/src/main/resources/common/message/LeaveGroupRequest.json
+++ b/clients/src/main/resources/common/message/LeaveGroupRequest.json
@@ -40,7 +40,7 @@
         "versions": "3+", "nullableVersions": "3+", "default": "null",
         "about": "The group instance ID to remove from the group." },
       { "name": "Reason", "type": "string",
-        "versions": "5+", "nullableVersions": "5+", "default": "null",
+        "versions": "5+", "nullableVersions": "5+", "default": "null", "ignorable": true,
         "about": "The reason why the member left the group." }
     ]}
   ]


### PR DESCRIPTION
newer clients see errors when including reason in JoinGroupRequest to older broker:
```
Attempted to write a non-default reason at version 7. 
```
make reason field in JoinGroupRequest and LeaveGroupRequest ignorable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
