### PR TITLE
MINOR: Do not throw exception when InterBrokerSecurityProtocolProp value is empty string

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1928,9 +1928,11 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
   private def getInterBrokerListenerNameAndSecurityProtocol: (ListenerName, SecurityProtocol) = {
     Option(getString(KafkaConfig.InterBrokerListenerNameProp)) match {
-      case Some(_) if originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) =>
-        throw new ConfigException(s"Only one of ${KafkaConfig.InterBrokerListenerNameProp} and " +
-          s"${KafkaConfig.InterBrokerSecurityProtocolProp} should be set.")
+      case Some(_) if originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) &&
+        getString(KafkaConfig.InterBrokerSecurityProtocolProp).nonEmpty =>
+          throw new ConfigException(s"Only one of ${KafkaConfig.InterBrokerListenerNameProp} : " +
+            s"${getString(KafkaConfig.InterBrokerListenerNameProp)} and ${KafkaConfig.InterBrokerSecurityProtocolProp} : " +
+              s"${getString(KafkaConfig.InterBrokerSecurityProtocolProp)} should be set.")
       case Some(name) =>
         val listenerName = ListenerName.normalised(name)
         val securityProtocol = effectiveListenerSecurityProtocolMap.getOrElse(listenerName,

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1928,12 +1928,11 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
   private def getInterBrokerListenerNameAndSecurityProtocol: (ListenerName, SecurityProtocol) = {
     Option(getString(KafkaConfig.InterBrokerListenerNameProp)) match {
-      case Some(_) if originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) &&
-        getString(KafkaConfig.InterBrokerSecurityProtocolProp).nonEmpty =>
-          throw new ConfigException(s"Only one of ${KafkaConfig.InterBrokerListenerNameProp} : " +
-            s"${getString(KafkaConfig.InterBrokerListenerNameProp)} and ${KafkaConfig.InterBrokerSecurityProtocolProp} : " +
-              s"${getString(KafkaConfig.InterBrokerSecurityProtocolProp)} should be set.")
       case Some(name) =>
+        if (originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) &&
+          getString(KafkaConfig.InterBrokerSecurityProtocolProp).nonEmpty)
+            throw new ConfigException(s"Only one of ${KafkaConfig.InterBrokerListenerNameProp} : ${name}  and " +
+              s"${KafkaConfig.InterBrokerSecurityProtocolProp} : ${getString(KafkaConfig.InterBrokerSecurityProtocolProp)} should be set.")
         val listenerName = ListenerName.normalised(name)
         val securityProtocol = effectiveListenerSecurityProtocolMap.getOrElse(listenerName,
           throw new ConfigException(s"Listener with name ${listenerName.value} defined in " +


### PR DESCRIPTION
When we set broker config as follows
```
security.inter.broker.protocol=
inter.broker.listener.name=INNER
```
and restart broker, the exception `org.apache.kafka.common.config.ConfigException: Only one of inter.broker.listener.name and security.inter.broker.protocol should be set.` will be throw and server start failed.

This pr will 
(1) add a nonEmpty check for value of InterBrokerSecurityProtocolProp to make through empty value case
(2) detailed info When exception throw

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
