### PR TITLE
KAFKA-13698; KRaft authorizer should use host address instead of name

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -372,7 +372,7 @@ public class StandardAuthorizerData {
         // The hostname should be cached in the InetAddress object, so calling this more
         // than once shouldn't be too expensive.
         if (!acl.host().equals(WILDCARD)) {
-            String host = requestContext.clientAddress().getHostName();
+            String host = requestContext.clientAddress().getHostAddress();
             if (!acl.host().equals(host)) return null;
         }
         // Check if the operation field matches. Here we hit a slight complication.

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -29,9 +29,11 @@ import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -258,6 +260,57 @@ public class StandardAuthorizerTest {
             authorizer.authorize(new MockAuthorizableRequestContext.Builder().
                     setPrincipal(new KafkaPrincipal(USER_TYPE, "fred")).build(),
                 Collections.singletonList(newAction(ALTER_CONFIGS, GROUP, "bar"))));
+    }
+
+    @Test
+    public void testHostAddressAclValidation() throws Exception {
+        InetAddress host1 = InetAddress.getByName("192.168.1.1");
+        InetAddress host2 = InetAddress.getByName("192.168.1.2");
+
+        StandardAuthorizer authorizer = new StandardAuthorizer();
+        authorizer.configure(Collections.emptyMap());
+        List<StandardAcl> acls = Arrays.asList(
+            new StandardAcl(TOPIC, "foo", LITERAL, "User:alice", host1.getHostAddress(), READ, DENY),
+            new StandardAcl(TOPIC, "foo", LITERAL, "User:alice", "*", READ, ALLOW),
+            new StandardAcl(TOPIC, "bar", LITERAL, "User:bob", host2.getHostAddress(), READ, ALLOW),
+            new StandardAcl(TOPIC, "bar", LITERAL, "User:*", InetAddress.getLocalHost().getHostAddress(), DESCRIBE, ALLOW)
+        );
+
+        acls.forEach(acl -> {
+            StandardAclWithId aclWithId = withId(acl);
+            authorizer.addAcl(aclWithId.id(), aclWithId.acl());
+        });
+
+        List<Action> actions = Arrays.asList(
+            newAction(READ, TOPIC, "foo"),
+            newAction(READ, TOPIC, "bar"),
+            newAction(DESCRIBE, TOPIC, "bar")
+        );
+
+        assertEquals(Arrays.asList(ALLOWED, DENIED, ALLOWED), authorizer.authorize(
+            newRequestContext("alice", InetAddress.getLocalHost()), actions));
+
+        assertEquals(Arrays.asList(DENIED, DENIED, DENIED), authorizer.authorize(
+            newRequestContext("alice", host1), actions));
+
+        assertEquals(Arrays.asList(ALLOWED, DENIED, DENIED), authorizer.authorize(
+            newRequestContext("alice", host2), actions));
+
+        assertEquals(Arrays.asList(DENIED, DENIED, ALLOWED), authorizer.authorize(
+            newRequestContext("bob", InetAddress.getLocalHost()), actions));
+
+        assertEquals(Arrays.asList(DENIED, DENIED, DENIED), authorizer.authorize(
+            newRequestContext("bob", host1), actions));
+
+        assertEquals(Arrays.asList(DENIED, ALLOWED, ALLOWED), authorizer.authorize(
+            newRequestContext("bob", host2), actions));
+    }
+
+    private AuthorizableRequestContext newRequestContext(String principal, InetAddress clientAddress) throws Exception {
+        return new MockAuthorizableRequestContext.Builder()
+            .setPrincipal(new KafkaPrincipal(USER_TYPE, principal))
+            .setClientAddress(clientAddress)
+            .build();
     }
 
     private static StandardAuthorizer createAuthorizerWithManyAcls() {


### PR DESCRIPTION
Use `InetAddress.getHostAddress` in `StandardAuthorizer` instead of `InetAddress.getHostName`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
