### PR TITLE
KAFKA-13629: Use faster algorithm for ByteUtils sizeOfXxx algorithm

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
@@ -430,9 +430,7 @@ public final class ByteUtils {
         long v = (value << 1) ^ (value >> 63);
 
         // For implementation notes @see #sizeOfUnsignedVarint(int)
-
         // Similar logic is applied to allow for 64bit input -> 1-9byte output.
-
         // return (70 - leadingZeros) / 7 + leadingZeros / 64;
 
         int leadingZeros = Long.numberOfLeadingZeros(v);

--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
@@ -386,18 +386,39 @@ public final class ByteUtils {
         buffer.putDouble(value);
     }
 
+    final static int[] LEADING_ZEROS_TO_U_VARINT_SIZE = new int[] {
+        // 32 bits, and each 7-bits adds one byte to the output
+        5, 5, 5, 5, // 32
+        4, 4, 4, 4, 4, 4, 4, // 28
+        3, 3, 3, 3, 3, 3, 3, // 21
+        2, 2, 2, 2, 2, 2, 2, // 14
+        1, 1, 1, 1, 1, 1, 1, // 7
+        1 // 0
+    };
+
+    final static int[] LEADING_ZEROS_TO_U_VARLONG_SIZE = new int[] {
+        // 64 bits, and each 7-bits adds one byte to the output
+        10, // 64
+        9, 9, 9, 9, 9, 9, 9, // 63
+        8, 8, 8, 8, 8, 8, 8, // 56
+        7, 7, 7, 7, 7, 7, 7, // 49
+        6, 6, 6, 6, 6, 6, 6, // 42
+        5, 5, 5, 5, 5, 5, 5, // 35
+        4, 4, 4, 4, 4, 4, 4, // 28
+        3, 3, 3, 3, 3, 3, 3, // 21
+        2, 2, 2, 2, 2, 2, 2, // 14
+        1, 1, 1, 1, 1, 1, 1, // 7
+        1 // 0
+    };
+
     /**
      * Number of bytes needed to encode an integer in unsigned variable-length format.
      *
      * @param value The signed value
      */
     public static int sizeOfUnsignedVarint(int value) {
-        int bytes = 1;
-        while ((value & 0xffffff80) != 0L) {
-            bytes += 1;
-            value >>>= 7;
-        }
-        return bytes;
+        int leadingZeros = Integer.numberOfLeadingZeros(value);
+        return LEADING_ZEROS_TO_U_VARINT_SIZE[leadingZeros];
     }
 
     /**
@@ -416,12 +437,8 @@ public final class ByteUtils {
      */
     public static int sizeOfVarlong(long value) {
         long v = (value << 1) ^ (value >> 63);
-        int bytes = 1;
-        while ((v & 0xffffffffffffff80L) != 0L) {
-            bytes += 1;
-            v >>>= 7;
-        }
-        return bytes;
+        int leadingZeros = Long.numberOfLeadingZeros(v);
+        return LEADING_ZEROS_TO_U_VARLONG_SIZE[leadingZeros];
     }
 
     private static IllegalArgumentException illegalVarintException(int value) {

--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
@@ -386,31 +386,6 @@ public final class ByteUtils {
         buffer.putDouble(value);
     }
 
-    final static int[] LEADING_ZEROS_TO_U_VARINT_SIZE = new int[] {
-        // 32 bits, and each 7-bits adds one byte to the output
-        5, 5, 5, 5, // 32
-        4, 4, 4, 4, 4, 4, 4, // 28
-        3, 3, 3, 3, 3, 3, 3, // 21
-        2, 2, 2, 2, 2, 2, 2, // 14
-        1, 1, 1, 1, 1, 1, 1, // 7
-        1 // 0
-    };
-
-    final static int[] LEADING_ZEROS_TO_U_VARLONG_SIZE = new int[] {
-        // 64 bits, and each 7-bits adds one byte to the output
-        10, // 64
-        9, 9, 9, 9, 9, 9, 9, // 63
-        8, 8, 8, 8, 8, 8, 8, // 56
-        7, 7, 7, 7, 7, 7, 7, // 49
-        6, 6, 6, 6, 6, 6, 6, // 42
-        5, 5, 5, 5, 5, 5, 5, // 35
-        4, 4, 4, 4, 4, 4, 4, // 28
-        3, 3, 3, 3, 3, 3, 3, // 21
-        2, 2, 2, 2, 2, 2, 2, // 14
-        1, 1, 1, 1, 1, 1, 1, // 7
-        1 // 0
-    };
-
     /**
      * Number of bytes needed to encode an integer in unsigned variable-length format.
      *
@@ -418,7 +393,32 @@ public final class ByteUtils {
      */
     public static int sizeOfUnsignedVarint(int value) {
         int leadingZeros = Integer.numberOfLeadingZeros(value);
-        return LEADING_ZEROS_TO_U_VARINT_SIZE[leadingZeros];
+
+        // magic sequence of numbers that produces a function equivalent to this lookup
+        // table, where the index in the lookup table is provided by the number of
+        // leading zeros of the value, and the result is the number of bytes used
+        // in the output
+
+        // see the test cases as well to verify the implementation matches the prior
+        // for-loop logic
+
+        // final static byte[] LEADING_ZEROS_TO_U_VARINT_SIZE = new byte[] {
+        //     // 32 bits, and each 7-bits adds one byte to the output
+        //     5, 5, 5, 5, // 32
+        //     4, 4, 4, 4, 4, 4, 4, // 28
+        //     3, 3, 3, 3, 3, 3, 3, // 21
+        //     2, 2, 2, 2, 2, 2, 2, // 14
+        //     1, 1, 1, 1, 1, 1, 1, // 7
+        //     1 // 0
+        // };
+
+        // this is the core logic, but the Java encoding is suboptimal when we have a narrow
+        // range of integers, so we can do better here
+
+        // return (38 - leadingZeros) / 7 + leadingZeros / 32;
+
+        int leadingZerosBelow38DividedBy7 = ((38 - leadingZeros) * 0b10010010010010011) >>> 19;
+        return leadingZerosBelow38DividedBy7 + (leadingZeros >>> 5);
     }
 
     /**
@@ -434,11 +434,36 @@ public final class ByteUtils {
      * Number of bytes needed to encode a long in variable-length format.
      *
      * @param value The signed value
+     * @see #sizeOfUnsignedVarint(int)
      */
     public static int sizeOfVarlong(long value) {
         long v = (value << 1) ^ (value >> 63);
         int leadingZeros = Long.numberOfLeadingZeros(v);
-        return LEADING_ZEROS_TO_U_VARLONG_SIZE[leadingZeros];
+
+        // For implementation notes see sizeOfUnsignedVarint, assuming the below table
+
+        // final static byte[] LEADING_ZEROS_TO_U_VARLONG_SIZE = new byte[] {
+        //     // 63 bits, and each 7-bits adds one byte to the output
+        //     9, // 64
+        //     8, 9, 9, 9, 9, 9, 9, // 63
+        //     7, 8, 8, 8, 8, 8, 8, // 56
+        //     6, 7, 7, 7, 7, 7, 7, // 49
+        //     5, 6, 6, 6, 6, 6, 6, // 42
+        //     4, 5, 5, 5, 5, 5, 5, // 35
+        //     3, 4, 4, 4, 4, 4, 4, // 28
+        //     2, 3, 3, 3, 3, 3, 3, // 21
+        //     1, 2, 2, 2, 2, 2, 2, // 14
+        //     0, 1, 1, 1, 1, 1, 1, // 7
+        //     0 // 0
+        // };
+
+        // this is the core logic, but the Java encoding is suboptimal when we have a narrow
+        // range of integers, so we can do better here
+
+        // return (70 - leadingZeros) / 7 + leadingZeros / 64;
+
+        int leadingZerosBelow70DividedBy7 = ((70 - leadingZeros) * 0b10010010010010011) >>> 19;
+        return leadingZerosBelow70DividedBy7 + (leadingZeros >>> 6);
     }
 
     private static IllegalArgumentException illegalVarintException(int value) {

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
@@ -239,6 +239,44 @@ public class ByteUtilsTest {
         assertDoubleSerde(Double.NEGATIVE_INFINITY, 0xFFF0000000000000L);
     }
 
+    private static int oldSizeOfUnsignedVarint(int value) {
+        int bytes = 1;
+        // use highestOneBit or numberOfLeadingZeros
+        while ((value & 0xffffff80) != 0L) {
+            bytes += 1;
+            value >>>= 7;
+        }
+        return bytes;
+    }
+
+    @Test
+    public void testSizeOfUnsignedVarint() {
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
+            final int expected = oldSizeOfUnsignedVarint(i);
+            final int actual = ByteUtils.sizeOfUnsignedVarint(i);
+            assertEquals(expected, actual);
+        }
+    }
+
+    private static int oldSizeOfVarlong(long value) {
+        long v = (value << 1) ^ (value >> 63);
+        int bytes = 1;
+        while ((v & 0xffffffffffffff80L) != 0L) {
+            bytes += 1;
+            v >>>= 7;
+        }
+        return bytes;
+    }
+
+    @Test
+    public void testSizeOfVarlong() {
+        for (long l = Integer.MIN_VALUE - 100; l <= Integer.MAX_VALUE + 100; l++) {
+            final int expected = oldSizeOfVarlong(l);
+            final int actual = ByteUtils.sizeOfVarlong(l);
+            assertEquals(expected, actual);
+        }
+    }
+
     private void assertUnsignedVarintSerde(int value, byte[] expectedEncoding) throws IOException {
         ByteBuffer buf = ByteBuffer.allocate(32);
         ByteUtils.writeUnsignedVarint(value, buf);

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
@@ -239,6 +239,25 @@ public class ByteUtilsTest {
         assertDoubleSerde(Double.NEGATIVE_INFINITY, 0xFFF0000000000000L);
     }
 
+    private static int mathSizeOfUnsignedVarint(int value) {
+        int leadingZeros = Integer.numberOfLeadingZeros(value);
+        // return (38 - leadingZeros) / 7 + leadingZeros / 32;
+        int leadingZerosBelow38DividedBy7 = ((38 - leadingZeros) * 0b10010010010010011) >>> 19;
+        return leadingZerosBelow38DividedBy7 + (leadingZeros >>> 5);
+    }
+
+    @Test
+    public void testSizeOfUnsignedVarintMath() {
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
+            final int actual = mathSizeOfUnsignedVarint(i);
+            final int expected = oldSizeOfUnsignedVarint(i);
+            assertEquals(expected, actual);
+        }
+    }
+
+    /**
+     * The old well-known implementation for sizeOfUnsignedVarint
+     */
     private static int oldSizeOfUnsignedVarint(int value) {
         int bytes = 1;
         // use highestOneBit or numberOfLeadingZeros
@@ -258,6 +277,9 @@ public class ByteUtilsTest {
         }
     }
 
+    /**
+     * The old well-known implementation for sizeOfVarlong
+     */
     private static int oldSizeOfVarlong(long value) {
         long v = (value << 1) ^ (value >> 63);
         int bytes = 1;
@@ -270,7 +292,7 @@ public class ByteUtilsTest {
 
     @Test
     public void testSizeOfVarlong() {
-        for (long l = Integer.MIN_VALUE - 100; l <= Integer.MAX_VALUE + 100; l++) {
+        for (long l = Integer.MIN_VALUE - 10000000000L; l <= Integer.MAX_VALUE + 10000000000L; l += 10000) {
             final int expected = oldSizeOfVarlong(l);
             final int actual = ByteUtils.sizeOfVarlong(l);
             assertEquals(expected, actual);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -57,13 +57,34 @@ public class ByteUtilsBenchmark {
     @Fork(3)
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 10, time = 1)
-    public int testSizeOfUnsignedVarintOriginal() {
+    public int testSizeOfUnsignedVarintSimple() {
         int value = input;
         int bytes = 1;
-        // use highestOneBit or numberOfLeadingZeros
         while ((value & 0xffffff80) != 0L) {
             bytes += 1;
             value >>>= 7;
+        }
+        return bytes;
+    }
+
+    @Benchmark
+    @Fork(3)
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 10, time = 1)
+    public int testSizeOfVarlong() {
+        return ByteUtils.sizeOfVarlong(input);
+    }
+
+    @Benchmark
+    @Fork(3)
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 10, time = 1)
+    public int testSizeOfVarlongSimple() {
+        long v = (input << 1) ^ (input >> 63);
+        int bytes = 1;
+        while ((v & 0xffffffffffffff80L) != 0L) {
+            bytes += 1;
+            v >>>= 7;
         }
         return bytes;
     }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.utils.ByteUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ByteUtilsBenchmark {
+    private static final int INPUT_COUNT = 10_000;
+    private static final int MAX_INT = 2 * 1024 * 1024;
+
+    private final int[] sizeOfInputs = new int[INPUT_COUNT];
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        for (int i = 0; i < INPUT_COUNT; ++i) {
+            sizeOfInputs[i] = ThreadLocalRandom.current().nextInt(MAX_INT);
+        }
+    }
+
+    @Benchmark
+    public long testSizeOfUnsignedVarint() {
+        long result = 0;
+        for (final int input : sizeOfInputs) {
+            result += ByteUtils.sizeOfUnsignedVarint(input);
+        }
+        return result;
+    }
+
+    @Benchmark
+    public long testSizeOfUnsignedVarintOriginal() {
+        long result = 0;
+        for (int input : sizeOfInputs) {
+            int bytes = 1;
+            // use highestOneBit or numberOfLeadingZeros
+            while ((input & 0xffffff80) != 0L) {
+                bytes += 1;
+                input >>>= 7;
+            }
+            result += bytes;
+        }
+        return result;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(ByteUtilsBenchmark.class.getSimpleName())
+                .forks(2)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -57,6 +57,16 @@ public class ByteUtilsBenchmark {
     }
 
     @Benchmark
+    public long testSizeOfUnsignedVarintMath() {
+        long result = 0;
+        for (final int input : sizeOfInputs) {
+             int leadingZeros = Integer.numberOfLeadingZeros(input);
+             result += (38 - leadingZeros) / 7 + leadingZeros / 32;
+        }
+        return result;
+    }
+
+    @Benchmark
     public long testSizeOfUnsignedVarintOriginal() {
         long result = 0;
         for (int input : sizeOfInputs) {
@@ -79,5 +89,7 @@ public class ByteUtilsBenchmark {
 
         new Runner(opt).run();
     }
+
+
 
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -49,7 +49,7 @@ public class ByteUtilsBenchmark {
     @Fork(3)
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 10, time = 1)
-    public long testSizeOfUnsignedVarint() {
+    public int testSizeOfUnsignedVarint() {
         return ByteUtils.sizeOfUnsignedVarint(input);
     }
 
@@ -57,16 +57,7 @@ public class ByteUtilsBenchmark {
     @Fork(3)
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 10, time = 1)
-    public long testSizeOfUnsignedVarintMath() {
-        int leadingZeros = Integer.numberOfLeadingZeros(input);
-        return (38 - leadingZeros) / 7 + leadingZeros / 32;
-    }
-
-    @Benchmark
-    @Fork(3)
-    @Warmup(iterations = 5, time = 1)
-    @Measurement(iterations = 10, time = 1)
-    public long testSizeOfUnsignedVarintOriginal() {
+    public int testSizeOfUnsignedVarintOriginal() {
         int value = input;
         int bytes = 1;
         // use highestOneBit or numberOfLeadingZeros
@@ -85,7 +76,4 @@ public class ByteUtilsBenchmark {
 
         new Runner(opt).run();
     }
-
-
-
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -72,8 +72,6 @@ public class ByteUtilsBenchmark {
 
     @Benchmark
     public int testSizeOfVarlongSimple() {
-        // spotbugs does not like the >> 63 rightshift if input is an int
-        // quite reasonable
         long v = (inputLong << 1) ^ (inputLong >> 63);
         int bytes = 1;
         while ((v & 0xffffffffffffff80L) != 0L) {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -37,6 +37,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
 public class ByteUtilsBenchmark {
     private int input;
 
@@ -46,17 +49,11 @@ public class ByteUtilsBenchmark {
     }
 
     @Benchmark
-    @Fork(3)
-    @Warmup(iterations = 5, time = 1)
-    @Measurement(iterations = 10, time = 1)
     public int testSizeOfUnsignedVarint() {
         return ByteUtils.sizeOfUnsignedVarint(input);
     }
 
     @Benchmark
-    @Fork(3)
-    @Warmup(iterations = 5, time = 1)
-    @Measurement(iterations = 10, time = 1)
     public int testSizeOfUnsignedVarintSimple() {
         int value = input;
         int bytes = 1;
@@ -68,17 +65,11 @@ public class ByteUtilsBenchmark {
     }
 
     @Benchmark
-    @Fork(3)
-    @Warmup(iterations = 5, time = 1)
-    @Measurement(iterations = 10, time = 1)
     public int testSizeOfVarlong() {
         return ByteUtils.sizeOfVarlong(input);
     }
 
     @Benchmark
-    @Fork(3)
-    @Warmup(iterations = 5, time = 1)
-    @Measurement(iterations = 10, time = 1)
     public int testSizeOfVarlongSimple() {
         long v = (input << 1) ^ (input >> 63);
         int bytes = 1;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -57,6 +57,11 @@ public class ByteUtilsBenchmark {
     }
 
     @Benchmark
+    public long testSizeOfUnsignedVarintOne() {
+        return ByteUtils.sizeOfUnsignedVarint(sizeOfInputs[0]);
+    }
+
+    @Benchmark
     public long testSizeOfUnsignedVarintMath() {
         long result = 0;
         for (final int input : sizeOfInputs) {
@@ -64,6 +69,12 @@ public class ByteUtilsBenchmark {
              result += (38 - leadingZeros) / 7 + leadingZeros / 32;
         }
         return result;
+    }
+
+    @Benchmark
+    public long testSizeOfUnsignedVarintMathOne() {
+        int leadingZeros = Integer.numberOfLeadingZeros(sizeOfInputs[0]);
+        return (38 - leadingZeros) / 7 + leadingZeros / 32;
     }
 
     @Benchmark
@@ -79,6 +90,18 @@ public class ByteUtilsBenchmark {
             result += bytes;
         }
         return result;
+    }
+
+    @Benchmark
+    public long testSizeOfUnsignedVarintOriginalOne() {
+        int input = sizeOfInputs[0];
+        int bytes = 1;
+        // use highestOneBit or numberOfLeadingZeros
+        while ((input & 0xffffff80) != 0L) {
+            bytes += 1;
+            input >>>= 7;
+        }
+        return bytes;
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -41,21 +41,22 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 10, time = 1)
 public class ByteUtilsBenchmark {
-    private int input;
-
+    private int inputInt;
+    private long inputLong;
     @Setup(Level.Iteration)
     public void setUp() {
-        input = ThreadLocalRandom.current().nextInt(2 * 1024 * 1024);
+        inputInt = ThreadLocalRandom.current().nextInt();
+        inputLong = ThreadLocalRandom.current().nextLong();
     }
 
     @Benchmark
     public int testSizeOfUnsignedVarint() {
-        return ByteUtils.sizeOfUnsignedVarint(input);
+        return ByteUtils.sizeOfUnsignedVarint(inputInt);
     }
 
     @Benchmark
     public int testSizeOfUnsignedVarintSimple() {
-        int value = input;
+        int value = inputInt;
         int bytes = 1;
         while ((value & 0xffffff80) != 0L) {
             bytes += 1;
@@ -66,12 +67,14 @@ public class ByteUtilsBenchmark {
 
     @Benchmark
     public int testSizeOfVarlong() {
-        return ByteUtils.sizeOfVarlong(input);
+        return ByteUtils.sizeOfVarlong(inputLong);
     }
 
     @Benchmark
     public int testSizeOfVarlongSimple() {
-        long v = (input << 1) ^ (input >> 63);
+        // spotbugs does not like the >> 63 rightshift if input is an int
+        // quite reasonable
+        long v = (inputLong << 1) ^ (inputLong >> 63);
         int bytes = 1;
         while ((v & 0xffffffffffffff80L) != 0L) {
             bytes += 1;


### PR DESCRIPTION
Replace loop with a branch-free implementation.

Include:
- Unit tests that includes old code and new code and runs through several ints/longs.
- JMH benchmark that compares old vs new performance of algorithm.

JMH results with JDK 17.0.2 and `compiler` blackhole mode are 2.8-3.4 faster with
the new implementation. In a real application, a 6% reduction in CPU cycles was
observed in the `send()` path via flamegraphs.

```
ByteUtilsBenchmark.testSizeOfUnsignedVarint                            thrpt    4  1472440.102 ±  67331.797  ops/ms
ByteUtilsBenchmark.testSizeOfUnsignedVarint:·async                     thrpt               NaN                  ---
ByteUtilsBenchmark.testSizeOfUnsignedVarint:·gc.alloc.rate             thrpt    4       ≈ 10⁻⁴               MB/sec
ByteUtilsBenchmark.testSizeOfUnsignedVarint:·gc.alloc.rate.norm        thrpt    4       ≈ 10⁻⁷                 B/op
ByteUtilsBenchmark.testSizeOfUnsignedVarint:·gc.count                  thrpt    4          ≈ 0               counts
ByteUtilsBenchmark.testSizeOfUnsignedVarintSimple                      thrpt    4   521333.117 ± 595169.618  ops/ms
ByteUtilsBenchmark.testSizeOfUnsignedVarintSimple:·async               thrpt               NaN                  ---
ByteUtilsBenchmark.testSizeOfUnsignedVarintSimple:·gc.alloc.rate       thrpt    4       ≈ 10⁻⁴               MB/sec
ByteUtilsBenchmark.testSizeOfUnsignedVarintSimple:·gc.alloc.rate.norm  thrpt    4       ≈ 10⁻⁶                 B/op
ByteUtilsBenchmark.testSizeOfUnsignedVarintSimple:·gc.count            thrpt    4          ≈ 0               counts
ByteUtilsBenchmark.testSizeOfVarlong                                   thrpt    4  1106519.633 ±  16556.502  ops/ms
ByteUtilsBenchmark.testSizeOfVarlong:·async                            thrpt               NaN                  ---
ByteUtilsBenchmark.testSizeOfVarlong:·gc.alloc.rate                    thrpt    4       ≈ 10⁻⁴               MB/sec
ByteUtilsBenchmark.testSizeOfVarlong:·gc.alloc.rate.norm               thrpt    4       ≈ 10⁻⁶                 B/op
ByteUtilsBenchmark.testSizeOfVarlong:·gc.count                         thrpt    4          ≈ 0               counts
ByteUtilsBenchmark.testSizeOfVarlongSimple                             thrpt    4   324435.607 ± 147754.813  ops/ms
ByteUtilsBenchmark.testSizeOfVarlongSimple:·async                      thrpt               NaN                  ---
ByteUtilsBenchmark.testSizeOfVarlongSimple:·gc.alloc.rate              thrpt    4       ≈ 10⁻⁴               MB/sec
ByteUtilsBenchmark.testSizeOfVarlongSimple:·gc.alloc.rate.norm         thrpt    4       ≈ 10⁻⁶                 B/op
ByteUtilsBenchmark.testSizeOfVarlongSimple:·gc.count                   thrpt    4          ≈ 0               counts
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
