### PR TITLE
KAFKA-13778: Fix follower broker also always execute preferred read-replica selection

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1234,8 +1234,9 @@ class ReplicaManager(val config: KafkaConfig,
                                fetchOffset: Long,
                                currentTimeMs: Long): Option[Int] = {
     partition.leaderReplicaIdOpt.flatMap { leaderReplicaId =>
-      // Don't look up preferred for follower fetches via normal replication
-      if (Request.isValidBrokerId(replicaId))
+      // Don't look up preferred for follower fetches via normal replication and
+      // don't look up preferred read replica while fetch from follower replica
+      if (Request.isValidBrokerId(replicaId) || !partition.isLeader)
         None
       else {
         replicaSelectorOpt.flatMap { replicaSelector =>

--- a/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
@@ -25,11 +25,16 @@ import org.apache.kafka.common.errors.{FencedLeaderEpochException, NotLeaderOrFo
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.MemoryRecords
+import org.apache.kafka.common.replica.ClientMetadata
+import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.requests.FetchRequest
+import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions._
 import org.mockito.ArgumentMatchers.{any, anyInt}
 import org.mockito.Mockito.{mock, when}
+
+import java.net.InetAddress
 
 class DelayedFetchTest {
   private val maxBytes = 1024
@@ -166,6 +171,34 @@ class DelayedFetchTest {
     assertTrue(fetchResultOpt.isDefined)
   }
 
+
+  @Test
+  def testHasPreferredReadReplica(): Unit = {
+    val topicIdPartition = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
+    val fetchOffset = 500L
+    val logStartOffset = 0L
+    val currentLeaderEpoch = Optional.of[Integer](10)
+    val lastFetchedEpoch = Optional.of[Integer](9)
+    val replicaId = -1
+
+    val fetchStatus = FetchPartitionStatus(
+      startOffsetMetadata = LogOffsetMetadata(fetchOffset),
+      fetchInfo = new FetchRequest.PartitionData(topicIdPartition.topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch))
+    val metadata: ClientMetadata = new DefaultClientMetadata("rack-id", "client-id",
+      InetAddress.getByName("localhost"), KafkaPrincipal.ANONYMOUS, "default")
+    expectReadFromReplica(replicaId, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE, false)
+    expectReadFromReplica(replicaId, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE, false, Some(metadata), Some(1))
+
+    val noPreferredReadReplicaLogReadResult = replicaManager.readFromLocalLog(replicaId, false,
+      FetchLogEnd, maxBytes, false, Seq((topicIdPartition, fetchStatus.fetchInfo)), replicaQuota, None)
+    assertTrue(needDelayFetchResponse(noPreferredReadReplicaLogReadResult))
+
+    val hasPreferredReadReplicaLogReadResult = replicaManager.readFromLocalLog(replicaId, false,
+      FetchLogEnd, maxBytes, false,
+      Seq((topicIdPartition, fetchStatus.fetchInfo)), replicaQuota, Some(metadata))
+    assertFalse(needDelayFetchResponse(hasPreferredReadReplicaLogReadResult))
+  }
+
   private def buildFetchMetadata(replicaId: Int,
                                  topicIdPartition: TopicIdPartition,
                                  fetchStatus: FetchPartitionStatus): FetchMetadata = {
@@ -182,20 +215,23 @@ class DelayedFetchTest {
   private def expectReadFromReplica(replicaId: Int,
                                     topicIdPartition: TopicIdPartition,
                                     fetchPartitionData: FetchRequest.PartitionData,
-                                    error: Errors): Unit = {
+                                    error: Errors,
+                                    fetchOnlyFromLeader: Boolean = true,
+                                    clientMetadata: Option[ClientMetadata] = None,
+                                    preferredReadReplica: Option[Int] = None): Unit = {
     when(replicaManager.readFromLocalLog(
       replicaId = replicaId,
-      fetchOnlyFromLeader = true,
+      fetchOnlyFromLeader = fetchOnlyFromLeader,
       fetchIsolation = FetchLogEnd,
       fetchMaxBytes = maxBytes,
       hardMaxBytesLimit = false,
       readPartitionInfo = Seq((topicIdPartition, fetchPartitionData)),
-      clientMetadata = None,
+      clientMetadata = clientMetadata,
       quota = replicaQuota))
-      .thenReturn(Seq((topicIdPartition, buildReadResult(error))))
+      .thenReturn(Seq((topicIdPartition, buildReadResult(error,preferredReadReplica))))
   }
 
-  private def buildReadResult(error: Errors): LogReadResult = {
+  private def buildReadResult(error: Errors, preferredReadReplica: Option[Int]): LogReadResult = {
     LogReadResult(
       exception = if (error != Errors.NONE) Some(error.exception) else None,
       info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY),
@@ -205,7 +241,17 @@ class DelayedFetchTest {
       leaderLogEndOffset = -1L,
       followerLogStartOffset = -1L,
       fetchTimeMs = -1L,
-      lastStableOffset = None)
+      lastStableOffset = None,
+      preferredReadReplica = preferredReadReplica)
+  }
+
+  private def needDelayFetchResponse(logReadResults: Seq[(TopicIdPartition, LogReadResult)]): Boolean = {
+    var needDelayFetchResponse = true
+    logReadResults.foreach { case (_, logReadResult) =>
+      if (logReadResult.preferredReadReplica.nonEmpty)
+        needDelayFetchResponse = false
+    }
+    needDelayFetchResponse
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1314,10 +1314,11 @@ class ReplicaManagerTest {
       val tidp0 = new TopicIdPartition(topicId, tp0)
 
       initializeLogAndTopicId(replicaManager, tp0, topicId)
+
       when(replicaManager.metadataCache.getPartitionReplicaEndpoints(
         tp0,
-        new ListenerName("default"))
-      ).thenReturn(Map(
+        new ListenerName("default")
+      )).thenReturn(Map(
         leaderBrokerId -> new Node(leaderBrokerId, "host1", 9092, "rack-a"),
         followerBrokerId -> new Node(followerBrokerId, "host2", 9092, "rack-b")
       ).toMap)
@@ -1345,8 +1346,8 @@ class ReplicaManagerTest {
 
       // If a preferred read replica is selected, the fetch response returns immediately, even if min bytes and timeout conditions are not met.
       val consumerResult = fetchAsConsumer(replicaManager, tidp0,
-        new PartitionData(Uuid.ZERO_UUID, 0, 0, 100000, Optional.empty()), minBytes = 1,
-        clientMetadata = Some(metadata), timeout = 5000)
+        new PartitionData(Uuid.ZERO_UUID, 0, 0, 100000, Optional.empty()),
+        minBytes = 1, clientMetadata = Some(metadata), timeout = 5000)
 
       // Fetch from leader succeeds
       assertTrue(consumerResult.isFired)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1334,15 +1334,16 @@ class ReplicaManagerTest {
         Collections.singletonMap(topic, topicId),
         Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava).build()
       replicaManager.becomeLeaderOrFollower(1, leaderAndIsrRequest2, (_, _) => ())
-      // avoid the replica selector ignore the follower replica if it not have the data that need to fetch
+      // Avoid the replica selector ignore the follower replica if it not have the data that need to fetch
       replicaManager.getPartitionOrException(tp0).updateFollowerFetchState(followerBrokerId, new LogOffsetMetadata(0), 0, 0, 0)
 
       val metadata = new DefaultClientMetadata("rack-b", "client-id",
         InetAddress.getByName("localhost"), KafkaPrincipal.ANONYMOUS, "default")
 
+      //If a preferred read replica is selected, the fetch response will return immediately，even with minBytes and timeout configured
       val consumerResult = fetchAsConsumer(replicaManager, tidp0,
         new PartitionData(Uuid.ZERO_UUID, 0, 0, 100000, Optional.empty()), minBytes = 1,
-        clientMetadata = Some(metadata), timeout = 500)
+        clientMetadata = Some(metadata), timeout = 5000)
 
       // Fetch from leader succeeds
       assertTrue(consumerResult.isFired)


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

The design purpose of the code is that only the leader broker can determine the preferred read-replica. But in fact, since the broker does not judge whether it is the leader or not, the follower will also execute the preferred read-replica selection.
