### PR TITLE
Use default non-zero value for retries in producer

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -248,8 +248,6 @@ public class VerifiableProducer implements AutoCloseable {
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.StringSerializer");
         producerProps.put(ProducerConfig.ACKS_CONFIG, Integer.toString(res.getInt("acks")));
-        // No producer retries
-        producerProps.put(ProducerConfig.RETRIES_CONFIG, "0");
         if (configFile != null) {
             try {
                 producerProps.putAll(loadProps(configFile));


### PR DESCRIPTION
Signed-off-by: Michal T <mtoth@redhat.com>

Recent changes to idempotent client uncovered issue with Verifiable producer using 0 retries instead of default int_max.
This was failing multiple system tests and should fix the issue.

PerformanceProducer is also affected.