### PR TITLE
KAFKA-13672: Race condition in DynamicBrokerConfig

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -539,13 +539,13 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
       try {
         val customConfigs = new util.HashMap[String, Object](newConfig.originalsFromThisConfig) // non-Kafka configs
         newConfig.valuesFromThisConfig.keySet.forEach(k => customConfigs.remove(k))
-        reconfigurables.asScala.foreach {
+        reconfigurables.forEach( {
           case listenerReconfigurable: ListenerReconfigurable =>
             processListenerReconfigurable(listenerReconfigurable, newConfig, customConfigs, validateOnly, reloadOnly = false)
           case reconfigurable =>
             if (needsReconfiguration(reconfigurable.reconfigurableConfigs, changeMap.keySet, deletedKeySet))
               processReconfigurable(reconfigurable, changeMap.keySet, newConfig.valuesFromThisConfig, customConfigs, validateOnly)
-        }
+        })
 
         // BrokerReconfigurable updates are processed after config is updated. Only do the validation here.
         val brokerReconfigurablesToUpdate = mutable.Buffer[BrokerReconfigurable]()

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -202,7 +202,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
   private[server] val staticDefaultConfigs = ConfigDef.convertToStringMapWithPasswordValues(KafkaConfig.defaultValues.asJava).asScala
   private val dynamicBrokerConfigs = mutable.Map[String, String]()
   private val dynamicDefaultConfigs = mutable.Map[String, String]()
-  
+
   // Use COWArrayList to prevent concurrent modification exception when reconfigurable added while iteration over list occurring
   private val reconfigurables = new CopyOnWriteArrayList[Reconfigurable]()
   private val brokerReconfigurables = mutable.Buffer[BrokerReconfigurable]()

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -728,7 +728,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   }
 
   @Test
-  @Disabled // TODO: To be re-enabled once we can make it less flaky (KAFKA-13672)
   def testThreadPoolResize(): Unit = {
     val requestHandlerPrefix = "data-plane-kafka-request-handler-"
     val networkThreadPrefix = "data-plane-kafka-network-thread-"


### PR DESCRIPTION
Prevent race condition in `DynamicBrokerConfig` that can prevent configuration being dynamically applied when broker is running slowly.

The race condition occurs when multiple `alterBrokerConfigs` requests are being processed concurrently (but also seems to require the broker to be running under heavy load so that the request processing is slow enough for this issue to occur). Two or more separate threads can interact with the mutable buffer caching `Reconfigurable` objects inside `DynamicBrokerConfig`, and one thread may add a `Reconfigurable` to that buffer while another thread is iterating over it, causing the second thread to hit a `ConcurrentModificationException`.

Firstly in `KafkaApis#handlerAlterConfigsRequest`, the [preprocess](https://github.com/apache/kafka/blob/52621613fd386203773ba93903abd50b46fa093a/core/src/main/scala/kafka/server/KafkaApis.scala#L2633) method call ultimately reaches down into `DynamicBrokerConfig#processReconfiguration` to validate (and only validate) new settings. This validation process iterates over the reconfigurables, but does not modify the buffer.

However, the `ConfigChangedNotificationHandler` that responds to config changes being stored in ZK, also [has a code path](https://github.com/apache/kafka/blob/81e709c4e2554f045a9961e520c0b7cc1a7b3495/core/src/main/scala/kafka/server/ZkConfigManager.scala#L125) that ultimately ends up in `DynamicBrokerConfig#processReconfiguration`, but unlike the `KafkaApis` code path, this one is actually applying config changes. 

So while `KafkaApis` is iterating over the reconfigurables, `ConfigChangedNotificationHandler` can add a reconfigurable to the buffer, causing the concurrent modification exception. 





*This race condition was made visible by an integration test `DynamicBrokerReconfigurationTest#testThreadPoolResize` which was originally considered flaky, as it repeatedly failed under the CI build, but passed locally. It had been temporarily disabled due to this perceived flakiness. The ideal approach to testing is to re-enable the integration test.*

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
