### PR TITLE
KAFKA#13702 - Connect RestClient overrides response status code on request failure

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -139,6 +139,9 @@ public class RestClient {
                         Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                         "Unexpected status code when handling forwarded request: " + responseCode);
             }
+        } catch (ConnectRestException e) {
+            log.error("Connect Rest error forwarding REST request: ", e);
+            throw e;
         } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
             log.error("IO error forwarding REST request: ", e);
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "IO Error trying to forward REST request: " + e.getMessage(), e);


### PR DESCRIPTION
As described in Jira:

In case the submitted request status is >=400, the connect RestClient [throws](https://github.com/apache/kafka/blob/8047ba3800436d6162d0f8eb707e28857ab9eb68/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java#L133) a ConnectRestException with the proper response code, but it gets intercepted and [rethrown with 500 status code](https://github.com/apache/kafka/blob/8047ba3800436d6162d0f8eb707e28857ab9eb68/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java#L147), effectively overriding the actual failure status.

**So this PR fixes this problem - simple catch the exception and rethrow it, keeping the original http status.**

It was difficult to test because `RestClient` class doens't has any tests on it (Maybe another issue?). So I ran all tests to check if everything was ok.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
