### PR TITLE
KAFKA-13741 Don't generate Uuid with a leading "-"

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -31,13 +31,11 @@ public class Uuid implements Comparable<Uuid> {
      * A UUID for the metadata topic in KRaft mode. Will never be returned by the randomUuid method.
      */
     public static final Uuid METADATA_TOPIC_ID = new Uuid(0L, 1L);
-    private static final java.util.UUID METADATA_TOPIC_ID_INTERNAL = new java.util.UUID(0L, 1L);
 
     /**
      * A UUID that represents a null or empty UUID. Will never be returned by the randomUuid method.
      */
     public static final Uuid ZERO_UUID = new Uuid(0L, 0L);
-    private static final java.util.UUID ZERO_ID_INTERNAL = new java.util.UUID(0L, 0L);
 
     private final long mostSignificantBits;
     private final long leastSignificantBits;
@@ -51,15 +49,22 @@ public class Uuid implements Comparable<Uuid> {
         this.leastSignificantBits = leastSigBits;
     }
 
+    private static Uuid unsafeRandomUuid() {
+        java.util.UUID jUuid = java.util.UUID.randomUUID();
+        return new Uuid(jUuid.getMostSignificantBits(), jUuid.getLeastSignificantBits());
+    }
+
     /**
      * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
+     *
+     * This will not generate a UUID equal to 0, 1, or one whose string representation starts with a dash ("-")
      */
     public static Uuid randomUuid() {
-        java.util.UUID uuid = java.util.UUID.randomUUID();
-        while (uuid.equals(METADATA_TOPIC_ID_INTERNAL) || uuid.equals(ZERO_ID_INTERNAL)) {
-            uuid = java.util.UUID.randomUUID();
+        Uuid uuid = unsafeRandomUuid();
+        while (uuid.equals(METADATA_TOPIC_ID) || uuid.equals(ZERO_UUID) || uuid.toString().startsWith("-")) {
+            uuid = unsafeRandomUuid();
         }
-        return new Uuid(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        return uuid;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/UuidTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/UuidTest.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.common;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -72,12 +74,13 @@ public class UuidTest {
         assertEquals(Uuid.fromString(zeroIdString), Uuid.ZERO_UUID);
     }
 
-    @Test
+    @RepeatedTest(100)
     public void testRandomUuid() {
         Uuid randomID = Uuid.randomUuid();
 
         assertNotEquals(randomID, Uuid.ZERO_UUID);
         assertNotEquals(randomID, Uuid.METADATA_TOPIC_ID);
+        assertFalse(randomID.toString().startsWith("-"));
     }
 
     @Test


### PR DESCRIPTION
Since we use URL-safe base64 encoded Uuid's for cluster ID, it is possible for dash ("-") characters to be present in the ID string. This causes problems with the argument parsing for things like `kafka-storage.sh format`.  This patch regenerates a Uuid if it has a leading `-`.

This issue is not a problem for generated topic IDs since our command line tools use topic name. However, with this patch, topic IDs (and any other internal Uuid we generate) will not have leading "-". 