### PR TITLE
KAFKA-13690: Fix flaky test in EosIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -40,21 +40,17 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.QueryableStoreTypes;
-import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
-import org.apache.kafka.streams.state.internals.RocksDBStore;
-import org.apache.kafka.streams.state.internals.RocksDbKeyValueBytesStoreSupplier;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.MockInternalProcessorContext;
-import org.apache.kafka.test.MockKeyValueStore;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.AfterClass;
@@ -71,7 +67,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,6 +86,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
+import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
 import static org.apache.kafka.test.StreamsTestUtils.startKafkaStreamsAndWaitForRunningState;
 import static org.apache.kafka.test.TestUtils.consumerConfig;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
@@ -98,7 +94,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
@@ -284,20 +279,7 @@ public class EosIntegrationTest {
             try (final KafkaStreams streams = new KafkaStreams(builder.build(), config)) {
                 startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
 
-                final List<KeyValue<Long, Long>> committedRecords = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
-                    TestUtils.consumerConfig(
-                        CLUSTER.bootstrapServers(),
-                        CONSUMER_GROUP_ID,
-                        LongDeserializer.class,
-                        LongDeserializer.class,
-                        Utils.mkProperties(Collections.singletonMap(
-                            ConsumerConfig.ISOLATION_LEVEL_CONFIG,
-                            IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT)))
-                        ),
-                    outputTopic,
-                    inputData.size()
-                );
-
+                final List<KeyValue<Long, Long>> committedRecords = readResult(outputTopic, inputData.size(), CONSUMER_GROUP_ID);
                 checkResultPerKey(committedRecords, inputData, "The committed records do not match what expected");
             }
         }
@@ -365,21 +347,7 @@ public class EosIntegrationTest {
                 CLUSTER.time
             );
 
-            final List<KeyValue<Long, Long>> firstCommittedRecords =
-                IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
-                    TestUtils.consumerConfig(
-                        CLUSTER.bootstrapServers(),
-                        CONSUMER_GROUP_ID,
-                        LongDeserializer.class,
-                        LongDeserializer.class,
-                        Utils.mkProperties(Collections.singletonMap(
-                            ConsumerConfig.ISOLATION_LEVEL_CONFIG,
-                            IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT)))
-                        ),
-                    SINGLE_PARTITION_OUTPUT_TOPIC,
-                    firstBurstOfData.size()
-                );
-
+            final List<KeyValue<Long, Long>> firstCommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, firstBurstOfData.size(), CONSUMER_GROUP_ID);
             assertThat(firstCommittedRecords, equalTo(firstBurstOfData));
 
             IntegrationTestUtils.produceKeyValuesSynchronously(
@@ -389,21 +357,7 @@ public class EosIntegrationTest {
                 CLUSTER.time
             );
 
-            final List<KeyValue<Long, Long>> secondCommittedRecords =
-                IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
-                    TestUtils.consumerConfig(
-                        CLUSTER.bootstrapServers(),
-                        CONSUMER_GROUP_ID,
-                        LongDeserializer.class,
-                        LongDeserializer.class,
-                        Utils.mkProperties(Collections.singletonMap(
-                            ConsumerConfig.ISOLATION_LEVEL_CONFIG,
-                            IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT)))
-                        ),
-                    SINGLE_PARTITION_OUTPUT_TOPIC,
-                    secondBurstOfData.size()
-                );
-
+            final List<KeyValue<Long, Long>> secondCommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, secondBurstOfData.size(), CONSUMER_GROUP_ID);
             assertThat(secondCommittedRecords, equalTo(secondBurstOfData));
         }
     }
@@ -445,7 +399,7 @@ public class EosIntegrationTest {
             // p-0: ---> 10 rec + C
             // p-1: ---> 10 rec + C
 
-            final List<KeyValue<Long, Long>> committedRecords = readResult(committedDataBeforeFailure.size(), CONSUMER_GROUP_ID);
+            final List<KeyValue<Long, Long>> committedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, committedDataBeforeFailure.size(), CONSUMER_GROUP_ID);
             checkResultPerKey(
                 committedRecords,
                 committedDataBeforeFailure,
@@ -458,7 +412,7 @@ public class EosIntegrationTest {
             // p-0: ---> 10 rec + C  + 5 rec (pending)
             // p-1: ---> 10 rec + C  + 5 rec (pending)
 
-            final List<KeyValue<Long, Long>> uncommittedRecords = readResult(dataBeforeFailure.size(), null);
+            final List<KeyValue<Long, Long>> uncommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, dataBeforeFailure.size(), null);
             checkResultPerKey(
                 uncommittedRecords,
                 dataBeforeFailure,
@@ -477,10 +431,12 @@ public class EosIntegrationTest {
             // p-1: ---> 10 rec + C  + 5 rec + C    + 5 rec + C
 
             final List<KeyValue<Long, Long>> allCommittedRecords = readResult(
+                SINGLE_PARTITION_OUTPUT_TOPIC,
                 committedDataBeforeFailure.size() + uncommittedDataBeforeFailure.size() + dataAfterFailure.size(),
                 CONSUMER_GROUP_ID + "_ALL");
 
             final List<KeyValue<Long, Long>> committedRecordsAfterFailure = readResult(
+                SINGLE_PARTITION_OUTPUT_TOPIC,
                 uncommittedDataBeforeFailure.size() + dataAfterFailure.size(),
                 CONSUMER_GROUP_ID);
 
@@ -551,7 +507,7 @@ public class EosIntegrationTest {
             // p-0: ---> 10 rec + C
             // p-1: ---> 10 rec + C
 
-            final List<KeyValue<Long, Long>> committedRecords = readResult(committedDataBeforeFailure.size(), CONSUMER_GROUP_ID);
+            final List<KeyValue<Long, Long>> committedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, committedDataBeforeFailure.size(), CONSUMER_GROUP_ID);
             checkResultPerKey(
                 committedRecords,
                 computeExpectedResult(committedDataBeforeFailure),
@@ -564,7 +520,7 @@ public class EosIntegrationTest {
             // p-0: ---> 10 rec + C  + 5 rec (pending)
             // p-1: ---> 10 rec + C  + 5 rec (pending)
 
-            final List<KeyValue<Long, Long>> uncommittedRecords = readResult(dataBeforeFailure.size(), null);
+            final List<KeyValue<Long, Long>> uncommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, dataBeforeFailure.size(), null);
             final List<KeyValue<Long, Long>> expectedResultBeforeFailure = computeExpectedResult(dataBeforeFailure);
 
 
@@ -590,10 +546,12 @@ public class EosIntegrationTest {
             // p-1: ---> 10 rec + C  + 5 rec + C    + 5 rec + C
 
             final List<KeyValue<Long, Long>> allCommittedRecords = readResult(
+                SINGLE_PARTITION_OUTPUT_TOPIC,
                 committedDataBeforeFailure.size() + uncommittedDataBeforeFailure.size() + dataAfterFailure.size(),
                 CONSUMER_GROUP_ID + "_ALL");
 
             final List<KeyValue<Long, Long>> committedRecordsAfterFailure = readResult(
+                SINGLE_PARTITION_OUTPUT_TOPIC,
                 uncommittedDataBeforeFailure.size() + dataAfterFailure.size(),
                 CONSUMER_GROUP_ID);
 
@@ -671,7 +629,7 @@ public class EosIntegrationTest {
             // p-0: ---> 10 rec + C
             // p-1: ---> 10 rec + C
 
-            final List<KeyValue<Long, Long>> committedRecords = readResult(committedDataBeforeStall.size(), CONSUMER_GROUP_ID);
+            final List<KeyValue<Long, Long>> committedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, committedDataBeforeStall.size(), CONSUMER_GROUP_ID);
             checkResultPerKey(
                 committedRecords,
                 committedDataBeforeStall,
@@ -684,7 +642,7 @@ public class EosIntegrationTest {
             // p-0: ---> 10 rec + C  + 5 rec (pending)
             // p-1: ---> 10 rec + C  + 5 rec (pending)
 
-            final List<KeyValue<Long, Long>> uncommittedRecords = readResult(dataBeforeStall.size(), null);
+            final List<KeyValue<Long, Long>> uncommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, dataBeforeStall.size(), null);
             checkResultPerKey(
                 uncommittedRecords,
                 dataBeforeStall,
@@ -730,6 +688,7 @@ public class EosIntegrationTest {
             // p-1: ---> 10 rec + C  + 5 rec + C    + 5 rec + C
 
             final List<KeyValue<Long, Long>> committedRecordsAfterRebalance = readResult(
+                SINGLE_PARTITION_OUTPUT_TOPIC,
                 uncommittedDataBeforeStall.size() + dataToTriggerFirstRebalance.size(),
                 CONSUMER_GROUP_ID);
 
@@ -766,6 +725,7 @@ public class EosIntegrationTest {
             // p-1: ---> 10 rec + C  + 5 rec + C    + 5 rec + C   + 10 rec + C
 
             final List<KeyValue<Long, Long>> allCommittedRecords = readResult(
+                SINGLE_PARTITION_OUTPUT_TOPIC,
                 committedDataBeforeStall.size() + uncommittedDataBeforeStall.size()
                 + dataToTriggerFirstRebalance.size() + dataAfterSecondRebalance.size(),
                 CONSUMER_GROUP_ID + "_ALL");
@@ -791,48 +751,35 @@ public class EosIntegrationTest {
         final List<KeyValue<Long, Long>> expectedResult = computeExpectedResult(writtenData);
 
         try (final KafkaStreams streams = getKafkaStreams("streams", true, "appDir", 1, eosConfig, MAX_POLL_INTERVAL_MS)) {
+            writeInputData(writtenData);
 
             startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
-
-            writeInputData(writtenData);
 
             waitForCondition(
                     () -> commitRequested.get() == 2, MAX_WAIT_TIME_MS,
                     "SteamsTasks did not request commit.");
 
-            final List<KeyValue<Long, Long>> committedRecords = readResult(writtenData.size(), CONSUMER_GROUP_ID);
+            final List<KeyValue<Long, Long>> committedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, writtenData.size(), CONSUMER_GROUP_ID);
 
-            checkResultPerKey(
-                    committedRecords,
-                    expectedResult,
-                    "The committed records do not match what expected");
+            if (!eosConfig.equals(StreamsConfig.AT_LEAST_ONCE)) {
+                checkResultPerKey(
+                        committedRecords,
+                        expectedResult,
+                        "The committed records do not match what expected");
 
-            verifyStateStore(
-                    streams,
-                    getMaxPerKey(expectedResult),
-                    "The state store content do not match what expected");
+                verifyStateStore(
+                        streams,
+                        getMaxPerKey(expectedResult),
+                        "The state store content do not match what expected");
+            }
         }
 
-        final Set<KeyValue<Long, Long>> expectedState = getMaxPerKey(expectedResult);
-        verifyStateIsInStoreAndOffsetsAreInCheckpoint(0, expectedState);
-        verifyStateIsInStoreAndOffsetsAreInCheckpoint(1, expectedState);
-
-        assertThat("Not all expected state values were found in the state stores", expectedState.isEmpty());
+        verifyOffsetsAreInCheckpoint(0);
+        verifyOffsetsAreInCheckpoint(1);
     }
 
-    private void verifyStateIsInStoreAndOffsetsAreInCheckpoint(final int partition, final Set<KeyValue<Long, Long>> expectedState) throws IOException {
+    private void verifyOffsetsAreInCheckpoint(final int partition) throws IOException {
         final String stateStoreDir = stateTmpDir + File.separator + "appDir" + File.separator + applicationId + File.separator + "0_" + partition + File.separator;
-
-        // Verify that the data in the state store on disk is fully up-to-date
-        final StateStoreContext context = new MockInternalProcessorContext(new Properties(), new TaskId(0, 0), new File(stateStoreDir));
-        final MockKeyValueStore stateStore = new MockKeyValueStore("store", false);
-        final RocksDBStore store = (RocksDBStore) new RocksDbKeyValueBytesStoreSupplier(storeName, false).get();
-        store.init(context, stateStore);
-
-        store.all().forEachRemaining(kv -> {
-            final KeyValue<Long, Long> kv2 = new KeyValue<>(new BigInteger(kv.key.get()).longValue(), new BigInteger(kv.value).longValue());
-            expectedState.remove(kv2);
-        });
 
         // Verify that the checkpointed offsets match exactly with max offset of the records in the changelog
         final OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(stateStoreDir + ".checkpoint"));
@@ -866,8 +813,8 @@ public class EosIntegrationTest {
     private List<KeyValue<Long, Long>> prepareData(final long fromInclusive,
                                                    final long toExclusive,
                                                    final Long... keys) {
-        final Long dataSize = keys.length * (toExclusive - fromInclusive);
-        final List<KeyValue<Long, Long>> data = new ArrayList<>(dataSize.intValue());
+        final long dataSize = keys.length * (toExclusive - fromInclusive);
+        final List<KeyValue<Long, Long>> data = new ArrayList<>((int) dataSize);
 
         for (final Long k : keys) {
             for (long v = fromInclusive; v < toExclusive; ++v) {
@@ -1022,7 +969,8 @@ public class EosIntegrationTest {
         );
     }
 
-    private List<KeyValue<Long, Long>> readResult(final int numberOfRecords,
+    private List<KeyValue<Long, Long>> readResult(final String topic,
+                                                  final int numberOfRecords,
                                                   final String groupId) throws Exception {
         if (groupId != null) {
             return IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
@@ -1034,7 +982,7 @@ public class EosIntegrationTest {
                     Utils.mkProperties(Collections.singletonMap(
                         ConsumerConfig.ISOLATION_LEVEL_CONFIG,
                         IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT)))),
-                SINGLE_PARTITION_OUTPUT_TOPIC,
+                topic,
                 numberOfRecords
             );
         }
@@ -1042,7 +990,7 @@ public class EosIntegrationTest {
         // read uncommitted
         return IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
             TestUtils.consumerConfig(CLUSTER.bootstrapServers(), LongDeserializer.class, LongDeserializer.class),
-            SINGLE_PARTITION_OUTPUT_TOPIC,
+            topic,
             numberOfRecords
         );
     }
@@ -1088,17 +1036,21 @@ public class EosIntegrationTest {
 
     private void verifyStateStore(final KafkaStreams streams,
                                   final Set<KeyValue<Long, Long>> expectedStoreContent,
-                                  final String reason) throws Exception {
-        final ReadOnlyKeyValueStore<Long, Long> store = IntegrationTestUtils
-            .getStore(300_000L, storeName, streams, QueryableStoreTypes.keyValueStore());
-        assertNotNull(store);
+                                  final String reason) {
+        final StateQueryRequest<KeyValueIterator<Long, Long>> request =
+                inStore(storeName).withQuery(RangeQuery.withNoBounds());
 
-        try (final KeyValueIterator<Long, Long> it = store.all()) {
-            while (it.hasNext()) {
-                assertTrue(reason, expectedStoreContent.remove(it.next()));
+        final StateQueryResult<KeyValueIterator<Long, Long>> result =
+                IntegrationTestUtils.iqv2WaitForResult(streams, request);
+
+        for (final QueryResult<KeyValueIterator<Long, Long>> partitionResult: result.getPartitionResults().values()) {
+            try (final KeyValueIterator<Long, Long> it = partitionResult.getResult()) {
+                while (it.hasNext()) {
+                    assertTrue(reason, expectedStoreContent.remove(it.next()));
+                }
             }
-
-            assertTrue(reason, expectedStoreContent.isEmpty());
         }
+
+        assertTrue(reason, expectedStoreContent.isEmpty());
     }
 }


### PR DESCRIPTION
I found a couple of flakiness with the integration test.

1) IQv1 on stores failed although getting the store itself is covered with timeouts, since the InvalidStoreException is upon the query (`store.all()`). I changed to the util function with IQv2 whose timeout/retry covers the whole procedure. Example of such failure is: https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-11802/11/tests/

2) With ALOS we should not check that the output, as well as the state store content is exactly as of processed once, since it is possible that during processing we got spurious task-migrate exceptions and re-processed with duplicates. I actually cannot reproduce this error locally, but from the jenkins errors it seems possible indeed. Example of such failure is: https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-11433/4/tests/

3) Some minor cleanups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
