### PR TITLE
KAFKA-13697; KRaft authorizer should support AclOperation.ALL

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -343,13 +343,13 @@ public class StandardAuthorizerData {
      * The set of operations which imply DESCRIBE permission, when used in an ALLOW acl.
      */
     private static final Set<AclOperation> IMPLIES_DESCRIBE = Collections.unmodifiableSet(
-        EnumSet.of(DESCRIBE, READ, WRITE, DELETE, ALTER, ALL));
+        EnumSet.of(DESCRIBE, READ, WRITE, DELETE, ALTER));
 
     /**
      * The set of operations which imply DESCRIBE_CONFIGS permission, when used in an ALLOW acl.
      */
     private static final Set<AclOperation> IMPLIES_DESCRIBE_CONFIGS = Collections.unmodifiableSet(
-        EnumSet.of(DESCRIBE_CONFIGS, ALTER_CONFIGS, ALL));
+        EnumSet.of(DESCRIBE_CONFIGS, ALTER_CONFIGS));
 
     /**
      * Determine what the result of applying an ACL to the given action and request
@@ -383,23 +383,26 @@ public class StandardAuthorizerData {
         //
         // But this rule only applies to ALLOW ACLs. So for example, a DENY ACL for READ
         // on a resource does not DENY describe for that resource.
-        if (acl.permissionType().equals(ALLOW)) {
-            switch (action.operation()) {
-                case DESCRIBE:
-                    if (!IMPLIES_DESCRIBE.contains(acl.operation())) return null;
-                    break;
-                case DESCRIBE_CONFIGS:
-                    if (!IMPLIES_DESCRIBE_CONFIGS.contains(acl.operation())) return null;
-                    break;
-                default:
-                    if (acl.operation() != ALL && action.operation() != acl.operation()) {
-                        return null;
-                    }
-                    break;
+        if (acl.operation() != ALL) {
+            if (acl.permissionType().equals(ALLOW)) {
+                switch (action.operation()) {
+                    case DESCRIBE:
+                        if (!IMPLIES_DESCRIBE.contains(acl.operation())) return null;
+                        break;
+                    case DESCRIBE_CONFIGS:
+                        if (!IMPLIES_DESCRIBE_CONFIGS.contains(acl.operation())) return null;
+                        break;
+                    default:
+                        if (action.operation() != acl.operation()) {
+                            return null;
+                        }
+                        break;
+                }
+            } else if (action.operation() != acl.operation()) {
+                return null;
             }
-        } else if (acl.operation() != ALL && action.operation() != acl.operation()) {
-            return null;
         }
+
         return acl.permissionType().equals(ALLOW) ? ALLOWED : DENIED;
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -285,7 +285,7 @@ public class StandardAuthorizerTest {
                 newAction(DESCRIBE_CONFIGS, TOPIC, "bar"),
                 newAction(DESCRIBE, TOPIC, "baz"))));
 
-        assertEquals(Arrays.asList(ALLOWED, DENIED, DENIED), authorizer.authorize(
+        assertEquals(Arrays.asList(ALLOWED, DENIED, ALLOWED), authorizer.authorize(
             newRequestContext("bob"),
             Arrays.asList(
                 newAction(WRITE, TOPIC, "foo"),

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -41,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.acl.AclOperation.ALL;
 import static org.apache.kafka.common.acl.AclOperation.ALTER_CONFIGS;
 import static org.apache.kafka.common.acl.AclOperation.CREATE;
 import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
@@ -250,14 +253,57 @@ public class StandardAuthorizerTest {
             withId(newBarAcl(ALTER_CONFIGS, ALLOW)));
         fooAcls.forEach(a -> authorizer.addAcl(a.id(), a.acl()));
         barAcls.forEach(a -> authorizer.addAcl(a.id(), a.acl()));
-        assertEquals(Collections.singletonList(ALLOWED),
+        assertEquals(singletonList(ALLOWED),
             authorizer.authorize(new MockAuthorizableRequestContext.Builder().
                 setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
-                    Collections.singletonList(newAction(READ, TOPIC, "foo_"))));
-        assertEquals(Collections.singletonList(ALLOWED),
+                    singletonList(newAction(READ, TOPIC, "foo_"))));
+        assertEquals(singletonList(ALLOWED),
             authorizer.authorize(new MockAuthorizableRequestContext.Builder().
                     setPrincipal(new KafkaPrincipal(USER_TYPE, "fred")).build(),
-                Collections.singletonList(newAction(ALTER_CONFIGS, GROUP, "bar"))));
+                singletonList(newAction(ALTER_CONFIGS, GROUP, "bar"))));
+    }
+
+    @Test
+    public void testTopicAclWithOperationAll() throws Exception {
+        StandardAuthorizer authorizer = new StandardAuthorizer();
+        authorizer.configure(Collections.emptyMap());
+        List<StandardAcl> acls = Arrays.asList(
+            new StandardAcl(TOPIC, "foo", LITERAL, "User:*", "*", ALL, ALLOW),
+            new StandardAcl(TOPIC, "bar", PREFIXED, "User:alice", "*", ALL, ALLOW),
+            new StandardAcl(TOPIC, "baz", LITERAL, "User:bob", "*", ALL, ALLOW)
+        );
+
+        acls.forEach(acl -> {
+            StandardAclWithId aclWithId = withId(acl);
+            authorizer.addAcl(aclWithId.id(), aclWithId.acl());
+        });
+
+        assertEquals(Arrays.asList(ALLOWED, ALLOWED, DENIED), authorizer.authorize(
+            newRequestContext("alice"),
+            Arrays.asList(
+                newAction(WRITE, TOPIC, "foo"),
+                newAction(DESCRIBE_CONFIGS, TOPIC, "bar"),
+                newAction(DESCRIBE, TOPIC, "baz"))));
+
+        assertEquals(Arrays.asList(ALLOWED, DENIED, DENIED), authorizer.authorize(
+            newRequestContext("bob"),
+            Arrays.asList(
+                newAction(WRITE, TOPIC, "foo"),
+                newAction(READ, TOPIC, "bar"),
+                newAction(DESCRIBE, TOPIC, "baz"))));
+
+        assertEquals(Arrays.asList(ALLOWED, DENIED, DENIED), authorizer.authorize(
+            newRequestContext("malory"),
+            Arrays.asList(
+                newAction(DESCRIBE, TOPIC, "foo"),
+                newAction(WRITE, TOPIC, "bar"),
+                newAction(READ, TOPIC, "baz"))));
+    }
+
+    private AuthorizableRequestContext newRequestContext(String principal) throws Exception {
+        return new MockAuthorizableRequestContext.Builder()
+            .setPrincipal(new KafkaPrincipal(USER_TYPE, principal))
+            .build();
     }
 
     private static StandardAuthorizer createAuthorizerWithManyAcls() {


### PR DESCRIPTION
AclOperation.ALL implies all other operation types, but we are not checking for it in StandardAuthorizer. The patch fixes the issue and adds some test cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
