### PR TITLE
MINOR: remove version check when setting reason for Join/LeaveGroupRequest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1715,7 +1715,8 @@ public class RequestResponseTest {
             .setSessionTimeoutMs(30000)
             .setMemberId("consumer1")
             .setProtocolType("consumer")
-            .setProtocols(protocols);
+            .setProtocols(protocols)
+            .setReason("reason: test");
 
         // v1 and above contains rebalance timeout
         if (version >= 1)
@@ -1724,10 +1725,6 @@ public class RequestResponseTest {
         // v5 and above could set group instance id
         if (version >= 5)
             data.setGroupInstanceId("groupInstanceId");
-
-        // v8 and above can set reason
-        if (version >= 8)
-            data.setReason("reason: test");
 
         return new JoinGroupRequest.Builder(data).build(version);
     }
@@ -1841,10 +1838,7 @@ public class RequestResponseTest {
     }
 
     private LeaveGroupRequest createLeaveGroupRequest(short version) {
-        MemberIdentity member = new MemberIdentity().setMemberId("consumer1");
-        if (version >= 5) {
-            member.setReason("reason: test");
-        }
+        MemberIdentity member = new MemberIdentity().setMemberId("consumer1").setReason("reason: test");
         return new LeaveGroupRequest.Builder("group1", Collections.singletonList(member))
                 .build(version);
     }


### PR DESCRIPTION
set reason field for all api versions in `JOIN_GROUP` and `LEAVE_GROUP` to test cases where newer clients speak with older brokers.

confirmed that removing `"ignorable: true"` from the reason field fails the updated test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
