### PR TITLE
KAFKA-13785: [2/N][emit final] add processor metadata to be committed with offset

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
@@ -62,6 +61,7 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
         valueSerde = null;
         keySerde = null;
         this.cache = cache;
+        processorMetadata = ProcessorMetadata.emptyMetadata();
     }
 
     protected abstract StateManager stateManager();
@@ -258,17 +258,18 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
     }
 
     @Override
-    public void addGlobalProcessorMetadata(final Bytes key, final byte[] value) {
-        processorMetadata.addGlobalMetadata(key, value);
+    public void addProcessorMetadataKeyValue(final String key, final long value) {
+        processorMetadata.addMetadata(key, value);
     }
 
     @Override
-    public byte[] getGlobalProcessorMetadata(final Bytes key) {
-        return processorMetadata.getGlobalMetadata(key);
+    public Long getProcessorMetadataForKey(final String key) {
+        return processorMetadata.getMetadata(key);
     }
 
     @Override
     public void setProcessorMetadata(final ProcessorMetadata metadata) {
+        Objects.requireNonNull(metadata);
         processorMetadata = metadata;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
@@ -48,6 +49,7 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
     protected ProcessorNode<?, ?, ?, ?> currentNode;
     private long cachedSystemTimeMs;
     protected ThreadCache cache;
+    private ProcessorMetadata processorMetadata;
 
     public AbstractProcessorContext(final TaskId taskId,
                                     final StreamsConfig config,
@@ -253,5 +255,25 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
     @Override
     public String changelogFor(final String storeName) {
         return stateManager().changelogFor(storeName);
+    }
+
+    @Override
+    public void addGlobalProcessorMetadata(final Bytes key, final byte[] value) {
+        processorMetadata.addGlobalMetadata(key, value);
+    }
+
+    @Override
+    public byte[] getGlobalProcessorMetadata(final Bytes key) {
+        return processorMetadata.getGlobalMetadata(key);
+    }
+
+    @Override
+    public void setProcessorMetadata(final ProcessorMetadata metadata) {
+        processorMetadata = metadata;
+    }
+
+    @Override
+    public ProcessorMetadata getProcessorMetadata() {
+        return processorMetadata;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -61,7 +61,7 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
         valueSerde = null;
         keySerde = null;
         this.cache = cache;
-        processorMetadata = ProcessorMetadata.emptyMetadata();
+        processorMetadata = new ProcessorMetadata();
     }
 
     protected abstract StateManager stateManager();
@@ -259,12 +259,12 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
 
     @Override
     public void addProcessorMetadataKeyValue(final String key, final long value) {
-        processorMetadata.addMetadata(key, value);
+        processorMetadata.put(key, value);
     }
 
     @Override
-    public Long getProcessorMetadataForKey(final String key) {
-        return processorMetadata.getMetadata(key);
+    public Long processorMetadataForKey(final String key) {
+        return processorMetadata.get(key);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -121,9 +121,9 @@ public interface InternalProcessorContext<KOut, VOut>
 
     String changelogFor(final String storeName);
 
-    void addGlobalProcessorMetadata(final Bytes key, final byte[] value);
+    void addProcessorMetadataKeyValue(final String key, final long value);
 
-    byte[] getGlobalProcessorMetadata(final Bytes key);
+    Long getProcessorMetadataForKey(final String key);
 
     void setProcessorMetadata(final ProcessorMetadata metadata);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -123,7 +123,7 @@ public interface InternalProcessorContext<KOut, VOut>
 
     void addProcessorMetadataKeyValue(final String key, final long value);
 
-    Long getProcessorMetadataForKey(final String key);
+    Long processorMetadataForKey(final String key);
 
     void setProcessorMetadata(final ProcessorMetadata metadata);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -120,4 +120,13 @@ public interface InternalProcessorContext<KOut, VOut>
                    final Position position);
 
     String changelogFor(final String storeName);
+
+    void addGlobalProcessorMetadata(final Bytes key, final byte[] value);
+
+    byte[] getGlobalProcessorMetadata(final Bytes key);
+
+    void setProcessorMetadata(final ProcessorMetadata metadata);
+
+    ProcessorMetadata getProcessorMetadata();
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorMetadata.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+
+/**
+ * ProcessorMetadata to be access and populated by processor node. This will be committed along with
+ * offset
+ */
+public class ProcessorMetadata {
+
+    // Does this need to be thread safe? I think not since there's one per task
+    private final Map<Bytes, byte[]> globalMetadata;
+
+    public ProcessorMetadata() {
+        globalMetadata = new HashMap<>();
+    }
+
+    public static ProcessorMetadata deserialize(final byte[] ProcessorMetadata, final TopicPartition partition) {
+        // TODO: deserialize
+        return null;
+    }
+
+    public void merge(final ProcessorMetadata other) {
+        // TODO: merge with other data
+    }
+
+    public byte[] serialize(final TopicPartition partition) {
+        // TODO: serialize for partition
+        return null;
+    }
+
+    public void addGlobalMetadata(final Bytes key, final byte[] value) {
+      globalMetadata.put(key, value);
+    }
+
+    public byte[] getGlobalMetadata(final Bytes key) {
+      return globalMetadata.get(key);
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadata.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metadata to be committed together with TopicPartition offset
+ */
+public class TopicPartitionMetadata {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TopicPartitionMetadata.class);
+
+    // visible for testing
+    static final byte LATEST_MAGIC_BYTE = 2;
+
+    private final long partitionTime;
+    private final ProcessorMetadata processorMetadata;
+
+    static TopicPartitionMetadata with(final long partitionTime, final ProcessorMetadata processorMetadata) {
+      return new TopicPartitionMetadata(partitionTime, processorMetadata);
+    }
+
+    private TopicPartitionMetadata(final long partitionTime, final ProcessorMetadata processorMetadata) {
+        Objects.requireNonNull(processorMetadata);
+        this.partitionTime = partitionTime;
+        this.processorMetadata = processorMetadata;
+    }
+
+    public long partitionTime() {
+      return partitionTime;
+    }
+
+    public ProcessorMetadata processorMetadata() {
+      return processorMetadata;
+    }
+
+    public String encode() {
+        final byte[] serializedMeta = processorMetadata.serialize();
+        // Format: MAGIC_BYTE(1) + PartitionTime(8) + processMeta
+        final ByteBuffer buffer = ByteBuffer.allocate(Byte.BYTES + Long.BYTES + serializedMeta.length);
+        buffer.put(LATEST_MAGIC_BYTE);
+        buffer.putLong(partitionTime);
+        buffer.put(serializedMeta);
+        return Base64.getEncoder().encodeToString(buffer.array());
+    }
+
+    public static TopicPartitionMetadata decode(final String encryptedString) {
+      long timestamp = RecordQueue.UNKNOWN;
+      ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+
+      if (encryptedString == null || encryptedString.isEmpty()) {
+        return with(timestamp, metadata);
+      }
+      try {
+        final ByteBuffer buffer = ByteBuffer.wrap(Base64.getDecoder().decode(encryptedString));
+        final byte version = buffer.get();
+        switch (version) {
+          case (byte) 1:
+            timestamp = buffer.getLong();
+            break;
+          case LATEST_MAGIC_BYTE:
+            timestamp = buffer.getLong();
+            if (buffer.remaining() > 0) {
+              final byte[] metaBytes = new byte[buffer.remaining()];
+              buffer.get(metaBytes);
+              metadata = ProcessorMetadata.deserialize(metaBytes);
+            }
+            break;
+          default:
+            LOG.warn(
+                "Unsupported offset metadata version found. Supported version <= {}. Found version {}.",
+                LATEST_MAGIC_BYTE, version);
+        }
+      } catch (final Exception exception) {
+        LOG.warn("Unsupported offset metadata found");
+      }
+      return with(timestamp, metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionTime, processorMetadata);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null || obj.getClass() != getClass()) {
+          return false;
+        }
+
+        if (obj == this) {
+          return true;
+        }
+
+        return partitionTime == ((TopicPartitionMetadata) obj).partitionTime
+            && Objects.equals(processorMetadata, ((TopicPartitionMetadata) obj).processorMetadata);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadata.java
@@ -35,11 +35,7 @@ public class TopicPartitionMetadata {
     private final long partitionTime;
     private final ProcessorMetadata processorMetadata;
 
-    static TopicPartitionMetadata with(final long partitionTime, final ProcessorMetadata processorMetadata) {
-        return new TopicPartitionMetadata(partitionTime, processorMetadata);
-    }
-
-    private TopicPartitionMetadata(final long partitionTime, final ProcessorMetadata processorMetadata) {
+    public TopicPartitionMetadata(final long partitionTime, final ProcessorMetadata processorMetadata) {
         Objects.requireNonNull(processorMetadata);
         this.partitionTime = partitionTime;
         this.processorMetadata = processorMetadata;
@@ -65,10 +61,10 @@ public class TopicPartitionMetadata {
 
     public static TopicPartitionMetadata decode(final String encryptedString) {
         long timestamp = RecordQueue.UNKNOWN;
-        ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        ProcessorMetadata metadata = new ProcessorMetadata();
 
-        if (encryptedString == null || encryptedString.isEmpty()) {
-            return with(timestamp, metadata);
+        if (encryptedString.isEmpty()) {
+            return new TopicPartitionMetadata(timestamp, metadata);
         }
         try {
             final ByteBuffer buffer = ByteBuffer.wrap(Base64.getDecoder().decode(encryptedString));
@@ -93,7 +89,7 @@ public class TopicPartitionMetadata {
         } catch (final Exception exception) {
             LOG.warn("Unsupported offset metadata found");
         }
-        return with(timestamp, metadata);
+        return new TopicPartitionMetadata(timestamp, metadata);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadata.java
@@ -36,7 +36,7 @@ public class TopicPartitionMetadata {
     private final ProcessorMetadata processorMetadata;
 
     static TopicPartitionMetadata with(final long partitionTime, final ProcessorMetadata processorMetadata) {
-      return new TopicPartitionMetadata(partitionTime, processorMetadata);
+        return new TopicPartitionMetadata(partitionTime, processorMetadata);
     }
 
     private TopicPartitionMetadata(final long partitionTime, final ProcessorMetadata processorMetadata) {
@@ -46,11 +46,11 @@ public class TopicPartitionMetadata {
     }
 
     public long partitionTime() {
-      return partitionTime;
+        return partitionTime;
     }
 
     public ProcessorMetadata processorMetadata() {
-      return processorMetadata;
+        return processorMetadata;
     }
 
     public String encode() {
@@ -64,36 +64,36 @@ public class TopicPartitionMetadata {
     }
 
     public static TopicPartitionMetadata decode(final String encryptedString) {
-      long timestamp = RecordQueue.UNKNOWN;
-      ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        long timestamp = RecordQueue.UNKNOWN;
+        ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
 
-      if (encryptedString == null || encryptedString.isEmpty()) {
-        return with(timestamp, metadata);
-      }
-      try {
-        final ByteBuffer buffer = ByteBuffer.wrap(Base64.getDecoder().decode(encryptedString));
-        final byte version = buffer.get();
-        switch (version) {
-          case (byte) 1:
-            timestamp = buffer.getLong();
-            break;
-          case LATEST_MAGIC_BYTE:
-            timestamp = buffer.getLong();
-            if (buffer.remaining() > 0) {
-              final byte[] metaBytes = new byte[buffer.remaining()];
-              buffer.get(metaBytes);
-              metadata = ProcessorMetadata.deserialize(metaBytes);
-            }
-            break;
-          default:
-            LOG.warn(
-                "Unsupported offset metadata version found. Supported version <= {}. Found version {}.",
-                LATEST_MAGIC_BYTE, version);
+        if (encryptedString == null || encryptedString.isEmpty()) {
+            return with(timestamp, metadata);
         }
-      } catch (final Exception exception) {
-        LOG.warn("Unsupported offset metadata found");
-      }
-      return with(timestamp, metadata);
+        try {
+            final ByteBuffer buffer = ByteBuffer.wrap(Base64.getDecoder().decode(encryptedString));
+            final byte version = buffer.get();
+            switch (version) {
+                case (byte) 1:
+                    timestamp = buffer.getLong();
+                    break;
+                case LATEST_MAGIC_BYTE:
+                    timestamp = buffer.getLong();
+                    if (buffer.remaining() > 0) {
+                        final byte[] metaBytes = new byte[buffer.remaining()];
+                        buffer.get(metaBytes);
+                        metadata = ProcessorMetadata.deserialize(metaBytes);
+                    }
+                    break;
+                default:
+                    LOG.warn(
+                        "Unsupported offset metadata version found. Supported version <= {}. Found version {}.",
+                        LATEST_MAGIC_BYTE, version);
+            }
+        } catch (final Exception exception) {
+            LOG.warn("Unsupported offset metadata found");
+        }
+        return with(timestamp, metadata);
     }
 
     @Override
@@ -104,11 +104,11 @@ public class TopicPartitionMetadata {
     @Override
     public boolean equals(final Object obj) {
         if (obj == null || obj.getClass() != getClass()) {
-          return false;
+            return false;
         }
 
         if (obj == this) {
-          return true;
+            return true;
         }
 
         return partitionTime == ((TopicPartitionMetadata) obj).partitionTime

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Objects;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -58,6 +59,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextImpl.BYTEARRAY_VALUE_SERIALIZER;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextImpl.BYTES_KEY_SERIALIZER;
 import static org.easymock.EasyMock.anyLong;
@@ -69,6 +72,7 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -566,6 +570,36 @@ public class ProcessorContextImplTest {
     @Test
     public void shouldMatchStreamTime() {
         assertEquals(STREAM_TIME, context.currentStreamTimeMs());
+    }
+
+    @Test
+    public void shouldAddAndGetProcessorKeyValue() {
+        context.addProcessorMetadataKeyValue("key1", 100L);
+        final Long value = context.getProcessorMetadataForKey("key1");
+        assertEquals(100L, value.longValue());
+
+        final Long noValue = context.getProcessorMetadataForKey("nokey");
+        assertNull(noValue);
+    }
+
+    @Test
+    public void shouldSetAndGetProcessorMetaData() {
+        final ProcessorMetadata emptyMetadata = ProcessorMetadata.emptyMetadata();
+        context.setProcessorMetadata(emptyMetadata);
+        assertEquals(emptyMetadata, context.getProcessorMetadata());
+
+        final ProcessorMetadata metadata = ProcessorMetadata.with(
+            mkMap(
+                mkEntry("key1", 10L),
+                mkEntry("key2", 100L)
+            )
+        );
+
+        context.setProcessorMetadata(metadata);
+        assertEquals(10L, context.getProcessorMetadataForKey("key1").longValue());
+        assertEquals(100L, context.getProcessorMetadataForKey("key2").longValue());
+
+        assertThrows(NullPointerException.class, () -> context.setProcessorMetadata(null));
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -574,20 +574,20 @@ public class ProcessorContextImplTest {
     @Test
     public void shouldAddAndGetProcessorKeyValue() {
         context.addProcessorMetadataKeyValue("key1", 100L);
-        final Long value = context.getProcessorMetadataForKey("key1");
+        final Long value = context.processorMetadataForKey("key1");
         assertEquals(100L, value.longValue());
 
-        final Long noValue = context.getProcessorMetadataForKey("nokey");
+        final Long noValue = context.processorMetadataForKey("nokey");
         assertNull(noValue);
     }
 
     @Test
     public void shouldSetAndGetProcessorMetaData() {
-        final ProcessorMetadata emptyMetadata = ProcessorMetadata.emptyMetadata();
+        final ProcessorMetadata emptyMetadata = new ProcessorMetadata();
         context.setProcessorMetadata(emptyMetadata);
         assertEquals(emptyMetadata, context.getProcessorMetadata());
 
-        final ProcessorMetadata metadata = ProcessorMetadata.with(
+        final ProcessorMetadata metadata = new ProcessorMetadata(
             mkMap(
                 mkEntry("key1", 10L),
                 mkEntry("key2", 100L)
@@ -595,8 +595,8 @@ public class ProcessorContextImplTest {
         );
 
         context.setProcessorMetadata(metadata);
-        assertEquals(10L, context.getProcessorMetadataForKey("key1").longValue());
-        assertEquals(100L, context.getProcessorMetadataForKey("key2").longValue());
+        assertEquals(10L, context.processorMetadataForKey("key1").longValue());
+        assertEquals(100L, context.processorMetadataForKey("key2").longValue());
 
         assertThrows(NullPointerException.class, () -> context.setProcessorMetadata(null));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.Objects;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -30,16 +31,16 @@ public class ProcessorMetadataTest {
 
     @Test
     public void shouldAddandGetKeyValueWithEmptyConstructor() {
-        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final ProcessorMetadata metadata = new ProcessorMetadata();
         final String key = "some_key";
         final long value = 100L;
 
-        metadata.addMetadata(key, value);
-        final Long actualValue =  metadata.getMetadata(key);
+        metadata.put(key, value);
+        final Long actualValue =  metadata.get(key);
 
         assertThat(actualValue, is(value));
 
-        final Long noValue = metadata.getMetadata("no_key");
+        final Long noValue = metadata.get("no_key");
         assertThat(noValue, is(nullValue()));
     }
 
@@ -49,103 +50,114 @@ public class ProcessorMetadataTest {
         map.put("key1", 1L);
         map.put("key2", 2L);
 
-        final ProcessorMetadata metadata = ProcessorMetadata.with(map);
+        final ProcessorMetadata metadata = new ProcessorMetadata(map);
 
-        final long value1 = metadata.getMetadata("key1");
+        final long value1 = metadata.get("key1");
         assertThat(value1, is(1L));
 
-        final long value2 = metadata.getMetadata("key2");
+        final long value2 = metadata.get("key2");
         assertThat(value2, is(2L));
 
-        final Long noValue = metadata.getMetadata("key3");
+        final Long noValue = metadata.get("key3");
         assertThat(noValue, is(nullValue()));
 
-        metadata.addMetadata("key3", 3L);
-        final long value3 = metadata.getMetadata("key3");
+        metadata.put("key3", 3L);
+        final long value3 = metadata.get("key3");
         assertThat(value3, is(3L));
     }
 
     @Test
     public void shouldSerializeAndDeserialize() {
-        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final ProcessorMetadata metadata = new ProcessorMetadata();
         final String key1 = "key1", key2 = "key2", key3 = "key3";
         final long value1 = 1L, value2 = 2L, value3 = 3L;
 
-        metadata.addMetadata(key1, value1);
-        metadata.addMetadata(key2, value2);
-        metadata.addMetadata(key3, value3);
+        metadata.put(key1, value1);
+        metadata.put(key2, value2);
+        metadata.put(key3, value3);
 
         final byte[] serialized = metadata.serialize();
         final ProcessorMetadata deserialized = ProcessorMetadata.deserialize(serialized);
 
-        assertThat(deserialized.getMetadata(key1), is(value1));
-        assertThat(deserialized.getMetadata(key2), is(value2));
-        assertThat(deserialized.getMetadata(key3), is(value3));
+        assertThat(deserialized.get(key1), is(value1));
+        assertThat(deserialized.get(key2), is(value2));
+        assertThat(deserialized.get(key3), is(value3));
     }
 
     @Test
     public void shouldDeserializeNull() {
         final ProcessorMetadata deserialized = ProcessorMetadata.deserialize(null);
-        assertThat(deserialized, is(ProcessorMetadata.emptyMetadata()));
+        assertThat(deserialized, is(new ProcessorMetadata()));
     }
 
     @Test
     public void shouldUpdate() {
-        final ProcessorMetadata emptyMeta = ProcessorMetadata.emptyMetadata();
+        final ProcessorMetadata emptyMeta = new ProcessorMetadata();
         emptyMeta.update(null);
 
-        assertThat(emptyMeta, is(ProcessorMetadata.emptyMetadata()));
+        assertThat(emptyMeta, is(new ProcessorMetadata()));
 
         {
             final Map<String, Long> map1 = new HashMap<>();
             map1.put("key1", 1L);
             map1.put("key2", 2L);
-            final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+            final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
             emptyMeta.update(metadata1);
-            assertThat(emptyMeta.getMetadata("key1"), is(1L));
-            assertThat(emptyMeta.getMetadata("key2"), is(2L));
+            assertThat(emptyMeta.get("key1"), is(1L));
+            assertThat(emptyMeta.get("key2"), is(2L));
         }
 
         {
             final Map<String, Long> map1 = new HashMap<>();
             map1.put("key1", 0L);
             map1.put("key2", 1L);
-            final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+            final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
             emptyMeta.update(metadata1);
-            assertThat(emptyMeta.getMetadata("key1"), is(1L));
-            assertThat(emptyMeta.getMetadata("key2"), is(2L));
+            assertThat(emptyMeta.get("key1"), is(1L));
+            assertThat(emptyMeta.get("key2"), is(2L));
         }
 
         {
             final Map<String, Long> map1 = new HashMap<>();
             map1.put("key1", 2L);
             map1.put("key2", 3L);
-            final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+            final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
             emptyMeta.update(metadata1);
-            assertThat(emptyMeta.getMetadata("key1"), is(2L));
-            assertThat(emptyMeta.getMetadata("key2"), is(3L));
+            assertThat(emptyMeta.get("key1"), is(2L));
+            assertThat(emptyMeta.get("key2"), is(3L));
         }
     }
 
     @Test
     public void shouldUpdateCommitFlag() {
-        final ProcessorMetadata emptyMeta = ProcessorMetadata.emptyMetadata();
-        assertFalse(emptyMeta.needCommit());
+        final ProcessorMetadata emptyMeta = new ProcessorMetadata();
+        assertFalse(emptyMeta.needsCommit());
 
         emptyMeta.setNeedsCommit(true);
-        assertTrue(emptyMeta.needCommit());
+        assertTrue(emptyMeta.needsCommit());
 
         emptyMeta.setNeedsCommit(false);
-        assertFalse(emptyMeta.needCommit());
+        assertFalse(emptyMeta.needsCommit());
 
-        emptyMeta.addMetadata("key1", 1L);
-        assertTrue(emptyMeta.needCommit());
+        emptyMeta.put("key1", 1L);
+        assertTrue(emptyMeta.needsCommit());
 
         final Map<String, Long> map1 = new HashMap<>();
         map1.put("key1", 2L);
         map1.put("key2", 3L);
-        final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+        final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
         emptyMeta.update(metadata1);
-        assertTrue(emptyMeta.needCommit());
+        assertTrue(emptyMeta.needsCommit());
+    }
+
+    @Test
+    public void shouldNotUseCommitFlagForHashcodeAndEquals() {
+        final ProcessorMetadata metadata1 = new ProcessorMetadata();
+        metadata1.setNeedsCommit(true);
+        final ProcessorMetadata metadata2 = new ProcessorMetadata();
+        metadata2.setNeedsCommit(false);
+
+        assertEquals(metadata1, metadata2);
+        assertEquals(metadata1.hashCode(), metadata2.hashCode());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ProcessorMetadataTest {
+
+    @Test
+    public void shouldAddandGetKeyValueWithEmptyConstructor() {
+        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final String key = "some_key";
+        final long value = 100L;
+
+        metadata.addMetadata(key, value);
+        final Long actualValue =  metadata.getMetadata(key);
+
+        assertThat(actualValue, is(value));
+
+        final Long noValue = metadata.getMetadata("no_key");
+        assertThat(noValue, is(nullValue()));
+    }
+
+    @Test
+    public void shouldAddandGetKeyValueWithExistingMeta() {
+        final Map<String, Long> map = new HashMap<>();
+        map.put("key1", 1L);
+        map.put("key2", 2L);
+
+        final ProcessorMetadata metadata = ProcessorMetadata.with(map);
+
+        final long value1 = metadata.getMetadata("key1");
+        assertThat(value1, is(1L));
+
+        final long value2 = metadata.getMetadata("key2");
+        assertThat(value2, is(2L));
+
+        final Long noValue = metadata.getMetadata("key3");
+        assertThat(noValue, is(nullValue()));
+
+        metadata.addMetadata("key3", 3L);
+        final long value3 = metadata.getMetadata("key3");
+        assertThat(value3, is(3L));
+    }
+
+    @Test
+    public void shouldSerializeAndDeserialize() {
+        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final String key1 = "key1", key2 = "key2", key3 = "key3";
+        final long value1 = 1L, value2 = 2L, value3 = 3L;
+
+        metadata.addMetadata(key1, value1);
+        metadata.addMetadata(key2, value2);
+        metadata.addMetadata(key3, value3);
+
+        final byte[] serialized = metadata.serialize();
+        final ProcessorMetadata deserialized = ProcessorMetadata.deserialize(serialized);
+
+        assertThat(deserialized.getMetadata(key1), is(value1));
+        assertThat(deserialized.getMetadata(key2), is(value2));
+        assertThat(deserialized.getMetadata(key3), is(value3));
+    }
+
+    @Test
+    public void shouldDeserializeNull() {
+        final ProcessorMetadata deserialized = ProcessorMetadata.deserialize(null);
+        assertThat(deserialized, is(ProcessorMetadata.emptyMetadata()));
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ProcessorMetadataTest {
 
@@ -87,4 +89,63 @@ public class ProcessorMetadataTest {
         assertThat(deserialized, is(ProcessorMetadata.emptyMetadata()));
     }
 
+    @Test
+    public void shouldUpdate() {
+        final ProcessorMetadata emptyMeta = ProcessorMetadata.emptyMetadata();
+        emptyMeta.update(null);
+
+        assertThat(emptyMeta, is(ProcessorMetadata.emptyMetadata()));
+
+        {
+            final Map<String, Long> map1 = new HashMap<>();
+            map1.put("key1", 1L);
+            map1.put("key2", 2L);
+            final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+            emptyMeta.update(metadata1);
+            assertThat(emptyMeta.getMetadata("key1"), is(1L));
+            assertThat(emptyMeta.getMetadata("key2"), is(2L));
+        }
+
+        {
+            final Map<String, Long> map1 = new HashMap<>();
+            map1.put("key1", 0L);
+            map1.put("key2", 1L);
+            final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+            emptyMeta.update(metadata1);
+            assertThat(emptyMeta.getMetadata("key1"), is(1L));
+            assertThat(emptyMeta.getMetadata("key2"), is(2L));
+        }
+
+        {
+            final Map<String, Long> map1 = new HashMap<>();
+            map1.put("key1", 2L);
+            map1.put("key2", 3L);
+            final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+            emptyMeta.update(metadata1);
+            assertThat(emptyMeta.getMetadata("key1"), is(2L));
+            assertThat(emptyMeta.getMetadata("key2"), is(3L));
+        }
+    }
+
+    @Test
+    public void shouldUpdateCommitFlag() {
+        final ProcessorMetadata emptyMeta = ProcessorMetadata.emptyMetadata();
+        assertFalse(emptyMeta.needCommit());
+
+        emptyMeta.setNeedsCommit(true);
+        assertTrue(emptyMeta.needCommit());
+
+        emptyMeta.setNeedsCommit(false);
+        assertFalse(emptyMeta.needCommit());
+
+        emptyMeta.addMetadata("key1", 1L);
+        assertTrue(emptyMeta.needCommit());
+
+        final Map<String, Long> map1 = new HashMap<>();
+        map1.put("key1", 2L);
+        map1.put("key2", 3L);
+        final ProcessorMetadata metadata1 = ProcessorMetadata.with(map1);
+        emptyMeta.update(metadata1);
+        assertTrue(emptyMeta.needCommit());
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.HashMap;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import static org.apache.kafka.streams.processor.internals.TopicPartitionMetadata.with;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TopicPartitionMetadataTest {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import org.junit.Test;
+
+import static org.apache.kafka.streams.processor.internals.TopicPartitionMetadata.with;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TopicPartitionMetadataTest {
+
+    @Test
+    public void shouldGetPartitonTimeAndProcessorMeta() {
+        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final String key = "some_key";
+        final long value = 100L;
+        metadata.addMetadata(key, value);
+
+        final TopicPartitionMetadata topicMeta = with(100L, metadata);
+
+        assertThat(topicMeta.partitionTime(), is(100L));
+        assertThat(topicMeta.processorMetadata(), is(metadata));
+    }
+
+    @Test
+    public void shouldDecodeVersionOne() {
+        final byte[] serialized = ByteBuffer.allocate(Byte.BYTES + Long.BYTES)
+            .put((byte) 1)
+            .putLong(100L)
+            .array();
+        final String serializedString = Base64.getEncoder().encodeToString(serialized);
+
+        final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
+
+        assertThat(topicMeta.partitionTime(), is(100L));
+        assertThat(topicMeta.processorMetadata(), is(ProcessorMetadata.emptyMetadata()));
+    }
+
+    @Test
+    public void shouldEncodeDecodeVersionTwo() {
+        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final String key = "some_key";
+        final long value = 100L;
+        metadata.addMetadata(key, value);
+
+        final TopicPartitionMetadata expected = with(100L, metadata);
+        final String serializedString = expected.encode();
+        final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
+
+        assertThat(topicMeta, is(expected));
+    }
+
+    @Test
+    public void shouldEncodeDecodeNullMetaVersionTwo() {
+        final TopicPartitionMetadata expected = with(100L, ProcessorMetadata.emptyMetadata());
+        final String serializedString = expected.encode();
+        final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
+
+        assertThat(topicMeta, is(expected));
+    }
+
+    @Test
+    public void shouldDecodeNullVersionTwo() {
+        final TopicPartitionMetadata expected = with(RecordQueue.UNKNOWN, ProcessorMetadata.emptyMetadata());
+        final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(null);
+
+        assertThat(topicMeta, is(expected));
+    }
+
+    @Test
+    public void shouldDecodeEmptyStringVersionTwo() {
+        final TopicPartitionMetadata expected = with(RecordQueue.UNKNOWN, ProcessorMetadata.emptyMetadata());
+        final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode("");
+
+        assertThat(topicMeta, is(expected));
+    }
+
+    @Test
+    public void shouldReturnUnknownTimestampIfUnknownVersion() {
+        final byte[] emptyMessage = {TopicPartitionMetadata.LATEST_MAGIC_BYTE + 1};
+        final String encodedString = Base64.getEncoder().encodeToString(emptyMessage);
+
+        final TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(encodedString);
+
+        assertThat(decoded.partitionTime(), is(RecordQueue.UNKNOWN));
+        assertThat(decoded.processorMetadata(), is(ProcessorMetadata.emptyMetadata()));
+    }
+
+    @Test
+    public void shouldReturnUnknownTimestampIfInvalidMetadata() {
+        final String invalidBase64String = "{}";
+
+        final TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(invalidBase64String);
+
+        assertThat(decoded.partitionTime(), is(RecordQueue.UNKNOWN));
+        assertThat(decoded.processorMetadata(), is(ProcessorMetadata.emptyMetadata()));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer;
 import java.util.Base64;
 import org.junit.Test;
 
-import static org.apache.kafka.streams.processor.internals.TopicPartitionMetadata.with;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -28,12 +27,12 @@ public class TopicPartitionMetadataTest {
 
     @Test
     public void shouldGetPartitonTimeAndProcessorMeta() {
-        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final ProcessorMetadata metadata = new ProcessorMetadata();
         final String key = "some_key";
         final long value = 100L;
-        metadata.addMetadata(key, value);
+        metadata.put(key, value);
 
-        final TopicPartitionMetadata topicMeta = with(100L, metadata);
+        final TopicPartitionMetadata topicMeta = new TopicPartitionMetadata(100L, metadata);
 
         assertThat(topicMeta.partitionTime(), is(100L));
         assertThat(topicMeta.processorMetadata(), is(metadata));
@@ -50,17 +49,17 @@ public class TopicPartitionMetadataTest {
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
 
         assertThat(topicMeta.partitionTime(), is(100L));
-        assertThat(topicMeta.processorMetadata(), is(ProcessorMetadata.emptyMetadata()));
+        assertThat(topicMeta.processorMetadata(), is(new ProcessorMetadata()));
     }
 
     @Test
     public void shouldEncodeDecodeVersionTwo() {
-        final ProcessorMetadata metadata = ProcessorMetadata.emptyMetadata();
+        final ProcessorMetadata metadata = new ProcessorMetadata();
         final String key = "some_key";
         final long value = 100L;
-        metadata.addMetadata(key, value);
+        metadata.put(key, value);
 
-        final TopicPartitionMetadata expected = with(100L, metadata);
+        final TopicPartitionMetadata expected = new TopicPartitionMetadata(100L, metadata);
         final String serializedString = expected.encode();
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
 
@@ -68,25 +67,17 @@ public class TopicPartitionMetadataTest {
     }
 
     @Test
-    public void shouldEncodeDecodeNullMetaVersionTwo() {
-        final TopicPartitionMetadata expected = with(100L, ProcessorMetadata.emptyMetadata());
+    public void shouldEncodeDecodeEmptyMetaVersionTwo() {
+        final TopicPartitionMetadata expected = new TopicPartitionMetadata(100L, new ProcessorMetadata());
         final String serializedString = expected.encode();
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
-
-        assertThat(topicMeta, is(expected));
-    }
-
-    @Test
-    public void shouldDecodeNullVersionTwo() {
-        final TopicPartitionMetadata expected = with(RecordQueue.UNKNOWN, ProcessorMetadata.emptyMetadata());
-        final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(null);
 
         assertThat(topicMeta, is(expected));
     }
 
     @Test
     public void shouldDecodeEmptyStringVersionTwo() {
-        final TopicPartitionMetadata expected = with(RecordQueue.UNKNOWN, ProcessorMetadata.emptyMetadata());
+        final TopicPartitionMetadata expected = new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata());
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode("");
 
         assertThat(topicMeta, is(expected));
@@ -100,7 +91,7 @@ public class TopicPartitionMetadataTest {
         final TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(encodedString);
 
         assertThat(decoded.partitionTime(), is(RecordQueue.UNKNOWN));
-        assertThat(decoded.processorMetadata(), is(ProcessorMetadata.emptyMetadata()));
+        assertThat(decoded.processorMetadata(), is(new ProcessorMetadata()));
     }
 
     @Test
@@ -110,6 +101,6 @@ public class TopicPartitionMetadataTest {
         final TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(invalidBase64String);
 
         assertThat(decoded.partitionTime(), is(RecordQueue.UNKNOWN));
-        assertThat(decoded.processorMetadata(), is(ProcessorMetadata.emptyMetadata()));
+        assertThat(decoded.processorMetadata(), is(new ProcessorMetadata()));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
@@ -53,12 +53,12 @@ public class MockInternalNewProcessorContext<KOut, VOut> extends MockProcessorCo
     private ProcessorMetadata processorMetadata;
 
     public MockInternalNewProcessorContext() {
-        processorMetadata = ProcessorMetadata.emptyMetadata();
+        processorMetadata = new ProcessorMetadata();
     }
 
     public MockInternalNewProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
         super(config, taskId, stateDir);
-        processorMetadata = ProcessorMetadata.emptyMetadata();
+        processorMetadata = new ProcessorMetadata();
     }
 
     @Override
@@ -214,12 +214,12 @@ public class MockInternalNewProcessorContext<KOut, VOut> extends MockProcessorCo
 
     @Override
     public void addProcessorMetadataKeyValue(final String key, final long value) {
-        processorMetadata.addMetadata(key, value);
+        processorMetadata.put(key, value);
     }
 
     @Override
-    public Long getProcessorMetadataForKey(final String key) {
-        return processorMetadata.getMetadata(key);
+    public Long processorMetadataForKey(final String key) {
+        return processorMetadata.get(key);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalNewProcessorContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import java.util.Objects;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
@@ -26,6 +27,7 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.api.MockProcessorContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorMetadata;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
@@ -48,12 +50,15 @@ public class MockInternalNewProcessorContext<KOut, VOut> extends MockProcessorCo
 
     private long timestamp = 0;
     private Headers headers = new RecordHeaders();
+    private ProcessorMetadata processorMetadata;
 
     public MockInternalNewProcessorContext() {
+        processorMetadata = ProcessorMetadata.emptyMetadata();
     }
 
     public MockInternalNewProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
         super(config, taskId, stateDir);
+        processorMetadata = ProcessorMetadata.emptyMetadata();
     }
 
     @Override
@@ -205,5 +210,26 @@ public class MockInternalNewProcessorContext<KOut, VOut> extends MockProcessorCo
     @Override
     public String changelogFor(final String storeName) {
         return "mock-changelog";
+    }
+
+    @Override
+    public void addProcessorMetadataKeyValue(final String key, final long value) {
+        processorMetadata.addMetadata(key, value);
+    }
+
+    @Override
+    public Long getProcessorMetadataForKey(final String key) {
+        return processorMetadata.getMetadata(key);
+    }
+
+    @Override
+    public void setProcessorMetadata(final ProcessorMetadata metadata) {
+        Objects.requireNonNull(metadata);
+        processorMetadata = metadata;
+    }
+
+    @Override
+    public ProcessorMetadata getProcessorMetadata() {
+        return processorMetadata;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
@@ -54,12 +54,12 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
     private ProcessorMetadata processorMetadata;
 
     public MockInternalProcessorContext() {
-        processorMetadata = ProcessorMetadata.emptyMetadata();
+        processorMetadata = new ProcessorMetadata();
     }
 
     public MockInternalProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
         super(config, taskId, stateDir);
-        processorMetadata = ProcessorMetadata.emptyMetadata();
+        processorMetadata = new ProcessorMetadata();
     }
 
     @Override
@@ -189,12 +189,12 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
 
     @Override
     public void addProcessorMetadataKeyValue(final String key, final long value) {
-        processorMetadata.addMetadata(key, value);
+        processorMetadata.put(key, value);
     }
 
     @Override
-    public Long getProcessorMetadataForKey(final String key) {
-        return processorMetadata.getMetadata(key);
+    public Long processorMetadataForKey(final String key) {
+        return processorMetadata.get(key);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import java.util.Objects;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.MockProcessorContext;
@@ -26,6 +27,7 @@ import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorMetadata;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
@@ -49,12 +51,15 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
     private RecordCollector recordCollector;
     private long currentSystemTimeMs;
     private TaskType taskType = TaskType.ACTIVE;
+    private ProcessorMetadata processorMetadata;
 
     public MockInternalProcessorContext() {
+        processorMetadata = ProcessorMetadata.emptyMetadata();
     }
 
     public MockInternalProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
         super(config, taskId, stateDir);
+        processorMetadata = ProcessorMetadata.emptyMetadata();
     }
 
     @Override
@@ -180,5 +185,26 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
     @Override
     public String changelogFor(final String storeName) {
         return "mock-changelog";
+    }
+
+    @Override
+    public void addProcessorMetadataKeyValue(final String key, final long value) {
+        processorMetadata.addMetadata(key, value);
+    }
+
+    @Override
+    public Long getProcessorMetadataForKey(final String key) {
+        return processorMetadata.getMetadata(key);
+    }
+
+    @Override
+    public void setProcessorMetadata(final ProcessorMetadata metadata) {
+        Objects.requireNonNull(metadata);
+        processorMetadata = metadata;
+    }
+
+    @Override
+    public ProcessorMetadata getProcessorMetadata() {
+        return processorMetadata;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.util.ArrayList;
@@ -82,5 +83,12 @@ public class MockProcessor<K, V> extends org.apache.kafka.streams.processor.Abst
 
     public ArrayList<KeyValueTimestamp<K, V>> processed() {
         return delegate.processed();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void addProcessorMetadata(final String key, final long value) {
+        if (context instanceof InternalProcessorContext) {
+            ((InternalProcessorContext<K, V>) context).addProcessorMetadataKeyValue(key, value);
+        }
     }
 }


### PR DESCRIPTION
Add processor metadata to be committed with offset to broker. Adding this so that we can store last processed window time gracefully.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
