### PR TITLE
KAFKA-10000: Add producer fencing API to admin client (KIP-618)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1576,6 +1576,29 @@ public interface Admin extends AutoCloseable {
     ListTransactionsResult listTransactions(ListTransactionsOptions options);
 
     /**
+     * Fence out all active producers that use any of the provided transactional IDs, with the default options.
+     * <p>
+     * This is a convenience method for {@link #fenceProducers(Collection, FenceProducersOptions)}
+     * with default options. See the overload for more details.
+     *
+     * @param transactionalIds The IDs of the producers to fence.
+     * @return The FenceProducersResult.
+     */
+    default FenceProducersResult fenceProducers(Collection<String> transactionalIds) {
+        return fenceProducers(transactionalIds, new FenceProducersOptions());
+    }
+
+    /**
+     * Fence out all active producers that use any of the provided transactional IDs.
+     *
+     * @param transactionalIds The IDs of the producers to fence.
+     * @param options          The options to use when fencing the producers.
+     * @return The FenceProducersResult.
+     */
+    FenceProducersResult fenceProducers(Collection<String> transactionalIds,
+                                        FenceProducersOptions options);
+
+    /**
      * Get the metrics kept by the adminClient
      */
     Map<MetricName, ? extends Metric> metrics();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/FenceProducersOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FenceProducersOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
+/**
+ * Options for {@link Admin#fenceProducers(Collection, FenceProducersOptions)}
+ *
+ * The API of this class is evolving. See {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class FenceProducersOptions extends AbstractOptions<FenceProducersOptions> {
+
+    @Override
+    public String toString() {
+        return "FenceProducersOptions{" +
+                "timeoutMs=" + timeoutMs +
+                '}';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/FenceProducersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FenceProducersResult.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.admin.internals.CoordinatorKey;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The result of the {@link Admin#fenceProducers(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class FenceProducersResult {
+
+    private final Map<CoordinatorKey, KafkaFuture<ProducerIdAndEpoch>> futures;
+
+    FenceProducersResult(Map<CoordinatorKey, KafkaFuture<ProducerIdAndEpoch>> futures) {
+        this.futures = futures;
+    }
+
+    /**
+     * Return a map from transactional ID to futures which can be used to check the status of
+     * individual fencings.
+     */
+    public Map<String, KafkaFuture<Void>> fencedProducers() {
+        return futures.entrySet().stream().collect(Collectors.toMap(
+            e -> e.getKey().idValue,
+            e -> e.getValue().thenApply(p -> null)
+        ));
+    }
+
+    /**
+     * Returns a future that provides the producer ID generated while initializing the given transaction when the request completes.
+     */
+    public KafkaFuture<Long> producerId(String transactionalId) {
+        return findAndApply(transactionalId, p -> p.producerId);
+    }
+
+    /**
+     * Returns a future that provides the epoch ID generated while initializing the given transaction when the request completes.
+     */
+    public KafkaFuture<Short> epochId(String transactionalId) {
+        return findAndApply(transactionalId, p -> p.epoch);
+    }
+
+    /**
+     * Return a future which succeeds only if all the producer fencings succeed.
+     */
+    public KafkaFuture<Void> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+    }
+
+    private <T> KafkaFuture<T> findAndApply(String transactionalId, KafkaFuture.BaseFunction<ProducerIdAndEpoch, T> followup) {
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
+        KafkaFuture<ProducerIdAndEpoch> future = futures.get(key);
+        if (future == null) {
+            throw new IllegalArgumentException("TransactionalId " +
+                "`" + transactionalId + "` was not included in the request");
+        }
+        return future.thenApply(followup);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -47,6 +47,7 @@ import org.apache.kafka.clients.admin.internals.DeleteConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeConsumerGroupsHandler;
 import org.apache.kafka.clients.admin.internals.DescribeProducersHandler;
 import org.apache.kafka.clients.admin.internals.DescribeTransactionsHandler;
+import org.apache.kafka.clients.admin.internals.FenceProducersHandler;
 import org.apache.kafka.clients.admin.internals.ListConsumerGroupOffsetsHandler;
 import org.apache.kafka.clients.admin.internals.ListTransactionsHandler;
 import org.apache.kafka.clients.admin.internals.MetadataOperationContext;
@@ -234,6 +235,7 @@ import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
@@ -4388,6 +4390,15 @@ public class KafkaAdminClient extends AdminClient {
         ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
         invokeDriver(handler, future, options.timeoutMs);
         return new ListTransactionsResult(future.all());
+    }
+
+    @Override
+    public FenceProducersResult fenceProducers(Collection<String> transactionalIds, FenceProducersOptions options) {
+        AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ProducerIdAndEpoch> future =
+            FenceProducersHandler.newFuture(transactionalIds);
+        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        invokeDriver(handler, future, options.timeoutMs);
+        return new FenceProducersResult(future.all());
     }
 
     private <K, V> void invokeDriver(

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 
-public class AbortTransactionHandler implements AdminApiHandler<TopicPartition, Void> {
+public class AbortTransactionHandler extends AdminApiHandler.Batched<TopicPartition, Void> {
     private final Logger log;
     private final AbortTransactionSpec abortSpec;
     private final PartitionLeaderStrategy lookupStrategy;
@@ -69,7 +69,7 @@ public class AbortTransactionHandler implements AdminApiHandler<TopicPartition, 
     }
 
     @Override
-    public WriteTxnMarkersRequest.Builder buildRequest(
+    public WriteTxnMarkersRequest.Builder buildBatchedRequest(
         int brokerId,
         Set<TopicPartition> topicPartitions
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
@@ -20,10 +20,12 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public interface AdminApiHandler<K, V> {
 
@@ -33,16 +35,18 @@ public interface AdminApiHandler<K, V> {
     String apiName();
 
     /**
-     * Build the request. The set of keys are derived by {@link AdminApiDriver}
-     * during the lookup stage as the set of keys which all map to the same
-     * destination broker.
+     * Build the requests necessary for the given keys. The set of keys is derived by
+     * {@link AdminApiDriver} during the lookup stage as the set of keys which all map
+     * to the same destination broker. Handlers can choose to issue a single request for
+     * all of the provided keys (see {@link Batched}, issue one request per key (see
+     * {@link Unbatched}, or implement their own custom grouping logic if necessary.
      *
      * @param brokerId the target brokerId for the request
      * @param keys the set of keys that should be handled by this request
      *
-     * @return a builder for the request containing the given keys
+     * @return a collection of {@link RequestAndKeys} for the requests containing the given keys
      */
-    AbstractRequest.Builder<?> buildRequest(int brokerId, Set<K> keys);
+    Collection<RequestAndKeys<K>> buildRequest(int brokerId, Set<K> keys);
 
     /**
      * Callback that is invoked when a request returns successfully.
@@ -122,4 +126,54 @@ public interface AdminApiHandler<K, V> {
         }
     }
 
+    class RequestAndKeys<K> {
+        public final AbstractRequest.Builder<?> request;
+        public final Set<K> keys;
+
+        public RequestAndKeys(AbstractRequest.Builder<?> request, Set<K> keys) {
+            this.request = request;
+            this.keys = keys;
+        }
+    }
+
+    /**
+     * An {@link AdminApiHandler} that will group multiple keys into a single request when possible.
+     * Keys will be grouped together whenever they target the same broker. This type of handler
+     * should be used when when interacting with broker APIs that can act on multiple keys at once,
+     * such as describing or listing transactions.
+     */
+    abstract class Batched<K, V> implements AdminApiHandler<K, V> {
+        abstract AbstractRequest.Builder<?> buildBatchedRequest(int brokerId, Set<K> keys);
+
+        @Override
+        public final Collection<RequestAndKeys<K>> buildRequest(int brokerId, Set<K> keys) {
+            return Collections.singleton(new RequestAndKeys<>(buildBatchedRequest(brokerId, keys), keys));
+        }
+    }
+
+    /**
+     * An {@link AdminApiHandler} that will create one request per key, not performing any grouping based
+     * on the targeted broker. This type of handler should only be used for broker APIs that do not accept
+     * multiple keys at once, such as initializing a transactional producer.
+     */
+    abstract class Unbatched<K, V> implements AdminApiHandler<K, V> {
+        abstract AbstractRequest.Builder<?> buildSingleRequest(int brokerId, K key);
+        abstract ApiResult<K, V> handleSingleResponse(Node broker, K key, AbstractResponse response);
+
+        @Override
+        public final Collection<RequestAndKeys<K>> buildRequest(int brokerId, Set<K> keys) {
+            return keys.stream()
+                .map(key -> new RequestAndKeys<>(buildSingleRequest(brokerId, key), Collections.singleton(key)))
+                .collect(Collectors.toSet());
+        }
+
+        @Override
+        public final ApiResult<K, V> handleResponse(Node broker, Set<K> keys, AbstractResponse response) {
+            if (keys.size() != 1) {
+                throw new IllegalArgumentException("Unbatched admin handler should only be required to handle responses for a single key at a time");
+            }
+            K key = keys.iterator().next();
+            return handleSingleResponse(broker, key, response);
+        }
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
@@ -139,8 +139,8 @@ public interface AdminApiHandler<K, V> {
     /**
      * An {@link AdminApiHandler} that will group multiple keys into a single request when possible.
      * Keys will be grouped together whenever they target the same broker. This type of handler
-     * should be used when when interacting with broker APIs that can act on multiple keys at once,
-     * such as describing or listing transactions.
+     * should be used when interacting with broker APIs that can act on multiple keys at once, such
+     * as describing or listing transactions.
      */
     abstract class Batched<K, V> implements AdminApiHandler<K, V> {
         abstract AbstractRequest.Builder<?> buildBatchedRequest(int brokerId, Set<K> keys);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandler.java
@@ -41,7 +41,7 @@ import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class AlterConsumerGroupOffsetsHandler implements AdminApiHandler<CoordinatorKey, Map<TopicPartition, Errors>> {
+public class AlterConsumerGroupOffsetsHandler extends AdminApiHandler.Batched<CoordinatorKey, Map<TopicPartition, Errors>> {
 
     private final CoordinatorKey groupId;
     private final Map<TopicPartition, OffsetAndMetadata> offsets;
@@ -83,7 +83,7 @@ public class AlterConsumerGroupOffsetsHandler implements AdminApiHandler<Coordin
     }
 
     @Override
-    public OffsetCommitRequest.Builder buildRequest(
+    public OffsetCommitRequest.Builder buildBatchedRequest(
         int coordinatorId,
         Set<CoordinatorKey> groupIds
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupOffsetsHandler.java
@@ -38,7 +38,7 @@ import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class DeleteConsumerGroupOffsetsHandler implements AdminApiHandler<CoordinatorKey, Map<TopicPartition, Errors>> {
+public class DeleteConsumerGroupOffsetsHandler extends AdminApiHandler.Batched<CoordinatorKey, Map<TopicPartition, Errors>> {
 
     private final CoordinatorKey groupId;
     private final Set<TopicPartition> partitions;
@@ -80,7 +80,7 @@ public class DeleteConsumerGroupOffsetsHandler implements AdminApiHandler<Coordi
     }
 
     @Override
-    public OffsetDeleteRequest.Builder buildRequest(int coordinatorId, Set<CoordinatorKey> groupIds) {
+    public OffsetDeleteRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> groupIds) {
         validateKeys(groupIds);
 
         final OffsetDeleteRequestTopicCollection topics = new OffsetDeleteRequestTopicCollection();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupsHandler.java
@@ -36,7 +36,7 @@ import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class DeleteConsumerGroupsHandler implements AdminApiHandler<CoordinatorKey, Void> {
+public class DeleteConsumerGroupsHandler extends AdminApiHandler.Batched<CoordinatorKey, Void> {
 
     private final Logger log;
     private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
@@ -71,7 +71,7 @@ public class DeleteConsumerGroupsHandler implements AdminApiHandler<CoordinatorK
     }
 
     @Override
-    public DeleteGroupsRequest.Builder buildRequest(
+    public DeleteGroupsRequest.Builder buildBatchedRequest(
         int coordinatorId,
         Set<CoordinatorKey> keys
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandler.java
@@ -51,7 +51,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
-public class DescribeConsumerGroupsHandler implements AdminApiHandler<CoordinatorKey, ConsumerGroupDescription> {
+public class DescribeConsumerGroupsHandler extends AdminApiHandler.Batched<CoordinatorKey, ConsumerGroupDescription> {
 
     private final boolean includeAuthorizedOperations;
     private final Logger log;
@@ -89,7 +89,7 @@ public class DescribeConsumerGroupsHandler implements AdminApiHandler<Coordinato
     }
 
     @Override
-    public DescribeGroupsRequest.Builder buildRequest(int coordinatorId, Set<CoordinatorKey> keys) {
+    public DescribeGroupsRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> keys) {
         List<String> groupIds = keys.stream().map(key -> {
             if (key.type != FindCoordinatorRequest.CoordinatorType.GROUP) {
                 throw new IllegalArgumentException("Invalid transaction coordinator key " + key +

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
@@ -46,7 +46,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class DescribeProducersHandler implements AdminApiHandler<TopicPartition, PartitionProducerState> {
+public class DescribeProducersHandler extends AdminApiHandler.Batched<TopicPartition, PartitionProducerState> {
     private final Logger log;
     private final DescribeProducersOptions options;
     private final AdminApiLookupStrategy<TopicPartition> lookupStrategy;
@@ -82,7 +82,7 @@ public class DescribeProducersHandler implements AdminApiHandler<TopicPartition,
     }
 
     @Override
-    public DescribeProducersRequest.Builder buildRequest(
+    public DescribeProducersRequest.Builder buildBatchedRequest(
         int brokerId,
         Set<TopicPartition> topicPartitions
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
@@ -43,7 +43,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class DescribeTransactionsHandler implements AdminApiHandler<CoordinatorKey, TransactionDescription> {
+public class DescribeTransactionsHandler extends AdminApiHandler.Batched<CoordinatorKey, TransactionDescription> {
     private final Logger log;
     private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
 
@@ -77,7 +77,7 @@ public class DescribeTransactionsHandler implements AdminApiHandler<CoordinatorK
     }
 
     @Override
-    public DescribeTransactionsRequest.Builder buildRequest(
+    public DescribeTransactionsRequest.Builder buildBatchedRequest(
         int brokerId,
         Set<CoordinatorKey> keys
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
@@ -121,10 +121,6 @@ public class FenceProducersHandler extends AdminApiHandler.Unbatched<Coordinator
                         "InitProducerId request for transactionalId `" + transactionalIdKey.idValue + "` " +
                                 "failed due to transactional ID authorization failure"));
 
-            // We intentionally omit cases for PRODUCER_FENCED, TRANSACTIONAL_ID_NOT_FOUND, and INVALID_PRODUCER_EPOCH
-            // since those errors should never happen when our InitProducerIdRequest doesn't include a producer epoch or ID
-            // and should therefore fall under the "unexpected error" catch-all case below
-
             case COORDINATOR_LOAD_IN_PROGRESS:
                 // If the coordinator is in the middle of loading, then we just need to retry
                 log.debug("InitProducerId request for transactionalId `{}` failed because the " +
@@ -139,6 +135,10 @@ public class FenceProducersHandler extends AdminApiHandler.Unbatched<Coordinator
                 log.debug("InitProducerId request for transactionalId `{}` returned error {}. Will attempt " +
                         "to find the coordinator again and retry", transactionalIdKey.idValue, error);
                 return ApiResult.unmapped(Collections.singletonList(transactionalIdKey));
+
+            // We intentionally omit cases for PRODUCER_FENCED, TRANSACTIONAL_ID_NOT_FOUND, and INVALID_PRODUCER_EPOCH
+            // since those errors should never happen when our InitProducerIdRequest doesn't include a producer epoch or ID
+            // and should therefore fall under the "unexpected error" catch-all case below
 
             default:
                 return ApiResult.failed(transactionalIdKey, error.exception("InitProducerId request for " +

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
+import org.apache.kafka.common.errors.TransactionalIdNotFoundException;
+import org.apache.kafka.common.message.InitProducerIdRequestData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.InitProducerIdRequest;
+import org.apache.kafka.common.requests.InitProducerIdResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FenceProducersHandler extends AdminApiHandler.Unbatched<CoordinatorKey, ProducerIdAndEpoch> {
+    private final Logger log;
+    private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
+
+    public FenceProducersHandler(
+            LogContext logContext
+    ) {
+        this.log = logContext.logger(DescribeTransactionsHandler.class);
+        this.lookupStrategy = new CoordinatorStrategy(FindCoordinatorRequest.CoordinatorType.TRANSACTION, logContext);
+    }
+
+    public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ProducerIdAndEpoch> newFuture(
+            Collection<String> transactionalIds
+    ) {
+        return AdminApiFuture.forKeys(buildKeySet(transactionalIds));
+    }
+
+    private static Set<CoordinatorKey> buildKeySet(Collection<String> transactionalIds) {
+        return transactionalIds.stream()
+                .map(CoordinatorKey::byTransactionalId)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String apiName() {
+        return "fenceProducer";
+    }
+
+    @Override
+    public AdminApiLookupStrategy<CoordinatorKey> lookupStrategy() {
+        return lookupStrategy;
+    }
+
+    @Override
+    InitProducerIdRequest.Builder buildSingleRequest(int brokerId, CoordinatorKey key) {
+        if (key.type != FindCoordinatorRequest.CoordinatorType.TRANSACTION) {
+            throw new IllegalArgumentException("Invalid group coordinator key " + key +
+                    " when building `InitProducerId` request");
+        }
+        InitProducerIdRequestData data = new InitProducerIdRequestData()
+                .setProducerEpoch(ProducerIdAndEpoch.NONE.epoch)
+                .setProducerId(ProducerIdAndEpoch.NONE.producerId)
+                .setTransactionalId(key.idValue)
+                // Set transaction timeout to 1 since it's only being initialized to fence out older producers with the same transactional ID,
+                // and shouldn't be used for any actual record writes
+                .setTransactionTimeoutMs(1);
+        return new InitProducerIdRequest.Builder(data);
+    }
+
+    @Override
+    public ApiResult<CoordinatorKey, ProducerIdAndEpoch> handleSingleResponse(
+            Node broker,
+            CoordinatorKey key,
+            AbstractResponse abstractResponse
+    ) {
+        InitProducerIdResponse response = (InitProducerIdResponse) abstractResponse;
+
+        Errors error = Errors.forCode(response.data().errorCode());
+        if (error != Errors.NONE) {
+            return handleError(key, error);
+        }
+
+        Map<CoordinatorKey, ProducerIdAndEpoch> completed = Collections.singletonMap(key, new ProducerIdAndEpoch(
+                response.data().producerId(),
+                response.data().producerEpoch()
+        ));
+
+        return new ApiResult<>(completed, Collections.emptyMap(), Collections.emptyList());
+    }
+
+    private ApiResult<CoordinatorKey, ProducerIdAndEpoch> handleError(CoordinatorKey transactionalIdKey, Errors error) {
+        switch (error) {
+            case TRANSACTIONAL_ID_AUTHORIZATION_FAILED:
+            case CLUSTER_AUTHORIZATION_FAILED:
+                return ApiResult.failed(transactionalIdKey, new TransactionalIdAuthorizationException(
+                    "InitProducerId request for transactionalId `" + transactionalIdKey.idValue + "` " +
+                        "failed due to authorization failure"));
+
+            case TRANSACTIONAL_ID_NOT_FOUND:
+                return ApiResult.failed(transactionalIdKey, new TransactionalIdNotFoundException(
+                        "InitProducerId request for transactionalId `" + transactionalIdKey.idValue + "` " +
+                                "failed because the ID could not be found"));
+
+            case INVALID_PRODUCER_EPOCH:
+                return ApiResult.failed(transactionalIdKey, new InvalidProducerEpochException(
+                    "InitProducerId request with " + transactionalIdKey.idValue + " failed due an invalid producer epoch"));
+
+            case COORDINATOR_LOAD_IN_PROGRESS:
+                // If the coordinator is in the middle of loading, then we just need to retry
+                log.debug("InitProducerId request for transactionalId `{}` failed because the " +
+                                "coordinator is still in the process of loading state. Will retry",
+                        transactionalIdKey.idValue);
+                return ApiResult.empty();
+
+            case NOT_COORDINATOR:
+            case COORDINATOR_NOT_AVAILABLE:
+                // If the coordinator is unavailable or there was a coordinator change, then we unmap
+                // the key so that we retry the `FindCoordinator` request
+                log.debug("InitProducerId request for transactionalId `{}` returned error {}. Will attempt " +
+                        "to find the coordinator again and retry", transactionalIdKey.idValue, error);
+                return ApiResult.unmapped(Collections.singletonList(transactionalIdKey));
+
+            default:
+                return ApiResult.failed(transactionalIdKey, error.exception("InitProducerId request for " +
+                        "transactionalId `" + transactionalIdKey.idValue + "` failed due to unexpected error"));
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/FenceProducersHandler.java
@@ -41,9 +41,9 @@ public class FenceProducersHandler extends AdminApiHandler.Unbatched<Coordinator
     private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
 
     public FenceProducersHandler(
-            LogContext logContext
+        LogContext logContext
     ) {
-        this.log = logContext.logger(DescribeTransactionsHandler.class);
+        this.log = logContext.logger(FenceProducersHandler.class);
         this.lookupStrategy = new CoordinatorStrategy(FindCoordinatorRequest.CoordinatorType.TRANSACTION, logContext);
     }
 
@@ -111,8 +111,8 @@ public class FenceProducersHandler extends AdminApiHandler.Unbatched<Coordinator
             case TRANSACTIONAL_ID_AUTHORIZATION_FAILED:
             case CLUSTER_AUTHORIZATION_FAILED:
                 return ApiResult.failed(transactionalIdKey, new TransactionalIdAuthorizationException(
-                    "InitProducerId request for transactionalId `" + transactionalIdKey.idValue + "` " +
-                        "failed due to authorization failure"));
+                        "InitProducerId request for transactionalId `" + transactionalIdKey.idValue + "` " +
+                                "failed due to authorization failure"));
 
             case TRANSACTIONAL_ID_NOT_FOUND:
                 return ApiResult.failed(transactionalIdKey, new TransactionalIdNotFoundException(
@@ -121,7 +121,7 @@ public class FenceProducersHandler extends AdminApiHandler.Unbatched<Coordinator
 
             case INVALID_PRODUCER_EPOCH:
                 return ApiResult.failed(transactionalIdKey, new InvalidProducerEpochException(
-                    "InitProducerId request with " + transactionalIdKey.idValue + " failed due an invalid producer epoch"));
+                        "InitProducerId request with " + transactionalIdKey.idValue + " failed due to an invalid producer epoch"));
 
             case COORDINATOR_LOAD_IN_PROGRESS:
                 // If the coordinator is in the middle of loading, then we just need to retry

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandler.java
@@ -36,7 +36,7 @@ import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class ListConsumerGroupOffsetsHandler implements AdminApiHandler<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> {
+public class ListConsumerGroupOffsetsHandler extends AdminApiHandler.Batched<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> {
 
     private final CoordinatorKey groupId;
     private final List<TopicPartition> partitions;
@@ -78,7 +78,7 @@ public class ListConsumerGroupOffsetsHandler implements AdminApiHandler<Coordina
     }
 
     @Override
-    public OffsetFetchRequest.Builder buildRequest(int coordinatorId, Set<CoordinatorKey> groupIds) {
+    public OffsetFetchRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> groupIds) {
         validateKeys(groupIds);
         // Set the flag to false as for admin client request,
         // we don't need to wait for any pending offset state to clear.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ListTransactionsHandler implements AdminApiHandler<AllBrokersStrategy.BrokerKey, Collection<TransactionListing>> {
+public class ListTransactionsHandler extends AdminApiHandler.Batched<AllBrokersStrategy.BrokerKey, Collection<TransactionListing>> {
     private final Logger log;
     private final ListTransactionsOptions options;
     private final AllBrokersStrategy lookupStrategy;
@@ -64,7 +64,7 @@ public class ListTransactionsHandler implements AdminApiHandler<AllBrokersStrate
     }
 
     @Override
-    public ListTransactionsRequest.Builder buildRequest(
+    public ListTransactionsRequest.Builder buildBatchedRequest(
         int brokerId,
         Set<AllBrokersStrategy.BrokerKey> keys
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/RemoveMembersFromConsumerGroupHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/RemoveMembersFromConsumerGroupHandler.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class RemoveMembersFromConsumerGroupHandler implements AdminApiHandler<CoordinatorKey, Map<MemberIdentity, Errors>> {
+public class RemoveMembersFromConsumerGroupHandler extends AdminApiHandler.Batched<CoordinatorKey, Map<MemberIdentity, Errors>> {
 
     private final CoordinatorKey groupId;
     private final List<MemberIdentity> members;
@@ -79,7 +79,7 @@ public class RemoveMembersFromConsumerGroupHandler implements AdminApiHandler<Co
     }
 
     @Override
-    public LeaveGroupRequest.Builder buildRequest(int coordinatorId, Set<CoordinatorKey> groupIds) {
+    public LeaveGroupRequest.Builder buildBatchedRequest(int coordinatorId, Set<CoordinatorKey> groupIds) {
         validateKeys(groupIds);
         return new LeaveGroupRequest.Builder(groupId.idValue, members);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdRequest.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 
 public class InitProducerIdRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<InitProducerIdRequest> {
-        private final InitProducerIdRequestData data;
+        public final InitProducerIdRequestData data;
 
         public Builder(InitProducerIdRequestData data) {
             super(ApiKeys.INIT_PRODUCER_ID);

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1416,7 +1416,7 @@ public final class Utils {
     }
 
     /**
-     * Get an array containing all of the {@link Object#toString names} of a given enumerable type.
+     * Get an array containing all of the {@link Object#toString string representations} of a given enumerable type.
      * @param enumClass the enum class; may not be null
      * @return an array with the names of every value for the enum class; never null, but may be empty
      * if there are no values defined for the enum

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -109,6 +109,7 @@ import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
+import org.apache.kafka.common.message.InitProducerIdResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
@@ -167,6 +168,8 @@ import org.apache.kafka.common.requests.ElectLeadersResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
+import org.apache.kafka.common.requests.InitProducerIdRequest;
+import org.apache.kafka.common.requests.InitProducerIdResponse;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.LeaveGroupRequest;
 import org.apache.kafka.common.requests.LeaveGroupResponse;
@@ -6278,6 +6281,30 @@ public class KafkaAdminClientTest {
                 "Timed out waiting for retry");
             env.kafkaClient().respond(prepareMetadataResponse(cluster, Errors.NONE));
             assertEquals(0, result.listings().get().size());
+        }
+    }
+
+    @Test
+    public void testFenceProducers() throws Exception {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            String transactionalId = "copyCat";
+            Node transactionCoordinator = env.cluster().nodes().iterator().next();
+
+            env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, transactionalId, transactionCoordinator));
+
+            InitProducerIdResponseData initProducerIdResponseData = new InitProducerIdResponseData()
+                    .setProducerId(4761)
+                    .setProducerEpoch((short) 489);
+            env.kafkaClient().prepareResponseFrom(
+                    request -> request instanceof InitProducerIdRequest,
+                    new InitProducerIdResponse(initProducerIdResponseData),
+                    transactionCoordinator
+            );
+
+            FenceProducersResult result = env.adminClient().fenceProducers(Collections.singleton(transactionalId));
+            assertNull(result.all().get());
+            assertEquals(4761, result.producerId(transactionalId).get());
+            assertEquals((short) 489, result.epochId(transactionalId).get());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1004,6 +1004,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public FenceProducersResult fenceProducers(Collection<String> transactionalIds, FenceProducersOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public void close(Duration timeout) {}
 
     public synchronized void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandlerTest.java
@@ -63,7 +63,7 @@ public class AbortTransactionHandlerTest {
     @Test
     public void testValidBuildRequestCall() {
         AbortTransactionHandler handler = new AbortTransactionHandler(abortSpec, logContext);
-        WriteTxnMarkersRequest.Builder request = handler.buildRequest(1, singleton(topicPartition));
+        WriteTxnMarkersRequest.Builder request = handler.buildBatchedRequest(1, singleton(topicPartition));
         assertEquals(1, request.data.markers().size());
 
         WriteTxnMarkersRequestData.WritableTxnMarker markerRequest = request.data.markers().get(0);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
@@ -734,7 +734,7 @@ class AdminApiDriverTest {
         }
     }
 
-    private static class MockAdminApiHandler<K, V> implements AdminApiHandler<K, V> {
+    private static class MockAdminApiHandler<K, V> extends AdminApiHandler.Batched<K, V> {
         private final Map<Set<K>, ApiResult<K, V>> expectedRequests = new HashMap<>();
         private final MockLookupStrategy<K> lookupStrategy;
 
@@ -757,7 +757,7 @@ class AdminApiDriverTest {
         }
 
         @Override
-        public AbstractRequest.Builder<?> buildRequest(int brokerId, Set<K> keys) {
+        public AbstractRequest.Builder<?> buildBatchedRequest(int brokerId, Set<K> keys) {
             // The request is just a placeholder in these tests
             assertTrue(expectedRequests.containsKey(keys), "Unexpected fulfillment request for keys " + keys);
             return new MetadataRequest.Builder(Collections.emptyList(), false);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategyIntegrationTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategyIntegrationTest.java
@@ -215,7 +215,7 @@ public class AllBrokersStrategyIntegrationTest {
         return new MetadataResponse(response, ApiKeys.METADATA.latestVersion());
     }
 
-    private class MockApiHandler implements AdminApiHandler<AllBrokersStrategy.BrokerKey, Integer> {
+    private class MockApiHandler extends AdminApiHandler.Batched<AllBrokersStrategy.BrokerKey, Integer> {
         private final AllBrokersStrategy allBrokersStrategy = new AllBrokersStrategy(logContext);
 
         @Override
@@ -224,7 +224,7 @@ public class AllBrokersStrategyIntegrationTest {
         }
 
         @Override
-        public AbstractRequest.Builder<?> buildRequest(
+        public AbstractRequest.Builder<?> buildBatchedRequest(
             int brokerId,
             Set<AllBrokersStrategy.BrokerKey> keys
         ) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AlterConsumerGroupOffsetsHandlerTest.java
@@ -62,7 +62,7 @@ public class AlterConsumerGroupOffsetsHandlerTest {
     @Test
     public void testBuildRequest() {
         AlterConsumerGroupOffsetsHandler handler = new AlterConsumerGroupOffsetsHandler(groupId, partitions, logContext);
-        OffsetCommitRequest request = handler.buildRequest(-1, singleton(CoordinatorKey.byGroupId(groupId))).build();
+        OffsetCommitRequest request = handler.buildBatchedRequest(-1, singleton(CoordinatorKey.byGroupId(groupId))).build();
         assertEquals(groupId, request.data().groupId());
         assertEquals(2, request.data().topics().size());
         assertEquals(2, request.data().topics().get(0).partitions().size());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupOffsetsHandlerTest.java
@@ -59,7 +59,7 @@ public class DeleteConsumerGroupOffsetsHandlerTest {
     @Test
     public void testBuildRequest() {
         DeleteConsumerGroupOffsetsHandler handler = new DeleteConsumerGroupOffsetsHandler(groupId, tps, logContext);
-        OffsetDeleteRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
+        OffsetDeleteRequest request = handler.buildBatchedRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
         assertEquals(groupId, request.data().groupId());
         assertEquals(2, request.data().topics().size());
         assertEquals(2, request.data().topics().find("t0").partitions().size());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DeleteConsumerGroupsHandlerTest.java
@@ -45,7 +45,7 @@ public class DeleteConsumerGroupsHandlerTest {
     @Test
     public void testBuildRequest() {
         DeleteConsumerGroupsHandler handler = new DeleteConsumerGroupsHandler(logContext);
-        DeleteGroupsRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId1))).build();
+        DeleteGroupsRequest request = handler.buildBatchedRequest(1, singleton(CoordinatorKey.byGroupId(groupId1))).build();
         assertEquals(1, request.data().groupsNames().size());
         assertEquals(groupId1, request.data().groupsNames().get(0));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeConsumerGroupsHandlerTest.java
@@ -69,12 +69,12 @@ public class DescribeConsumerGroupsHandlerTest {
     @Test
     public void testBuildRequest() {
         DescribeConsumerGroupsHandler handler = new DescribeConsumerGroupsHandler(false, logContext);
-        DescribeGroupsRequest request = handler.buildRequest(1, keys).build();
+        DescribeGroupsRequest request = handler.buildBatchedRequest(1, keys).build();
         assertEquals(2, request.data().groups().size());
         assertFalse(request.data().includeAuthorizedOperations());
 
         handler = new DescribeConsumerGroupsHandler(true, logContext);
-        request = handler.buildRequest(1, keys).build();
+        request = handler.buildBatchedRequest(1, keys).build();
         assertEquals(2, request.data().groups().size());
         assertTrue(request.data().includeAuthorizedOperations());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandlerTest.java
@@ -118,7 +118,7 @@ public class DescribeProducersHandlerTest {
         );
 
         int brokerId = 3;
-        DescribeProducersRequest.Builder request = handler.buildRequest(brokerId, topicPartitions);
+        DescribeProducersRequest.Builder request = handler.buildBatchedRequest(brokerId, topicPartitions);
 
         List<DescribeProducersRequestData.TopicRequest> topics = request.data.topics();
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
@@ -156,7 +156,7 @@ public class DescribeTransactionsHandlerTest {
         Set<String> transactionalIds
     ) {
         Set<CoordinatorKey> keys = coordinatorKeys(transactionalIds);
-        DescribeTransactionsRequest.Builder request = handler.buildRequest(1, keys);
+        DescribeTransactionsRequest.Builder request = handler.buildBatchedRequest(1, keys);
         assertEquals(transactionalIds, new HashSet<>(request.data.transactionalIds()));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.message.InitProducerIdResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.InitProducerIdRequest;
+import org.apache.kafka.common.requests.InitProducerIdResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FenceProducersHandlerTest {
+    private final LogContext logContext = new LogContext();
+    private final Node node = new Node(1, "host", 1234);
+
+    @Test
+    public void testBuildRequest() {
+        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        mkSet("foo", "bar", "baz").forEach(transactionalId -> assertLookup(handler, transactionalId));
+    }
+
+    @Test
+    public void testHandleSuccessfulResponse() {
+        String transactionalId = "foo";
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
+
+        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+
+        short epoch = 57;
+        long producerId = 7;
+        InitProducerIdResponse response = new InitProducerIdResponse(new InitProducerIdResponseData()
+            .setProducerEpoch(epoch)
+            .setProducerId(producerId));
+
+        ApiResult<CoordinatorKey, ProducerIdAndEpoch> result = handler.handleSingleResponse(
+            node, key, response);
+
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(emptyMap(), result.failedKeys);
+        assertEquals(singleton(key), result.completedKeys.keySet());
+
+        ProducerIdAndEpoch expected = new ProducerIdAndEpoch(producerId, epoch);
+        assertEquals(expected, result.completedKeys.get(key));
+    }
+
+    @Test
+    public void testHandleErrorResponse() {
+        String transactionalId = "foo";
+        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
+        assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_NOT_FOUND);
+        assertFatalError(handler, transactionalId, Errors.UNKNOWN_SERVER_ERROR);
+        assertFatalError(handler, transactionalId, Errors.INVALID_PRODUCER_EPOCH);
+        assertRetriableError(handler, transactionalId, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        assertUnmappedKey(handler, transactionalId, Errors.NOT_COORDINATOR);
+        assertUnmappedKey(handler, transactionalId, Errors.COORDINATOR_NOT_AVAILABLE);
+    }
+
+    private void assertFatalError(
+        FenceProducersHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
+        ApiResult<CoordinatorKey, ProducerIdAndEpoch> result = handleResponseError(handler, transactionalId, error);
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(mkSet(key), result.failedKeys.keySet());
+
+        Throwable throwable = result.failedKeys.get(key);
+        assertTrue(error.exception().getClass().isInstance(throwable));
+    }
+
+    private void assertRetriableError(
+        FenceProducersHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        ApiResult<CoordinatorKey, ProducerIdAndEpoch> result = handleResponseError(handler, transactionalId, error);
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(emptyMap(), result.failedKeys);
+    }
+
+    private void assertUnmappedKey(
+        FenceProducersHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
+        ApiResult<CoordinatorKey, ProducerIdAndEpoch> result = handleResponseError(handler, transactionalId, error);
+        assertEquals(emptyMap(), result.failedKeys);
+        assertEquals(singletonList(key), result.unmappedKeys);
+    }
+
+    private ApiResult<CoordinatorKey, ProducerIdAndEpoch> handleResponseError(
+        FenceProducersHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        int brokerId = 1;
+
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
+        Set<CoordinatorKey> keys = mkSet(key);
+
+        InitProducerIdResponse response = new InitProducerIdResponse(new InitProducerIdResponseData()
+            .setErrorCode(error.code()));
+
+        ApiResult<CoordinatorKey, ProducerIdAndEpoch> result = handler.handleResponse(node, keys, response);
+        assertEquals(emptyMap(), result.completedKeys);
+        return result;
+    }
+
+    private void assertLookup(FenceProducersHandler handler, String transactionalId) {
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
+        InitProducerIdRequest.Builder request = handler.buildSingleRequest(1, key);
+        assertEquals(transactionalId, request.data.transactionalId());
+        assertEquals(1, request.data.transactionTimeoutMs());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/FenceProducersHandlerTest.java
@@ -75,8 +75,10 @@ public class FenceProducersHandlerTest {
         String transactionalId = "foo";
         FenceProducersHandler handler = new FenceProducersHandler(logContext);
         assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
-        assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_NOT_FOUND);
+        assertFatalError(handler, transactionalId, Errors.CLUSTER_AUTHORIZATION_FAILED);
         assertFatalError(handler, transactionalId, Errors.UNKNOWN_SERVER_ERROR);
+        assertFatalError(handler, transactionalId, Errors.PRODUCER_FENCED);
+        assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_NOT_FOUND);
         assertFatalError(handler, transactionalId, Errors.INVALID_PRODUCER_EPOCH);
         assertRetriableError(handler, transactionalId, Errors.COORDINATOR_LOAD_IN_PROGRESS);
         assertUnmappedKey(handler, transactionalId, Errors.NOT_COORDINATOR);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -56,7 +56,7 @@ public class ListConsumerGroupOffsetsHandlerTest {
     @Test
     public void testBuildRequest() {
         ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupId, tps, logContext);
-        OffsetFetchRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
+        OffsetFetchRequest request = handler.buildBatchedRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
         assertEquals(groupId, request.data().groups().get(0).groupId());
         assertEquals(2, request.data().groups().get(0).topics().size());
         assertEquals(2, request.data().groups().get(0).topics().get(0).partitionIndexes().size());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
@@ -52,7 +52,7 @@ public class ListTransactionsHandlerTest {
         BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
         ListTransactionsOptions options = new ListTransactionsOptions();
         ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
-        ListTransactionsRequest request = handler.buildRequest(brokerId, singleton(brokerKey)).build();
+        ListTransactionsRequest request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build();
         assertEquals(Collections.emptyList(), request.data().producerIdFilters());
         assertEquals(Collections.emptyList(), request.data().stateFilters());
     }
@@ -65,7 +65,7 @@ public class ListTransactionsHandlerTest {
         ListTransactionsOptions options = new ListTransactionsOptions()
             .filterProducerIds(singleton(filteredProducerId));
         ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
-        ListTransactionsRequest request = handler.buildRequest(brokerId, singleton(brokerKey)).build();
+        ListTransactionsRequest request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build();
         assertEquals(Collections.singletonList(filteredProducerId), request.data().producerIdFilters());
         assertEquals(Collections.emptyList(), request.data().stateFilters());
     }
@@ -78,7 +78,7 @@ public class ListTransactionsHandlerTest {
         ListTransactionsOptions options = new ListTransactionsOptions()
             .filterStates(singleton(filteredState));
         ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
-        ListTransactionsRequest request = handler.buildRequest(brokerId, singleton(brokerKey)).build();
+        ListTransactionsRequest request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build();
         assertEquals(Collections.singletonList(filteredState.toString()), request.data().stateFilters());
         assertEquals(Collections.emptyList(), request.data().producerIdFilters());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/RemoveMembersFromConsumerGroupHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/RemoveMembersFromConsumerGroupHandlerTest.java
@@ -55,7 +55,7 @@ public class RemoveMembersFromConsumerGroupHandlerTest {
     @Test
     public void testBuildRequest() {
         RemoveMembersFromConsumerGroupHandler handler = new RemoveMembersFromConsumerGroupHandler(groupId, members, logContext);
-        LeaveGroupRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
+        LeaveGroupRequest request = handler.buildBatchedRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
         assertEquals(groupId, request.data().groupId());
         assertEquals(2, request.data().members().size());
     }


### PR DESCRIPTION
Implements the new admin client API described in [KIP-618](https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors#KIP618:ExactlyOnceSupportforSourceConnectors-AdminAPItoFenceoutTransactionalProducers).

Note that this API is not used by the Connect framework in this PR. It will be leveraged by Connect in downstream PRs.