### PR TITLE
MINOR: Pass materialized to the inner KTable instance

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
@@ -249,7 +249,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
   def mapValues[VR](mapper: (K, V) => VR, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
-    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey))
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, materialized))
 
   /**
    * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value


### PR DESCRIPTION
Bug Fix: the mapValues method with key-value mapper and materialized did not pass materialized to the inner KTable representation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
