### PR TITLE
MINOR: Fix sensor removal assertion in `MetricTest.testRemoveInactiveMetrics` 

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -304,12 +304,12 @@ public class MetricsTest {
         assertNotNull(
                 metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")), "MetricName test.s2.count must be present");
 
-        // After another 1 second sleep, the metric should be purged
-        time.sleep(1000);
+        // After another 1001 ms sleep, the metric should be purged
+        time.sleep(1001);
         purger.run();
-        assertNull(metrics.getSensor("test.s1"), "Sensor test.s2 should have been purged");
+        assertNull(metrics.getSensor("test.s2"), "Sensor test.s2 should have been purged");
         assertNull(
-                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")), "MetricName test.s2.count should have been purged");
+                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")), "MetricName test.s2.count should have been purged");
 
         // After purging, it should be possible to recreate a metric
         s1 = metrics.sensor("test.s1", null, 1);


### PR DESCRIPTION
The MetricTest  testRemoveInactiveMetrics()  should  have tested to remove inactive metrics， but it was not tested the sensor s2 when time passed，the code should be modified to test sensor s2

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
