### PR TITLE
KAFKA-13785: [Emit final][3/N][KIP-825] introduce a new API to control when aggregated results are produced

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/EmitStrategy.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/EmitStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.kstream.internals.UnlimitedWindow;
+import org.apache.kafka.streams.kstream.internals.emitstrategy.WindowCloseStrategy;
+import org.apache.kafka.streams.kstream.internals.emitstrategy.WindowUpdateStrategy;
+
+/**
+ * This interface controls the strategy that can be used to control how we emit results in a processor.
+ */
+public interface EmitStrategy {
+
+    enum StrategyType {
+        ON_WINDOW_CLOSE,
+        ON_WINDOW_UPDATE
+    }
+
+    /**
+     * Returns the strategy type
+     * @return Emit strategy type
+     */
+    StrategyType type();
+
+    /**
+     * This strategy indicates that the aggregated result for a window will only be outputted when the
+     * window closes instead of when there's an update to the window.
+     *
+     * <p>This strategy should only be used for window which can close. For example, it doesn't make sense
+     * to be used with {@link UnlimitedWindow}
+     *
+     * @see WindowUpdateStrategy
+     *
+     * @return WindowCloseStrategy instance
+     */
+    static EmitStrategy onWindowClose() {
+        return new WindowCloseStrategy();
+    }
+
+    /**
+     * This strategy indicates that the aggregated result for a window will be outputted everytime
+     * when there's an update to the window instead of when the window closes.
+     *
+     * @see WindowCloseStrategy
+     *
+     * @return WindowCloseStrategy instance
+     */
+    static EmitStrategy onWindowUpdate() {
+        return new WindowUpdateStrategy();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -654,5 +654,5 @@ public interface SessionWindowedKStream<K, V> {
      * @param emitStrategy Emit strategy to be set
      * @return SessionWindowedKStream with new emit strategy
      */
-    SessionWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy);
+    //SessionWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -643,4 +643,16 @@ public interface SessionWindowedKStream<K, V> {
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                   final Named named,
                                   final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized);
+
+    /**
+     * Set the emit strategy for windowed stream.
+     *
+     * @see EmitStrategy
+     * @see org.apache.kafka.streams.kstream.internals.emitstrategy.WindowUpdateStrategy
+     * @see org.apache.kafka.streams.kstream.internals.emitstrategy.WindowCloseStrategy
+     *
+     * @param emitStrategy Emit strategy to be set
+     * @return SessionWindowedKStream with new emit strategy
+     */
+    SessionWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -648,4 +648,18 @@ public interface TimeWindowedKStream<K, V> {
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                   final Named named,
                                   final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
+
+
+    /**
+     * Set the emit strategy for windowed stream.
+     *
+     * @see EmitStrategy
+     * @see org.apache.kafka.streams.kstream.internals.emitstrategy.WindowUpdateStrategy
+     * @see org.apache.kafka.streams.kstream.internals.emitstrategy.WindowCloseStrategy
+     *
+     * @param emitStrategy Emit strategy to be set
+     * @return TimeWindowedKStream with new emit strategy
+     */
+    TimeWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy);
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -660,6 +660,6 @@ public interface TimeWindowedKStream<K, V> {
      * @param emitStrategy Emit strategy to be set
      * @return TimeWindowedKStream with new emit strategy
      */
-    TimeWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy);
+    //TimeWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy);
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -225,7 +225,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             materializedInternal.valueSerde());
     }
 
-    @Override
+    //@Override
     public SessionWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy) {
         this.emitStrategy = emitStrategy;
         return this;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
@@ -194,7 +194,7 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                 materializedInternal.valueSerde());
     }
 
-    @Override
+    //@Override
     public TimeWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy) {
         this.emitStrategy = emitStrategy;
         return this;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -213,7 +213,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
                 materializedInternal.valueSerde());
     }
 
-    @Override
+    //@Override
     public TimeWindowedKStream<K, V> emitStrategy(final EmitStrategy emitStrategy) {
         if (this.windows instanceof UnlimitedWindows
             && emitStrategy.type() == StrategyType.ON_WINDOW_CLOSE) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/emitstrategy/WindowCloseStrategy.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/emitstrategy/WindowCloseStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.emitstrategy;
+
+import org.apache.kafka.streams.kstream.EmitStrategy;
+
+/**
+ * An emit strategy which indicates only output when a window closes.
+ */
+public class WindowCloseStrategy implements EmitStrategy {
+
+    @Override
+    public StrategyType type() {
+        return StrategyType.ON_WINDOW_CLOSE;
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/emitstrategy/WindowUpdateStrategy.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/emitstrategy/WindowUpdateStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.emitstrategy;
+
+import org.apache.kafka.streams.kstream.EmitStrategy;
+
+/**
+ * An emit strategy which indicates output everytime when a window gets an update.
+ */
+public class WindowUpdateStrategy implements EmitStrategy {
+
+    @Override
+    public StrategyType type() {
+        return StrategyType.ON_WINDOW_UPDATE;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/EmitStrategyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/EmitStrategyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
+import org.apache.kafka.streams.kstream.internals.emitstrategy.WindowCloseStrategy;
+import org.apache.kafka.streams.kstream.internals.emitstrategy.WindowUpdateStrategy;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EmitStrategyTest {
+
+    @Test
+    public void shouldReturnCorrectStrategy() {
+        final EmitStrategy windowCloseStrategy = EmitStrategy.onWindowClose();
+        assertThat(windowCloseStrategy, is(instanceOf(WindowCloseStrategy.class)));
+        assertThat(windowCloseStrategy.type(), is(StrategyType.ON_WINDOW_CLOSE));
+
+        final EmitStrategy windowUpdateStrategy = EmitStrategy.onWindowUpdate();
+        assertThat(windowUpdateStrategy, is(instanceOf(WindowUpdateStrategy.class)));
+        assertThat(windowUpdateStrategy.type(), is(StrategyType.ON_WINDOW_UPDATE));
+    }
+}


### PR DESCRIPTION
*More detailed description of your change,
Change window api to add a emit final option for `SlidingWindow`, `SessionWindow` and `TimedWindow`.

*Summary of testing strategy (including rationale)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
