### PR TITLE
MINOR: Clarify producer idempotence default in upgrade docs

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -69,6 +69,13 @@
     </li>
 </ol>
 
+<h5><a id="upgrade_300_notable" href="#upgrade_301_notable">Notable changes in 3.1.1</a></h5>
+<ul>
+    <li>A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
+	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
+        This issue was fixed and the default is properly applied.</li>
+</ul>
+
 <h5><a id="upgrade_310_notable" href="#upgrade_310_notable">Notable changes in 3.1.0</a></h5>
 <ul>
     <li>Apache Kafka supports Java 17.</li>
@@ -132,8 +139,20 @@
     </li>
 </ol>
 
+<h5><a id="upgrade_300_notable" href="#upgrade_301_notable">Notable changes in 3.0.1</a></h5>
+<ul>
+    <li>A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
+	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
+        This issue was fixed and the default is properly applied.</li>
+</ul>
+
 <h5><a id="upgrade_300_notable" href="#upgrade_300_notable">Notable changes in 3.0.0</a></h5>
 <ul>
+    <li>The producer has stronger delivery guarantees by default: <code>idempotence</code> is enabled and <code>acks</code> is set to <code>all</code> instead of <code>1</code>.
+        See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default">KIP-679</a> for details.
+	In 3.0.0 and 3.1.0, a bug prevented the idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
+	<code>enable.idempotence</code> to true. Note that the bug did not affect the <code>acks=all</code> change. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
+        This issue was fixed and the default is properly applied in 3.0.1, 3.1.1, and 3.2.0.
     <li>ZooKeeper has been upgraded to version 3.6.3.</li>
     <li>A preview of KRaft mode is available, though upgrading to it from the 2.8 Early Access release is not possible. See
         the <code>config/kraft/README.md</code> file for details.</li>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -69,7 +69,7 @@
     </li>
 </ol>
 
-<h5><a id="upgrade_300_notable" href="#upgrade_301_notable">Notable changes in 3.1.1</a></h5>
+<h5><a id="upgrade_311_notable" href="#upgrade_311_notable">Notable changes in 3.1.1</a></h5>
 <ul>
     <li>A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
 	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
@@ -139,7 +139,7 @@
     </li>
 </ol>
 
-<h5><a id="upgrade_300_notable" href="#upgrade_301_notable">Notable changes in 3.0.1</a></h5>
+<h5><a id="upgrade_301_notable" href="#upgrade_301_notable">Notable changes in 3.0.1</a></h5>
 <ul>
     <li>A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
 	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.


### PR DESCRIPTION
* Mention `acks=1` to `acks=all` change in 3.0.0 upgrade docs
* Have a separate section for 3.0.1 and 3.1.1 as some may skip the
  3.0.0/3.1.0 section when upgrading to a bug fix.
* Move the 3.0.0 note to the top since it's more impactful than the
  other changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
