### PR TITLE
KAFKA-13613: Remove hard dependency on HmacSHA256 algorithm for Connect

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
@@ -33,6 +33,9 @@ import java.util.Map;
 
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.INTER_WORKER_KEY_GENERATION_ALGORITHM_CONFIG;
+import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.INTER_WORKER_SIGNATURE_ALGORITHM_CONFIG;
+import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.INTER_WORKER_VERIFICATION_ALGORITHMS_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -63,7 +66,7 @@ public class DistributedConfigTest {
     }
 
     @Test
-    public void shouldNotValidateDefaultKeyAlgorithms() {
+    public void testDefaultAlgorithmsNotPresent() {
         final String fakeKeyGenerationAlgorithm = "FakeKeyGenerationAlgorithm";
         final String fakeMacAlgorithm = "FakeMacAlgorithm";
 
@@ -97,7 +100,23 @@ public class DistributedConfigTest {
             mac.when(() -> Mac.getInstance(fakeMacAlgorithm))
                     .thenReturn(fakeMac);
 
+            // Should succeed; even though the defaults aren't present, the manually-specified algorithms are valid
             new DistributedConfig(configs);
+
+            // Should fail; the default key generation algorithm isn't present, and no override is specified
+            String removed = configs.remove(INTER_WORKER_KEY_GENERATION_ALGORITHM_CONFIG);
+            assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
+            configs.put(INTER_WORKER_KEY_GENERATION_ALGORITHM_CONFIG, removed);
+
+            // Should fail; the default key generation algorithm isn't present, and no override is specified
+            removed = configs.remove(INTER_WORKER_SIGNATURE_ALGORITHM_CONFIG);
+            assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
+            configs.put(INTER_WORKER_SIGNATURE_ALGORITHM_CONFIG, removed);
+
+            // Should fail; the default key generation algorithm isn't present, and no override is specified
+            removed = configs.remove(INTER_WORKER_VERIFICATION_ALGORITHMS_CONFIG);
+            assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
+            configs.put(INTER_WORKER_VERIFICATION_ALGORITHMS_CONFIG, removed);
         }
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13613)

Some JVMs don't come with the `HmacSHA256` algorithm out of the box, but do come with other key generation and/or MAC algorithms. However, it's impossible at the moment to run Connect on such a JVM, because the defaults for the `inter.worker.*.algorithm` properties are validated during worker startup, and that validation includes a check to make sure that the algorithm in question is provided by the worker's JVM.

To address this, automatic validation using the `ConfigDef::Validator` interface is disabled and all KIP-507 [1] related config validation is moved into the `DistributedConfig` constructor, which allows validation to take place only for the algorithms that the worker is actually configured to use. Any of these algorithms may still be the default, but if not, the default will never be validated.

In addition, a bug in the logic for ensuring that a worker's signature algorithm is included in its list of verification algorithms is fixed. The existing logic checks to see if its **key generation** algorithm is included in the list of verification algorithms, which does not adhere to KIP-507 [1] (see docstring for the `inter.worker.verification.algorithms` property), and serves no practical purpose.

[1] - https://cwiki.apache.org/confluence/display/KAFKA/KIP-507%3A+Securing+Internal+Connect+REST+Endpoints#KIP507:SecuringInternalConnectRESTEndpoints-ProposedChanges

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
