### PR TITLE
KAFKA-13776: Upgrade RocksDB from 6.27.3 to 6.29.4.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -107,7 +107,7 @@ versions += [
   netty: "4.1.73.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
-  rocksDB: "6.27.3",
+  rocksDB: "6.29.4.1",
   scalaCollectionCompat: "2.6.0",
   scalafmt: "2.7.5",
   scalaJava8Compat : "1.0.2",


### PR DESCRIPTION
RocksDB 6.27.3 does not run on arm64 M1 Macs which would prevent people on this platform to run Kafka Streams. Thus, this PR upgrades RocksDB to 6.29.4.1 which contains the following fix to allow to run RocksDB on arm64 M1 Macs:

https://github.com/facebook/rocksdb/issues/7720

The source compatibility report between 6.27.3 and 6.29.4.1 (attached to the ticket) reports a couple of incompatibilities. However, the incompatibilities do not seem to affect Kafka Streams' backwards compatibility.
- The changes to class `RocksDB` only apply when inheriting from RocksDB. RocksDB is not exposed to users in Streams.
- The changes to class `WriteBatch` and class `WriteBatchInterface` also only apply with inheritance. Both classes are not exposed to users in Streams.
-The change to enum `SanityLevel` seem also not to apply to Streams since `SanityLevel` is only used in `ConfigOptions` which is only used to load options from files and properties objects. Loading options from files or properties is not exposed to users in Streams.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
