### PR TITLE
[KAFKA-13687]  Allowing dumping logs for a small segment

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -446,6 +446,14 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     /**
+     * Allows to limit the batches on the file record in bytes
+     */
+    public static FileRecords open(File file, int end) throws IOException {
+        FileChannel channel = openChannel(file, false, false, 0, false);
+        return new FileRecords(file, channel, 0, end, false);
+    }
+
+    /**
      * Open a channel for the given file
      * For windows NTFS and some old LINUX file system, set preallocate to true and initFileSize
      * with one value (for example 512 * 1025 *1024 ) can improve the kafka produce performance.


### PR DESCRIPTION
### Summary
This PR allows to limit the output batches while they are inspected via the `kafka-dump-log.sh`  script.

The idea is to take samples from the logsegments without affecting a production cluster  as the current script will read the whole files, this could create issues in term of page.

More information can be found in the ticket [here](https://issues.apache.org/jira/browse/KAFKA-13687)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

