### PR TITLE
KAFKA-13293: Reloading SSL Engine Factory

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -130,6 +130,15 @@ public class SslConfigs {
     public static final String SSL_ENGINE_FACTORY_CLASS_CONFIG = "ssl.engine.factory.class";
     public static final String SSL_ENGINE_FACTORY_CLASS_DOC = "The class of type org.apache.kafka.common.security.auth.SslEngineFactory to provide SSLEngine objects. Default value is org.apache.kafka.common.security.ssl.DefaultSslEngineFactory";
 
+    public static final String SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG = "ssl.reloading.engine.factory.class";
+    public static final String SSL_RELOADING_ENGINE_FACTORY_CLASS_DOC = "The class of type org.apache.kafka.common.security.auth.SslEngineFactory to provide SSLEngine objects. Default value is org.apache.kafka.common.security.ssl.DefaultSslEngineFactory";
+
+    public static final String SSL_RELOADING_ENGINE_FACTORY_ID_CONFIG = "ssl.reloading.engine.factory.id";
+    public static final String SSL_RELOADING_ENGINE_FACTORY_ID_DOC = "A discriminating SslEngineFactory identifier when using multiple distinct SSL configurations in the same JVM.";
+
+    public static final String SSL_RELOADING_ENGINE_FACTORY_INTERVAL_CONFIG = "ssl.reloading.engine.factory.interval.ms";
+    public static final String SSL_RELOADING_ENGINE_FACTORY_INTERVAL_DOC = "The interval in milliseconds at which the delegate SslEngineFactory will be recreated. Default value is 12hrs. A negative value disables the scheduling.";
+
     public static void addClientSslSupport(ConfigDef config) {
         config.define(SslConfigs.SSL_PROTOCOL_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_PROTOCOL, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_PROTOCOL_DOC)
                 .define(SslConfigs.SSL_PROVIDER_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_PROVIDER_DOC)
@@ -149,7 +158,10 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTMANAGER_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_DOC)
-                .define(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, ConfigDef.Type.CLASS, null, ConfigDef.Importance.LOW, SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC);
+                .define(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, ConfigDef.Type.CLASS, null, ConfigDef.Importance.LOW, SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC)
+                .define(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG, ConfigDef.Type.CLASS, null, ConfigDef.Importance.LOW, SslConfigs.SSL_RELOADING_ENGINE_FACTORY_CLASS_DOC)
+                .define(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_ID_CONFIG, Type.STRING, null, ConfigDef.Importance.LOW, SslConfigs.SSL_RELOADING_ENGINE_FACTORY_ID_DOC)
+                .define(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_INTERVAL_CONFIG, Type.LONG, null, ConfigDef.Importance.LOW, SslConfigs.SSL_RELOADING_ENGINE_FACTORY_INTERVAL_DOC);
     }
 
     public static final Set<String> RECONFIGURABLE_CONFIGS = Utils.mkSet(
@@ -174,5 +186,8 @@ public class SslConfigs {
             SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG,
             SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG,
             SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG,
-            SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG);
+            SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG,
+            SslConfigs.SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG,
+            SslConfigs.SSL_RELOADING_ENGINE_FACTORY_ID_CONFIG,
+            SslConfigs.SSL_RELOADING_ENGINE_FACTORY_INTERVAL_CONFIG);
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/ReloadingSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/ReloadingSslEngineFactory.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
+
+import java.io.IOException;
+import java.security.KeyStore;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.SSLEngine;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SslEngineFactory;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is an implementation of a {@link SslEngineFactory} that exists to enable the reloading of renewed certificates by
+ * producer and consumer clients. It achieves this by recreating an internal delegate {@link SslEngineFactory} when necessary, so
+ * that the new delegate instance is able to acquire and use the most recent certificate information.
+ *
+ * The new {@link SslEngineFactory} delegate will be used to set up the SSL context for any new connections created
+ * by Kafka Producer/Consumer instances.
+ *
+ * Enable this factory by setting kafka config {@link org.apache.kafka.common.config.SslConfigs#SSL_ENGINE_FACTORY_CLASS_CONFIG}
+ * to {@link ReloadingSslEngineFactory#getClass()}
+ *
+ * Specify the delegate {@link SslEngineFactory} by setting kafka config {@link org.apache.kafka.common.config.SslConfigs#SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG}
+ * to your chosen implementation; this will default to the standard {@link DefaultSslEngineFactory}.
+ *
+ * The reload interval can be configured using kafka config {@link SslConfigs#SSL_RELOADING_ENGINE_FACTORY_INTERVAL_CONFIG}.
+ * The default reload interval is {@link ReloadingSslEngineFactory#DEFAULT_SSL_RELOADING_ENGINE_FACTORY_INTERVAL} (12 hours).
+ * With an interval less than zero, config will never automatically reload.
+ * With an interval equal to zero, config will reload for every new connection.
+ *
+ * JKS certificates from the filesystem will be automatically reloaded at the specified interval, with no further intervention (as long as
+ * some external actor periodically updates the JKS stores in the correct location.
+ *
+ * Inline PEM certificates will not be automatically reloaded as these form part of the configuration map. In this case, you (the client)
+ * are responsible for calling {@link ReloadingSslEngineFactory#applyPatch(String, Map)} to provide patch the existing configuration.
+ * The new patch will be merged with the initial configuration and applied for any new connections.
+ * If you need multiple configurations, you can specify the {@code ID} for patching using the configuration option
+ * {@link SslConfigs#SSL_RELOADING_ENGINE_FACTORY_ID_CONFIG}, otherwise {@link ReloadingSslEngineFactory#DEFAULT_SSL_RELOADING_ENGINE_FACTORY_ID} will be used.
+ *
+ * Note that this implementation uses {@link System#currentTimeMillis()} to track expiry, which
+ * will cause unpredictable behaviour if time moves backwards.
+ *
+ * See also <a href="https://issues.apache.org/jira/browse/KAFKA-13293">KAFKA-13293</a>
+ *
+ * @author Joe Jordan
+ * @author Kevin Nguyen
+ * @author Elliot West
+ */
+public class ReloadingSslEngineFactory implements SslEngineFactory {
+
+    public static final Class<? extends SslEngineFactory> DEFAULT_SSL_RELOADING_ENGINE_FACTORY_CLASS = DefaultSslEngineFactory.class;
+    public static final String DEFAULT_SSL_RELOADING_ENGINE_FACTORY_ID = ReloadingSslEngineFactory.class.getCanonicalName();
+    public static final long DEFAULT_SSL_RELOADING_ENGINE_FACTORY_INTERVAL = Duration.ofHours(12).toMillis();
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReloadingSslEngineFactory.class);
+    private static final Map<String, Map<String, Object>> CONFIG_PATCHES = new ConcurrentHashMap<>();
+
+    private final Object lock = new Object();
+    private final Clock clock;
+    // default for test access
+    SslEngineFactory delegate;
+    private String id;
+    private Long reloadInterval;
+    private Map<String, Object> baseConfig;
+    private Map<String, Object> configPatch;
+    private long expiry;
+
+    public ReloadingSslEngineFactory() {
+        this(Clock.systemUTC());
+    }
+
+    ReloadingSslEngineFactory(Clock clock) {
+        this.clock = clock;
+    }
+
+    static void clearPatches() {
+        CONFIG_PATCHES.clear();
+    }
+
+    public static void applyPatch(Map<String, ?> patch) {
+        applyPatch(DEFAULT_SSL_RELOADING_ENGINE_FACTORY_ID, patch);
+    }
+
+    public static void applyPatch(String factoryId, Map<String, ?> patch) {
+        final ConfigDef configDef = new ConfigDef()
+                .withClientSslSupport();
+        final Map<String, Object> configPatch = configDef.parse(patch)
+                .entrySet()
+                .stream()
+                .filter(config -> config.getValue() != null)
+                .filter(config -> SslConfigs.RECONFIGURABLE_CONFIGS.contains(config.getKey()))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        CONFIG_PATCHES.put(factoryId, unmodifiableMap(configPatch));
+    }
+
+    private static SslEngineFactory newDelegateSslEngineFactory(Map<String, ?> config) {
+        @SuppressWarnings("unchecked")
+        Class<? extends SslEngineFactory> sslEngineFactoryClass =
+                (Class<? extends SslEngineFactory>) config.get(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG);
+        if (sslEngineFactoryClass == null) {
+            sslEngineFactoryClass = DEFAULT_SSL_RELOADING_ENGINE_FACTORY_CLASS;
+        }
+        return Utils.newInstance(sslEngineFactoryClass);
+    }
+
+    private static long reloadInterval(Map<String, ?> config) {
+        if (config != null) {
+            final Object configuredReloadInterval = config.get(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_INTERVAL_CONFIG);
+            if (configuredReloadInterval instanceof Number) {
+                return ((Number) configuredReloadInterval).longValue();
+            } else if (configuredReloadInterval instanceof String) {
+                return Long.parseLong((String) configuredReloadInterval);
+            }
+        }
+        return DEFAULT_SSL_RELOADING_ENGINE_FACTORY_INTERVAL;
+    }
+
+    private static String id(Map<String, ?> config) {
+        if (config != null) {
+            final Object factoryId = config.get(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_ID_CONFIG);
+            if (factoryId instanceof String) {
+                return (String) factoryId;
+            }
+        }
+        return DEFAULT_SSL_RELOADING_ENGINE_FACTORY_ID;
+    }
+
+    @Override
+    public void configure(Map<String, ?> config) {
+        synchronized (lock) {
+            baseConfig = unmodifiableMap(config);
+            id = id(baseConfig);
+            reloadInterval = reloadInterval(baseConfig);
+            renewDelegate();
+        }
+    }
+
+    private SslEngineFactory delegate() {
+        synchronized (lock) {
+            if (delegate == null || clock.millis() >= expiry || CONFIG_PATCHES.get(id) != configPatch) {
+                renewDelegate();
+            }
+            return delegate;
+        }
+    }
+
+    private void renewDelegate() {
+        synchronized (lock) {
+            final SslEngineFactory newDelegate = newDelegateSslEngineFactory(baseConfig);
+            if (baseConfig != null) {
+                configPatch = CONFIG_PATCHES.get(id);
+                final Map<String, Object> patchedConfig;
+                if (configPatch == null || configPatch.isEmpty()) {
+                    patchedConfig = baseConfig;
+                } else {
+                    patchedConfig = new HashMap<>(baseConfig);
+                    patchedConfig.putAll(configPatch);
+                }
+                newDelegate.configure(patchedConfig);
+            }
+            delegate = newDelegate;
+            if (reloadInterval < 0) {
+                expiry = Long.MAX_VALUE;
+            } else {
+                expiry = clock.millis() + reloadInterval;
+            }
+            LOG.info("Created new {} - valid until {}.", delegate.getClass().getSimpleName(), Instant.ofEpochMilli(expiry));
+        }
+    }
+
+    @Override
+    public SSLEngine createClientSslEngine(String peerHost, int peerPort, String endpointIdentification) {
+        return delegate().createClientSslEngine(peerHost, peerPort, endpointIdentification);
+    }
+
+    @Override
+    public SSLEngine createServerSslEngine(String peerHost, int peerPort) {
+        return delegate().createServerSslEngine(peerHost, peerPort);
+    }
+
+    @Override
+    public boolean shouldBeRebuilt(Map<String, Object> nextConfigs) {
+        return delegate().shouldBeRebuilt(nextConfigs);
+    }
+
+    @Override
+    public Set<String> reconfigurableConfigs() {
+        return delegate().reconfigurableConfigs();
+    }
+
+    @Override
+    public KeyStore keystore() {
+        return delegate().keystore();
+    }
+
+    @Override
+    public KeyStore truststore() {
+        return delegate().truststore();
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (lock) {
+            if (delegate != null) {
+                delegate.close();
+            }
+        }
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/ReloadingSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/ReloadingSslEngineFactoryTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.security.auth.SslEngineFactory;
+import org.apache.kafka.common.security.ssl.mock.TestSslEngineFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ReloadingSslEngineFactoryTest {
+
+    private final Map<String, Object> config = new HashMap<>();
+    private Clock clock;
+    private ReloadingSslEngineFactory factory;
+
+    @BeforeEach
+    public void setUp() {
+        ReloadingSslEngineFactory.clearPatches();
+        clock = Mockito.mock(Clock.class);
+        config.put(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG, TestSslEngineFactory.class);
+        config.put(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_INTERVAL_CONFIG, 100L);
+        config.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "JKS");
+        config.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "JKS");
+        factory = new ReloadingSslEngineFactory(clock);
+    }
+
+    @Test
+    public void constructsDefaultDelegate() {
+        config.remove(SslConfigs.SSL_RELOADING_ENGINE_FACTORY_CLASS_CONFIG);
+        config.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+        factory.configure(config);
+        assertTrue(factory.delegate instanceof DefaultSslEngineFactory);
+    }
+
+    @Test
+    public void constructsConfiguredDelegate() {
+        factory.configure(config);
+        assertTrue(factory.delegate instanceof TestSslEngineFactory);
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).configure(config);
+    }
+
+    @Test
+    public void keystoreDelegation() {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+        factory.keystore();
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).keystore();
+    }
+
+    @Test
+    public void truststoreDelegation() {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+        factory.truststore();
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).truststore();
+    }
+
+    @Test
+    public void closeDelegation() throws IOException {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+        factory.close();
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).close();
+    }
+
+    @Test
+    public void reconfigurableConfigsDelegation() {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+        factory.reconfigurableConfigs();
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).reconfigurableConfigs();
+    }
+
+    @Test
+    public void createClientSslEngineDelegation() {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+        factory.createClientSslEngine("host", 1, "endpoint");
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).
+                createClientSslEngine("host", 1, "endpoint");
+    }
+
+    @Test
+    public void createServerSslEngineDelegation() {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+        factory.createServerSslEngine("host", 1);
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).
+                createServerSslEngine("host", 1);
+    }
+
+    @Test
+    public void reloadOnExpire() {
+        factory.configure(config);
+        // First delegation will be at T1, second will be at T101.
+        // We expect first delegate to expire at T100.
+        when(clock.millis()).thenReturn(1L, 101L);
+
+        factory.keystore();
+        SslEngineFactory delegate1 = factory.delegate;
+        factory.keystore();
+        SslEngineFactory delegate2 = factory.delegate;
+
+        assertNotNull(delegate1);
+        assertNotNull(delegate2);
+        assertNotEquals(delegate1, delegate2);
+    }
+
+    @Test
+    public void reuseUnexpiredDelegate() {
+        factory.configure(config);
+        // First delegation will be at T1, second will be at T99.
+        // We expect first delegate to expire at T100.
+        when(clock.millis()).thenReturn(1L, 99L);
+
+        factory.keystore();
+        SslEngineFactory delegate1 = factory.delegate;
+        factory.keystore();
+        SslEngineFactory delegate2 = factory.delegate;
+
+        assertNotNull(delegate1);
+        assertNotNull(delegate2);
+        assertEquals(delegate1, delegate2);
+    }
+
+    @Test
+    public void reloadOnPatch() {
+        factory.configure(config);
+        when(clock.millis()).thenReturn(1L);
+
+        factory.keystore();
+        SslEngineFactory delegate1 = factory.delegate;
+
+        Map<String, Object> patch = new HashMap<>();
+        patch.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, new Password("value"));
+        ReloadingSslEngineFactory.applyPatch(patch);
+
+        factory.keystore();
+        SslEngineFactory delegate2 = factory.delegate;
+
+        Map<String, Object> patchedConfig = new HashMap<>(config);
+        patchedConfig.putAll(patch);
+
+        verify(((TestSslEngineFactory) factory.delegate).internalMock, times(1)).
+                configure(patchedConfig);
+
+        assertNotNull(delegate1);
+        assertNotNull(delegate2);
+        assertNotEquals(delegate1, delegate2);
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestSslEngineFactory.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestSslEngineFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl.mock;
+
+import java.io.IOException;
+import java.security.KeyStore;
+import java.util.Map;
+import java.util.Set;
+import javax.net.ssl.SSLEngine;
+
+import org.apache.kafka.common.security.auth.SslEngineFactory;
+import org.mockito.Mockito;
+
+/**
+ * A wrapper on a {@link SslEngineFactory} mock that can be instantiated by reflection and also used as a mock.
+ */
+public class TestSslEngineFactory implements SslEngineFactory {
+
+    public final SslEngineFactory internalMock = Mockito.mock(SslEngineFactory.class);
+
+    @Override
+    public void configure(Map<String, ?> configs) {internalMock.configure(configs);}
+
+    @Override
+    public SSLEngine createClientSslEngine(String peerHost, int peerPort, String endpointIdentification) {return internalMock.createClientSslEngine(peerHost, peerPort, endpointIdentification);}
+
+    @Override
+    public SSLEngine createServerSslEngine(String peerHost, int peerPort) {return internalMock.createServerSslEngine(peerHost, peerPort);}
+
+    @Override
+    public boolean shouldBeRebuilt(Map<String, Object> nextConfigs) {return internalMock.shouldBeRebuilt(nextConfigs);}
+
+    @Override
+    public Set<String> reconfigurableConfigs() {return internalMock.reconfigurableConfigs();}
+
+    @Override
+    public KeyStore keystore() {return internalMock.keystore();}
+
+    @Override
+    public KeyStore truststore() {return internalMock.truststore();}
+
+    @Override
+    public void close() throws IOException {internalMock.close();}
+
+}


### PR DESCRIPTION
This PR adds an optional `SslEngineFactory` implementation that decorates and manages a delegate. It is able to recreate the delegate either on a schedule, or in response to a SSL configuration patch being applied. The purpose of this implementation is to permit the automatic reload of renewed client certificates as described in [KAFKA-13293](href="https://issues.apache.org/jira/browse/KAFKA-13293).

This implementation includes a supporting unit test.

Thanks go to my colleague @joedj for the implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
