### PR TITLE
KAFKA-13705: CoreUtils.swallow uses logging parameter instead of Logger 

### DIFF
--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -68,11 +68,11 @@ object CoreUtils {
       action
     } catch {
       case e: Throwable => logLevel match {
-        case Level.ERROR => logger.error(e.getMessage, e)
-        case Level.WARN => logger.warn(e.getMessage, e)
-        case Level.INFO => logger.info(e.getMessage, e)
-        case Level.DEBUG => logger.debug(e.getMessage, e)
-        case Level.TRACE => logger.trace(e.getMessage, e)
+        case Level.ERROR => logging.error(e.getMessage, e)
+        case Level.WARN => logging.warn(e.getMessage, e)
+        case Level.INFO => logging.info(e.getMessage, e)
+        case Level.DEBUG => logging.debug(e.getMessage, e)
+        case Level.TRACE => logging.trace(e.getMessage, e)
       }
     }
   }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -71,6 +71,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             SE_NO_SUITABLE_CONSTRUCTOR: Class is Serializable but its superclass doesn't define a void constructor -->
         <Source name="~.*\.scala" />
         <Or>
+            <Bug pattern="SA_FIELD_SELF_COMPARISON"/>
             <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE"/>
             <Bug pattern="NP_NULL_ON_SOME_PATH"/>
             <Bug pattern="NP_NULL_PARAM_DEREF"/>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -49,6 +49,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
              some categories of bug reports when using Scala, since spotbugs generates huge
              numbers of false positives in some of these categories when examining Scala code.
 
+            SA_FIELD_SELF_COMPARISON: This method compares a field with itself, and may indicate a typo or a logic error.
             NP_LOAD_OF_KNOWN_NULL_VALUE: The variable referenced at this point is known to be null
             due to an earlier check against null.
             NP_NULL_PARAM_DEREF: Method call passes null for non-null parameter.

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -49,7 +49,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
              some categories of bug reports when using Scala, since spotbugs generates huge
              numbers of false positives in some of these categories when examining Scala code.
 
-            SA_FIELD_SELF_COMPARISON: This method compares a field with itself, and may indicate a typo or a logic error.
+            SA_FIELD_SELF_COMPARISON: This method compares a field with itself, and may indicate a typo or a logic error. Issue: https://github.com/spotbugs/spotbugs/issues/1963
             NP_LOAD_OF_KNOWN_NULL_VALUE: The variable referenced at this point is known to be null
             due to an earlier check against null.
             NP_NULL_PARAM_DEREF: Method call passes null for non-null parameter.


### PR DESCRIPTION
As described in the issue, the: 
- Javadoc says: **The logging instance to use for logging the thrown exception.**

But logging parameter it is never used.

The testing strategy used was to run the `CoreUtilsTest` class and all test projects classes to check if any was broken.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
