### PR TITLE
KAFKA-13497: Add trace logging to RegexRouter

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/RegexRouter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/RegexRouter.java
@@ -20,12 +20,16 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.transforms.util.RegexValidator;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RegexRouter<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final Logger log = LoggerFactory.getLogger(RegexRouter.class);
 
     public static final String OVERVIEW_DOC = "Update the record topic using the configured regular expression and replacement string."
             + "<p/>Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>. "
@@ -57,7 +61,10 @@ public class RegexRouter<R extends ConnectRecord<R>> implements Transformation<R
         final Matcher matcher = regex.matcher(record.topic());
         if (matcher.matches()) {
             final String topic = matcher.replaceFirst(replacement);
+            log.trace("Rerouting from topic '{}' to new topic '{}'", record.topic(), topic);
             return record.newRecord(topic, record.kafkaPartition(), record.keySchema(), record.key(), record.valueSchema(), record.value(), record.timestamp());
+        } else {
+            log.trace("Not rerouting topic '{}' as it does not match the configured regex", record.topic());
         }
         return record;
     }


### PR DESCRIPTION
[JIRA](https://issues.apache.org/jira/browse/KAFKA-13497)

Adds runtime logging to the `RegexRouter` to show exactly which topics get routed where.

As noted in the Jira ticket, this is similar to existing logging in the `Cast` SMT: https://github.com/apache/kafka/blob/620f1d88d80fdf8150bd0b75be307bc4a2d3a0ea/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java#L174

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
