### PR TITLE
KAFKA-12648: avoid modifying state until NamedTopology has passed validation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -163,7 +163,7 @@ public class KafkaStreams implements AutoCloseable {
     // usage only and should not be exposed to users at all.
     private final Time time;
     private final Logger log;
-    private final String clientId;
+    protected final String clientId;
     private final Metrics metrics;
     protected final StreamsConfig applicationConfigs;
     protected final List<StreamThread> threads;
@@ -904,6 +904,7 @@ public class KafkaStreams implements AutoCloseable {
         }
         final LogContext logContext = new LogContext(String.format("stream-client [%s] ", clientId));
         this.log = logContext.logger(getClass());
+        topologyMetadata.setLog(logContext);
 
         // use client id instead of thread client id since this admin client may be shared among threads
         this.clientSupplier = clientSupplier;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -160,12 +160,13 @@ class ActiveTaskCreator {
 
             final LogContext logContext = getLogContext(taskId);
 
-            final ProcessorTopology topology = topologyMetadata.buildSubtopology(taskId);
-            if (topology == null) {
-                // task belongs to a named topology that hasn't been added yet, wait until it has to create this
+            // task belongs to a named topology that hasn't been added yet, wait until it has to create this
+            if (taskId.topologyName() != null && !topologyMetadata.namedTopologiesView().contains(taskId.topologyName())) {
                 newUnknownTasks.put(taskId, partitions);
                 continue;
             }
+
+            final ProcessorTopology topology = topologyMetadata.buildSubtopology(taskId);
 
             final ProcessorStateManager stateManager = new ProcessorStateManager(
                 taskId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -90,12 +90,13 @@ class StandbyTaskCreator {
             final TaskId taskId = newTaskAndPartitions.getKey();
             final Set<TopicPartition> partitions = newTaskAndPartitions.getValue();
 
-            final ProcessorTopology topology = topologyMetadata.buildSubtopology(taskId);
-            if (topology == null) {
-                // task belongs to a named topology that hasn't been added yet, wait until it has to create this
+            // task belongs to a named topology that hasn't been added yet, wait until it has to create this
+            if (taskId.topologyName() != null && !topologyMetadata.namedTopologiesView().contains(taskId.topologyName())) {
                 newUnknownTasks.put(taskId, partitions);
                 continue;
             }
+
+            final ProcessorTopology topology = topologyMetadata.buildSubtopology(taskId);
 
             if (topology.hasStateWithChangelogs()) {
                 final ProcessorStateManager stateManager = new ProcessorStateManager(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -412,11 +412,13 @@ public class TopologyMetadata {
     }
 
     /**
-     * @return the subtopology built for this task, or null if the corresponding NamedTopology does not (yet) exist
+     * @return the {@link ProcessorTopology subtopology} built for this task, guaranteed to be non-null
+     *
+     * @throws UnknownTopologyException  if the task is from a named topology that this client isn't aware of
      */
     public ProcessorTopology buildSubtopology(final TaskId task) {
         final InternalTopologyBuilder builder = lookupBuilderForTask(task);
-        return builder == null ? null : builder.buildSubtopology(task.subtopology());
+        return builder.buildSubtopology(task.subtopology());
     }
 
     public ProcessorTopology globalTaskTopology() {
@@ -507,6 +509,11 @@ public class TopologyMetadata {
         return copartitionGroups;
     }
 
+    /**
+     * @return the {@link InternalTopologyBuilder} for this task's topology, guaranteed to be non-null
+     *
+     * @throws UnknownTopologyException  if the task is from a named topology that this client isn't aware of
+     */
     private InternalTopologyBuilder lookupBuilderForTask(final TaskId task) {
         final InternalTopologyBuilder builder = task.topologyName() == null ?
             builders.get(UNNAMED_TOPOLOGY) :
@@ -517,6 +524,7 @@ public class TopologyMetadata {
             return builder;
         }
     }
+
 
     /**
      * @return the InternalTopologyBuilder for the NamedTopology with the given {@code topologyName}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -512,7 +512,7 @@ public class TopologyMetadata {
             builders.get(UNNAMED_TOPOLOGY) :
             builders.get(task.topologyName());
         if (builder == null) {
-            throw new UnknownTopologyException("Unable to locate topology builder" ,task.topologyName());
+            throw new UnknownTopologyException("Unable to locate topology builder", task.topologyName());
         } else {
             return builder;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/AddNamedTopologyResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/AddNamedTopologyResult.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals.namedtopology;
 
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.streams.errors.StreamsException;
+import java.util.concurrent.ExecutionException;
 
 public class AddNamedTopologyResult {
 
@@ -33,5 +35,24 @@ public class AddNamedTopologyResult {
      */
     public KafkaFuture<Void> all() {
         return addTopologyFuture;
+    }
+
+    /**
+     * Boiler plate to get the root cause as a StreamsException if completed exceptionally, otherwise returns {@code null}.
+     * Non-blocking.
+     */
+    public StreamsException exceptionNow() {
+        try {
+            addTopologyFuture.getNow(null);
+            return null;
+        } catch (final ExecutionException e) {
+            if (e.getCause() instanceof StreamsException) {
+                return (StreamsException) e.getCause();
+            } else {
+                return new StreamsException(e.getCause());
+            }
+        } catch (final InterruptedException e) {
+            return null;
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals.namedtopology;
 
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability.Unstable;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
@@ -44,7 +43,6 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -230,7 +228,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
 
         if (resetOffsets) {
             log.info("Resetting offsets for the following partitions of {} removed NamedTopology {}: {}",
-                     removeTopologyFuture.isCompletedExceptionally() ? "unsuccessfully ": "successfully",
+                     removeTopologyFuture.isCompletedExceptionally() ? "unsuccessfully" : "successfully",
                      topologyToRemove, partitionsToReset
             );
             if (!partitionsToReset.isEmpty()) {
@@ -259,7 +257,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                                 log.debug("The offsets have been reset by another client or the group has been deleted, no need to retry further.");
                                 break;
                             } else {
-                                 removeTopologyFuture.completeExceptionally(ex);
+                                removeTopologyFuture.completeExceptionally(ex);
                             }
                             deleteOffsetsResult = null;
                         }
@@ -269,7 +267,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                             ex.printStackTrace();
                         }
                     }
-                     removeTopologyFuture.complete(null);
+                    removeTopologyFuture.complete(null);
                 });
                 return new RemoveNamedTopologyResult(removeTopologyFuture,  removeTopologyFuture);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
@@ -72,7 +73,7 @@ import java.util.stream.Collectors;
 @Unstable
 public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
 
-    private final Logger log = LoggerFactory.getLogger(KafkaStreamsNamedTopologyWrapper.class);
+    private final Logger log;
 
     /**
      * An empty Kafka Streams application that allows NamedTopologies to be added at a later point
@@ -87,6 +88,8 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
 
     private KafkaStreamsNamedTopologyWrapper(final StreamsConfig config, final KafkaClientSupplier clientSupplier) {
         super(new TopologyMetadata(new ConcurrentSkipListMap<>(), config), config, clientSupplier);
+        final LogContext logContext = new LogContext(String.format("stream-client [%s] ", clientId));
+        this.log = logContext.logger(getClass());
     }
 
     /**
@@ -97,11 +100,17 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
     }
 
     /**
-     * Start up Streams with a collection of initial NamedTopologies
+     * Start up Streams with a collection of initial NamedTopologies (may be empty)
      */
     public void start(final Collection<NamedTopology> initialTopologies) {
+        log.info("Starting Streams with topologies: {}", initialTopologies);
         for (final NamedTopology topology : initialTopologies) {
-            addNamedTopology(topology);
+            final AddNamedTopologyResult addNamedTopologyResult = addNamedTopology(topology);
+            if (addNamedTopologyResult.all().isCompletedExceptionally()) {
+                final StreamsException e = addNamedTopologyResult.exceptionNow();
+                log.error("Failed to start Streams when adding topology " + topology.name() + " due to", e);
+                throw e;
+            }
         }
         super.start();
     }
@@ -148,21 +157,29 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * it to begin processing the new topology.
      * This method is not purely Async.
      *
+     * May complete exceptionally (does not actually directly throw) with:
+     *
      * @throws IllegalArgumentException if this topology name is already in use
      * @throws IllegalStateException    if streams has not been started or has already shut down
      * @throws TopologyException        if this topology subscribes to any input topics or pattern already in use
      */
     public AddNamedTopologyResult addNamedTopology(final NamedTopology newTopology) {
         log.info("Adding new NamedTopology: {}", newTopology.name());
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+
         if (hasStartedOrFinishedShuttingDown()) {
-            throw new IllegalStateException("Cannot add a NamedTopology while the state is " + super.state);
+            future.completeExceptionally(
+                new IllegalStateException("Cannot add a NamedTopology while the state is " + super.state)
+            );
         } else if (getTopologyByName(newTopology.name()).isPresent()) {
-            throw new IllegalArgumentException("Unable to add the new NamedTopology " + newTopology.name() +
-                                                   " as another of the same name already exists");
+            future.completeExceptionally(
+                new IllegalArgumentException("Unable to add the new NamedTopology " + newTopology.name() +
+                                                   " as another of the same name already exists")
+            );
+        } else {
+            topologyMetadata.registerAndBuildNewTopology(future, newTopology.internalTopologyBuilder());
         }
-        return new AddNamedTopologyResult(
-            topologyMetadata.registerAndBuildNewTopology(newTopology.internalTopologyBuilder())
-        );
+        return new AddNamedTopologyResult(future);
     }
 
     /**
@@ -174,16 +191,30 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * @param topologyToRemove          name of the topology to be removed
      * @param resetOffsets              whether to reset the committed offsets for any source topics
      *
+     * May complete exceptionally (does not actually directly throw) with:
+     *
      * @throws IllegalArgumentException if this topology name cannot be found
      * @throws IllegalStateException    if streams has not been started or has already shut down
-     * @throws TopologyException        if this topology subscribes to any input topics or pattern already in use
      */
     public RemoveNamedTopologyResult removeNamedTopology(final String topologyToRemove, final boolean resetOffsets) {
-        log.info("Removing existing NamedTopology: {}", topologyToRemove);
+        log.info("Informed to remove topology {} with resetOffsets={} ", topologyToRemove, resetOffsets);
+
+        final KafkaFutureImpl<Void> removeTopologyFuture = new KafkaFutureImpl<>();
+
         if (!isRunningOrRebalancing()) {
-            throw new IllegalStateException("Cannot remove a NamedTopology while the state is " + super.state);
+            log.error("Attempted to remove topology {} from while the Kafka Streams was in state {}, "
+                          + "application must be started first.", topologyToRemove, state
+            );
+            removeTopologyFuture.completeExceptionally(
+                new IllegalStateException("Cannot remove a NamedTopology while the state is " + super.state)
+            );
         } else if (!getTopologyByName(topologyToRemove).isPresent()) {
-            throw new UnknownTopologyException("Unable to remove topology", topologyToRemove);
+            log.error("Attempted to remove unknown topology {}. This application currently contains the"
+                          + "following topologies: {}.", topologyToRemove, topologyMetadata.namedTopologiesView()
+            );
+            removeTopologyFuture.completeExceptionally(
+                new UnknownTopologyException("Unable to remove topology", topologyToRemove)
+            );
         }
         final Set<TopicPartition> partitionsToReset = metadataForLocalThreads()
             .stream()
@@ -195,15 +226,17 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
             .filter(t -> topologyMetadata.sourceTopicsForTopology(topologyToRemove).contains(t.topic()))
             .collect(Collectors.toSet());
 
-        final KafkaFuture<Void> removeTopologyFuture = topologyMetadata.unregisterTopology(topologyToRemove);
+        topologyMetadata.unregisterTopology(removeTopologyFuture, topologyToRemove);
 
         if (resetOffsets) {
-            final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
-            log.info("Resetting offsets for the following partitions of NamedTopology {}: {}", topologyToRemove, partitionsToReset);
+            log.info("Resetting offsets for the following partitions of {} removed NamedTopology {}: {}",
+                     removeTopologyFuture.isCompletedExceptionally() ? "unsuccessfully ": "successfully",
+                     topologyToRemove, partitionsToReset
+            );
             if (!partitionsToReset.isEmpty()) {
                 removeTopologyFuture.whenComplete((v, throwable) -> {
                     if (throwable != null) {
-                        future.completeExceptionally(throwable);
+                        removeTopologyFuture.completeExceptionally(throwable);
                     }
                     DeleteConsumerGroupOffsetsResult deleteOffsetsResult = null;
                     while (deleteOffsetsResult == null) {
@@ -226,7 +259,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                                 log.debug("The offsets have been reset by another client or the group has been deleted, no need to retry further.");
                                 break;
                             } else {
-                                future.completeExceptionally(ex);
+                                 removeTopologyFuture.completeExceptionally(ex);
                             }
                             deleteOffsetsResult = null;
                         }
@@ -236,9 +269,9 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                             ex.printStackTrace();
                         }
                     }
-                    future.complete(null);
+                     removeTopologyFuture.complete(null);
                 });
-                return new RemoveNamedTopologyResult(removeTopologyFuture, future);
+                return new RemoveNamedTopologyResult(removeTopologyFuture,  removeTopologyFuture);
             }
         }
         return new RemoveNamedTopologyResult(removeTopologyFuture);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -180,11 +180,9 @@ public class NamedTopologyIntegrationTest {
 
     private Properties props;
     private Properties props2;
-    private Properties props3;
 
     private KafkaStreamsNamedTopologyWrapper streams;
     private KafkaStreamsNamedTopologyWrapper streams2;
-    private KafkaStreamsNamedTopologyWrapper streams3;
 
     // builders for the 1st Streams instance (default)
     private NamedTopologyBuilder topology1Builder;
@@ -195,10 +193,6 @@ public class NamedTopologyIntegrationTest {
     // builders for the 2nd Streams instance
     private NamedTopologyBuilder topology1Builder2;
     private NamedTopologyBuilder topology2Builder2;
-
-    // builders for the 3rd Streams instance
-    private NamedTopologyBuilder topology1Builder3;
-    private NamedTopologyBuilder topology2Builder3;
 
     private Properties configProps(final String appId, final String host) {
         final Properties streamsConfiguration = new Properties();
@@ -243,13 +237,6 @@ public class NamedTopologyIntegrationTest {
         topology2Builder2 = streams2.newNamedTopologyBuilder(TOPOLOGY_2);
     }
 
-    private void setupThirdKafkaStreams() {
-        props3 = configProps(appId, "host3");
-        streams3 = new KafkaStreamsNamedTopologyWrapper(props3, clientSupplier);
-        topology1Builder3 = streams3.newNamedTopologyBuilder(TOPOLOGY_1);
-        topology2Builder3 = streams3.newNamedTopologyBuilder(TOPOLOGY_2);
-    }
-
     @After
     public void shutdown() throws Exception {
         if (streams != null) {
@@ -257,9 +244,6 @@ public class NamedTopologyIntegrationTest {
         }
         if (streams2 != null) {
             streams2.close(Duration.ofSeconds(30));
-        }
-        if (streams3 != null) {
-            streams3.close(Duration.ofSeconds(30));
         }
 
         CLUSTER.getAllTopicsInCluster().stream().filter(t -> t.contains("-changelog") || t.contains("-repartition")).forEach(t -> {
@@ -455,45 +439,6 @@ public class NamedTopologyIntegrationTest {
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
-    }
-
-    @Test
-    public void shouldAddNamedTopologyToWithThreeNodeApplication() throws Exception {
-        setupSecondKafkaStreams();
-        setupThirdKafkaStreams();
-        topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
-        topology1Builder2.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
-        topology1Builder3.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
-        streams.start(topology1Builder.build());
-        streams2.start(topology1Builder2.build());
-        streams3.start(topology1Builder3.build());
-
-        waitForApplicationState(asList(streams, streams2, streams3), State.RUNNING, Duration.ofSeconds(30));
-
-        topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
-        topology2Builder2.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
-        topology2Builder3.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
-
-        streams.addNamedTopology(topology2Builder.build()).all().get();
-
-        Thread.sleep(15 * 1000L);
-
-        waitForApplicationState(asList(streams, streams2, streams3), State.RUNNING, Duration.ofSeconds(30));
-
-        streams2.addNamedTopology(topology2Builder2.build()).all().get();
-
-        Thread.sleep(15 * 1000L);
-
-        waitForApplicationState(asList(streams, streams2, streams3), State.RUNNING, Duration.ofSeconds(30));
-
-        streams3.addNamedTopology(topology2Builder3.build()).all().get();
-
-        waitForApplicationState(asList(streams, streams2, streams3), State.RUNNING, Duration.ofSeconds(30));
-
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
-
-
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
@@ -134,6 +135,23 @@ public class NamedTopologyTest {
                 builder1.build(),
                 builder2.build()))
         );
+    }
+
+    @Test
+    public void shouldThrowTopologyExceptionWhenAddingNamedTopologyReadingFromSameInputTopic() {
+        builder1.stream("stream");
+        builder2.stream("stream");
+
+        streams.start();
+
+        streams.addNamedTopology(builder1.build());
+
+        final ExecutionException exception = assertThrows(
+            ExecutionException.class,
+            () -> streams.addNamedTopology(builder2.build()).all().get()
+        );
+
+        assertThat(exception.getCause().getClass(), equalTo(TopologyException.class));
     }
 
     @Test


### PR DESCRIPTION
Previously we were only verifying the new query could be added after we had already inserted it into the TopologyMetadata, so we need to move the validation upfront.

Also adds a test case for this and improves handling of NPE in case of future or undiscovered bugs