### PR TITLE
KAFKA-13730: OAuth access token validation fails if it does not conta…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidator.java
@@ -131,7 +131,6 @@ public class ValidatorAccessTokenValidator implements AccessTokenValidator {
             .setJwsAlgorithmConstraints(DISALLOW_NONE)
             .setRequireExpirationTime()
             .setRequireIssuedAt()
-            .setRequireSubject()
             .setVerificationKeyResolver(verificationKeyResolver)
             .build();
         this.scopeClaimName = scopeClaimName;

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/secured/ValidatorAccessTokenValidatorTest.java
@@ -59,6 +59,25 @@ public class ValidatorAccessTokenValidatorTest extends AccessTokenValidatorTest 
             "fake is an unknown, unsupported or unavailable alg algorithm");
     }
 
+    @Test
+    public void testMissingSubShouldBeValid() throws Exception {
+        String subClaimName = "client_id";
+        String subject = "otherSub";
+        PublicJsonWebKey jwk = createRsaJwk();
+        AccessTokenBuilder tokenBuilder = new AccessTokenBuilder()
+            .jwk(jwk)
+            .alg(AlgorithmIdentifiers.RSA_USING_SHA256)
+            .addCustomClaim(subClaimName, subject)
+            .subjectClaimName(subClaimName)
+            .subject(null);
+        AccessTokenValidator validator = createAccessTokenValidator(tokenBuilder);
+
+        // Validation should succeed (e.g. signature verification) even if sub claim is missing
+        OAuthBearerToken token = validator.validate(tokenBuilder.build());
+
+        assertEquals(subject, token.principalName());
+    }
+
     private void testEncryptionAlgorithm(PublicJsonWebKey jwk, String alg) throws Exception {
         AccessTokenBuilder builder = new AccessTokenBuilder().jwk(jwk).alg(alg);
         AccessTokenValidator validator = createAccessTokenValidator(builder);


### PR DESCRIPTION
…in the "sub" claim

Removes the requirement of presence of sub claim in JWT access tokens, when clients authenticate via OAuth.
This does not interfere with OAuth specifications and is to ensure wider compatibility with OAuth providers.
Unit test added.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
