### PR TITLE
MINOR: RegisterBroker should use an atomic append

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -252,7 +252,7 @@ public class ClusterControlManager {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         records.add(new ApiMessageAndVersion(record,
             REGISTER_BROKER_RECORD.highestSupportedVersion()));
-        return ControllerResult.of(records, new BrokerRegistrationReply(brokerEpoch));
+        return ControllerResult.atomicOf(records, new BrokerRegistrationReply(brokerEpoch));
     }
 
     public void replay(RegisterBrokerRecord record) {


### PR DESCRIPTION
The batch of records that registers a new broker should be committed atomically. This doesn't matter
right now, because we only create a single record to register the broker. But if we create multiple
records in the future, this could matter. In order to avoid confusion, this should use
ControllerResult#atomicOf.