### PR TITLE
MINOR: Eliminate FileRecords mutable flag

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -125,7 +125,7 @@ object DumpLogSegments {
                                maxMessageSize: Int): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     val logFile = new File(file.getAbsoluteFile.getParent, file.getName.split("\\.")(0) + UnifiedLog.LogFileSuffix)
-    val fileRecords = FileRecords.open(logFile, false)
+    val fileRecords = FileRecords.open(logFile)
     val index = new OffsetIndex(file, baseOffset = startOffset, writable = false)
 
     if (index.entries == 0) {
@@ -166,7 +166,7 @@ object DumpLogSegments {
                                    timeIndexDumpErrors: TimeIndexDumpErrors): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     val logFile = new File(file.getAbsoluteFile.getParent, file.getName.split("\\.")(0) + UnifiedLog.LogFileSuffix)
-    val fileRecords = FileRecords.open(logFile, false)
+    val fileRecords = FileRecords.open(logFile)
     val indexFile = new File(file.getAbsoluteFile.getParent, file.getName.split("\\.")(0) + UnifiedLog.IndexFileSuffix)
     val index = new OffsetIndex(indexFile, baseOffset = startOffset, writable = false)
     val timeIndex = new TimeIndex(file, baseOffset = startOffset, writable = false)
@@ -249,7 +249,7 @@ object DumpLogSegments {
                       skipRecordMetadata: Boolean): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     println("Starting offset: " + startOffset)
-    val fileRecords = FileRecords.open(file, false)
+    val fileRecords = FileRecords.open(file)
     try {
       var validBytes = 0L
       var lastOffset = -1L

--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotReader.java
@@ -78,7 +78,6 @@ public final class FileRawSnapshotReader implements RawSnapshotReader, AutoClose
         try {
             fileRecords = FileRecords.open(
                 filePath.toFile(),
-                false, // mutable
                 true, // fileAlreadyExists
                 0, // initFileSize
                 false // preallocate

--- a/shell/src/main/java/org/apache/kafka/shell/SnapshotFileReader.java
+++ b/shell/src/main/java/org/apache/kafka/shell/SnapshotFileReader.java
@@ -72,7 +72,7 @@ public final class SnapshotFileReader implements AutoCloseable {
         queue.append(new EventQueue.Event() {
             @Override
             public void run() throws Exception {
-                fileRecords = FileRecords.open(new File(snapshotPath), false);
+                fileRecords = FileRecords.open(new File(snapshotPath));
                 batchIterator = fileRecords.batches().iterator();
                 scheduleHandleNextBatch();
                 future.complete(null);


### PR DESCRIPTION
The `mutable` flag in `FileRecords` doesn't appear to be necessary. I've removed it in this PR to help simplify the code a bit.

**Tests:**
I'm relying on existing tests.