### PR TITLE
MINOR: Adding kafka-storage.bat file (similar to kafka-storage.sh) fo…

### DIFF
--- a/bin/windows/kafka-storage.bat
+++ b/bin/windows/kafka-storage.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+"%~dp0kafka-run-class.bat" kafka.tools.StorageTool %*


### PR DESCRIPTION
…r windows.

`kafka-storage.sh` was added as part of pull request [#10043](https://github.com/apache/kafka/pull/10043). But in windows, the `.bat` file was not included and hence caused issue while starting server using kraft

Cc @junrao 