### PR TITLE
KAFKA-12879: Addendum to reduce flakiness of tests

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -88,10 +88,13 @@ public class RetryUtil {
                 lastError = e;
             }
 
-            long millisRemaining = Math.max(0, end - System.currentTimeMillis());
-            if (millisRemaining < retryBackoffMs) {
-                // exit when the time remaining is less than retryBackoffMs
-                break;
+            if (retryBackoffMs > 0) {
+                long millisRemaining = Math.max(0, end - System.currentTimeMillis());
+                if (millisRemaining < retryBackoffMs) {
+                    // exit when the time remaining is less than retryBackoffMs
+                    break;
+                }
+                Utils.sleep(retryBackoffMs);
             }
             Utils.sleep(retryBackoffMs);
         } while (System.currentTimeMillis() < end);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -36,6 +36,8 @@ import java.util.function.Supplier;
 @RunWith(PowerMockRunner.class)
 public class RetryUtilTest {
 
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
     private Callable<String> mockCallable;
     private final Supplier<String> testMsg = () -> "Test";
 
@@ -69,7 +71,7 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException())
                 .thenReturn("success");
 
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 1));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, 1));
         Mockito.verify(mockCallable, Mockito.times(4)).call();
     }
 
@@ -83,7 +85,7 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException("timeout"))
                 .thenThrow(new NullPointerException("Non retriable"));
         NullPointerException e = assertThrows(NullPointerException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 0));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, 0));
         assertEquals("Non retriable", e.getMessage());
         Mockito.verify(mockCallable, Mockito.times(6)).call();
     }
@@ -114,7 +116,7 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException())
                 .thenReturn("success");
 
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 0));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, 0));
         Mockito.verify(mockCallable, Mockito.times(4)).call();
     }
 
@@ -151,7 +153,7 @@ public class RetryUtilTest {
         Mockito.when(mockCallable.call())
                 .thenThrow(new TimeoutException("timeout"))
                 .thenReturn("success");
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), -1));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, -1));
         Mockito.verify(mockCallable, Mockito.times(2)).call();
     }
 


### PR DESCRIPTION
This is an addendum to the KAFKA-12879 (#11797) to fix some tests that are somewhat flaky when a build machine is heavily loaded (when the timeouts are too small).

- Add an if check to void sleep(0)
- Increase timeout in the tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
