### PR TITLE
MINOR: Optimize collection method in Utils

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -763,6 +763,7 @@ public final class Utils {
      * @return Set
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> Set<T> mkSet(T... elems) {
         return new HashSet<>(Arrays.asList(elems));
     }
@@ -774,6 +775,7 @@ public final class Utils {
      * @return SortedSet
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T extends Comparable<T>> SortedSet<T> mkSortedSet(T... elems) {
         return new TreeSet<>(Arrays.asList(elems));
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -764,10 +764,7 @@ public final class Utils {
      */
     @SafeVarargs
     public static <T> Set<T> mkSet(T... elems) {
-        Set<T> result = new HashSet<>((int) (elems.length / 0.75) + 1);
-        for (T elem : elems)
-            result.add(elem);
-        return result;
+        return new HashSet<>(Arrays.asList(elems));
     }
 
     /**
@@ -778,10 +775,7 @@ public final class Utils {
      */
     @SafeVarargs
     public static <T extends Comparable<T>> SortedSet<T> mkSortedSet(T... elems) {
-        SortedSet<T> result = new TreeSet<>();
-        for (T elem : elems)
-            result.add(elem);
-        return result;
+        return new TreeSet<>(Arrays.asList(elems));
     }
 
     /**
@@ -807,7 +801,7 @@ public final class Utils {
      */
     @SafeVarargs
     public static <K, V> Map<K, V> mkMap(final Map.Entry<K, V>... entries) {
-        final LinkedHashMap<K, V> result = new LinkedHashMap<>();
+        final LinkedHashMap<K, V> result = new LinkedHashMap<>(entries.length);
         for (final Map.Entry<K, V> entry : entries) {
             result.put(entry.getKey(), entry.getValue());
         }
@@ -822,9 +816,7 @@ public final class Utils {
      */
     public static Properties mkProperties(final Map<String, String> properties) {
         final Properties result = new Properties();
-        for (final Map.Entry<String, String> entry : properties.entrySet()) {
-            result.setProperty(entry.getKey(), entry.getValue());
-        }
+        result.putAll(properties);
         return result;
     }
 
@@ -836,9 +828,7 @@ public final class Utils {
      */
     public static Properties mkObjectProperties(final Map<String, Object> properties) {
         final Properties result = new Properties();
-        for (final Map.Entry<String, Object> entry : properties.entrySet()) {
-            result.put(entry.getKey(), entry.getValue());
-        }
+        result.putAll(properties);
         return result;
     }
 


### PR DESCRIPTION
* It's better to initialize collection size when create a collection like set, and the constructor like `HashSet(Collection<? extends E> c)` will calculate the best initialize size, so we don't need to calculate by ourselves.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
