### PR TITLE
KAFKA-12738: send LeaveGroup request when thread dies to optimize replacement time

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -546,7 +546,8 @@ public class StreamThread extends Thread {
             cleanRun = runLoop();
         } catch (final Throwable e) {
             failedStreamThreadSensor.record();
-            this.streamsUncaughtExceptionHandler.accept(e, false);
+            streamsUncaughtExceptionHandler.accept(e, false);
+            requestLeaveGroupDuringShutdown();
         } finally {
             completeShutdown(cleanRun);
         }
@@ -1249,7 +1250,7 @@ public class StreamThread extends Thread {
     }
 
     public void requestLeaveGroupDuringShutdown() {
-        this.leaveGroupRequested.set(true);
+        leaveGroupRequested.set(true);
     }
 
     public Map<MetricName, Metric> producerMetrics() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -546,8 +546,8 @@ public class StreamThread extends Thread {
             cleanRun = runLoop();
         } catch (final Throwable e) {
             failedStreamThreadSensor.record();
-            streamsUncaughtExceptionHandler.accept(e, false);
             requestLeaveGroupDuringShutdown();
+            streamsUncaughtExceptionHandler.accept(e, false);
         } finally {
             completeShutdown(cleanRun);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ErrorHandlingIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ErrorHandlingIntegrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ErrorHandlingIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ErrorHandlingIntegrationTest.java
@@ -96,8 +96,7 @@ public class ErrorHandlingIntegrationTest {
                 mkEntry(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0),
                 mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 15000L),
                 mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class),
-                mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                mkEntry(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000))
+                mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class))
         );
     }
 


### PR DESCRIPTION
Quick followup to #11787 to optimize the impact of the task backoff by reducing the time to replace a thread. I noticed it would take around the `session.timeout` for the new thread to come up and start processing after a thread-fatal error, and realized we weren't sending a LeaveGroup request when a thread hit an exception and died. 

Removing the `session.timeout.ms` override in the ErrorHandlingIntegrationTest.shouldBackOffTaskAndEmitDataWithinSameTopology test causes it to revert to the new default value of this config, which is 45s.

Since the current task backoff is a constant 15s, without this change the integration test would fail when using the 45s session timeout. With this fix, we can now remove the config override and verify that the backoff works with the default configuration

This also speeds up the test greatly, it now takes under .5s whereas previously it was taking 45s+