### PR TITLE
KAFKA-12648: fix NPE due to race condtion between resetting offsets and removing a topology

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1259,13 +1259,15 @@ public class InternalTopologyBuilder {
         } else if (maybeDecorateInternalSourceTopics(latestResetTopics).contains(topic) ||
             latestResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {
             return LATEST;
-        } else if (maybeDecorateInternalSourceTopics(rawSourceTopicNames).contains(topic)
-                || !hasNamedTopology()
-                || (usesPatternSubscription() && Pattern.compile(sourceTopicPatternString).matcher(topic).matches())) {
+        } else if (fullSourceTopicNames().contains(topic)
+                || (usesPatternSubscription() && Pattern.compile(sourceTopicPatternString()).matcher(topic).matches())) {
             return NONE;
         } else {
-            // return null if the topic wasn't found at all while using NamedTopologies as it's likely in another
-            return null;
+            throw new IllegalStateException(String.format(
+                "Unable to lookup offset reset strategy for the following topic as it does not exist in the topology%s: %s",
+                hasNamedTopology() ? topologyName : "",
+                topic)
+            );
         }
     }
 
@@ -1416,13 +1418,17 @@ public class InternalTopologyBuilder {
         return fullSourceTopicNames;
     }
 
-    synchronized String sourceTopicsPatternString() {
+    synchronized String sourceTopicPatternString() {
         // With a NamedTopology, it may be that this topology does not use pattern subscription but another one does
         // in which case we would need to initialize the pattern string where we would otherwise have not
         if (sourceTopicPatternString == null && hasNamedTopology()) {
             sourceTopicPatternString = buildSourceTopicsPatternString();
         }
         return sourceTopicPatternString;
+    }
+
+    public boolean containsSourceTopic(final String topic) {
+        return fullSourceTopicNames().contains(topic) || Pattern.compile(sourceTopicPatternString()).matcher(topic).matches();
     }
 
     public boolean hasNoLocalTopology() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1259,8 +1259,7 @@ public class InternalTopologyBuilder {
         } else if (maybeDecorateInternalSourceTopics(latestResetTopics).contains(topic) ||
             latestResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {
             return LATEST;
-        } else if (fullSourceTopicNames().contains(topic)
-                || (usesPatternSubscription() && Pattern.compile(sourceTopicPatternString()).matcher(topic).matches())) {
+        } else if (containsTopic(topic)) {
             return NONE;
         } else {
             throw new IllegalStateException(String.format(
@@ -1427,8 +1426,10 @@ public class InternalTopologyBuilder {
         return sourceTopicPatternString;
     }
 
-    public boolean containsSourceTopic(final String topic) {
-        return fullSourceTopicNames().contains(topic) || Pattern.compile(sourceTopicPatternString()).matcher(topic).matches();
+    public boolean containsTopic(final String topic) {
+        return fullSourceTopicNames().contains(topic)
+            || (usesPatternSubscription() && Pattern.compile(sourceTopicPatternString()).matcher(topic).matches())
+            || changelogTopicToStore.containsKey(topic);
     }
 
     public boolean hasNoLocalTopology() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1421,7 +1421,7 @@ public class InternalTopologyBuilder {
     synchronized String sourceTopicPatternString() {
         // With a NamedTopology, it may be that this topology does not use pattern subscription but another one does
         // in which case we would need to initialize the pattern string where we would otherwise have not
-        if (sourceTopicPatternString == null && hasNamedTopology()) {
+        if (sourceTopicPatternString == null) {
             sourceTopicPatternString = buildSourceTopicsPatternString();
         }
         return sourceTopicPatternString;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -978,24 +979,30 @@ public class StreamThread extends Thread {
         final Set<TopicPartition> notReset = new HashSet<>();
 
         for (final TopicPartition partition : partitions) {
-            switch (topologyMetadata.offsetResetStrategy(partition.topic())) {
-                case EARLIEST:
-                    addToResetList(partition, seekToBeginning, "Setting topic '{}' to consume from {} offset", "earliest", loggedTopics);
-                    break;
-                case LATEST:
-                    addToResetList(partition, seekToEnd, "Setting topic '{}' to consume from {} offset", "latest", loggedTopics);
-                    break;
-                case NONE:
-                    if ("earliest".equals(originalReset)) {
-                        addToResetList(partition, seekToBeginning, "No custom setting defined for topic '{}' using original config '{}' for offset reset", "earliest", loggedTopics);
-                    } else if ("latest".equals(originalReset)) {
-                        addToResetList(partition, seekToEnd, "No custom setting defined for topic '{}' using original config '{}' for offset reset", "latest", loggedTopics);
-                    } else {
-                        notReset.add(partition);
-                    }
-                    break;
-                default:
-                    throw new IllegalStateException("Unable to locate topic " + partition.topic() + " in the topology");
+            final OffsetResetStrategy offsetResetStrategy = topologyMetadata.offsetResetStrategy(partition.topic());
+
+            // This may be null if the task we are currently processing was apart of a named topology that was just removed.
+            // TODO KAFKA-13713: keep the StreamThreads and TopologyMetadata view of named topologies in sync until final thread has acked
+            if (offsetResetStrategy != null) {
+                switch (offsetResetStrategy) {
+                    case EARLIEST:
+                        addToResetList(partition, seekToBeginning, "Setting topic '{}' to consume from {} offset", "earliest", loggedTopics);
+                        break;
+                    case LATEST:
+                        addToResetList(partition, seekToEnd, "Setting topic '{}' to consume from {} offset", "latest", loggedTopics);
+                        break;
+                    case NONE:
+                        if ("earliest".equals(originalReset)) {
+                            addToResetList(partition, seekToBeginning, "No custom setting defined for topic '{}' using original config '{}' for offset reset", "earliest", loggedTopics);
+                        } else if ("latest".equals(originalReset)) {
+                            addToResetList(partition, seekToEnd, "No custom setting defined for topic '{}' using original config '{}' for offset reset", "latest", loggedTopics);
+                        } else {
+                            notReset.add(partition);
+                        }
+                        break;
+                    default:
+                        throw new IllegalStateException("Unable to locate topic " + partition.topic() + " in the topology");
+                }
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -102,6 +102,7 @@ public class TopologyMetadata {
         this.version = new TopologyVersion();
         this.processingMode = StreamsConfigUtils.processingMode(config);
         this.config = config;
+        this.log = LoggerFactory.getLogger(getClass());
 
         builders = new ConcurrentSkipListMap<>();
         if (builder.hasNamedTopology()) {
@@ -382,7 +383,7 @@ public class TopologyMetadata {
 
     public OffsetResetStrategy offsetResetStrategy(final String topic) {
         for (final InternalTopologyBuilder builder : builders.values()) {
-            if (builder.containsSourceTopic(topic)) {
+            if (builder.containsTopic(topic)) {
                 return builder.offsetResetStrategy(topic);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -382,13 +382,19 @@ public class TopologyMetadata {
 
     public OffsetResetStrategy offsetResetStrategy(final String topic) {
         for (final InternalTopologyBuilder builder : builders.values()) {
-            final OffsetResetStrategy resetStrategy = builder.offsetResetStrategy(topic);
-            if (resetStrategy != null) {
-                return resetStrategy;
+            if (builder.containsSourceTopic(topic)) {
+                return builder.offsetResetStrategy(topic);
             }
         }
+        log.warn("Unable to look up offset reset strategy for topic {} " +
+            "as this topic does not appear in the sources of any of the current topologies: {}\n " +
+                "This may be due to natural race condition when removing a topology but it should not " +
+                "persist or appear frequently.",
+            topic, namedTopologiesView()
+        );
         return null;
     }
+
 
     public Collection<String> fullSourceTopicNamesForTopology(final String topologyName) {
         Objects.requireNonNull(topologyName, "topology name must not be null");
@@ -405,7 +411,7 @@ public class TopologyMetadata {
         final StringBuilder patternBuilder = new StringBuilder();
 
         applyToEachBuilder(b -> {
-            final String patternString = b.sourceTopicsPatternString();
+            final String patternString = b.sourceTopicPatternString();
             if (patternString.length() > 0) {
                 patternBuilder.append(patternString).append("|");
             }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -285,6 +285,7 @@ public class InternalStreamsBuilderTest {
         final String topicName = "topic-1";
 
         builder.table(topicName, consumed, materialized);
+        builder.buildAndOptimizeTopology();
 
         assertThat(builder.internalTopologyBuilder.offsetResetStrategy(topicName), equalTo(OffsetResetStrategy.NONE));
     }
@@ -295,6 +296,7 @@ public class InternalStreamsBuilderTest {
         final String topic = "topic-5";
 
         builder.stream(topicPattern, consumed);
+        builder.buildAndOptimizeTopology();
 
         assertThat(builder.internalTopologyBuilder.offsetResetStrategy(topic), equalTo(OffsetResetStrategy.NONE));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -125,7 +125,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source", null, stringSerde.deserializer(), stringSerde.deserializer(), Pattern.compile("test-.*"));
         builder.initializeSubscription();
 
-        assertThat(expectedPattern.pattern(), builder.sourceTopicsPatternString(), equalTo("test-.*"));
+        assertThat(expectedPattern.pattern(), builder.sourceTopicPatternString(), equalTo("test-.*"));
 
         assertThat(builder.offsetResetStrategy("test-topic"), equalTo(OffsetResetStrategy.NONE));
     }
@@ -307,7 +307,7 @@ public class InternalTopologyBuilderTest {
         builder.initializeSubscription();
 
         final Pattern expectedPattern = Pattern.compile("X-topic-3|topic-1|topic-2|topic-4|topic-5");
-        final String patternString = builder.sourceTopicsPatternString();
+        final String patternString = builder.sourceTopicPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
     }
@@ -331,7 +331,7 @@ public class InternalTopologyBuilderTest {
 
         final Pattern expectedPattern = Pattern.compile("topic-1|topic-2");
 
-        final String patternString = builder.sourceTopicsPatternString();
+        final String patternString = builder.sourceTopicPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
     }
@@ -361,7 +361,7 @@ public class InternalTopologyBuilderTest {
         final Pattern expectedPattern = Pattern.compile("topic-\\d");
         builder.addSource(null, "source-1", null, null, null, expectedPattern);
         builder.initializeSubscription();
-        final String patternString = builder.sourceTopicsPatternString();
+        final String patternString = builder.sourceTopicPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
     }
@@ -372,7 +372,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-1", null, null, null, Pattern.compile("topics[A-Z]"));
         builder.addSource(null, "source-2", null, null, null, Pattern.compile(".*-\\d"));
         builder.initializeSubscription();
-        final String patternString = builder.sourceTopicsPatternString();
+        final String patternString = builder.sourceTopicPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
     }
@@ -383,7 +383,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-1", null, null, null, "topic-foo", "topic-bar");
         builder.addSource(null, "source-2", null, null, null, Pattern.compile(".*-\\d"));
         builder.initializeSubscription();
-        final String patternString = builder.sourceTopicsPatternString();
+        final String patternString = builder.sourceTopicPatternString();
 
         assertEquals(expectedPattern.pattern(), Pattern.compile(patternString).pattern());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1349,6 +1349,7 @@ public class StreamThreadTest {
                 ),
                 "proc"
         );
+        internalTopologyBuilder.buildTopology();
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());


### PR DESCRIPTION
While debugging the flaky `NamedTopologyIntegrationTest. shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing` test, I did discover one real bug. The problem was that we update the TopologyMetadata's `builders` map (with the known topologies) inside the #removeNamedTopology call directly, whereas the StreamThread may not yet have reached the `poll()` in the loop and in case of an offset reset, we get an NP.e
I changed the NPE to just log a warning for now, going forward I think we should try to tackle some tech debt by keeping the processing tasks and the TopologyMetadata in sync