### PR TITLE
KAFKA-13768: Don't mark expired batches as unresolved when using transactional producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -382,7 +382,7 @@ public class Sender implements Runnable {
             String errorMessage = "Expiring " + expiredBatch.recordCount + " record(s) for " + expiredBatch.topicPartition
                 + ":" + (now - expiredBatch.createdMs) + " ms has passed since batch creation";
             failBatch(expiredBatch, new TimeoutException(errorMessage), false);
-            if (transactionManager != null && expiredBatch.inRetry()) {
+            if (transactionManager != null && !transactionManager.isTransactional() && expiredBatch.inRetry()) {
                 // This ensures that no new batches are drained until the current in flight batches are fully resolved.
                 transactionManager.markSequenceUnresolved(expiredBatch);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -833,27 +833,13 @@ public class TransactionManager {
                     iter.remove();
                 } else {
                     // We would enter this branch if all in flight batches were ultimately expired in the producer.
-                    if (isTransactional()) {
-                        // For the transactional producer, we bump the epoch if possible, otherwise we transition to a fatal error
-                        String unackedMessagesErr = "The client hasn't received acknowledgment for some previously " +
-                                "sent messages and can no longer retry them. ";
-                        if (canBumpEpoch()) {
-                            epochBumpRequired = true;
-                            KafkaException exception = new KafkaException(unackedMessagesErr + "It is safe to abort " +
-                                    "the transaction and continue.");
-                            transitionToAbortableError(exception);
-                        } else {
-                            KafkaException exception = new KafkaException(unackedMessagesErr + "It isn't safe to continue.");
-                            transitionToFatalError(exception);
-                        }
-                    } else {
+                    if (!isTransactional()) {
                         // For the idempotent producer, bump the epoch
                         log.info("No inflight batches remaining for {}, last ack'd sequence for partition is {}, next sequence is {}. " +
                                         "Going to bump epoch and reset sequence numbers.", topicPartition,
                                 lastAckedSequence(topicPartition).orElse(NO_LAST_ACKED_SEQUENCE_NUMBER), sequenceNumber(topicPartition));
                         requestEpochBumpForPartition(topicPartition);
                     }
-
                     iter.remove();
                 }
             }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1456,7 +1456,7 @@ public class SenderTest {
     }
 
     @Test
-    public void testUnresolvedSequencesAreNotFatal() throws Exception {
+    public void testUnresolvedSequencesShouldNotOccurInTransaction() throws Exception {
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
         TransactionManager txnManager = new TransactionManager(logContext, "testUnresolvedSeq", 60000, 100, apiVersions);
@@ -1489,10 +1489,7 @@ public class SenderTest {
 
         sender.runOnce(); // now expire the first batch.
         assertFutureFailure(request1, TimeoutException.class);
-        assertTrue(txnManager.hasUnresolvedSequence(tp0));
-
-        // Loop once and confirm that the transaction manager does not enter a fatal error state
-        sender.runOnce();
+        assertFalse(txnManager.hasUnresolvedSequence(tp0));
         assertTrue(txnManager.hasAbortableError());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -2550,7 +2550,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testTransitionToFatalErrorWhenRetriedBatchIsExpired() throws InterruptedException {
+    public void testTransitionToAbortableErrorWhenRetriedBatchIsExpired() throws InterruptedException {
         apiVersions.update("0", new NodeApiVersions(Arrays.asList(
                 new ApiVersion()
                     .setApiKey(ApiKeys.INIT_PRODUCER_ID.id)
@@ -2603,9 +2603,7 @@ public class TransactionManagerTest {
         }
         runUntil(commitResult::isCompleted);
         assertFalse(commitResult.isSuccessful());  // the commit should have been dropped.
-
-        assertTrue(transactionManager.hasFatalError());
-        assertFalse(transactionManager.hasOngoingTransaction());
+        assertTrue(transactionManager.hasAbortableError());
     }
 
     @Test


### PR DESCRIPTION
When an idempotent producer's request failed and we retried it and put it into accumulator again, and these batches eventually timeout and expired by the accumulator, it will be marked as `SequenceUnresolved` in `sendProducerData`. And it will finally make producer's epoch bumped.

But in transactional cases, there's no need to handle it this way. In `sendProducerData`, `failBatch` has already been called after batches expired. So the `TimeoutException` will be thrown out and the transaction will be abort safely. I didn't think out any case it will cause data duplication.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
