### PR TITLE
MINOR: handle appending to configuration values that are empty better

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -495,10 +495,7 @@ object ConfigAdminManager {
         case OpType.APPEND => {
           if (!listType(alterConfigOp.configEntry.name, configKeys))
             throw new InvalidRequestException(s"Config value append is not allowed for config key: ${alterConfigOp.configEntry.name}")
-          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry.name))
-            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
-            .getOrElse("")
-            .split(",").toList
+          val oldValueList = getConfigPropertyAsList(configProps, configKeys, configPropName)
           val newValueList = oldValueList ::: alterConfigOp.configEntry.value.split(",").toList
           configProps.setProperty(alterConfigOp.configEntry.name, newValueList.mkString(","))
         }
@@ -514,5 +511,17 @@ object ConfigAdminManager {
         }
       }
     }
+  }
+
+  def getConfigPropertyAsList(
+    configProps: Properties,
+    configKeys: Map[String, ConfigKey],
+    configPropName: String
+  ): List[String] = {
+    Option(configProps.getProperty(configPropName))
+      .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
+      .filter(_.trim.nonEmpty)
+      .map(_.split(",").toList)
+      .getOrElse(List.empty)
   }
 }


### PR DESCRIPTION
If a configuration value is empty or contains only whitespace, appending to it should not result in
a comma getting added to the configuration value. So, for example, adding "first" to " " should
result in "first", not " ,first". Fix this and add a unit test.