### PR TITLE
KAFKA-13785: [8/N][emit final] time-ordered session store

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBTimeOrderedSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBTimeOrderedSegmentedBytesStore.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * RocksDB store backed by two SegmentedBytesStores which can optimize scan by time as well as window
+ * lookup for a specific key.
+ *
+ * Schema for first SegmentedBytesStore (base store) is as below:
+ *     Key schema: | timestamp + [timestamp] + recordkey |
+ *     Value schema: | value |. Value here is determined by caller.
+ *
+ * Schema for second SegmentedBytesStore (index store) is as below:
+ *     Key schema: | record + timestamp + [timestamp]|
+ *     Value schema: ||
+ *
+ * Note there could be two timestamps if we store both window end time and window start time.
+ *
+ * Operations:
+ *     Put: 1. Put to index store. 2. Put to base store.
+ *     Delete: 1. Delete from base store. 2. Delete from index store.
+ * Since we need to update two stores, failure can happen in the middle. We put in index store first
+ * to make sure if a failure happens in second step and the view is inconsistent, we can't get the
+ * value for the key. We delete from base store first to make sure if a failure happens in second step
+ * and the view is inconsistent, we can't get the value for the key.
+ *
+ * Note:
+ *     Index store can be optional if we can construct the timestamp in base store instead of looking
+ *     them up from index store.
+ *
+ * @see RocksDBTimeOrderedSessionSegmentedBytesStore
+ * @see RocksDBTimeOrderedSegmentedBytesStore
+ */
+public abstract class AbstractRocksDBTimeOrderedSegmentedBytesStore extends AbstractDualSchemaRocksDBSegmentedBytesStore<KeyValueSegment> {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractDualSchemaRocksDBSegmentedBytesStore.class);
+
+    abstract class IndexToBaseStoreIterator implements KeyValueIterator<Bytes, byte[]> {
+        private final KeyValueIterator<Bytes, byte[]> indexIterator;
+        private byte[] cachedValue;
+
+
+        IndexToBaseStoreIterator(final KeyValueIterator<Bytes, byte[]> indexIterator) {
+            this.indexIterator = indexIterator;
+        }
+
+        @Override
+        public void close() {
+            indexIterator.close();
+        }
+
+        @Override
+        public Bytes peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return getBaseKey(indexIterator.peekNextKey());
+        }
+
+        @Override
+        public boolean hasNext() {
+            while (indexIterator.hasNext()) {
+                final Bytes key = indexIterator.peekNextKey();
+                final Bytes baseKey = getBaseKey(key);
+
+                cachedValue = get(baseKey);
+                if (cachedValue == null) {
+                    // Key not in base store, inconsistency happened and remove from index.
+                    indexIterator.next();
+                    AbstractRocksDBTimeOrderedSegmentedBytesStore.this.removeIndex(key);
+                } else {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public KeyValue<Bytes, byte[]> next() {
+            if (cachedValue == null && !hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<Bytes, byte[]> ret = indexIterator.next();
+            final byte[] value = cachedValue;
+            cachedValue = null;
+            return KeyValue.pair(getBaseKey(ret.key), value);
+        }
+
+        abstract protected Bytes getBaseKey(final Bytes indexKey);
+    }
+
+    AbstractRocksDBTimeOrderedSegmentedBytesStore(final String name,
+                                          final String metricsScope,
+                                          final long retention,
+                                          final long segmentInterval,
+                                          final KeySchema baseKeySchema,
+                                          final Optional<KeySchema> indexKeySchema) {
+        super(name, metricsScope, baseKeySchema, indexKeySchema,
+            new KeyValueSegments(name, metricsScope, retention, segmentInterval));
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> fetch(final Bytes key,
+                                                 final long from,
+                                                 final long to) {
+        return fetch(key, from, to, true);
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> backwardFetch(final Bytes key,
+                                                         final long from,
+                                                         final long to) {
+        return fetch(key, from, to, false);
+    }
+
+    abstract protected IndexToBaseStoreIterator getIndexToBaseStoreIterator(final SegmentIterator<KeyValueSegment> segmentIterator);
+
+    KeyValueIterator<Bytes, byte[]> fetch(final Bytes key,
+                                          final long from,
+                                          final long to,
+                                          final boolean forward) {
+        if (indexKeySchema.isPresent()) {
+            final List<KeyValueSegment> searchSpace = indexKeySchema.get().segmentsToSearch(segments, from, to,
+                forward);
+
+            final Bytes binaryFrom = indexKeySchema.get().lowerRangeFixedSize(key, from);
+            final Bytes binaryTo = indexKeySchema.get().upperRangeFixedSize(key, to);
+
+            return getIndexToBaseStoreIterator(new SegmentIterator<>(
+                searchSpace.iterator(),
+                indexKeySchema.get().hasNextCondition(key, key, from, to, forward),
+                binaryFrom,
+                binaryTo,
+                forward));
+        }
+
+        final List<KeyValueSegment> searchSpace = baseKeySchema.segmentsToSearch(segments, from, to,
+            forward);
+
+        final Bytes binaryFrom = baseKeySchema.lowerRangeFixedSize(key, from);
+        final Bytes binaryTo = baseKeySchema.upperRangeFixedSize(key, to);
+
+        return new SegmentIterator<>(
+            searchSpace.iterator(),
+            baseKeySchema.hasNextCondition(key, key, from, to, forward),
+            binaryFrom,
+            binaryTo,
+            forward);
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> fetch(final Bytes keyFrom,
+                                                 final Bytes keyTo,
+                                                 final long from,
+                                                 final long to) {
+        return fetch(keyFrom, keyTo, from, to, true);
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> backwardFetch(final Bytes keyFrom,
+                                                         final Bytes keyTo,
+                                                         final long from,
+                                                         final long to) {
+        return fetch(keyFrom, keyTo, from, to, false);
+    }
+
+    KeyValueIterator<Bytes, byte[]> fetch(final Bytes keyFrom,
+                                          final Bytes keyTo,
+                                          final long from,
+                                          final long to,
+                                          final boolean forward) {
+        if (keyFrom != null && keyTo != null && keyFrom.compareTo(keyTo) > 0) {
+            LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. " +
+                    "This may be due to range arguments set in the wrong order, " +
+                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
+                    "Note that the built-in numerical serdes do not follow this for negative numbers");
+            return KeyValueIterators.emptyIterator();
+        }
+
+        if (indexKeySchema.isPresent()) {
+            final List<KeyValueSegment> searchSpace = indexKeySchema.get().segmentsToSearch(segments, from, to,
+                forward);
+
+            final Bytes binaryFrom = indexKeySchema.get().lowerRange(keyFrom, from);
+            final Bytes binaryTo = indexKeySchema.get().upperRange(keyTo, to);
+
+            return getIndexToBaseStoreIterator(new SegmentIterator<>(
+                searchSpace.iterator(),
+                indexKeySchema.get().hasNextCondition(keyFrom, keyTo, from, to, forward),
+                binaryFrom,
+                binaryTo,
+                forward));
+        }
+
+        final List<KeyValueSegment> searchSpace = baseKeySchema.segmentsToSearch(segments, from, to,
+            forward);
+
+        final Bytes binaryFrom = baseKeySchema.lowerRange(keyFrom, from);
+        final Bytes binaryTo = baseKeySchema.upperRange(keyTo, to);
+
+        return new SegmentIterator<>(
+            searchSpace.iterator(),
+            baseKeySchema.hasNextCondition(keyFrom, keyTo, from, to, forward),
+            binaryFrom,
+            binaryTo,
+            forward);
+    }
+
+
+    @Override
+    public void remove(final Bytes key, final long timestamp) {
+        throw new UnsupportedOperationException("Not supported operation");
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> fetchAll(final long timeFrom,
+                                                    final long timeTo) {
+        final List<KeyValueSegment> searchSpace = segments.segments(timeFrom, timeTo, true);
+        final Bytes binaryFrom = baseKeySchema.lowerRange(null, timeFrom);
+        final Bytes binaryTo = baseKeySchema.upperRange(null, timeTo);
+
+        return new SegmentIterator<>(
+                searchSpace.iterator(),
+                baseKeySchema.hasNextCondition(null, null, timeFrom, timeTo, true),
+                binaryFrom,
+                binaryTo,
+                true);
+    }
+
+    @Override
+    public KeyValueIterator<Bytes, byte[]> backwardFetchAll(final long timeFrom,
+                                                            final long timeTo) {
+        final List<KeyValueSegment> searchSpace = segments.segments(timeFrom, timeTo, false);
+        final Bytes binaryFrom = baseKeySchema.lowerRange(null, timeFrom);
+        final Bytes binaryTo = baseKeySchema.upperRange(null, timeTo);
+
+        return new SegmentIterator<>(
+                searchSpace.iterator(),
+                baseKeySchema.hasNextCondition(null, null, timeFrom, timeTo, false),
+                binaryFrom,
+                binaryTo,
+                false);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedSessionKeySchemas.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedSessionKeySchemas.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import java.util.Arrays;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedSessionKeySchemas.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedSessionKeySchemas.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.Arrays;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.internals.SegmentedBytesStore.KeySchema;
+
+import static org.apache.kafka.streams.state.StateSerdes.TIMESTAMP_SIZE;
+
+public class PrefixedSessionKeySchemas {
+
+    private static final int PREFIX_SIZE = 1;
+    private static final byte TIME_FIRST_PREFIX = 0;
+    private static final byte KEY_FIRST_PREFIX = 1;
+
+    private static byte extractPrefix(final byte[] binaryBytes) {
+        return binaryBytes[0];
+    }
+
+    public static class TimeFirstSessionKeySchema implements KeySchema {
+
+        @Override
+        public Bytes upperRange(final Bytes key, final long to) {
+            if (key == null) {
+                // Put next prefix instead of null so that we can start from right prefix
+                // when scanning backwards
+                final byte nextPrefix = TIME_FIRST_PREFIX + 1;
+                return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE).put(nextPrefix).array());
+            }
+            return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE + 2 * TIMESTAMP_SIZE + key.get().length)
+                .put(TIME_FIRST_PREFIX)
+                // the end timestamp can be as large as possible as long as it's larger than start time
+                .putLong(Long.MAX_VALUE)
+                // this is the start timestamp
+                .putLong(to)
+                .put(key.get())
+                .array());
+        }
+
+        @Override
+        public Bytes lowerRange(final Bytes key, final long from) {
+            if (key == null) {
+                return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE + TIMESTAMP_SIZE)
+                    .put(TIME_FIRST_PREFIX)
+                    .putLong(from)
+                    .array());
+            }
+
+            return Bytes.wrap(ByteBuffer.allocate(PREFIX_SIZE + 2 * TIMESTAMP_SIZE + key.get().length)
+                .put(TIME_FIRST_PREFIX)
+                .putLong(from)
+                .putLong(0L)
+                .put(key.get())
+                .array());
+        }
+
+        /**
+         *
+         * @param key the key in the range
+         * @param to the latest start time
+         * @return
+         */
+        @Override
+        public Bytes upperRangeFixedSize(final Bytes key, final long to) {
+            return toBinary(key, to, Long.MAX_VALUE);
+        }
+
+        /**
+         *
+         * @param key the key in the range
+         * @param from the earliest end timestamp in the range
+         * @return
+         */
+        @Override
+        public Bytes lowerRangeFixedSize(final Bytes key, final long from) {
+            return toBinary(key, 0, Math.max(0, from));
+        }
+
+        @Override
+        public long segmentTimestamp(final Bytes key) {
+            return extractEndTimestamp(key.get());
+        }
+
+        @Override
+        public HasNextCondition hasNextCondition(final Bytes binaryKeyFrom,
+            final Bytes binaryKeyTo, final long from, final long to, final boolean forward) {
+            return iterator -> {
+                while (iterator.hasNext()) {
+                    final Bytes bytes = iterator.peekNextKey();
+                    final byte prefix = extractPrefix(bytes.get());
+
+                    if (prefix != TIME_FIRST_PREFIX) {
+                        return false;
+                    }
+
+                    final Windowed<Bytes> windowedKey = from(bytes);
+                    final long endTime = windowedKey.window().end();
+                    final long startTime = windowedKey.window().start();
+
+                    // We can return false directly here since keys are sorted by end time and if
+                    // we get time smaller than `from`, there won't be time within range.
+                    if (!forward && endTime < from) {
+                        return false;
+                    }
+
+                    if ((binaryKeyFrom == null || windowedKey.key().compareTo(binaryKeyFrom) >= 0)
+                        && (binaryKeyTo == null || windowedKey.key().compareTo(binaryKeyTo) <= 0)
+                        && endTime >= from && startTime <= to) {
+                        return true;
+                    }
+                    iterator.next();
+                }
+                return false;
+            };
+        }
+
+        @Override
+        public <S extends Segment> List<S> segmentsToSearch(final Segments<S> segments,
+                                                            final long from,
+                                                            final long to,
+                                                            final boolean forward) {
+            return segments.segments(from, Long.MAX_VALUE, forward);
+        }
+
+        static long extractStartTimestamp(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getLong(PREFIX_SIZE + TIMESTAMP_SIZE);
+        }
+
+        static long extractEndTimestamp(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getLong(PREFIX_SIZE);
+        }
+
+        private static <K> K extractKey(final byte[] binaryKey,
+                                        final Deserializer<K> deserializer,
+                                        final String topic) {
+            return deserializer.deserialize(topic, extractKeyBytes(binaryKey));
+        }
+
+        static byte[] extractKeyBytes(final byte[] binaryKey) {
+            final byte[] bytes = new byte[binaryKey.length - 2 * TIMESTAMP_SIZE - PREFIX_SIZE];
+            System.arraycopy(binaryKey, PREFIX_SIZE + 2 * TIMESTAMP_SIZE, bytes, 0, bytes.length);
+            return bytes;
+        }
+
+        static Window extractWindow(final byte[] binaryKey) {
+            final ByteBuffer buffer = ByteBuffer.wrap(binaryKey);
+            final long start = buffer.getLong(PREFIX_SIZE + TIMESTAMP_SIZE);
+            final long end = buffer.getLong(PREFIX_SIZE);
+            return new SessionWindow(start, end);
+        }
+
+        public static Windowed<Bytes> from(final Bytes bytesKey) {
+            final byte[] binaryKey = bytesKey.get();
+            final Window window = extractWindow(binaryKey);
+            return new Windowed<>(Bytes.wrap(extractKeyBytes(binaryKey)), window);
+        }
+
+        public static <K> Windowed<K> from(final byte[] binaryKey,
+                                           final Deserializer<K> keyDeserializer,
+                                           final String topic) {
+            final K key = extractKey(binaryKey, keyDeserializer, topic);
+            final Window window = extractWindow(binaryKey);
+            return new Windowed<>(key, window);
+        }
+
+        public static <K> byte[] toBinary(final Windowed<K> sessionKey,
+                                          final Serializer<K> serializer,
+                                          final String topic) {
+            final byte[] bytes = serializer.serialize(topic, sessionKey.key());
+            return toBinary(Bytes.wrap(bytes), sessionKey.window().start(), sessionKey.window().end()).get();
+        }
+
+        public static Bytes toBinary(final Windowed<Bytes> sessionKey) {
+            return toBinary(sessionKey.key(), sessionKey.window().start(), sessionKey.window().end());
+        }
+
+        public static Bytes toBinary(final Bytes key,
+                                     final long startTime,
+                                     final long endTime) {
+            final byte[] bytes = key.get();
+            final ByteBuffer buf = ByteBuffer.allocate(PREFIX_SIZE + bytes.length + 2 * TIMESTAMP_SIZE)
+                .put(TIME_FIRST_PREFIX)
+                .putLong(endTime)
+                .putLong(startTime)
+                .put(bytes);
+            return Bytes.wrap(buf.array());
+        }
+
+        public static byte[] fromNonPrefixSessionKey(final byte[] binaryKey) {
+            final ByteBuffer buffer = ByteBuffer.allocate(PREFIX_SIZE + binaryKey.length).put(TIME_FIRST_PREFIX);
+            // Put timestamp
+            buffer.put(binaryKey, binaryKey.length - 2 * TIMESTAMP_SIZE, 2 * TIMESTAMP_SIZE);
+            buffer.put(binaryKey, 0, binaryKey.length - 2 * TIMESTAMP_SIZE);
+
+            return buffer.array();
+        }
+    }
+
+    public static class KeyFirstSessionKeySchema implements KeySchema {
+
+        @Override
+        public Bytes upperRange(final Bytes key, final long to) {
+            final Bytes noPrefixBytes = new SessionKeySchema().upperRange(key, to);
+            return wrapPrefix(noPrefixBytes, true);
+        }
+
+        @Override
+        public Bytes lowerRange(final Bytes key, final long from) {
+            final Bytes noPrefixBytes = new SessionKeySchema().lowerRange(key, from);
+            // Wrap at least prefix even key is null
+            return wrapPrefix(noPrefixBytes, false);
+        }
+
+        @Override
+        public Bytes lowerRangeFixedSize(final Bytes key, final long from) {
+            final Bytes noPrefixBytes = new SessionKeySchema().lowerRangeFixedSize(key, from);
+            return wrapPrefix(noPrefixBytes, false);
+        }
+
+        @Override
+        public Bytes upperRangeFixedSize(final Bytes key, final long to) {
+            final Bytes noPrefixBytes = new SessionKeySchema().upperRangeFixedSize(key, to);
+            return wrapPrefix(noPrefixBytes, true);
+        }
+
+        @Override
+        public long segmentTimestamp(final Bytes key) {
+            return extractEndTimestamp(key.get());
+        }
+
+        @Override
+        public HasNextCondition hasNextCondition(final Bytes binaryKeyFrom,
+                                                 final Bytes binaryKeyTo,
+                                                 final long from,
+                                                 final long to,
+                                                 final boolean forward) {
+            return iterator -> {
+                while (iterator.hasNext()) {
+                    final Bytes bytes = iterator.peekNextKey();
+                    final byte prefix = extractPrefix(bytes.get());
+
+                    if (prefix != KEY_FIRST_PREFIX) {
+                        return false;
+                    }
+
+                    final Windowed<Bytes> windowedKey = from(bytes);
+                    final long endTime = windowedKey.window().end();
+                    final long startTime = windowedKey.window().start();
+
+                    if ((binaryKeyFrom == null || windowedKey.key().compareTo(binaryKeyFrom) >= 0)
+                        && (binaryKeyTo == null || windowedKey.key().compareTo(binaryKeyTo) <= 0)
+                        && endTime >= from
+                        && startTime <= to) {
+                        return true;
+                    }
+                    iterator.next();
+                }
+                return false;
+            };
+        }
+
+        @Override
+        public <S extends Segment> List<S> segmentsToSearch(final Segments<S> segments,
+                                                            final long from,
+                                                            final long to,
+                                                            final boolean forward) {
+            return segments.segments(from, Long.MAX_VALUE, forward);
+        }
+
+        static Window extractWindow(final byte[] binaryKey) {
+            final ByteBuffer buffer = ByteBuffer.wrap(binaryKey);
+            final long start = buffer.getLong(binaryKey.length - TIMESTAMP_SIZE);
+            final long end = buffer.getLong(binaryKey.length - 2 * TIMESTAMP_SIZE);
+            return new SessionWindow(start, end);
+        }
+
+        static byte[] extractKeyBytes(final byte[] binaryKey) {
+            final byte[] bytes = new byte[binaryKey.length - 2 * TIMESTAMP_SIZE - PREFIX_SIZE];
+            System.arraycopy(binaryKey, PREFIX_SIZE, bytes, 0, bytes.length);
+            return bytes;
+        }
+
+        public static Windowed<Bytes> from(final Bytes bytesKey) {
+            final byte[] binaryKey = bytesKey.get();
+            final Window window = extractWindow(binaryKey);
+            return new Windowed<>(Bytes.wrap(extractKeyBytes(binaryKey)), window);
+        }
+
+        private static <K> K extractKey(final byte[] binaryKey,
+                                        final Deserializer<K> deserializer,
+                                        final String topic) {
+            return deserializer.deserialize(topic, extractKeyBytes(binaryKey));
+        }
+
+        public static <K> Windowed<K> from(final byte[] binaryKey,
+                                           final Deserializer<K> keyDeserializer,
+                                           final String topic) {
+            final K key = extractKey(binaryKey, keyDeserializer, topic);
+            final Window window = extractWindow(binaryKey);
+            return new Windowed<>(key, window);
+        }
+
+        static long extractStartTimestamp(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getLong(binaryKey.length - TIMESTAMP_SIZE);
+        }
+
+        static long extractEndTimestamp(final byte[] binaryKey) {
+            return ByteBuffer.wrap(binaryKey).getLong(binaryKey.length - 2 * TIMESTAMP_SIZE);
+        }
+
+        public static Bytes toBinary(final Windowed<Bytes> sessionKey) {
+            return toBinary(sessionKey.key(), sessionKey.window().start(), sessionKey.window().end());
+        }
+
+        public static <K> byte[] toBinary(final Windowed<K> sessionKey,
+                                          final Serializer<K> serializer,
+                                          final String topic) {
+            final byte[] bytes = serializer.serialize(topic, sessionKey.key());
+            return toBinary(Bytes.wrap(bytes), sessionKey.window().start(), sessionKey.window().end()).get();
+        }
+
+        public static Bytes toBinary(final Bytes key,
+                                     final long startTime,
+                                     final long endTime) {
+            final byte[] bytes = key.get();
+            final ByteBuffer buf = ByteBuffer.allocate(PREFIX_SIZE + bytes.length + 2 * TIMESTAMP_SIZE);
+            buf.put(KEY_FIRST_PREFIX);
+            buf.put(bytes);
+            buf.putLong(endTime);
+            buf.putLong(startTime);
+            return Bytes.wrap(buf.array());
+        }
+
+        private static Bytes wrapPrefix(final Bytes noPrefixKey, final boolean upperRange) {
+            // Need to scan from prefix even key is null
+            if (noPrefixKey == null) {
+                final byte prefix = upperRange ? KEY_FIRST_PREFIX + 1 : KEY_FIRST_PREFIX;
+                final byte[] ret = ByteBuffer.allocate(PREFIX_SIZE)
+                    .put(prefix)
+                    .array();
+                return Bytes.wrap(ret);
+            }
+            final byte[] ret = ByteBuffer.allocate(PREFIX_SIZE + noPrefixKey.get().length)
+                .put(KEY_FIRST_PREFIX)
+                .put(noPrefixKey.get())
+                .array();
+            return Bytes.wrap(ret);
+        }
+
+        public static byte[] fromNonPrefixSessionKey(final byte[] binaryKey) {
+            return wrapPrefix(Bytes.wrap(binaryKey), false).get();
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedWindowKeySchemas.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedWindowKeySchemas.java
@@ -41,7 +41,7 @@ public class PrefixedWindowKeySchemas {
         return binaryBytes[0];
     }
 
-    public static class TimeFirstWindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
+    public static class TimeFirstWindowKeySchema implements KeySchema {
 
         @Override
         public Bytes upperRange(final Bytes key, final long to) {
@@ -226,8 +226,6 @@ public class PrefixedWindowKeySchemas {
 
     public static class KeyFirstWindowKeySchema implements KeySchema {
 
-
-
         @Override
         public Bytes upperRange(final Bytes key, final long to) {
             final Bytes noPrefixBytes = new WindowKeySchema().upperRange(key, to);
@@ -255,7 +253,7 @@ public class PrefixedWindowKeySchemas {
 
         @Override
         public long segmentTimestamp(final Bytes key) {
-            return KeyFirstWindowKeySchema.extractStoreTimestamp(key.get());
+            return extractStoreTimestamp(key.get());
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSessionStore.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.Objects;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.internals.PrefixedSessionKeySchemas.TimeFirstSessionKeySchema;
+
+public class RocksDBTimeOrderedSessionStore
+    extends WrappedStateStore<RocksDBTimeOrderedSessionSegmentedBytesStore, Object, Object>
+    implements SessionStore<Bytes, byte[]> {
+
+    private StateStoreContext stateStoreContext;
+
+    RocksDBTimeOrderedSessionStore(final RocksDBTimeOrderedSessionSegmentedBytesStore store) {
+        super(store);
+        Objects.requireNonNull(store, "store is null");
+    }
+
+    @Override
+    public void init(final StateStoreContext context, final StateStore root) {
+        wrapped().init(context, root);
+        this.stateStoreContext = context;
+    }
+
+    @Override
+    public <R> QueryResult<R> query(final Query<R> query,
+                                    final PositionBound positionBound,
+                                    final QueryConfig config) {
+
+        return StoreQueryUtils.handleBasicQueries(
+            query,
+            positionBound,
+            config,
+            this,
+            getPosition(),
+            stateStoreContext
+        );
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes key,
+                                                                  final long earliestSessionEndTime,
+                                                                  final long latestSessionStartTime) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = wrapped().fetch(
+            key,
+            earliestSessionEndTime,
+            latestSessionStartTime
+        );
+        return new WrappedSessionStoreIterator(bytesIterator, TimeFirstSessionKeySchema::from);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes key,
+                                                                          final long earliestSessionEndTime,
+                                                                          final long latestSessionStartTime) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = wrapped().backwardFetch(
+            key,
+            earliestSessionEndTime,
+            latestSessionStartTime
+        );
+        return new WrappedSessionStoreIterator(bytesIterator, TimeFirstSessionKeySchema::from);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes keyFrom,
+                                                                  final Bytes keyTo,
+                                                                  final long earliestSessionEndTime,
+                                                                  final long latestSessionStartTime) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = wrapped().fetch(
+            keyFrom,
+            keyTo,
+            earliestSessionEndTime,
+            latestSessionStartTime
+        );
+        return new WrappedSessionStoreIterator(bytesIterator, TimeFirstSessionKeySchema::from);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes keyFrom,
+                                                                          final Bytes keyTo,
+                                                                          final long earliestSessionEndTime,
+                                                                          final long latestSessionStartTime) {
+        final KeyValueIterator<Bytes, byte[]> bytesIterator = wrapped().backwardFetch(
+            keyFrom,
+            keyTo,
+            earliestSessionEndTime,
+            latestSessionStartTime
+        );
+        return new WrappedSessionStoreIterator(bytesIterator, TimeFirstSessionKeySchema::from);
+    }
+
+    @Override
+    public byte[] fetchSession(final Bytes key,
+                               final long earliestSessionEndTime,
+                               final long latestSessionStartTime) {
+        return wrapped().fetchSession(
+            key,
+            earliestSessionEndTime,
+            latestSessionStartTime
+        );
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes key) {
+        return findSessions(key, 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes key) {
+        return backwardFindSessions(key, 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
+        return findSessions(keyFrom, keyTo, 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo) {
+        return backwardFindSessions(keyFrom, keyTo, 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public void remove(final Windowed<Bytes> sessionKey) {
+        wrapped().remove(sessionKey);
+    }
+
+    @Override
+    public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
+        wrapped().put(sessionKey, aggregate);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIndexedTimeOrderedSessionBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIndexedTimeOrderedSessionBytesStoreSupplier.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
+import org.apache.kafka.streams.state.SessionStore;
+
+public class RocksDbIndexedTimeOrderedSessionBytesStoreSupplier implements SessionBytesStoreSupplier {
+    private final String name;
+    private final long retentionPeriod;
+    private final boolean withIndex;
+
+    public RocksDbIndexedTimeOrderedSessionBytesStoreSupplier(final String name,
+                                                              final long retentionPeriod,
+                                                              final boolean withIndex) {
+        this.name = name;
+        this.retentionPeriod = retentionPeriod;
+        this.withIndex = withIndex;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public SessionStore<Bytes, byte[]> get() {
+        return new RocksDBTimeOrderedSessionStore(
+            new RocksDBTimeOrderedSessionSegmentedBytesStore(
+                name,
+                metricsScope(),
+                retentionPeriod,
+                segmentIntervalMs(),
+                withIndex
+            )
+        );
+    }
+
+    @Override
+    public String metricsScope() {
+        return "rocksdb-session";
+    }
+
+    @Override
+    public long segmentIntervalMs() {
+        // Selected somewhat arbitrarily. Profiling may reveal a different value is preferable.
+        return Math.max(retentionPeriod / 2, 60_000L);
+    }
+
+    @Override
+    public long retentionPeriod() {
+        return retentionPeriod;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.ChangelogRecordDeserializationHelper;
@@ -48,6 +49,8 @@ import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.internals.PrefixedSessionKeySchemas.KeyFirstSessionKeySchema;
+import org.apache.kafka.streams.state.internals.PrefixedSessionKeySchemas.TimeFirstSessionKeySchema;
 import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.KeyFirstWindowKeySchema;
 import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.TimeFirstWindowKeySchema;
 import org.apache.kafka.streams.state.internals.SegmentedBytesStore.KeySchema;
@@ -98,7 +101,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     private AbstractDualSchemaRocksDBSegmentedBytesStore<S> bytesStore;
     private File stateDir;
     private final Window[] windows = new Window[4];
-    private Window nextSegmentWindow;
+    private Window nextSegmentWindow, startEdgeWindow, endEdgeWindow;
+    private long startEdgeTime = Long.MAX_VALUE - 700L;
+    private long endEdgeTime = Long.MAX_VALUE - 600L;
 
     final long retention = 1000;
     final long segmentInterval = 60_000L;
@@ -106,6 +111,20 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
     @Before
     public void before() {
+        if (getBaseSchema() instanceof TimeFirstSessionKeySchema) {
+            windows[0] = new SessionWindow(10L, 10L);
+            windows[1] = new SessionWindow(500L, 1000L);
+            windows[2] = new SessionWindow(1_000L, 1_500L);
+            windows[3] = new SessionWindow(30_000L, 60_000L);
+            // All four of the previous windows will go into segment 1.
+            // The nextSegmentWindow is computed be a high enough time that when it gets written
+            // to the segment store, it will advance stream time past the first segment's retention time and
+            // expire it.
+            nextSegmentWindow = new SessionWindow(segmentInterval + retention, segmentInterval + retention);
+
+            startEdgeWindow = new SessionWindow(0L, startEdgeTime);
+            endEdgeWindow = new SessionWindow(endEdgeTime, Long.MAX_VALUE);
+        }
         if (getBaseSchema() instanceof TimeFirstWindowKeySchema) {
             windows[0] = timeWindowForSize(10L, windowSizeForTimeWindow);
             windows[1] = timeWindowForSize(500L, windowSizeForTimeWindow);
@@ -116,6 +135,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
             // to the segment store, it will advance stream time past the first segment's retention time and
             // expire it.
             nextSegmentWindow = timeWindowForSize(segmentInterval + retention, windowSizeForTimeWindow);
+
+            startEdgeWindow = timeWindowForSize(startEdgeTime, windowSizeForTimeWindow);
+            endEdgeWindow = timeWindowForSize(endEdgeTime, windowSizeForTimeWindow);
         }
 
         bytesStore = getBytesStore();
@@ -286,7 +308,322 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     }
 
     @Test
+    public void shouldPutAndFetchEdge() {
+        final String keyA = "a";
+        final String keyB = "b";
+
+        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false, Integer.MAX_VALUE);
+
+        bytesStore.put(serializedKeyAStart, serializeValue(10));
+        bytesStore.put(serializedKeyAEnd, serializeValue(50));
+        bytesStore.put(serializedKeyBStart, serializeValue(100));
+        bytesStore.put(serializedKeyBEnd, serializeValue(150));
+
+        // Can fetch start/end edge for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyA.getBytes()), startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch start/end edge for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyB.getBytes()), startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from 0 to max for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyA.getBytes()), 0, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from 0 to max for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyB.getBytes()), 0, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from start/end for key range
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from 0 to max for key range
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 0L, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+            assertEquals(expected, toList(values));
+        }
+
+        // KeyB should be ignored and KeyA should be included even in storage
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            null, Bytes.wrap(keyA.getBytes()), startEdgeTime, endEdgeTime - 1L)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            Bytes.wrap(keyB.getBytes()), null, startEdgeTime + 1, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            null, null, 0, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+            assertEquals(expected, toList(values));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
+            null, null, startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+    }
+
+    @Test
+    public void shouldPutAndBackwardFetchEdge() {
+        final String keyA = "a";
+        final String keyB = "b";
+
+        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false, Integer.MAX_VALUE);
+
+        bytesStore.put(serializedKeyAStart, serializeValue(10));
+        bytesStore.put(serializedKeyAEnd, serializeValue(50));
+        bytesStore.put(serializedKeyBStart, serializeValue(100));
+        bytesStore.put(serializedKeyBEnd, serializeValue(150));
+
+        // Can fetch start/end edge for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyA.getBytes()), startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch start/end edge for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyB.getBytes()), startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from 0 to max for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyA.getBytes()), 0, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from 0 to max for single key
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyB.getBytes()), 0, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from start/end for key range
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+            assertEquals(expected, toList(values));
+        }
+
+        // Can fetch from 0 to max for key range
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 0L, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+            assertEquals(expected, toList(values));
+        }
+
+        // KeyB should be ignored and KeyA should be included even in storage
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            null, Bytes.wrap(keyA.getBytes()), startEdgeTime, endEdgeTime - 1L)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            Bytes.wrap(keyB.getBytes()), null, startEdgeTime + 1, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L)
+            );
+
+            assertEquals(expected, toList(values));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            null, null, 0, Long.MAX_VALUE)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+            assertEquals(expected, toList(values));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
+            null, null, startEdgeTime, endEdgeTime)) {
+
+            final List<KeyValue<Windowed<String>, Long>> expected = getIndexSchema() == null ? asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            ) : asList(
+                KeyValue.pair(new Windowed<>(keyB, endEdgeWindow), 150L),
+                KeyValue.pair(new Windowed<>(keyB, startEdgeWindow), 100L),
+                KeyValue.pair(new Windowed<>(keyA, endEdgeWindow), 50L),
+                KeyValue.pair(new Windowed<>(keyA, startEdgeWindow), 10L)
+            );
+            assertEquals(expected, toList(values));
+        }
+    }
+
+    @Test
     public void shouldPutAndFetchWithPrefixKey() {
+        // Only for TimeFirstWindowKeySchema schema
+        if (!(getBaseSchema() instanceof TimeFirstWindowKeySchema)) {
+            return;
+        }
         final String keyA = "a";
         final String keyB = "aa";
         final String keyC = "aaa";
@@ -365,6 +702,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
     @Test
     public void shouldPutAndBackwardFetchWithPrefix() {
+        // Only for TimeFirstWindowKeySchema schema
+        if (!(getBaseSchema() instanceof TimeFirstWindowKeySchema)) {
+            return;
+        }
+
         final String keyA = "a";
         final String keyB = "aa";
         final String keyC = "aaa";
@@ -1081,10 +1423,16 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
     private Bytes serializeKey(final Windowed<String> key, final boolean changeLog, final int seq) {
         final StateSerdes<String, Long> stateSerdes = StateSerdes.withBuiltinTypes("dummy", String.class, Long.class);
-        if (changeLog) {
-            return WindowKeySchema.toStoreKeyBinary(key, seq, stateSerdes);
-        } else if (getBaseSchema() instanceof TimeFirstWindowKeySchema) {
+        if (getBaseSchema() instanceof TimeFirstWindowKeySchema) {
+            if (changeLog) {
+                return WindowKeySchema.toStoreKeyBinary(key, seq, stateSerdes);
+            }
             return TimeFirstWindowKeySchema.toStoreKeyBinary(key, seq, stateSerdes);
+        } else if (getBaseSchema() instanceof TimeFirstSessionKeySchema) {
+            if (changeLog) {
+                return Bytes.wrap(SessionKeySchema.toBinary(key, stateSerdes.keySerializer(), "dummy"));
+            }
+            return Bytes.wrap(TimeFirstSessionKeySchema.toBinary(key, stateSerdes.keySerializer(), "dummy"));
         } else {
             throw new IllegalStateException("Unrecognized serde schema");
         }
@@ -1094,6 +1442,8 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         final StateSerdes<String, Long> stateSerdes = StateSerdes.withBuiltinTypes("dummy", String.class, Long.class);
         if (getIndexSchema() instanceof KeyFirstWindowKeySchema) {
             return KeyFirstWindowKeySchema.toStoreKeyBinary(key, 0, stateSerdes);
+        } else if (getIndexSchema() instanceof KeyFirstSessionKeySchema) {
+            return Bytes.wrap(KeyFirstSessionKeySchema.toBinary(key, stateSerdes.keySerializer(), "dummy"));
         } else {
             throw new IllegalStateException("Unrecognized serde schema");
         }
@@ -1116,6 +1466,12 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
                         stateSerdes.keyDeserializer(),
                         stateSerdes.topic()
                     ),
+                    stateSerdes.valueDeserializer().deserialize("dummy", next.value)
+                );
+                results.add(deserialized);
+            } else if (getBaseSchema() instanceof TimeFirstSessionKeySchema) {
+                final KeyValue<Windowed<String>, Long> deserialized = KeyValue.pair(
+                    TimeFirstSessionKeySchema.from(next.key.get(), stateSerdes.keyDeserializer(), "dummy"),
                     stateSerdes.valueDeserializer().deserialize("dummy", next.value)
                 );
                 results.add(deserialized);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -102,8 +102,8 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     private File stateDir;
     private final Window[] windows = new Window[4];
     private Window nextSegmentWindow, startEdgeWindow, endEdgeWindow;
-    private long startEdgeTime = Long.MAX_VALUE - 700L;
-    private long endEdgeTime = Long.MAX_VALUE - 600L;
+    private final long startEdgeTime = Long.MAX_VALUE - 700L;
+    private final long endEdgeTime = Long.MAX_VALUE - 600L;
 
     final long retention = 1000;
     final long segmentInterval = 60_000L;
@@ -308,14 +308,18 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     }
 
     @Test
-    public void shouldPutAndFetchEdge() {
+    public void shouldPutAndFetchEdgeSingleKey() {
         final String keyA = "a";
         final String keyB = "b";
 
-        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false, Integer.MAX_VALUE);
-        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false, Integer.MAX_VALUE);
-        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false, Integer.MAX_VALUE);
-        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false,
+            Integer.MAX_VALUE);
 
         bytesStore.put(serializedKeyAStart, serializeValue(10));
         bytesStore.put(serializedKeyAEnd, serializeValue(50));
@@ -369,7 +373,26 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
             assertEquals(expected, toList(values));
         }
+    }
 
+    @Test
+    public void shouldPutAndFetchEdgeKeyRange() {
+        final String keyA = "a";
+        final String keyB = "b";
+
+        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false,
+            Integer.MAX_VALUE);
+
+        bytesStore.put(serializedKeyAStart, serializeValue(10));
+        bytesStore.put(serializedKeyAEnd, serializeValue(50));
+        bytesStore.put(serializedKeyBStart, serializeValue(100));
+        bytesStore.put(serializedKeyBEnd, serializeValue(150));
         // Can fetch from start/end for key range
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), startEdgeTime, endEdgeTime)) {
@@ -464,14 +487,18 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     }
 
     @Test
-    public void shouldPutAndBackwardFetchEdge() {
+    public void shouldPutAndBackwardFetchEdgeSingleKey() {
         final String keyA = "a";
         final String keyB = "b";
 
-        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false, Integer.MAX_VALUE);
-        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false, Integer.MAX_VALUE);
-        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false, Integer.MAX_VALUE);
-        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false, Integer.MAX_VALUE);
+        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false,
+            Integer.MAX_VALUE);
 
         bytesStore.put(serializedKeyAStart, serializeValue(10));
         bytesStore.put(serializedKeyAEnd, serializeValue(50));
@@ -525,6 +552,26 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
             assertEquals(expected, toList(values));
         }
+    }
+
+    @Test
+    public void shouldPutAndBackwardFetchEdgeKeyRange() {
+        final String keyA = "a";
+        final String keyB = "b";
+
+        final Bytes serializedKeyAStart = serializeKey(new Windowed<>(keyA, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyAEnd = serializeKey(new Windowed<>(keyA, endEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBStart = serializeKey(new Windowed<>(keyB, startEdgeWindow), false,
+            Integer.MAX_VALUE);
+        final Bytes serializedKeyBEnd = serializeKey(new Windowed<>(keyB, endEdgeWindow), false,
+            Integer.MAX_VALUE);
+
+        bytesStore.put(serializedKeyAStart, serializeValue(10));
+        bytesStore.put(serializedKeyAEnd, serializeValue(50));
+        bytesStore.put(serializedKeyBStart, serializeValue(100));
+        bytesStore.put(serializedKeyBEnd, serializeValue(150));
 
         // Can fetch from start/end for key range
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.Collection;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -27,29 +28,78 @@ import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.Stores;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashSet;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
 
 import static java.time.Duration.ofMillis;
+import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(Parameterized.class)
 public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
 
     private static final String STORE_NAME = "rocksDB session store";
+
+    enum StoreType {
+        RocksDBSessionStore,
+        RocksDBTimeOrderedSessionStoreWithIndex,
+        RocksDBTimeOrderedSessionStoreWithoutIndex
+    }
+    @Parameter
+    public StoreType storeType;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> getKeySchema() {
+        return asList(new Object[][] {
+            {StoreType.RocksDBSessionStore},
+            {StoreType.RocksDBTimeOrderedSessionStoreWithIndex},
+            {StoreType.RocksDBTimeOrderedSessionStoreWithoutIndex}
+        });
+    }
 
     @Override
     <K, V> SessionStore<K, V> buildSessionStore(final long retentionPeriod,
                                                  final Serde<K> keySerde,
                                                  final Serde<V> valueSerde) {
-        return Stores.sessionStoreBuilder(
-            Stores.persistentSessionStore(
-                STORE_NAME,
-                ofMillis(retentionPeriod)),
-            keySerde,
-            valueSerde).build();
+        switch (storeType) {
+            case RocksDBSessionStore: {
+                return Stores.sessionStoreBuilder(
+                    Stores.persistentSessionStore(
+                        STORE_NAME,
+                        ofMillis(retentionPeriod)),
+                    keySerde,
+                    valueSerde).build();
+            }
+            case RocksDBTimeOrderedSessionStoreWithIndex: {
+                return Stores.sessionStoreBuilder(
+                    new RocksDbIndexedTimeOrderedSessionBytesStoreSupplier(
+                        STORE_NAME,
+                        retentionPeriod,
+                        true
+                    ),
+                    keySerde,
+                    valueSerde
+                ).build();
+            }
+            case RocksDBTimeOrderedSessionStoreWithoutIndex: {
+                return Stores.sessionStoreBuilder(
+                    new RocksDbIndexedTimeOrderedSessionBytesStoreSupplier(
+                        STORE_NAME,
+                        retentionPeriod,
+                       false
+                    ),
+                    keySerde,
+                    valueSerde
+                ).build();
+            }
+            default:
+                throw new IllegalStateException("Unknown StoreType: " + storeType);
+        }
     }
 
     @Test
@@ -64,7 +114,7 @@ public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
             sessionStore.findSessions("a", "b", 0L, Long.MAX_VALUE)
         ) {
-            assertEquals(valuesToSet(iterator), new HashSet<>(Arrays.asList(2L, 3L, 4L)));
+            assertEquals(valuesToSet(iterator), new HashSet<>(asList(2L, 3L, 4L)));
         }
     }
 
@@ -72,7 +122,7 @@ public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
     public void shouldMatchPositionAfterPut() {
         final MeteredSessionStore<String, Long> meteredSessionStore = (MeteredSessionStore<String, Long>) sessionStore;
         final ChangeLoggingSessionBytesStore changeLoggingSessionBytesStore = (ChangeLoggingSessionBytesStore) meteredSessionStore.wrapped();
-        final RocksDBSessionStore rocksDBSessionStore = (RocksDBSessionStore) changeLoggingSessionBytesStore.wrapped();
+        final WrappedStateStore rocksDBSessionStore = (WrappedStateStore) changeLoggingSessionBytesStore.wrapped();
 
         context.setRecordContext(new ProcessorRecordContext(0, 1, 0, "", new RecordHeaders()));
         sessionStore.put(new Windowed<String>("a", new SessionWindow(0, 0)), 1L);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
@@ -227,7 +227,7 @@ public class SessionKeySchemaTest {
         );
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-             assertThat(upper, equalTo(toBinary.apply(
+            assertThat(upper, equalTo(toBinary.apply(
                 new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}),
                     new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
             );
@@ -264,7 +264,7 @@ public class SessionKeySchemaTest {
         final Function<Windowed<Bytes>, Bytes> toBinary = WINDOW_TO_STORE_BINARY_MAP.get(schemaType);
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-             assertThat(upper, equalTo(toBinary.apply(
+            assertThat(upper, equalTo(toBinary.apply(
                 new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE))))
             );
         } else {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
@@ -17,30 +17,101 @@
 
 package org.apache.kafka.streams.state.internals;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.internals.PrefixedSessionKeySchemas.KeyFirstSessionKeySchema;
+import org.apache.kafka.streams.state.internals.PrefixedSessionKeySchemas.TimeFirstSessionKeySchema;
+import org.apache.kafka.streams.state.internals.SegmentedBytesStore.KeySchema;
 import org.apache.kafka.test.KeyValueIteratorStub;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@RunWith(Parameterized.class)
 public class SessionKeySchemaTest {
+    private static final Map<SchemaType, KeySchema> SCHEMA_TYPE_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, new SessionKeySchema()),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, new KeyFirstSessionKeySchema()),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, new TimeFirstSessionKeySchema())
+    );
+
+    private static final Map<SchemaType, Function<Windowed<Bytes>, Bytes>> WINDOW_TO_STORE_BINARY_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::toBinary),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::toBinary),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::toBinary)
+    );
+
+    private static final Map<SchemaType, Function<byte[], Long>> EXTRACT_END_TS_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractEndTimestamp),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractEndTimestamp),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractEndTimestamp)
+    );
+
+    private static final Map<SchemaType, Function<byte[], Long>> EXTRACT_START_TS_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractStartTimestamp),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractStartTimestamp),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractStartTimestamp)
+    );
+
+    @FunctionalInterface
+    interface TriFunction<A, B, C, R> {
+        R apply(A a, B b, C c);
+    }
+
+    private static final Map<SchemaType, TriFunction<Windowed<String>, Serializer<String>, String, byte[]>> SERDE_TO_STORE_BINARY_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::toBinary),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::toBinary),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::toBinary)
+    );
+
+    private static final Map<SchemaType, TriFunction<byte[], Deserializer<String>, String, Windowed<String>>> SERDE_FROM_BYTES_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::from),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::from),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::from)
+    );
+
+    private static final Map<SchemaType, Function<Bytes, Windowed<Bytes>>> FROM_BYTES_MAP = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::from),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::from),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::from)
+    );
+
+    private static final Map<SchemaType, Function<byte[], Window>> EXTRACT_WINDOW = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractWindow),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractWindow),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractWindow)
+    );
+
+    private static final Map<SchemaType, Function<byte[], byte[]>> EXTRACT_KEY_BYTES = mkMap(
+        mkEntry(SchemaType.SessionKeySchema, SessionKeySchema::extractKeyBytes),
+        mkEntry(SchemaType.PrefixedKeyFirstSchema, KeyFirstSessionKeySchema::extractKeyBytes),
+        mkEntry(SchemaType.PrefixedTimeFirstSchema, TimeFirstSessionKeySchema::extractKeyBytes)
+    );
 
     private final String key = "key";
     private final String topic = "topic";
@@ -52,8 +123,45 @@ public class SessionKeySchemaTest {
     private final Windowed<String> windowedKey = new Windowed<>(key, window);
     private final Serde<Windowed<String>> keySerde = new WindowedSerdes.SessionWindowedSerde<>(serde);
 
-    private final SessionKeySchema sessionKeySchema = new SessionKeySchema();
+    private final KeySchema keySchema;
     private DelegatingPeekingKeyValueIterator<Bytes, Integer> iterator;
+    private final SchemaType schemaType;
+    private final Function<Windowed<Bytes>, Bytes> toBinary;
+    private final TriFunction<Windowed<String>, Serializer<String>, String, byte[]> serdeToBinary;
+    private final TriFunction<byte[], Deserializer<String>, String, Windowed<String>> serdeFromBytes;
+    private final Function<Bytes, Windowed<Bytes>> fromBytes;
+    private final Function<byte[], Long> extractStartTS;
+    private final Function<byte[], Long> extractEndTS;
+    private final Function<byte[], byte[]> extractKeyBytes;
+    private final Function<byte[], Window> extractWindow;
+
+    private enum SchemaType {
+        SessionKeySchema,
+        PrefixedTimeFirstSchema,
+        PrefixedKeyFirstSchema
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return asList(new Object[][] {
+            {SchemaType.SessionKeySchema},
+            {SchemaType.PrefixedTimeFirstSchema},
+            {SchemaType.PrefixedKeyFirstSchema}
+        });
+    }
+
+    public SessionKeySchemaTest(final SchemaType type) {
+        schemaType = type;
+        keySchema = SCHEMA_TYPE_MAP.get(type);
+        toBinary = WINDOW_TO_STORE_BINARY_MAP.get(schemaType);
+        serdeToBinary = SERDE_TO_STORE_BINARY_MAP.get(schemaType);
+        serdeFromBytes = SERDE_FROM_BYTES_MAP.get(schemaType);
+        fromBytes = FROM_BYTES_MAP.get(schemaType);
+        extractStartTS = EXTRACT_START_TS_MAP.get(schemaType);
+        extractEndTS = EXTRACT_END_TS_MAP.get(schemaType);
+        extractKeyBytes = EXTRACT_KEY_BYTES.get(schemaType);
+        extractWindow = EXTRACT_WINDOW.get(schemaType);
+    }
 
     @After
     public void after() {
@@ -64,44 +172,44 @@ public class SessionKeySchemaTest {
 
     @Before
     public void before() {
-        final List<KeyValue<Bytes, Integer>> keys = Arrays.asList(KeyValue.pair(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0, 0}), new SessionWindow(0, 0))), 1),
-                                                                  KeyValue.pair(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0}), new SessionWindow(0, 0))), 2),
-                                                                  KeyValue.pair(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0, 0, 0}), new SessionWindow(0, 0))), 3),
-                                                                  KeyValue.pair(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0}), new SessionWindow(10, 20))), 4),
-                                                                  KeyValue.pair(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0, 0}), new SessionWindow(10, 20))), 5),
-                                                                  KeyValue.pair(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0, 0, 0}), new SessionWindow(10, 20))), 6));
+        final List<KeyValue<Bytes, Integer>> keys = asList(KeyValue.pair(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0, 0}), new SessionWindow(0, 0))), 1),
+                                                                  KeyValue.pair(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0}), new SessionWindow(0, 0))), 2),
+                                                                  KeyValue.pair(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0, 0, 0}), new SessionWindow(0, 0))), 3),
+                                                                  KeyValue.pair(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0}), new SessionWindow(10, 20))), 4),
+                                                                  KeyValue.pair(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0, 0}), new SessionWindow(10, 20))), 5),
+                                                                  KeyValue.pair(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0, 0, 0}), new SessionWindow(10, 20))), 6));
         iterator = new DelegatingPeekingKeyValueIterator<>("foo", new KeyValueIteratorStub<>(keys.iterator()));
     }
 
     @Test
     public void shouldFetchExactKeysSkippingLongerKeys() {
         final Bytes key = Bytes.wrap(new byte[]{0});
-        final List<Integer> result = getValues(sessionKeySchema.hasNextCondition(key, key, 0, Long.MAX_VALUE, true));
-        assertThat(result, equalTo(Arrays.asList(2, 4)));
+        final List<Integer> result = getValues(keySchema.hasNextCondition(key, key, 0, Long.MAX_VALUE, true));
+        assertThat(result, equalTo(asList(2, 4)));
     }
 
     @Test
     public void shouldFetchExactKeySkippingShorterKeys() {
         final Bytes key = Bytes.wrap(new byte[]{0, 0});
-        final HasNextCondition hasNextCondition = sessionKeySchema.hasNextCondition(key, key, 0, Long.MAX_VALUE, true);
+        final HasNextCondition hasNextCondition = keySchema.hasNextCondition(key, key, 0, Long.MAX_VALUE, true);
         final List<Integer> results = getValues(hasNextCondition);
-        assertThat(results, equalTo(Arrays.asList(1, 5)));
+        assertThat(results, equalTo(asList(1, 5)));
     }
 
     @Test
     public void shouldFetchAllKeysUsingNullKeys() {
-        final HasNextCondition hasNextCondition = sessionKeySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE, true);
+        final HasNextCondition hasNextCondition = keySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE, true);
         final List<Integer> results = getValues(hasNextCondition);
-        assertThat(results, equalTo(Arrays.asList(1, 2, 3, 4, 5, 6)));
+        assertThat(results, equalTo(asList(1, 2, 3, 4, 5, 6)));
     }
     
     @Test
     public void testUpperBoundWithLargeTimestamps() {
-        final Bytes upper = sessionKeySchema.upperRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), Long.MAX_VALUE);
+        final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), Long.MAX_VALUE);
 
         assertThat(
             "shorter key with max timestamp should be in range",
-            upper.compareTo(SessionKeySchema.toBinary(
+            upper.compareTo(toBinary.apply(
                 new Windowed<>(
                     Bytes.wrap(new byte[]{0xA}),
                     new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
@@ -110,7 +218,7 @@ public class SessionKeySchemaTest {
 
         assertThat(
             "shorter key with max timestamp should be in range",
-            upper.compareTo(SessionKeySchema.toBinary(
+            upper.compareTo(toBinary.apply(
                 new Windowed<>(
                     Bytes.wrap(new byte[]{0xA, 0xB}),
                     new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
@@ -118,18 +226,26 @@ public class SessionKeySchemaTest {
             )) >= 0
         );
 
-        assertThat(upper, equalTo(SessionKeySchema.toBinary(
-            new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
-        );
+        if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
+             assertThat(upper, equalTo(toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}),
+                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
+            );
+        } else {
+            assertThat(upper, equalTo(toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA}),
+                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
+            );
+        }
     }
 
     @Test
     public void testUpperBoundWithKeyBytesLargerThanFirstTimestampByte() {
-        final Bytes upper = sessionKeySchema.upperRange(Bytes.wrap(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}), Long.MAX_VALUE);
+        final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}), Long.MAX_VALUE);
 
         assertThat(
             "shorter key with max timestamp should be in range",
-            upper.compareTo(SessionKeySchema.toBinary(
+            upper.compareTo(toBinary.apply(
                 new Windowed<>(
                     Bytes.wrap(new byte[]{0xA, (byte) 0x8F}),
                     new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
@@ -137,40 +253,53 @@ public class SessionKeySchemaTest {
             ) >= 0
         );
 
-        assertThat(upper, equalTo(SessionKeySchema.toBinary(
+        assertThat(upper, equalTo(toBinary.apply(
             new Windowed<>(Bytes.wrap(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
         );
     }
 
     @Test
     public void testUpperBoundWithZeroTimestamp() {
-        final Bytes upper = sessionKeySchema.upperRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), 0);
+        final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), 0);
+        final Function<Windowed<Bytes>, Bytes> toBinary = WINDOW_TO_STORE_BINARY_MAP.get(schemaType);
 
-        assertThat(upper, equalTo(SessionKeySchema.toBinary(
-            new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(0, Long.MAX_VALUE))))
-        );
+        if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
+             assertThat(upper, equalTo(toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE))))
+            );
+        } else {
+            assertThat(upper, equalTo(toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(0, Long.MAX_VALUE))))
+            );
+        }
     }
 
     @Test
     public void testLowerBoundWithZeroTimestamp() {
-        final Bytes lower = sessionKeySchema.lowerRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), 0);
-        assertThat(lower, equalTo(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0)))));
+        final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), 0);
+        assertThat(lower, equalTo(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0)))));
     }
 
     @Test
     public void testLowerBoundMatchesTrailingZeros() {
-        final Bytes lower = sessionKeySchema.lowerRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), Long.MAX_VALUE);
+        final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), Long.MAX_VALUE);
 
         assertThat(
             "appending zeros to key should still be in range",
-            lower.compareTo(SessionKeySchema.toBinary(
+            lower.compareTo(toBinary.apply(
                 new Windowed<>(
                     Bytes.wrap(new byte[]{0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
                     new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
             )) < 0
         );
 
-        assertThat(lower, equalTo(SessionKeySchema.toBinary(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0)))));
+        if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
+            assertThat(lower, equalTo(toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE)))));
+        } else {
+            assertThat(lower, equalTo(toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0)))));
+        }
     }
 
     @Test
@@ -197,47 +326,47 @@ public class SessionKeySchemaTest {
 
     @Test
     public void shouldConvertToBinaryAndBack() {
-        final byte[] serialized = SessionKeySchema.toBinary(windowedKey, serde.serializer(), "dummy");
-        final Windowed<String> result = SessionKeySchema.from(serialized, Serdes.String().deserializer(), "dummy");
+        final byte[] serialized = serdeToBinary.apply(windowedKey, serde.serializer(), "dummy");
+        final Windowed<String> result = serdeFromBytes.apply(serialized, Serdes.String().deserializer(), "dummy");
         assertEquals(windowedKey, result);
     }
 
     @Test
     public void shouldExtractEndTimeFromBinary() {
-        final byte[] serialized = SessionKeySchema.toBinary(windowedKey, serde.serializer(), "dummy");
-        assertEquals(endTime, SessionKeySchema.extractEndTimestamp(serialized));
+        final byte[] serialized = serdeToBinary.apply(windowedKey, serde.serializer(), "dummy");
+        assertEquals(endTime, (long) extractEndTS.apply(serialized));
     }
 
     @Test
     public void shouldExtractStartTimeFromBinary() {
-        final byte[] serialized = SessionKeySchema.toBinary(windowedKey, serde.serializer(), "dummy");
-        assertEquals(startTime, SessionKeySchema.extractStartTimestamp(serialized));
+        final byte[] serialized = serdeToBinary.apply(windowedKey, serde.serializer(), "dummy");
+        assertEquals(startTime, (long) extractStartTS.apply(serialized));
     }
 
     @Test
     public void shouldExtractWindowFromBindary() {
-        final byte[] serialized = SessionKeySchema.toBinary(windowedKey, serde.serializer(), "dummy");
-        assertEquals(window, SessionKeySchema.extractWindow(serialized));
+        final byte[] serialized = serdeToBinary.apply(windowedKey, serde.serializer(), "dummy");
+        assertEquals(window, extractWindow.apply(serialized));
     }
 
     @Test
     public void shouldExtractKeyBytesFromBinary() {
-        final byte[] serialized = SessionKeySchema.toBinary(windowedKey, serde.serializer(), "dummy");
-        assertArrayEquals(key.getBytes(), SessionKeySchema.extractKeyBytes(serialized));
+        final byte[] serialized = serdeToBinary.apply(windowedKey, serde.serializer(), "dummy");
+        assertArrayEquals(key.getBytes(), extractKeyBytes.apply(serialized));
     }
 
     @Test
     public void shouldExtractKeyFromBinary() {
-        final byte[] serialized = SessionKeySchema.toBinary(windowedKey, serde.serializer(), "dummy");
-        assertEquals(windowedKey, SessionKeySchema.from(serialized, serde.deserializer(), "dummy"));
+        final byte[] serialized = serdeToBinary.apply(windowedKey, serde.serializer(), "dummy");
+        assertEquals(windowedKey, serdeFromBytes.apply(serialized, serde.deserializer(), "dummy"));
     }
 
     @Test
     public void shouldExtractBytesKeyFromBinary() {
         final Bytes bytesKey = Bytes.wrap(key.getBytes());
         final Windowed<Bytes> windowedBytesKey = new Windowed<>(bytesKey, window);
-        final Bytes serialized = SessionKeySchema.toBinary(windowedBytesKey);
-        assertEquals(windowedBytesKey, SessionKeySchema.from(serialized));
+        final Bytes serialized = toBinary.apply(windowedBytesKey);
+        assertEquals(windowedBytesKey, fromBytes.apply(serialized));
     }
 
     private List<Integer> getValues(final HasNextCondition hasNextCondition) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
@@ -130,7 +130,7 @@ public class WindowKeySchemaTest {
     final private KeySchema keySchema;
     final private Serde<Windowed<String>> keySerde = new WindowedSerdes.TimeWindowedSerde<>(serde, Long.MAX_VALUE);
     final private StateSerdes<String, byte[]> stateSerdes = new StateSerdes<>("dummy", serde, Serdes.ByteArray());
-    final private SchemaType schemaType;
+    final public SchemaType schemaType;
 
     private enum SchemaType {
         WindowKeySchema,
@@ -141,13 +141,13 @@ public class WindowKeySchemaTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
-            {"WindowKeySchema", SchemaType.WindowKeySchema},
-            {"PrefixedTimeFirstSchema", SchemaType.PrefixedTimeFirstSchema},
-            {"PrefixedKeyFirstSchema", SchemaType.PrefixedKeyFirstSchema}
+            {SchemaType.WindowKeySchema},
+            {SchemaType.PrefixedTimeFirstSchema},
+            {SchemaType.PrefixedKeyFirstSchema}
         });
     }
 
-    public WindowKeySchemaTest(final String name, final SchemaType type) {
+    public WindowKeySchemaTest(final SchemaType type) {
         schemaType = type;
         keySchema = SCHEMA_TYPE_MAP.get(type);
     }


### PR DESCRIPTION
### Description
Time ordered session store implementation. I introduced `AbstractRocksDBTimeOrderedSegmentedBytesStore ` to make it generic for `RocksDBTimeOrderedSessionSegmentedBytesStore` and `RocksDBTimeOrderedSegmentedBytesStore`

### Testing
Unit tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
