### PR TITLE
KAFKA-6502: Update consumed offsets on corrupted records.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.util.Objects;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.header.Headers;
 
 /**
  * This class represents a version of a {@link StampedRecord} that failed to deserialize. We need
@@ -27,46 +26,14 @@ import org.apache.kafka.common.header.Headers;
  */
 public class CorruptedRecord extends StampedRecord {
 
-    private final ConsumerRecord<byte[], byte[]> rawRecord;
-
     CorruptedRecord(final ConsumerRecord<byte[], byte[]> rawRecord) {
-        super(null, ConsumerRecord.NO_TIMESTAMP);
-        this.rawRecord = rawRecord;
-    }
-
-    @Override
-    public String topic() {
-        return rawRecord.topic();
-    }
-
-    @Override
-    public int partition() {
-        return rawRecord.partition();
-    }
-
-    @Override
-    public byte[] key() {
-        return rawRecord.key();
-    }
-
-    @Override
-    public byte[] value() {
-        return rawRecord.value();
-    }
-
-    public long offset() {
-        return rawRecord.offset();
-    }
-
-    @Override
-    public Headers headers() {
-        return rawRecord.headers();
+        super(rawRecord, ConsumerRecord.NO_TIMESTAMP);
     }
 
     @Override
     public String toString() {
         return "CorruptedRecord(" +
-            "rawRecord = " + rawRecord +
+            "value = " + value +
             ")";
     }
 
@@ -82,11 +49,11 @@ public class CorruptedRecord extends StampedRecord {
             return false;
         }
         final CorruptedRecord that = (CorruptedRecord) o;
-        return Objects.equals(rawRecord, that.rawRecord);
+        return Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), rawRecord);
+        return Objects.hash(value);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/CorruptedRecord.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.Objects;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * This class represents a version of a {@link StampedRecord} that failed to deserialize. We need
+ * a special record type so that {@link StreamTask} can update consumed offsets. See KAFKA-6502
+ * for more details.
+ */
+public class CorruptedRecord extends StampedRecord {
+
+    private final ConsumerRecord<byte[], byte[]> rawRecord;
+
+    CorruptedRecord(final ConsumerRecord<byte[], byte[]> rawRecord) {
+        super(null, ConsumerRecord.NO_TIMESTAMP);
+        this.rawRecord = rawRecord;
+    }
+
+    @Override
+    public String topic() {
+        return rawRecord.topic();
+    }
+
+    @Override
+    public int partition() {
+        return rawRecord.partition();
+    }
+
+    @Override
+    public byte[] key() {
+        return rawRecord.key();
+    }
+
+    @Override
+    public byte[] value() {
+        return rawRecord.value();
+    }
+
+    public long offset() {
+        return rawRecord.offset();
+    }
+
+    @Override
+    public Headers headers() {
+        return rawRecord.headers();
+    }
+
+    @Override
+    public String toString() {
+        return "CorruptedRecord(" +
+            "rawRecord = " + rawRecord +
+            ")";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final CorruptedRecord that = (CorruptedRecord) o;
+        return Objects.equals(rawRecord, that.rawRecord);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), rawRecord);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
@@ -19,9 +19,9 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 
-public class StampedRecord extends Stamped<ConsumerRecord<Object, Object>> {
+public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
-    public StampedRecord(final ConsumerRecord<Object, Object> record, final long timestamp) {
+    public StampedRecord(final ConsumerRecord<?, ?> record, final long timestamp) {
         super(record, timestamp);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -704,33 +704,12 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             }
         }
 
-
         try {
-            // process the record by passing to the source node of the topology
-            final ProcessorNode<Object, Object, Object, Object> currNode = (ProcessorNode<Object, Object, Object, Object>) recordInfo.node();
             final TopicPartition partition = recordInfo.partition();
 
-            log.trace("Start processing one record [{}]", record);
-
-            final ProcessorRecordContext recordContext = new ProcessorRecordContext(
-                record.timestamp,
-                record.offset(),
-                record.partition(),
-                record.topic(),
-                record.headers()
-            );
-            updateProcessorContext(currNode, wallClockTime, recordContext);
-
-            maybeRecordE2ELatency(record.timestamp, wallClockTime, currNode.name());
-            final Record<Object, Object> toProcess = new Record<>(
-                record.key(),
-                record.value(),
-                processorContext.timestamp(),
-                processorContext.headers()
-            );
-            maybeMeasureLatency(() -> currNode.process(toProcess), time, processLatencySensor);
-
-            log.trace("Completed processing one record [{}]", record);
+            if (!(record instanceof CorruptedRecord)) {
+                doProcess(wallClockTime);
+            }
 
             // update the consumed offset map after processing is done
             consumedOffsets.put(partition, record.offset());
@@ -774,6 +753,33 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         }
 
         return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void doProcess(final long wallClockTime) {
+        // process the record by passing to the source node of the topology
+        final ProcessorNode<Object, Object, Object, Object> currNode = (ProcessorNode<Object, Object, Object, Object>) recordInfo.node();
+        log.trace("Start processing one record [{}]", record);
+
+        final ProcessorRecordContext recordContext = new ProcessorRecordContext(
+            record.timestamp,
+            record.offset(),
+            record.partition(),
+            record.topic(),
+            record.headers()
+        );
+        updateProcessorContext(currNode, wallClockTime, recordContext);
+
+        maybeRecordE2ELatency(record.timestamp, wallClockTime, currNode.name());
+        final Record<Object, Object> toProcess = new Record<>(
+            record.key(),
+            record.value(),
+            processorContext.timestamp(),
+            processorContext.headers()
+        );
+        maybeMeasureLatency(() -> currNode.process(toProcess), time, processLatencySensor);
+
+        log.trace("Completed processing one record [{}]", record);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -292,23 +292,28 @@ public class RecordQueueTest {
     @Test
     public void shouldNotThrowStreamsExceptionWhenKeyDeserializationFailsWithSkipHandler() {
         final byte[] key = Serdes.Long().serializer().serialize("foo", 1L);
-        final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(
-            new ConsumerRecord<>("topic", 1, 1, 0L, TimestampType.CREATE_TIME, 0, 0, key, recordValue,
-                new RecordHeaders(), Optional.empty()));
+        final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("topic", 1, 1, 0L,
+            TimestampType.CREATE_TIME, 0, 0, key, recordValue,
+            new RecordHeaders(), Optional.empty());
+        final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(record);
 
         queueThatSkipsDeserializeErrors.addRawRecords(records);
-        assertEquals(0, queueThatSkipsDeserializeErrors.size());
+        assertEquals(1, queueThatSkipsDeserializeErrors.size());
+        assertEquals(new CorruptedRecord(record), queueThatSkipsDeserializeErrors.poll());
     }
 
     @Test
     public void shouldNotThrowStreamsExceptionWhenValueDeserializationFailsWithSkipHandler() {
         final byte[] value = Serdes.Long().serializer().serialize("foo", 1L);
+        final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("topic", 1, 1, 0L,
+            TimestampType.CREATE_TIME, 0, 0, recordKey, value,
+            new RecordHeaders(), Optional.empty());
         final List<ConsumerRecord<byte[], byte[]>> records = Collections.singletonList(
-            new ConsumerRecord<>("topic", 1, 1, 0L, TimestampType.CREATE_TIME, 0, 0, recordKey, value,
-                new RecordHeaders(), Optional.empty()));
+            record);
 
         queueThatSkipsDeserializeErrors.addRawRecords(records);
-        assertEquals(0, queueThatSkipsDeserializeErrors.size());
+        assertEquals(1, queueThatSkipsDeserializeErrors.size());
+        assertEquals(new CorruptedRecord(record), queueThatSkipsDeserializeErrors.poll());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -45,6 +45,8 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
+import org.apache.kafka.streams.errors.LogAndFailExceptionHandler;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
@@ -225,6 +227,13 @@ public class StreamTaskTest {
     }
 
     private static StreamsConfig createConfig(final String eosConfig, final String enforcedProcessingValue) {
+        return createConfig(eosConfig, enforcedProcessingValue, LogAndFailExceptionHandler.class.getName());
+    }
+
+    private static StreamsConfig createConfig(
+        final String eosConfig,
+        final String enforcedProcessingValue,
+        final String deserializationExceptionHandler) {
         final String canonicalPath;
         try {
             canonicalPath = BASE_DIR.getCanonicalPath();
@@ -238,7 +247,8 @@ public class StreamTaskTest {
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, canonicalPath),
             mkEntry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName()),
             mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, eosConfig),
-            mkEntry(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, enforcedProcessingValue)
+            mkEntry(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, enforcedProcessingValue),
+            mkEntry(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, deserializationExceptionHandler)
         )));
     }
 
@@ -2221,12 +2231,92 @@ public class StreamTaskTest {
     }
 
     @Test
-    public void shouldCLearTaskTimeout() {
+    public void shouldClearTaskTimeout() {
         task = createStatelessTask(createConfig());
 
         task.maybeInitTaskTimeoutOrThrow(0L, null);
         task.clearTaskTimeout();
         task.maybeInitTaskTimeoutOrThrow(Duration.ofMinutes(5).plus(Duration.ofMillis(1L)).toMillis(), null);
+    }
+
+    @Test
+    public void shouldUpdateOffsetIfAllRecordsAreCorrupted() {
+        task = createStatelessTask(createConfig(AT_LEAST_ONCE,
+            "0",
+            LogAndContinueExceptionHandler.class.getName()));
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+
+        long offset = -1;
+        final List<ConsumerRecord<byte[], byte[]>> records = asList(
+            getCorruptedConsumerRecordWithOffsetAsTimestamp(++offset),
+            getCorruptedConsumerRecordWithOffsetAsTimestamp(++offset));
+        consumer.addRecord(records.get(0));
+        consumer.addRecord(records.get(1));
+        consumer.poll(Duration.ZERO);
+        task.addRecords(partition1, records);
+
+        assertTrue(task.process(offset));
+        assertTrue(task.commitNeeded());
+        assertThat(task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1,
+                new OffsetAndMetadata(offset + 1, encodeTimestamp(-1))))));
+    }
+
+    @Test
+    public void shouldUpdateOffsetIfValidRecordFollowsCorrupted() {
+        task = createStatelessTask(createConfig(AT_LEAST_ONCE,
+            "0",
+            LogAndContinueExceptionHandler.class.getName()));
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+
+        long offset = -1;
+
+        final List<ConsumerRecord<byte[], byte[]>> records = asList(
+            getCorruptedConsumerRecordWithOffsetAsTimestamp(++offset),
+            getConsumerRecordWithOffsetAsTimestamp(partition1, ++offset));
+        consumer.addRecord(records.get(0));
+        consumer.addRecord(records.get(1));
+        consumer.poll(Duration.ZERO);
+        task.addRecords(partition1, records);
+
+        assertTrue(task.process(offset));
+        assertTrue(task.commitNeeded());
+        assertThat(task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1,
+                new OffsetAndMetadata(offset + 1, encodeTimestamp(offset))))));
+    }
+
+    @Test
+    public void shouldUpdateOffsetIfCorruptedRecordFollowsValid() {
+        task = createStatelessTask(createConfig(AT_LEAST_ONCE,
+            "0",
+            LogAndContinueExceptionHandler.class.getName()));
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+
+        long offset = -1;
+
+        final List<ConsumerRecord<byte[], byte[]>> records = asList(
+            getConsumerRecordWithOffsetAsTimestamp(partition1, ++offset),
+            getCorruptedConsumerRecordWithOffsetAsTimestamp(++offset));
+        consumer.addRecord(records.get(0));
+        consumer.addRecord(records.get(1));
+        consumer.poll(Duration.ZERO);
+        task.addRecords(partition1, records);
+
+        assertTrue(task.process(offset));
+        assertTrue(task.commitNeeded());
+        assertThat(task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1,
+                new OffsetAndMetadata(1, encodeTimestamp(0))))));
+
+        assertTrue(task.process(offset));
+        assertTrue(task.commitNeeded());
+        assertThat(task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1,
+                new OffsetAndMetadata(2, encodeTimestamp(0))))));
     }
 
     private List<MetricName> getTaskMetrics() {
@@ -2579,6 +2669,22 @@ public class StreamTaskTest {
             0,
             new IntegerSerializer().serialize(topic1, key),
             recordValue,
+            new RecordHeaders(),
+            Optional.empty()
+        );
+    }
+
+    private ConsumerRecord<byte[], byte[]> getCorruptedConsumerRecordWithOffsetAsTimestamp(final long offset) {
+        return new ConsumerRecord<>(
+            topic1,
+            1,
+            offset,
+            offset, // use the offset as the timestamp
+            TimestampType.CREATE_TIME,
+            -1,
+            -1,
+            new byte[0],
+            "I am not an integer.".getBytes(),
             new RecordHeaders(),
             Optional.empty()
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2241,9 +2241,11 @@ public class StreamTaskTest {
 
     @Test
     public void shouldUpdateOffsetIfAllRecordsAreCorrupted() {
-        task = createStatelessTask(createConfig(AT_LEAST_ONCE,
+        task = createStatelessTask(createConfig(
+            AT_LEAST_ONCE,
             "0",
-            LogAndContinueExceptionHandler.class.getName()));
+            LogAndContinueExceptionHandler.class.getName()
+        ));
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
 
@@ -2258,16 +2260,19 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1,
-                new OffsetAndMetadata(offset + 1, encodeTimestamp(-1))))));
+        assertThat(
+            task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(offset + 1, encodeTimestamp(-1)))))
+        );
     }
 
     @Test
     public void shouldUpdateOffsetIfValidRecordFollowsCorrupted() {
-        task = createStatelessTask(createConfig(AT_LEAST_ONCE,
+        task = createStatelessTask(createConfig(
+            AT_LEAST_ONCE,
             "0",
-            LogAndContinueExceptionHandler.class.getName()));
+            LogAndContinueExceptionHandler.class.getName()
+        ));
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
 
@@ -2283,14 +2288,16 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1,
-                new OffsetAndMetadata(offset + 1, encodeTimestamp(offset))))));
+        assertThat(
+            task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(offset + 1, encodeTimestamp(offset)))))
+        );
     }
 
     @Test
     public void shouldUpdateOffsetIfCorruptedRecordFollowsValid() {
-        task = createStatelessTask(createConfig(AT_LEAST_ONCE,
+        task = createStatelessTask(createConfig(
+            AT_LEAST_ONCE,
             "0",
             LogAndContinueExceptionHandler.class.getName()));
         task.initializeIfNeeded();
@@ -2308,15 +2315,17 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1,
-                new OffsetAndMetadata(1, encodeTimestamp(0))))));
+        assertThat(
+            task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(1, encodeTimestamp(0)))))
+        );
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(task.prepareCommit(),
-            equalTo(mkMap(mkEntry(partition1,
-                new OffsetAndMetadata(2, encodeTimestamp(0))))));
+        assertThat(
+            task.prepareCommit(),
+            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(2, encodeTimestamp(0)))))
+        );
     }
 
     private List<MetricName> getTaskMetrics() {


### PR DESCRIPTION
Without this patch, `RecordQueue` just skips records that failed to
deserialize when `DeserializationExceptionHandler` is set to
`LogAndContinueExceptionHandler`. This way, if the entire stream consists
of corrupted records, the task never updated consumed offsets.

This patch introduces a new record type - `CorruptedRecord` that
wraps a raw record that failed to deserialize. `RecordQueue`'s `headRecord`
becomes `CorruptedRecord` if there were records in the `fifoQueue` and all
of them failed to deserialize. In turn, `StreamTask#process` checks that
a found record is not corrupted before processing it. If the record is
an instance of `CorruptedRecord`, it updates the offset, sets `commitNeeded`
to `true` and returns.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
