### PR TITLE
MINOR: fix testDescribeUnderMinIsrPartitionsMixed

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandIntegrationTest.scala
@@ -682,9 +682,9 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
       val output = TestUtils.grabConsoleOutput(
         topicService.describeTopic(new TopicCommandOptions(Array("--under-min-isr-partitions"))))
       val rows = output.split("\n")
+      assertEquals(2, rows.length)
       assertTrue(rows(0).startsWith(s"\tTopic: $underMinIsrTopic"))
       assertTrue(rows(1).startsWith(s"\tTopic: $offlineTopic"))
-      assertEquals(2, rows.length)
     } finally {
       restartDeadBrokers()
     }


### PR DESCRIPTION
We should assert row.length before reading row(0) and row(1); Otherwise we could get an ArrayIndexOutOfBoundsException out of blue which is not easy to read
