### PR TITLE
MINOR: jmh.sh swallows compile errors

### DIFF
--- a/jmh-benchmarks/jmh.sh
+++ b/jmh-benchmarks/jmh.sh
@@ -29,9 +29,9 @@ fi
 gradleCmd="${gradlew_dir}/gradlew"
 libDir="${base_dir}/build/libs"
 
-echo "running gradlew :jmh-benchmarks:clean :jmh-benchmarks:shadowJar in quiet mode"
+echo "running gradlew :jmh-benchmarks:clean :jmh-benchmarks:shadowJar"
 
-$gradleCmd  -q :jmh-benchmarks:clean :jmh-benchmarks:shadowJar
+$gradleCmd  :jmh-benchmarks:clean :jmh-benchmarks:shadowJar
 
 echo "gradle build done"
 


### PR DESCRIPTION
jmh.sh runs tasks in quiet mode which swallows compiler errors. This is a pain and I frequently have to edit the shell script to see the error.