### PR TITLE
MINOR: Correct Connect docs on connector/task states

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -129,7 +129,7 @@ public class ConnectMetricsRegistry {
 
         connectorStatus = createTemplate("status", CONNECTOR_GROUP_NAME,
                                          "The status of the connector. One of 'unassigned', 'running', 'paused', 'failed', or " +
-                                         "'destroyed'.",
+                                         "'restarting'.",
                                          connectorTags);
         connectorType = createTemplate("connector-type", CONNECTOR_GROUP_NAME, "The type of the connector. One of 'source' or 'sink'.",
                                        connectorTags);
@@ -144,7 +144,7 @@ public class ConnectMetricsRegistry {
 
         taskStatus = createTemplate("status", TASK_GROUP_NAME,
                                     "The status of the connector task. One of 'unassigned', 'running', 'paused', 'failed', or " +
-                                    "'destroyed'.",
+                                    "'restarting'.",
                                     workerTaskTags);
         taskRunningRatio = createTemplate("running-ratio", TASK_GROUP_NAME,
                                           "The fraction of time this task has spent in the running state.", workerTaskTags);

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -710,7 +710,6 @@ Struct struct = new Struct(schema)
     <li><b>RUNNING:</b> The connector/task is running.</li>
     <li><b>PAUSED:</b> The connector/task has been administratively paused.</li>
     <li><b>FAILED:</b> The connector/task has failed (usually by raising an exception, which is reported in the status output).</li>
-    <li><b>DESTROYED:</b> The connector/task has been administratively removed and will stop appearing in the Connect cluster.</li>
     </ul>
 
     <p>

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -710,6 +710,7 @@ Struct struct = new Struct(schema)
     <li><b>RUNNING:</b> The connector/task is running.</li>
     <li><b>PAUSED:</b> The connector/task has been administratively paused.</li>
     <li><b>FAILED:</b> The connector/task has failed (usually by raising an exception, which is reported in the status output).</li>
+    <li><b>RESTARTING:</b> The connector/task is either actively restarting or is expected to restart soon</li>
     </ul>
 
     <p>


### PR DESCRIPTION
The `DESTROYED` state is represented internally as a tombstone record when running in distributed mode ([1]) and by the removal of the connector/task from the in-memory status map when running in standalone mode ([2], [3]). As a result, it will never appear to users of the REST API, and we should remove mention of it from our docs so that developers creating tooling against the REST API don't write unnecessary logic to account for that state.

[1] - https://github.com/apache/kafka/blob/3dacdc5694da5db283524889d2270695defebbaa/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java#L318

[2] - https://github.com/apache/kafka/blob/3dacdc5694da5db283524889d2270695defebbaa/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryStatusBackingStore.java#L64-L65

[3] - https://github.com/apache/kafka/blob/3dacdc5694da5db283524889d2270695defebbaa/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryStatusBackingStore.java#L77-L78

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
