### PR TITLE
KAFKA-13735/KAFKA-13736: Reenable SocketServerTest.closingChannelWithBufferedReceives and SocketServerTest.remoteCloseWithoutBufferedReceives

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1389,7 +1389,6 @@ class SocketServerTest {
    * buffered receive.
    */
   @Test
-  @Disabled // TODO: re-enabled until KAFKA-13735 is fixed
   def remoteCloseWithoutBufferedReceives(): Unit = {
     verifyRemoteCloseWithBufferedReceives(numComplete = 0, hasIncomplete = false)
   }
@@ -1427,7 +1426,6 @@ class SocketServerTest {
    * The channel must be closed after pending receives are processed.
    */
   @Test
-  @Disabled // TODO: re-enable after KAFKA-13736 is fixed
   def closingChannelWithBufferedReceives(): Unit = {
     verifyRemoteCloseWithBufferedReceives(numComplete = 3, hasIncomplete = false, makeClosing = true)
   }


### PR DESCRIPTION
I think that those tests have been fixed by https://github.com/apache/kafka/commit/b27000ec6af6edfe8a6958dfcc3c0745667e25f4 so we can reenable them. I ran the CI 10 times (tests got run 50 times), no failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
