### PR TITLE
KAFKA-13728: fix PushHttpMetricsReporter no longer pushes metrics when network failure is recovered.

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
@@ -213,7 +213,6 @@ public class PushHttpMetricsReporter implements MetricsReporter {
                 }
             } catch (Throwable t) {
                 log.error("Error reporting metrics", t);
-                throw new KafkaException("Failed to report current metrics", t);
             } finally {
                 if (connection != null) {
                     connection.disconnect();


### PR DESCRIPTION
### Description

The class `PushHttpMetricsReporter` no longer pushes metrics when network failure is recovered.


I debugged the code and found the problem here :
https://github.com/apache/kafka/blob/dc36dedd28ff384218b669de13993646483db966/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java#L214-L221

 

When we submit a task to the `ScheduledThreadPoolExecutor` that needs to be executed periodically, if the task throws an exception and is not swallowed, the task will no longer be scheduled to execute.

### Conclusion
So when an IO exception occasionally occurs on the network, we should swallow it rather than throw it in task `HttpReporter`.
