### PR TITLE
KAFKA-13687: Limiting the amount of bytes to be read in a segment logs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -446,14 +446,6 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     /**
-     * Allows to limit the batches on the file record in bytes
-     */
-    public static FileRecords open(File file, int end) throws IOException {
-        FileChannel channel = openChannel(file, false, false, 0, false);
-        return new FileRecords(file, channel, 0, end, false);
-    }
-
-    /**
      * Open a channel for the given file
      * For windows NTFS and some old LINUX file system, set preallocate to true and initFileSize
      * with one value (for example 512 * 1025 *1024 ) can improve the kafka produce performance.

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -446,6 +446,14 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     /**
+     * Allows to limit the batches on the file record in bytes
+     */
+    public static FileRecords open(File file, int end) throws IOException {
+        FileChannel channel = openChannel(file, false, false, 0, false);
+        return new FileRecords(file, channel, 0, end, false);
+    }
+
+    /**
      * Open a channel for the given file
      * For windows NTFS and some old LINUX file system, set preallocate to true and initFileSize
      * with one value (for example 512 * 1025 *1024 ) can improve the kafka produce performance.

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -250,7 +250,7 @@ object DumpLogSegments {
                       maxBatchesSize: Int): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     println("Starting offset: " + startOffset)
-    val fileRecords = FileRecords.open(file, false).slice(0, maxMessageSize)
+    val fileRecords = FileRecords.open(file, false).slice(0, maxBatchesSize)
     try {
       var validBytes = 0L
       var lastOffset = -1L

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -250,7 +250,7 @@ object DumpLogSegments {
                       maxBatchesSize: Int): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     println("Starting offset: " + startOffset)
-    val fileRecords = FileRecords.open(file, maxBatchesSize)
+    val fileRecords = FileRecords.open(file, false).slice(startOffset, maxMessageSize)
     try {
       var validBytes = 0L
       var lastOffset = -1L

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -250,7 +250,7 @@ object DumpLogSegments {
                       maxBatchesSize: Int): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     println("Starting offset: " + startOffset)
-    val fileRecords = FileRecords.open(file, false).slice(startOffset, maxMessageSize)
+    val fileRecords = FileRecords.open(file, false).slice(0, maxMessageSize)
     try {
       var validBytes = 0L
       var lastOffset = -1L

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -59,7 +59,7 @@ object DumpLogSegments {
       suffix match {
         case UnifiedLog.LogFileSuffix =>
           dumpLog(file, opts.shouldPrintDataLog, nonConsecutivePairsForLogFilesMap, opts.isDeepIteration,
-            opts.messageParser, opts.skipRecordMetadata)
+            opts.messageParser, opts.skipRecordMetadata, opts.maxBatchesSize)
         case UnifiedLog.IndexFileSuffix =>
           dumpIndex(file, opts.indexSanityOnly, opts.verifyOnly, misMatchesForIndexFilesMap, opts.maxMessageSize)
         case UnifiedLog.TimeIndexFileSuffix =>
@@ -246,10 +246,11 @@ object DumpLogSegments {
                       nonConsecutivePairsForLogFilesMap: mutable.Map[String, List[(Long, Long)]],
                       isDeepIteration: Boolean,
                       parser: MessageParser[_, _],
-                      skipRecordMetadata: Boolean): Unit = {
+                      skipRecordMetadata: Boolean,
+                      maxBatchesSize: Int): Unit = {
     val startOffset = file.getName.split("\\.")(0).toLong
     println("Starting offset: " + startOffset)
-    val fileRecords = FileRecords.open(file, false)
+    val fileRecords = FileRecords.open(file, maxBatchesSize)
     try {
       var validBytes = 0L
       var lastOffset = -1L
@@ -306,7 +307,7 @@ object DumpLogSegments {
         validBytes += batch.sizeInBytes
       }
       val trailingBytes = fileRecords.sizeInBytes - validBytes
-      if (trailingBytes > 0)
+      if ( (trailingBytes > 0) && (maxBatchesSize == Integer.MAX_VALUE) )
         println(s"Found $trailingBytes invalid bytes at the end of ${file.getName}")
     } finally fileRecords.closeHandlers()
   }
@@ -430,6 +431,11 @@ object DumpLogSegments {
       .describedAs("size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(5 * 1024 * 1024)
+    val maxBatchesSizeOpt = parser.accepts("max-batches-size", "Limit the amount of total batches in bytes avoiding reading the whole file(s).")
+       .withRequiredArg
+       .describedAs("size")
+       .ofType(classOf[java.lang.Integer])
+       .defaultsTo(Integer.MAX_VALUE)
     val deepIterationOpt = parser.accepts("deep-iteration", "if set, uses deep instead of shallow iteration. Automatically set if print-data-log is enabled.")
     val valueDecoderOpt = parser.accepts("value-decoder-class", "if set, used to deserialize the messages. This class should implement kafka.serializer.Decoder trait. Custom jar should be available in kafka/libs directory.")
       .withOptionalArg()
@@ -473,6 +479,7 @@ object DumpLogSegments {
     lazy val indexSanityOnly: Boolean = options.has(indexSanityOpt)
     lazy val files = options.valueOf(filesOpt).split(",")
     lazy val maxMessageSize = options.valueOf(maxMessageSizeOpt).intValue()
+    lazy val maxBatchesSize = options.valueOf(maxBatchesSizeOpt).intValue()
 
     def checkArgs(): Unit = CommandLineUtils.checkRequiredArgs(parser, options, filesOpt)
 

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -431,7 +431,7 @@ object DumpLogSegments {
       .describedAs("size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(5 * 1024 * 1024)
-    val maxBytesOpt = parser.accepts("max-bytes", "Limit the amount of total batches in bytes avoiding reading the whole file(s).")
+    val maxBytesOpt = parser.accepts("max-bytes", "Limit the amount of total batches read in bytes avoiding reading the whole .log file(s).")
        .withRequiredArg
        .describedAs("size")
        .ofType(classOf[java.lang.Integer])

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -352,7 +352,6 @@ class DumpLogSegmentsTest {
         batchesCounter += 1
       }
     }
-    return batchesBytes
   }
 
   private def countBatches(lines: util.ListIterator[String]): Int = {

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -143,7 +143,6 @@ class DumpLogSegmentsTest {
       def isBatch(index: Int): Boolean = {
         var i = 0
         batches.zipWithIndex.foreach { case (batch, _) =>
-          println(batch)
           if (i == index)
             return true
 
@@ -348,7 +347,7 @@ class DumpLogSegmentsTest {
       if (line.startsWith("baseOffset")) {
         line match {
           case sizePattern(size) => batchesSize += size.toInt
-          case _ => throw new IllegalStateException(s"Failed to parse and find size value for batch line:" + line)
+          case _ => throw new IllegalStateException(s"Failed to parse and find size value for batch line: $line")
         }
         batchesCounter += 1
       }

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.matching.Regex
 
 case class BatchInfo(records: Seq[SimpleRecord], hasKeys: Boolean, hasValues: Boolean)
 
@@ -142,6 +143,7 @@ class DumpLogSegmentsTest {
       def isBatch(index: Int): Boolean = {
         var i = 0
         batches.zipWithIndex.foreach { case (batch, _) =>
+          println(batch)
           if (i == index)
             return true
 
@@ -298,6 +300,29 @@ class DumpLogSegmentsTest {
     outContent.toString
   }
 
+  @Test
+  def testPrintDataLogPartialBatches(): Unit = {
+    addSimpleRecords()
+    val totalBatches = batches.size
+    val partialBatches = totalBatches / 2
+
+    // Get all the batches
+    val output = runDumpLogSegments(Array("--files", logFilePath))
+    val lines = util.Arrays.asList(output.split("\n"): _*).listIterator()
+
+    // Get total bytes of the partial batches
+    val partialBatchesSize = readPartialBatchesSize(lines, partialBatches)
+
+    // Request only the partial batches by bytes
+    val partialOutput = runDumpLogSegments(Array("--max-batches-size", partialBatchesSize.toString, "--files", logFilePath))
+    val partialLines = util.Arrays.asList(partialOutput.split("\n"): _*).listIterator()
+
+    // Count the total of partial batches limited by bytes
+    val partialBatchesCount = countBatches(partialLines)
+
+    assertEquals(partialBatches, partialBatchesCount)
+  }
+
   private def readBatchMetadata(lines: util.ListIterator[String]): Option[String] = {
     while (lines.hasNext) {
       val line = lines.next()
@@ -308,6 +333,38 @@ class DumpLogSegmentsTest {
       }
     }
     None
+  }
+
+  // Returns the total bytes of the batches specified
+  private def readPartialBatchesSize(lines: util.ListIterator[String], limit: Int): Int = {
+    val sizePattern: Regex = raw".+?size:\s(\d+).+".r
+    var batchesSize = 0
+    var batchesCounter = 0
+    while (lines.hasNext) {
+      if (batchesCounter >= limit){
+        return batchesSize
+      }
+      val line = lines.next()
+      if (line.startsWith("baseOffset")) {
+        line match {
+          case sizePattern(size) => batchesSize += size.toInt
+          case _ => throw new IllegalStateException(s"Failed to parse and find size value for batch line:" + line)
+        }
+        batchesCounter += 1
+      }
+    }
+    return batchesSize
+  }
+
+  private def countBatches(lines: util.ListIterator[String]): Int = {
+    var countBatches = 0
+    while (lines.hasNext) {
+      val line = lines.next()
+      if (line.startsWith("baseOffset")) {
+        countBatches += 1
+      }
+    }
+    return countBatches
   }
 
   private def readBatchRecords(lines: util.ListIterator[String]): Seq[String] = {

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -352,6 +352,7 @@ class DumpLogSegmentsTest {
         batchesCounter += 1
       }
     }
+    batchesBytes
   }
 
   private def countBatches(lines: util.ListIterator[String]): Int = {
@@ -362,7 +363,7 @@ class DumpLogSegmentsTest {
         countBatches += 1
       }
     }
-    return countBatches
+    countBatches
   }
 
   private def readBatchRecords(lines: util.ListIterator[String]): Seq[String] = {

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -310,10 +310,10 @@ class DumpLogSegmentsTest {
     val lines = util.Arrays.asList(output.split("\n"): _*).listIterator()
 
     // Get total bytes of the partial batches
-    val partialBatchesSize = readPartialBatchesSize(lines, partialBatches)
+    val partialBatchesBytes = readPartialBatchesBytes(lines, partialBatches)
 
     // Request only the partial batches by bytes
-    val partialOutput = runDumpLogSegments(Array("--max-batches-size", partialBatchesSize.toString, "--files", logFilePath))
+    val partialOutput = runDumpLogSegments(Array("--max-bytes", partialBatchesBytes.toString, "--files", logFilePath))
     val partialLines = util.Arrays.asList(partialOutput.split("\n"): _*).listIterator()
 
     // Count the total of partial batches limited by bytes
@@ -335,24 +335,24 @@ class DumpLogSegmentsTest {
   }
 
   // Returns the total bytes of the batches specified
-  private def readPartialBatchesSize(lines: util.ListIterator[String], limit: Int): Int = {
+  private def readPartialBatchesBytes(lines: util.ListIterator[String], limit: Int): Int = {
     val sizePattern: Regex = raw".+?size:\s(\d+).+".r
-    var batchesSize = 0
+    var batchesBytes = 0
     var batchesCounter = 0
     while (lines.hasNext) {
       if (batchesCounter >= limit){
-        return batchesSize
+        return batchesBytes
       }
       val line = lines.next()
       if (line.startsWith("baseOffset")) {
         line match {
-          case sizePattern(size) => batchesSize += size.toInt
+          case sizePattern(size) => batchesBytes += size.toInt
           case _ => throw new IllegalStateException(s"Failed to parse and find size value for batch line: $line")
         }
         batchesCounter += 1
       }
     }
-    return batchesSize
+    return batchesBytes
   }
 
   private def countBatches(lines: util.ListIterator[String]): Int = {


### PR DESCRIPTION
### Summary
This PR allows to limit the output batches while they are inspected via the `kafka-dump-log.sh`  script.

The idea is to take samples from the logsegments without affecting a production cluster  as the current script will read the whole files, this could create issues related to performance.

Please see the [KIP-824](https://cwiki.apache.org/confluence/display/KAFKA/KIP-824%3A+Allowing+dumping+segmentlogs+limiting+the+batches+in+the+output)


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
