### PR TITLE
MINOR: Add KRaft broker api to protocol docs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -231,7 +231,7 @@ public enum ApiKeys {
         b.append("<th>Name</th>\n");
         b.append("<th>Key</th>\n");
         b.append("</tr>");
-        for (ApiKeys key : zkBrokerApis()) {
+        for (ApiKeys key : clientApis()) {
             b.append("<tr>\n");
             b.append("<td>");
             b.append("<a href=\"#The_Messages_" + key.name + "\">" + key.name + "</a>");
@@ -271,15 +271,22 @@ public enum ApiKeys {
         return apisForListener(ApiMessageType.ListenerType.CONTROLLER);
     }
 
+    public static EnumSet<ApiKeys> clientApis() {
+        List<ApiKeys> apis = Arrays.stream(ApiKeys.values())
+            .filter(apiKey -> apiKey.inScope(ApiMessageType.ListenerType.ZK_BROKER) || apiKey.inScope(ApiMessageType.ListenerType.BROKER))
+            .collect(Collectors.toList());
+        return EnumSet.copyOf(apis);
+    }
+
     public static EnumSet<ApiKeys> apisForListener(ApiMessageType.ListenerType listener) {
         return APIS_BY_LISTENER.get(listener);
     }
 
     private static EnumSet<ApiKeys> filterApisForListener(ApiMessageType.ListenerType listener) {
-        List<ApiKeys> controllerApis = Arrays.stream(ApiKeys.values())
-            .filter(apiKey -> apiKey.messageType.listeners().contains(listener))
+        List<ApiKeys> apis = Arrays.stream(ApiKeys.values())
+            .filter(apiKey -> apiKey.inScope(listener))
             .collect(Collectors.toList());
-        return EnumSet.copyOf(controllerApis);
+        return EnumSet.copyOf(apis);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -133,7 +133,7 @@ public class Protocol {
             b.append("</pre>\n");
             schemaToFieldTableHtml(ResponseHeaderData.SCHEMAS[i], b);
         }
-        for (ApiKeys key : ApiKeys.zkBrokerApis()) {
+        for (ApiKeys key : ApiKeys.clientApis()) {
             // Key
             b.append("<h5>");
             b.append("<a name=\"The_Messages_" + key.name + "\">");


### PR DESCRIPTION
*More detailed description of your change*
Currently in the [kafka protocols page](https://kafka.apache.org/protocol), we miss some KRaft protocol, for example DescribeQuorumRequest(55)
![image](https://user-images.githubusercontent.com/26023240/154472292-b315a9dd-3051-4a04-9823-6426ab36f77f.png)


*Summary of testing strategy (including rationale)*
After this change, DescribeQuorumRequest is listed in the table:
![image](https://user-images.githubusercontent.com/26023240/154473509-8331586a-4bcd-46e4-9eb8-6b29181284f6.png)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
