### PR TITLE
KAFKA-13599: Upgrade RocksDB to 6.27.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -105,7 +105,7 @@ versions += [
   netty: "4.1.68.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
-  rocksDB: "6.22.1.1",
+  rocksDB: "6.27.3",
   scalaCollectionCompat: "2.4.4",
   scalafmt: "2.7.5",
   scalaJava8Compat : "1.0.0",

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -1685,6 +1685,10 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
         return this;
     }
 
+    //
+    // BEGIN options for blobs (integrated BlobDB)
+    //
+    
     @Override
     public Options setEnableBlobFiles(final boolean enableBlobFiles) {
         columnFamilyOptions.setEnableBlobFiles(enableBlobFiles);
@@ -1761,6 +1765,10 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
     public double blobGarbageCollectionForceThreshold() {
         return columnFamilyOptions.blobGarbageCollectionForceThreshold();
     }
+
+    //
+    // END options for blobs (integrated BlobDB)
+    //
 
     @Override
     public void close() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -1553,6 +1553,17 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
     }
 
     @Override
+    public Options setPeriodicCompactionSeconds(final long periodicCompactionSeconds) {
+        columnFamilyOptions.setPeriodicCompactionSeconds(periodicCompactionSeconds);
+        return this;
+    }
+
+    @Override
+    public long periodicCompactionSeconds() {
+        return columnFamilyOptions.periodicCompactionSeconds();
+    }
+
+    @Override
     public Options setAtomicFlush(final boolean atomicFlush) {
         dbOptions.setAtomicFlush(atomicFlush);
         return this;
@@ -1662,14 +1673,93 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
         return columnFamilyOptions.compactionThreadLimiter();
     }
 
+    @Override
     public Options setCompactionFilter(final AbstractCompactionFilter<? extends AbstractSlice<?>> compactionFilter) {
         columnFamilyOptions.setCompactionFilter(compactionFilter);
         return this;
     }
 
+    @Override
     public Options setCompactionFilterFactory(final AbstractCompactionFilterFactory<? extends AbstractCompactionFilter<?>> compactionFilterFactory) {
         columnFamilyOptions.setCompactionFilterFactory(compactionFilterFactory);
         return this;
+    }
+
+    @Override
+    public Options setEnableBlobFiles(final boolean enableBlobFiles) {
+        columnFamilyOptions.setEnableBlobFiles(enableBlobFiles);
+        return this;
+    }
+
+    @Override
+    public boolean enableBlobFiles() {
+        return columnFamilyOptions.enableBlobFiles();
+    }
+
+    @Override
+    public Options setMinBlobSize(final long minBlobSize) {
+        columnFamilyOptions.setMinBlobSize(minBlobSize);
+        return this;
+    }
+
+    @Override
+    public long minBlobSize() {
+        return columnFamilyOptions.minBlobSize();
+    }
+
+    @Override
+    public Options setBlobFileSize(final long blobFileSize) {
+        columnFamilyOptions.setBlobFileSize(blobFileSize);
+        return this;
+    }
+
+    @Override
+    public long blobFileSize() {
+        return columnFamilyOptions.blobFileSize();
+    }
+
+    @Override
+    public Options setBlobCompressionType(final CompressionType compressionType) {
+        columnFamilyOptions.setBlobCompressionType(compressionType);
+        return this;
+    }
+
+    @Override
+    public CompressionType blobCompressionType() {
+        return columnFamilyOptions.blobCompressionType();
+    }
+
+    @Override
+    public Options setEnableBlobGarbageCollection(final boolean enableBlobGarbageCollection) {
+        columnFamilyOptions.setEnableBlobGarbageCollection(enableBlobGarbageCollection);
+        return this;
+    }
+
+    @Override
+    public boolean enableBlobGarbageCollection() {
+        return columnFamilyOptions.enableBlobGarbageCollection();
+    }
+
+    @Override
+    public Options setBlobGarbageCollectionAgeCutoff(final double blobGarbageCollectionAgeCutoff) {
+        columnFamilyOptions.setBlobGarbageCollectionAgeCutoff(blobGarbageCollectionAgeCutoff);
+        return this;
+    }
+
+    @Override
+    public double blobGarbageCollectionAgeCutoff() {
+        return columnFamilyOptions.blobGarbageCollectionAgeCutoff();
+    }
+
+    @Override
+    public Options setBlobGarbageCollectionForceThreshold(final double blobGarbageCollectionForceThreshold) {
+        columnFamilyOptions.setBlobGarbageCollectionForceThreshold(blobGarbageCollectionForceThreshold);
+        return this;
+    }
+
+    @Override
+    public double blobGarbageCollectionForceThreshold() {
+        return columnFamilyOptions.blobGarbageCollectionForceThreshold();
     }
 
     @Override


### PR DESCRIPTION
RocksDB v6.27.3 has been released and it is the first release to support s390x. RocksDB is currently the only dependency in gradle/dependencies.gradle without s390x support.

RocksDB v6.27.3 has added some new options that require an update to streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java but no other changes are needed to upgrade.

I have run the unit/integration tests locally on s390x and also the :streams tests on x86_64 and they pass.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
