### PR TITLE
KAFKA-13667: Make listeners mandatory in kraft mode

### DIFF
--- a/config/kraft/broker.properties
+++ b/config/kraft/broker.properties
@@ -31,8 +31,7 @@ controller.quorum.voters=1@localhost:9093
 
 ############################# Socket Server Settings #############################
 
-# The address the socket server listens on. If not configured, the host name will be equal to the value of
-# java.net.InetAddress.getCanonicalHostName(), with PLAINTEXT listener name, and port 9092.
+# The address the socket server listens on, must be explicit set for kraft broker
 #   FORMAT:
 #     listeners = listener_name://host_name:port
 #   EXAMPLE:

--- a/config/kraft/server.properties
+++ b/config/kraft/server.properties
@@ -32,13 +32,11 @@ controller.quorum.voters=1@localhost:9093
 ############################# Socket Server Settings #############################
 
 # The address the socket server listens on.
-# Combined nodes (i.e. those with `process.roles=broker,controller`) must list the controller listener here at a minimum.
-# If the broker listener is not defined, the default listener will use a host name that is equal to the value of java.net.InetAddress.getCanonicalHostName(),
-# with PLAINTEXT listener name, and port 9092.
+# Both controller listener and broker listener should be explicit set for combined nodes(process.roles=broker,controller)
 #   FORMAT:
-#     listeners = listener_name://host_name:port
+#     listeners = broker_listener_name://host_name:port,controller_listener_name://host_name:port
 #   EXAMPLE:
-#     listeners = PLAINTEXT://your.host.name:9092
+#     listeners = PLAINTEXT://your.host.name:9092,CONTROLLER://your.host.name:9092
 listeners=PLAINTEXT://:9092,CONTROLLER://:9093
 
 # Name of listener used for communication between brokers.

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -64,6 +64,7 @@ final class KafkaMetadataLogTest {
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
     props.put(MetadataLogSegmentBytesProp, Int.box(10240))
     props.put(MetadataLogSegmentMillisProp, Int.box(10 * 1024))
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     assertThrows(classOf[InvalidConfigurationException], () => {
       val kafkaConfig = KafkaConfig.fromProps(props)
       val metadataConfig = MetadataLogConfig.apply(kafkaConfig, KafkaRaftClient.MAX_BATCH_SIZE_BYTES, KafkaRaftClient.MAX_FETCH_SIZE_BYTES)

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -120,7 +120,6 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
 
     createBrokers(startup = true)
 
-
     // default implementation is a no-op, it is overridden by subclasses if required
     configureSecurityAfterServersStart()
   }

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -51,6 +51,7 @@ class RaftManagerTest {
           props.setProperty(KafkaConfig.QuorumVotersProp, s"${nodeId}@localhost:9093")
         } else { // broker-only
           val voterId = (nodeId.toInt + 1)
+          props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
           props.setProperty(KafkaConfig.QuorumVotersProp, s"${voterId}@localhost:9093")
         }
       } else if (processRoles.contains("controller")) { // controller-only

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -47,6 +47,7 @@ class BrokerLifecycleManagerTest {
     val properties = new Properties()
     properties.setProperty(KafkaConfig.LogDirsProp, "/tmp/foo")
     properties.setProperty(KafkaConfig.ProcessRolesProp, "broker")
+    properties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     properties.setProperty(KafkaConfig.NodeIdProp, "1")
     properties.setProperty(KafkaConfig.QuorumVotersProp, s"2@localhost:9093")
     properties.setProperty(KafkaConfig.ControllerListenerNamesProp, "SSL")

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -95,6 +95,7 @@ class ControllerApisTest {
                                    props: Properties = new Properties()): ControllerApis = {
     props.put(KafkaConfig.NodeIdProp, nodeId: java.lang.Integer)
     props.put(KafkaConfig.ProcessRolesProp, "controller")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9093")
     props.put(KafkaConfig.ControllerListenerNamesProp, "PLAINTEXT")
     props.put(KafkaConfig.QuorumVotersProp, s"$nodeId@localhost:9092")
     new ControllerApis(

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -290,6 +290,7 @@ class KafkaConfigTest {
   def testControllerListenerDefinedForKRaftBroker(): Unit = {
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.NodeIdProp, "1")
     props.put(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
 
@@ -356,6 +357,7 @@ class KafkaConfigTest {
   def testControllerListenerNameMapsToPlaintextByDefaultForKRaft(): Unit = {
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
     props.put(KafkaConfig.NodeIdProp, "1")
     props.put(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
@@ -370,7 +372,7 @@ class KafkaConfigTest {
     props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
     props.put(KafkaConfig.ListenersProp, "SSL://localhost:9092")
     assertBadConfigContainingMessage(props, controllerNotFoundInMapMessage)
-    props.remove(KafkaConfig.ListenersProp)
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     // ensure we don't map it to PLAINTEXT when it is explicitly mapped otherwise
     props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "PLAINTEXT:PLAINTEXT,CONTROLLER:SSL")
     assertEquals(Some(SecurityProtocol.SSL),
@@ -528,7 +530,7 @@ class KafkaConfigTest {
     CoreUtils.listenerListToEndPoints(listenerList, securityProtocolMap)
 
   @Test
-  def testListenerDefaults(): Unit = {
+  def testListenerDefaultsInZkMode(): Unit = {
     val props = new Properties()
     props.put(KafkaConfig.BrokerIdProp, "1")
     props.put(KafkaConfig.ZkConnectProp, "localhost:2181")
@@ -538,6 +540,54 @@ class KafkaConfigTest {
     assertEquals(listenerListToEndPoints("PLAINTEXT://:9092"), conf.listeners)
     assertNull(conf.listeners.find(_.securityProtocol == SecurityProtocol.PLAINTEXT).get.host)
     assertEquals(conf.effectiveAdvertisedListeners, listenerListToEndPoints("PLAINTEXT://:9092"))
+  }
+
+  @Test
+  def testListenerShouldBeSetForKRaftBrokerNode(): Unit = {
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
+    props.put(KafkaConfig.NodeIdProp, "2")
+    props.put(KafkaConfig.QuorumVotersProp, "1@localhost:9093")
+
+    assertFalse(isValidKafkaConfig(props))
+    assertBadConfigContainingMessage(props,
+      s"${KafkaConfig.ListenersProp} must be explicit set for all kraft nodes, for example, PLAINTEXT://:9092 for broker nodes(${KafkaConfig.ProcessRolesProp}=broker)")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
+    KafkaConfig.fromProps(props)
+    assertTrue(isValidKafkaConfig(props))
+  }
+
+  @Test
+  def testListenerShouldBeSetForKRaftControllerNode(): Unit = {
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "controller")
+    props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
+    props.put(KafkaConfig.NodeIdProp, "2")
+    props.put(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
+
+    assertFalse(isValidKafkaConfig(props))
+    assertBadConfigContainingMessage(props,
+      s"${KafkaConfig.ListenersProp} must be explicit set for all kraft nodes, for example, PLAINTEXT://:9093 for controller nodes(${KafkaConfig.ProcessRolesProp}=controller)")
+    props.put(KafkaConfig.ListenersProp, "CONTROLLER://:9093")
+    assertTrue(isValidKafkaConfig(props))
+  }
+
+  @Test
+  def testListenerShouldBeSetForKRaftCombinedNode(): Unit = {
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker,controller")
+    props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
+    props.put(KafkaConfig.NodeIdProp, "2")
+    props.put(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
+
+    assertFalse(isValidKafkaConfig(props))
+    // This is a little different from the previous 2 cases.
+    assertBadConfigContainingMessage(props,
+      s"${KafkaConfig.ListenersProp} must be explicit set for all kraft nodes, for example, PLAINTEXT://:9092,CONTROLLER://:9093 for combined nodes(${KafkaConfig.ProcessRolesProp}=broker,controller)")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092,CONTROLLER://:9093")
+    KafkaConfig.fromProps(props)
+    assertTrue(isValidKafkaConfig(props))
   }
 
   @nowarn("cat=deprecation")
@@ -1396,6 +1446,7 @@ class KafkaConfigTest {
 
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
     props.put(KafkaConfig.MetadataLogDirProp, metadataDir)
     props.put(KafkaConfig.LogDirProp, dataDir)
@@ -1415,6 +1466,7 @@ class KafkaConfigTest {
 
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
     props.put(KafkaConfig.LogDirProp, s"$dataDir1,$dataDir2")
     props.put(KafkaConfig.NodeIdProp, "1")
@@ -1474,6 +1526,7 @@ class KafkaConfigTest {
   def testNodeIdIsInferredByBrokerIdWithKraft(): Unit = {
     val props = new Properties()
     props.setProperty(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
     props.setProperty(KafkaConfig.BrokerIdProp, "3")
     props.setProperty(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
@@ -1489,6 +1542,7 @@ class KafkaConfigTest {
   def testBrokerIdIsInferredByNodeIdWithKraft(): Unit = {
     val props = new Properties()
     props.setProperty(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
     props.setProperty(KafkaConfig.NodeIdProp, "3")
     props.setProperty(KafkaConfig.QuorumVotersProp, "1@localhost:9093")

--- a/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
@@ -61,6 +61,7 @@ class KafkaRaftServerTest {
     val configProperties = new Properties
 
     configProperties.put(KafkaConfig.ProcessRolesProp, "controller")
+    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9093")
     configProperties.put(KafkaConfig.NodeIdProp, configNodeId.toString)
     configProperties.put(KafkaConfig.QuorumVotersProp, s"$configNodeId@localhost:9092")
     configProperties.put(KafkaConfig.ControllerListenerNamesProp, "PLAINTEXT")
@@ -107,6 +108,7 @@ class KafkaRaftServerTest {
 
     val configProperties = new Properties
     configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
+    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
     configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
     configProperties.put(KafkaConfig.LogDirProp, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
@@ -129,6 +131,7 @@ class KafkaRaftServerTest {
     val invalidDir = TestUtils.tempFile("blah")
     val configProperties = new Properties
     configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
+    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
     configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
     configProperties.put(KafkaConfig.MetadataLogDirProp, invalidDir.getAbsolutePath)
@@ -152,6 +155,7 @@ class KafkaRaftServerTest {
     val invalidDir = TestUtils.tempFile("blah")
     val configProperties = new Properties
     configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
+    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
     configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
     configProperties.put(KafkaConfig.MetadataLogDirProp, validDir.getAbsolutePath)
@@ -182,6 +186,7 @@ class KafkaRaftServerTest {
 
     val configProperties = new Properties
     configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
+    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9093")
     configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
     configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
     configProperties.put(KafkaConfig.MetadataLogDirProp, metadataDir.getAbsolutePath)
@@ -205,6 +210,7 @@ class KafkaRaftServerTest {
 
     val configProperties = new Properties
     configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
+    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
     configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
     configProperties.put(KafkaConfig.LogDirProp, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -147,6 +147,7 @@ class ReplicaManagerConcurrencyTest {
     val props = new Properties
     props.put(KafkaConfig.QuorumVotersProp, "100@localhost:12345")
     props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     props.put(KafkaConfig.NodeIdProp, localId.toString)
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
     props.put(KafkaConfig.LogDirProp, logDir.getAbsolutePath)

--- a/core/src/test/scala/unit/kafka/server/ServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerTest.scala
@@ -37,6 +37,7 @@ class ServerTest {
     props.put(KafkaConfig.NodeIdProp, nodeId.toString)
     props.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9093")
     props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9092")
     val config = KafkaConfig.fromProps(props)
 
     val context = Server.createKafkaMetricsContext(config, clusterId)

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -36,6 +36,7 @@ class StorageToolTest {
     val properties = new Properties()
     properties.setProperty(KafkaConfig.LogDirsProp, "/tmp/foo,/tmp/bar")
     properties.setProperty(KafkaConfig.ProcessRolesProp, "controller")
+    properties.put(KafkaConfig.ListenersProp, "PLAINTEXT://:9093")
     properties.setProperty(KafkaConfig.NodeIdProp, "2")
     properties.setProperty(KafkaConfig.QuorumVotersProp, s"2@localhost:9092")
     properties.setProperty(KafkaConfig.ControllerListenerNamesProp, "PLAINTEXT")


### PR DESCRIPTION
*More detailed description of your change*
Currently, default "listeners" value for kraft broker node is permitted but it's not allowed for kraft controller node and combine node, this is not very elegant so we'd better make "listeners" mandatory.  

*Summary of testing strategy (including rationale)*
Unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
