### PR TITLE
MINOR: Fix class comparison in `AlterConfigPolicy.RequestMetadata.equals()`

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -323,6 +323,10 @@
       <allow pkg="org.apache.kafka.server.log" />
       <allow pkg="org.apache.kafka.test" />
 
+      <subpackage name="policy">
+        <allow pkg="org.apache.kafka.server.policy" />
+      </subpackage>
+
       <subpackage name="remote">
         <allow pkg="scala.collection" />
       </subpackage>

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -310,6 +310,9 @@
   <subpackage name="server">
     <allow pkg="org.apache.kafka.common" />
 
+    <!-- This is required to make AlterConfigPolicyTest work. -->
+    <allow pkg="org.apache.kafka.server.policy" />
+
     <subpackage name="common">
       <allow pkg="org.apache.kafka.server.common" />
     </subpackage>
@@ -322,10 +325,6 @@
       <allow pkg="org.apache.kafka.server.common" />
       <allow pkg="org.apache.kafka.server.log" />
       <allow pkg="org.apache.kafka.test" />
-
-      <subpackage name="policy">
-        <allow pkg="org.apache.kafka.server.policy" />
-      </subpackage>
 
       <subpackage name="remote">
         <allow pkg="scala.collection" />

--- a/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
@@ -71,7 +71,7 @@ public interface AlterConfigPolicy extends Configurable, AutoCloseable {
 
         @Override
         public boolean equals(Object o) {
-            if (o == null || o.getClass() != o.getClass()) return false;
+            if ((o == null) || (!o.getClass().equals(getClass()))) return false;
             RequestMetadata other = (RequestMetadata) o;
             return resource.equals(other.resource) &&
                 configs.equals(other.configs);

--- a/clients/src/test/java/org/apache/kafka/server/policy/AlterConfigPolicyTest.java
+++ b/clients/src/test/java/org/apache/kafka/server/policy/AlterConfigPolicyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.policy;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.ConfigResource.Type;
+import org.apache.kafka.server.policy.AlterConfigPolicy.RequestMetadata;
+
+import org.junit.jupiter.api.Test;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class AlterConfigPolicyTest {
+
+    @Test
+    public void testRequestMetadataEquals() {
+        RequestMetadata requestMetadata = new RequestMetadata(
+            new ConfigResource(Type.BROKER, "0"),
+            Collections.singletonMap("foo", "bar")
+        );
+
+        assertEquals(requestMetadata, requestMetadata);
+
+        assertNotEquals(requestMetadata, null);
+        assertNotEquals(requestMetadata, new Object());
+        assertNotEquals(requestMetadata, new RequestMetadata(
+            new ConfigResource(Type.BROKER, "1"),
+            Collections.singletonMap("foo", "bar")
+        ));
+        assertNotEquals(requestMetadata, new RequestMetadata(
+            new ConfigResource(Type.BROKER, "0"),
+            Collections.emptyMap()
+        ));
+    }
+}


### PR DESCRIPTION
It was checking 'o' against itself.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
