### PR TITLE
MINOR: revert back to 60s session timeout for static membership test

### DIFF
--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -690,10 +690,9 @@ class StaticMemberTestService(StreamsTestBaseService):
                       streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
                       streams_property.NUM_THREADS: self.NUM_THREADS,
                       consumer_property.GROUP_INSTANCE_ID: self.GROUP_INSTANCE_ID,
-                      consumer_property.SESSION_TIMEOUT_MS: 60000,
+                      consumer_property.SESSION_TIMEOUT_MS: 60000, # set longer session timeout for static member test
                       'input.topic': self.INPUT_TOPIC,
-                      "acceptable.recovery.lag": "9223372036854775807", # enable a one-shot assignment
-                      "session.timeout.ms": "10000" # set back to 10s for tests. See KIP-735
+                      "acceptable.recovery.lag": "9223372036854775807" # enable a one-shot assignment
                       }
 
 


### PR DESCRIPTION
In this PR: https://github.com/apache/kafka/pull/11236/files#diff-bd4be654a82d362772b2010a0fa22a44916ff0da241ca7e6072741f7ef710136L689-R696 , we tried to reduce the session timeout for running tests faster. However, we accidentally overrode the session timeout in static membership tests, where we expected to set to a longer session timeout to test the static member won't trigger rebalance. Revert it back to 60 seconds.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
