### PR TITLE
KAFKA-12558: Do not prematurely mutate partiton state and provide con…

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -352,8 +352,8 @@ public class MirrorSourceTaskTest {
         mirrorSourceTask.commitRecord(sourceRecord, recordMetadata);
         assertEquals(recordOffset, partitionState.lastSyncUpstreamOffset, "no sync");
         assertEquals(metadataOffset, partitionState.lastSyncDownstreamOffset, "no sync");
-        assertEquals(newRecordOffset, partitionState.previousUpstreamOffset, "update previuos upstream offset");
-        assertEquals(newMetadataOffset, partitionState.previousDownstreamOffset, "update previuos upstream offset");
+        assertEquals(newRecordOffset, partitionState.previousUpstreamOffset, "update previous upstream offset");
+        assertEquals(newMetadataOffset, partitionState.previousDownstreamOffset, "update previous upstream offset");
 
         when(outstandingOffsetSyncs.tryAcquire()).thenReturn(true);
         mirrorSourceTask.commitRecord(sourceRecord, recordMetadata);
@@ -375,5 +375,4 @@ public class MirrorSourceTaskTest {
                     "taskHeader's value expected to equal " + taskHeader.value().toString());
         }
     }
-
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -35,8 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,16 +79,65 @@ public class MirrorSourceTaskTest {
     public void testOffsetSync() {
         MirrorSourceTask.PartitionState partitionState = new MirrorSourceTask.PartitionState(50);
 
-        assertTrue(partitionState.update(0, 100), "always emit offset sync on first update");
-        assertTrue(partitionState.update(2, 102), "upstream offset skipped -> resync");
-        assertFalse(partitionState.update(3, 152), "no sync");
-        assertFalse(partitionState.update(4, 153), "no sync");
-        assertFalse(partitionState.update(5, 154), "no sync");
-        assertTrue(partitionState.update(6, 205), "one past target offset");
-        assertTrue(partitionState.update(2, 206), "upstream reset");
-        assertFalse(partitionState.update(3, 207), "no sync");
-        assertTrue(partitionState.update(4, 3), "downstream reset");
-        assertFalse(partitionState.update(5, 4), "no sync");
+        long upstreamOffset = 0;
+        long downstreamOffset = 100;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "always emit offset sync on first update");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "always emit offset sync on first update");
+
+        upstreamOffset = 2;
+        downstreamOffset = 102;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "upstream offset skipped -> resync");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "upstream offset skipped -> resync");
+
+        upstreamOffset = 3;
+        downstreamOffset = 152;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertNotEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "no sync");
+        assertNotEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "no sync");
+
+        upstreamOffset = 4;
+        downstreamOffset = 153;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertNotEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "no sync");
+        assertNotEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "no sync");
+
+        upstreamOffset = 5;
+        downstreamOffset = 154;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertNotEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "no sync");
+        assertNotEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "no sync");
+
+        upstreamOffset = 6;
+        downstreamOffset = 205;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "one past target offset");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "one past target offset");
+
+        upstreamOffset = 2;
+        downstreamOffset = 206;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "upstream reset");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "upstream reset");
+
+        upstreamOffset = 3;
+        downstreamOffset = 207;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertNotEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "no sync");
+        assertNotEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "no sync");
+
+        upstreamOffset = 4;
+        downstreamOffset = 3;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "downstream reset");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "downstream reset");
+
+        upstreamOffset = 5;
+        downstreamOffset = 4;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertNotEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "no sync");
+        assertNotEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "no sync");
     }
 
     @Test
@@ -97,16 +145,65 @@ public class MirrorSourceTaskTest {
         MirrorSourceTask.PartitionState partitionState = new MirrorSourceTask.PartitionState(0);
 
         // if max offset lag is zero, should always emit offset syncs
-        assertTrue(partitionState.update(0, 100), "zeroOffsetSync downStreamOffset 100 is incorrect");
-        assertTrue(partitionState.update(2, 102), "zeroOffsetSync downStreamOffset 102 is incorrect");
-        assertTrue(partitionState.update(3, 153), "zeroOffsetSync downStreamOffset 153 is incorrect");
-        assertTrue(partitionState.update(4, 154), "zeroOffsetSync downStreamOffset 154 is incorrect");
-        assertTrue(partitionState.update(5, 155), "zeroOffsetSync downStreamOffset 155 is incorrect");
-        assertTrue(partitionState.update(6, 207), "zeroOffsetSync downStreamOffset 207 is incorrect");
-        assertTrue(partitionState.update(2, 208), "zeroOffsetSync downStreamOffset 208 is incorrect");
-        assertTrue(partitionState.update(3, 209), "zeroOffsetSync downStreamOffset 209 is incorrect");
-        assertTrue(partitionState.update(4, 3), "zeroOffsetSync downStreamOffset 3 is incorrect");
-        assertTrue(partitionState.update(5, 4), "zeroOffsetSync downStreamOffset 4 is incorrect");
+        long upstreamOffset = 0;
+        long downstreamOffset = 100;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 100 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 100 is incorrect");
+
+        upstreamOffset = 2;
+        downstreamOffset = 102;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 102 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 102 is incorrect");
+
+        upstreamOffset = 3;
+        downstreamOffset = 153;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 153 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 153 is incorrect");
+
+        upstreamOffset = 4;
+        downstreamOffset = 154;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 154 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 154 is incorrect");
+
+        upstreamOffset = 5;
+        downstreamOffset = 155;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 155 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 155 is incorrect");
+
+        upstreamOffset = 6;
+        downstreamOffset = 207;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 207 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 207 is incorrect");
+
+        upstreamOffset = 2;
+        downstreamOffset = 208;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 208 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 208 is incorrect");
+
+        upstreamOffset = 3;
+        downstreamOffset = 209;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 209 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 209 is incorrect");
+
+        upstreamOffset = 4;
+        downstreamOffset = 3;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 3 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 3 is incorrect");
+
+        upstreamOffset = 5;
+        downstreamOffset = 4;
+        partitionState.update(upstreamOffset, downstreamOffset);
+        assertEquals(upstreamOffset, partitionState.lastSyncUpstreamOffset, "zeroOffsetSync downStreamOffset 4 is incorrect");
+        assertEquals(downstreamOffset, partitionState.lastSyncDownstreamOffset, "zeroOffsetSync downStreamOffset 4 is incorrect");
     }
 
     @Test

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -305,8 +305,10 @@ public class MirrorConnectorsIntegrationBaseTest {
         Map<TopicPartition, OffsetAndMetadata> backupOffsets = backupClient.remoteConsumerOffsets(consumerGroupName, PRIMARY_CLUSTER_ALIAS,
             Duration.ofMillis(CHECKPOINT_DURATION_MS));
 
-        assertTrue(backupOffsets.containsKey(
-            new TopicPartition("primary.test-topic-1", 0)), "Offsets not translated downstream to backup cluster. Found: " + backupOffsets);
+        for (int i = 0; i < NUM_PARTITIONS; i++) {
+            assertTrue(backupOffsets.containsKey(new TopicPartition("primary.test-topic-1", i)),
+                   "Offsets not translated downstream to backup cluster. Found: " + backupOffsets);
+        }
 
         // Failover consumer group to backup cluster.
         try (Consumer<byte[], byte[]> primaryConsumer = backup.kafka().createConsumer(Collections.singletonMap("group.id", consumerGroupName))) {


### PR DESCRIPTION
This PR addresses the issue described here [KAFKA-12558](https://issues.apache.org/jira/browse/KAFKA-12558). 

Additionally, The PR also allows to configure the max outstanding syncs in MirrorSourceTask because it is currently [hardcoded](https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java#L53).
A lot of offset syncs messages are lost during burst of messages in the source cluster or when the MirrorMaker has a lot to catch up (fist run or being inactive for a while). In such scenario it will take a while to sync the offsets in the destination cluster with partitions without regular activity even with reaching the maximum parallelism - 1 task per partition.

The PR tries to mitigate the issue by providing a way to change the maximum allowed concurrent offset syncs so that there are less offset syncs loses.

Here are my steps to reproduce the offset syncs issue because of the max outstanding syncs limited to 10:
1. Source topic with 12 partitions and 1400 messages with minimal activity. Messages are getting produced on daily basis
2. Run MirrorMaker2 process within the destination cluster network with offset syncs topic location set to target and 5 tasks
3. 372 offset syncs messages arrived in the destination cluster offset syncs topic
4. 9 out of 12 partitions are not synced correctly in the destination cluster
5. Waiting for hours and more for new messages to arrive in source Kafka cluster which will sync the correct offsets