### PR TITLE
MINOR: Add autoupdate of gradle checksum together with gradle version update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 import org.ajoberstar.grgit.Grgit
+import org.gradle.util.DistributionLocator
+import org.gradle.util.GradleVersion
 
 import java.nio.charset.StandardCharsets
 
@@ -105,6 +107,19 @@ ext {
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
 
   commitId = determineCommitId()
+}
+
+wrapper {
+  distributionType = 'ALL'
+  doLast {
+    final DistributionLocator locator = new DistributionLocator()
+    final GradleVersion version = GradleVersion.version(wrapper.gradleVersion)
+    final URI distributionUri = locator.getDistributionFor(version, wrapper.distributionType.name().toLowerCase(Locale.ENGLISH))
+    final URI sha256Uri = new URI(distributionUri.toString() + ".sha256")
+    final String sha256Sum = new String(sha256Uri.toURL().bytes)
+    wrapper.getPropertiesFile() << "distributionSha256Sum=${sha256Sum}\n"
+    println "Added checksum to wrapper properties"
+  }
 }
 
 allprojects {


### PR DESCRIPTION
The problem that during gradle version update `./gradlew wrapper --gradle-version <version>` it removes checksums
This PR adds autoupdate of gradle's checksums in `gradle-wrapper.properties`
The idea was taken from OpenSearch https://github.com/opensearch-project/OpenSearch/blob/27ed6fc82c7db7a3a741499f0dbd7722fa053f9d/build.gradle#L451

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
