### PR TITLE
MINOR: Upgrade jetty-server to 9.4.44.v20210927

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,7 +69,7 @@ versions += [
   jackson: "2.12.3",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",
-  jetty: "9.4.43.v20210629",
+  jetty: "9.4.44.v20210927",
   jersey: "2.34",
   jline: "3.12.1",
   jmh: "1.32",


### PR DESCRIPTION
Release notes: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.44.v20210927

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
