### PR TITLE
MINOR: Fix log4j entry in RepartitionTopics that have only one parameter while two required

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
@@ -154,15 +154,17 @@ public class RepartitionTopics {
                 final Set<String> missingSourceTopicsForSubtopology = computeMissingExternalSourceTopics(topicsInfo, clusterMetadata);
                 missingSourceTopicsForTopology.addAll(missingSourceTopicsForSubtopology);
                 if (!missingSourceTopicsForSubtopology.isEmpty()) {
-                    missingInputTopicsBySubtopology.put(subtopologyEntry.getKey(), missingSourceTopicsForSubtopology);
+                    final Subtopology subtopology = subtopologyEntry.getKey();
+                    missingInputTopicsBySubtopology.put(subtopology, missingSourceTopicsForSubtopology);
                     log.error("Subtopology {} was missing source topics {} and will be excluded from the current assignment, "
                         + "this can be due to the consumer client's metadata being stale or because they have "
                         + "not been created yet. Please verify that you have created all input topics; if they "
                         + "do exist, you just need to wait for the metadata to be updated, at which time a new "
-                        + "rebalance will be kicked off automatically and the topology will be retried at that time."
-                        + topologyName, missingSourceTopicsForTopology);
+                        + "rebalance will be kicked off automatically and the topology will be retried at that time.",
+                        subtopology.nodeGroupId, missingSourceTopicsForSubtopology);
                 }
             }
+
             if (missingSourceTopicsForTopology.isEmpty()) {
                 allRepartitionTopicConfigs.putAll(repartitionTopicConfigsForTopology);
                 allTopicsInfo.addAll(topicsInfoForTopology);


### PR DESCRIPTION
I noticed two issues in the log4j entry:

1. It's formatted as "{}...{}" + param1, param2; effectively it is one param only, and the printed line is effectively mis-aligned: we always print `Subtopology [sourceTopics set] was missing source topics {}`
2. Even fix 1) is not enough, since `topologyName` may be null. On the other hand I think the original goal is not to print the topology name but the sub-topology id since it's within the per-sub-topology loop.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
