### PR TITLE
KAFKA-12648: fix #getMinThreadVersion and include IOException + topologyName in StreamsException when topology dir cleanup fails

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -535,8 +535,9 @@ public class StateDirectory {
         try {
             Utils.delete(namedTopologyDir);
         } catch (final IOException e) {
-            log.error("Hit an unexpected error while clearing local state for NamedTopology {}", topologyName);
-            throw new StreamsException("Unable to delete state for the named topology " + topologyName);
+            log.error("Hit an unexpected error while clearing local state for topology " + topologyName, e);
+            throw new StreamsException("Unable to delete state for the named topology " + topologyName,
+                                       e, new TaskId(-1, -1, topologyName)); // use dummy taskid to report source topology for this error
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1122,14 +1122,14 @@ public class StreamThread extends Thread {
         log.info("Shutting down");
 
         try {
-            topologyMetadata.unregisterThread(threadMetadata.threadName());
-        } catch (final Throwable e) {
-            log.error("Failed to unregister thread due to the following error:", e);
-        }
-        try {
             taskManager.shutdown(cleanRun);
         } catch (final Throwable e) {
             log.error("Failed to close task manager due to the following error:", e);
+        }
+        try {
+            topologyMetadata.unregisterThread(threadMetadata.threadName());
+        } catch (final Throwable e) {
+            log.error("Failed to unregister thread due to the following error:", e);
         }
         try {
             changelogReader.clear();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -42,6 +42,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -199,8 +200,10 @@ public class TopologyMetadata {
         }
     }
 
+    // Return the minimum version across all live threads, or Long.MAX_VALUE if there are no threads running
     private long getMinimumThreadVersion() {
-        return threadVersions.values().stream().min(Long::compare).get();
+        final Optional<Long> minVersion = threadVersions.values().stream().min(Long::compare);
+        return minVersion.orElse(Long.MAX_VALUE);
     }
 
     public void wakeupThreads() {


### PR DESCRIPTION
Quick fix to make sure we log the actual source of the failure both in the actual log message as well as the StreamsException that we bubble up to the user's exception handler, and also to report the offending topology by filling in the StreamsException's `taskId` field.

Also prevents a `NoSuchElementException` from being thrown when trying to compute the minimum topology version across all threads when the last thread is being unregistered during shutdown.

This aims to fix some flakiness that has shown up in the NamedTopologyIntegrationTest's `#shouldAddToEmptyInitialTopologyRemoveResetOffsetsThenAddSameNamedTopologyWithRepartitioning` recently