### PR TITLE
KAFKA-12648: fix #add/removeNamedTopology blocking behavior when app is in CREATED

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -258,7 +258,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
     }
 
     private RemoveNamedTopologyResult resetOffsets(final KafkaFutureImpl<Void> removeTopologyFuture,
-                                                   Set<TopicPartition> partitionsToReset) {
+                                                   final Set<TopicPartition> partitionsToReset) {
         if (!partitionsToReset.isEmpty()) {
             removeTopologyFuture.whenComplete((v, throwable) -> {
                 if (throwable != null) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
@@ -125,6 +125,17 @@ public class NamedTopologyTest {
     }
 
     @Test
+    public void shouldAllowAddingAndRemovingNamedTopologyAndReturnBeforeCallingStart() throws Exception {
+        builder1.stream("stream-1").selectKey((k, v) -> v).groupByKey().count(Materialized.as(Stores.inMemoryKeyValueStore("store")));
+        builder2.stream("stream-2").selectKey((k, v) -> v).groupByKey().count(Materialized.as(Stores.inMemoryKeyValueStore("store")));
+
+        streams.addNamedTopology(builder1.build()).all().get();
+        streams.addNamedTopology(builder2.build()).all().get();
+
+        streams.removeNamedTopology("topology-2").all().get();
+    }
+
+    @Test
     public void shouldThrowTopologyExceptionWhenMultipleNamedTopologiesCreateStreamFromSameInputTopic() {
         builder1.stream("stream");
         builder2.stream("stream");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
@@ -149,12 +149,27 @@ public class NamedTopologyTest {
     }
 
     @Test
-    public void shouldThrowTopologyExceptionWhenAddingNamedTopologyReadingFromSameInputTopic() {
+    public void shouldThrowTopologyExceptionWhenAddingNamedTopologyReadingFromSameInputTopicAfterStart() {
         builder1.stream("stream");
         builder2.stream("stream");
 
         streams.start();
 
+        streams.addNamedTopology(builder1.build());
+
+        final ExecutionException exception = assertThrows(
+            ExecutionException.class,
+            () -> streams.addNamedTopology(builder2.build()).all().get()
+        );
+
+        assertThat(exception.getCause().getClass(), equalTo(TopologyException.class));
+    }
+
+    @Test
+    public void shouldThrowTopologyExceptionWhenAddingNamedTopologyReadingFromSameInputTopicBeforeStart() {
+        builder1.stream("stream");
+        builder2.stream("stream");
+        
         streams.addNamedTopology(builder1.build());
 
         final ExecutionException exception = assertThrows(


### PR DESCRIPTION
Currently the #add/removeNamedTopology APIs behave a little wonky when the application is still in CREATED. Since adding and removing topologies runs some validation steps there is valid reason to want to add or remove a topology on a dummy app that you don't plan to start, or a real app that you haven't started yet. But to actually check the results of the validation you need to call `get()` on the future, so we need to make sure that `get()` won't block forever in the case of no failure -- as is currently the case