### PR TITLE
MINOR: Use timeout config in KafkaAdminClient

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -524,6 +524,7 @@ public class KafkaAdminClient extends AdminClient {
                 config.getLong(AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
                 config.getInt(AdminClientConfig.SEND_BUFFER_CONFIG),
                 config.getInt(AdminClientConfig.RECEIVE_BUFFER_CONFIG),
+                // We set this to a large enough value in KAFKA-5324 so that we can overwrite per-call timeouts with a longer value than the default timeout.
                 (int) TimeUnit.HOURS.toMillis(1),
                 config.getLong(AdminClientConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
                 config.getLong(AdminClientConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),


### PR DESCRIPTION
*More detailed description of your change*
Currently we use a fixed value 3600000 as requestTimeout when creating NetworkClient in KafkaAdminClient, it's better to use the `request.timeout.ms` config like KafkaConsumer and KafkaProducer.

In fact, this change has no effect unless request.timeout.ms is set to a value greater than 3600000.

*Summary of testing strategy (including rationale)*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
