### PR TITLE
Install missing 'tc' utility - iproute2 for systemtests

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -33,7 +33,7 @@ LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
 # we have to install git since it is included in openjdk:8 but not openjdk:11
-RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
+RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute iproute2 && apt-get -y clean
 RUN python3 -m pip install -U pip==21.1.1;
 RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 debugpy && pip3 install --upgrade ducktape==0.8.1
 


### PR DESCRIPTION
Signed-off-by: Michal T <mtoth@redhat.com>

Some system tests are failing on missing `tc` traffic control utility, which is provided on debian in iproute2 package.
This fixes issues with failing tests

```
File "/opt/kafka-dev/tests/kafkatest/services/trogdor/trogdor.py", line 325, in done
21:07:43      raise RuntimeError("Failed to gracefully stop %s: got task error: %s" % (self.id, error))
21:07:43  RuntimeError: Failed to gracefully stop rate-1000: got task error: worker.start() exception: org.apache.kafka.common.utils.Shell$ExitCodeException: sudo: tc: command not found
```

Some tests from 
```
kafkatest.tests.core.round_trip_fault_test.RoundTripFaultTest.test_produce_consume_with_latency
kafkatest.tests.core.network_degrade_test.NetworkDegradeTest.test_rate
```
