### PR TITLE
MINOR: Fix bug of empty position in windowed and session stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -22,7 +22,6 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
-import org.apache.kafka.streams.query.RangeQuery;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,14 +118,6 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
         final PositionBound positionBound,
         final boolean collectExecutionInfo) {
 
-        if (query instanceof RangeQuery) {
-            final RangeQuery<Bytes, byte[]> typedQuery = (RangeQuery<Bytes, byte[]>) query;
-            final KeyValueIterator<Bytes, byte[]> keyValueIterator = this.range(
-                    typedQuery.getLowerBound().orElse(null), typedQuery.getUpperBound().orElse(null));
-            final R result = (R) keyValueIterator;
-            final QueryResult<R> queryResult = QueryResult.forResult(result);
-            return queryResult;
-        }
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -39,6 +39,7 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.WindowRangeQuery;
+import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StateSerdes;
@@ -455,7 +456,7 @@ public class MeteredSessionStore<K, V>
                         time
                     );
                 final QueryResult<MeteredWindowedKeyValueIterator<K, V>> typedQueryResult =
-                    QueryResult.forResult(typedResult);
+                    InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);
                 result = (QueryResult<R>) typedQueryResult;
             } else {
                 // the generic type doesn't matter, since failed queries have no result set.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.WindowKeyQuery;
 import org.apache.kafka.streams.query.WindowRangeQuery;
+import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.WindowStore;
@@ -426,9 +427,7 @@ public class MeteredWindowStore<K, V>
                         time
                     );
                 final QueryResult<MeteredWindowedKeyValueIterator<K, V>> typedQueryResult =
-                    QueryResult.forResult(
-                        typedResult
-                    );
+                    InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);
                 result = (QueryResult<R>) typedQueryResult;
             } else {
                 // the generic type doesn't matter, since failed queries have no result set.
@@ -477,9 +476,7 @@ public class MeteredWindowStore<K, V>
                     time
                 );
                 final QueryResult<MeteredWindowStoreIterator<V>> typedQueryResult =
-                    QueryResult.forResult(
-                        typedResult
-                    );
+                    InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);
                 queryResult = (QueryResult<R>) typedQueryResult;
             } else {
                 // the generic type doesn't matter, since failed queries have no result set.

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -101,6 +101,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -133,6 +135,10 @@ public class IQv2StoreIntegrationTest {
         (RECORD_TIME / WINDOW_SIZE.toMillis()) * WINDOW_SIZE.toMillis();
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    private static final Position POSITION_0 =
+        Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 1L)))));
+    private static final Position POSITION_BOTH =
+        Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 1L), mkEntry(1, 1L)))));
 
     public static class UnknownQuery implements Query<Void> { }
 
@@ -1065,9 +1071,9 @@ public class IQv2StoreIntegrationTest {
         final V result1 = queryResult.getResult();
         final Integer integer = valueExtactor.apply(result1);
         assertThat(integer, is(expectedValue));
-
         assertThat(queryResult.getExecutionInfo(), is(empty()));
-    }
+        assertThat(queryResult.getPosition(), is(POSITION_0));
+    }   
 
     public <V> void shouldHandleRangeQuery(
         final Optional<Integer> lower,
@@ -1123,6 +1129,7 @@ public class IQv2StoreIntegrationTest {
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
             assertThat(actualValue, is(expectedValue));
+            assertThat(result.getPosition(), is(POSITION_BOTH));
         }
     }
 
@@ -1177,6 +1184,7 @@ public class IQv2StoreIntegrationTest {
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
             assertThat(actualValue, is(expectedValue));
+            assertThat(result.getPosition(), is(POSITION_BOTH));
         }
     }
 
@@ -1226,6 +1234,7 @@ public class IQv2StoreIntegrationTest {
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
             assertThat(actualValue, is(expectedValue));
+            assertThat(result.getPosition(), is(POSITION_BOTH));
         }
     }
 
@@ -1272,6 +1281,7 @@ public class IQv2StoreIntegrationTest {
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
             assertThat(actualValue, is(expectedValue));
+            assertThat(result.getPosition(), is(POSITION_BOTH));
         }
     }
 


### PR DESCRIPTION
Fix the bug where the Metered window and session stores are returning an empty position although the query result contains the correct position.
Also added checks in the store integration test about the position.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
