### PR TITLE
KAFKA-13636: Fix for the group coordinator issue where the offsets are deleted for unstable groups

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -763,8 +763,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     }
 
     val expiredOffsets: Map[TopicPartition, OffsetAndMetadata] = protocolType match {
-      case Some(_) if is(Empty) || !is(Stable)=>
-        // no consumer exists in the group =>
+      case Some(_) if is(Empty) =>
+        // no consumer exists in the group || group is not stable =>
         // - if current state timestamp exists and retention period has passed since group became Empty,
         //   expire all offsets with no pending offset commit;
         // - if there is no current state timestamp (old group metadata schema) and retention period has passed
@@ -774,7 +774,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
             .getOrElse(commitRecordMetadataAndOffset.offsetAndMetadata.commitTimestamp)
         )
 
-      case Some(ConsumerProtocol.PROTOCOL_TYPE) if subscribedTopics.isDefined =>
+      case Some(ConsumerProtocol.PROTOCOL_TYPE) if subscribedTopics.isDefined && is(Stable) =>
         // consumers exist in the group =>
         // - if the group is aware of the subscribed topics and retention period had passed since the
         //   the last commit timestamp, expire the offset. offset with pending offset commit are not

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -763,7 +763,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     }
 
     val expiredOffsets: Map[TopicPartition, OffsetAndMetadata] = protocolType match {
-      case Some(_) if is(Empty) =>
+      case Some(_) if is(Empty) || !is(Stable)=>
         // no consumer exists in the group =>
         // - if current state timestamp exists and retention period has passed since group became Empty,
         //   expire all offsets with no pending offset commit;

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -764,7 +764,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
     val expiredOffsets: Map[TopicPartition, OffsetAndMetadata] = protocolType match {
       case Some(_) if is(Empty) =>
-        // no consumer exists in the group || group is not stable =>
+        // no consumer exists in the group =>
         // - if current state timestamp exists and retention period has passed since group became Empty,
         //   expire all offsets with no pending offset commit;
         // - if there is no current state timestamp (old group metadata schema) and retention period has passed
@@ -775,7 +775,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
         )
 
       case Some(ConsumerProtocol.PROTOCOL_TYPE) if subscribedTopics.isDefined && is(Stable) =>
-        // consumers exist in the group =>
+        // consumers exist in the group and group is stable =>
         // - if the group is aware of the subscribed topics and retention period had passed since the
         //   the last commit timestamp, expire the offset. offset with pending offset commit are not
         //   expired

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -264,6 +264,7 @@ class GroupMetadataTest {
     val topic = "foo"
     val partition = new TopicPartition(topic, 0)
     val time = new MockTime()
+    group = new GroupMetadata("groupId", Empty, time)
 
     // Rebalance once in order to commit offsets
     val member = new MemberMetadata(memberId, None, clientId, clientHost, rebalanceTimeoutMs,

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{Time, MockTime}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test}
 
@@ -257,6 +257,47 @@ class GroupMetadataTest {
     assertTrue(group.supportsProtocols(protocolType, Set("roundrobin", "foo")))
     assertFalse(group.supportsProtocols("invalid_type", Set("roundrobin", "foo")))
     assertFalse(group.supportsProtocols(protocolType, Set("range", "foo")))
+  }
+
+  @Test
+  def testOffsetRemovalDuringTransitionFromEmptyToNonEmpty(): Unit = {
+    val topic = "foo"
+    val partition = new TopicPartition(topic, 0)
+    val time = new MockTime()
+
+    // Rebalance once in order to commit offsets
+    val member = new MemberMetadata(memberId, None, clientId, clientHost, rebalanceTimeoutMs,
+      sessionTimeoutMs, protocolType, List(("range", ConsumerProtocol.serializeSubscription(new Subscription(List("foo").asJava)).array())))
+    group.transitionTo(PreparingRebalance)
+    group.add(member)
+    group.initNextGeneration()
+    assertEquals(Some(Set("foo")), group.getSubscribedTopics)
+
+    val offset = offsetAndMetadata(offset = 37, timestamp = time.milliseconds())
+    val commitRecordOffset = 3
+
+    group.prepareOffsetCommit(Map(partition -> offset))
+    assertTrue(group.hasOffsets)
+    assertEquals(None, group.offset(partition))
+    group.onOffsetCommitAppend(partition, CommitRecordMetadataAndOffset(Some(commitRecordOffset), offset))
+
+    val offsetRetentionMs = 50000L
+    time.sleep(offsetRetentionMs + 1)
+
+    // Rebalance again so that the group becomes empty
+    group.transitionTo(PreparingRebalance)
+    group.remove(memberId)
+    group.initNextGeneration()
+
+    // The group is empty, but we should not expire the offset because the state was just changed
+    assertEquals(Empty, group.currentState)
+    assertEquals(Map.empty, group.removeExpiredOffsets(time.milliseconds(), offsetRetentionMs))
+
+    // Start a new rebalance to add the member back. The offset should not be expired
+    // while the rebalance is in progress.
+    group.transitionTo(PreparingRebalance)
+    group.add(member)
+    assertEquals(Map.empty, group.removeExpiredOffsets(time.milliseconds(), offsetRetentionMs))
   }
 
   @Test
@@ -718,8 +759,8 @@ class GroupMetadataTest {
     assertTrue(group.is(targetState))
   }
 
-  private def offsetAndMetadata(offset: Long): OffsetAndMetadata = {
-    OffsetAndMetadata(offset, "", Time.SYSTEM.milliseconds())
+  private def offsetAndMetadata(offset: Long, timestamp: Long = Time.SYSTEM.milliseconds()): OffsetAndMetadata = {
+    OffsetAndMetadata(offset, "", timestamp)
   }
 
 }


### PR DESCRIPTION
Fix for bug where group coordinator can garbage collect offsets for groups that are in flux: https://issues.apache.org/jira/browse/KAFKA-13636)

cc: @dajac 
Tested: Added a test; ensured that it fails without the patch and passes with the path.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
