### PR TITLE
KAFKA-12879: Revert changes from KAFKA-12339 and instead add retry capability to KafkaBasedLog

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/MetadataOperationContext.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/MetadataOperationContext.java
@@ -82,7 +82,6 @@ public final class MetadataOperationContext<T, O extends AbstractOptions<O>> {
 
     public static void handleMetadataErrors(MetadataResponse response) {
         for (TopicMetadata tm : response.topicMetadata()) {
-            if (shouldRefreshMetadata(tm.error())) throw tm.error().exception();
             for (PartitionMetadata pm : tm.partitionMetadata()) {
                 if (shouldRefreshMetadata(pm.error)) {
                     throw pm.error.exception();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -489,16 +489,12 @@ public class KafkaAdminClientTest {
     }
 
     private static MetadataResponse prepareMetadataResponse(Cluster cluster, Errors error) {
-        return prepareMetadataResponse(cluster, error, error);
-    }
-
-    private static MetadataResponse prepareMetadataResponse(Cluster cluster, Errors topicError, Errors partitionError) {
         List<MetadataResponseTopic> metadata = new ArrayList<>();
         for (String topic : cluster.topics()) {
             List<MetadataResponsePartition> pms = new ArrayList<>();
             for (PartitionInfo pInfo : cluster.availablePartitionsForTopic(topic)) {
                 MetadataResponsePartition pm  = new MetadataResponsePartition()
-                    .setErrorCode(partitionError.code())
+                    .setErrorCode(error.code())
                     .setPartitionIndex(pInfo.partition())
                     .setLeaderId(pInfo.leader().id())
                     .setLeaderEpoch(234)
@@ -508,7 +504,7 @@ public class KafkaAdminClientTest {
                 pms.add(pm);
             }
             MetadataResponseTopic tm = new MetadataResponseTopic()
-                .setErrorCode(topicError.code())
+                .setErrorCode(error.code())
                 .setName(topic)
                 .setIsInternal(false)
                 .setPartitions(pms);
@@ -4336,40 +4332,6 @@ public class KafkaAdminClientTest {
                 result.partitionResult(new TopicPartition("unknown", 0)).get();
                 fail("should have thrown IllegalArgumentException");
             } catch (IllegalArgumentException expected) { }
-        }
-    }
-
-    @Test
-    public void testListOffsetsRetriableErrorOnMetadata() throws Exception {
-        Node node = new Node(0, "localhost", 8120);
-        List<Node> nodes = Collections.singletonList(node);
-        final Cluster cluster = new Cluster(
-            "mockClusterId",
-            nodes,
-            Collections.singleton(new PartitionInfo("foo", 0, node, new Node[]{node}, new Node[]{node})),
-            Collections.emptySet(),
-            Collections.emptySet(),
-            node);
-        final TopicPartition tp0 = new TopicPartition("foo", 0);
-
-        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(cluster)) {
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.NONE));
-            // metadata refresh because of UNKNOWN_TOPIC_OR_PARTITION
-            env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
-            // listoffsets response from broker 0
-            ListOffsetsResponseData responseData = new ListOffsetsResponseData()
-                .setThrottleTimeMs(0)
-                .setTopics(Collections.singletonList(ListOffsetsResponse.singletonListOffsetsTopicResponse(tp0, Errors.NONE, -1L, 123L, 321)));
-            env.kafkaClient().prepareResponseFrom(new ListOffsetsResponse(responseData), node);
-
-            ListOffsetsResult result = env.adminClient().listOffsets(Collections.singletonMap(tp0, OffsetSpec.latest()));
-
-            Map<TopicPartition, ListOffsetsResultInfo> offsets = result.all().get(3, TimeUnit.SECONDS);
-            assertEquals(1, offsets.size());
-            assertEquals(123L, offsets.get(tp0).offset());
-            assertEquals(321, offsets.get(tp0).leaderEpoch().get().intValue());
-            assertEquals(-1L, offsets.get(tp0).timestamp());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -814,6 +814,7 @@ public class KafkaAdminClientTest {
 
         try (AdminClientUnitTestEnv env = mockClientEnv(time,
             AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, String.valueOf(defaultApiTimeout))) {
+    ;
 
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -814,7 +814,6 @@ public class KafkaAdminClientTest {
 
         try (AdminClientUnitTestEnv env = mockClientEnv(time,
             AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, String.valueOf(defaultApiTimeout))) {
-    ;
 
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -320,11 +320,11 @@ public class KafkaBasedLog<K, V> {
     }
 
     /**
-     * This method finds the end offsets using the <code>listOffsets</code> method of the admin client.
-     * As the <code>listOffsets</code> method might throw a {@link RetriableException}, the <code>shouldRetry</code>
-     * flag enables retry, upon catching such exception, if it is set to <code>True</code>.
+     * This method finds the end offsets using the {@code listOffsets()} method of the admin client.
+     * As the {@code listOffsets()} method might throw a {@link RetriableException}, the {@code shouldRetry}
+     * flag enables retry, upon catching such exception, if it is set to {@code True}.
      *
-     * @param shouldRetry Boolean flag to enable retry for the admin client <code>listOffsets</code> call.
+     * @param shouldRetry Boolean flag to enable retry for the admin client {@code listOffsets()} call.
      * @see TopicAdmin#retryEndOffsets
      */
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -319,10 +319,17 @@ public class KafkaBasedLog<K, V> {
         }
     }
 
+    /**
+     * This method finds the end offsets using the <code>listOffsets</code> method of the admin client.
+     * As the <code>listOffsets</code> method might throw a {@link RetriableException}, the <code>shouldRetry</code>
+     * flag enables retry, upon catching such exception, if it is set to <code>True</code>.
+     *
+     * @param shouldRetry Boolean flag to enable retry for the admin client <code>listOffsets</code> call.
+     */
+
     private void readToLogEnd(boolean shouldRetry) {
         Set<TopicPartition> assignment = consumer.assignment();
-        // readEndOffsets makes listOffsets call to adminClient, if shouldRetry is set to True, the adminClinet
-        // will retry on RetriableExceptions
+        // it will subsequently invoke the listOffsets call here
         Map<TopicPartition, Long> endOffsets = readEndOffsets(assignment, shouldRetry);
         log.trace("Reading to end of log offsets {}", endOffsets);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -320,14 +320,12 @@ public class KafkaBasedLog<K, V> {
     }
 
     /**
-     * This method finds the end offsets using the {@code listOffsets()} method of the admin client.
-     * As the {@code listOffsets()} method might throw a {@link RetriableException}, the {@code shouldRetry}
-     * flag enables retry, upon catching such exception, if it is set to {@code True}.
+     * This method finds the end offsets of the Kafka log's topic partitions, optionally retrying
+     * if the {@code listOffsets()} method of the admin client throws a {@link RetriableException}.
      *
      * @param shouldRetry Boolean flag to enable retry for the admin client {@code listOffsets()} call.
      * @see TopicAdmin#retryEndOffsets
      */
-
     private void readToLogEnd(boolean shouldRetry) {
         Set<TopicPartition> assignment = consumer.assignment();
         Map<TopicPartition, Long> endOffsets = readEndOffsets(assignment, shouldRetry);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -79,7 +79,7 @@ public class KafkaBasedLog<K, V> {
     // 15min of admin retry duration to ensure successful metadata propagation.  10 seconds of backoff
     // in between retries
     private static final Duration ADMIN_CLIENT_RETRY_DURATION = Duration.ofMinutes(15);
-    private static final long ADMIN_CLIENT_RETRY_BACKOFF_MS = 10 * 1000;
+    private static final long ADMIN_CLIENT_RETRY_BACKOFF_MS = TimeUnit.SECONDS.toMillis(10);
 
     private Time time;
     private final String topic;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -325,11 +325,11 @@ public class KafkaBasedLog<K, V> {
      * flag enables retry, upon catching such exception, if it is set to <code>True</code>.
      *
      * @param shouldRetry Boolean flag to enable retry for the admin client <code>listOffsets</code> call.
+     * @see TopicAdmin#retryEndOffsets
      */
 
     private void readToLogEnd(boolean shouldRetry) {
         Set<TopicPartition> assignment = consumer.assignment();
-        // it will subsequently invoke the listOffsets call here
         Map<TopicPartition, Long> endOffsets = readEndOffsets(assignment, shouldRetry);
         log.trace("Reading to end of log offsets {}", endOffsets);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -321,6 +321,8 @@ public class KafkaBasedLog<K, V> {
 
     private void readToLogEnd(boolean shouldRetry) {
         Set<TopicPartition> assignment = consumer.assignment();
+        // readEndOffsets makes listOffsets call to adminClient, if shouldRetry is set to True, the adminClinet
+        // will retry on RetriableExceptions
         Map<TopicPartition, Long> endOffsets = readEndOffsets(assignment, shouldRetry);
         log.trace("Reading to end of log offsets {}", endOffsets);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -359,7 +359,6 @@ public class KafkaBasedLog<K, V> {
         if (admin != null) {
             // Use the admin client to immediately find the end offsets for the assigned topic partitions.
             // Unlike using the consumer
-            System.out.println("getting end offset : " + shouldRetry);
             try {
                 if (shouldRetry) {
                     return admin.retryEndOffsets(assignment);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -33,11 +33,11 @@ public class RetryUtil {
      * {@link org.apache.kafka.connect.errors.RetriableException} is being thrown.  If all retries are exhausted,
      * then the last exception is wrapped with a {@link org.apache.kafka.connect.errors.ConnectException} and thrown.
      *
-     * <p>If <code>maxRetries</code> is set to 0, the task will be
-     * executed exactly once.  If <code>maxRetries</code> is set to <code>n</code>, the callable will be executed at
-     * most <code>n + 1</code> times.
+     * <p>If {@code maxRetries} is set to 0, the task will be
+     * executed exactly once.  If {@code maxRetries} is set to ,{@code n} the callable will be executed at
+     * most {@code n + 1} times.
      *
-     * <p>If <code>retryBackoffMs</code> is set to 0, no wait will happen in between the retries.
+     * <p>If {@code retryBackoffMs} is set to 0, no wait will happen in between the retries.
      *
      * @param callable the function to execute.
      * @param maxRetries maximum number of retries; must be 0 or more

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -47,6 +47,6 @@ public class RetryUtil {
             Utils.sleep(retryBackoffMs);
         }
 
-        throw new ConnectException(lastError);
+        throw new ConnectException("Fail to retry the operation after " + maxRetries + " attempts.  Reason: " + lastError, lastError);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -36,6 +36,10 @@ public class RetryUtil {
      * {@link org.apache.kafka.connect.errors.RetriableException} is being thrown.  If timeout is exhausted,
      * then the last exception is wrapped with a {@link org.apache.kafka.connect.errors.ConnectException} and thrown.
      *
+     * <p>{@code description} supplies the message that indicates the purpose of the callable since the message will
+     * be used for logging.  For example, "list offsets". If the supplier is null or the supplied string is
+     * null, {@call callable} will be used as the default string.
+     *
      * <p>If {@code timeoutDuration} is set to 0, the task will be
      * executed exactly once.  If {@code timeoutDuration} is less than {@code retryBackoffMs}, the callable will be
      * executed only once.
@@ -43,8 +47,7 @@ public class RetryUtil {
      * <p>If {@code retryBackoffMs} is set to 0, no wait will happen in between the retries.
      *
      * @param callable          the function to execute.
-     * @param description       supplier lambda that supplies custom message for logging purpose;if {@code description}
-     *                          is null, {@code callable} will be used as the default message
+     * @param description       supplier that provides custom message for logging purpose
      * @param timeoutDuration   timeout duration; may not be null
      * @param retryBackoffMs    the number of milliseconds to delay upon receiving a
      *                          {@link org.apache.kafka.connect.errors.RetriableException} before retrying again;
@@ -52,9 +55,11 @@ public class RetryUtil {
      * @throws ConnectException If the task exhausted all the retries.
      */
     public static <T> T retryUntilTimeout(Callable<T> callable, Supplier<String> description, Duration timeoutDuration, long retryBackoffMs) throws Exception {
-        if (timeoutDuration == null)
+        if (timeoutDuration == null) {
             throw new IllegalArgumentException("timeoutDuration cannot be null");
+        }
 
+        // if null supplier or string is provided, the message will be default to "callabe"
         String descriptionStr = Optional.ofNullable(description)
                 .map(Supplier::get)
                 .orElse("callable");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -82,7 +82,7 @@ public class RetryUtil {
         long end = System.currentTimeMillis() + timeoutMs;
         int attempt = 0;
         Throwable lastError = null;
-        while (System.currentTimeMillis() <= end) {
+        do {
             attempt++;
             try {
                 return callable.call();
@@ -100,7 +100,7 @@ public class RetryUtil {
             if (sleepMs > 0) {  // won't sleep if retryBackoffMs is less or equals to 0
                 Utils.sleep(sleepMs);
             }
-        }
+        } while (System.currentTimeMillis() < end);
 
         throw new ConnectException("Fail to " + descriptionStr + " after " + attempt + " attempts.  Reason: " + lastError.getMessage(), lastError);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -34,7 +34,7 @@ public class RetryUtil {
      * then the last exception is wrapped with a {@link org.apache.kafka.connect.errors.ConnectException} and thrown.
      *
      * <p>If {@code maxRetries} is set to 0, the task will be
-     * executed exactly once.  If {@code maxRetries} is set to ,{@code n} the callable will be executed at
+     * executed exactly once.  If {@code maxRetries} is set to {@code n}, the callable will be executed at
      * most {@code n + 1} times.
      *
      * <p>If {@code retryBackoffMs} is set to 0, no wait will happen in between the retries.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -39,11 +39,11 @@ public class RetryUtil {
      *
      * <p>If {@code retryBackoffMs} is set to 0, no wait will happen in between the retries.
      *
-     * @param callable the function to execute.
-     * @param maxRetries maximum number of retries; must be 0 or more
+     * @param callable       the function to execute.
+     * @param maxRetries     maximum number of retries; must be 0 or more
      * @param retryBackoffMs the number of milliseconds to delay upon receiving a
-     * {@link org.apache.kafka.connect.errors.RetriableException} before retrying again; must be 0 or more
-     *
+     *                       {@link org.apache.kafka.connect.errors.RetriableException} before retrying again; 
+     *                       must be 0 or more
      * @throws ConnectException If the task exhausted all the retries.
      */
     public static <T> T retry(Callable<T> callable, long maxRetries, long retryBackoffMs) throws Exception {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -64,12 +64,12 @@ public class RetryUtil {
                 .orElse(0L);
 
         if (retryBackoffMs >= timeoutMs) {
-            log.warn("Executing {} only once, since retryBackoffMs={} is larger than total timeoutMs={}",
+            log.debug("Executing {} only once, since retryBackoffMs={} is larger than total timeoutMs={}",
                     descriptionStr, retryBackoffMs, timeoutMs);
         }
 
         if (retryBackoffMs < 0) {
-            log.warn("Invalid retryBackoffMs, must be non-negative but got {}. 0 will be used instead",
+            log.debug("Invalid retryBackoffMs, must be non-negative but got {}. 0 will be used instead",
                     retryBackoffMs);
             retryBackoffMs = 0;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -50,13 +50,13 @@ public class RetryUtil {
     public static <T> T retry(Callable<T> callable, long maxRetries, long retryBackoffMs) throws Exception {
         Throwable lastError = null;
         int attempt = 0;
-        long maxAttempts = maxRetries + 1;
-        while (attempt++ < maxAttempts) {
+        final long maxAttempts = maxRetries + 1;
+        while (++attempt <= maxAttempts) {
             try {
                 return callable.call();
             } catch (RetriableException | org.apache.kafka.connect.errors.RetriableException e) {
-                log.warn("RetriableException caught, retrying automatically up to {} more times. " +
-                        "Reason: {}", maxRetries - attempt, e.getMessage());
+                log.warn("RetriableException caught on attempt {}, retrying automatically up to {} more times. " +
+                        "Reason: {}", attempt, maxRetries - attempt, e.getMessage());
                 lastError = e;
             } catch (WakeupException e) {
                 lastError = e;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Callable;
+
+public class RetryUtil {
+    private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
+
+    public static <T> T retry(Callable<T> callable, long maxRetries, long retryBackoffMs) throws Exception {
+        Throwable lastError = null;
+        int retries = 0;
+        while (retries++ < maxRetries) {
+            try {
+                return callable.call();
+            } catch (RetriableException | org.apache.kafka.connect.errors.RetriableException e) {
+                log.warn("RetriableException caught, retrying automatically up to {} more times. " +
+                        "Reason: {}", maxRetries - retries, e.getMessage());
+                lastError = e;
+            } catch (WakeupException e) {
+                lastError = e;
+            } catch (Exception e) {
+                log.warn("Non-retriable exception caught. Re-throwing. Reason: {}, {}", e.getClass(), e.getMessage());
+                throw e;
+            }
+            Utils.sleep(retryBackoffMs);
+        }
+
+        throw new ConnectException(lastError);
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -41,7 +41,7 @@ public class RetryUtil {
      * <p>If {@code retryBackoffMs} is set to 0, no wait will happen in between the retries.
      *
      * @param callable          the function to execute.
-     * @param timeoutDuration   timeout duration
+     * @param timeoutDuration   timeout duration; may not be null
      * @param retryBackoffMs    the number of milliseconds to delay upon receiving a
      *                          {@link org.apache.kafka.connect.errors.RetriableException} before retrying again;
      *                          must be 0 or more
@@ -77,8 +77,9 @@ public class RetryUtil {
 
             // if current time is less than the ending time, no more retry is necessary
             // won't sleep if retryBackoffMs equals to 0
-            if (retryBackoffMs > 0 && System.currentTimeMillis() < end) {
-                Utils.sleep(retryBackoffMs);
+            long millisRemaining = Math.max(0, end - System.currentTimeMillis());
+            if (millisRemaining > 0) {
+                Utils.sleep(millisRemaining)
             }
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -67,14 +67,9 @@ public class RetryUtil {
             log.debug("Assuming no retry backoff since retryBackoffMs={} is negative", retryBackoffMs);
             retryBackoffMs = 0;
         }
-
-        if (retryBackoffMs >= timeoutMs) {
-            log.debug("Executing {} only once, since retryBackoffMs={} is equal to or larger than total timeoutDurationMs={}",
-                    descriptionStr, retryBackoffMs, timeoutMs);
-        }
-
         if (timeoutMs <= 0 || retryBackoffMs >= timeoutMs) {
-            // no retry
+            log.debug("Executing {} only once, since timeoutMs={} is not larger than retryBackoffMs={}",
+                    descriptionStr, timeoutMs, retryBackoffMs);
             return callable.call();
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -40,18 +40,16 @@ public class RetryUtil {
      * be used for logging.  For example, "list offsets". If the supplier is null or the supplied string is
      * null, {@code callable} will be used as the default string.
      *
-     * <p>If {@code timeoutDuration} is set to 0, the task will be
-     * executed exactly once.  If {@code timeoutDuration} is less than {@code retryBackoffMs}, the callable will be
-     * executed only once.
+     * <p>The task will be executed at least once. No retries will be performed 
+     * if {@code timeoutDuration} is 0 or negative, or if {@code timeoutDuration} is less than {@code retryBackoffMs}.
      *
-     * <p>If {@code retryBackoffMs} is set to 0, no wait will happen in between the retries.
+     * <p>A {@code retryBackoffMs} that is negative or zero will result in no delays between retries.
      *
      * @param callable          the function to execute
      * @param description       supplier that provides custom message for logging purpose
-     * @param timeoutDuration   timeout duration; must not be null or negative
+     * @param timeoutDuration   timeout duration; must not be null
      * @param retryBackoffMs    the number of milliseconds to delay upon receiving a
-     *                          {@link org.apache.kafka.connect.errors.RetriableException} before retrying again;
-     *                          must be 0 or more
+     *                          {@link org.apache.kafka.connect.errors.RetriableException} before retrying again
      * @throws ConnectException If the task exhausted all the retries
      */
     public static <T> T retryUntilTimeout(Callable<T> callable, Supplier<String> description, Duration timeoutDuration, long retryBackoffMs) throws Exception {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -67,7 +67,7 @@ public class RetryUtil {
         long timeoutMs = timeoutDuration.toMillis();
 
         if (retryBackoffMs >= timeoutMs) {
-            log.warn("Call to {} will only execute once, since retryBackoffMs={} is larger than total timeoutMs={}",
+            log.warn("Executing {} only once, since retryBackoffMs={} is larger than total timeoutMs={}",
                     descriptionStr, retryBackoffMs, timeoutMs);
         }
 
@@ -85,7 +85,7 @@ public class RetryUtil {
             try {
                 return callable.call();
             } catch (RetriableException | org.apache.kafka.connect.errors.RetriableException e) {
-                log.warn("Attempt {} to execute {} resulted in RetriableException; retrying automatically. " +
+                log.warn("Attempt {} to {} resulted in RetriableException; retrying automatically. " +
                         "Reason: {}", attempt, descriptionStr, e.getMessage(), e);
                 lastError = e;
             } catch (WakeupException e) {
@@ -96,10 +96,10 @@ public class RetryUtil {
             // won't sleep if retryBackoffMs equals to 0
             long millisRemaining = Math.max(0, end - System.currentTimeMillis());
             if (millisRemaining > 0) {
-                Utils.sleep(retryBackoffMs);
+                Utils.sleep(Math.min(retryBackoffMs, millisRemaining));
             }
         }
 
-        throw new ConnectException("Fail to execute " + descriptionStr + " after " + attempt + " attempts.  Reason: " + lastError.getMessage(), lastError);
+        throw new ConnectException("Fail to " + descriptionStr + " after " + attempt + " attempts.  Reason: " + lastError.getMessage(), lastError);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -656,7 +656,7 @@ public class TopicAdmin implements AutoCloseable {
      * @throws TimeoutException if the offset metadata could not be fetched before the amount of time allocated
      *         by {@code request.timeout.ms} expires, and this call can be retried
      * @throws LeaderNotAvailableException if the leader was not available and this call can be retried
-     * @throws RetriableException if a retriable error occurs, or the thread is interrupted while attempting 
+     * @throws RetriableException if a retriable error occurs, or the thread is interrupted while attempting
      *         to perform this operation
      * @throws ConnectException if a non retriable error occurs
      */
@@ -665,26 +665,18 @@ public class TopicAdmin implements AutoCloseable {
             return Collections.emptyMap();
         }
 
-        System.out.println("balbaba");
         Map<TopicPartition, OffsetSpec> offsetSpecMap = partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
         ListOffsetsResult resultFuture = admin.listOffsets(offsetSpecMap);
         // Get the individual result for each topic partition so we have better error messages
         Map<TopicPartition, Long> result = new HashMap<>();
         for (TopicPartition partition : partitions) {
 
-            System.out.println("balbabadddddd: " + partition.topic());
             try {
-                System.out.println("0");
                 ListOffsetsResultInfo info = resultFuture.partitionResult(partition).get();
-                System.out.println("1");
-
                 result.put(partition, info.offset());
             } catch (ExecutionException e) {
-                System.out.println("topicexception");
-
                 Throwable cause = e.getCause();
                 String topic = partition.topic();
-                System.out.println("topic");
 
                 if (cause instanceof AuthorizationException) {
                     String msg = String.format("Not authorized to get the end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
@@ -696,7 +688,6 @@ public class TopicAdmin implements AutoCloseable {
                     throw new UnsupportedVersionException(msg, e);
                 } else if (cause instanceof TimeoutException) {
                     String msg = String.format("Timed out while waiting to get end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
-                    System.out.println("retriable");
 
                     throw new TimeoutException(msg, e);
                 } else if (cause instanceof LeaderNotAvailableException) {
@@ -713,9 +704,7 @@ public class TopicAdmin implements AutoCloseable {
                 String msg = String.format("Interrupted while attempting to read end offsets for topic '%s' on brokers at %s", partition.topic(), bootstrapServers());
                 throw new RetriableException(msg, e);
             }
-            System.out.println("next");
         }
-        System.out.println("@@");
         return result;
     }
 
@@ -727,7 +716,6 @@ public class TopicAdmin implements AutoCloseable {
         int retries = 0;
 
         while (retries++ < maxRetries) {
-            System.out.println("@@");
             try {
                 return endOffsets(partitions);
             } catch (TimeoutException e) {
@@ -747,7 +735,6 @@ public class TopicAdmin implements AutoCloseable {
                 throw e;
             }
             log.info("Backing off {} ms, before retry", retryBackoffMs);
-            System.out.println("retrying");
             Utils.sleep(retryBackoffMs);
         }
         throw new ConnectException("Failed to read offsets for topic partitions " + partitions + " after " + maxRetries + " attempts", lastError);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -703,7 +703,13 @@ public class TopicAdmin implements AutoCloseable {
         return result;
     }
 
-    protected Map<TopicPartition, Long> retryEndOffsets(Set<TopicPartition> partitions, Duration timeoutDuration, long retryBackoffMs) {
+    /**
+     * Fetch the most recent offset for each of the supplied {@link TopicPartition} objects, and performs retry when
+     * {@link org.apache.kafka.connect.errors.RetriableException} is thrown.
+     * 
+     * @see TopicAdmin#endOffsets(Set) 
+     */
+    public Map<TopicPartition, Long> retryEndOffsets(Set<TopicPartition> partitions, Duration timeoutDuration, long retryBackoffMs) {
 
         try {
             return RetryUtil.retryUntilTimeout(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -706,15 +706,12 @@ public class TopicAdmin implements AutoCloseable {
         return result;
     }
 
-    protected Map<TopicPartition, Long> retryEndOffsets(Set<TopicPartition> partitions) {
-        // maxRetries will be 0 or higher, enforced by the admin client when it is instantiated and configured
-        int maxRetries = Integer.parseInt(adminConfig.getOrDefault(AdminClientConfig.RETRIES_CONFIG, DEFAULT_ADMIN_CLIENT_RETRIES).toString());
-        long retryBackoffMs = Long.parseLong(adminConfig.getOrDefault(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, DEFAULT_ADMIN_CLIENT_BACKOFF_MS).toString());
+    protected Map<TopicPartition, Long> retryEndOffsets(Set<TopicPartition> partitions, Duration timeoutDuration, long retryBackoffMs) {
 
         try {
-            return RetryUtil.retry(
+            return RetryUtil.retryUntilTimeout(
                     () -> endOffsets(partitions),
-                    maxRetries,
+                    timeoutDuration,
                     retryBackoffMs);
         } catch (Exception e) {
             throw new ConnectException("Failed to read offsets for topic partitions.", e);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -647,7 +647,7 @@ public class TopicAdmin implements AutoCloseable {
     }
 
     /**
-     * Fetch the most recent offset for each of the supplied {@link TopicPartition} objects.
+     * Fetch the most recent offset for each of the supplied {@link TopicPartition} objects.:667
      *
      * @param partitions the topic partitions
      * @return the map of offset for each topic partition, or an empty map if the supplied partitions
@@ -664,20 +664,17 @@ public class TopicAdmin implements AutoCloseable {
         if (partitions == null || partitions.isEmpty()) {
             return Collections.emptyMap();
         }
-
         Map<TopicPartition, OffsetSpec> offsetSpecMap = partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
         ListOffsetsResult resultFuture = admin.listOffsets(offsetSpecMap);
         // Get the individual result for each topic partition so we have better error messages
         Map<TopicPartition, Long> result = new HashMap<>();
         for (TopicPartition partition : partitions) {
-
             try {
                 ListOffsetsResultInfo info = resultFuture.partitionResult(partition).get();
                 result.put(partition, info.offset());
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 String topic = partition.topic();
-
                 if (cause instanceof AuthorizationException) {
                     String msg = String.format("Not authorized to get the end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
                     throw new ConnectException(msg, e);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -716,7 +716,7 @@ public class TopicAdmin implements AutoCloseable {
                     maxRetries,
                     retryBackoffMs);
         } catch (Exception e) {
-            throw new ConnectException("Failed to read offsets for topic partitions " + partitions + " after " + maxRetries + " attempts", e);
+            throw new ConnectException("Failed to read offsets for topic partitions.", e);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -707,6 +707,7 @@ public class TopicAdmin implements AutoCloseable {
     }
 
     protected Map<TopicPartition, Long> retryEndOffsets(Set<TopicPartition> partitions) {
+        // maxRetries will be 0 or higher, enforced by the admin client when it is instantiated and configured
         int maxRetries = Integer.parseInt(adminConfig.getOrDefault(AdminClientConfig.RETRIES_CONFIG, DEFAULT_ADMIN_CLIENT_RETRIES).toString());
         long retryBackoffMs = Long.parseLong(adminConfig.getOrDefault(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, DEFAULT_ADMIN_CLIENT_BACKOFF_MS).toString());
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -706,8 +706,16 @@ public class TopicAdmin implements AutoCloseable {
     /**
      * Fetch the most recent offset for each of the supplied {@link TopicPartition} objects, and performs retry when
      * {@link org.apache.kafka.connect.errors.RetriableException} is thrown.
-     * 
-     * @see TopicAdmin#endOffsets(Set) 
+     *
+     * @param partitions        the topic partitions
+     * @param timeoutDuration   timeout duration; may not be null
+     * @param retryBackoffMs    the number of milliseconds to delay upon receiving a
+     *                          {@link org.apache.kafka.connect.errors.RetriableException} before retrying again;
+     *                          must be 0 or more
+     * @return                  the map of offset for each topic partition, or an empty map if the supplied partitions
+     *                          are null or empty
+     * @throws ConnectException if {@code timeoutDuration} is exhausted
+     * @see TopicAdmin#endOffsets(Set)
      */
     public Map<TopicPartition, Long> retryEndOffsets(Set<TopicPartition> partitions, Duration timeoutDuration, long retryBackoffMs) {
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -649,7 +649,7 @@ public class TopicAdmin implements AutoCloseable {
     }
 
     /**
-     * Fetch the most recent offset for each of the supplied {@link TopicPartition} objects.:667
+     * Fetch the most recent offset for each of the supplied {@link TopicPartition} objects.
      *
      * @param partitions the topic partitions
      * @return the map of offset for each topic partition, or an empty map if the supplied partitions
@@ -687,7 +687,6 @@ public class TopicAdmin implements AutoCloseable {
                     throw new UnsupportedVersionException(msg, e);
                 } else if (cause instanceof TimeoutException) {
                     String msg = String.format("Timed out while waiting to get end offsets for topic '%s' on brokers at %s", topic, bootstrapServers());
-
                     throw new TimeoutException(msg, e);
                 } else if (cause instanceof LeaderNotAvailableException) {
                     String msg = String.format("Unable to get end offsets during leader election for topic '%s' on brokers at %s", topic, bootstrapServers());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -124,9 +124,6 @@ public class TopicAdmin implements AutoCloseable {
     public static final int NO_PARTITIONS = -1;
     public static final short NO_REPLICATION_FACTOR = -1;
 
-    private static final String DEFAULT_ADMIN_CLIENT_RETRIES = "10";
-    private static final String DEFAULT_ADMIN_CLIENT_BACKOFF_MS = "100";
-
     private static final String CLEANUP_POLICY_CONFIG = TopicConfig.CLEANUP_POLICY_CONFIG;
     private static final String CLEANUP_POLICY_COMPACT = TopicConfig.CLEANUP_POLICY_COMPACT;
     private static final String MIN_INSYNC_REPLICAS_CONFIG = TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG;
@@ -711,6 +708,7 @@ public class TopicAdmin implements AutoCloseable {
         try {
             return RetryUtil.retryUntilTimeout(
                     () -> endOffsets(partitions),
+                    () -> "list offsets",
                     timeoutDuration,
                     retryBackoffMs);
         } catch (Exception e) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -708,11 +708,11 @@ public class TopicAdmin implements AutoCloseable {
         try {
             return RetryUtil.retryUntilTimeout(
                     () -> endOffsets(partitions),
-                    () -> "list offsets",
+                    () -> "list offsets for topic partitions",
                     timeoutDuration,
                     retryBackoffMs);
         } catch (Exception e) {
-            throw new ConnectException("Failed to read offsets for topic partitions.", e);
+            throw new ConnectException("Failed to list offsets for topic partitions.", e);
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -490,7 +490,7 @@ public class KafkaBasedLogTest {
         Map<TopicPartition, Long> endOffsets = new HashMap<>();
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
-        admin.retryEndOffsets(EasyMock.eq(tps));
+        admin.retryEndOffsets(EasyMock.eq(tps), EasyMock.anyObject(), EasyMock.anyLong());
         PowerMock.expectLastCall().andReturn(endOffsets).times(1);
         admin.endOffsets(EasyMock.eq(tps));
         PowerMock.expectLastCall().andReturn(endOffsets).times(1);
@@ -509,7 +509,7 @@ public class KafkaBasedLogTest {
 
         Set<TopicPartition> tps = new HashSet<>(Arrays.asList(TP0, TP1));
         // Getting end offsets using the admin client should fail with unsupported version
-        admin.retryEndOffsets(EasyMock.eq(tps));
+        admin.retryEndOffsets(EasyMock.eq(tps), EasyMock.anyObject(), EasyMock.anyLong());
         PowerMock.expectLastCall().andThrow(new UnsupportedVersionException("too old"));
 
         // Falls back to the consumer
@@ -535,7 +535,7 @@ public class KafkaBasedLogTest {
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
         // Getting end offsets upon startup should work fine
-        admin.retryEndOffsets(EasyMock.eq(tps));
+        admin.retryEndOffsets(EasyMock.eq(tps), EasyMock.anyObject(), EasyMock.anyLong());
         PowerMock.expectLastCall().andReturn(endOffsets).times(1);
         // Getting end offsets using the admin client should fail with leader not available
         admin.endOffsets(EasyMock.eq(tps));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -490,13 +490,15 @@ public class KafkaBasedLogTest {
         Map<TopicPartition, Long> endOffsets = new HashMap<>();
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
+        admin.retryEndOffsets(EasyMock.eq(tps));
+        PowerMock.expectLastCall().andReturn(endOffsets).times(1);
         admin.endOffsets(EasyMock.eq(tps));
-        PowerMock.expectLastCall().andReturn(endOffsets).times(2);
+        PowerMock.expectLastCall().andReturn(endOffsets).times(1);
 
         PowerMock.replayAll();
 
         store.start();
-        assertEquals(endOffsets, store.readEndOffsets(tps));
+        assertEquals(endOffsets, store.readEndOffsets(tps, false));
     }
 
     @Test
@@ -507,7 +509,7 @@ public class KafkaBasedLogTest {
 
         Set<TopicPartition> tps = new HashSet<>(Arrays.asList(TP0, TP1));
         // Getting end offsets using the admin client should fail with unsupported version
-        admin.endOffsets(EasyMock.eq(tps));
+        admin.retryEndOffsets(EasyMock.eq(tps));
         PowerMock.expectLastCall().andThrow(new UnsupportedVersionException("too old"));
 
         // Falls back to the consumer
@@ -519,7 +521,7 @@ public class KafkaBasedLogTest {
         PowerMock.replayAll();
 
         store.start();
-        assertEquals(endOffsets, store.readEndOffsets(tps));
+        assertEquals(endOffsets, store.readEndOffsets(tps, false));
     }
 
     @Test
@@ -533,7 +535,7 @@ public class KafkaBasedLogTest {
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
         // Getting end offsets upon startup should work fine
-        admin.endOffsets(EasyMock.eq(tps));
+        admin.retryEndOffsets(EasyMock.eq(tps));
         PowerMock.expectLastCall().andReturn(endOffsets).times(1);
         // Getting end offsets using the admin client should fail with leader not available
         admin.endOffsets(EasyMock.eq(tps));
@@ -542,7 +544,7 @@ public class KafkaBasedLogTest {
         PowerMock.replayAll();
 
         store.start();
-        assertThrows(LeaderNotAvailableException.class, () -> store.readEndOffsets(tps));
+        assertThrows(LeaderNotAvailableException.class, () -> store.readEndOffsets(tps, false));
     }
 
     @SuppressWarnings("unchecked")

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -149,15 +149,15 @@ public class RetryUtilTest {
 
         ConnectException e = assertThrows(ConnectException.class,
                 () -> RetryUtil.retryUntilTimeout(mockCallable, null, Duration.ofMillis(100), 10));
-        assertTrue(e.getMessage().startsWith("Fail to execute callable"));
+        assertTrue(e.getMessage().startsWith("Fail to callable"));
 
         e = assertThrows(ConnectException.class,
                 () -> RetryUtil.retryUntilTimeout(mockCallable, () -> null, Duration.ofMillis(100), 10));
-        assertTrue(e.getMessage().startsWith("Fail to execute callable"));
+        assertTrue(e.getMessage().startsWith("Fail to callable"));
 
         e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, () -> "bad service call", Duration.ofMillis(500), 10));
-        assertTrue(e.getMessage().startsWith("Fail to execute bad service call"));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, () -> "execute lambda", Duration.ofMillis(500), 10));
+        assertTrue(e.getMessage().startsWith("Fail to execute lambda"));
         Mockito.verify(mockCallable, Mockito.atLeast(3)).call();
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -65,7 +65,7 @@ public class RetryUtilTest {
         } catch (Exception e) {
             fail("Only expecting ConnectException");
         }
-        Mockito.verify(mockCallable, Mockito.times(1)).call();
+        Mockito.verify(mockCallable, Mockito.times(10)).call();
     }
 
     @Test
@@ -81,23 +81,6 @@ public class RetryUtilTest {
             fail("Not expecting an exception: ", e.getCause());
         }
         Mockito.verify(mockCallable, Mockito.times(4)).call();
-    }
-
-    @Test
-    public void RetriesEventuallyFail() throws Exception {
-        Mockito.when(mockCallable.call())
-                .thenThrow(new TimeoutException("timeout"));
-        try {
-            for (int i = 0; i < 10; i++) {
-                RetryUtil.retry(mockCallable, 10, 100);
-            }
-            fail("Not expecting an exception: ");
-        } catch (ConnectException e) {
-           // good
-        } catch (Exception e) {
-            fail("Expecting ConnectException");
-        }
-        Mockito.verify(mockCallable, Mockito.times(10)).call();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -51,7 +51,8 @@ public class RetryUtilTest {
         Mockito.verify(mockCallable, Mockito.times(1)).call();
     }
 
-    @Test(timeout = 150)
+    // timeout the test after 1000ms if unable to complete within a reasonable time frame
+    @Test(timeout = 1000)
     public void testExhaustingRetries() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException());
         ConnectException e = assertThrows(ConnectException.class,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -43,14 +43,14 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void TestSuccess() throws Exception {
+    public void testSuccess() throws Exception {
         Mockito.when(mockCallable.call()).thenReturn("success");
         assertEquals("success", RetryUtil.retry(mockCallable, 10, 100));
         Mockito.verify(mockCallable, Mockito.times(1)).call();
     }
 
     @Test
-    public void TestExhaustingRetries() throws Exception {
+    public void testExhaustingRetries() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException());
         ConnectException e = assertThrows(ConnectException.class,
                 () -> RetryUtil.retry(mockCallable, 10, 100));
@@ -59,7 +59,7 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void RetriesEventuallySucceed() throws Exception {
+    public void retriesEventuallySucceed() throws Exception {
         Mockito.when(mockCallable.call())
                 .thenThrow(new TimeoutException())
                 .thenThrow(new TimeoutException())
@@ -71,7 +71,7 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void FailWithNonRetriableException() throws Exception {
+    public void failWithNonRetriableException() throws Exception {
         Mockito.when(mockCallable.call())
                 .thenThrow(new TimeoutException("timeout"))
                 .thenThrow(new TimeoutException("timeout"))
@@ -86,7 +86,7 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void NoRetryAndSucceed() throws Exception {
+    public void noRetryAndSucceed() throws Exception {
         Mockito.when(mockCallable.call()).thenReturn("success");
 
         assertEquals("success", RetryUtil.retry(mockCallable, 0, 100));
@@ -94,17 +94,17 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void NoRetryAndFailed() throws Exception {
+    public void noRetryAndFailed() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
 
-        ConnectException e = assertThrows(ConnectException.class,
+        TimeoutException e = assertThrows(TimeoutException.class,
                 () -> RetryUtil.retry(mockCallable, 0, 100));
         Mockito.verify(mockCallable, Mockito.times(1)).call();
-        assertEquals("Fail to retry the task after 0 attempts.  Reason: org.apache.kafka.common.errors.TimeoutException: timeout exception", e.getMessage());
+        assertEquals("timeout exception", e.getMessage());
     }
 
     @Test
-    public void TestNoBackoffTimeAndSucceed() throws Exception {
+    public void testNoBackoffTimeAndSucceed() throws Exception {
         Mockito.when(mockCallable.call())
                 .thenThrow(new TimeoutException())
                 .thenThrow(new TimeoutException())
@@ -116,12 +116,12 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void TestNoBackoffTimeAndFail() throws Exception {
+    public void testNoBackoffTimeAndFail() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
 
         ConnectException e  = assertThrows(ConnectException.class,
                 () -> RetryUtil.retry(mockCallable, 10, 0));
         Mockito.verify(mockCallable, Mockito.times(11)).call();
-        assertEquals("Fail to retry the task after 10 attempts.  Reason: org.apache.kafka.common.errors.TimeoutException: timeout exception", e.getMessage());
+        assertEquals("Fail to retry the task after 11 attempts.  Reason: timeout exception", e.getMessage());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Before;
 import org.junit.Test;
@@ -170,5 +171,14 @@ public class RetryUtilTest {
                 () -> RetryUtil.retryUntilTimeout(mockCallable, () -> "execute lambda", Duration.ofMillis(500), 10));
         assertTrue(e.getMessage().startsWith("Fail to execute lambda"));
         Mockito.verify(mockCallable, Mockito.atLeast(3)).call();
+    }
+
+    @Test
+    public void testWakeupException() throws Exception {
+        Mockito.when(mockCallable.call()).thenThrow(new WakeupException());
+
+        ConnectException e = assertThrows(ConnectException.class,
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 10));
+        Mockito.verify(mockCallable, Mockito.atLeastOnce()).call();
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -137,10 +137,21 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void testNullDurationShouldFail() throws Exception {
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, null, 0));
-        assertEquals("timeoutDuration cannot be null", e.getMessage());
+    public void testInvalidTimeDuration() throws Exception {
+        Mockito.when(mockCallable.call()).thenReturn("success");
+
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, null, 10));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(-1), 10));
+        Mockito.verify(mockCallable, Mockito.times(2)).call();
+    }
+
+    @Test
+    public void testInvalidRetryTimeout() throws Exception {
+        Mockito.when(mockCallable.call())
+                .thenThrow(new TimeoutException("timeout"))
+                .thenReturn("success");
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), -1));
+        Mockito.verify(mockCallable, Mockito.times(2)).call();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.concurrent.Callable;
+
+@RunWith(PowerMockRunner.class)
+public class RetryUtilTest {
+
+    @Mock
+    private Callable<String> mockCallable;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+        mockCallable = Mockito.mock(Callable.class);
+    }
+
+    @Test
+    public void TestSuccess() throws Exception {
+        Mockito.when(mockCallable.call()).thenReturn("success");
+        //EasyMock.expect(mockCallable.call()).andReturn("success").times(1);
+        try {
+            assertEquals("success", RetryUtil.retry(mockCallable, 10, 100));
+        } catch (Exception e) {
+            fail("Not expecting an exception: ", e.getCause());
+        }
+        Mockito.verify(mockCallable, Mockito.times(1)).call();
+    }
+
+    @Test
+    public void TestFailingRetries() throws Exception {
+        Mockito.when(mockCallable.call()).thenThrow(new TimeoutException());
+        try {
+            RetryUtil.retry(mockCallable, 10, 100);
+            fail("Expect exception being thrown here");
+        } catch (ConnectException e) {
+            // expecting a connect exception
+        } catch (Exception e) {
+            fail("Only expecting ConnectException");
+        }
+        Mockito.verify(mockCallable, Mockito.times(1)).call();
+    }
+
+    @Test
+    public void RetriesEventuallySucceed() throws Exception {
+        Mockito.when(mockCallable.call())
+                .thenThrow(new TimeoutException())
+                .thenThrow(new TimeoutException())
+                .thenThrow(new TimeoutException())
+                .thenReturn("success");
+        try {
+            assertEquals("success", RetryUtil.retry(mockCallable, 10, 100));
+        } catch (Exception e) {
+            fail("Not expecting an exception: ", e.getCause());
+        }
+        Mockito.verify(mockCallable, Mockito.times(4)).call();
+    }
+
+    @Test
+    public void RetriesEventuallyFail() throws Exception {
+        Mockito.when(mockCallable.call())
+                .thenThrow(new TimeoutException("timeout"));
+        try {
+            for (int i = 0; i < 10; i++) {
+                RetryUtil.retry(mockCallable, 10, 100);
+            }
+            fail("Not expecting an exception: ");
+        } catch (ConnectException e) {
+           // good
+        } catch (Exception e) {
+            fail("Expecting ConnectException");
+        }
+        Mockito.verify(mockCallable, Mockito.times(10)).call();
+    }
+
+    @Test
+    public void FailWithNonRetriableException() throws Exception {
+        Mockito.when(mockCallable.call())
+                .thenThrow(new TimeoutException("timeout"))
+                .thenThrow(new TimeoutException("timeout"))
+                .thenThrow(new TimeoutException("timeout"))
+                .thenThrow(new TimeoutException("timeout"))
+                .thenThrow(new TimeoutException("timeout"))
+                .thenThrow(new NullPointerException("Non Retriable"));
+        try {
+            for (int i = 0; i < 10; i++) {
+                RetryUtil.retry(mockCallable, 10, 100);
+            }
+            fail("Not expecting an exception: ");
+        } catch (ConnectException e) {
+            fail("Should Fail with NPE");
+        } catch (NullPointerException e) {
+            // good
+        }
+        Mockito.verify(mockCallable, Mockito.times(6)).call();
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -33,7 +32,6 @@ import java.util.concurrent.Callable;
 @RunWith(PowerMockRunner.class)
 public class RetryUtilTest {
 
-    @Mock
     private Callable<String> mockCallable;
 
     @SuppressWarnings("unchecked")

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -55,7 +55,7 @@ public class RetryUtilTest {
     public void testExhaustingRetries() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException());
         ConnectException e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 1));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 10));
         Mockito.verify(mockCallable, Mockito.atLeastOnce()).call();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -128,12 +128,12 @@ public class RetryUtilTest {
     }
 
     @Test
-    public void testBackoffLessThanTimeout() throws Exception {
+    public void testBackoffMoreThanTimeoutWillOnlyExecuteOnce() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
 
         TimeoutException e = assertThrows(TimeoutException.class,
                 () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 100));
-        Mockito.verify(mockCallable, Mockito.atMostOnce()).call();
+        Mockito.verify(mockCallable, Mockito.times(1)).call();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -108,14 +108,14 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException("timeout"))
                 .thenThrow(new TimeoutException("timeout"))
                 .thenThrow(new TimeoutException("timeout"))
-                .thenThrow(new NullPointerException("Non Retriable"));
+                .thenThrow(new NullPointerException("Non retriable"));
         try {
             for (int i = 0; i < 10; i++) {
                 RetryUtil.retry(mockCallable, 10, 100);
             }
             fail("Not expecting an exception: ");
         } catch (ConnectException e) {
-            fail("Should Fail with NPE");
+            fail("Should fail with NPE");
         } catch (NullPointerException e) {
             // good
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -54,6 +54,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -484,7 +485,7 @@ public class TopicAdminTest {
             TopicAdmin admin = new TopicAdmin(adminConfig, env.adminClient());
 
             assertThrows(ConnectException.class, () -> {
-                admin.retryEndOffsets(tps);
+                admin.retryEndOffsets(tps, Duration.ofMillis(100), 1);
             });
         }
     }
@@ -508,7 +509,7 @@ public class TopicAdminTest {
             Map<String, Object> adminConfig = new HashMap<>();
             adminConfig.put(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, "0");
             TopicAdmin admin = new TopicAdmin(adminConfig, env.adminClient());
-            Map<TopicPartition, Long> endoffsets = admin.retryEndOffsets(tps);
+            Map<TopicPartition, Long> endoffsets = admin.retryEndOffsets(tps, Duration.ofMillis(100), 1);
             assertNotNull(endoffsets);
             assertTrue(endoffsets.containsKey(tp1));
             assertEquals(1000L, endoffsets.get(tp1).longValue());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -471,7 +471,7 @@ public class TopicAdminTest {
         String topicName = "myTopic";
         TopicPartition tp1 = new TopicPartition(topicName, 0);
         Set<TopicPartition> tps = Collections.singleton(tp1);
-        Long offset = 1000L; // response should use error
+        Long offset = 1000L;
         Cluster cluster = createCluster(1, "myTopic", 1);
 
         try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(500), cluster)) {
@@ -496,7 +496,7 @@ public class TopicAdminTest {
         String topicName = "myTopic";
         TopicPartition tp1 = new TopicPartition(topicName, 0);
         Set<TopicPartition> tps = Collections.singleton(tp1);
-        Long offset = 1000L; // response should use error
+        Long offset = 1000L;
         Cluster cluster = createCluster(1, "myTopic", 1);
 
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(500), cluster)) {
@@ -743,13 +743,6 @@ public class TopicAdminTest {
     private ListOffsetsResponse listOffsetsResultWithClusterAuthorizationException(TopicPartition tp1, Long offset1) {
         return listOffsetsResult(
                 new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED, "Not authorized to create topic(s)"),
-                Collections.singletonMap(tp1, offset1)
-        );
-    }
-
-    private ListOffsetsResponse listOffsetsResultWithUnknownTopicOrPartitionException(TopicPartition tp1, Long offset1) {
-        return listOffsetsResult(
-                new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "unknown topics"),
                 Collections.singletonMap(tp1, offset1)
         );
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -491,7 +491,7 @@ public class TopicAdminTest {
     }
 
     @Test
-    public void endOffsetsShouldRetryWhenTopicNotFound() {
+    public void retryEndOffsetsShouldRetryWhenTopicNotFound() {
         String topicName = "myTopic";
         TopicPartition tp1 = new TopicPartition(topicName, 0);
         Set<TopicPartition> tps = Collections.singleton(tp1);


### PR DESCRIPTION
**Summary**
Fixes the compatibility issue regarding KAFKA-12879 by reverting the changes to the admin client from KAFKA-12339 (#10152), and instead perform the retries within the KafkaBasedLog via a new `TopicAdmin.retryEndOffsets(..)`.  This method will delegate to the existing `TopicAdmin.endOffsets(...)` and will retry on RetriableException until the _retries_ (max retries) is hit, or until a specified timeout.  

This change should be backward compatible to the KAFKA-12339.

Notable changes are:
**Reverted KAFKA-12339**

**TopicAdmin**
Added new `retryEndOffsets(...)` method that utilizes the new `RetryUtil` to list end offsets for a set of topic partitions and perform retries upon any RetriableException (including UnknownTopicOrPartitionException, TimeoutException).

**KafkaBasdLog**
During startup calls `TopicAdmin.retryEndOffsets(...)` to read end offsets for the log topic and retries if the topic is not available (or any RetriableException).

**RetryUtil**
A general utility that takes a Callable function, the total duration to retry (may be 0), and backoff time in ms, and that calls the function at least once, and performs retries using the parameters when the function throws RetriableException (e.g. UnknownTopicOrPartitionException, TimeoutException)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
