### PR TITLE
(docs) Add JavaDocs for org.apache.kafka.common.security.oauthbearer.secured

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1304,6 +1304,7 @@ project(':clients') {
     include "**/org/apache/kafka/common/security/scram/*"
     include "**/org/apache/kafka/common/security/token/delegation/*"
     include "**/org/apache/kafka/common/security/oauthbearer/*"
+    include "**/org/apache/kafka/common/security/oauthbearer/secured/*"
     include "**/org/apache/kafka/server/authorizer/*"
     include "**/org/apache/kafka/server/policy/*"
     include "**/org/apache/kafka/server/quota/*"


### PR DESCRIPTION
Single-line change to build.gradle to render javadocs for new org.apache.kafka.common.security.oauthbearer.secured package (part of [KIP-768](https://issues.apache.org/jira/browse/KAFKA-13202))

Cherry-pick of https://github.com/apache/kafka/pull/11811 for 3.1

cc @junrao