### PR TITLE
KAFKA-13676: Commit successfully processed tasks on error

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -48,12 +48,17 @@ public class TaskExecutor {
 
     private final Logger log;
 
+    private final boolean hasNamedTopologies;
     private final ProcessingMode processingMode;
     private final Tasks tasks;
 
-    public TaskExecutor(final Tasks tasks, final ProcessingMode processingMode, final LogContext logContext) {
+    public TaskExecutor(final Tasks tasks,
+                        final ProcessingMode processingMode,
+                        final boolean hasNamedTopologies,
+                        final LogContext logContext) {
         this.tasks = tasks;
         this.processingMode = processingMode;
+        this.hasNamedTopologies = hasNamedTopologies;
         this.log = logContext.logger(getClass());
     }
 
@@ -88,7 +93,8 @@ public class TaskExecutor {
                 task.clearTaskTimeout();
                 processed++;
             }
-            if (processingMode != EXACTLY_ONCE_V2) {
+            // TODO: enable regardless of whether using named topologies
+            if (hasNamedTopologies && processingMode != EXACTLY_ONCE_V2) {
                 tasks.addToSuccessfullyProcessed(task);
             }
         } catch (final TimeoutException timeoutException) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -116,7 +116,7 @@ public class TaskManager {
         this.log = logContext.logger(getClass());
 
         this.tasks = new Tasks(logContext, topologyMetadata,  streamsMetrics, activeTaskCreator, standbyTaskCreator);
-        this.taskExecutor = new TaskExecutor(tasks, processingMode, logContext);
+        this.taskExecutor = new TaskExecutor(tasks, processingMode, topologyMetadata.hasNamedTopologies(), logContext);
     }
 
     void setMainConsumer(final Consumer<byte[], byte[]> mainConsumer) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -59,6 +59,7 @@ class Tasks {
     // TODO: change type to `StandbyTask`
     private final Map<TaskId, Task> readOnlyStandbyTasksPerId = Collections.unmodifiableMap(standbyTasksPerId);
     private final Set<TaskId> readOnlyStandbyTaskIds = Collections.unmodifiableSet(standbyTasksPerId.keySet());
+    private final Collection<Task> successfullyProcessed = new HashSet<>();
 
     private final ActiveTaskCreator activeTaskCreator;
     private final StandbyTaskCreator standbyTaskCreator;
@@ -317,6 +318,22 @@ class Tasks {
 
     Consumer<byte[], byte[]> mainConsumer() {
         return mainConsumer;
+    }
+
+    Collection<Task> successfullyProcessed() {
+        return successfullyProcessed;
+    }
+
+    void addToSuccessfullyProcessed(final Task task) {
+        successfullyProcessed.add(task);
+    }
+
+    void removeTaskFromCuccessfullyProcessedBeforeClosing(final Task task) {
+        successfullyProcessed.remove(task);
+    }
+
+    void clearSuccessfullyProcessed() {
+        successfullyProcessed.clear();
     }
 
     // for testing only

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
@@ -202,11 +202,11 @@ public class EmitOnChangeIntegrationTest {
             final AtomicInteger twoOutputExpected = new AtomicInteger(0);
             builder.stream(inputTopic2).peek((k, v) -> twoOutputExpected.incrementAndGet()).to(outputTopic2);
             builder.stream(inputTopic)
-            .peek((k, v) -> {
-                throw new RuntimeException("Kaboom");
-            })
-            .peek((k, v) -> noOutputExpected.incrementAndGet())
-            .to(outputTopic);
+                .peek((k, v) -> {
+                    throw new RuntimeException("Kaboom");
+                })
+                .peek((k, v) -> noOutputExpected.incrementAndGet())
+                .to(outputTopic);
 
             kafkaStreams.addNamedTopology(builder.build());            
             

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
-import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.StreamsTestUtils;


### PR DESCRIPTION
When we hit an exception when processing tasks we should save the work we have done so far.
This will only be relevant with ALOS and EOS-v1, not EOS-v2. It will actually reduce the number of duplicated record in ALOS because we will not be successfully processing tasks successfully more than once in many cases.

This is currently enabled only for named topologies.

The behavior was rather throughly tested. There is a `EmitOnChangeIntegrationTest` that makes sure if there is an exception in a task, after replacing the thread and if the exception does not throw again the record would still be processed. I just added another task into the test such that even if the other task keep throwing exceptions and hence never complete processing its record, this new task that could process successfully would be able to make progress and commit its offset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
