### PR TITLE
MINOR: MiniTrogdorCluster mutates objects from other threads

### DIFF
--- a/trogdor/src/test/java/org/apache/kafka/trogdor/common/MiniTrogdorCluster.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/common/MiniTrogdorCluster.java
@@ -66,19 +66,19 @@ public class MiniTrogdorCluster implements AutoCloseable {
 
         private static class NodeData {
             String hostname;
-            AgentRestResource agentRestResource = null;
-            JsonRestServer agentRestServer = null;
+            volatile AgentRestResource agentRestResource = null;
+            volatile JsonRestServer agentRestServer = null;
             int agentPort = 0;
 
-            JsonRestServer coordinatorRestServer = null;
+            volatile JsonRestServer coordinatorRestServer = null;
             int coordinatorPort = 0;
-            CoordinatorRestResource coordinatorRestResource = null;
+            volatile CoordinatorRestResource coordinatorRestResource = null;
 
-            Platform platform = null;
-            Agent agent = null;
-            Coordinator coordinator = null;
+            volatile Platform platform = null;
+            volatile Agent agent = null;
+            volatile Coordinator coordinator = null;
 
-            BasicNode node = null;
+            volatile BasicNode node = null;
         }
 
         public Builder() {


### PR DESCRIPTION
MiniTrogdorCluster spins up agents from a different thread when
scheduling them, but does not use volatiles in these objects. It's not
clear that the updated fields are visible.

The hope is that this will fix a failure where it test becomes stuck waiting for MiniTrogdorCluster to shutdown:
```
	Suppressed: java.lang.InterruptedException
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2088)
		at java.util.concurrent.ThreadPoolExecutor.awaitTermination(ThreadPoolExecutor.java:1475)
		at java.util.concurrent.Executors$DelegatedExecutorService.awaitTermination(Executors.java:675)
		at org.apache.kafka.trogdor.coordinator.TaskManager.waitForShutdown(TaskManager.java:699)
		at org.apache.kafka.trogdor.coordinator.Coordinator.waitForShutdown(Coordinator.java:133)
		at org.apache.kafka.trogdor.common.MiniTrogdorCluster.close(MiniTrogdorCluster.java:289)
		at org.apache.kafka.trogdor.coordinator.CoordinatorTest.testTaskRequestWithOldStartMsGetsUpdated(CoordinatorTest.java:595)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
		at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
		at org.junit.jupiter.engine.extension.TimeoutInvocation.proceed(TimeoutInvocation.java:46)
```