### PR TITLE
KAFKA-13692: include metadata wait time in total blocked time

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -894,6 +894,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             throwIfProducerClosed();
             // first make sure the metadata for the topic is available
             long nowMs = time.milliseconds();
+            long nowNanos = time.nanoseconds();
             ClusterAndWaitTime clusterAndWaitTime;
             try {
                 clusterAndWaitTime = waitOnMetadata(record.topic(), record.partition(), nowMs, maxBlockTimeMs);
@@ -903,7 +904,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 throw e;
             }
             nowMs += clusterAndWaitTime.waitedOnMetadataMs;
-            producerMetrics.recordMetadataWait(clusterAndWaitTime.waitedOnMetadataMs);
+            producerMetrics.recordMetadataWait(time.nanoseconds() - nowNanos);
             long remainingWaitMs = Math.max(0, maxBlockTimeMs - clusterAndWaitTime.waitedOnMetadataMs);
             Cluster cluster = clusterAndWaitTime.cluster;
             byte[] serializedKey;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -903,6 +903,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 throw e;
             }
             nowMs += clusterAndWaitTime.waitedOnMetadataMs;
+            producerMetrics.recordMetadataWait(clusterAndWaitTime.waitedOnMetadataMs);
             long remainingWaitMs = Math.max(0, maxBlockTimeMs - clusterAndWaitTime.waitedOnMetadataMs);
             Cluster cluster = clusterAndWaitTime.cluster;
             byte[] serializedKey;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
@@ -34,6 +34,8 @@ public class KafkaProducerMetrics implements AutoCloseable {
     private static final String TXN_COMMIT = "txn-commit";
     private static final String TXN_ABORT = "txn-abort";
     private static final String TOTAL_TIME_SUFFIX = "-time-ns-total";
+    private static final String TOTAL_TIME_MS_SUFFIX = "-time-ms-total";
+    private static final String METADATA_WAIT = "metadata-wait";
 
     private final Map<String, String> tags;
     private final Metrics metrics;
@@ -43,6 +45,7 @@ public class KafkaProducerMetrics implements AutoCloseable {
     private final Sensor sendOffsetsSensor;
     private final Sensor commitTxnSensor;
     private final Sensor abortTxnSensor;
+    private final Sensor metadataWaitSensor;
 
     public KafkaProducerMetrics(Metrics metrics) {
         this.metrics = metrics;
@@ -71,6 +74,10 @@ public class KafkaProducerMetrics implements AutoCloseable {
             TXN_ABORT,
             "Total time producer has spent in abortTransaction in nanoseconds."
         );
+        metadataWaitSensor = newLatencySensor(
+            METADATA_WAIT,
+            "Total time producer has spent waiting on metadata in "
+        );
     }
 
     @Override
@@ -81,6 +88,7 @@ public class KafkaProducerMetrics implements AutoCloseable {
         removeMetric(TXN_SEND_OFFSETS);
         removeMetric(TXN_COMMIT);
         removeMetric(TXN_ABORT);
+        removeMetric(METADATA_WAIT);
     }
 
     public void recordFlush(long duration) {
@@ -105,6 +113,10 @@ public class KafkaProducerMetrics implements AutoCloseable {
 
     public void recordAbortTxn(long duration) {
         abortTxnSensor.record(duration);
+    }
+
+    public void recordMetadataWait(long durationMs) {
+        metadataWaitSensor.record(durationMs);
     }
 
     private Sensor newLatencySensor(String name, String description) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
@@ -34,7 +34,6 @@ public class KafkaProducerMetrics implements AutoCloseable {
     private static final String TXN_COMMIT = "txn-commit";
     private static final String TXN_ABORT = "txn-abort";
     private static final String TOTAL_TIME_SUFFIX = "-time-ns-total";
-    private static final String TOTAL_TIME_MS_SUFFIX = "-time-ms-total";
     private static final String METADATA_WAIT = "metadata-wait";
 
     private final Map<String, String> tags;
@@ -76,7 +75,7 @@ public class KafkaProducerMetrics implements AutoCloseable {
         );
         metadataWaitSensor = newLatencySensor(
             METADATA_WAIT,
-            "Total time producer has spent waiting on metadata in "
+            "Total time producer has spent waiting on metadata on topic metadata."
         );
     }
 
@@ -115,8 +114,8 @@ public class KafkaProducerMetrics implements AutoCloseable {
         abortTxnSensor.record(duration);
     }
 
-    public void recordMetadataWait(long durationMs) {
-        metadataWaitSensor.record(durationMs);
+    public void recordMetadataWait(long duration) {
+        metadataWaitSensor.record(duration);
     }
 
     private Sensor newLatencySensor(String name, String description) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
@@ -75,7 +75,7 @@ public class KafkaProducerMetrics implements AutoCloseable {
         );
         metadataWaitSensor = newLatencySensor(
             METADATA_WAIT,
-            "Total time producer has spent waiting on topic metadata."
+            "Total time producer has spent waiting on topic metadata in nanoseconds."
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
@@ -75,7 +75,7 @@ public class KafkaProducerMetrics implements AutoCloseable {
         );
         metadataWaitSensor = newLatencySensor(
             METADATA_WAIT,
-            "Total time producer has spent waiting on metadata on topic metadata."
+            "Total time producer has spent waiting on topic metadata."
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetricsTest.java
@@ -32,6 +32,7 @@ class KafkaProducerMetricsTest {
     private static final String TXN_COMMIT_TIME_TOTAL = "txn-commit-time-ns-total";
     private static final String TXN_ABORT_TIME_TOTAL = "txn-abort-time-ns-total";
     private static final String TXN_SEND_OFFSETS_TIME_TOTAL = "txn-send-offsets-time-ns-total";
+    private static final String METADATA_WAIT_TIME_TOTAL = "metadata-wait-time-ms-total";
 
     private final Metrics metrics = new Metrics();
     private final KafkaProducerMetrics producerMetrics = new KafkaProducerMetrics(metrics);
@@ -91,6 +92,15 @@ class KafkaProducerMetricsTest {
     }
 
     @Test
+    public void shouldRecordMetadataWaitTime() {
+        // When:
+        producerMetrics.recordMetadataWait(METRIC_VALUE);
+
+        // Then:
+        assertMetricValue(METADATA_WAIT_TIME_TOTAL);
+    }
+
+    @Test
     public void shouldRemoveMetricsOnClose() {
         // When:
         producerMetrics.close();
@@ -102,6 +112,7 @@ class KafkaProducerMetricsTest {
         assertMetricRemoved(TXN_COMMIT_TIME_TOTAL);
         assertMetricRemoved(TXN_ABORT_TIME_TOTAL);
         assertMetricRemoved(TXN_SEND_OFFSETS_TIME_TOTAL);
+        assertMetricRemoved(METADATA_WAIT_TIME_TOTAL);
     }
 
     private void assertMetricRemoved(final String name) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetricsTest.java
@@ -32,7 +32,7 @@ class KafkaProducerMetricsTest {
     private static final String TXN_COMMIT_TIME_TOTAL = "txn-commit-time-ns-total";
     private static final String TXN_ABORT_TIME_TOTAL = "txn-abort-time-ns-total";
     private static final String TXN_SEND_OFFSETS_TIME_TOTAL = "txn-send-offsets-time-ns-total";
-    private static final String METADATA_WAIT_TIME_TOTAL = "metadata-wait-time-ms-total";
+    private static final String METADATA_WAIT_TIME_TOTAL = "metadata-wait-time-ns-total";
 
     private final Metrics metrics = new Metrics();
     private final KafkaProducerMetrics producerMetrics = new KafkaProducerMetrics(metrics);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.time.Duration;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
@@ -223,7 +224,9 @@ public class StreamsProducer {
             + getMetricValue(producer.metrics(), "txn-begin-time-ns-total")
             + getMetricValue(producer.metrics(), "txn-send-offsets-time-ns-total")
             + getMetricValue(producer.metrics(), "txn-commit-time-ns-total")
-            + getMetricValue(producer.metrics(), "txn-abort-time-ns-total");
+            + getMetricValue(producer.metrics(), "txn-abort-time-ns-total")
+            + Duration.ofMillis(
+                (long) getMetricValue(producer.metrics(), "metadata-wait-time-ms-total")).toNanos();
     }
 
     public double totalBlockedTime() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.time.Duration;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
@@ -225,8 +224,7 @@ public class StreamsProducer {
             + getMetricValue(producer.metrics(), "txn-send-offsets-time-ns-total")
             + getMetricValue(producer.metrics(), "txn-commit-time-ns-total")
             + getMetricValue(producer.metrics(), "txn-abort-time-ns-total")
-            + Duration.ofMillis(
-                (long) getMetricValue(producer.metrics(), "metadata-wait-time-ms-total")).toNanos();
+            + getMetricValue(producer.metrics(), "metadata-wait-time-ns-total");
     }
 
     public double totalBlockedTime() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -1258,6 +1258,6 @@ public class StreamsProducerTest {
         addMetric(producer, "txn-send-offsets-time-ns-total", txnSendOffsetsTime);
         addMetric(producer, "txn-commit-time-ns-total", txnCommitTime);
         addMetric(producer, "txn-abort-time-ns-total", txnAbortTime);
-        addMetric(producer, "metadata-wait-time-ms-total", metadataWaitTime);
+        addMetric(producer, "metadata-wait-time-ns-total", metadataWaitTime);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -69,15 +69,14 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class StreamsProducerTest {
-    private static final double BUFFER_POOL_WAIT_TIME = 1000000;
-    private static final double FLUSH_TME = 2000000;
-    private static final double TXN_INIT_TIME = 3000000;
-    private static final double TXN_BEGIN_TIME = 4000000;
-    private static final double TXN_SEND_OFFSETS_TIME = 5000000;
-    private static final double TXN_COMMIT_TIME = 6000000;
-    private static final double TXN_ABORT_TIME = 7000000;
-    private static final double METADATA_WAIT_TIME_MS = 8;
-    private static final double METADATA_WAIT_TIME = 8000000;
+    private static final double BUFFER_POOL_WAIT_TIME = 1;
+    private static final double FLUSH_TME = 2;
+    private static final double TXN_INIT_TIME = 3;
+    private static final double TXN_BEGIN_TIME = 4;
+    private static final double TXN_SEND_OFFSETS_TIME = 5;
+    private static final double TXN_COMMIT_TIME = 6;
+    private static final double TXN_ABORT_TIME = 7;
+    private static final double METADATA_WAIT_TIME = 8;
 
     private final LogContext logContext = new LogContext("test ");
     private final String topic = "topic";
@@ -1170,7 +1169,7 @@ public class StreamsProducerTest {
             TXN_SEND_OFFSETS_TIME,
             TXN_COMMIT_TIME,
             TXN_ABORT_TIME,
-            METADATA_WAIT_TIME_MS
+            METADATA_WAIT_TIME
         );
 
         final double expectedTotalBlocked = BUFFER_POOL_WAIT_TIME + FLUSH_TME + TXN_INIT_TIME +
@@ -1190,7 +1189,7 @@ public class StreamsProducerTest {
             TXN_SEND_OFFSETS_TIME,
             TXN_COMMIT_TIME,
             TXN_ABORT_TIME,
-            METADATA_WAIT_TIME_MS
+            METADATA_WAIT_TIME
         );
         final double expectedTotalBlocked = BUFFER_POOL_WAIT_TIME + FLUSH_TME + TXN_INIT_TIME +
             TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME +
@@ -1211,7 +1210,7 @@ public class StreamsProducerTest {
             TXN_SEND_OFFSETS_TIME,
             TXN_COMMIT_TIME,
             TXN_ABORT_TIME,
-            METADATA_WAIT_TIME_MS
+            METADATA_WAIT_TIME
         );
 
         assertThat(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -69,13 +69,15 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class StreamsProducerTest {
-    private static final double BUFFER_POOL_WAIT_TIME = 1;
-    private static final double FLUSH_TME = 2;
-    private static final double TXN_INIT_TIME = 3;
-    private static final double TXN_BEGIN_TIME = 4;
-    private static final double TXN_SEND_OFFSETS_TIME = 5;
-    private static final double TXN_COMMIT_TIME = 6;
-    private static final double TXN_ABORT_TIME = 7;
+    private static final double BUFFER_POOL_WAIT_TIME = 1000000;
+    private static final double FLUSH_TME = 2000000;
+    private static final double TXN_INIT_TIME = 3000000;
+    private static final double TXN_BEGIN_TIME = 4000000;
+    private static final double TXN_SEND_OFFSETS_TIME = 5000000;
+    private static final double TXN_COMMIT_TIME = 6000000;
+    private static final double TXN_ABORT_TIME = 7000000;
+    private static final double METADATA_WAIT_TIME_MS = 8;
+    private static final double METADATA_WAIT_TIME = 8000000;
 
     private final LogContext logContext = new LogContext("test ");
     private final String topic = "topic";
@@ -1167,11 +1169,13 @@ public class StreamsProducerTest {
             TXN_BEGIN_TIME,
             TXN_SEND_OFFSETS_TIME,
             TXN_COMMIT_TIME,
-            TXN_ABORT_TIME
+            TXN_ABORT_TIME,
+            METADATA_WAIT_TIME_MS
         );
 
         final double expectedTotalBlocked = BUFFER_POOL_WAIT_TIME + FLUSH_TME + TXN_INIT_TIME +
-            TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME;
+            TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME +
+            METADATA_WAIT_TIME;
         assertThat(nonEosStreamsProducer.totalBlockedTime(), closeTo(expectedTotalBlocked, 0.01));
     }
 
@@ -1185,10 +1189,12 @@ public class StreamsProducerTest {
             TXN_BEGIN_TIME,
             TXN_SEND_OFFSETS_TIME,
             TXN_COMMIT_TIME,
-            TXN_ABORT_TIME
+            TXN_ABORT_TIME,
+            METADATA_WAIT_TIME_MS
         );
         final double expectedTotalBlocked = BUFFER_POOL_WAIT_TIME + FLUSH_TME + TXN_INIT_TIME +
-            TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME;
+            TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME +
+            METADATA_WAIT_TIME;
         assertThat(eosBetaStreamsProducer.totalBlockedTime(), equalTo(expectedTotalBlocked));
         reset(mockTime);
         final long closeStart = 1L;
@@ -1204,7 +1210,8 @@ public class StreamsProducerTest {
             TXN_BEGIN_TIME,
             TXN_SEND_OFFSETS_TIME,
             TXN_COMMIT_TIME,
-            TXN_ABORT_TIME
+            TXN_ABORT_TIME,
+            METADATA_WAIT_TIME_MS
         );
 
         assertThat(
@@ -1243,7 +1250,8 @@ public class StreamsProducerTest {
         final double txnBeginTime,
         final double txnSendOffsetsTime,
         final double txnCommitTime,
-        final double txnAbortTime) {
+        final double txnAbortTime,
+        final double metadataWaitTime) {
         addMetric(producer, "bufferpool-wait-time-ns-total", bufferPoolWaitTime);
         addMetric(producer, "flush-time-ns-total", flushTime);
         addMetric(producer, "txn-init-time-ns-total", txnInitTime);
@@ -1251,5 +1259,6 @@ public class StreamsProducerTest {
         addMetric(producer, "txn-send-offsets-time-ns-total", txnSendOffsetsTime);
         addMetric(producer, "txn-commit-time-ns-total", txnCommitTime);
         addMetric(producer, "txn-abort-time-ns-total", txnAbortTime);
+        addMetric(producer, "metadata-wait-time-ms-total", metadataWaitTime);
     }
 }


### PR DESCRIPTION
This patch includes metadata wait time in total blocked time. First, this patch
adds a new metric for total producer time spent waiting on metadata, called
metadata-wait-time-ms-total. Then, this time is included in the total blocked
time computed from StreamsProducer