### PR TITLE
 MINOR: Optimize StorageTool#formatCommand, remove return result

### DIFF
--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -228,9 +228,7 @@ abstract class QuorumTestHarness extends Logging {
     var out: PrintStream = null
     try {
       out = new PrintStream(stream)
-      if (StorageTool.formatCommand(out, directories, metaProperties, false) != 0) {
-        throw new RuntimeException(stream.toString())
-      }
+      StorageTool.formatCommand(out, directories, metaProperties, ignoreFormatted = false)
       debug(s"Formatted storage directory(ies) ${directories}")
     } finally {
       if (out != null) out.close()

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -159,20 +159,21 @@ Found problem:
       val metaProperties = MetaProperties(
         clusterId = "XcZZOzUqS4yHOjhMQB6JLQ", nodeId = 2)
       val stream = new ByteArrayOutputStream()
-      assertEquals(0, StorageTool.
-        formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, false))
+      StorageTool.
+        formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, false)
       assertEquals("Formatting %s%n".format(tempDir), stream.toString())
 
-      try assertEquals(1, StorageTool.
-        formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties, false)) catch {
+      try StorageTool.
+        formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties, false)
+      catch {
         case e: TerseFailure => assertEquals(s"Log directory ${tempDir} is already " +
           "formatted. Use --ignore-formatted to ignore this directory and format the " +
           "others.", e.getMessage)
       }
 
       val stream2 = new ByteArrayOutputStream()
-      assertEquals(0, StorageTool.
-        formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, true))
+      StorageTool.
+        formatCommand(new PrintStream(stream2), Seq(tempDir.toString), metaProperties, true)
       assertEquals("All of the log directories are already formatted.%n".format(), stream2.toString())
     } finally Utils.delete(tempDir)
   }


### PR DESCRIPTION
The method StorageTool#formatCommand will always return 0 if execute success, so it might be better to remove this return result.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
