### PR TITLE
MINOR: Fix JavaDoc of OffsetIndex#append

### DIFF
--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -136,7 +136,8 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
 
   /**
    * Append an entry for the given offset/location pair to the index. This entry must have a larger offset than all subsequent entries.
-   * @throws IndexOffsetOverflowException if the offset causes index offset to overflow
+   * @throws kafka.common.IndexOffsetOverflowException if the offset causes index offset to overflow
+   * @throws InvalidOffsetException if provided offset is not larger than the last offset
    */
   def append(offset: Long, position: Int): Unit = {
     inLock(lock) {


### PR DESCRIPTION
The Java doc for the thrown exception is added in (apache#4975)
https://github.com/apache/kafka/pull/4975/files#diff-f3714fa2bb7e07c857d2cafde9dcb5d310fafd2cceed9f4124cc6342671a2c89R137

~By the time it was already a typo.~
 
It was documenting the error thrown from `relativeOffset`, but the Exception from line
```scala
        throw new InvalidOffsetException(s"Attempt to append an offset ($offset) to position $entries no larger than" +
          s" the last offset appended (${_lastOffset}) to ${file.getAbsolutePath}.")
```
is not in the Java doc, which can be confusing.