### PR TITLE
MINOR: improve JavaDocs for ReadOnlySessionStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlySessionStore.java
@@ -33,8 +33,21 @@ public interface ReadOnlySessionStore<K, AGG> {
     /**
      * Fetch any sessions with the matching key and the sessions end is &ge; earliestSessionEndTime
      * and the sessions start is &le; latestSessionStartTime iterating from earliest to latest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
+     *
      *
      * @param key                    the key to return sessions for
      * @param earliestSessionEndTime the end timestamp of the earliest session to search for, where
@@ -55,6 +68,18 @@ public interface ReadOnlySessionStore<K, AGG> {
     /**
      * Fetch any sessions with the matching key and the sessions end is &ge; earliestSessionEndTime
      * and the sessions start is &le; latestSessionStartTime iterating from earliest to latest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -77,6 +102,18 @@ public interface ReadOnlySessionStore<K, AGG> {
     /**
      * Fetch any sessions with the matching key and the sessions end is &ge; earliestSessionEndTime
      * and the sessions start is &le; latestSessionStartTime iterating from latest to earliest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -99,6 +136,18 @@ public interface ReadOnlySessionStore<K, AGG> {
     /**
      * Fetch any sessions with the matching key and the sessions end is &ge; earliestSessionEndTime
      * and the sessions start is &le; latestSessionStartTime iterating from latest to earliest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -122,6 +171,18 @@ public interface ReadOnlySessionStore<K, AGG> {
      * Fetch any sessions in the given range of keys and the sessions end is &ge;
      * earliestSessionEndTime and the sessions start is &le; latestSessionStartTime iterating from
      * earliest to latest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -148,6 +209,18 @@ public interface ReadOnlySessionStore<K, AGG> {
      * Fetch any sessions in the given range of keys and the sessions end is &ge;
      * earliestSessionEndTime and the sessions start is &le; latestSessionStartTime iterating from
      * earliest to latest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -174,6 +247,18 @@ public interface ReadOnlySessionStore<K, AGG> {
      * Fetch any sessions in the given range of keys and the sessions end is &ge;
      * earliestSessionEndTime and the sessions start is &le; latestSessionStartTime iterating from
      * latest to earliest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -200,6 +285,18 @@ public interface ReadOnlySessionStore<K, AGG> {
      * Fetch any sessions in the given range of keys and the sessions end is &ge;
      * earliestSessionEndTime and the sessions start is &le; latestSessionStartTime iterating from
      * latest to earliest.
+     * I.e., earliestSessionEndTime is the lower bound of the search interval and latestSessionStartTime
+     * is the upper bound of the search interval, and the method returns all sessions that overlap
+     * with the search interval.
+     * Thus, if a session ends before earliestSessionEndTime, or starts after latestSessionStartTime
+     * if won't be contained in the result:
+     * <pre>{@code
+     * earliestSessionEndTime: ESET
+     * latestSessionStartTime: LSST
+     *
+     *                       [ESET............LSST]
+     * [not-included] [included]   [included]   [included] [not-included]
+     * }</pre>
      * <p>
      * This iterator must be closed after use.
      *
@@ -226,14 +323,14 @@ public interface ReadOnlySessionStore<K, AGG> {
      * Get the value of key from a single session.
      *
      * @param key                    the key to fetch
-     * @param earliestSessionEndTime start timestamp of the session
-     * @param latestSessionStartTime end timestamp of the session
+     * @param sessionStartTime start timestamp of the session
+     * @param sessionEndTime end timestamp of the session
      * @return The value or {@code null} if no session associated with the key can be found
      * @throws NullPointerException If {@code null} is used for any key.
      */
     default AGG fetchSession(final K key,
-                             final long earliestSessionEndTime,
-                             final long latestSessionStartTime) {
+                             final long sessionStartTime,
+                             final long sessionEndTime) {
         throw new UnsupportedOperationException(
             "This API is not supported by this implementation of ReadOnlySessionStore.");
     }
@@ -242,14 +339,14 @@ public interface ReadOnlySessionStore<K, AGG> {
      * Get the value of key from a single session.
      *
      * @param key                    the key to fetch
-     * @param earliestSessionEndTime start timestamp of the session
-     * @param latestSessionStartTime end timestamp of the session
+     * @param sessionStartTime start timestamp of the session
+     * @param sessionEndTime end timestamp of the session
      * @return The value or {@code null} if no session associated with the key can be found
      * @throws NullPointerException If {@code null} is used for any key.
      */
     default AGG fetchSession(final K key,
-                             final Instant earliestSessionEndTime,
-                             final Instant latestSessionStartTime) {
+                             final Instant sessionStartTime,
+                             final Instant sessionEndTime) {
         throw new UnsupportedOperationException(
             "This API is not supported by this implementation of ReadOnlySessionStore.");
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlySessionStore.java
@@ -325,7 +325,8 @@ public interface ReadOnlySessionStore<K, AGG> {
      * @param key                    the key to fetch
      * @param sessionStartTime start timestamp of the session
      * @param sessionEndTime end timestamp of the session
-     * @return The value or {@code null} if no session associated with the key can be found
+     * @return The value or {@code null} if no session with the exact start and end timestamp exists
+     *         for the given key
      * @throws NullPointerException If {@code null} is used for any key.
      */
     default AGG fetchSession(final K key,
@@ -341,7 +342,8 @@ public interface ReadOnlySessionStore<K, AGG> {
      * @param key                    the key to fetch
      * @param sessionStartTime start timestamp of the session
      * @param sessionEndTime end timestamp of the session
-     * @return The value or {@code null} if no session associated with the key can be found
+     * @return The value or {@code null} if no session with the exact start and end timestamp exists
+     *         for the given key
      * @throws NullPointerException If {@code null} is used for any key.
      */
     default AGG fetchSession(final K key,


### PR DESCRIPTION
The JavaDocs explaining the `findSession` search interval is correct, but hard to understand. We should be more explicit how it works.