### PR TITLE
KAKFA-13699: new ProcessorContext is missing methods

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ProcessorContext.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.streams.processor.api;
 
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -247,4 +249,30 @@ public interface ProcessorContext<KForward, VForward> {
      * @return the key/values matching the given prefix from the StreamsConfig properties.
      */
     Map<String, Object> appConfigsWithPrefix(final String prefix);
+
+    /**
+     * Return the current system timestamp (also called wall-clock time) in milliseconds.
+     *
+     * <p> Note: this method returns the internally cached system timestamp from the Kafka Stream runtime.
+     * Thus, it may return a different value compared to {@code System.currentTimeMillis()}.
+     *
+     * @return the current system timestamp in milliseconds
+     */
+    long currentSystemTimeMs();
+
+    /**
+     * Return the current stream-time in milliseconds.
+     *
+     * <p> Stream-time is the maximum observed {@link TimestampExtractor record timestamp} so far
+     * (including the currently processed record), i.e., it can be considered a high-watermark.
+     * Stream-time is tracked on a per-task basis and is preserved across restarts and during task migration.
+     *
+     * <p> Note: this method is not supported for global processors (cf. {@link Topology#addGlobalStore} (...)
+     * and {@link StreamsBuilder#addGlobalStore} (...),
+     * because there is no concept of stream-time for this case.
+     * Calling this method in a global processor will result in an {@link UnsupportedOperationException}.
+     *
+     * @return the current stream-time in milliseconds
+     */
+    long currentStreamTimeMs();
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -285,6 +285,16 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
     }
 
     @Override
+    public long currentSystemTimeMs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long currentStreamTimeMs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Serde<?> keySerde() {
         return config.defaultKeySerde();
     }


### PR DESCRIPTION
We added `currentSystemTimeMs()` and `currentStreamTimeMs()` to the
`ProcessorContext` via KIP-622, but forgot to add both methods to the new
`api.ProcessorContext`.