### PR TITLE
[RFC][2/N] add restoration logic for RocksDBTimeOrderedWindowStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -50,9 +50,9 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
     private static final Logger LOG = LoggerFactory.getLogger(AbstractRocksDBSegmentedBytesStore.class);
 
     private final String name;
-    private final AbstractSegments<S> segments;
+    protected final AbstractSegments<S> segments;
     private final String metricScope;
-    private final KeySchema keySchema;
+    protected final KeySchema keySchema;
 
     private ProcessorContext context;
     private StateStoreContext stateStoreContext;
@@ -135,8 +135,8 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
 
         final List<S> searchSpace = keySchema.segmentsToSearch(segments, from, to, forward);
 
-        final Bytes binaryFrom = keyFrom == null ? null : keySchema.lowerRange(keyFrom, from);
-        final Bytes binaryTo = keyTo == null ? null : keySchema.upperRange(keyTo, to);
+        final Bytes binaryFrom = keySchema.lowerRange(keyFrom, from);
+        final Bytes binaryTo = keySchema.upperRange(keyTo, to);
 
         return new SegmentIterator<>(
                 searchSpace.iterator(),
@@ -262,7 +262,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
                 metrics
         );
 
-        segments.openExisting(this.context, observedStreamTime);
+        openSegments(this.context);
 
         final File positionCheckpointFile = new File(context.stateDir(), name() + ".position");
         this.positionCheckpoint = new OffsetCheckpoint(positionCheckpointFile);
@@ -281,6 +281,10 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
                 context.appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false);
+    }
+
+    public void openSegments(final ProcessorContext context) {
+        segments.openExisting(context, observedStreamTime);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedWindowKeySchemas.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedWindowKeySchemas.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static org.apache.kafka.streams.state.StateSerdes.TIMESTAMP_SIZE;
+import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
+
+public class PrefixedWindowKeySchemas {
+
+    private static final int PREFIX_SIZE = 1;
+    private static final byte TIME_FIRST_PREFIX = 1;
+    private static final byte KEY_FIRST_PREFIX = 2;
+    private static final int SEQNUM_SIZE = 4;
+    private static final int SUFFIX_SIZE = TIMESTAMP_SIZE + SEQNUM_SIZE;
+    private static final byte[] MIN_SUFFIX = new byte[SUFFIX_SIZE];
+
+    private static byte extractPrefix(final byte[] binaryBytes) {
+        return binaryBytes[0];
+    }
+
+    public static class TimeFirstWindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
+
+        @Override
+        public Bytes upperRange(final Bytes key, final long to) {
+            if (to == Long.MAX_VALUE) {
+                return null;
+            }
+
+            return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE + TIMESTAMP_SIZE)
+                .put(TIME_FIRST_PREFIX)
+                .putLong(to + 1)
+                .array());
+        }
+
+        @Override
+        public Bytes lowerRange(final Bytes key, final long from) {
+            if (key == null) {
+                return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE + TIMESTAMP_SIZE)
+                    .put(TIME_FIRST_PREFIX)
+                    .putLong(from)
+                    .array());
+            }
+
+            /*
+             * Larger timestamp or key's byte order can't be smaller than this lower range. Reason:
+             *     1. Timestamp is fixed length (with big endian byte order). Since we put timestamp
+             *        first, larger timestamp will have larger byte order.
+             *     2. If timestamp is the same but key (k1) is larger than this lower range key (k2):
+             *         a. If k2 is not a prefix of k1, then k1 will always have larger byte order no
+             *            matter what seqnum k2 has
+             *         b. If k2 is a prefix of k1, since k2's seqnum is 0, after k1 appends seqnum,
+             *            it will always be larger than (k1 + seqnum).
+             */
+            return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE + TIMESTAMP_SIZE + key.get().length + SEQNUM_SIZE)
+                .put(TIME_FIRST_PREFIX)
+                .putLong(from)
+                .put(key.get())
+                .putInt(0)
+                .array());
+        }
+
+        @Override
+        public Bytes lowerRangeFixedSize(final Bytes key, final long from) {
+            return TimeFirstWindowKeySchema.toTimeOrderedStoreKeyBinary(key, Math.max(0, from),
+                0);
+        }
+
+        @Override
+        public Bytes upperRangeFixedSize(final Bytes key, final long to) {
+            return TimeFirstWindowKeySchema.toTimeOrderedStoreKeyBinary(key, to, Integer.MAX_VALUE);
+        }
+
+        @Override
+        public long segmentTimestamp(final Bytes key) {
+            return WindowKeySchema.extractStoreTimestamp(key.get());
+        }
+
+        @Override
+        public HasNextCondition hasNextCondition(final Bytes binaryKeyFrom,
+            final Bytes binaryKeyTo,
+            final long from,
+            final long to) {
+            return iterator -> {
+                while (iterator.hasNext()) {
+                    final Bytes bytes = iterator.peekNextKey();
+                    final byte prefix = extractPrefix(bytes.get());
+
+                    if (prefix != TIME_FIRST_PREFIX) {
+                        return false;
+                    }
+
+                    final long time = TimeFirstWindowKeySchema.extractStoreTimestamp(bytes.get());
+
+                    // We can return false directly here since keys are sorted by time and if
+                    // we get time larger than `to`, there won't be time within range.
+                    if (time > to) {
+                        return false;
+                    }
+
+                     final Bytes keyBytes = Bytes.wrap(
+                        TimeFirstWindowKeySchema.extractStoreKeyBytes(bytes.get()));
+                    if ((binaryKeyFrom == null || keyBytes.compareTo(binaryKeyFrom) >= 0)
+                        && (binaryKeyTo == null || keyBytes.compareTo(binaryKeyTo) <= 0)
+                        && time >= from) {
+                        return true;
+                    }
+                    iterator.next();
+                }
+                return false;
+            };
+        }
+
+        @Override
+        public <S extends Segment> List<S> segmentsToSearch(final Segments<S> segments,
+            final long from,
+            final long to,
+            final boolean forward) {
+            return segments.segments(from, to, forward);
+        }
+
+        static byte[] extractStoreKeyBytes(final byte[] binaryKey) {
+            final byte[] bytes = new byte[binaryKey.length - TIMESTAMP_SIZE - SEQNUM_SIZE - PREFIX_SIZE];
+            System.arraycopy(binaryKey, TIMESTAMP_SIZE + PREFIX_SIZE, bytes, 0, bytes.length);
+            return bytes;
+        }
+
+        static long extractStoreTimestamp(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getLong(PREFIX_SIZE);
+        }
+
+        // for store serdes
+        public static Bytes toTimeOrderedStoreKeyBinary(final Bytes key,
+            final long timestamp,
+            final int seqnum) {
+            final byte[] serializedKey = key.get();
+            return toTimeOrderedStoreKeyBinary(serializedKey, timestamp, seqnum);
+        }
+
+        static Bytes toTimeOrderedStoreKeyBinary(final byte[] serializedKey,
+            final long timestamp,
+            final int seqnum) {
+            final ByteBuffer buf = ByteBuffer.allocate(
+                PREFIX_SIZE + TIMESTAMP_SIZE + serializedKey.length + SEQNUM_SIZE);
+            buf.put(TIME_FIRST_PREFIX);
+            buf.putLong(timestamp);
+            buf.put(serializedKey);
+            buf.putInt(seqnum);
+
+            return Bytes.wrap(buf.array());
+        }
+
+        public static Windowed<Bytes> fromStoreBytesKey(final byte[] binaryKey,
+                                                    final long windowSize) {
+            final Bytes key = Bytes.wrap(extractStoreKeyBytes(binaryKey));
+            final Window window = extractStoreWindow(binaryKey, windowSize);
+            return new Windowed<>(key, window);
+        }
+
+        static Window extractStoreWindow(final byte[] binaryKey,
+                                     final long windowSize) {
+            final long start = WindowKeySchema.extractStoreTimestamp(binaryKey);
+            return timeWindowForSize(start, windowSize);
+        }
+    }
+
+    public static class KeyFirstWindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
+        @Override
+        public Bytes upperRange(final Bytes key, final long to) {
+            if (key == null) {
+                return null;
+            }
+            final byte[] maxSuffix = ByteBuffer.allocate(SUFFIX_SIZE)
+                .putLong(to)
+                .putInt(Integer.MAX_VALUE)
+                .array();
+
+            return OrderedBytes.upperRange(key, maxSuffix);
+        }
+
+        @Override
+        public Bytes lowerRange(final Bytes key, final long from) {
+            if (key == null) {
+                return null;
+            }
+            return OrderedBytes.lowerRange(key, MIN_SUFFIX);
+        }
+
+        @Override
+        public Bytes lowerRangeFixedSize(final Bytes key, final long from) {
+            return WindowKeySchema.toStoreKeyBinary(key, Math.max(0, from), 0);
+        }
+
+        @Override
+        public Bytes upperRangeFixedSize(final Bytes key, final long to) {
+            return WindowKeySchema.toStoreKeyBinary(key, to, Integer.MAX_VALUE);
+        }
+
+        @Override
+        public long segmentTimestamp(final Bytes key) {
+            return WindowKeySchema.extractStoreTimestamp(key.get());
+        }
+
+        @Override
+        public HasNextCondition hasNextCondition(final Bytes binaryKeyFrom,
+                                                 final Bytes binaryKeyTo,
+                                                 final long from,
+                                                 final long to) {
+            return iterator -> {
+                while (iterator.hasNext()) {
+                    final Bytes bytes = iterator.peekNextKey();
+                    final byte prefix = extractPrefix(bytes.get());
+
+                    if (prefix != KEY_FIRST_PREFIX) {
+                        return false;
+                    }
+
+                    final Bytes keyBytes = Bytes.wrap(KeyFirstWindowKeySchema.extractStoreKeyBytes(bytes.get()));
+                    final long time = KeyFirstWindowKeySchema.extractStoreTimestamp(bytes.get());
+                    if ((binaryKeyFrom == null || keyBytes.compareTo(binaryKeyFrom) >= 0)
+                        && (binaryKeyTo == null || keyBytes.compareTo(binaryKeyTo) <= 0)
+                        && time >= from
+                        && time <= to) {
+                        return true;
+                    }
+                    iterator.next();
+                }
+                return false;
+            };
+        }
+
+        @Override
+        public <S extends Segment> List<S> segmentsToSearch(final Segments<S> segments,
+                                                            final long from,
+                                                            final long to,
+                                                            final boolean forward) {
+            return segments.segments(from, to, forward);
+        }
+
+        public static Bytes toStoreKeyBinary(final Bytes key,
+                                             final long timestamp,
+                                             final int seqnum) {
+            final byte[] serializedKey = key.get();
+            return toStoreKeyBinary(serializedKey, timestamp, seqnum);
+        }
+
+        static Bytes toStoreKeyBinary(final byte[] serializedKey,
+                                      final long timestamp,
+                                      final int seqnum) {
+            final ByteBuffer buf = ByteBuffer.allocate(PREFIX_SIZE + serializedKey.length + TIMESTAMP_SIZE + SEQNUM_SIZE);
+            buf.put(KEY_FIRST_PREFIX);
+            buf.put(serializedKey);
+            buf.putLong(timestamp);
+            buf.putInt(seqnum);
+
+            return Bytes.wrap(buf.array());
+        }
+
+        static byte[] extractStoreKeyBytes(final byte[] binaryKey) {
+            final byte[] bytes = new byte[binaryKey.length - TIMESTAMP_SIZE - SEQNUM_SIZE - PREFIX_SIZE];
+            System.arraycopy(binaryKey, PREFIX_SIZE, bytes, 0, bytes.length);
+            return bytes;
+        }
+
+        static long extractStoreTimestamp(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getLong(binaryKey.length - TIMESTAMP_SIZE - SEQNUM_SIZE);
+        }
+
+        static int extractStoreSeqnum(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getInt(binaryKey.length - SEQNUM_SIZE);
+        }
+
+        public static Windowed<Bytes> fromStoreBytesKey(final byte[] binaryKey,
+                                                    final long windowSize) {
+            final Bytes key = Bytes.wrap(extractStoreKeyBytes(binaryKey));
+            final Window window = extractStoreWindow(binaryKey, windowSize);
+            return new Windowed<>(key, window);
+        }
+
+        static Window extractStoreWindow(final byte[] binaryKey,
+                                     final long windowSize) {
+            final long start = WindowKeySchema.extractStoreTimestamp(binaryKey);
+            return timeWindowForSize(start, windowSize);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSegmentedBytesStore.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.List;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.TimeFirstWindowKeySchema;
+
+public class RocksDBTimeOrderedSegmentedBytesStore extends AbstractRocksDBSegmentedBytesStore<KeyValueSegment> {
+
+    RocksDBTimeOrderedSegmentedBytesStore(final String name,
+                               final String metricsScope,
+                               final long retention,
+                               final long segmentInterval) {
+        super(name, metricsScope, new TimeFirstWindowKeySchema(), new KeyValueSegments(name, metricsScope, retention, segmentInterval));
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> fetchAll(final long timeFrom,
+                                                    final long timeTo) {
+        final List<KeyValueSegment> searchSpace = segments.segments(timeFrom, timeTo, true);
+        final Bytes binaryFrom = keySchema.lowerRange(null, timeFrom);
+        final Bytes binaryTo = keySchema.upperRange(null, timeTo);
+
+        return new SegmentIterator<>(
+                searchSpace.iterator(),
+                keySchema.hasNextCondition(null, null, timeFrom, timeTo),
+                binaryFrom,
+                binaryTo,
+                true);
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> backwardFetchAll(final long timeFrom,
+                                                            final long timeTo) {
+        final List<KeyValueSegment> searchSpace = segments.segments(timeFrom, timeTo, false);
+        final Bytes binaryFrom = keySchema.lowerRange(null, timeFrom);
+        final Bytes binaryTo = keySchema.upperRange(null, timeTo);
+
+        return new SegmentIterator<>(
+                searchSpace.iterator(),
+                keySchema.hasNextCondition(null, null, timeFrom, timeTo),
+                binaryFrom,
+                binaryTo,
+                false);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
@@ -16,14 +16,23 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+
+import java.io.File;
+import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.ChangelogRecordDeserializationHelper;
+import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
 import org.apache.kafka.streams.processor.internals.StoreToProcessorContextAdapter;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
@@ -35,6 +44,7 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.KeyFirstWindowKeySchema;
 import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.TimeFirstWindowKeySchema;
+import org.apache.kafka.streams.state.internals.SegmentedBytesStore.SegmentRestorationCallback;
 
 /**
  * RocksDB store backed by two SegmentedBytesStores which can optimize scan by time as well as window
@@ -63,8 +73,6 @@ import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.TimeFir
  */
 public class RocksDBTimeOrderedWindowStore implements WindowStore<Bytes, byte[]> {
 
-
-
     private final boolean retainDuplicates;
     private final long windowSize;
     private final String name;
@@ -73,8 +81,9 @@ public class RocksDBTimeOrderedWindowStore implements WindowStore<Bytes, byte[]>
     private RocksDBSegmentedBytesStore indexStore;
 
     private StateStoreContext stateStoreContext;
+    private boolean consistencyEnabled = false;
     private Position position;
-    private boolean open;
+    protected OffsetCheckpoint positionCheckpoint;
 
 
     private class IndexToBaseStoreIterator implements KeyValueIterator<Bytes, byte[]> {
@@ -166,16 +175,92 @@ public class RocksDBTimeOrderedWindowStore implements WindowStore<Bytes, byte[]>
         if (hasIndexStore()) {
             indexStore.openSegments(context);
         }
-        open = true;
 
-        // TODO: register changelog callback and populate base and index store
         // register callback here since only window store knows how the keys are serialized in changelog
+        final File positionCheckpointFile = new File(context.stateDir(), name() + ".position");
+        this.positionCheckpoint = new OffsetCheckpoint(positionCheckpointFile);
+        this.position = StoreQueryUtils.readPositionFromCheckpoint(positionCheckpoint);
+
+        // register and possibly restore the state from the logs
+        stateStoreContext.register(
+            root,
+            (RecordBatchingStateRestoreCallback) this::restoreAllInternal,
+            () -> StoreQueryUtils.checkpointPosition(positionCheckpoint, position)
+        );
+
+        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+                context.appConfigs(),
+                IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
+                false);
     }
 
     @Override
     public void init(final StateStoreContext context, final StateStore root) {
         this.stateStoreContext = context;
         init(StoreToProcessorContextAdapter.adapt(context), root);
+    }
+
+    // Visible for testing
+    void restoreAllInternal(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+        // Record key should be serialized using index's format, for index store we need to transfer
+        // record key so that it has prefix and record value to be empty.
+        // For base store, we need to reformat record key.
+        final SegmentRestorationCallback<byte[], byte[]> callback = (segment, record) -> {
+            if (segment != null) {
+                ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
+                    record,
+                    consistencyEnabled,
+                    position
+                );
+            }
+        };
+
+
+        if (hasIndexStore()) {
+            Collection<ConsumerRecord<byte[], byte[]>> keyFirstRecords = records.stream().map(record ->  {
+                final byte[] key = WindowKeySchema.extractStoreKeyBytes(record.key());
+                final long timeStamp = WindowKeySchema.extractStoreTimestamp(record.key());
+                final int seqNum = WindowKeySchema.extractStoreSequence(record.key());
+                final byte[] newKey = PrefixedWindowKeySchemas.TimeFirstWindowKeySchema
+                    .toTimeOrderedStoreKeyBinary(Bytes.wrap(key), timeStamp, seqNum).get();
+                return new ConsumerRecord<>(
+                    record.topic(),
+                    record.partition(),
+                    record.offset(),
+                    record.timestamp(),
+                    record.timestampType(),
+                    record.serializedKeySize(),
+                    record.serializedValueSize(),
+                    newKey,
+                    record.value(),
+                    record.headers(),
+                    record.leaderEpoch()
+                );
+            }).collect(Collectors.toList());
+            indexStore.restoreAllInternal(keyFirstRecords, callback);
+        }
+
+        Collection<ConsumerRecord<byte[], byte[]>> timeFirstRecords = records.stream().map(record ->  {
+            final byte[] key = WindowKeySchema.extractStoreKeyBytes(record.key());
+            final long timeStamp = WindowKeySchema.extractStoreTimestamp(record.key());
+            final int seqNum = WindowKeySchema.extractStoreSequence(record.key());
+            final byte[] newKey = PrefixedWindowKeySchemas.TimeFirstWindowKeySchema
+                .toTimeOrderedStoreKeyBinary(Bytes.wrap(key), timeStamp, seqNum).get();
+            return new ConsumerRecord<>(
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                record.timestamp(),
+                record.timestampType(),
+                record.serializedKeySize(),
+                record.serializedValueSize(),
+                newKey,
+                record.value(),
+                record.headers(),
+                record.leaderEpoch()
+            );
+        }).collect(Collectors.toList());
+        baseStore.restoreAllInternal(timeFirstRecords, callback);
     }
 
     @Override
@@ -188,7 +273,6 @@ public class RocksDBTimeOrderedWindowStore implements WindowStore<Bytes, byte[]>
 
     @Override
     public void close() {
-        open = false;
         baseStore.close();
         if (hasIndexStore()) {
             indexStore.close();
@@ -207,7 +291,7 @@ public class RocksDBTimeOrderedWindowStore implements WindowStore<Bytes, byte[]>
 
     @Override
     public boolean isOpen() {
-        return open;
+        return baseStore.isOpen() && (!hasIndexStore() || indexStore.isOpen());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.StoreToProcessorContextAdapter;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.KeyFirstWindowKeySchema;
+import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.TimeFirstWindowKeySchema;
+
+/**
+ * RocksDB store backed by two SegmentedBytesStores which can optimize scan by time as well as window
+ * lookup for a specific key.
+ *
+ * Schema for first SegmentedBytesStore (base store) is as below:
+ *     Key schema: | timestamp + recordkey |
+ *     Value schema: | value |. Value here is determined by caller.
+ *
+ * Schema for second SegmentedBytesStore (index store) is as below:
+ *     Key schema: | record + timestamp |
+ *     Value schema: ||
+ *
+ * Operations:
+ *     Put: 1. Put to index store. 2. Put to base store.
+ *     Delete: 1. Delete from base store. 2. Delete from index store.
+ * Since we need to update two stores, failure can happen in the middle. We put in index store first
+ * to make sure if a failure happens in second step and the view is inconsistent, we can't get the
+ * value for the key. We delete from base store first to make sure if a failure happens in second step
+ * and the view is inconsistent, we can't get the value for the key.
+ *
+ * Note:
+ *     Index store can be optional if we can construct the timestamp in base store instead of looking
+ *     them up from index store.
+ *
+ */
+public class RocksDBTimeOrderedWindowStore implements WindowStore<Bytes, byte[]> {
+
+
+
+    private final boolean retainDuplicates;
+    private final long windowSize;
+    private final String name;
+    private int seqnum = 0;
+    private RocksDBTimeOrderedSegmentedBytesStore baseStore;
+    private RocksDBSegmentedBytesStore indexStore;
+
+    private StateStoreContext stateStoreContext;
+    private Position position;
+    private boolean open;
+
+
+    private class IndexToBaseStoreIterator implements KeyValueIterator<Bytes, byte[]> {
+        private final KeyValueIterator<Bytes, byte[]> indexIterator;
+        private byte[] cachedValue;
+
+
+        IndexToBaseStoreIterator(final KeyValueIterator<Bytes, byte[]> indexIterator) {
+            this.indexIterator = indexIterator;
+        }
+
+        @Override
+        public void close() {
+            indexIterator.close();
+        }
+
+        @Override
+        public Bytes peekNextKey() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return indexIterator.peekNextKey();
+        }
+
+        @Override
+        public boolean hasNext() {
+            while (indexIterator.hasNext()) {
+                final Bytes key = indexIterator.peekNextKey();
+                final Bytes keyBytes = Bytes.wrap(KeyFirstWindowKeySchema.extractStoreKeyBytes(key.get()));
+                final long timestamp = KeyFirstWindowKeySchema.extractStoreTimestamp(key.get());
+                final int seqnum = KeyFirstWindowKeySchema.extractStoreSeqnum(key.get());
+
+                cachedValue = baseStore.get(TimeFirstWindowKeySchema.toTimeOrderedStoreKeyBinary(key, timestamp, seqnum));
+                if (cachedValue == null) {
+                    // Key not in base store, inconsistency happened. Skip this key and reply on
+                    // segment store to clean this.
+                    indexIterator.next();
+                } else {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public KeyValue<Bytes, byte[]> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            KeyValue<Bytes, byte[]> ret = indexIterator.next();
+            return KeyValue.pair(ret.key, cachedValue);
+        }
+    }
+
+    RocksDBTimeOrderedWindowStore(
+        final RocksDBTimeOrderedSegmentedBytesStore baseStore,
+        final String name,
+        final boolean retainDuplicates,
+        final long windowSize
+    ) {
+        this(baseStore, null, name, retainDuplicates, windowSize);
+    }
+
+    RocksDBTimeOrderedWindowStore(
+        final RocksDBTimeOrderedSegmentedBytesStore baseStore,
+        final RocksDBSegmentedBytesStore indexStore,
+        final String name,
+        final boolean retainDuplicates,
+        final long windowSize
+    ) {
+        Objects.requireNonNull(baseStore, "baseStore is null");
+        Objects.requireNonNull(name, "name is null");
+        this.baseStore = baseStore;
+        this.indexStore = indexStore;
+        this.name = name;
+        this.retainDuplicates = retainDuplicates;
+        this.windowSize = windowSize;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Deprecated
+    @Override
+    public void init(final ProcessorContext context, final StateStore root) {
+        baseStore.openSegments(context);
+        if (hasIndexStore()) {
+            indexStore.openSegments(context);
+        }
+        open = true;
+
+        // TODO: register changelog callback and populate base and index store
+        // register callback here since only window store knows how the keys are serialized in changelog
+    }
+
+    @Override
+    public void init(final StateStoreContext context, final StateStore root) {
+        this.stateStoreContext = context;
+        init(StoreToProcessorContextAdapter.adapt(context), root);
+    }
+
+    @Override
+    public void flush() {
+        baseStore.flush();
+        if (hasIndexStore()) {
+            indexStore.flush();
+        }
+    }
+
+    @Override
+    public void close() {
+        open = false;
+        baseStore.close();
+        if (hasIndexStore()) {
+            indexStore.close();
+        }
+    }
+
+    @Override
+    public Position getPosition() {
+        return position;
+    }
+
+    @Override
+    public boolean persistent() {
+        return true;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void put(final Bytes key, final byte[] value, final long windowStartTimestamp) {
+        // Skip if value is null and duplicates are allowed since this delete is a no-op
+        if (!(value == null && retainDuplicates)) {
+            maybeUpdateSeqnumForDups();
+            if (hasIndexStore()) {
+                indexStore.put(
+                    KeyFirstWindowKeySchema.toStoreKeyBinary(key, windowStartTimestamp, seqnum), new byte[0]);
+            }
+            baseStore.put(
+                TimeFirstWindowKeySchema.toTimeOrderedStoreKeyBinary(key, windowStartTimestamp, seqnum), value);
+        }
+    }
+
+    @Override
+    public byte[] fetch(final Bytes key, final long timestamp) {
+        // TODO: check if some segments in index store can be purged
+        return baseStore.get(TimeFirstWindowKeySchema.toTimeOrderedStoreKeyBinary(key, timestamp, seqnum));
+    }
+
+    @Override
+    public WindowStoreIterator<byte[]> fetch(final Bytes key, final long timeFrom, final long timeTo) {
+        if (hasIndexStore()) {
+            // If index store exists, we still prefer to fetch from index store since it's ordered
+            // by key. The number of invalid keys we fetched should be much less than fetching
+            // from base store.
+            final KeyValueIterator<Bytes, byte[]> bytesIterator = indexStore.fetch(key, timeFrom,
+                timeTo);
+            return new WindowStoreIteratorWrapper(new IndexToBaseStoreIterator(bytesIterator),
+                windowSize,
+                KeyFirstWindowKeySchema::extractStoreTimestamp,
+                KeyFirstWindowKeySchema::fromStoreBytesKey).valuesIterator();
+        }
+
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.fetch(key, timeFrom, timeTo);
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).valuesIterator();
+    }
+
+    @Override
+    public WindowStoreIterator<byte[]> backwardFetch(final Bytes key, final long timeFrom, final long timeTo) {
+        if (hasIndexStore()) {
+            // If index store exists, we still prefer to fetch from index store since it's ordered
+            // by key. The number of invalid keys we fetched should be much less than fetching
+            // from base store.
+            final KeyValueIterator<Bytes, byte[]> bytesIterator = indexStore.backwardFetch(key, timeFrom,
+                timeTo);
+            return new WindowStoreIteratorWrapper(new IndexToBaseStoreIterator(bytesIterator),
+                windowSize,
+                KeyFirstWindowKeySchema::extractStoreTimestamp,
+                KeyFirstWindowKeySchema::fromStoreBytesKey).valuesIterator();
+        }
+
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.backwardFetch(key, timeFrom, timeTo);
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).valuesIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom,
+                                                           final Bytes keyTo,
+                                                           final long timeFrom,
+                                                           final long timeTo) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.fetch(keyFrom, keyTo, timeFrom, timeTo);
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).keyValueIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom,
+                                                                   final Bytes keyTo,
+                                                                   final long timeFrom,
+                                                                   final long timeTo) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.backwardFetch(keyFrom, keyTo, timeFrom, timeTo);
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).keyValueIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> all() {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.all();
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).keyValueIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardAll() {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.backwardAll();
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).keyValueIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(final long timeFrom, final long timeTo) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.fetchAll(timeFrom, timeTo);
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).keyValueIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(final long timeFrom, final long timeTo) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = baseStore.backwardFetchAll(timeFrom, timeTo);
+        return new WindowStoreIteratorWrapper(bytesIterator,
+            windowSize,
+            TimeFirstWindowKeySchema::extractStoreTimestamp,
+            TimeFirstWindowKeySchema::fromStoreBytesKey).keyValueIterator();
+    }
+
+    @Override
+    public <R> QueryResult<R> query(final Query<R> query,
+                                    final PositionBound positionBound,
+                                    final QueryConfig config) {
+
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            config,
+            this,
+            getPosition(),
+            stateStoreContext
+        );
+    }
+
+    private void maybeUpdateSeqnumForDups() {
+        if (retainDuplicates) {
+            seqnum = (seqnum + 1) & 0x7FFFFFFF;
+        }
+    }
+
+    private boolean hasIndexStore() {
+        return indexStore != null;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
@@ -223,5 +224,9 @@ public interface SegmentedBytesStore extends StateStore {
          * @return  List of segments to search
          */
         <S extends Segment> List<S> segmentsToSearch(Segments<S> segments, long from, long to, boolean forward);
+    }
+
+    interface SegmentRestorationCallback<K, V> {
+        void onRestoraton(final Segment segment, final ConsumerRecord<K, V> record);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionKeySchema.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionKeySchema.java
@@ -48,6 +48,9 @@ public class SessionKeySchema implements SegmentedBytesStore.KeySchema {
 
     @Override
     public Bytes upperRange(final Bytes key, final long to) {
+        if (key == null) {
+            return null;
+        }
         final byte[] maxSuffix = ByteBuffer.allocate(SUFFIX_SIZE)
             // the end timestamp can be as large as possible as long as it's larger than start time
             .putLong(Long.MAX_VALUE)
@@ -59,6 +62,9 @@ public class SessionKeySchema implements SegmentedBytesStore.KeySchema {
 
     @Override
     public Bytes lowerRange(final Bytes key, final long from) {
+        if (key == null) {
+            return null;
+        }
         return OrderedBytes.lowerRange(key, MIN_SUFFIX);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowKeySchema.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowKeySchema.java
@@ -41,6 +41,9 @@ public class WindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
 
     @Override
     public Bytes upperRange(final Bytes key, final long to) {
+        if (key == null) {
+            return null;
+        }
         final byte[] maxSuffix = ByteBuffer.allocate(SUFFIX_SIZE)
             .putLong(to)
             .putInt(Integer.MAX_VALUE)
@@ -51,6 +54,9 @@ public class WindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
 
     @Override
     public Bytes lowerRange(final Bytes key, final long from) {
+        if (key == null) {
+            return null;
+        }
         return OrderedBytes.lowerRange(key, MIN_SUFFIX);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreIteratorWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreIteratorWrapper.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
@@ -26,32 +29,46 @@ class WindowStoreIteratorWrapper {
 
     private final KeyValueIterator<Bytes, byte[]> bytesIterator;
     private final long windowSize;
+    private final Function<byte[], Long> timestampExtractor;
+    private final BiFunction<byte[], Long, Windowed<Bytes>> windowConstructor;
 
     WindowStoreIteratorWrapper(final KeyValueIterator<Bytes, byte[]> bytesIterator,
                                final long windowSize) {
+        this(bytesIterator, windowSize, WindowKeySchema::extractStoreTimestamp, WindowKeySchema::fromStoreBytesKey);
+    }
+
+    WindowStoreIteratorWrapper(final KeyValueIterator<Bytes, byte[]> bytesIterator,
+                               final long windowSize,
+                               final Function<byte[], Long> timestampExtractor,
+                               final BiFunction<byte[], Long, Windowed<Bytes>> windowConstructor) {
         this.bytesIterator = bytesIterator;
         this.windowSize = windowSize;
+        this.timestampExtractor = timestampExtractor;
+        this.windowConstructor = windowConstructor;
     }
 
     public WindowStoreIterator<byte[]> valuesIterator() {
-        return new WrappedWindowStoreIterator(bytesIterator);
+        return new WrappedWindowStoreIterator(bytesIterator, timestampExtractor);
     }
 
     public KeyValueIterator<Windowed<Bytes>, byte[]> keyValueIterator() {
-        return new WrappedKeyValueIterator(bytesIterator, windowSize);
+        return new WrappedKeyValueIterator(bytesIterator, windowSize, windowConstructor);
     }
 
     private static class WrappedWindowStoreIterator implements WindowStoreIterator<byte[]> {
         final KeyValueIterator<Bytes, byte[]> bytesIterator;
+        final Function<byte[], Long> timestampExtractor;
 
         WrappedWindowStoreIterator(
-            final KeyValueIterator<Bytes, byte[]> bytesIterator) {
+            final KeyValueIterator<Bytes, byte[]> bytesIterator,
+            final Function<byte[], Long> timestampExtractor) {
             this.bytesIterator = bytesIterator;
+            this.timestampExtractor = timestampExtractor;
         }
 
         @Override
         public Long peekNextKey() {
-            return WindowKeySchema.extractStoreTimestamp(bytesIterator.peekNextKey().get());
+            return timestampExtractor.apply(bytesIterator.peekNextKey().get());
         }
 
         @Override
@@ -62,7 +79,7 @@ class WindowStoreIteratorWrapper {
         @Override
         public KeyValue<Long, byte[]> next() {
             final KeyValue<Bytes, byte[]> next = bytesIterator.next();
-            final long timestamp = WindowKeySchema.extractStoreTimestamp(next.key.get());
+            final long timestamp = timestampExtractor.apply(next.key.get());
             return KeyValue.pair(timestamp, next.value);
         }
 
@@ -75,17 +92,20 @@ class WindowStoreIteratorWrapper {
     private static class WrappedKeyValueIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
         final KeyValueIterator<Bytes, byte[]> bytesIterator;
         final long windowSize;
+        final BiFunction<byte[], Long, Windowed<Bytes>> windowConstructor;
 
         WrappedKeyValueIterator(final KeyValueIterator<Bytes, byte[]> bytesIterator,
-                                final long windowSize) {
+                                final long windowSize,
+                                final BiFunction<byte[], Long, Windowed<Bytes>> windowConstructor) {
             this.bytesIterator = bytesIterator;
             this.windowSize = windowSize;
+            this.windowConstructor = windowConstructor;
         }
 
         @Override
         public Windowed<Bytes> peekNextKey() {
             final byte[] nextKey = bytesIterator.peekNextKey().get();
-            return WindowKeySchema.fromStoreBytesKey(nextKey, windowSize);
+            return windowConstructor.apply(nextKey, windowSize);
         }
 
         @Override
@@ -96,7 +116,7 @@ class WindowStoreIteratorWrapper {
         @Override
         public KeyValue<Windowed<Bytes>, byte[]> next() {
             final KeyValue<Bytes, byte[]> next = bytesIterator.next();
-            return KeyValue.pair(WindowKeySchema.fromStoreBytesKey(next.key.get(), windowSize), next.value);
+            return KeyValue.pair(windowConstructor.apply(next.key.get(), windowSize), next.value);
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -498,7 +498,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         final Collection<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>();
         records.add(new ConsumerRecord<>("", 0, 0L, serializeKey(new Windowed<>(key, windows[0])).get(), serializeValue(50L)));
         records.add(new ConsumerRecord<>("", 0, 0L, serializeKey(new Windowed<>(key, windows[3])).get(), serializeValue(100L)));
-        final Map<S, WriteBatch> writeBatchMap = bytesStore.getWriteBatches(records);
+        final Map<S, WriteBatch> writeBatchMap = bytesStore.getWriteBatches(records, null);
         assertEquals(2, writeBatchMap.size());
         for (final WriteBatch batch : writeBatchMap.values()) {
             assertEquals(1, batch.count());


### PR DESCRIPTION
Add restoration logic for `RocksDBTimeOrderedWindowStore`. Changelog's key is serialized from `WindowKeySchema` and transform key format to match index and base store's format



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
