### PR TITLE
KAFKA-13706: remove closed connections from MockSelector.ready

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -83,6 +83,7 @@ public class MockSelector implements Selectable {
 
         removeSendsForNode(id, completedSends);
         removeSendsForNode(id, initiatedSends);
+        ready.remove(id);
 
         for (int i = 0; i < this.connected.size(); i++) {
             if (this.connected.get(i).equals(id)) {


### PR DESCRIPTION
On connection close, remove closed connection from MockSelector.ready

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
