### PR TITLE
KAFKA-13607 Fix of the empty values to be treated as if they were absent

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -271,6 +271,11 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
 
     // Visibility to override for testing
     protected SecurityStore createKeystore(String type, String path, Password password, Password keyPassword, Password privateKey, Password certificateChain) {
+        path = nullify(path);
+        password = nullify(password);
+        keyPassword = nullify(keyPassword);
+        privateKey = nullify(privateKey);
+        certificateChain = nullify(certificateChain);
         if (privateKey != null) {
             if (!PEM_TYPE.equals(type))
                 throw new InvalidConfigurationException("SSL private key can be specified only for PEM, but key store type is " + type + ".");
@@ -302,6 +307,9 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
     }
 
     private static SecurityStore createTruststore(String type, String path, Password password, Password trustStoreCerts) {
+        path = nullify(path);
+        password = nullify(password);
+        trustStoreCerts = nullify(trustStoreCerts);
         if (trustStoreCerts != null) {
             if (!PEM_TYPE.equals(type))
                 throw new InvalidConfigurationException("SSL trust store certs can be specified only for PEM, but trust store type is " + type + ".");
@@ -322,6 +330,22 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
             return new FileBasedStore(type, path, password, null, false);
         } else
             return null;
+    }
+
+    private static String nullify(String string) {
+        if (string == null || "".equals(string)) {
+            return null;
+        } else {
+            return string;
+        }
+    }
+
+    private static Password nullify(Password password) {
+        if (password == null || "".equals(password.value())) {
+            return null;
+        } else {
+            return password;
+        }
     }
 
     interface SecurityStore {


### PR DESCRIPTION
Added normalization to the input parameters of the createKeystore and createTruststore

After the change the empty string values of path and passwords are treated as null. The change
allows the existing entries to be replaced with empty values.

The scenario is when the final configuration of a client (consumer, producer or admin) is defined as a template
and then refined with specific values. In particular in mTLS configuration the template may specify
JKS/PKCS12 keystore, but the final configuration uses KIP-651 PEM coded strings.
