### PR TITLE
 KAFKA-13750: Client Compatability KafkaTest uses invalid idempotency configs

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -43,9 +43,11 @@ def get_broker_features(broker_version):
     if broker_version < V_0_11_0_0:
         features["describe-acls-supported"] = False
         features["describe-configs-supported"] = False
+        features["idempotent-producer-supported"] = False
     else:
         features["describe-acls-supported"] = True
         features["describe-configs-supported"] = True
+        features["idempotent-producer-supported"] = True
     return features
 
 def run_command(node, cmd, ssh_log_file):

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -175,12 +175,12 @@ public class ClientCompatibilityTest {
             .metavar("DESCRIBE_CONFIGS_SUPPORTED")
             .help("Whether describeConfigs is supported in the AdminClient.");
         parser.addArgument("--idempotent-producer-supported")
-                .action(store())
-                .required(true)
-                .type(Boolean.class)
-                .dest("idempotentProducerSupported")
-                .metavar("IDEMPOTENT_PRODUCER_SUPPORTED")
-                .help("Whether the producer supports idempotency.");
+            .action(store())
+            .required(true)
+            .type(Boolean.class)
+            .dest("idempotentProducerSupported")
+            .metavar("IDEMPOTENT_PRODUCER_SUPPORTED")
+            .help("Whether the producer supports idempotency.");
 
         Namespace res = null;
         try {

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -88,6 +88,7 @@ public class ClientCompatibilityTest {
         final boolean createTopicsSupported;
         final boolean describeAclsSupported;
         final boolean describeConfigsSupported;
+        final boolean idempotentProducerSupported;
 
         TestConfig(Namespace res) {
             this.bootstrapServer = res.getString("bootstrapServer");
@@ -99,6 +100,7 @@ public class ClientCompatibilityTest {
             this.createTopicsSupported = res.getBoolean("createTopicsSupported");
             this.describeAclsSupported = res.getBoolean("describeAclsSupported");
             this.describeConfigsSupported = res.getBoolean("describeConfigsSupported");
+            this.idempotentProducerSupported = res.get("idempotentProducerSupported");
         }
     }
 
@@ -172,6 +174,13 @@ public class ClientCompatibilityTest {
             .dest("describeConfigsSupported")
             .metavar("DESCRIBE_CONFIGS_SUPPORTED")
             .help("Whether describeConfigs is supported in the AdminClient.");
+        parser.addArgument("--idempotent-producer-supported")
+                .action(store())
+                .required(true)
+                .type(Boolean.class)
+                .dest("idempotentProducerSupported")
+                .metavar("IDEMPOTENT_PRODUCER_SUPPORTED")
+                .help("Whether the producer supports idempotency.");
 
         Namespace res = null;
         try {
@@ -243,6 +252,9 @@ public class ClientCompatibilityTest {
     public void testProduce() throws Exception {
         Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, testConfig.bootstrapServer);
+        if (!testConfig.idempotentProducerSupported) {
+            producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "false");
+        }
         ByteArraySerializer serializer = new ByteArraySerializer();
         KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps, serializer, serializer);
         ProducerRecord<byte[], byte[]> record1 = new ProducerRecord<>(testConfig.topic, message1);


### PR DESCRIPTION
With the switch to idempotency as a default, ClientCompatibilityFeaturesTest.run_compatibility_test broke for versions prior to 0.11 where EOS was enabled. This PR disables idempotency for kafka versions prior to 0.11.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
