### PR TITLE
KAFKA-13598: set log4j appender to default acks

### DIFF
--- a/log4j-appender/src/main/java/org/apache/kafka/log4jappender/KafkaLog4jAppender.java
+++ b/log4j-appender/src/main/java/org/apache/kafka/log4jappender/KafkaLog4jAppender.java
@@ -74,9 +74,9 @@ public class KafkaLog4jAppender extends AppenderSkeleton {
     private String kerb5ConfPath;
     private Integer maxBlockMs;
     private String sslEngineFactoryClass;
+    private Integer requiredNumAcks;
 
     private int retries = Integer.MAX_VALUE;
-    private int requiredNumAcks = 1;
     private int deliveryTimeoutMs = 120000;
     private int lingerMs = 0;
     private int batchSize = 16384;
@@ -285,7 +285,9 @@ public class KafkaLog4jAppender extends AppenderSkeleton {
         if (compressionType != null)
             props.put(COMPRESSION_TYPE_CONFIG, compressionType);
 
-        props.put(ACKS_CONFIG, Integer.toString(requiredNumAcks));
+        if (requiredNumAcks != null)
+            props.put(ACKS_CONFIG, Integer.toString(requiredNumAcks));
+
         props.put(RETRIES_CONFIG, retries);
         props.put(DELIVERY_TIMEOUT_MS_CONFIG, deliveryTimeoutMs);
         props.put(LINGER_MS_CONFIG, lingerMs);


### PR DESCRIPTION
After https://github.com/apache/kafka/pull/11691, the
KafkaLog4JAppender causes the process to crash due
to the mismatch between the new produce default
idempotent mode and the appender's overridden
`acks=1` property.

* Removes the `acks=1` override, so the appender falls
back on the producer's default acks config.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
