### PR TITLE
KAFKA-12648: standardize startup timeout to fix some flaky NamedTopologyIntegrationTest tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -96,6 +96,8 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 
 public class NamedTopologyIntegrationTest {
+    private static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(45);
+    
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
 
     private static final String TOPOLOGY_1 = "topology-1";
@@ -287,7 +289,7 @@ public class NamedTopologyIntegrationTest {
             Materialized.with(null, serdeScope.decorateSerde(Serdes.String(), props, false)));
 
         streams.start(asList(fkjBuilder.build(), countBuilder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         final String countTopicPrefix = TOPIC_PREFIX + "-" + countTopologyName;
         final String fkjTopicPrefix = TOPIC_PREFIX + "-" + fkjTopologyName;
@@ -315,7 +317,7 @@ public class NamedTopologyIntegrationTest {
             .count(ROCKSDB_STORE)
             .toStream().to(OUTPUT_STREAM_1);
         streams.start(topology1Builder.build());
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
         final List<KeyValue<String, Long>> results = waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3);
         assertThat(results, equalTo(COUNT_OUTPUT_DATA));
 
@@ -330,7 +332,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -398,7 +400,7 @@ public class NamedTopologyIntegrationTest {
             topology2Builder2.stream(SINGLE_PARTITION_INPUT_STREAM).groupByKey().count(Materialized.as(topology2Store)).toStream().to(SINGLE_PARTITION_OUTPUT_STREAM);
 
             streams2.start(asList(topology1Builder2.build(), topology2Builder2.build()));
-            waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(30));
+            waitForApplicationState(asList(streams, streams2), State.RUNNING, STARTUP_TIMEOUT);
 
             verifyMetadataForTopology(
                 TOPOLOGY_1,
@@ -437,7 +439,7 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         streams.start(topology1Builder.build());
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
         streams.addNamedTopology(topology2Builder.build()).all().get();
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -450,7 +452,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         streams.addNamedTopology(topology3Builder.build()).all().get();
 
@@ -470,7 +472,7 @@ public class NamedTopologyIntegrationTest {
 
         streams.start(topology1Builder.build());
         streams2.start(topology1Builder2.build());
-        waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(asList(streams, streams2), State.RUNNING, STARTUP_TIMEOUT);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
 
@@ -490,7 +492,7 @@ public class NamedTopologyIntegrationTest {
 
         streams.start(topology1Builder.build());
         streams2.start(topology1Builder2.build());
-        waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(asList(streams, streams2), State.RUNNING, STARTUP_TIMEOUT);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
 
@@ -529,7 +531,7 @@ public class NamedTopologyIntegrationTest {
             throw new IllegalStateException("Should not process any records for removed topology-2");
         });
         streams.start(asList(topology1Builder.build(), topology2Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         streams.removeNamedTopology("topology-2").all().get();
 
@@ -547,7 +549,7 @@ public class NamedTopologyIntegrationTest {
         inputStream1.groupByKey().count().toStream().to(COUNT_OUTPUT);
         inputStream1.groupByKey().reduce(Long::sum).toStream().to(SUM_OUTPUT);
         streams.start(singletonList(topology1Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 3), equalTo(SUM_OUTPUT_DATA));
@@ -574,7 +576,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -587,7 +589,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
+        waitForApplicationState(singletonList(streams), State.RUNNING, STARTUP_TIMEOUT);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -683,7 +685,7 @@ public class NamedTopologyIntegrationTest {
 
             streams.start(topology1Builder.build());
             streams2.start(topology1Builder2.build());
-            waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(45));
+            waitForApplicationState(asList(streams, streams2), State.RUNNING, STARTUP_TIMEOUT);
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
 
             topology2Builder.stream(NEW_STREAM).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
@@ -741,7 +743,7 @@ public class NamedTopologyIntegrationTest {
 
         streams.start(topology1Builder.build());
         streams2.start(topology1Builder2.build());
-        waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(asList(streams, streams2), State.RUNNING, STARTUP_TIMEOUT);
 
         retryOnExceptionWithTimeout(() -> {
             final Throwable error = handler.nextError(TOPOLOGY_1);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -287,7 +287,7 @@ public class NamedTopologyIntegrationTest {
             Materialized.with(null, serdeScope.decorateSerde(Serdes.String(), props, false)));
 
         streams.start(asList(fkjBuilder.build(), countBuilder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(60));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         final String countTopicPrefix = TOPIC_PREFIX + "-" + countTopologyName;
         final String fkjTopicPrefix = TOPIC_PREFIX + "-" + fkjTopologyName;
@@ -315,7 +315,7 @@ public class NamedTopologyIntegrationTest {
             .count(ROCKSDB_STORE)
             .toStream().to(OUTPUT_STREAM_1);
         streams.start(topology1Builder.build());
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
         final List<KeyValue<String, Long>> results = waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3);
         assertThat(results, equalTo(COUNT_OUTPUT_DATA));
 
@@ -330,7 +330,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -437,7 +437,7 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         streams.start(topology1Builder.build());
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
         streams.addNamedTopology(topology2Builder.build()).all().get();
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -450,7 +450,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         streams.addNamedTopology(topology3Builder.build()).all().get();
 
@@ -529,7 +529,7 @@ public class NamedTopologyIntegrationTest {
             throw new IllegalStateException("Should not process any records for removed topology-2");
         });
         streams.start(asList(topology1Builder.build(), topology2Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         streams.removeNamedTopology("topology-2").all().get();
 
@@ -547,7 +547,7 @@ public class NamedTopologyIntegrationTest {
         inputStream1.groupByKey().count().toStream().to(COUNT_OUTPUT);
         inputStream1.groupByKey().reduce(Long::sum).toStream().to(SUM_OUTPUT);
         streams.start(singletonList(topology1Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 3), equalTo(SUM_OUTPUT_DATA));
@@ -574,7 +574,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -587,7 +587,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(30));
+        waitForApplicationState(singletonList(streams), State.RUNNING, Duration.ofSeconds(45));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -683,7 +683,7 @@ public class NamedTopologyIntegrationTest {
 
             streams.start(topology1Builder.build());
             streams2.start(topology1Builder2.build());
-            waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(30));
+            waitForApplicationState(asList(streams, streams2), State.RUNNING, Duration.ofSeconds(45));
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
 
             topology2Builder.stream(NEW_STREAM).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -25,9 +25,9 @@ log4j.logger.org.apache.zookeeper=ERROR
 
 # printing out the configs takes up a huge amount of the allotted characters,
 # and provides little value as we can always figure out the test configs without the logs
-org.apache.kafka.clients.producer.ProducerConfig=ERROR
-org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
-org.apache.kafka.clients.admin.AdminClientConfig=ERROR
+log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
 log4j.logger.org.apache.kafka.streams.StreamsConfig=ERROR
 
 # These are the only logs we will likely ever find anything useful in to debug Streams test failures

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -18,9 +18,9 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=INFO
+log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 
-log4j.logger.org.apache.kafka.clients=WARN
+log4j.logger.org.apache.kafka.clients=INFO
 log4j.logger.org.apache.kafka.streams=INFO

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -19,8 +19,17 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=ERROR
+log4j.logger.state=ERROR
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 
+# printing out the configs takes up a huge amount of the allotted characters,
+# and provides little value as we can always figure out the test configs without the logs
+org.apache.kafka.clients.producer.ProducerConfig=ERROR
+org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
+org.apache.kafka.clients.admin.AdminClientConfig=ERROR
+log4j.logger.org.apache.kafka.streams.StreamsConfig=ERROR
+
+# These are the only logs we will likely ever find anything useful in to debug Streams test failures
 log4j.logger.org.apache.kafka.clients=INFO
 log4j.logger.org.apache.kafka.streams=INFO

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -18,18 +18,9 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=ERROR
-log4j.logger.state=ERROR
+log4j.logger.kafka=INFO
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 
-# printing out the configs takes up a huge amount of the allotted characters,
-# and provides little value as we can always figure out the test configs without the logs
-log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
-log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
-log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
-log4j.logger.org.apache.kafka.streams.StreamsConfig=ERROR
-
-# These are the only logs we will likely ever find anything useful in to debug Streams test failures
-log4j.logger.org.apache.kafka.clients=INFO
+log4j.logger.org.apache.kafka.clients=WARN
 log4j.logger.org.apache.kafka.streams=INFO


### PR DESCRIPTION
Seen a few of the new tests added [fail on PR builds](https://ci-builds.apache.org/job/Kafka/job/kafka-pr/job/PR-11812/3/testReport/org.apache.kafka.streams.integration/NamedTopologyIntegrationTest/Build___JDK_11_and_Scala_2_13___shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing/) lately with the classic 
```
java.lang.AssertionError: Expected all streams instances in [org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper@7fb3e6b0] to be RUNNING within 30000 ms, but the following were not: {org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper@7fb3e6b0=ERROR}
```

Since Jenkins unfortunately truncates the logs before we even get to running this specific test (due to large kafka & Config logging, see #11823) so I can't say for sure that it's environmental vs an actual issue, but bumping up the timeout will help us rule this out if we continue to see failures. We already had some tests using the 30s timeout while others were bumped all the way up to 60s, I figured we should try out a default timeout of 45s and if we still see failures in specific tests we can go from there