### PR TITLE
MINOR: ConsoleConsumer should not always exit when Consumer::poll returns an empty record batch

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -452,7 +452,7 @@ object ConsoleConsumer extends Logging {
     }
 
     def receive(): ConsumerRecord[Array[Byte], Array[Byte]] = {
-      if (!recordIter.hasNext) {
+      while (!recordIter.hasNext) {
         recordIter = consumer.poll(Duration.ofMillis(timeoutMs)).iterator
       }
 

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -29,7 +29,7 @@ import kafka.utils.Implicits._
 import kafka.utils.{Exit, _}
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.{MessageFormatter, TopicPartition}
-import org.apache.kafka.common.errors.{AuthenticationException, TimeoutException, WakeupException}
+import org.apache.kafka.common.errors.{AuthenticationException, WakeupException}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.requests.ListOffsetsRequest
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, Deserializer}

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -454,8 +454,6 @@ object ConsoleConsumer extends Logging {
     def receive(): ConsumerRecord[Array[Byte], Array[Byte]] = {
       if (!recordIter.hasNext) {
         recordIter = consumer.poll(Duration.ofMillis(timeoutMs)).iterator
-        if (!recordIter.hasNext)
-          throw new TimeoutException()
       }
 
       recordIter.next

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -463,7 +463,6 @@ object ConsoleConsumer extends Logging {
       val startTimeMs = time.milliseconds
       while (!recordIter.hasNext) {
         recordIter = consumer.poll(Duration.ofMillis(timeoutMs)).iterator
-        System.out.println(time.milliseconds - startTimeMs)
         if (!recordIter.hasNext && (time.milliseconds - startTimeMs > timeoutMs)) {
           throw new TimeoutException()
         }


### PR DESCRIPTION
Transactions system tests fail in trunk: http://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2022-01-26--001.system-test-kafka-trunk--1643203818--confluentinc--master--100303aecc/report.html.

Error:
```
[2022-01-28 08:25:24,917] TRACE [Consumer clientId=console-consumer, groupId=concurrent_consumer] Returning empty records from `poll()` since the consumer's position has advanced for at least one topic partition (org.apache.kafka.clients.consumer.KafkaConsumer)
[2022-01-28 08:25:24,917] ERROR Error processing message, terminating consumer process:  (kafka.tools.ConsoleConsumer$)
org.apache.kafka.common.errors.TimeoutException
```

With https://github.com/apache/kafka/commit/ddb6959c6272d2039ed8c9f595634c3c9573f85e, `Consumer::poll` will return an empty record batch when position advances due to aborted transactions or control records. This makes the `ConsoleConsumer` exists because it assumes that `poll` returns due to the timeout being reached.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
