### PR TITLE
KAFKA-10000: Per-connector offsets topics (KIP-618)

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -171,7 +171,9 @@ public class WorkerConnector implements Runnable {
                 SinkConnectorConfig.validate(config);
                 connector.initialize(new WorkerSinkConnectorContext());
             } else {
+                Objects.requireNonNull(offsetStore, "Offset store cannot be null for source connectors");
                 Objects.requireNonNull(offsetStorageReader, "Offset reader cannot be null for source connectors");
+                offsetStore.start();
                 connector.initialize(new WorkerSourceConnectorContext(offsetStorageReader));
             }
         } catch (Throwable t) {
@@ -281,7 +283,9 @@ public class WorkerConnector implements Runnable {
             Utils.closeQuietly(ctx, "connector context for " + connName);
             Utils.closeQuietly(metrics, "connector metrics for " + connName);
             Utils.closeQuietly(offsetStorageReader, "offset reader for " + connName);
-            Utils.closeQuietly(offsetStore::stop, "offset backing store for " + connName);
+            if (offsetStore != null) {
+                Utils.closeQuietly(offsetStore::stop, "offset backing store for " + connName);
+            }
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -73,7 +73,7 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
                             Map<String, TopicCreationGroup> topicGroups,
                             CloseableOffsetStorageReader offsetReader,
                             OffsetStorageWriter offsetWriter,
-                            ConnectorOffsetBackingStore offsetBackingStore,
+                            ConnectorOffsetBackingStore offsetStore,
                             WorkerConfig workerConfig,
                             ClusterConfigState configState,
                             ConnectMetrics connectMetrics,
@@ -85,7 +85,7 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
 
         super(id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, transformationChain,
                 new WorkerSourceTaskContext(offsetReader, id, configState, null), producer,
-                admin, topicGroups, offsetReader, offsetWriter, offsetBackingStore, workerConfig, connectMetrics, loader,
+                admin, topicGroups, offsetReader, offsetWriter, offsetStore, workerConfig, connectMetrics, loader,
                 time, retryWithToleranceOperator, statusBackingStore, closeExecutor);
 
         this.committableOffsets = CommittableOffsets.EMPTY;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -52,10 +52,10 @@ abstract class WorkerTask implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(WorkerTask.class);
     private static final String THREAD_NAME_PREFIX = "task-thread-";
 
-    protected final ConnectorTaskId id;
     private final TaskStatus.Listener statusListener;
-    protected final ClassLoader loader;
     private final StatusBackingStore statusBackingStore;
+    protected final ConnectorTaskId id;
+    protected final ClassLoader loader;
     protected final Time time;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
     private final TaskMetricsGroup taskMetricsGroup;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
@@ -16,56 +16,326 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.connect.util.LoggingContext;
+import org.apache.kafka.connect.util.TopicAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
+/**
+ * An {@link OffsetBackingStore} with support for reading from and writing to a worker-global
+ * offset backing store and/or a connector-specific offset backing store.
+ */
 public class ConnectorOffsetBackingStore implements OffsetBackingStore {
 
-    private final OffsetBackingStore workerStore;
-    private final String primaryOffsetsTopic;
+    private static final Logger log = LoggerFactory.getLogger(ConnectorOffsetBackingStore.class);
 
-    public ConnectorOffsetBackingStore(
+    /**
+     * Builds an offset store that uses a connector-specific offset topic as the primary store and
+     * the worker-global offset store as the secondary store.
+     *
+     * @param loggingContext a {@link Supplier} for the {@link LoggingContext} that should be used
+     *                       for messages logged by this offset store; may not be null, and may never return null
+     * @param workerStore the worker-global offset store; may not be null
+     * @param connectorStore the connector-specific offset store; may not be null
+     * @param connectorOffsetsTopic the name of the connector-specific offset topic; may not be null
+     * @param connectorStoreAdmin the topic admin to use for the connector-specific offset topic; may not be null
+     * @return an offset store backed primarily by the connector-specific offset topic and secondarily
+     * by the worker-global offset store; never null
+     */
+    public static ConnectorOffsetBackingStore withConnectorAndWorkerStores(
+            Supplier<LoggingContext> loggingContext,
             OffsetBackingStore workerStore,
-            String primaryOffsetsTopic
+            KafkaOffsetBackingStore connectorStore,
+            String connectorOffsetsTopic,
+            TopicAdmin connectorStoreAdmin
     ) {
-        this.workerStore = workerStore;
+        Objects.requireNonNull(loggingContext);
+        Objects.requireNonNull(workerStore);
+        Objects.requireNonNull(connectorStore);
+        Objects.requireNonNull(connectorOffsetsTopic);
+        Objects.requireNonNull(connectorStoreAdmin);
+        return new ConnectorOffsetBackingStore(
+                Time.SYSTEM,
+                loggingContext,
+                connectorOffsetsTopic,
+                workerStore,
+                connectorStore,
+                connectorStoreAdmin
+        );
+    }
+
+    /**
+     * Builds an offset store that uses the worker-global offset store as the primary store, and no secondary store.
+     *
+     * @param loggingContext a {@link Supplier} for the {@link LoggingContext} that should be used
+     *                       for messages logged by this offset store; may not be null, and may never return null
+     * @param workerStore the worker-global offset store; may not be null
+     * @param workerOffsetsTopic the name of the worker-global offset topic; may be null if the worker
+     *                           does not use an offset topic for its offset store
+     * @return an offset store for the connector backed solely by the worker-global offset store; never null
+     */
+    public static ConnectorOffsetBackingStore withOnlyWorkerStore(
+            Supplier<LoggingContext> loggingContext,
+            OffsetBackingStore workerStore,
+            String workerOffsetsTopic
+    ) {
+        Objects.requireNonNull(loggingContext);
+        Objects.requireNonNull(workerStore);
+        return new ConnectorOffsetBackingStore(Time.SYSTEM, loggingContext, workerOffsetsTopic, workerStore, null, null);
+    }
+
+    /**
+     * Builds an offset store that uses a connector-specific offset topic as the primary store, and no secondary store.
+     *
+     * @param loggingContext a {@link Supplier} for the {@link LoggingContext} that should be used
+     *                       for messages logged by this offset store; may not be null, and may never return null
+     * @param connectorStore the connector-specific offset store; may not be null
+     * @param connectorOffsetsTopic the name of the connector-specific offset topic; may not be null
+     * @param connectorStoreAdmin the topic admin to use for the connector-specific offset topic; may not be null
+     * @return an offset store for the connector backed solely by the connector-specific offset topic; never null
+     */
+    public static ConnectorOffsetBackingStore withOnlyConnectorStore(
+            Supplier<LoggingContext> loggingContext,
+            KafkaOffsetBackingStore connectorStore,
+            String connectorOffsetsTopic,
+            TopicAdmin connectorStoreAdmin
+    ) {
+        Objects.requireNonNull(loggingContext);
+        Objects.requireNonNull(connectorOffsetsTopic);
+        Objects.requireNonNull(connectorStoreAdmin);
+        return new ConnectorOffsetBackingStore(
+                Time.SYSTEM,
+                loggingContext,
+                connectorOffsetsTopic,
+                null,
+                connectorStore,
+                connectorStoreAdmin
+        );
+    }
+
+    private final Time time;
+    private final Supplier<LoggingContext> loggingContext;
+    private final String primaryOffsetsTopic;
+    private final Optional<OffsetBackingStore> workerStore;
+    private final Optional<KafkaOffsetBackingStore> connectorStore;
+    private final Optional<TopicAdmin> connectorStoreAdmin;
+
+    ConnectorOffsetBackingStore(
+            Time time,
+            Supplier<LoggingContext> loggingContext,
+            String primaryOffsetsTopic,
+            OffsetBackingStore workerStore,
+            KafkaOffsetBackingStore connectorStore,
+            TopicAdmin connectorStoreAdmin
+    ) {
+        if (workerStore == null && connectorStore == null) {
+            throw new IllegalArgumentException("At least one non-null offset store must be provided");
+        }
+        this.time = time;
+        this.loggingContext = loggingContext;
         this.primaryOffsetsTopic = primaryOffsetsTopic;
+        this.workerStore = Optional.ofNullable(workerStore);
+        this.connectorStore = Optional.ofNullable(connectorStore);
+        this.connectorStoreAdmin = Optional.ofNullable(connectorStoreAdmin);
     }
 
     public String primaryOffsetsTopic() {
         return primaryOffsetsTopic;
     }
 
+    /**
+     * If configured to use a connector-specific offset store, {@link OffsetBackingStore#start() start} that store.
+     *
+     * <p>The worker-global offset store is not modified; it is the caller's responsibility to ensure that it is started
+     * before calls to {@link #get(Collection)} and {@link #set(Map, Callback)} take place.
+     */
     @Override
     public void start() {
-        // TODO
+        // Worker offset store should already be started
+        connectorStore.ifPresent(OffsetBackingStore::start);
     }
 
+    /**
+     * If configured to use a connector-specific offset store, {@link OffsetBackingStore#stop() stop} that store,
+     * and {@link TopicAdmin#close(Duration) close} the topic admin used by that store.
+     *
+     * <p>The worker-global offset store is not modified as it may be used for other connectors that either already exist,
+     * or will be created, on this worker.
+     */
     @Override
     public void stop() {
-        // TODO
+        // Worker offset store should not be stopped as it may be used for multiple connectors
+        connectorStore.ifPresent(OffsetBackingStore::stop);
+        connectorStoreAdmin.ifPresent(TopicAdmin::close);
     }
 
+    /**
+     * Get the offset values for the specified keys.
+     *
+     * <p>If configured to use a connector-specific offset store, priority is given to the values contained in that store,
+     * and the values in the worker-global offset store (if one is provided) are used as a fallback for keys that are not
+     * present in the connector-specific store.
+     *
+     * <p>If not configured to use a connector-specific offset store, only the values contained in the worker-global
+     * offset store are returned.
+
+     * @param keys list of keys to look up
+     * @return future for the resulting map from key to value
+     */
     @Override
     public Future<Map<ByteBuffer, ByteBuffer>> get(Collection<ByteBuffer> keys) {
-        // TODO
-        return workerStore.get(keys);
+        Future<Map<ByteBuffer, ByteBuffer>> workerGetFuture = getFromStore(workerStore, keys);
+        Future<Map<ByteBuffer, ByteBuffer>> connectorGetFuture = getFromStore(connectorStore, keys);
+
+        return new Future<Map<ByteBuffer, ByteBuffer>>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                // Note the use of | instead of || here; this causes cancel to be invoked on both futures,
+                // even if the first call to cancel returns true
+                return workerGetFuture.cancel(mayInterruptIfRunning)
+                        | connectorGetFuture.cancel(mayInterruptIfRunning);
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return workerGetFuture.isCancelled()
+                        || connectorGetFuture.isCancelled();
+            }
+
+            @Override
+            public boolean isDone() {
+                return workerGetFuture.isDone()
+                        && connectorGetFuture.isDone();
+            }
+
+            @Override
+            public Map<ByteBuffer, ByteBuffer> get() throws InterruptedException, ExecutionException {
+                Map<ByteBuffer, ByteBuffer> result = new HashMap<>(workerGetFuture.get());
+                result.putAll(connectorGetFuture.get());
+                return result;
+            }
+
+            @Override
+            public Map<ByteBuffer, ByteBuffer> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                long timeoutMs = unit.toMillis(timeout);
+                long endTime = time.milliseconds() + timeoutMs;
+                Map<ByteBuffer, ByteBuffer> result = new HashMap<>(workerGetFuture.get(timeoutMs, unit));
+                timeoutMs = Math.max(1, endTime - time.milliseconds());
+                result.putAll(connectorGetFuture.get(timeoutMs, TimeUnit.MILLISECONDS));
+                return result;
+            }
+        };
     }
 
+    /**
+     * Store the specified offset key/value pairs.
+     *
+     * <p>If configured to use a connector-specific offset store, the returned {@link Future} corresponds to a
+     * write to that store, and the passed-in {@link Callback} is invoked once that write completes. If a worker-global
+     * store is provided, a secondary write is made to that store if the write to the connector-specific store
+     * succeeds. Errors with this secondary write are not reflected in the returned {@link Future} or the passed-in
+     * {@link Callback}; they are only logged as a warning to users.
+     *
+     * <p>If not configured to use a connector-specific offset store, the returned {@link Future} corresponds to a
+     * write to the worker-global offset store, and the passed-in {@link Callback} is invoked once that write completes.
+
+     * @param values map from key to value
+     * @param callback callback to invoke on completion of the primary write
+     * @return void future for the primary write
+     */
     @Override
     public Future<Void> set(Map<ByteBuffer, ByteBuffer> values, Callback<Void> callback) {
-        // TODO
-        return workerStore.set(values, callback);
+        final OffsetBackingStore primaryStore;
+        final OffsetBackingStore secondaryStore;
+        if (connectorStore.isPresent()) {
+            primaryStore = connectorStore.get();
+            secondaryStore = workerStore.orElse(null);
+        } else if (workerStore.isPresent()) {
+            primaryStore = workerStore.get();
+            secondaryStore = null;
+        } else {
+            // Should never happen since we check for this case in the constructor, but just in case, this should
+            // be more informative than the NPE that would otherwise be thrown
+            throw new IllegalStateException("At least one non-null offset store must be provided");
+        }
+
+        return primaryStore.set(values, (primaryWriteError, ignored) -> {
+            if (secondaryStore != null) {
+                if (primaryWriteError != null) {
+                    log.trace("Skipping offsets write to secondary store because primary write has failed", primaryWriteError);
+                } else {
+                    try {
+                        // Invoke OffsetBackingStore::set but ignore the resulting future; we don't block on writes to this
+                        // backing store.
+                        secondaryStore.set(values, (secondaryWriteError, ignored2) -> {
+                            try (LoggingContext context = loggingContext()) {
+                                if (secondaryWriteError != null) {
+                                    log.warn("Failed to write offsets to secondary backing store", secondaryWriteError);
+                                } else {
+                                    log.debug("Successfully flushed offsets to secondary backing store");
+                                }
+                            }
+                        });
+                    } catch (Exception e) {
+                        log.warn("Failed to write offsets to secondary backing store", e);
+                    }
+                }
+            }
+            try (LoggingContext context = loggingContext()) {
+                callback.onCompletion(primaryWriteError, ignored);
+            }
+        });
     }
 
+    /**
+     * If configured to use a connector-specific offset store,
+     * {@link OffsetBackingStore#configure(WorkerConfig) configure} that store.
+     *
+     * <p>The worker-global offset store is not modified; it is the caller's responsibility to ensure that it is configured
+     * before calls to {@link #start()}, {@link #get(Collection)} and {@link #set(Map, Callback)} take place.
+     */
     @Override
     public void configure(WorkerConfig config) {
-        // TODO
+        // Worker offset store should already be configured
+        connectorStore.ifPresent(store -> store.configure(config));
+    }
+
+    // For testing
+    public boolean hasConnectorSpecificStore() {
+        return connectorStore.isPresent();
+    }
+
+    // For testing
+    public boolean hasWorkerGlobalStore() {
+        return workerStore.isPresent();
+    }
+
+    private LoggingContext loggingContext() {
+        LoggingContext result = loggingContext.get();
+        Objects.requireNonNull(result);
+        return result;
+    }
+
+    private static Future<Map<ByteBuffer, ByteBuffer>> getFromStore(Optional<? extends OffsetBackingStore> store, Collection<ByteBuffer> keys) {
+        return store.map(s -> s.get(keys)).orElseGet(() -> CompletableFuture.completedFuture(Collections.emptyMap()));
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -355,9 +355,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
     public void stop() {
         log.info("Closing KafkaConfigBackingStore");
 
-        if (fencableProducer != null) {
-            Utils.closeQuietly(() -> fencableProducer.close(Duration.ZERO), "fencable producer for config topic");
-        }
+        relinquishWritePrivileges();
         Utils.closeQuietly(ownTopicAdmin, "admin for config topic");
         Utils.closeQuietly(configLog::stop, "KafkaBasedLog for config topic");
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -17,15 +17,20 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
@@ -38,9 +43,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -63,19 +70,99 @@ import java.util.function.Supplier;
 public class KafkaOffsetBackingStore implements OffsetBackingStore {
     private static final Logger log = LoggerFactory.getLogger(KafkaOffsetBackingStore.class);
 
-    private KafkaBasedLog<byte[], byte[]> offsetLog;
-    private HashMap<ByteBuffer, ByteBuffer> data;
+    /**
+     * Build a connector-specific offset store with read and write support. The producer will be {@link Producer#close(Duration) closed}
+     * and the consumer will be {@link Consumer#close(Duration) closed} when this store is {@link #stop() stopped}, but the topic admin
+     * must be {@link TopicAdmin#close(Duration) closed} by the caller.
+     * @param topic the name of the offsets topic to use
+     * @param producer the producer to use for writing to the offsets topic
+     * @param consumer the consumer to use for reading from the offsets topic
+     * @param topicAdmin the topic admin to use for creating and querying metadata for the offsets topic
+     * @return an offset store backed by the given topic and Kafka clients
+     */
+    public static KafkaOffsetBackingStore forTask(
+            String topic,
+            Producer<byte[], byte[]> producer,
+            Consumer<byte[], byte[]> consumer,
+            TopicAdmin topicAdmin
+    ) {
+        return new KafkaOffsetBackingStore(() -> topicAdmin) {
+            @Override
+            public void configure(final WorkerConfig config) {
+                this.exactlyOnce = config.exactlyOnceSourceEnabled();
+                this.offsetLog = KafkaBasedLog.withExistingClients(
+                        topic,
+                        consumer,
+                        producer,
+                        topicAdmin,
+                        consumedCallback,
+                        Time.SYSTEM,
+                        initialize(topic, newTopicDescription(topic, config))
+                );
+            }
+        };
+    }
+
+    /**
+     * Build a connector-specific offset store with read-only support. The consumer will be {@link Consumer#close(Duration) closed}
+     * when this store is {@link #stop() stopped}, but the topic admin must be {@link TopicAdmin#close(Duration) closed} by the caller.
+     * @param topic the name of the offsets topic to use
+     * @param consumer the consumer to use for reading from the offsets topic
+     * @param topicAdmin the topic admin to use for creating and querying metadata for the offsets topic
+     * @return a read-only offset store backed by the given topic and Kafka clients
+     */
+    public static KafkaOffsetBackingStore forConnector(
+            String topic,
+            Consumer<byte[], byte[]> consumer,
+            TopicAdmin topicAdmin
+    ) {
+        return new KafkaOffsetBackingStore(() -> topicAdmin) {
+            @Override
+            public void configure(final WorkerConfig config) {
+                this.exactlyOnce = config.exactlyOnceSourceEnabled();
+                this.offsetLog = KafkaBasedLog.withExistingClients(
+                        topic,
+                        consumer,
+                        null,
+                        topicAdmin,
+                        consumedCallback,
+                        Time.SYSTEM,
+                        initialize(topic, newTopicDescription(topic, config))
+                );
+            }
+        };
+    }
+
+    protected KafkaBasedLog<byte[], byte[]> offsetLog;
+    private final HashMap<ByteBuffer, ByteBuffer> data = new HashMap<>();
     private final Supplier<TopicAdmin> topicAdminSupplier;
     private SharedTopicAdmin ownTopicAdmin;
+    protected boolean exactlyOnce;
 
+    /**
+     * Create an {@link OffsetBackingStore} backed by a Kafka topic. This constructor will cause the
+     * store to instantiate and close its own {@link TopicAdmin} during {@link #configure(WorkerConfig)}
+     * and {@link #stop()}, respectively.
+     *
+     * @deprecated use {@link #KafkaOffsetBackingStore(Supplier)} instead
+     */
     @Deprecated
     public KafkaOffsetBackingStore() {
         this.topicAdminSupplier = null;
     }
 
+    /**
+     * Create an {@link OffsetBackingStore} backed by a Kafka topic. This constructor will use the given
+     * {@link Supplier} to acquire a {@link TopicAdmin} that will be used for interactions with the backing
+     * Kafka topic. The caller is expected to manage the lifecycle of that object, including
+     * {@link TopicAdmin#close(Duration) closing} it when it is no longer needed.
+     * @param topicAdmin a {@link Supplier} for the {@link TopicAdmin} to use for this backing store;
+     *                   may not be null, and may not return null
+     */
     public KafkaOffsetBackingStore(Supplier<TopicAdmin> topicAdmin) {
         this.topicAdminSupplier = Objects.requireNonNull(topicAdmin);
     }
+
 
     @Override
     public void configure(final WorkerConfig config) {
@@ -83,8 +170,9 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         if (topic == null || topic.trim().length() == 0)
             throw new ConfigException("Offset storage topic must be specified");
 
+        this.exactlyOnce = config.exactlyOnceSourceEnabled();
+
         String clusterId = ConnectUtils.lookupKafkaClusterId(config);
-        data = new HashMap<>();
 
         Map<String, Object> originals = config.originals();
         Map<String, Object> producerProps = new HashMap<>(originals);
@@ -103,6 +191,13 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
+        if (config.exactlyOnceSourceEnabled()) {
+            ConnectUtils.ensureProperty(
+                    consumerProps, ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT),
+                    "for the worker offsets topic consumer when exactly-once source support is enabled",
+                    false
+            );
+        }
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
@@ -111,27 +206,36 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
             adminSupplier = topicAdminSupplier;
         } else {
             // Create our own topic admin supplier that we'll close when we're stopped
-            ownTopicAdmin = new SharedTopicAdmin(adminProps);
+            this.ownTopicAdmin = new SharedTopicAdmin(adminProps);
             adminSupplier = ownTopicAdmin;
         }
-        Map<String, Object> topicSettings = config instanceof DistributedConfig
-                                            ? ((DistributedConfig) config).offsetStorageTopicSettings()
-                                            : Collections.emptyMap();
-        NewTopic topicDescription = TopicAdmin.defineTopic(topic)
-                .config(topicSettings) // first so that we override user-supplied settings as needed
-                .compacted()
-                .partitions(config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG))
-                .replicationFactor(config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG))
-                .build();
+        NewTopic topicDescription = newTopicDescription(topic, config);
 
-        offsetLog = createKafkaBasedLog(topic, producerProps, consumerProps, consumedCallback, topicDescription, adminSupplier);
+        this.offsetLog = createKafkaBasedLog(topic, producerProps, consumerProps, consumedCallback, topicDescription, adminSupplier);
     }
 
     private KafkaBasedLog<byte[], byte[]> createKafkaBasedLog(String topic, Map<String, Object> producerProps,
                                                               Map<String, Object> consumerProps,
                                                               Callback<ConsumerRecord<byte[], byte[]>> consumedCallback,
                                                               final NewTopic topicDescription, Supplier<TopicAdmin> adminSupplier) {
-        java.util.function.Consumer<TopicAdmin> createTopics = admin -> {
+        java.util.function.Consumer<TopicAdmin> createTopics = initialize(topic, topicDescription);
+        return new KafkaBasedLog<>(topic, producerProps, consumerProps, adminSupplier, consumedCallback, Time.SYSTEM, createTopics);
+    }
+
+    protected NewTopic newTopicDescription(final String topic, final WorkerConfig config) {
+        Map<String, Object> topicSettings = config instanceof DistributedConfig
+                ? ((DistributedConfig) config).offsetStorageTopicSettings()
+                : Collections.emptyMap();
+        return TopicAdmin.defineTopic(topic)
+                .config(topicSettings) // first so that we override user-supplied settings as needed
+                .compacted()
+                .partitions(config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG))
+                .replicationFactor(config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG))
+                .build();
+    }
+
+    protected java.util.function.Consumer<TopicAdmin> initialize(final String topic, final NewTopic topicDescription) {
+        return admin -> {
             log.debug("Creating admin client to manage Connect internal offset topic");
             // Create the topic if it doesn't exist
             Set<String> newTopics = admin.createTopics(topicDescription);
@@ -142,16 +246,40 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
                         DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "source connector offsets");
             }
         };
-        return new KafkaBasedLog<>(topic, producerProps, consumerProps, adminSupplier, consumedCallback, Time.SYSTEM, createTopics);
     }
 
     @Override
     public void start() {
         log.info("Starting KafkaOffsetBackingStore");
-        offsetLog.start();
+        try {
+            offsetLog.start();
+        } catch (UnsupportedVersionException e) {
+            String message;
+            if (exactlyOnce) {
+                message = "Enabling exactly-once support for source connectors requires a Kafka broker version that allows "
+                        + "admin clients to read consumer offsets. Please either disable the worker's exactly-once "
+                        + "support for source connectors, or upgrade to a newer Kafka broker version.";
+            } else {
+                message = "When " + ConsumerConfig.ISOLATION_LEVEL_CONFIG + "is set to "
+                        + IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT)
+                        + ", a Kafka broker version that allows admin clients to read consumer offsets is required. "
+                        + "Please either reconfigure the worker or connector, or upgrade to a newer Kafka broker version.";
+            }
+            throw new ConnectException(message, e);
+        }
         log.info("Finished reading offsets topic and starting KafkaOffsetBackingStore");
     }
 
+    /**
+     * Stop reading from and writing to the offsets topic, and relinquish resources allocated for interacting
+     * with it, including Kafka clients.
+     * <p>
+     * <b>Note:</b> if the now-deprecated {@link #KafkaOffsetBackingStore()} constructor was used to create
+     * this store, the underlying admin client allocated for interacting with the offsets topic will be closed.
+     * On the other hand, if the recommended {@link #KafkaOffsetBackingStore(Supplier)} constructor was used to
+     * create this store, the admin client derived from the given {@link Supplier} will not be closed and it is the
+     * caller's responsibility to manage its lifecycle accordingly.
+     */
     @Override
     public void stop() {
         log.info("Stopping KafkaOffsetBackingStore");
@@ -197,7 +325,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         return producerCallback;
     }
 
-    private final Callback<ConsumerRecord<byte[], byte[]>> consumedCallback = new Callback<ConsumerRecord<byte[], byte[]>>() {
+    protected final Callback<ConsumerRecord<byte[], byte[]>> consumedCallback = new Callback<ConsumerRecord<byte[], byte[]>>() {
         @Override
         public void onCompletion(Throwable error, ConsumerRecord<byte[], byte[]> record) {
             ByteBuffer key = record.key() != null ? ByteBuffer.wrap(record.key()) : null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -23,11 +23,13 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.ListOffsetsOptions;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
@@ -264,37 +266,32 @@ public class TopicAdmin implements AutoCloseable {
     }
 
     private static final Logger log = LoggerFactory.getLogger(TopicAdmin.class);
-    private final Map<String, Object> adminConfig;
+    private final String bootstrapServers;
     private final Admin admin;
     private final boolean logCreation;
 
     /**
      * Create a new topic admin component with the given configuration.
+     * <p>
+     * Note that this will create an underlying {@link Admin} instance which must be freed when this
+     * topic admin is no longer needed by calling {@link #close()} or {@link #close(Duration)}.
      *
      * @param adminConfig the configuration for the {@link Admin}
      */
     public TopicAdmin(Map<String, Object> adminConfig) {
-        this(adminConfig, Admin.create(adminConfig));
+        this(adminConfig.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), Admin.create(adminConfig));
     }
 
     // visible for testing
-    TopicAdmin(Map<String, Object> adminConfig, Admin adminClient) {
-        this(adminConfig, adminClient, true);
+    TopicAdmin(Object bootstrapServers, Admin adminClient) {
+        this(bootstrapServers, adminClient, true);
     }
 
     // visible for testing
-    TopicAdmin(Map<String, Object> adminConfig, Admin adminClient, boolean logCreation) {
+    TopicAdmin(Object bootstrapServers, Admin adminClient, boolean logCreation) {
         this.admin = adminClient;
-        this.adminConfig = adminConfig != null ? adminConfig : Collections.emptyMap();
+        this.bootstrapServers = bootstrapServers != null ? bootstrapServers.toString() : "<unknown>";
         this.logCreation = logCreation;
-    }
-
-    /**
-     * Get the {@link Admin} client used by this topic admin object.
-     * @return the Kafka admin instance; never null
-     */
-    public Admin admin() {
-        return admin;
     }
 
    /**
@@ -371,7 +368,6 @@ public class TopicAdmin implements AutoCloseable {
             }
         }
         if (topicsByName.isEmpty()) return EMPTY_CREATION;
-        String bootstrapServers = bootstrapServers();
         String topicNameList = Utils.join(topicsByName.keySet(), "', '");
 
         // Attempt to create any missing topics
@@ -448,7 +444,6 @@ public class TopicAdmin implements AutoCloseable {
         if (topics == null) {
             return Collections.emptyMap();
         }
-        String bootstrapServers = bootstrapServers();
         String topicNameList = String.join(", ", topics);
 
         Map<String, KafkaFuture<TopicDescription>> newResults =
@@ -604,7 +599,6 @@ public class TopicAdmin implements AutoCloseable {
         if (topics.isEmpty()) {
             return Collections.emptyMap();
         }
-        String bootstrapServers = bootstrapServers();
         String topicNameList = String.join(", ", topics);
         Collection<ConfigResource> resources = topics.stream()
                                                      .map(t -> new ConfigResource(ConfigResource.Type.TOPIC, t))
@@ -664,7 +658,7 @@ public class TopicAdmin implements AutoCloseable {
             return Collections.emptyMap();
         }
         Map<TopicPartition, OffsetSpec> offsetSpecMap = partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
-        ListOffsetsResult resultFuture = admin.listOffsets(offsetSpecMap);
+        ListOffsetsResult resultFuture = admin.listOffsets(offsetSpecMap, new ListOffsetsOptions(IsolationLevel.READ_UNCOMMITTED));
         // Get the individual result for each topic partition so we have better error messages
         Map<TopicPartition, Long> result = new HashMap<>();
         for (TopicPartition partition : partitions) {
@@ -675,28 +669,28 @@ public class TopicAdmin implements AutoCloseable {
                 Throwable cause = e.getCause();
                 String topic = partition.topic();
                 if (cause instanceof AuthorizationException) {
-                    String msg = String.format("Not authorized to get the end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
+                    String msg = String.format("Not authorized to get the end offsets for topic '%s' on brokers at %s", topic, bootstrapServers);
                     throw new ConnectException(msg, e);
                 } else if (cause instanceof UnsupportedVersionException) {
                     // Should theoretically never happen, because this method is the same as what the consumer uses and therefore
                     // should exist in the broker since before the admin client was added
-                    String msg = String.format("API to get the get the end offsets for topic '%s' is unsupported on brokers at %s", topic, bootstrapServers());
+                    String msg = String.format("API to get the get the end offsets for topic '%s' is unsupported on brokers at %s", topic, bootstrapServers);
                     throw new UnsupportedVersionException(msg, e);
                 } else if (cause instanceof TimeoutException) {
-                    String msg = String.format("Timed out while waiting to get end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
+                    String msg = String.format("Timed out while waiting to get end offsets for topic '%s' on brokers at %s", topic, bootstrapServers);
                     throw new TimeoutException(msg, e);
                 } else if (cause instanceof LeaderNotAvailableException) {
-                    String msg = String.format("Unable to get end offsets during leader election for topic '%s' on brokers at %s", topic, bootstrapServers());
+                    String msg = String.format("Unable to get end offsets during leader election for topic '%s' on brokers at %s", topic, bootstrapServers);
                     throw new LeaderNotAvailableException(msg, e);
                 } else if (cause instanceof org.apache.kafka.common.errors.RetriableException) {
                     throw (org.apache.kafka.common.errors.RetriableException) cause;
                 } else {
-                    String msg = String.format("Error while getting end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
+                    String msg = String.format("Error while getting end offsets for topic '%s' on brokers at %s", topic, bootstrapServers);
                     throw new ConnectException(msg, e);
                 }
             } catch (InterruptedException e) {
                 Thread.interrupted();
-                String msg = String.format("Interrupted while attempting to read end offsets for topic '%s' on brokers at %s", partition.topic(), bootstrapServers());
+                String msg = String.format("Interrupted while attempting to read end offsets for topic '%s' on brokers at %s", partition.topic(), bootstrapServers);
                 throw new RetriableException(msg, e);
             }
         }
@@ -741,10 +735,5 @@ public class TopicAdmin implements AutoCloseable {
 
     public void close(Duration timeout) {
         admin.close(timeout);
-    }
-
-    private String bootstrapServers() {
-        Object servers = adminConfig.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
-        return servers != null ? servers.toString() : "<unknown>";
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -381,9 +381,10 @@ public class ErrorHandlingTaskTest {
 
         EasyMock.expect(workerSourceTask.commitOffsets()).andReturn(true);
 
+        offsetStore.start();
+        EasyMock.expectLastCall();
         sourceTask.initialize(EasyMock.anyObject());
         EasyMock.expectLastCall();
-
         sourceTask.start(EasyMock.anyObject());
         EasyMock.expectLastCall();
 
@@ -445,9 +446,10 @@ public class ErrorHandlingTaskTest {
 
         EasyMock.expect(workerSourceTask.commitOffsets()).andReturn(true);
 
+        offsetStore.start();
+        EasyMock.expectLastCall();
         sourceTask.initialize(EasyMock.anyObject());
         EasyMock.expectLastCall();
-
         sourceTask.start(EasyMock.anyObject());
         EasyMock.expectLastCall();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -351,6 +351,9 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
         createWorkerTask();
 
         expectCall(preProducerCheck::run);
+        expectCall(producer::initTransactions);
+        expectCall(postProducerCheck::run);
+
         Exception exception = new ConnectException("No soup for you!");
         expectCall(offsetStore::start).andThrow(exception);
 
@@ -374,7 +377,6 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
         createWorkerTask();
 
         expectCall(preProducerCheck::run);
-        expectCall(offsetStore::start);
         expectCall(producer::initTransactions);
         Exception exception = new ConnectException("You can't do that!");
         expectCall(postProducerCheck::run).andThrow(exception);
@@ -399,7 +401,6 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
         createWorkerTask();
 
         expectCall(preProducerCheck::run);
-        expectCall(offsetStore::start);
         Exception exception = new ConnectException("New task configs for the connector have already been generated");
         expectCall(producer::initTransactions).andThrow(exception);
 
@@ -1293,9 +1294,9 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
 
     private void expectPreflight() {
         expectCall(preProducerCheck::run);
-        expectCall(offsetStore::start);
         expectCall(producer::initTransactions);
         expectCall(postProducerCheck::run);
+        expectCall(offsetStore::start);
     }
 
     private void expectStartup() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
@@ -89,6 +89,9 @@ public class WorkerConnectorTest extends EasyMockSupport {
         connector.version();
         expectLastCall().andReturn(VERSION);
 
+        offsetStore.start();
+        expectLastCall();
+
         connector.initialize(EasyMock.notNull(SourceConnectorContext.class));
         expectLastCall().andThrow(exception);
 
@@ -172,6 +175,9 @@ public class WorkerConnectorTest extends EasyMockSupport {
         connector = sourceConnector;
         connector.version();
         expectLastCall().andReturn(VERSION);
+
+        offsetStore.start();
+        expectLastCall();
 
         connector.initialize(EasyMock.notNull(SourceConnectorContext.class));
         expectLastCall();
@@ -279,6 +285,9 @@ public class WorkerConnectorTest extends EasyMockSupport {
         expectLastCall().andReturn(VERSION);
 
         connector.initialize(EasyMock.notNull(SourceConnectorContext.class));
+        expectLastCall();
+
+        offsetStore.start();
         expectLastCall();
 
         listener.onPause(CONNECTOR);
@@ -429,6 +438,9 @@ public class WorkerConnectorTest extends EasyMockSupport {
         connector.version();
         expectLastCall().andReturn(VERSION);
 
+        offsetStore.start();
+        expectLastCall();
+
         connector.initialize(EasyMock.notNull(SourceConnectorContext.class));
         expectLastCall();
 
@@ -477,6 +489,9 @@ public class WorkerConnectorTest extends EasyMockSupport {
         connector = sourceConnector;
         connector.version();
         expectLastCall().andReturn(VERSION);
+
+        offsetStore.start();
+        expectLastCall();
 
         connector.initialize(EasyMock.notNull(SourceConnectorContext.class));
         expectLastCall();
@@ -529,6 +544,9 @@ public class WorkerConnectorTest extends EasyMockSupport {
         connector = sourceConnector;
         connector.version();
         expectLastCall().andReturn(VERSION);
+
+        offsetStore.start();
+        expectLastCall();
 
         connector.initialize(EasyMock.notNull(SourceConnectorContext.class));
         expectLastCall();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -269,12 +269,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     public void testPause() throws Exception {
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         AtomicInteger count = new AtomicInteger(0);
         CountDownLatch pollLatch = expectPolls(10, count);
@@ -323,12 +318,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     public void testPollsInBackground() throws Exception {
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         final CountDownLatch pollLatch = expectPolls(10);
         // In this test, we don't flush, so nothing goes any further than the offset writer
@@ -366,12 +356,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     public void testFailureInPoll() throws Exception {
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         final CountDownLatch pollLatch = new CountDownLatch(1);
         final RuntimeException exception = new RuntimeException();
@@ -408,12 +393,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     public void testFailureInPollAfterCancel() throws Exception {
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         final CountDownLatch pollLatch = new CountDownLatch(1);
         final CountDownLatch workerCancelLatch = new CountDownLatch(1);
@@ -456,12 +436,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     public void testFailureInPollAfterStop() throws Exception {
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         final CountDownLatch pollLatch = new CountDownLatch(1);
         final CountDownLatch workerStopLatch = new CountDownLatch(1);
@@ -502,12 +477,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // Test that the task handles an empty list of records
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         // We'll wait for some data, then trigger a flush
         final CountDownLatch pollLatch = expectEmptyPolls(1, new AtomicInteger());
@@ -543,12 +513,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // Test that the task commits properly when prompted
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         // We'll wait for some data, then trigger a flush
         final CountDownLatch pollLatch = expectPolls(1);
@@ -589,12 +554,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // Test that the task commits properly when prompted
         createWorkerTask();
 
-        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
-        EasyMock.expectLastCall();
-        sourceTask.start(TASK_PROPS);
-        EasyMock.expectLastCall();
-        statusListener.onStartup(taskId);
-        EasyMock.expectLastCall();
+        expectCleanStartup();
 
         // We'll wait for some data, then trigger a flush
         final CountDownLatch pollLatch = expectPolls(1);
@@ -763,6 +723,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
         createWorkerTask();
 
+        offsetStore.start();
+        EasyMock.expectLastCall();
         sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
         EasyMock.expectLastCall();
         sourceTask.start(TASK_PROPS);
@@ -1086,6 +1048,17 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     }
 
     private abstract static class TestSourceTask extends SourceTask {
+    }
+
+    private void expectCleanStartup() {
+        offsetStore.start();
+        EasyMock.expectLastCall();
+        sourceTask.initialize(EasyMock.anyObject(SourceTaskContext.class));
+        EasyMock.expectLastCall();
+        sourceTask.start(TASK_PROPS);
+        EasyMock.expectLastCall();
+        statusListener.onStartup(taskId);
+        EasyMock.expectLastCall();
     }
 
     private void expectClose() {


### PR DESCRIPTION
Implements support for per-connector offsets topics as described in [KIP-618](https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors#KIP618:ExactlyOnceSupportforSourceConnectors-Per-connectoroffsetstopics).

Relies on changes from:
- https://github.com/apache/kafka/pull/11780