### PR TITLE
MINOR: Check the help and version options firstly

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -48,8 +48,8 @@ object ConsumerGroupCommand extends Logging {
 
     val opts = new ConsumerGroupCommandOptions(args)
     try {
-      opts.checkArgs()
       CommandLineUtils.printHelpAndExitIfNeeded(opts, "This tool helps to list all consumer groups, describe a consumer group, delete consumer group info, or reset consumer group offsets.")
+      opts.checkArgs()
 
       // should have exactly one action
       val actions = Seq(opts.listOpt, opts.describeOpt, opts.deleteOpt, opts.resetOffsetsOpt, opts.deleteOffsetsOpt).count(opts.options.has)


### PR DESCRIPTION
Currently, `bin/kafka-consumer-groups.sh --version` reqiures unnecessary `bootstrap-server` option.
```
% bin/kafka-consumer-groups.sh --version
Missing required argument "[bootstrap-server]"
Option                                  Description
------                                  -----------
--all-groups                            Apply to all consumer groups.
--all-topics                            Consider all topics assigned to a
                                          group in the `reset-offsets` process.
...
--version                               Display Kafka version.
```

```
% bin/kafka-consumer-groups.sh --version --bootstrap-server=localhost:9092
3.2.0-SNAPSHOT (Commit:21c3009ac12f79d0)
```

This PR fixes this problem.

```
% bin/kafka-consumer-groups.sh --version
3.2.0-SNAPSHOT (Commit:efe4bfd2c49997f7)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
