### PR TITLE
MINOR: set log4j.logger.kafka and all Config logger levels to ERROR for Streams tests

### DIFF
--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -18,9 +18,18 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=INFO
+log4j.logger.kafka=ERROR
+log4j.logger.state=ERROR
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 
-log4j.logger.org.apache.kafka.clients=WARN
+# printing out the configs takes up a huge amount of the allotted characters,
+# and provides little value as we can always figure out the test configs without the logs
+log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
+log4j.logger.org.apache.kafka.streams.StreamsConfig=ERROR
+
+# These are the only logs we will likely ever find anything useful in to debug Streams test failures
+log4j.logger.org.apache.kafka.clients=INFO
 log4j.logger.org.apache.kafka.streams=INFO

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -19,7 +19,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=ERROR
-log4j.logger.state=ERROR
+log4j.logger.state.change.logger=ERROR
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 


### PR DESCRIPTION
Pretty much any time we have an integration test failure that's flaky or only exposed when running on Jenkins through the PR builds, it's impossible to debug if it cannot be reproduced locally as the logs attached to the test results have truncated the entire useful part of the logs. This is due to the logs being flooded at the beginning of the test when the Kafka cluster is coming up, eating up all of the allotted characters before we even get to the actual Streams test. Setting ` log4j.logger.kafka` to `ERROR` greatly improves the situation and cuts down on most of the excessive logging in my local runs. To improve things even more and have some hope of getting the part of the logs we actually need, I also set the loggers for all of the Config objects to ERROR, as these print out the value of every single config (of which there are a lot) and are not useful as we can easily figure out what the configs were if necessary by just inspecting the test locally.

Hopefully this will help us debug and then fix some of the flaky tests within Streams that show up on PR builds