### PR TITLE
MINOR: Revert "KAFKA-13542: add rebalance reason in Kafka Streams (#11804)"

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -585,7 +585,7 @@ public class StreamThread extends Thread {
                 runOnce();
                 if (nextProbingRebalanceMs.get() < time.milliseconds()) {
                     log.info("Triggering the followup rebalance scheduled for {} ms.", nextProbingRebalanceMs.get());
-                    mainConsumer.enforceRebalance("Scheduled probing rebalance.");
+                    mainConsumer.enforceRebalance();
                     nextProbingRebalanceMs.set(Long.MAX_VALUE);
                 }
             } catch (final TaskCorruptedException e) {
@@ -597,7 +597,7 @@ public class StreamThread extends Thread {
                     final boolean enforceRebalance = taskManager.handleCorruption(e.corruptedTasks());
                     if (enforceRebalance && eosEnabled) {
                         log.info("Active task(s) got corrupted. Triggering a rebalance.");
-                        mainConsumer.enforceRebalance("Active tasks corrupted.");
+                        mainConsumer.enforceRebalance();
                     }
                 } catch (final TaskMigratedException taskMigrated) {
                     handleTaskMigrated(taskMigrated);
@@ -639,7 +639,7 @@ public class StreamThread extends Thread {
         if (assignmentErrorCode.get() == AssignorError.SHUTDOWN_REQUESTED.code()) {
             log.warn("Detected that shutdown was requested. " +
                     "All clients in this app will now begin to shutdown");
-            mainConsumer.enforceRebalance("Shutdown requested.");
+            mainConsumer.enforceRebalance();
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -481,13 +481,10 @@ public class StreamThreadTest {
         expect(mockConsumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
-
         final EasyMockConsumerClientSupplier mockClientSupplier = new EasyMockConsumerClientSupplier(mockConsumer);
+
         mockClientSupplier.setCluster(createCluster());
-
-        mockConsumer.enforceRebalance("Scheduled probing rebalance.");
         EasyMock.replay(mockConsumer);
-
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
         final StreamThread thread = StreamThread.create(
@@ -508,6 +505,7 @@ public class StreamThreadTest {
             null
         );
 
+        mockConsumer.enforceRebalance();
 
         mockClientSupplier.nextRebalanceMs().set(mockTime.milliseconds() - 1L);
 
@@ -2359,7 +2357,7 @@ public class StreamThreadTest {
         expect(task2.id()).andReturn(taskId2).anyTimes();
         expect(taskManager.handleCorruption(corruptedTasks)).andReturn(true);
 
-        consumer.enforceRebalance("Active tasks corrupted.");
+        consumer.enforceRebalance();
         expectLastCall();
 
         EasyMock.replay(task1, task2, taskManager, consumer);


### PR DESCRIPTION
This reverts commit 2ccc834faa3fffcd5d15d2463aeef3ee6f5cea13. We were seeing serious regressions in our state heavy benchmarks. We saw that our state heavy benchmarks were experiencing a really bad regression. The State heavy benchmarks runs with rolling bounces with 10 nodes.

We regularly saw this exception
```
17165 java.lang.OutOfMemoryError: Java heap space                                                                                                                                                                                              
17166 Dumping heap to ./senrollingBounce10-suNONE-stMEM-cENABLED-lENABLED-snkNO_SINK-ks1000000-kdsequential-prt100-ec2i3.large-1,1-heap-dump-try-1 ...
17167 Heap dump file created [4129525648 bytes in 12.538 secs]
17168 217283 [kafka-coordinator-heartbeat-thread | benchmark] ERROR org.apache.kafka.clients.consumer.internals.ConsumerCoordinator - [Consumer clientId=benchmark-727ac648-f5d5-43fb-95c3-549dc2da033d-StreamThread-1-consumer, groupId=benchm      ark] Heartbeat thread failed due to unexpected error
17169 java.lang.OutOfMemoryError: Java heap space
17169 java.lang.OutOfMemoryError: Java heap space
17170         at java.base/java.nio.HeapByteBuffer.<init>(HeapByteBuffer.java:61)
17171         at java.base/java.nio.ByteBuffer.allocate(ByteBuffer.java:348)
17172         at org.apache.kafka.common.memory.MemoryPool$1.tryAllocate(MemoryPool.java:30)
17173         at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:113)
17174         at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:452)
17175         at org.apache.kafka.common.network.KafkaChannel.read(KafkaChannel.java:402)
17176         at org.apache.kafka.common.network.Selector.attemptRead(Selector.java:674)
17177         at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:576)
17178         at org.apache.kafka.common.network.Selector.poll(Selector.java:481)
17179         at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:560)
17180         at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.poll(ConsumerNetworkClient.java:265)
17181         at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.pollNoWakeup(ConsumerNetworkClient.java:306)
17182         at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1420)
```

I ran through a git bisect and found this commit. We verified that the commit right before did not have the same issues as this one did. I then reverted the problematic commit and ran the benchmarks again on this commit and did not see any more issues. We are still looking into the root cause, but for now since this isn't a critical improvement so we can remove it temporarily. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
