### PR TITLE
MINOR: fix NPE in iqv2

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
@@ -74,14 +74,22 @@ public interface QueryResult<R> {
     static <R> QueryResult<R> notUpToBound(
         final Position currentPosition,
         final PositionBound positionBound,
-        final int partition) {
+        final Integer partition) {
 
-        return new FailedQueryResult<>(
-            FailureReason.NOT_UP_TO_BOUND,
-            "For store partition " + partition + ", the current position "
-                + currentPosition + " is not yet up to the bound "
-                + positionBound
-        );
+        if (partition == null) {
+            return new FailedQueryResult<>(
+                FailureReason.NOT_UP_TO_BOUND,
+                "The store is not initialized yet, so it is not yet up to the bound "
+                    + positionBound
+            );
+        } else {
+            return new FailedQueryResult<>(
+                FailureReason.NOT_UP_TO_BOUND,
+                "For store partition " + partition + ", the current position "
+                    + currentPosition + " is not yet up to the bound "
+                    + positionBound
+            );
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -102,7 +102,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
             collectExecutionInfo,
             this,
             position,
-            context.taskId().partition()
+            context
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -325,7 +325,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
             collectExecutionInfo,
             this,
             position,
-            context.taskId().partition()
+            context
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -361,7 +361,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
             collectExecutionInfo,
             this,
             position,
-            context.taskId().partition()
+            stateStoreContext
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -133,7 +133,7 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
             collectExecutionInfo,
             this,
             position,
-            context.taskId().partition()
+            context
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -61,7 +61,7 @@ public class RocksDBSessionStore
             collectExecutionInfo,
             this,
             position,
-            stateStoreContext.taskId().partition()
+            stateStoreContext
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -338,7 +338,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             collectExecutionInfo,
             this,
             position,
-            context.taskId().partition()
+            context
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -139,7 +139,7 @@ public class RocksDBWindowStore
             collectExecutionInfo,
             this,
             position,
-            stateStoreContext.taskId().partition()
+            stateStoreContext
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -97,7 +97,7 @@ public final class StoreQueryUtils {
         final boolean collectExecutionInfo,
         final StateStore store,
         final Position position,
-        final int partition
+        final StateStoreContext context
     ) {
 
         final long start = collectExecutionInfo ? System.nanoTime() : -1L;
@@ -106,8 +106,12 @@ public final class StoreQueryUtils {
         final QueryHandler handler = QUERY_HANDLER_MAP.get(query.getClass());
         if (handler == null) {
             result = QueryResult.forUnknownQueryType(query, store);
-        } else if (!isPermitted(position, positionBound, partition)) {
-            result = QueryResult.notUpToBound(position, positionBound, partition);
+        } else if (context == null || !isPermitted(position, positionBound, context.taskId().partition())) {
+            result = QueryResult.notUpToBound(
+                position,
+                positionBound,
+                context == null ? null : context.taskId().partition()
+            );
         } else {
             result = (QueryResult<R>) handler.apply(
                 query,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.KeyQuery;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class StoreQueryUtilsTest {
+
+    @Test
+    public void shouldReturnErrorOnNullContext() {
+        final Query query = Mockito.mock(KeyQuery.class);
+        final StateStore store = Mockito.mock(KeyValueStore.class);
+        final Position position = Position.emptyPosition().withComponent("topic", 0, 1);
+        final QueryResult queryResult = StoreQueryUtils.handleBasicQueries(
+            query,
+            PositionBound.at(position),
+            false,
+            store,
+            position,
+            null
+        );
+        assertThat(queryResult.isFailure(), is(true));
+        assertThat(queryResult.getFailureReason(), is(FailureReason.NOT_UP_TO_BOUND));
+        assertThat(
+            queryResult.getFailureMessage(),
+            is("The store is not initialized yet, so it is not yet up to the bound"
+                   + " PositionBound{position=Position{position={topic={0=1}}}}")
+        );
+    }
+
+    @Test
+    public void shouldReturnErrorOnBoundViolation() {
+        final Query query = Mockito.mock(KeyQuery.class);
+        final StateStore store = Mockito.mock(KeyValueStore.class);
+        final StateStoreContext context = Mockito.mock(StateStoreContext.class);
+        Mockito.when(context.taskId()).thenReturn(new TaskId(0, 0));
+        final QueryResult queryResult = StoreQueryUtils.handleBasicQueries(
+            query,
+            PositionBound.at(Position.emptyPosition().withComponent("topic", 0, 1)),
+            false,
+            store,
+            Position.emptyPosition().withComponent("topic", 0, 0),
+            context
+        );
+
+        assertThat(queryResult.isFailure(), is(true));
+        assertThat(queryResult.getFailureReason(), is(FailureReason.NOT_UP_TO_BOUND));
+        assertThat(
+            queryResult.getFailureMessage(),
+            is("For store partition 0, the current position Position{position={topic={0=0}}}"
+                   + " is not yet up to the bound"
+                   + " PositionBound{position=Position{position={topic={0=1}}}}")
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
@@ -16,17 +16,14 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
-import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -37,10 +34,12 @@ public class StoreQueryUtilsTest {
 
     @Test
     public void shouldReturnErrorOnNullContext() {
-        final Query query = Mockito.mock(KeyQuery.class);
-        final StateStore store = Mockito.mock(KeyValueStore.class);
+        @SuppressWarnings("unchecked") final KeyQuery<String, Integer> query =
+            Mockito.mock(KeyQuery.class);
+        @SuppressWarnings("unchecked") final KeyValueStore<String, Integer> store =
+            Mockito.mock(KeyValueStore.class);
         final Position position = Position.emptyPosition().withComponent("topic", 0, 1);
-        final QueryResult queryResult = StoreQueryUtils.handleBasicQueries(
+        final QueryResult<Integer> queryResult = StoreQueryUtils.handleBasicQueries(
             query,
             PositionBound.at(position),
             false,
@@ -59,11 +58,13 @@ public class StoreQueryUtilsTest {
 
     @Test
     public void shouldReturnErrorOnBoundViolation() {
-        final Query query = Mockito.mock(KeyQuery.class);
-        final StateStore store = Mockito.mock(KeyValueStore.class);
+        @SuppressWarnings("unchecked") final KeyQuery<String, Integer> query =
+            Mockito.mock(KeyQuery.class);
+        @SuppressWarnings("unchecked") final KeyValueStore<String, Integer> store =
+            Mockito.mock(KeyValueStore.class);
         final StateStoreContext context = Mockito.mock(StateStoreContext.class);
         Mockito.when(context.taskId()).thenReturn(new TaskId(0, 0));
-        final QueryResult queryResult = StoreQueryUtils.handleBasicQueries(
+        final QueryResult<Integer> queryResult = StoreQueryUtils.handleBasicQueries(
             query,
             PositionBound.at(Position.emptyPosition().withComponent("topic", 0, 1)),
             false,


### PR DESCRIPTION
There is a brief window between when the store is registered and when
it is initialized when it might handle a query, but there is no context.
We treat this condition just like a store that hasn't caught up to the
desired position yet.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
