### PR TITLE
KAFKA-13281: can remove topologies while in a created state

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -199,7 +199,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
 
         final KafkaFutureImpl<Void> removeTopologyFuture = new KafkaFutureImpl<>();
 
-        if (!isRunningOrRebalancing()) {
+        if (hasStartedOrFinishedShuttingDown()) {
             log.error("Attempted to remove topology {} from while the Kafka Streams was in state {}, "
                           + "application must be started first.", topologyToRemove, state
             );

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -340,7 +340,7 @@ public class NamedTopologyIntegrationTest {
     }
 
     @Test
-    public void shouldAddNamedTopologiesBeforeStartingAndRouteQueriesToCorrectTopology() throws Exception {
+    public void shouldAddAndRemoveNamedTopologiesBeforeStartingAndRouteQueriesToCorrectTopology() throws Exception {
         try {
             // for this test we have one of the topologies read from an input topic with just one partition so
             // that there's only one instance of that topology's store and thus should always have exactly one
@@ -354,6 +354,9 @@ public class NamedTopologyIntegrationTest {
 
             topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(Materialized.as(topology1Store)).toStream().to(OUTPUT_STREAM_1);
             topology2Builder.stream(SINGLE_PARTITION_INPUT_STREAM).groupByKey().count(Materialized.as(topology2Store)).toStream().to(SINGLE_PARTITION_OUTPUT_STREAM);
+            streams.addNamedTopology(topology1Builder.build());
+            streams.removeNamedTopology(TOPOLOGY_1);
+            assertThat(streams.getTopologyByName(TOPOLOGY_1), is(Optional.empty()));
             streams.addNamedTopology(topology1Builder.build());
             streams.addNamedTopology(topology2Builder.build());
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(singletonList(streams), Duration.ofSeconds(15));


### PR DESCRIPTION
We should be able to change the topologies in a created state. This should include removing them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
