### PR TITLE
KAFKA-13707: unify the naming convention of in-flight

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -672,7 +672,7 @@ public class NetworkClient implements KafkaClient {
         List<Node> nodes = this.metadataUpdater.fetchNodes();
         if (nodes.isEmpty())
             throw new IllegalStateException("There are no nodes in the Kafka cluster");
-        int inflight = Integer.MAX_VALUE;
+        int inFlight = Integer.MAX_VALUE;
 
         Node foundConnecting = null;
         Node foundCanConnect = null;
@@ -683,14 +683,14 @@ public class NetworkClient implements KafkaClient {
             int idx = (offset + i) % nodes.size();
             Node node = nodes.get(idx);
             if (canSendRequest(node.idString(), now)) {
-                int currInflight = this.inFlightRequests.count(node.idString());
-                if (currInflight == 0) {
+                int currInFlight = this.inFlightRequests.count(node.idString());
+                if (currInFlight == 0) {
                     // if we find an established connection with no in-flight requests we can stop right away
                     log.trace("Found least loaded node {} connected with no in-flight requests", node);
                     return node;
-                } else if (currInflight < inflight) {
+                } else if (currInFlight < inFlight) {
                     // otherwise if this is the best we have found so far, record that
-                    inflight = currInflight;
+                    inFlight = currInFlight;
                     foundReady = node;
                 }
             } else if (connectionStates.isPreparingConnection(node.idString())) {
@@ -710,7 +710,7 @@ public class NetworkClient implements KafkaClient {
         // We prefer established connections if possible. Otherwise, we will wait for connections
         // which are being established before connecting to new nodes.
         if (foundReady != null) {
-            log.trace("Found least loaded node {} with {} inflight requests", foundReady, inflight);
+            log.trace("Found least loaded node {} with {} in-flight requests", foundReady, inFlight);
             return foundReady;
         } else if (foundConnecting != null) {
             log.trace("Found least loaded connecting node {}", foundConnecting);
@@ -783,7 +783,7 @@ public class NetworkClient implements KafkaClient {
     }
 
     /**
-     * Iterate over all the inflight requests and expire any requests that have exceeded the configured requestTimeout.
+     * Iterate over all the in-flight requests and expire any requests that have exceeded the configured requestTimeout.
      * The connection to the node associated with the request will be terminated and will be treated as a disconnection.
      *
      * @param responses The list of responses to update

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -64,7 +64,7 @@ public final class Heartbeat {
         pollTimer.reset(maxPollIntervalMs);
     }
 
-    boolean hasInflight() {
+    boolean hasInFlight() {
         return heartbeatInFlight;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -442,7 +442,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
     // visible for testing
     Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
-        int maxInflightRequests = producerConfig.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
+        int maxInFlightRequests = producerConfig.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
         int requestTimeoutMs = producerConfig.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
         ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(producerConfig, time, logContext);
         ProducerMetrics metricsRegistry = new ProducerMetrics(this.metrics);
@@ -452,7 +452,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         this.metrics, time, "producer", channelBuilder, logContext),
                 metadata,
                 clientId,
-                maxInflightRequests,
+                maxInFlightRequests,
                 producerConfig.getLong(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG),
                 producerConfig.getLong(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
                 producerConfig.getInt(ProducerConfig.SEND_BUFFER_CONFIG),
@@ -471,7 +471,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 client,
                 metadata,
                 this.accumulator,
-                maxInflightRequests == 1,
+                maxInFlightRequests == 1,
                 producerConfig.getInt(ProducerConfig.MAX_REQUEST_SIZE_CONFIG),
                 acks,
                 producerConfig.getInt(ProducerConfig.RETRIES_CONFIG),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -201,7 +201,7 @@ public final class ProducerBatch {
     /**
      * Finalize the state of a batch. Final state, once set, is immutable. This function may be called
      * once or twice on a batch. It may be called twice if
-     * 1. An inflight batch expires before a response from the broker is received. The batch's final
+     * 1. An in-flight batch expires before a response from the broker is received. The batch's final
      * state is set to FAILED. But it could succeed on the broker and second time around batch.done() may
      * try to set SUCCEEDED final state.
      * 2. If a transaction abortion happens or if the producer is closed forcefully, the final state is

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -392,8 +392,8 @@ public final class RecordAccumulator {
             // The incoming batch can't be inserted at the front of the queue without violating the sequence ordering.
             // This means that the incoming batch should be placed somewhere further back.
             // We need to find the right place for the incoming batch and insert it there.
-            // We will only enter this branch if we have multiple inflights sent to different brokers and we need to retry
-            // the inflight batches.
+            // We will only enter this branch if we have multiple in-flights sent to different brokers and we need to retry
+            // the in-flight batches.
             //
             // Since we reenqueue exactly one batch a time and ensure that the queue is ordered by sequence always, it
             // is a simple linear scan of a subset of the in flight batches to find the right place in the queue each time.
@@ -514,7 +514,7 @@ public final class RecordAccumulator {
                 return true;
 
             if (!first.hasSequence()) {
-                if (transactionManager.hasInflightBatches(tp) && transactionManager.hasStaleProducerIdAndEpoch(tp)) {
+                if (transactionManager.hasInFlightBatches(tp) && transactionManager.hasStaleProducerIdAndEpoch(tp)) {
                     // Don't drain any new batches while the partition has in-flight batches with a different epoch
                     // and/or producer ID. Otherwise, a batch with a new epoch and sequence number
                     // 0 could be written before earlier batches complete, which would cause out of sequence errors

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -101,7 +101,7 @@ public class InFlightRequestsTest {
     }
 
     @Test
-    public void testCompleteNextThrowsIfNoInflights() {
+    public void testCompleteNextThrowsIfNoInFlights() {
         assertThrows(IllegalStateException.class, () -> inFlightRequests.completeNext(dest));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -850,7 +850,7 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> env.kafkaClient().inFlightRequestCount() == 1,
                 "Failed awaiting next CreateTopics request");
 
-            // Advance time past the default api timeout to time out the inflight request
+            // Advance time past the default api timeout to time out the in-flight request
             time.sleep(defaultApiTimeout + 1);
 
             assertNull(result.values().get("topic1").get());
@@ -1083,7 +1083,7 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> env.kafkaClient().inFlightRequestCount() == 1,
                 "Failed awaiting next DeleteTopics request");
 
-            // Advance time past the default api timeout to time out the inflight request
+            // Advance time past the default api timeout to time out the in-flight request
             time.sleep(defaultApiTimeout + 1);
 
             assertNull(result.topicNameValues().get("topic1").get());
@@ -1120,7 +1120,7 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> env.kafkaClient().inFlightRequestCount() == 1,
                     "Failed awaiting next DeleteTopics request");
 
-            // Advance time past the default api timeout to time out the inflight request
+            // Advance time past the default api timeout to time out the in-flight request
             time.sleep(defaultApiTimeout + 1);
 
             assertNull(resultIds.topicIdValues().get(topicId1).get());
@@ -1988,7 +1988,7 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> env.kafkaClient().inFlightRequestCount() == 1,
                 "Failed awaiting next CreatePartitions request");
 
-            // Advance time past the default api timeout to time out the inflight request
+            // Advance time past the default api timeout to time out the in-flight request
             time.sleep(defaultApiTimeout + 1);
 
             assertNull(result.values().get("topic1").get());
@@ -5231,10 +5231,10 @@ public class KafkaAdminClientTest {
 
             // Since api timeout bound is not hit, AdminClient should retry
             TestUtils.waitForCondition(() -> {
-                boolean hasInflightRequests = env.kafkaClient().hasInFlightRequests();
-                if (!hasInflightRequests)
+                boolean hasInFlightRequests = env.kafkaClient().hasInFlightRequests();
+                if (!hasInFlightRequests)
                     time.sleep(retryBackoffMs);
-                return hasInflightRequests;
+                return hasInFlightRequests;
             }, "Timed out waiting for Metadata request to be sent");
             time.sleep(requestTimeoutMs + 1);
 
@@ -5469,7 +5469,7 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> env.kafkaClient().inFlightRequestCount() == 1,
                 "Failed awaiting request");
 
-            // Advance time past the default api timeout to time out the inflight request
+            // Advance time past the default api timeout to time out the in-flight request
             time.sleep(defaultApiTimeout + 1);
 
             TestUtils.assertFutureThrows(result.values().get(tpr1), ApiException.class);
@@ -5670,7 +5670,7 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> env.kafkaClient().inFlightRequestCount() == 1,
                 "Failed awaiting request");
 
-            // Advance time past the default api timeout to time out the inflight request
+            // Advance time past the default api timeout to time out the in-flight request
             time.sleep(defaultApiTimeout + 1);
 
             TestUtils.assertFutureThrows(result.descriptions().get(0), ApiException.class);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -831,7 +831,7 @@ public class AbstractCoordinatorTest {
         mockTime.sleep(HEARTBEAT_INTERVAL_MS);
         TestUtils.waitForCondition(() -> !mockClient.requests().isEmpty(), 2000,
                 "The heartbeat request was not sent");
-        assertTrue(coordinator.heartbeat().hasInflight());
+        assertTrue(coordinator.heartbeat().hasInFlight());
 
         mockClient.respond(heartbeatResponse(Errors.REBALANCE_IN_PROGRESS));
         assertEquals(currGen, coordinator.generation());
@@ -849,7 +849,7 @@ public class AbstractCoordinatorTest {
 
         TestUtils.waitForCondition(() -> !mockClient.requests().isEmpty(), 2000,
             "The heartbeat request was not sent");
-        assertTrue(coordinator.heartbeat().hasInflight());
+        assertTrue(coordinator.heartbeat().hasInFlight());
 
         // change the generation
         final AbstractCoordinator.Generation newGen = new AbstractCoordinator.Generation(
@@ -863,7 +863,7 @@ public class AbstractCoordinatorTest {
         // the heartbeat error code should be ignored
         TestUtils.waitForCondition(() -> {
             coordinator.pollHeartbeat(mockTime.milliseconds());
-            return !coordinator.heartbeat().hasInflight();
+            return !coordinator.heartbeat().hasInFlight();
         }, 2000,
             "The heartbeat response was not received");
 
@@ -883,7 +883,7 @@ public class AbstractCoordinatorTest {
 
         TestUtils.waitForCondition(() -> !mockClient.requests().isEmpty(), 2000,
             "The heartbeat request was not sent");
-        assertTrue(coordinator.heartbeat().hasInflight());
+        assertTrue(coordinator.heartbeat().hasInFlight());
 
         // change the generation
         final AbstractCoordinator.Generation newGen = new AbstractCoordinator.Generation(
@@ -897,7 +897,7 @@ public class AbstractCoordinatorTest {
         // the heartbeat error code should be ignored
         TestUtils.waitForCondition(() -> {
             coordinator.pollHeartbeat(mockTime.milliseconds());
-            return !coordinator.heartbeat().hasInflight();
+            return !coordinator.heartbeat().hasInFlight();
         }, 2000,
             "The heartbeat response was not received");
 
@@ -918,7 +918,7 @@ public class AbstractCoordinatorTest {
         TestUtils.waitForCondition(() -> !mockClient.requests().isEmpty(), 2000,
             "The heartbeat request was not sent");
 
-        assertTrue(coordinator.heartbeat().hasInflight());
+        assertTrue(coordinator.heartbeat().hasInFlight());
 
         mockClient.respond(heartbeatResponse(Errors.REBALANCE_IN_PROGRESS));
 
@@ -926,7 +926,7 @@ public class AbstractCoordinatorTest {
 
         TestUtils.waitForCondition(() -> {
             coordinator.ensureActiveGroup(new MockTime(1L).timer(100L));
-            return !coordinator.heartbeat().hasInflight();
+            return !coordinator.heartbeat().hasInFlight();
         },
             2000,
             "The heartbeat response was not received");
@@ -953,7 +953,7 @@ public class AbstractCoordinatorTest {
 
         TestUtils.waitForCondition(() -> !mockClient.requests().isEmpty(), 2000,
             "The heartbeat request was not sent");
-        assertTrue(coordinator.heartbeat().hasInflight());
+        assertTrue(coordinator.heartbeat().hasInFlight());
 
         // change the generation
         final AbstractCoordinator.Generation newGen = new AbstractCoordinator.Generation(
@@ -967,7 +967,7 @@ public class AbstractCoordinatorTest {
         // the heartbeat error code should be ignored
         TestUtils.waitForCondition(() -> {
             coordinator.pollHeartbeat(mockTime.milliseconds());
-            return !coordinator.heartbeat().hasInflight();
+            return !coordinator.heartbeat().hasInFlight();
         }, 2000,
             "The heartbeat response was not received");
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -187,7 +187,7 @@ public class ConsumerNetworkClientTest {
     }
 
     @Test
-    public void blockOnlyForRetryBackoffIfNoInflightRequests() {
+    public void blockOnlyForRetryBackoffIfNoInFlightRequests() {
         long retryBackoffMs = 100L;
 
         NetworkClient mockNetworkClient = mock(NetworkClient.class);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -4433,7 +4433,7 @@ public class FetcherTest {
     }
 
     @Test
-    public void testOffsetValidationHandlesSeekWithInflightOffsetForLeaderRequest() {
+    public void testOffsetValidationHandlesSeekWithInFlightOffsetForLeaderRequest() {
         buildFetcher();
         assignFromUser(singleton(tp0));
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -361,7 +361,7 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testInflightRequestsAndIdempotenceForIdempotentProducers() {
+    public void testInFlightRequestsAndIdempotenceForIdempotentProducers() {
         Properties baseProps = new Properties() {{
                 setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
                 setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
@@ -982,7 +982,7 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testFlushCompleteSendOfInflightBatches() {
+    public void testFlushCompleteSendOfInFlightBatches() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
         // only test in idempotence disabled producer for simplicity

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -150,7 +150,7 @@ public class MockProducerTest {
     }
 
     @Test
-    public void shouldThrowOnBeginTransactionsIfTransactionInflight() {
+    public void shouldThrowOnBeginTransactionsIfTransactionInFlight() {
         buildMockProducer(true);
         producer.initTransactions();
         producer.beginTransaction();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -887,7 +887,7 @@ public class RecordAccumulatorTest {
         assertTrue(drained.isEmpty());
         //assertTrue(accum.soonToExpireInFlightBatches().isEmpty());
 
-        // advanced clock and send one batch out but it should not be included in soon to expire inflight
+        // advanced clock and send one batch out but it should not be included in soon to expire in-flight
         // batches because batch's expiry is quite far.
         time.sleep(lingerMs + 1);
         readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -490,7 +490,7 @@ public class SenderTest {
         Node clusterNode = metadata.fetch().nodes().get(0);
         Map<Integer, List<ProducerBatch>> drainedBatches =
             accumulator.drain(metadata.fetch(), Collections.singleton(clusterNode), Integer.MAX_VALUE, time.milliseconds());
-        sender.addToInflightBatches(drainedBatches);
+        sender.addToInFlightBatches(drainedBatches);
 
         // Disconnect the target node for the pending produce request. This will ensure that sender will try to
         // expire the batch.
@@ -684,7 +684,7 @@ public class SenderTest {
     }
 
     @Test
-    public void testIdempotenceWithMultipleInflights() throws Exception {
+    public void testIdempotenceWithMultipleInFlights() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = createTransactionManager();
         setupWithTransactionState(transactionManager);
@@ -733,7 +733,7 @@ public class SenderTest {
 
 
     @Test
-    public void testIdempotenceWithMultipleInflightsRetriedInOrder() throws Exception {
+    public void testIdempotenceWithMultipleInFlightsRetriedInOrder() throws Exception {
         // Send multiple in flight requests, retry them all one at a time, in the correct order.
         final long producerId = 343434L;
         TransactionManager transactionManager = createTransactionManager();
@@ -834,7 +834,7 @@ public class SenderTest {
     }
 
     @Test
-    public void testIdempotenceWithMultipleInflightsWhereFirstFailsFatallyAndSequenceOfFutureBatchesIsAdjusted() throws Exception {
+    public void testIdempotenceWithMultipleInFlightsWhereFirstFailsFatallyAndSequenceOfFutureBatchesIsAdjusted() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = createTransactionManager();
         setupWithTransactionState(transactionManager);
@@ -1223,7 +1223,7 @@ public class SenderTest {
 
         sender.runOnce(); // send request 0
         assertEquals(1, client.inFlightRequestCount());
-        sender.runOnce(); // don't do anything, only one inflight allowed once we are retrying.
+        sender.runOnce(); // don't do anything, only one in-flight allowed once we are retrying.
 
         assertEquals(1, client.inFlightRequestCount());
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
@@ -2429,7 +2429,7 @@ public class SenderTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testInflightBatchesExpireOnDeliveryTimeout() throws InterruptedException {
+    public void testInFlightBatchesExpireOnDeliveryTimeout() throws InterruptedException {
         long deliveryTimeoutMs = 1500L;
         setupWithTransactionState(null, true, null);
 
@@ -2749,7 +2749,7 @@ public class SenderTest {
             runUntil(sender, () -> client.requests().size() == 1);
             assertFalse(accumulator.hasUndrained());
             assertTrue(client.hasInFlightRequests());
-            assertTrue(txnManager.hasInflightBatches(tp0));
+            assertTrue(txnManager.hasInFlightBatches(tp0));
 
             // Enqueue another record and then commit the transaction. We expect the unsent record to
             // get sent before the transaction can be completed.
@@ -2759,7 +2759,7 @@ public class SenderTest {
 
             assertTrue(txnManager.isCompleting());
             assertFalse(txnManager.hasInFlightRequest());
-            assertTrue(txnManager.hasInflightBatches(tp0));
+            assertTrue(txnManager.hasInFlightBatches(tp0));
 
             // Now respond to the pending Produce requests.
             respondToProduce(tp0, Errors.NONE, 0L);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -597,7 +597,7 @@ public class TransactionManagerTest {
 
     @Test
     public void testBatchFailureAfterProducerReset() {
-        // This tests a scenario where the producerId is reset while pending requests are still inflight.
+        // This tests a scenario where the producerId is reset while pending requests are still in-flight.
         // The partition(s) that triggered the reset will have their sequence number reset, while any others will not
         final short epoch = Short.MAX_VALUE;
 
@@ -2609,7 +2609,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testBumpEpochAfterTimeoutWithoutPendingInflightRequests() {
+    public void testBumpEpochAfterTimeoutWithoutPendingInFlightRequests() {
         initializeTransactionManager(Optional.empty());
         long producerId = 15L;
         short epoch = 5;
@@ -2629,7 +2629,7 @@ public class TransactionManagerTest {
                 Errors.NONE, 500L, time.milliseconds(), 0L));
         assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
 
-        // Marking sequence numbers unresolved without inflight requests is basically a no-op.
+        // Marking sequence numbers unresolved without in-flight requests is basically a no-op.
         transactionManager.markSequenceUnresolved(b1);
         transactionManager.maybeResolveSequences();
         assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
@@ -2642,7 +2642,7 @@ public class TransactionManagerTest {
         transactionManager.handleFailedBatch(b2, new TimeoutException(), false);
         assertTrue(transactionManager.hasUnresolvedSequences());
 
-        // We only had one inflight batch, so we should be able to clear the unresolved status
+        // We only had one in-flight batch, so we should be able to clear the unresolved status
         // and bump the epoch
         transactionManager.maybeResolveSequences();
         assertFalse(transactionManager.hasUnresolvedSequences());
@@ -2692,7 +2692,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testEpochBumpAfterLastInflightBatchFails() {
+    public void testEpochBumpAfterLastInFlightBatchFails() {
         initializeTransactionManager(Optional.empty());
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(producerId, epoch);
         initializeIdempotentProducerId(producerId, epoch);
@@ -2715,7 +2715,7 @@ public class TransactionManagerTest {
         assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
         assertTrue(transactionManager.hasUnresolvedSequences());
 
-        // When the last inflight batch fails, we have to bump the epoch
+        // When the last in-flight batch fails, we have to bump the epoch
         transactionManager.handleFailedBatch(b3, new TimeoutException(), false);
 
         // Run sender loop to trigger epoch bump
@@ -3065,7 +3065,7 @@ public class TransactionManagerTest {
 
     @Test
     public void testHealthyPartitionRetriesDuringEpochBump() throws InterruptedException {
-        // Use a custom Sender to allow multiple inflight requests
+        // Use a custom Sender to allow multiple in-flight requests
         initializeTransactionManager(Optional.empty());
         Sender sender = new Sender(logContext, this.client, this.metadata, this.accumulator, false,
                 MAX_REQUEST_SIZE, ACKS_ALL, MAX_RETRIES, new SenderMetricsRegistry(new Metrics(time)), this.time,
@@ -3138,11 +3138,11 @@ public class TransactionManagerTest {
         transactionManager.handleCompletedBatch(tp1b2, t1b2Response);
 
         transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
-        assertFalse(transactionManager.hasInflightBatches(tp1));
+        assertFalse(transactionManager.hasInFlightBatches(tp1));
         assertEquals(0, transactionManager.sequenceNumber(tp1).intValue());
 
         // The last batch should now be drained and sent
-        runUntil(() -> transactionManager.hasInflightBatches(tp1));
+        runUntil(() -> transactionManager.hasInFlightBatches(tp1));
         assertTrue(accumulator.batches().get(tp1).isEmpty());
         ProducerBatch tp1b3 = transactionManager.nextBatchBySequence(tp1);
         assertEquals(epoch + 1, tp1b3.producerEpoch());
@@ -3153,7 +3153,7 @@ public class TransactionManagerTest {
         transactionManager.handleCompletedBatch(tp1b3, t1b3Response);
 
         transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
-        assertFalse(transactionManager.hasInflightBatches(tp1));
+        assertFalse(transactionManager.hasInFlightBatches(tp1));
         assertEquals(1, transactionManager.sequenceNumber(tp1).intValue());
     }
 
@@ -3188,8 +3188,8 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testFailedInflightBatchAfterEpochBump() throws InterruptedException {
-        // Use a custom Sender to allow multiple inflight requests
+    public void testFailedInFlightBatchAfterEpochBump() throws InterruptedException {
+        // Use a custom Sender to allow multiple in-flight requests
         initializeTransactionManager(Optional.empty());
         Sender sender = new Sender(logContext, this.client, this.metadata, this.accumulator, false,
                 MAX_REQUEST_SIZE, ACKS_ALL, MAX_RETRIES, new SenderMetricsRegistry(new Metrics(time)), this.time,
@@ -3262,11 +3262,11 @@ public class TransactionManagerTest {
         transactionManager.handleCompletedBatch(tp1b2, t1b2Response);
 
         transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
-        assertFalse(transactionManager.hasInflightBatches(tp1));
+        assertFalse(transactionManager.hasInFlightBatches(tp1));
         assertEquals(0, transactionManager.sequenceNumber(tp1).intValue());
 
         // The last batch should now be drained and sent
-        runUntil(() -> transactionManager.hasInflightBatches(tp1));
+        runUntil(() -> transactionManager.hasInFlightBatches(tp1));
         assertTrue(accumulator.batches().get(tp1).isEmpty());
         ProducerBatch tp1b3 = transactionManager.nextBatchBySequence(tp1);
         assertEquals(epoch + 1, tp1b3.producerEpoch());
@@ -3276,7 +3276,7 @@ public class TransactionManagerTest {
         tp1b3.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b3, t1b3Response);
 
-        assertFalse(transactionManager.hasInflightBatches(tp1));
+        assertFalse(transactionManager.hasInFlightBatches(tp1));
         assertEquals(1, transactionManager.sequenceNumber(tp1).intValue());
     }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -147,7 +147,7 @@ sealed trait IsrState {
   def maximalIsr: Set[Int]
 
   /**
-   * Indicates if we have an AlterIsr request inflight.
+   * Indicates if we have an AlterIsr request in-flight.
    */
   def isInflight: Boolean
 }
@@ -1400,7 +1400,7 @@ class Partition(val topicPartition: TopicPartition,
       case Errors.OPERATION_NOT_ATTEMPTED =>
         // Since the operation was not attempted, it is safe to reset back to the committed state.
         isrState = CommittedIsr(proposedIsrState.isr)
-        debug(s"Failed to update ISR to $proposedIsrState since there is a pending ISR update still inflight. " +
+        debug(s"Failed to update ISR to $proposedIsrState since there is a pending ISR update still in-flight. " +
           s"ISR state has been reset to the latest committed state $isrState")
         false
       case Errors.UNKNOWN_TOPIC_OR_PARTITION =>

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -152,7 +152,7 @@ class DefaultAutoTopicCreationManager(
 
       creatableTopicResponses
     } finally {
-      clearInflightRequests(creatableTopics)
+      clearInFlightRequests(creatableTopics)
     }
   }
 
@@ -171,12 +171,12 @@ class DefaultAutoTopicCreationManager(
 
     val requestCompletionHandler = new ControllerRequestCompletionHandler {
       override def onTimeout(): Unit = {
-        clearInflightRequests(creatableTopics)
+        clearInFlightRequests(creatableTopics)
         debug(s"Auto topic creation timed out for ${creatableTopics.keys}.")
       }
 
       override def onComplete(response: ClientResponse): Unit = {
-        clearInflightRequests(creatableTopics)
+        clearInFlightRequests(creatableTopics)
         if (response.authenticationException() != null) {
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception")
         } else if (response.versionMismatch() != null) {
@@ -225,9 +225,9 @@ class DefaultAutoTopicCreationManager(
     creatableTopicResponses
   }
 
-  private def clearInflightRequests(creatableTopics: Map[String, CreatableTopic]): Unit = {
+  private def clearInFlightRequests(creatableTopics: Map[String, CreatableTopic]): Unit = {
     creatableTopics.keySet.foreach(inflightTopics.remove)
-    debug(s"Cleared inflight topic creation state for $creatableTopics")
+    debug(s"Cleared in-flight topic creation state for $creatableTopics")
   }
 
   private def creatableTopic(topic: String): CreatableTopic = {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2472,9 +2472,9 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
         /**
          * Get the next expected offset, which might be larger than the last acked
-         * offset if there are inflight batches which have not been acked yet.
+         * offset if there are in-flight batches which have not been acked yet.
          * Note that when fetching from disk, we may not know the last offset of
-         * inflight data until it has been processed by the state machine. In this case,
+         * in-flight data until it has been processed by the state machine. In this case,
          * we delay sending additional data until the state machine has read to the
          * end and the last offset is determined.
          */

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -183,9 +183,9 @@ public class TransactionalMessageCopier {
                 "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.StringSerializer");
-        // We set a small batch size to ensure that we have multiple inflight requests per transaction.
+        // We set a small batch size to ensure that we have multiple in-flight requests per transaction.
         // If it is left at the default, each transaction will have only one batch per partition, hence not testing
-        // the case with multiple inflights.
+        // the case with multiple in-flights.
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, "512");
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
         props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, parsedArgs.getInt("transactionTimeout"));


### PR DESCRIPTION
Update the codes and comments in kafka-clients to unify the naming convention of in-flight, treated it as two words to alight with the configuration item `max.in.flight.requests.per.connection`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
