### PR TITLE
KAFKA-12380 Executor in Connect's Worker is not shut down when the worker is

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -91,6 +91,7 @@ import java.util.stream.Collectors;
 public class Worker {
 
     public static final long CONNECTOR_GRACEFUL_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5);
+    public static final long EXECUTOR_SHUTDOWN_TERMINATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
 
     private static final Logger log = LoggerFactory.getLogger(Worker.class);
 
@@ -222,6 +223,14 @@ public class Worker {
         connectorStatusMetricsGroup.close();
 
         workerConfigTransformer.close();
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -225,11 +225,17 @@ public class Worker {
         workerConfigTransformer.close();
         executor.shutdown();
         try {
+            // Wait a while for existing tasks to terminate
             if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                executor.shutdownNow();
+                executor.shutdownNow(); //cancel current executing threads
+                // Wait a while for tasks to respond to being cancelled
+                if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                    log.error("Pool did not terminate");
             }
         } catch (InterruptedException e) {
-            executor.shutdownNow();
+            executor.shutdownNow(); // (Re-)Cancel if current thread also interrupted
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -230,7 +230,7 @@ public class Worker {
                 executor.shutdownNow(); //cancel current executing threads
                 // Wait a while for tasks to respond to being cancelled
                 if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS))
-                    log.error("Pool did not terminate");
+                    log.error("Executor did not terminate in time");
             }
         } catch (InterruptedException e) {
             executor.shutdownNow(); // (Re-)Cancel if current thread also interrupted

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -1205,7 +1205,7 @@ public class WorkerTest extends ThreadedTest {
         worker.stop();
         verify(executorService, times(1)).shutdown();
         verify(executorService, times(1)).shutdownNow();
-        verify(executorService, times(1)).awaitTermination(1000L, TimeUnit.MILLISECONDS);
+        verify(executorService, times(2)).awaitTermination(1000L, TimeUnit.MILLISECONDS);
         verifyNoMoreInteractions(executorService);
 
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -103,12 +103,14 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstructionWithAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
@@ -411,7 +413,7 @@ public class WorkerTest extends ThreadedTest {
         when(plugins.newConnector(connectorAlias)).thenReturn(sinkConnector);
         when(delegatingLoader.connectorLoader(connectorAlias)).thenReturn(pluginLoader);
         when(sinkConnector.version()).thenReturn("1.0");
-        
+
         pluginsMockedStatic.when(() -> Plugins.compareAndSwapLoaders(pluginLoader)).thenReturn(delegatingLoader);
         pluginsMockedStatic.when(() -> Plugins.compareAndSwapLoaders(delegatingLoader)).thenReturn(pluginLoader);
         connectUtilsMockedStatic.when(() -> ConnectUtils.lookupKafkaClusterId(any(WorkerConfig.class)))
@@ -1168,6 +1170,63 @@ public class WorkerTest extends ThreadedTest {
         }
         //verify metric is created with correct jmx prefix
         assertNotNull(server.getObjectInstance(new ObjectName("kafka.connect:type=grp1")));
+    }
+
+    @Test
+    public void testExecutorServiceShutdown() throws InterruptedException {
+        ExecutorService executorService = mock(ExecutorService.class);
+        doNothing().when(executorService).shutdown();
+        when(executorService.awaitTermination(1000L, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config,
+                            offsetBackingStore, executorService,
+                            noneConnectorClientConfigOverridePolicy);
+        worker.start();
+
+        assertEquals(Collections.emptySet(), worker.connectorNames());
+        worker.stop();
+        verify(executorService, times(1)).shutdown();
+        verify(executorService, times(1)).awaitTermination(1000L, TimeUnit.MILLISECONDS);
+        verifyNoMoreInteractions(executorService);
+
+    }
+
+    @Test
+    public void testExecutorServiceShutdownWhenTerminationFails() throws InterruptedException {
+        ExecutorService executorService = mock(ExecutorService.class);
+        doNothing().when(executorService).shutdown();
+        when(executorService.awaitTermination(1000L, TimeUnit.MILLISECONDS)).thenReturn(false);
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config,
+                            offsetBackingStore, executorService,
+                            noneConnectorClientConfigOverridePolicy);
+        worker.start();
+
+        assertEquals(Collections.emptySet(), worker.connectorNames());
+        worker.stop();
+        verify(executorService, times(1)).shutdown();
+        verify(executorService, times(1)).shutdownNow();
+        verify(executorService, times(1)).awaitTermination(1000L, TimeUnit.MILLISECONDS);
+        verifyNoMoreInteractions(executorService);
+
+    }
+
+    @Test
+    public void testExecutorServiceShutdownWhenTerminationThrowsException() throws InterruptedException {
+        ExecutorService executorService = mock(ExecutorService.class);
+        doNothing().when(executorService).shutdown();
+        when(executorService.awaitTermination(1000L, TimeUnit.MILLISECONDS)).thenThrow(new InterruptedException("interrupt"));
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config,
+                            offsetBackingStore, executorService,
+                            noneConnectorClientConfigOverridePolicy);
+        worker.start();
+
+        assertEquals(Collections.emptySet(), worker.connectorNames());
+        worker.stop();
+        verify(executorService, times(1)).shutdown();
+        verify(executorService, times(1)).shutdownNow();
+        verify(executorService, times(1)).awaitTermination(1000L, TimeUnit.MILLISECONDS);
+        verifyNoMoreInteractions(executorService);
+
     }
 
     private void assertStatusMetrics(long expected, String metricName) {


### PR DESCRIPTION
added shutdown for executors and tests for the same

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
