### PR TITLE
KAFKA-13524: Add IQv2 query handling to the caching layer

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -66,6 +66,7 @@ import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
 import org.apache.kafka.streams.query.StateQueryResult;
@@ -1842,7 +1843,7 @@ public class KafkaStreams implements AutoCloseable {
                                     request.isRequireActive()
                                         ? PositionBound.unbounded()
                                         : request.getPositionBound(),
-                                    request.executionInfoEnabled()
+                                    new QueryConfig(request.executionInfoEnabled())
                                 );
                                 result.addResult(partition, r);
                             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
@@ -21,8 +21,10 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.StoreToProcessorContextAdapter;
 import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 
 /**
@@ -141,15 +143,22 @@ public interface StateStore {
      * <p>
      * @param query The query to execute
      * @param positionBound The position the store must be at or past
-     * @param collectExecutionInfo Whether the store should collect detailed execution info for the query
+     * @param config Per query configuration parameters, such as whether the store should collect detailed execution
+     * info for the query
      * @param <R> The result type
      */
     @Evolving
     default <R> QueryResult<R> query(
         Query<R> query,
         PositionBound positionBound,
-        boolean collectExecutionInfo) {
+        QueryConfig config) {
         // If a store doesn't implement a query handler, then all queries are unknown.
         return QueryResult.forUnknownQueryType(query, this);
     }
+
+    /**
+     * Returns the position the state store is at
+     * @return
+     */
+    Position getPosition();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/query/KeyQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/KeyQuery.java
@@ -27,9 +27,11 @@ import java.util.Objects;
 public final class KeyQuery<K, V> implements Query<V> {
 
     private final K key;
+    private final boolean skipCache;
 
-    private KeyQuery(final K key) {
+    private KeyQuery(final K key, final boolean skipCache) {
         this.key = Objects.requireNonNull(key);
+        this.skipCache = skipCache;
     }
 
     /**
@@ -40,7 +42,15 @@ public final class KeyQuery<K, V> implements Query<V> {
      * @param <V> The type of the value that will be retrieved
      */
     public static <K, V> KeyQuery<K, V> withKey(final K key) {
-        return new KeyQuery<>(key);
+        return new KeyQuery<>(key, false);
+    }
+
+    /**
+     * Specifies that the cache should be skipped during query evaluation. This means, that the query will always
+     * get forwarded to the underlying store.
+     */
+    public KeyQuery<K, V> skipCache() {
+        return new KeyQuery<>(key, true);
     }
 
     /**
@@ -48,5 +58,12 @@ public final class KeyQuery<K, V> implements Query<V> {
      */
     public K getKey() {
         return key;
+    }
+
+    /**
+     * The flag whether to skip the cache or not during query evaluation.
+     */
+    public boolean isSkipCache() {
+        return skipCache;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.query;
+
+import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
+
+/**
+ * Runtime configuration parameters
+ */
+@Evolving
+public class QueryConfig {
+    final boolean collectExecutionInfo;
+
+    public QueryConfig(final boolean collectExecutionInfo) {
+        this.collectExecutionInfo = collectExecutionInfo;
+    }
+
+    public boolean isCollectExecutionInfo() {
+        return collectExecutionInfo;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -349,7 +349,8 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         return writeBatchMap;
     }
 
-    Position getPosition() {
+    @Override
+    public Position getPosition() {
         return position;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -123,7 +123,7 @@ public class CachingKeyValueStore
         mergedPosition.merge(wrapped().getPosition());
         return mergedPosition;
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public <R> QueryResult<R> query(final Query<R> query,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -26,7 +26,12 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
+import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.slf4j.Logger;
@@ -34,11 +39,14 @@ import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.state.internals.ExceptionUtils.executeAll;
 import static org.apache.kafka.streams.state.internals.ExceptionUtils.throwSuppressed;
@@ -56,10 +64,34 @@ public class CachingKeyValueStore
     private Thread streamThread;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private Position position;
+    private final boolean timestampedSchema;
 
-    CachingKeyValueStore(final KeyValueStore<Bytes, byte[]> underlying) {
+    @FunctionalInterface
+    public interface CacheQueryHandler {
+        QueryResult<?> apply(
+            final Query<?> query,
+            final Position mergedPosition,
+            final PositionBound positionBound,
+            final QueryConfig config,
+            final StateStore store
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final Map<Class, CacheQueryHandler> queryHandlers =
+        mkMap(
+            mkEntry(
+                KeyQuery.class,
+                (query, mergedPosition, positionBound, config, store) ->
+                    runKeyQuery(query, mergedPosition, positionBound, config)
+            )
+        );
+
+
+    CachingKeyValueStore(final KeyValueStore<Bytes, byte[]> underlying, final boolean timestampedSchema) {
         super(underlying);
         position = Position.emptyPosition();
+        this.timestampedSchema = timestampedSchema;
     }
 
     @Deprecated
@@ -83,8 +115,93 @@ public class CachingKeyValueStore
         streamThread = Thread.currentThread();
     }
 
-    Position getPosition() {
-        return position;
+    @Override
+    public Position getPosition() {
+        // We return the merged position since the query uses the merged position as well
+        final Position mergedPosition = Position.emptyPosition();
+        mergedPosition.merge(position);
+        mergedPosition.merge(wrapped().getPosition());
+        return mergedPosition;
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> QueryResult<R> query(final Query<R> query,
+                                    final PositionBound positionBound,
+                                    final QueryConfig config) {
+
+        final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+        final QueryResult<R> result;
+
+        final CacheQueryHandler handler = queryHandlers.get(query.getClass());
+        if (handler == null) {
+            result = wrapped().query(query, positionBound, config);
+
+        } else {
+            final int partition = context.taskId().partition();
+            final Lock lock = this.lock.readLock();
+            lock.lock();
+            try {
+                validateStoreOpen();
+                final Position mergedPosition = getPosition();
+
+                // We use the merged position since the cache and the store may be at different positions
+                if (!StoreQueryUtils.isPermitted(mergedPosition, positionBound, partition)) {
+                    result = QueryResult.notUpToBound(mergedPosition, positionBound, partition);
+                } else {
+                    result = (QueryResult<R>) handler.apply(
+                        query,
+                        mergedPosition,
+                        positionBound,
+                        config,
+                        this
+                    );
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+        if (config.isCollectExecutionInfo()) {
+            result.addExecutionInfo(
+                "Handled in " + getClass() + " in " + (System.nanoTime() - start) + "ns");
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <R> QueryResult<R> runKeyQuery(final Query<R> query,
+                                           final Position mergedPosition,
+                                           final PositionBound positionBound,
+                                           final QueryConfig config) {
+        QueryResult<R> result = null;
+        final KeyQuery<Bytes, byte[]> keyQuery = (KeyQuery<Bytes, byte[]>) query;
+
+        if (keyQuery.isSkipCache()) {
+            return wrapped().query(query, positionBound, config);
+        }
+
+        final Bytes key = keyQuery.getKey();
+
+        if (context.cache() != null) {
+            final LRUCacheEntry lruCacheEntry = context.cache().get(cacheName, key);
+            if (lruCacheEntry != null) {
+                final byte[] rawValue;
+                if (timestampedSchema && !WrappedStateStore.isTimestamped(wrapped())) {
+                    rawValue = ValueAndTimestampDeserializer.rawValue(lruCacheEntry.value());
+                } else {
+                    rawValue = lruCacheEntry.value();
+                }
+                result = (QueryResult<R>) QueryResult.forResult(rawValue);
+            }
+        }
+
+        // We don't need to check the position at the state store since we already performed the check on
+        // the merged position above
+        if (result == null) {
+            result = wrapped().query(query, PositionBound.unbounded(), config);
+        }
+        result.setPosition(mergedPosition);
+        return result;
     }
 
     private void initInternal(final InternalProcessorContext<?, ?> context) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
@@ -23,7 +23,6 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
-import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -36,11 +35,9 @@ public class ChangeLoggingKeyValueBytesStore
         implements KeyValueStore<Bytes, byte[]> {
 
     InternalProcessorContext context;
-    Position position;
 
     ChangeLoggingKeyValueBytesStore(final KeyValueStore<Bytes, byte[]> inner) {
         super(inner);
-        this.position = Position.emptyPosition();
     }
 
     @Deprecated
@@ -79,7 +76,6 @@ public class ChangeLoggingKeyValueBytesStore
     public void put(final Bytes key,
                     final byte[] value) {
         wrapped().put(key, value);
-        StoreQueryUtils.updatePosition(position, context);
         log(key, value);
     }
 
@@ -143,6 +139,6 @@ public class ChangeLoggingKeyValueBytesStore
     }
 
     void log(final Bytes key, final byte[] value) {
-        context.logChange(name(), key, value, context.timestamp(), position);
+        context.logChange(name(), key, value, context.timestamp(), wrapped().getPosition());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingListValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingListValueBytesStore.java
@@ -28,7 +28,6 @@ public class ChangeLoggingListValueBytesStore extends ChangeLoggingKeyValueBytes
     @Override
     public void put(final Bytes key, final byte[] value) {
         wrapped().put(key, value);
-        StoreQueryUtils.updatePosition(position, context);
         // the provided new value will be added to the list in the inner put()
         // we need to log the full new list and thus call get() on the inner store below
         // if the value is a tombstone, we delete the whole list and thus can save the get call

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
@@ -22,7 +22,6 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
-import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 
@@ -37,11 +36,9 @@ class ChangeLoggingSessionBytesStore
         implements SessionStore<Bytes, byte[]> {
 
     private InternalProcessorContext context;
-    private Position position;
 
     ChangeLoggingSessionBytesStore(final SessionStore<Bytes, byte[]> bytesStore) {
         super(bytesStore);
-        this.position = Position.emptyPosition();
     }
 
     @Deprecated
@@ -83,16 +80,14 @@ class ChangeLoggingSessionBytesStore
 
     @Override
     public void remove(final Windowed<Bytes> sessionKey) {
-        StoreQueryUtils.updatePosition(position, context);
         wrapped().remove(sessionKey);
-        context.logChange(name(), SessionKeySchema.toBinary(sessionKey), null, context.timestamp(), position);
+        context.logChange(name(), SessionKeySchema.toBinary(sessionKey), null, context.timestamp(), wrapped().getPosition());
     }
 
     @Override
     public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
-        StoreQueryUtils.updatePosition(position, context);
         wrapped().put(sessionKey, aggregate);
-        context.logChange(name(), SessionKeySchema.toBinary(sessionKey), aggregate, context.timestamp(), position);
+        context.logChange(name(), SessionKeySchema.toBinary(sessionKey), aggregate, context.timestamp(), wrapped().getPosition());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStore.java
@@ -32,9 +32,9 @@ public class ChangeLoggingTimestampedKeyValueBytesStore extends ChangeLoggingKey
     void log(final Bytes key,
              final byte[] valueAndTimestamp) {
         if (valueAndTimestamp != null) {
-            context.logChange(name(), key, rawValue(valueAndTimestamp), timestamp(valueAndTimestamp), position);
+            context.logChange(name(), key, rawValue(valueAndTimestamp), timestamp(valueAndTimestamp), wrapped().getPosition());
         } else {
-            context.logChange(name(), key, null, context.timestamp(), position);
+            context.logChange(name(), key, null, context.timestamp(), wrapped().getPosition());
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStore.java
@@ -33,9 +33,9 @@ class ChangeLoggingTimestampedWindowBytesStore extends ChangeLoggingWindowBytesS
     void log(final Bytes key,
              final byte[] valueAndTimestamp) {
         if (valueAndTimestamp != null) {
-            context.logChange(name(), key, rawValue(valueAndTimestamp), timestamp(valueAndTimestamp), position);
+            context.logChange(name(), key, rawValue(valueAndTimestamp), timestamp(valueAndTimestamp), wrapped().getPosition());
         } else {
-            context.logChange(name(), key, null, context.timestamp(), position);
+            context.logChange(name(), key, null, context.timestamp(), wrapped().getPosition());
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.processor.internals.StoreToProcessorContextAdapt
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -87,19 +88,19 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         return open;
     }
 
-    Position getPosition() {
+    public Position getPosition() {
         return position;
     }
 
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+                                    final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
             position,
             context

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
@@ -122,7 +123,8 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         this.stateStoreContext = context;
     }
 
-    Position getPosition() {
+    @Override
+    public Position getPosition() {
         return position;
     }
 
@@ -317,12 +319,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+                                    final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
             position,
             context

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStore;
@@ -123,7 +124,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         this.stateStoreContext = context;
     }
 
-    Position getPosition() {
+    @Override
+    public Position getPosition() {
         return position;
     }
 
@@ -353,12 +355,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+                                    final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
             position,
             stateStoreContext

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
@@ -52,7 +52,7 @@ public class KeyValueStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, KeyVa
         if (!enableCaching) {
             return inner;
         }
-        return new CachingKeyValueStore(inner);
+        return new CachingKeyValueStore(inner, false);
     }
 
     private KeyValueStore<Bytes, byte[]> maybeWrapLogging(final KeyValueStore<Bytes, byte[]> inner) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
@@ -22,8 +22,10 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -122,18 +124,23 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final QueryConfig config) {
 
 
-        final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-        final QueryResult<R> result = store.query(query, positionBound, collectExecutionInfo);
-        if (collectExecutionInfo) {
+        final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+        final QueryResult<R> result = store.query(query, positionBound, config);
+        if (config.isCollectExecutionInfo()) {
             final long end = System.nanoTime();
             result.addExecutionInfo(
                 "Handled in " + getClass() + " in " + (end - start) + "ns"
             );
         }
         return result;
+    }
+
+    @Override
+    public Position getPosition() {
+        return store.getPosition();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ListValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ListValueStoreBuilder.java
@@ -51,7 +51,7 @@ public class ListValueStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, KeyV
         if (!enableCaching) {
             return inner;
         }
-        return new CachingKeyValueStore(inner);
+        return new CachingKeyValueStore(inner, false);
     }
 
     private KeyValueStore<Bytes, byte[]> maybeWrapLogging(final KeyValueStore<Bytes, byte[]> inner) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
 
     protected StateStoreContext context;
-    protected Position position = Position.emptyPosition();
+    private Position position = Position.emptyPosition();
 
     public interface EldestEntryRemovalListener {
         void apply(Bytes key, byte[] value);
@@ -110,6 +110,11 @@ public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
     @Override
     public boolean isOpen() {
         return open;
+    }
+
+    @Override
+    public Position getPosition() {
+        return position;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
@@ -116,14 +117,14 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
-            position,
+            getPosition(),
             context
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.WindowRangeQuery;
 import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
@@ -76,7 +77,7 @@ public class MeteredSessionStore<K, V>
             mkMap(
                     mkEntry(
                             WindowRangeQuery.class,
-                            (query, positionBound, collectExecutionInfo, store) -> runRangeQuery(query, positionBound, collectExecutionInfo)
+                            (query, positionBound, config, store) -> runRangeQuery(query, positionBound, config)
                     )
             );
 
@@ -405,14 +406,14 @@ public class MeteredSessionStore<K, V>
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+                                    final QueryConfig config) {
         final long start = time.nanoseconds();
         final QueryResult<R> result;
 
         final QueryHandler handler = queryHandlers.get(query.getClass());
         if (handler == null) {
-            result = wrapped().query(query, positionBound, collectExecutionInfo);
-            if (collectExecutionInfo) {
+            result = wrapped().query(query, positionBound, config);
+            if (config.isCollectExecutionInfo()) {
                 result.addExecutionInfo(
                     "Handled in " + getClass() + " in " + (time.nanoseconds() - start) + "ns");
             }
@@ -420,10 +421,10 @@ public class MeteredSessionStore<K, V>
             result = (QueryResult<R>) handler.apply(
                 query,
                 positionBound,
-                collectExecutionInfo,
+                config,
                 this
             );
-            if (collectExecutionInfo) {
+            if (config.isCollectExecutionInfo()) {
                 result.addExecutionInfo(
                     "Handled in " + getClass() + " with serdes "
                         + serdes + " in " + (time.nanoseconds() - start) + "ns");
@@ -435,7 +436,7 @@ public class MeteredSessionStore<K, V>
     @SuppressWarnings("unchecked")
     private <R> QueryResult<R> runRangeQuery(final Query<R> query,
                                              final PositionBound positionBound,
-                                             final boolean collectExecutionInfo) {
+                                             final QueryConfig config) {
         final QueryResult<R> result;
         final WindowRangeQuery<K, V> typedQuery = (WindowRangeQuery<K, V>) query;
         if (typedQuery.getKey().isPresent()) {
@@ -444,7 +445,7 @@ public class MeteredSessionStore<K, V>
                     Bytes.wrap(serdes.rawKey(typedQuery.getKey().get()))
                 );
             final QueryResult<KeyValueIterator<Windowed<Bytes>, byte[]>> rawResult =
-                wrapped().query(rawKeyQuery, positionBound, collectExecutionInfo);
+                wrapped().query(rawKeyQuery, positionBound, config);
             if (rawResult.isSuccess()) {
                 final MeteredWindowedKeyValueIterator<K, V> typedResult =
                     new MeteredWindowedKeyValueIterator<>(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
@@ -46,19 +47,20 @@ public class RocksDBSessionStore
         this.stateStoreContext = context;
     }
 
-    Position getPosition() {
+    @Override
+    public Position getPosition() {
         return position;
     }
 
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+                                    final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
             position,
             stateStoreContext

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -33,6 +33,7 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -330,12 +331,12 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
             position,
             context
@@ -741,7 +742,8 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         return userSpecifiedOptions;
     }
 
-    Position getPosition() {
+    @Override
+    public Position getPosition() {
         return position;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStore;
@@ -55,7 +56,8 @@ public class RocksDBWindowStore
         this.stateStoreContext = context;
     }
 
-    Position getPosition() {
+    @Override
+    public Position getPosition() {
         return position;
     }
 
@@ -131,12 +133,12 @@ public class RocksDBWindowStore
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
-                                    final boolean collectExecutionInfo) {
+                                    final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
-            collectExecutionInfo,
+            config,
             this,
             position,
             stateStoreContext

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
@@ -24,8 +24,10 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -78,7 +80,7 @@ public class TimestampedKeyValueStoreBuilder<K, V>
         if (!enableCaching) {
             return inner;
         }
-        return new CachingKeyValueStore(inner);
+        return new CachingKeyValueStore(inner, true);
     }
 
     private KeyValueStore<Bytes, byte[]> maybeWrapLogging(final KeyValueStore<Bytes, byte[]> inner) {
@@ -190,15 +192,20 @@ public class TimestampedKeyValueStoreBuilder<K, V>
         @Override
         public <R> QueryResult<R> query(final Query<R> query,
             final PositionBound positionBound,
-            final boolean collectExecutionInfo) {
+            final QueryConfig config) {
 
-            final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-            final QueryResult<R> result = wrapped.query(query, positionBound, collectExecutionInfo);
-            if (collectExecutionInfo) {
+            final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+            final QueryResult<R> result = wrapped.query(query, positionBound, config);
+            if (config.isCollectExecutionInfo()) {
                 final long end = System.nanoTime();
                 result.addExecutionInfo("Handled in " + getClass() + " in " + (end - start) + "ns");
             }
             return result;
+        }
+
+        @Override
+        public Position getPosition() {
+            return wrapped.getPosition();
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
@@ -23,8 +23,10 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
@@ -208,15 +210,20 @@ public class TimestampedWindowStoreBuilder<K, V>
         @Override
         public <R> QueryResult<R> query(final Query<R> query,
             final PositionBound positionBound,
-            final boolean collectExecutionInfo) {
+            final QueryConfig config) {
 
-            final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-            final QueryResult<R> result = wrapped.query(query, positionBound, collectExecutionInfo);
-            if (collectExecutionInfo) {
+            final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+            final QueryResult<R> result = wrapped.query(query, positionBound, config);
+            if (config.isCollectExecutionInfo()) {
                 final long end = System.nanoTime();
                 result.addExecutionInfo("Handled in " + getClass() + " in " + (end - start) + "ns");
             }
             return result;
+        }
+
+        @Override
+        public Position getPosition() {
+            return wrapped.getPosition();
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
@@ -67,7 +67,6 @@ class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<V
 
     static byte[] rawValue(final byte[] rawValueAndTimestamp) {
         final int rawValueLength = rawValueAndTimestamp.length - 8;
-
         return ByteBuffer
             .allocate(rawValueLength)
             .put(rawValueAndTimestamp, 8, rawValueLength)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowToTimestampedWindowByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowToTimestampedWindowByteStoreAdapter.java
@@ -21,8 +21,10 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStore;
@@ -190,17 +192,22 @@ class WindowToTimestampedWindowByteStoreAdapter implements WindowStore<Bytes, by
     public <R> QueryResult<R> query(
         final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final QueryConfig config) {
 
-        final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-        final QueryResult<R> result = store.query(query, positionBound, collectExecutionInfo);
-        if (collectExecutionInfo) {
+        final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+        final QueryResult<R> result = store.query(query, positionBound, config);
+        if (config.isCollectExecutionInfo()) {
             final long end = System.nanoTime();
             result.addExecutionInfo(
                 "Handled in " + getClass() + " in " + (end - start) + "ns"
             );
         }
         return result;
+    }
+
+    @Override
+    public Position getPosition() {
+        return store.getPosition();
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -20,8 +20,10 @@ import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 
@@ -109,17 +111,22 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
     @Override
     public <R> QueryResult<R> query(final Query<R> query,
         final PositionBound positionBound,
-        final boolean collectExecutionInfo) {
+        final QueryConfig config) {
 
-        final long start = collectExecutionInfo ? System.nanoTime() : -1L;
-        final QueryResult<R> result = wrapped().query(query, positionBound, collectExecutionInfo);
-        if (collectExecutionInfo) {
+        final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+        final QueryResult<R> result = wrapped().query(query, positionBound, config);
+        if (config.isCollectExecutionInfo()) {
             final long end = System.nanoTime();
             result.addExecutionInfo(
                 "Handled in " + getClass() + " via WrappedStateStore" + " in " + (end - start)
                     + "ns");
         }
         return result;
+    }
+
+    @Override
+    public Position getPosition() {
+        return wrapped.getPosition();
     }
 
     public S wrapped() {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -377,6 +377,11 @@ public class IQv2IntegrationTest {
                         }
 
                         @Override
+                        public Position getPosition() {
+                            throw new UnsupportedOperationException("Position handling not implemented");
+                        }
+
+                        @Override
                         public byte[] get(final Bytes key) {
                             return map.get(key);
                         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -52,6 +52,7 @@ import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.internals.StoreQueryUtils;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -315,19 +316,24 @@ public class IQv2IntegrationTest {
                     return new KeyValueStore<Bytes, byte[]>() {
                         private boolean open = false;
                         private Map<Bytes, byte[]> map = new HashMap<>();
+                        private Position position;
+                        private StateStoreContext context;
 
                         @Override
                         public void put(final Bytes key, final byte[] value) {
                             map.put(key, value);
+                            StoreQueryUtils.updatePosition(position,  context);
                         }
 
                         @Override
                         public byte[] putIfAbsent(final Bytes key, final byte[] value) {
+                            StoreQueryUtils.updatePosition(position,  context);
                             return map.putIfAbsent(key, value);
                         }
 
                         @Override
                         public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+                            StoreQueryUtils.updatePosition(position,  context);
                             for (final KeyValue<Bytes, byte[]> entry : entries) {
                                 map.put(entry.key, entry.value);
                             }
@@ -335,6 +341,7 @@ public class IQv2IntegrationTest {
 
                         @Override
                         public byte[] delete(final Bytes key) {
+                            StoreQueryUtils.updatePosition(position,  context);
                             return map.remove(key);
                         }
 
@@ -353,6 +360,8 @@ public class IQv2IntegrationTest {
                         public void init(final StateStoreContext context, final StateStore root) {
                             context.register(root, (key, value) -> put(Bytes.wrap(key), value));
                             this.open = true;
+                            this.position = Position.emptyPosition();
+                            this.context = context;
                         }
 
                         @Override
@@ -378,7 +387,7 @@ public class IQv2IntegrationTest {
 
                         @Override
                         public Position getPosition() {
-                            throw new UnsupportedOperationException("Position handling not implemented");
+                            return position;
                         }
 
                         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/NoOpWindowStore.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/NoOpWindowStore.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.query.Position;
 
 import java.util.NoSuchElementException;
 
@@ -78,6 +79,11 @@ public class NoOpWindowStore implements ReadOnlyWindowStore, StateStore {
     @Override
     public boolean isOpen() {
         return false;
+    }
+
+    @Override
+    public Position getPosition() {
+        throw new UnsupportedOperationException("Position handling not implemented");
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -75,7 +75,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         final String storeName = "store";
         underlyingStore = new InMemoryKeyValueStore(storeName);
         cacheFlushListener = new CacheFlushListenerStub<>(new StringDeserializer(), new StringDeserializer());
-        store = new CachingKeyValueStore(underlyingStore);
+        store = new CachingKeyValueStore(underlyingStore, false);
         store.setFlushListener(cacheFlushListener, false);
         cache = new ThreadCache(new LogContext("testCache "), maxCacheSizeBytes, new MockStreamsMetrics(new Metrics()));
         context = new InternalMockProcessorContext<>(null, null, null, null, cache);
@@ -106,7 +106,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldDelegateDeprecatedInit() {
         final KeyValueStore<Bytes, byte[]> inner = EasyMock.mock(InMemoryKeyValueStore.class);
-        final CachingKeyValueStore outer = new CachingKeyValueStore(inner);
+        final CachingKeyValueStore outer = new CachingKeyValueStore(inner, false);
         EasyMock.expect(inner.name()).andStubReturn("store");
         inner.init((ProcessorContext) context, outer);
         EasyMock.expectLastCall();
@@ -118,7 +118,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldDelegateInit() {
         final KeyValueStore<Bytes, byte[]> inner = EasyMock.mock(InMemoryKeyValueStore.class);
-        final CachingKeyValueStore outer = new CachingKeyValueStore(inner);
+        final CachingKeyValueStore outer = new CachingKeyValueStore(inner, false);
         EasyMock.expect(inner.name()).andStubReturn("store");
         inner.init((StateStoreContext) context, outer);
         EasyMock.expectLastCall();
@@ -202,7 +202,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         EasyMock.expect(underlyingStore.name()).andStubReturn("store-name");
         EasyMock.expect(underlyingStore.isOpen()).andStubReturn(true);
         EasyMock.replay(underlyingStore);
-        store = new CachingKeyValueStore(underlyingStore);
+        store = new CachingKeyValueStore(underlyingStore, false);
         cache = EasyMock.niceMock(ThreadCache.class);
         context = new InternalMockProcessorContext<>(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, new RecordHeaders()));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
@@ -58,6 +58,8 @@ public class ChangeLoggingSessionBytesStoreTest {
     private final Bytes bytesKey = Bytes.wrap(value1);
     private final Windowed<Bytes> key1 = new Windowed<>(bytesKey, new SessionWindow(0, 0));
 
+    private final static Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
+
     @Before
     public void setUp() {
         store = new ChangeLoggingSessionBytesStore(inner);
@@ -94,6 +96,7 @@ public class ChangeLoggingSessionBytesStoreTest {
 
     @Test
     public void shouldLogPuts() {
+        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
         inner.put(key1, value1);
         EasyMock.expectLastCall();
 
@@ -113,6 +116,7 @@ public class ChangeLoggingSessionBytesStoreTest {
 
     @Test
     public void shouldLogPutsWithPosition() {
+        EasyMock.expect(inner.getPosition()).andReturn(POSITION).anyTimes();
         inner.put(key1, value1);
         EasyMock.expectLastCall();
 
@@ -124,8 +128,7 @@ public class ChangeLoggingSessionBytesStoreTest {
         final RecordMetadata recordContext = new ProcessorRecordContext(0L, 1L, 0, "", new RecordHeaders());
         EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.of(recordContext));
         EasyMock.expect(context.timestamp()).andStubReturn(0L);
-        final Position position = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
-        context.logChange(store.name(), binaryKey, value1, 0L, position);
+        context.logChange(store.name(), binaryKey, value1, 0L, POSITION);
 
         EasyMock.replay(context);
         store.put(key1, value1);
@@ -135,6 +138,7 @@ public class ChangeLoggingSessionBytesStoreTest {
 
     @Test
     public void shouldLogRemoves() {
+        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
         inner.remove(key1);
         EasyMock.expectLastCall();
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStoreTest.java
@@ -58,6 +58,7 @@ public class ChangeLoggingTimestampedWindowBytesStoreTest {
     private ProcessorContextImpl context;
     private ChangeLoggingTimestampedWindowBytesStore store;
 
+    private final static Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
 
     @Before
     public void setUp() {
@@ -97,6 +98,7 @@ public class ChangeLoggingTimestampedWindowBytesStoreTest {
     @Test
     @SuppressWarnings("deprecation")
     public void shouldLogPuts() {
+        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
         inner.put(bytesKey, valueAndTimestamp, 0);
         EasyMock.expectLastCall();
 
@@ -116,6 +118,7 @@ public class ChangeLoggingTimestampedWindowBytesStoreTest {
 
     @Test
     public void shouldLogPutsWithPosition() {
+        EasyMock.expect(inner.getPosition()).andReturn(POSITION).anyTimes();
         inner.put(bytesKey, valueAndTimestamp, 0);
         EasyMock.expectLastCall();
 
@@ -163,6 +166,7 @@ public class ChangeLoggingTimestampedWindowBytesStoreTest {
     @SuppressWarnings("deprecation")
     public void shouldRetainDuplicatesWhenSet() {
         store = new ChangeLoggingTimestampedWindowBytesStore(inner, true);
+        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
         inner.put(bytesKey, valueAndTimestamp, 0);
         EasyMock.expectLastCall().times(2);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
@@ -57,6 +57,8 @@ public class ChangeLoggingWindowBytesStoreTest {
     private ProcessorContextImpl context;
     private ChangeLoggingWindowBytesStore store;
 
+    private final static Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
+
     @Before
     public void setUp() {
         store = new ChangeLoggingWindowBytesStore(inner, false, WindowKeySchema::toStoreKeyBinary);
@@ -94,6 +96,7 @@ public class ChangeLoggingWindowBytesStoreTest {
 
     @Test
     public void shouldLogPuts() {
+        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
         inner.put(bytesKey, value, 0);
         EasyMock.expectLastCall();
 
@@ -114,6 +117,7 @@ public class ChangeLoggingWindowBytesStoreTest {
 
     @Test
     public void shouldLogPutsWithPosition() {
+        EasyMock.expect(inner.getPosition()).andReturn(POSITION).anyTimes();
         inner.put(bytesKey, value, 0);
         EasyMock.expectLastCall();
 
@@ -185,7 +189,7 @@ public class ChangeLoggingWindowBytesStoreTest {
     @Test
     public void shouldRetainDuplicatesWhenSet() {
         store = new ChangeLoggingWindowBytesStore(inner, true, WindowKeySchema::toStoreKeyBinary);
-
+        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
         inner.put(bytesKey, value, 0);
         EasyMock.expectLastCall().times(2);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -397,6 +398,11 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
     @Override
     public boolean isOpen() {
         return open;
+    }
+
+    @Override
+    public Position getPosition() {
+        throw new UnsupportedOperationException("Position handling not implemented");
     }
 
     void setOpen(final boolean open) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class StoreQueryUtilsTest {
         final QueryResult<Integer> queryResult = StoreQueryUtils.handleBasicQueries(
             query,
             PositionBound.at(position),
-            false,
+            new QueryConfig(false),
             store,
             position,
             null
@@ -67,7 +68,7 @@ public class StoreQueryUtilsTest {
         final QueryResult<Integer> queryResult = StoreQueryUtils.handleBasicQueries(
             query,
             PositionBound.at(Position.emptyPosition().withComponent("topic", 0, 1)),
-            false,
+            new QueryConfig(false),
             store,
             Position.emptyPosition().withComponent("topic", 0, 0),
             context

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -87,6 +88,11 @@ public class MockKeyValueStore implements KeyValueStore<Object, Object> {
     @Override
     public boolean isOpen() {
         return !closed;
+    }
+
+    @Override
+    public Position getPosition() {
+        throw new UnsupportedOperationException("Position handling not implemented");
     }
 
     public final StateRestoreCallback stateRestoreCallback = new StateRestoreCallback() {

--- a/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
@@ -19,6 +19,7 @@ package org.apache.kafka.test;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 
@@ -106,6 +107,11 @@ public class NoOpReadOnlyStore<K, V> implements ReadOnlyKeyValueStore<K, V>, Sta
     @Override
     public boolean isOpen() {
         return open;
+    }
+
+    @Override
+    public Position getPosition() {
+        throw new UnsupportedOperationException("Position handling not implemented");
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
 
@@ -206,6 +207,11 @@ public class ReadOnlySessionStoreStub<K, V> implements ReadOnlySessionStore<K, V
     @Override
     public boolean isOpen() {
         return open;
+    }
+
+    @Override
+    public Position getPosition() {
+        throw new UnsupportedOperationException("Position handling not implemented");
     }
 
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -71,6 +71,7 @@ import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.internals.namedtopology.TopologyConfig.TaskConfig;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -1237,6 +1238,11 @@ public class TopologyTestDriver implements Closeable {
         public boolean isOpen() {
             return inner.isOpen();
         }
+
+        @Override
+        public Position getPosition() {
+            return inner.getPosition();
+        }
     }
 
     static class WindowStoreFacade<K, V> extends ReadOnlyWindowStoreFacade<K, V> implements WindowStore<K, V> {
@@ -1330,6 +1336,11 @@ public class TopologyTestDriver implements Closeable {
         @Override
         public boolean isOpen() {
             return inner.isOpen();
+        }
+
+        @Override
+        public Position getPosition() {
+            return inner.getPosition();
         }
     }
 


### PR DESCRIPTION
Currently, IQv2 forwards all queries to the underlying store. We add this bypass to allow handling of key queries in the cache. If a key exists in the cache, it will get answered from there.
As part of this PR, we realized we need access to the position of the underlying stores. So, I added the method `getPosition` to the public API and ensured all state stores implement it. Only the "leaf" stores (Rocks*, InMemory*) have an actual position, all wrapping stores access their wrapped store's position. 

Ran IQv2StoreIntegrationTest

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
