### PR TITLE
Fixed documentation and handles null topicPartition for KAFKA-12841

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -28,8 +28,7 @@ public interface Callback {
      * metadata will contain the special -1 value for all fields except for topicPartition, which will be valid.
      *
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
-     *                 with -1 value for all fields will be returned if an error occurred.  If the topicPartition was
-     *                 not set, a -1 value will be used.
+     *                 with -1 value for all fields will be returned if an error occurred.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      *                  Possible thrown exceptions include:
      *

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -25,11 +25,11 @@ public interface Callback {
     /**
      * A callback method the user can implement to provide asynchronous handling of request completion. This method will
      * be called when the record sent to the server has been acknowledged. When exception is not null in the callback,
-     * metadata will contain the special -1 value for all fields.
+     * metadata will contain the special -1 value for all fields. If topicPartition cannot be
+     * choosen, a -1 value will be assigned.
      *
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
-     *                 with -1 value for all fields will be returned if an error occurred.  If topicPartition cannot be
-     *                 choosen, a -1 value will be assigned.
+     *                 with -1 value for all fields will be returned if an error occurred.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      *                  Possible thrown exceptions include:
      *

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -25,7 +25,8 @@ public interface Callback {
     /**
      * A callback method the user can implement to provide asynchronous handling of request completion. This method will
      * be called when the record sent to the server has been acknowledged. When exception is not null in the callback,
-     * metadata will contain the special -1 value for all fields.
+     * metadata will contain the special -1 value for all fields. If topicPartition cannot be
+     * choosen, a -1 value will be assigned.
      *
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
      *                 with -1 value for all fields will be returned if an error occurred.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -28,7 +28,8 @@ public interface Callback {
      * metadata will contain the special -1 value for all fields except for topicPartition, which will be valid.
      *
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
-     *                 with -1 value for all fields except for topicPartition will be returned if an error occurred.
+     *                 with -1 value for all fields will be returned if an error occurred.  If the topicPartition was
+     *                 not set, a -1 value will be used.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      *                  Possible thrown exceptions include:
      *

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -25,7 +25,7 @@ public interface Callback {
     /**
      * A callback method the user can implement to provide asynchronous handling of request completion. This method will
      * be called when the record sent to the server has been acknowledged. When exception is not null in the callback,
-     * metadata will contain the special -1 value for all fields except for topicPartition, which will be valid.
+     * metadata will contain the special -1 value for all fields.
      *
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
      *                 with -1 value for all fields will be returned if an error occurred.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -28,7 +28,8 @@ public interface Callback {
      * metadata will contain the special -1 value for all fields.
      *
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset). An empty metadata
-     *                 with -1 value for all fields will be returned if an error occurred.
+     *                 with -1 value for all fields will be returned if an error occurred.  If topicPartition cannot be
+     *                 choosen, a -1 value will be assigned.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      *                  Possible thrown exceptions include:
      *

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -997,9 +997,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             log.debug("Exception occurred during message send:", e);
             // producer callback will make sure to call both 'callback' and interceptor callback
             if (tp == null) {
-                // This isn't the best option, but if we failed before we could create a TopicPartition, we need to give
-                // *something* to the callback, so at least let's provide the topic and the requested partition, if
-                // available, and if not, set it to a known invalid value.
+                // set topicPartition to -1 when null
                 tp = ProducerInterceptors.createTopicPartition(record);
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -998,7 +998,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             // producer callback will make sure to call both 'callback' and interceptor callback
             if (tp == null) {
                 // set topicPartition to -1 when null
-                tp = ProducerInterceptors.createTopicPartition(record);
+                tp = ProducerInterceptors.extractTopicPartition(record);
             }
 
             Callback interceptCallback = new InterceptorCallback<>(callback, this.interceptors, tp);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -995,8 +995,19 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             // for other exceptions throw directly
         } catch (ApiException e) {
             log.debug("Exception occurred during message send:", e);
-            if (callback != null)
-                callback.onCompletion(null, e);
+            // producer callback will make sure to call both 'callback' and interceptor callback
+            if (tp == null) {
+                // This isn't the best option, but if we failed before we could create a TopicPartition, we need to give
+                // *something* to the callback, so at least let's provide the topic and the requested partition, if
+                // available, and if not, set it to a known invalid value.
+                tp = ProducerInterceptors.createTopicPartition(record);
+            }
+
+            Callback interceptCallback = new InterceptorCallback<>(callback, this.interceptors, tp);
+
+            // The onCompletion callback does expect a non-null metadata, but one will be created inside
+            // the interceptor's onCompletion implementation before the user's callback is invoked.
+            interceptCallback.onCompletion(null, e);
             this.errors.record();
             this.interceptors.onSendError(record, tp, e);
             return new FutureFailure(e);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -110,8 +110,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                     interceptor.onAcknowledgement(null, exception);
                 } else {
                     if (interceptTopicPartition == null) {
-                        interceptTopicPartition = new TopicPartition(record.topic(),
-                                record.partition() == null ? RecordMetadata.UNKNOWN_PARTITION : record.partition());
+                        interceptTopicPartition = createTopicPartition(record);
                     }
                     interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1,
                                     RecordBatch.NO_TIMESTAMP, -1, -1), exception);
@@ -121,6 +120,10 @@ public class ProducerInterceptors<K, V> implements Closeable {
                 log.warn("Error executing interceptor onAcknowledgement callback", e);
             }
         }
+    }
+
+    public static <K, V> TopicPartition createTopicPartition(ProducerRecord<K, V> record) {
+        return new TopicPartition(record.topic(), record.partition() == null ? RecordMetadata.UNKNOWN_PARTITION : record.partition());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -110,7 +110,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                     interceptor.onAcknowledgement(null, exception);
                 } else {
                     if (interceptTopicPartition == null) {
-                        interceptTopicPartition = createTopicPartition(record);
+                        interceptTopicPartition = extractTopicPartition(record);
                     }
                     interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1,
                                     RecordBatch.NO_TIMESTAMP, -1, -1), exception);
@@ -122,7 +122,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
         }
     }
 
-    public static <K, V> TopicPartition createTopicPartition(ProducerRecord<K, V> record) {
+    public static <K, V> TopicPartition extractTopicPartition(ProducerRecord<K, V> record) {
         return new TopicPartition(record.topic(), record.partition() == null ? RecordMetadata.UNKNOWN_PARTITION : record.partition());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1530,19 +1530,9 @@ public class KafkaProducerTest {
                 assertNotNull(exception);
                 assertNotNull(recordMetadata);
 
-                try {
-                    assertNotNull(recordMetadata.topic());
-                } catch (NullPointerException e) {
-                    fail("Topic name should be valid even on send failure", e);
-                }
-
+                assertNotNull(recordMetadata.topic(), "Topic name should be valid even on send failure");
                 assertEquals(invalidTopicName, recordMetadata.topic());
-
-                try {
-                    assertEquals(RecordMetadata.UNKNOWN_PARTITION, recordMetadata.partition());
-                } catch (NullPointerException e) {
-                    fail("Partition should be valid even on send failure", e);
-                }
+                assertNotNull(recordMetadata.partition(), "Partition should be valid even on send failure");
 
                 assertFalse(recordMetadata.hasOffset());
                 assertEquals(ProduceResponse.INVALID_OFFSET, recordMetadata.offset());

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1530,19 +1530,9 @@ public class KafkaProducerTest {
                 assertNotNull(exception);
                 assertNotNull(recordMetadata);
 
-                try {
-                    assertNotNull(recordMetadata.topic());
-                } catch (NullPointerException e) {
-                    fail("Topic name should be valid even on send failure", e);
-                }
-
+                assertNotNull(recordMetadata.topic(), "Topic name should be valid even on send failure");
                 assertEquals(invalidTopicName, recordMetadata.topic());
-
-                try {
-                    assertEquals(RecordMetadata.UNKNOWN_PARTITION, recordMetadata.partition());
-                } catch (NullPointerException e) {
-                    fail("Partition should be valid even on send failure", e);
-                }
+                assertNotNull( recordMetadata.partition(), "Partition should be valid even on send failure");
 
                 assertFalse(recordMetadata.hasOffset());
                 assertEquals(ProduceResponse.INVALID_OFFSET, recordMetadata.offset());

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1542,6 +1542,7 @@ public class KafkaProducerTest {
 
                 assertEquals(-1, recordMetadata.serializedKeySize());
                 assertEquals(-1, recordMetadata.serializedValueSize());
+                assertEquals(-1, recordMetadata.partition());
             };
 
             producer.send(record, callBack);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.network.Selectable;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
 import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
@@ -57,6 +58,7 @@ import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.InitProducerIdResponse;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
@@ -1504,6 +1506,58 @@ public class KafkaProducerTest {
         // send a record with null topic should fail
         assertThrows(IllegalArgumentException.class, () -> new ProducerRecord<>(null, 1,
             "key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testCallbackHandlesError() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000");
+
+        Time time = new MockTime();
+        ProducerMetadata producerMetadata = newMetadata(0, Long.MAX_VALUE);
+        MockClient client = new MockClient(time, producerMetadata);
+
+        String invalidTopicName = "topic abc"; // Invalid topic name due to space
+
+        try (Producer<String, String> producer = kafkaProducer(configs, new StringSerializer(), new StringSerializer(),
+                producerMetadata, client, null, time)) {
+            ProducerRecord<String, String> record = new ProducerRecord<>(invalidTopicName, "HelloKafka");
+
+            // Here's the important piece of the test. Let's make sure that the RecordMetadata we get
+            // is non-null and adheres to the onCompletion contract.
+            Callback callBack = (recordMetadata, exception) -> {
+                assertNotNull(exception);
+                exception.printStackTrace();
+
+                assertNotNull(recordMetadata);
+
+                try {
+                    assertNotNull(recordMetadata.topic());
+                } catch (NullPointerException e) {
+                    fail("Topic name should be valid even on send failure", e);
+                }
+
+                assertEquals(invalidTopicName, recordMetadata.topic());
+
+                try {
+                    assertEquals(RecordMetadata.UNKNOWN_PARTITION, recordMetadata.partition());
+                } catch (NullPointerException e) {
+                    fail("Partition should be valid even on send failure", e);
+                }
+
+                assertFalse(recordMetadata.hasOffset());
+                assertEquals(ProduceResponse.INVALID_OFFSET, recordMetadata.offset());
+
+                assertFalse(recordMetadata.hasTimestamp());
+                assertEquals(RecordBatch.NO_TIMESTAMP, recordMetadata.timestamp());
+
+                assertEquals(-1, recordMetadata.serializedKeySize());
+                assertEquals(-1, recordMetadata.serializedValueSize());
+            };
+
+            producer.send(record, callBack);
+        }
     }
 
     private static final List<String> CLIENT_IDS = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1528,8 +1528,6 @@ public class KafkaProducerTest {
             // is non-null and adheres to the onCompletion contract.
             Callback callBack = (recordMetadata, exception) -> {
                 assertNotNull(exception);
-                exception.printStackTrace();
-
                 assertNotNull(recordMetadata);
 
                 try {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-12841

Using the `InterceptorCallback` wrapper in the case of `ApiException` so that we will adhere correctly to the `Callback` contract for `onCompletion` specifying a valid (dummy) `TopicPartition`.   Removed some documentation from Callback.java that stated "except topicPartition" as we are assigning -1 to the topicPartition if it doesn't exist.  The changes is based on https://issues.apache.org/jira/browse/KAFKA-3303

### Committer Checklist (excluded from commit message)
 * [ ]  Verify design and implementation
 * [ ]  Verify test coverage and CI build status
 * [ ]  Verify documentation (including upgrade notes)
 
