### PR TITLE
MINOR: Clarify logging behavior with errors.log.include.messages property

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -150,7 +150,7 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String ERRORS_LOG_INCLUDE_MESSAGES_CONFIG = "errors.log.include.messages";
     public static final String ERRORS_LOG_INCLUDE_MESSAGES_DISPLAY = "Log Error Details";
     public static final boolean ERRORS_LOG_INCLUDE_MESSAGES_DEFAULT = false;
-    public static final String ERRORS_LOG_INCLUDE_MESSAGES_DOC = "Whether to the include in the log the Connect record that resulted in a failure." +
+    public static final String ERRORS_LOG_INCLUDE_MESSAGES_DOC = "Whether to include in the log the Connect record that resulted in a failure." +
             "For sink records, the topic, partition, offset, and timestamp will be logged. " +
             "For source records, the key and value (and their schemas), all headers, and the timestamp, Kafka topic, Kafka partition, source partition, " +
             "and source offset will be logged. " +

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -150,9 +150,11 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String ERRORS_LOG_INCLUDE_MESSAGES_CONFIG = "errors.log.include.messages";
     public static final String ERRORS_LOG_INCLUDE_MESSAGES_DISPLAY = "Log Error Details";
     public static final boolean ERRORS_LOG_INCLUDE_MESSAGES_DEFAULT = false;
-    public static final String ERRORS_LOG_INCLUDE_MESSAGES_DOC = "Whether to the include in the log the Connect record that resulted in " +
-            "a failure. This is 'false' by default, which will prevent record keys, values, and headers from being written to log files, " +
-            "although some information such as topic and partition number will still be logged.";
+    public static final String ERRORS_LOG_INCLUDE_MESSAGES_DOC = "Whether to the include in the log the Connect record that resulted in a failure." +
+            "For sink records, the topic, partition, offset, and timestamp will be logged. " +
+            "For source records, the key and value (and their schemas), all headers, and the timestamp, Kafka topic, Kafka partition, source partition, " +
+            "and source offset will be logged. " +
+            "This is 'false' by default, which will prevent record keys, values, and headers from being written to log files.";
 
 
     public static final String CONNECTOR_CLIENT_PRODUCER_OVERRIDES_PREFIX = "producer.override.";


### PR DESCRIPTION
The docs are a little misleading and some users can be confused about the exact behavior of this property.

References:
- [LogReporter::report and LogReporter::message](https://github.com/apache/kafka/blob/b5b590cb6711617cbb3c978de9f8bb0903291efa/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/LogReporter.java#L51-L75)
- [ConnectorConfig::includeRecordDetailsInErrorLog](https://github.com/apache/kafka/blob/b5b590cb6711617cbb3c978de9f8bb0903291efa/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java#L264-L266)
- [ProcessingContext::toString](https://github.com/apache/kafka/blob/b5b590cb6711617cbb3c978de9f8bb0903291efa/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java#L164-L188)
- [SourceRecord::toString](https://github.com/apache/kafka/blob/b5b590cb6711617cbb3c978de9f8bb0903291efa/connect/api/src/main/java/org/apache/kafka/connect/source/SourceRecord.java#L129-L135)
- [ConnectRecord::toString](https://github.com/apache/kafka/blob/b5b590cb6711617cbb3c978de9f8bb0903291efa/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectRecord.java#L137-L149)

