### PR TITLE
KAFKA-13763 (1): Improve unit testing coverage and flexibility for IncrementalCooperativeAssignor

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -128,6 +128,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1");
+        assertBalancedAssignments();
 
         // Second assignment with a second worker joining and all connectors running on previous worker
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
@@ -139,11 +140,13 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // A fourth rebalance should not change assignments
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -162,6 +165,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // Second assignment with only one worker remaining in the group. The worker that left the
         // group was a follower. No re-assignments take place immediately and the count
@@ -185,6 +189,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 4, 0, 0, "worker1");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -203,6 +208,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // Second assignment with only one worker remaining in the group. The worker that left the
         // group was a follower. No re-assignments take place immediately and the count
@@ -236,6 +242,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -255,6 +262,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
+        assertBalancedAssignments();
 
         // Second assignment with two workers remaining in the group. The worker that left the
         // group was the leader. The new leader has no previous assignments and is not tracking a
@@ -270,10 +278,12 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
+        assertBalancedAssignments();
 
         // Third (incidental) assignment with still only one worker in the group.
         performStandardRebalance();
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -293,6 +303,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
+        assertBalancedAssignments();
 
         // Second assignment with two workers remaining in the group. The worker that left the
         // group was the leader. The new leader has no previous assignments and is not tracking a
@@ -308,6 +319,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
+        assertBalancedAssignments();
 
         // Third assignment with the previous leader returning as a follower. In this case, the
         // arrival of the previous leader is treated as an arrival of a new worker. Reassignment
@@ -320,6 +332,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -348,6 +361,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -366,6 +380,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         when(coordinator.configSnapshot()).thenReturn(configState);
         doThrow(new RuntimeException("Unable to send computed assignment with SyncGroupRequest"))
@@ -386,6 +401,12 @@ public class IncrementalCooperativeAssignorTest {
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
+        // Fourth assignment after revocations
+        performStandardRebalance();
+        assertDelay(0, returnedAssignments);
+        assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
+        assertBalancedAssignments();
+
         verifyCoordinatorInteractions();
     }
 
@@ -403,6 +424,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // Second assignment triggered by a third worker joining. The computed assignment should
         // revoke tasks from the existing group. But the assignment won't be correctly delivered
@@ -420,6 +442,12 @@ public class IncrementalCooperativeAssignorTest {
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
+        // Fourth assignment after revocations
+        performStandardRebalance();
+        assertDelay(0, returnedAssignments);
+        assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
+        assertBalancedAssignments();
+
         verifyCoordinatorInteractions();
     }
 
@@ -434,6 +462,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // Second assignment with an updated config state that reflects removal of a connector
         configState = clusterConfigState(offset + 1, 2, 4);
@@ -441,6 +470,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -867,6 +897,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1");
+        assertBalancedAssignments();
 
         // Second assignment with a second worker with duplicate assignment joining and all connectors running on previous worker
         ExtendedAssignment duplicatedWorkerAssignment = newExpandableAssignment();
@@ -886,11 +917,13 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // Fifth rebalance should not change assignments
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -904,8 +937,9 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1");
+        assertBalancedAssignments();
 
-        //delete connector1
+        // Delete connector1
         configState = clusterConfigState(offset, 2, 1, 4);
         when(coordinator.configSnapshot()).thenReturn(configState);
 
@@ -927,11 +961,13 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         // Fifth rebalance should not change assignments
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
+        assertBalancedAssignments();
 
         verifyCoordinatorInteractions();
     }
@@ -1188,6 +1224,32 @@ public class IncrementalCooperativeAssignorTest {
         assertThat("Tasks should be unique in assignments but duplicates where found",
                 Collections.emptyList(),
                 is(existingTasks));
+    }
+
+    private void assertBalancedAssignments() {
+        List<Integer> connectorCounts = memberConfigs.values().stream()
+                .map(e -> e.assignment().connectors().size())
+                .sorted()
+                .collect(Collectors.toList());
+        List<Integer> taskCounts = memberConfigs.values().stream()
+                .map(e -> e.assignment().tasks().size())
+                .sorted()
+                .collect(Collectors.toList());
+
+        int minConnectors = connectorCounts.get(0);
+        int maxConnectors = connectorCounts.get(connectorCounts.size() - 1);
+
+        int minTasks = taskCounts.get(0);
+        int maxTasks = taskCounts.get(taskCounts.size() - 1);
+
+        assertTrue(
+                "Assignments are imbalanced. The spread of connectors across each worker is: " + connectorCounts,
+                maxConnectors - minConnectors <= 1
+        );
+        assertTrue(
+                "Assignments are imbalanced. The spread of tasks across each worker is: " + taskCounts,
+                maxTasks - minTasks <= 1
+        );
     }
 
     private void verifyCoordinatorInteractions() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -173,11 +173,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -244,11 +240,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -332,11 +324,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -393,11 +381,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -469,11 +453,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -515,11 +495,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -577,11 +553,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -637,11 +609,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -675,11 +643,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -1157,11 +1121,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     @Test
@@ -1230,11 +1190,7 @@ public class IncrementalCooperativeAssignorTest {
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
-        verify(coordinator, times(rebalanceNum)).configSnapshot();
-        verify(coordinator, times(rebalanceNum)).leaderState(any());
-        verify(coordinator, times(2 * rebalanceNum)).generationId();
-        verify(coordinator, times(rebalanceNum)).memberId();
-        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+        verifyCoordinatorInteractions();
     }
 
     private WorkerLoad emptyWorkerLoad(String worker) {
@@ -1466,4 +1422,13 @@ public class IncrementalCooperativeAssignorTest {
                 .thenReturn(assignor.previousGenerationId + 1);
         when(coordinator.lastCompletedGenerationId()).thenReturn(assignor.previousGenerationId);
     }
+
+    private void verifyCoordinatorInteractions() {
+        verify(coordinator, times(rebalanceNum)).configSnapshot();
+        verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(2 * rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
+        verify(coordinator, times(rebalanceNum)).lastCompletedGenerationId();
+    }
+
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -84,7 +84,6 @@ public class IncrementalCooperativeAssignorTest {
 
     private ClusterConfigState configState;
     private Map<String, ExtendedWorkerState> memberConfigs;
-    private Map<String, ExtendedWorkerState> expectedMemberConfigs;
     private long offset;
     private String leader;
     private String leaderUrl;
@@ -129,7 +128,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1");
 
         // Second assignment with a second worker joining and all connectors running on previous worker
@@ -138,7 +137,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
         // Third assignment after revocations
@@ -146,7 +145,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
         // A fourth rebalance should not change assignments
@@ -154,7 +153,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -173,7 +172,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment with only one worker remaining in the group. The worker that left the
@@ -184,7 +183,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2);
@@ -195,7 +194,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2 + 1);
@@ -205,7 +204,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(1, 4, 0, 0, "worker1");
 
         verifyCoordinatorInteractions();
@@ -224,7 +223,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment with only one worker remaining in the group. The worker that left the
@@ -235,7 +234,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2);
@@ -246,7 +245,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 4);
@@ -258,7 +257,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(rebalanceDelay / 4, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         time.sleep(rebalanceDelay / 4);
@@ -269,7 +268,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -289,7 +288,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
 
         // Second assignment with two workers remaining in the group. The worker that left the
@@ -307,14 +306,14 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
 
         // Third (incidental) assignment with still only one worker in the group.
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -334,7 +333,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
 
         // Second assignment with two workers remaining in the group. The worker that left the
@@ -352,7 +351,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
 
         // Third assignment with the previous leader returning as a follower. In this case, the
@@ -362,7 +361,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker1", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Fourth assignment after revocations
@@ -370,7 +369,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -391,7 +390,7 @@ public class IncrementalCooperativeAssignorTest {
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment happens with members returning the same assignments (memberConfigs)
@@ -400,7 +399,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -419,7 +418,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         when(coordinator.configSnapshot()).thenReturn(configState);
@@ -434,7 +433,7 @@ public class IncrementalCooperativeAssignorTest {
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
@@ -442,7 +441,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -461,7 +460,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment triggered by a third worker joining. The computed assignment should
@@ -473,7 +472,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
@@ -481,7 +480,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performRebalanceWithMismatchedGeneration();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -497,7 +496,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
 
         // Second assignment with an updated config state that reflects removal of a connector
@@ -507,7 +506,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -934,7 +933,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1");
 
         // Second assignment with a second worker with duplicate assignment joining and all connectors running on previous worker
@@ -946,7 +945,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
@@ -954,7 +953,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(1, 4, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
@@ -962,7 +961,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
 
         // Fifth rebalance should not change assignments
@@ -970,7 +969,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -984,7 +983,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1");
 
         //delete connector1
@@ -1000,7 +999,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
@@ -1008,7 +1007,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
@@ -1016,7 +1015,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
 
         // Fifth rebalance should not change assignments
@@ -1024,7 +1023,7 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs = memberConfigs(leader, offset, assignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments(memberConfigs, expectedMemberConfigs);
+        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -1055,7 +1054,6 @@ public class IncrementalCooperativeAssignorTest {
         }
         ++rebalanceNum;
         returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
     }
 
     private void expectGeneration(boolean expectMismatch) {
@@ -1202,35 +1200,23 @@ public class IncrementalCooperativeAssignorTest {
     private void assertAssignment(int connectorNum, int taskNum,
                                   int revokedConnectorNum, int revokedTaskNum,
                                   String... workers) {
-        assertAssignment(leader, connectorNum, taskNum, revokedConnectorNum, revokedTaskNum, workers);
-    }
-
-    private void assertAssignment(String expectedLeader, int connectorNum, int taskNum,
-                                  int revokedConnectorNum, int revokedTaskNum,
-                                  String... workers) {
         assertThat("Wrong number of workers",
-                expectedMemberConfigs.keySet().size(),
+                returnedAssignments.keySet().size(),
                 is(workers.length));
         assertThat("Wrong set of workers",
-                new ArrayList<>(expectedMemberConfigs.keySet()), hasItems(workers));
+                new ArrayList<>(returnedAssignments.keySet()), hasItems(workers));
         assertThat("Wrong number of assigned connectors",
-                expectedMemberConfigs.values().stream().map(v -> v.assignment().connectors().size()).reduce(0, Integer::sum),
+                returnedAssignments.values().stream().map(v -> v.connectors().size()).reduce(0, Integer::sum),
                 is(connectorNum));
         assertThat("Wrong number of assigned tasks",
-                expectedMemberConfigs.values().stream().map(v -> v.assignment().tasks().size()).reduce(0, Integer::sum),
+                returnedAssignments.values().stream().map(v -> v.tasks().size()).reduce(0, Integer::sum),
                 is(taskNum));
         assertThat("Wrong number of revoked connectors",
-                expectedMemberConfigs.values().stream().map(v -> v.assignment().revokedConnectors().size()).reduce(0, Integer::sum),
+                returnedAssignments.values().stream().map(v -> v.revokedConnectors().size()).reduce(0, Integer::sum),
                 is(revokedConnectorNum));
         assertThat("Wrong number of revoked tasks",
-                expectedMemberConfigs.values().stream().map(v -> v.assignment().revokedTasks().size()).reduce(0, Integer::sum),
+                returnedAssignments.values().stream().map(v -> v.revokedTasks().size()).reduce(0, Integer::sum),
                 is(revokedTaskNum));
-        assertThat("Wrong leader in assignments",
-                expectedMemberConfigs.values().stream().map(v -> v.assignment().leader()).distinct().collect(Collectors.joining(", ")),
-                is(expectedLeader));
-        assertThat("Wrong leaderUrl in assignments",
-                expectedMemberConfigs.values().stream().map(v -> v.assignment().leaderUrl()).distinct().collect(Collectors.joining(", ")),
-                is(expectedLeaderUrl(expectedLeader)));
     }
 
     private void assertDelay(int expectedDelay, Map<String, ExtendedAssignment> newAssignments) {
@@ -1239,24 +1225,27 @@ public class IncrementalCooperativeAssignorTest {
                         "Wrong rebalance delay in " + a, expectedDelay, a.delay()));
     }
 
-    private void assertNoReassignments(Map<String, ExtendedWorkerState> existingAssignments,
-                                       Map<String, ExtendedWorkerState> newAssignments) {
+    private void assertNoReassignments() {
+        Map<String, ExtendedAssignment> existingAssignments = memberConfigs.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue().assignment()
+        ));
         assertNoDuplicateInAssignment(existingAssignments);
-        assertNoDuplicateInAssignment(newAssignments);
+        assertNoDuplicateInAssignment(returnedAssignments);
 
         List<String> existingConnectors = existingAssignments.values().stream()
-                .flatMap(a -> a.assignment().connectors().stream())
+                .flatMap(a -> a.connectors().stream())
                 .collect(Collectors.toList());
-        List<String> newConnectors = newAssignments.values().stream()
-                .flatMap(a -> a.assignment().connectors().stream())
+        List<String> newConnectors = returnedAssignments.values().stream()
+                .flatMap(a -> a.connectors().stream())
                 .collect(Collectors.toList());
 
         List<ConnectorTaskId> existingTasks = existingAssignments.values().stream()
-                .flatMap(a -> a.assignment().tasks().stream())
+                .flatMap(a -> a.tasks().stream())
                 .collect(Collectors.toList());
 
-        List<ConnectorTaskId> newTasks = newAssignments.values().stream()
-                .flatMap(a -> a.assignment().tasks().stream())
+        List<ConnectorTaskId> newTasks = returnedAssignments.values().stream()
+                .flatMap(a -> a.tasks().stream())
                 .collect(Collectors.toList());
 
         existingConnectors.retainAll(newConnectors);
@@ -1269,9 +1258,9 @@ public class IncrementalCooperativeAssignorTest {
                 is(existingConnectors));
     }
 
-    private void assertNoDuplicateInAssignment(Map<String, ExtendedWorkerState> existingAssignment) {
+    private void assertNoDuplicateInAssignment(Map<String, ExtendedAssignment> existingAssignment) {
         List<String> existingConnectors = existingAssignment.values().stream()
-                .flatMap(a -> a.assignment().connectors().stream())
+                .flatMap(a -> a.connectors().stream())
                 .collect(Collectors.toList());
         Set<String> existingUniqueConnectors = new HashSet<>(existingConnectors);
         existingConnectors.removeAll(existingUniqueConnectors);
@@ -1280,7 +1269,7 @@ public class IncrementalCooperativeAssignorTest {
                 is(existingConnectors));
 
         List<ConnectorTaskId> existingTasks = existingAssignment.values().stream()
-                .flatMap(a -> a.assignment().tasks().stream())
+                .flatMap(a -> a.tasks().stream())
                 .collect(Collectors.toList());
         Set<ConnectorTaskId> existingUniqueTasks = new HashSet<>(existingTasks);
         existingTasks.removeAll(existingUniqueTasks);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -127,29 +127,22 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1");
 
         // Second assignment with a second worker joining and all connectors running on previous worker
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
         // Third assignment after revocations
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
         // A fourth rebalance should not change assignments
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -168,36 +161,29 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment with only one worker remaining in the group. The worker that left the
         // group was a follower. No re-assignments take place immediately and the count
         // down for the rebalance delay starts
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.remove("worker2");
         performStandardRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2);
 
         // Third (incidental) assignment with still only one worker in the group. Max delay has not
         // been reached yet
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2 + 1);
 
         // Fourth assignment after delay expired
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(1, 4, 0, 0, "worker1");
 
         verifyCoordinatorInteractions();
@@ -216,48 +202,39 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment with only one worker remaining in the group. The worker that left the
         // group was a follower. No re-assignments take place immediately and the count
         // down for the rebalance delay starts
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.remove("worker2");
         performStandardRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2);
 
         // Third (incidental) assignment with still only one worker in the group. Max delay has not
         // been reached yet
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 4);
 
         // Fourth assignment with the second worker returning before the delay expires
         // Since the delay is still active, lost assignments are not reassigned yet
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(rebalanceDelay / 4, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         time.sleep(rebalanceDelay / 4);
 
         // Fifth assignment with the same two workers. The delay has expired, so the lost
         // assignments ought to be assigned to the worker that has appeared as returned.
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -277,16 +254,14 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
 
         // Second assignment with two workers remaining in the group. The worker that left the
         // group was the leader. The new leader has no previous assignments and is not tracking a
         // delay upon a leader's exit
+        memberConfigs.remove("worker1");
         leader = "worker2";
         leaderUrl = expectedLeaderUrl(leader);
-        applyAssignments(leader, offset, returnedAssignments);
-        memberConfigs.remove("worker1");
         // The fact that the leader bounces means that the assignor starts from a clean slate
         initAssignor();
 
@@ -294,13 +269,10 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
 
         // Third (incidental) assignment with still only one worker in the group.
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -320,16 +292,14 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
 
         // Second assignment with two workers remaining in the group. The worker that left the
         // group was the leader. The new leader has no previous assignments and is not tracking a
         // delay upon a leader's exit
+        memberConfigs.remove("worker1");
         leader = "worker2";
         leaderUrl = expectedLeaderUrl(leader);
-        applyAssignments(leader, offset, returnedAssignments);
-        memberConfigs.remove("worker1");
         // The fact that the leader bounces means that the assignor starts from a clean slate
         initAssignor();
 
@@ -337,23 +307,18 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
 
         // Third assignment with the previous leader returning as a follower. In this case, the
         // arrival of the previous leader is treated as an arrival of a new worker. Reassignment
         // happens immediately, first with a revocation
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.put("worker1", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Fourth assignment after revocations
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -374,7 +339,6 @@ public class IncrementalCooperativeAssignorTest {
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment happens with members returning the same assignments (memberConfigs)
@@ -383,7 +347,6 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -402,7 +365,6 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         when(coordinator.configSnapshot()).thenReturn(configState);
@@ -411,12 +373,10 @@ public class IncrementalCooperativeAssignorTest {
 
         // Second assignment triggered by a third worker joining. The computed assignment should
         // revoke tasks from the existing group. But the assignment won't be correctly delivered.
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
@@ -424,7 +384,6 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -443,18 +402,15 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment triggered by a third worker joining. The computed assignment should
         // revoke tasks from the existing group. But the assignment won't be correctly delivered
         // and sync group with fail on the leader worker.
-        applyAssignments(leader, offset, returnedAssignments);
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        performStandardRebalance();
+        performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
@@ -462,7 +418,6 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performRebalanceWithMismatchedGeneration();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         verifyCoordinatorInteractions();
@@ -478,16 +433,13 @@ public class IncrementalCooperativeAssignorTest {
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
 
         // Second assignment with an updated config state that reflects removal of a connector
         configState = clusterConfigState(offset + 1, 2, 4);
         when(coordinator.configSnapshot()).thenReturn(configState);
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -914,39 +866,30 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1");
 
         // Second assignment with a second worker with duplicate assignment joining and all connectors running on previous worker
-        applyAssignments(leader, offset, returnedAssignments);
         ExtendedAssignment duplicatedWorkerAssignment = newExpandableAssignment();
         duplicatedWorkerAssignment.connectors().addAll(newConnectors(1, 2));
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(1, 4, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
 
         // Fifth rebalance should not change assignments
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -960,7 +903,6 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(2, 8, 0, 0, "worker1");
 
         //delete connector1
@@ -968,35 +910,27 @@ public class IncrementalCooperativeAssignorTest {
         when(coordinator.configSnapshot()).thenReturn(configState);
 
         // Second assignment with a second worker with duplicate assignment joining and the duplicated assignment is deleted at the same time
-        applyAssignments(leader, offset, returnedAssignments);
         ExtendedAssignment duplicatedWorkerAssignment = newExpandableAssignment();
         duplicatedWorkerAssignment.connectors().addAll(newConnectors(1, 2));
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
 
         // Fifth rebalance should not change assignments
-        applyAssignments(leader, offset, returnedAssignments);
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
-        assertNoReassignments();
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
@@ -1014,25 +948,25 @@ public class IncrementalCooperativeAssignorTest {
         performRebalance(false, true);
     }
 
-    private void performRebalance(boolean expectAssignmentFailure, boolean expectGenerationMismatch) {
+    private void performRebalance(boolean assignmentFailure, boolean expectGenerationMismatch) {
         expectGeneration(expectGenerationMismatch);
+        // Member configs are tracked by the assignor; create a deep copy here so that modifications to our own memberConfigs field
+        // are not accidentally propagated to the one used by the assignor
+        Map<String, ExtendedWorkerState> memberConfigsCopy = memberConfigs.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> {
+                    ExtendedWorkerState originalWorkerState = e.getValue();
+                    return new ExtendedWorkerState(
+                            originalWorkerState.url(),
+                            originalWorkerState.offset(),
+                            duplicate(originalWorkerState.assignment())
+                    );
+                }
+        ));
         try {
-            // Member configs are tracked by the assignor; create a deep copy here so that modifications to our own memberConfigs field
-            // are not accidentally propagated to the one used by the assignor
-            Map<String, ExtendedWorkerState> memberConfigsCopy = memberConfigs.entrySet().stream().collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> {
-                        ExtendedWorkerState originalWorkerState = e.getValue();
-                        return new ExtendedWorkerState(
-                                originalWorkerState.url(),
-                                originalWorkerState.offset(),
-                                duplicate(originalWorkerState.assignment())
-                        );
-                    }
-            ));
             assignor.performTaskAssignment(leader, offset, memberConfigsCopy, coordinator, protocolVersion);
         } catch (RuntimeException e) {
-            if (expectAssignmentFailure) {
+            if (assignmentFailure) {
                 RequestFuture.failure(e);
             } else {
                 throw e;
@@ -1040,6 +974,10 @@ public class IncrementalCooperativeAssignorTest {
         }
         ++rebalanceNum;
         returnedAssignments = assignmentsCapture.getValue();
+        assertNoReassignments();
+        if (!assignmentFailure) {
+            applyAssignments(leader, offset, returnedAssignments);
+        }
     }
 
     private void expectGeneration(boolean expectMismatch) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -83,7 +83,7 @@ public class IncrementalCooperativeAssignorTest {
 
     @Parameters
     public static Iterable<?> mode() {
-        return Arrays.asList(new Object[][] {{CONNECT_PROTOCOL_V1}, {CONNECT_PROTOCOL_V2}});
+        return Arrays.asList(CONNECT_PROTOCOL_V1, CONNECT_PROTOCOL_V2);
     }
 
     @Parameter
@@ -1069,7 +1069,6 @@ public class IncrementalCooperativeAssignorTest {
 
     private void expectGeneration(boolean expectMismatch) {
         when(coordinator.generationId())
-                .thenReturn(assignor.previousGenerationId + 1)
                 .thenReturn(assignor.previousGenerationId + 1);
         int lastCompletedGenerationId = expectMismatch ? assignor.previousGenerationId - 1 : assignor.previousGenerationId;
         when(coordinator.lastCompletedGenerationId()).thenReturn(lastCompletedGenerationId);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -127,12 +127,8 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1");
 
@@ -140,36 +136,24 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
         // Third assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
         // A fourth rebalance should not change assignments
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
@@ -187,12 +171,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
@@ -202,12 +182,8 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         assignments.remove("worker2");
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
 
@@ -217,12 +193,8 @@ public class IncrementalCooperativeAssignorTest {
         // been reached yet
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
 
@@ -231,12 +203,8 @@ public class IncrementalCooperativeAssignorTest {
         // Fourth assignment after delay expired
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1");
 
@@ -254,12 +222,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
@@ -269,12 +233,8 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         assignments.remove("worker2");
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
 
@@ -284,12 +244,8 @@ public class IncrementalCooperativeAssignorTest {
         // been reached yet
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
 
@@ -300,12 +256,8 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(rebalanceDelay / 4, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
@@ -315,12 +267,8 @@ public class IncrementalCooperativeAssignorTest {
         // assignments ought to be assigned to the worker that has appeared as returned.
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
 
@@ -339,12 +287,8 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
 
@@ -361,23 +305,15 @@ public class IncrementalCooperativeAssignorTest {
 
         // Capture needs to be reset to point to the new assignor
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
 
         // Third (incidental) assignment with still only one worker in the group.
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performRebalance();
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
 
@@ -396,12 +332,8 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
 
@@ -418,12 +350,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // Capture needs to be reset to point to the new assignor
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
 
@@ -433,23 +361,15 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker1", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performRebalance();
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Fourth assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
 
@@ -486,12 +406,8 @@ public class IncrementalCooperativeAssignorTest {
         // as the first time. The assignor detects that the number of members did not change and
         // avoids the rebalance delay, treating the lost assignments as new assignments.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
@@ -509,12 +425,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
@@ -544,11 +456,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third assignment happens with members returning the same assignments (memberConfigs)
         // as the first time.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
@@ -568,12 +476,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
@@ -600,11 +504,7 @@ public class IncrementalCooperativeAssignorTest {
         // as the first time.
         when(coordinator.lastCompletedGenerationId()).thenReturn(assignor.previousGenerationId - 1);
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
@@ -620,12 +520,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
 
@@ -634,12 +530,8 @@ public class IncrementalCooperativeAssignorTest {
         when(coordinator.configSnapshot()).thenReturn(configState);
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
@@ -1065,11 +957,8 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1");
 
@@ -1080,44 +969,32 @@ public class IncrementalCooperativeAssignorTest {
         duplicatedWorkerAssignment.connectors().addAll(newConnectors(1, 2));
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
 
         // Fifth rebalance should not change assignments
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
@@ -1130,11 +1007,8 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1");
 
@@ -1149,48 +1023,44 @@ public class IncrementalCooperativeAssignorTest {
         duplicatedWorkerAssignment.connectors().addAll(newConnectors(1, 2));
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
 
         // Fifth rebalance should not change assignments
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
+        performRebalance();
         assertDelay(0, returnedAssignments);
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         verifyCoordinatorInteractions();
+    }
+
+    private void performRebalance() {
+        expectGeneration();
+        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
+        ++rebalanceNum;
+        returnedAssignments = assignmentsCapture.getValue();
+        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
     }
 
     private WorkerLoad emptyWorkerLoad(String worker) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -127,7 +127,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1");
@@ -136,7 +136,7 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
@@ -144,7 +144,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
@@ -152,7 +152,7 @@ public class IncrementalCooperativeAssignorTest {
         // A fourth rebalance should not change assignments
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
@@ -171,7 +171,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
@@ -182,7 +182,7 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         assignments.remove("worker2");
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
@@ -193,7 +193,7 @@ public class IncrementalCooperativeAssignorTest {
         // been reached yet
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
@@ -203,7 +203,7 @@ public class IncrementalCooperativeAssignorTest {
         // Fourth assignment after delay expired
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1");
@@ -222,7 +222,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
@@ -233,7 +233,7 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         assignments.remove("worker2");
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(rebalanceDelay, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
@@ -244,7 +244,7 @@ public class IncrementalCooperativeAssignorTest {
         // been reached yet
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(rebalanceDelay / 2, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1");
@@ -256,7 +256,7 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(rebalanceDelay / 4, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
@@ -267,7 +267,7 @@ public class IncrementalCooperativeAssignorTest {
         // assignments ought to be assigned to the worker that has appeared as returned.
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
@@ -287,7 +287,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
@@ -305,7 +305,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // Capture needs to be reset to point to the new assignor
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
@@ -313,7 +313,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third (incidental) assignment with still only one worker in the group.
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
 
@@ -332,7 +332,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
@@ -350,7 +350,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // Capture needs to be reset to point to the new assignor
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
@@ -361,14 +361,14 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker1", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Fourth assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
@@ -388,15 +388,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        try {
-            expectGeneration();
-            assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        } catch (RuntimeException e) {
-            RequestFuture.failure(e);
-        }
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
@@ -406,7 +398,7 @@ public class IncrementalCooperativeAssignorTest {
         // as the first time. The assignor detects that the number of members did not change and
         // avoids the rebalance delay, treating the lost assignments as new assignments.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
@@ -425,7 +417,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
@@ -439,15 +431,7 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        try {
-            expectGeneration();
-            assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        } catch (RuntimeException e) {
-            RequestFuture.failure(e);
-        }
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
@@ -456,7 +440,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third assignment happens with members returning the same assignments (memberConfigs)
         // as the first time.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
@@ -470,13 +454,12 @@ public class IncrementalCooperativeAssignorTest {
         time = new MockTime();
         initAssignor();
 
-        expectGeneration();
         when(coordinator.configSnapshot()).thenReturn(configState);
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
@@ -487,14 +470,7 @@ public class IncrementalCooperativeAssignorTest {
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
         memberConfigs.put("worker3", new ExtendedWorkerState(leaderUrl, offset, null));
-        when(coordinator.generationId())
-                .thenReturn(assignor.previousGenerationId + 1)
-                .thenReturn(assignor.previousGenerationId + 1);
-        when(coordinator.lastCompletedGenerationId()).thenReturn(assignor.previousGenerationId - 1);
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
-        ++rebalanceNum;
-        returnedAssignments = assignmentsCapture.getValue();
-        expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+        performStandardRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
@@ -502,9 +478,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
         // as the first time.
-        when(coordinator.lastCompletedGenerationId()).thenReturn(assignor.previousGenerationId - 1);
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
-        performRebalance();
+        performRebalanceWithMismatchedGeneration();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
@@ -520,7 +495,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, null));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
@@ -530,7 +505,7 @@ public class IncrementalCooperativeAssignorTest {
         when(coordinator.configSnapshot()).thenReturn(configState);
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
@@ -957,7 +932,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1");
@@ -969,7 +944,7 @@ public class IncrementalCooperativeAssignorTest {
         duplicatedWorkerAssignment.connectors().addAll(newConnectors(1, 2));
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
@@ -977,7 +952,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(1, 4, 0, 2, "worker1", "worker2");
@@ -985,7 +960,7 @@ public class IncrementalCooperativeAssignorTest {
         // fourth rebalance after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
@@ -993,7 +968,7 @@ public class IncrementalCooperativeAssignorTest {
         // Fifth rebalance should not change assignments
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
@@ -1007,7 +982,7 @@ public class IncrementalCooperativeAssignorTest {
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(2, 8, 0, 0, "worker1");
@@ -1023,7 +998,7 @@ public class IncrementalCooperativeAssignorTest {
         duplicatedWorkerAssignment.connectors().addAll(newConnectors(1, 2));
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
@@ -1031,7 +1006,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third assignment after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2");
@@ -1039,7 +1014,7 @@ public class IncrementalCooperativeAssignorTest {
         // fourth rebalance after revocations
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
@@ -1047,7 +1022,7 @@ public class IncrementalCooperativeAssignorTest {
         // Fifth rebalance should not change assignments
         applyAssignments(returnedAssignments);
         memberConfigs = memberConfigs(leader, offset, assignments);
-        performRebalance();
+        performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertNoReassignments(memberConfigs, expectedMemberConfigs);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
@@ -1055,12 +1030,40 @@ public class IncrementalCooperativeAssignorTest {
         verifyCoordinatorInteractions();
     }
 
-    private void performRebalance() {
-        expectGeneration();
-        assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
+    private void performStandardRebalance() {
+        performRebalance(false, false);
+    }
+
+    private void performFailedRebalance() {
+        performRebalance(true, false);
+    }
+
+    private void performRebalanceWithMismatchedGeneration() {
+        performRebalance(false, true);
+    }
+
+    private void performRebalance(boolean expectAssignmentFailure, boolean expectGenerationMismatch) {
+        expectGeneration(expectGenerationMismatch);
+        try {
+            assignor.performTaskAssignment(leader, offset, memberConfigs, coordinator, protocolVersion);
+        } catch (RuntimeException e) {
+            if (expectAssignmentFailure) {
+                RequestFuture.failure(e);
+            } else {
+                throw e;
+            }
+        }
         ++rebalanceNum;
         returnedAssignments = assignmentsCapture.getValue();
         expectedMemberConfigs = memberConfigs(leader, offset, returnedAssignments);
+    }
+
+    private void expectGeneration(boolean expectMismatch) {
+        when(coordinator.generationId())
+                .thenReturn(assignor.previousGenerationId + 1)
+                .thenReturn(assignor.previousGenerationId + 1);
+        int lastCompletedGenerationId = expectMismatch ? assignor.previousGenerationId - 1 : assignor.previousGenerationId;
+        when(coordinator.lastCompletedGenerationId()).thenReturn(lastCompletedGenerationId);
     }
 
     private WorkerLoad emptyWorkerLoad(String worker) {
@@ -1284,13 +1287,6 @@ public class IncrementalCooperativeAssignorTest {
         assertThat("Tasks should be unique in assignments but duplicates where found",
                 Collections.emptyList(),
                 is(existingTasks));
-    }
-
-    private void expectGeneration() {
-        when(coordinator.generationId())
-                .thenReturn(assignor.previousGenerationId + 1)
-                .thenReturn(assignor.previousGenerationId + 1);
-        when(coordinator.lastCompletedGenerationId()).thenReturn(assignor.previousGenerationId);
     }
 
     private void verifyCoordinatorInteractions() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.MockitoRule;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -130,7 +131,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with a second worker joining and all connectors running on previous worker
         addNewWorkers("worker2");
@@ -142,13 +143,13 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // A fourth rebalance should not change assignments
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -167,7 +168,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with only one worker remaining in the group. The worker that left the
         // group was a follower. No re-assignments take place immediately and the count
@@ -191,7 +192,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 4, 0, 0, "worker1");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -210,7 +211,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with only one worker remaining in the group. The worker that left the
         // group was a follower. No re-assignments take place immediately and the count
@@ -244,7 +245,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -263,7 +264,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with two workers remaining in the group. The worker that left the
         // group was the leader. The new leader has no previous assignments and is not tracking a
@@ -279,12 +280,12 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Third (incidental) assignment with still only one worker in the group.
         performStandardRebalance();
         assertAssignment(0, 0, 0, 0, "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -303,7 +304,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with two workers remaining in the group. The worker that left the
         // group was the leader. The new leader has no previous assignments and is not tracking a
@@ -319,7 +320,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Third assignment with the previous leader returning as a follower. In this case, the
         // arrival of the previous leader is treated as an arrival of a new worker. Reassignment
@@ -332,7 +333,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -361,7 +362,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -380,7 +381,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         when(coordinator.configSnapshot()).thenReturn(configState);
         doThrow(new RuntimeException("Unable to send computed assignment with SyncGroupRequest"))
@@ -405,7 +406,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -424,7 +425,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment triggered by a third worker joining. The computed assignment should
         // revoke tasks from the existing group. But the assignment won't be correctly delivered
@@ -446,7 +447,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -462,7 +463,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with an updated config state that reflects removal of a connector
         configState = clusterConfigState(offset + 1, 2, 4);
@@ -470,7 +471,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -897,7 +898,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Second assignment with a second worker with duplicate assignment joining and all connectors running on previous worker
         ExtendedAssignment duplicatedWorkerAssignment = newExpandableAssignment();
@@ -917,13 +918,13 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Fifth rebalance should not change assignments
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -937,7 +938,7 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(2, 8, 0, 0, "worker1");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Delete connector1
         configState = clusterConfigState(offset, 2, 1, 4);
@@ -961,13 +962,13 @@ public class IncrementalCooperativeAssignorTest {
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         // Fifth rebalance should not change assignments
         performStandardRebalance();
         assertDelay(0, returnedAssignments);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
-        assertBalancedAssignments();
+        assertBalancedAndCompleteAllocation();
 
         verifyCoordinatorInteractions();
     }
@@ -1244,7 +1245,12 @@ public class IncrementalCooperativeAssignorTest {
                 is(existingTasks));
     }
 
-    private void assertBalancedAssignments() {
+    private void assertBalancedAndCompleteAllocation() {
+        assertBalancedAllocation();
+        assertCompleteAllocation();
+    }
+
+    private void assertBalancedAllocation() {
         List<Integer> connectorCounts = memberConfigs.values().stream()
                 .map(e -> e.assignment().connectors().size())
                 .sorted()
@@ -1267,6 +1273,32 @@ public class IncrementalCooperativeAssignorTest {
         assertTrue(
                 "Assignments are imbalanced. The spread of tasks across each worker is: " + taskCounts,
                 maxTasks - minTasks <= 1
+        );
+    }
+
+    private void assertCompleteAllocation() {
+        Set<String> allAssignedConnectors = memberConfigs.values().stream()
+                .map(ExtendedWorkerState::assignment)
+                .map(ConnectProtocol.Assignment::connectors)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+        assertEquals(
+                "The set of connectors assigned across the cluster does not match the set of connectors in the config topic",
+                configState.connectors(),
+                allAssignedConnectors
+        );
+
+        Map<String, Set<ConnectorTaskId>> allAssignedTasks = memberConfigs.values().stream()
+                .map(ExtendedWorkerState::assignment)
+                .map(ConnectProtocol.Assignment::tasks)
+                .flatMap(Collection::stream)
+                .collect(Collectors.groupingBy(ConnectorTaskId::connector, Collectors.toSet()));
+        configState.connectors().forEach(connector ->
+            assertEquals(
+                    "The set of tasks assigned across the cluster for connector " + connector + " does not match the set of tasks in the config topic",
+                    new HashSet<>(configState.tasks(connector)),
+                    allAssignedTasks.get(connector)
+            )
         );
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -130,25 +130,25 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1");
         assertBalancedAndCompleteAllocation();
 
         // Second assignment with a second worker joining and all connectors running on previous worker
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
 
         // Third assignment after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
         // A fourth rebalance should not change assignments
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -167,7 +167,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -176,7 +176,7 @@ public class IncrementalCooperativeAssignorTest {
         // down for the rebalance delay starts
         removeWorkers("worker2");
         performStandardRebalance();
-        assertDelay(rebalanceDelay, returnedAssignments);
+        assertDelay(rebalanceDelay);
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2);
@@ -184,14 +184,14 @@ public class IncrementalCooperativeAssignorTest {
         // Third (incidental) assignment with still only one worker in the group. Max delay has not
         // been reached yet
         performStandardRebalance();
-        assertDelay(rebalanceDelay / 2, returnedAssignments);
+        assertDelay(rebalanceDelay / 2);
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2 + 1);
 
         // Fourth assignment after delay expired
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(1, 4, 0, 0, "worker1");
         assertBalancedAndCompleteAllocation();
 
@@ -210,7 +210,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -219,7 +219,7 @@ public class IncrementalCooperativeAssignorTest {
         // down for the rebalance delay starts
         removeWorkers("worker2");
         performStandardRebalance();
-        assertDelay(rebalanceDelay, returnedAssignments);
+        assertDelay(rebalanceDelay);
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 2);
@@ -227,7 +227,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third (incidental) assignment with still only one worker in the group. Max delay has not
         // been reached yet
         performStandardRebalance();
-        assertDelay(rebalanceDelay / 2, returnedAssignments);
+        assertDelay(rebalanceDelay / 2);
         assertAssignment(0, 0, 0, 0, "worker1");
 
         time.sleep(rebalanceDelay / 4);
@@ -236,7 +236,7 @@ public class IncrementalCooperativeAssignorTest {
         // Since the delay is still active, lost assignments are not reassigned yet
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(rebalanceDelay / 4, returnedAssignments);
+        assertDelay(rebalanceDelay / 4);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
 
         time.sleep(rebalanceDelay / 4);
@@ -244,7 +244,7 @@ public class IncrementalCooperativeAssignorTest {
         // Fifth assignment with the same two workers. The delay has expired, so the lost
         // assignments ought to be assigned to the worker that has appeared as returned.
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(1, 4, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -263,7 +263,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         addNewWorkers("worker2", "worker3");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -279,7 +279,7 @@ public class IncrementalCooperativeAssignorTest {
         // Capture needs to be reset to point to the new assignor
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -303,7 +303,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         addNewWorkers("worker2", "worker3");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -319,7 +319,7 @@ public class IncrementalCooperativeAssignorTest {
         // Capture needs to be reset to point to the new assignor
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(1, 3, 0, 0, "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -332,7 +332,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // Fourth assignment after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -353,7 +353,7 @@ public class IncrementalCooperativeAssignorTest {
         addNewWorkers("worker2");
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
 
         // Second assignment happens with members returning the same assignments (memberConfigs)
@@ -361,7 +361,7 @@ public class IncrementalCooperativeAssignorTest {
         // avoids the rebalance delay, treating the lost assignments as new assignments.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -380,7 +380,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -393,19 +393,19 @@ public class IncrementalCooperativeAssignorTest {
         addNewWorkers("worker3");
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
         // as the first time.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Fourth assignment after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -424,7 +424,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -434,19 +434,19 @@ public class IncrementalCooperativeAssignorTest {
         addNewWorkers("worker3");
         performFailedRebalance();
         // This was the assignment that should have been sent, but didn't make it all the way
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Third assignment happens with members returning the same assignments (memberConfigs)
         // as the first time.
         doReturn(Collections.EMPTY_MAP).when(assignor).serializeAssignments(assignmentsCapture.capture());
         performRebalanceWithMismatchedGeneration();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2", "worker3");
 
         // Fourth assignment after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2", "worker3");
         assertBalancedAndCompleteAllocation();
 
@@ -462,7 +462,7 @@ public class IncrementalCooperativeAssignorTest {
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         addNewWorkers("worker2");
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(3, 12, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -470,7 +470,7 @@ public class IncrementalCooperativeAssignorTest {
         configState = clusterConfigState(offset + 1, 2, 4);
         when(coordinator.configSnapshot()).thenReturn(configState);
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 1, 4, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -897,7 +897,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1");
         assertBalancedAndCompleteAllocation();
 
@@ -907,23 +907,23 @@ public class IncrementalCooperativeAssignorTest {
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(1, 4, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
         // Fifth rebalance should not change assignments
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -937,7 +937,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(2, 8, 0, 0, "worker1");
         assertBalancedAndCompleteAllocation();
 
@@ -951,23 +951,23 @@ public class IncrementalCooperativeAssignorTest {
         duplicatedWorkerAssignment.tasks().addAll(newTasks("connector1", 0, 4));
         memberConfigs.put("worker2", new ExtendedWorkerState(leaderUrl, offset, duplicatedWorkerAssignment));
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 2, 8, "worker1", "worker2");
 
         // Third assignment after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 2, "worker1", "worker2");
 
         // fourth rebalance after revocations
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 2, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
         // Fifth rebalance should not change assignments
         performStandardRebalance();
-        assertDelay(0, returnedAssignments);
+        assertDelay(0);
         assertAssignment(0, 0, 0, 0, "worker1", "worker2");
         assertBalancedAndCompleteAllocation();
 
@@ -1170,9 +1170,8 @@ public class IncrementalCooperativeAssignorTest {
                 is(revokedTaskNum));
     }
 
-    private void assertDelay(int expectedDelay, Map<String, ExtendedAssignment> newAssignments) {
-        newAssignments.values().stream()
-                .forEach(a -> assertEquals(
+    private void assertDelay(int expectedDelay) {
+        returnedAssignments.values().forEach(a -> assertEquals(
                         "Wrong rebalance delay in " + a, expectedDelay, a.delay()));
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13763)

This is strictly a testing refactor. No functional changes are made; this can be easily verified by confirming that the only affected file is the `IncrementalCooperativeAssignorTest.java` test suite.

These changes were initially discussed during review of https://github.com/apache/kafka/pull/10367, which partially focused on improving readability in the unit tests for incremental rebalancing in Connect.

The goals here include:
1. Simplify the logic that has to be manually specified on a per-test-case basis for simulating a rebalance (accomplished by extracting common logic into reusable utility methods such as `performRebalance` and `addNewEmptyWorkers`)
2. Reduce the cognitive burden for following testing logic by removing unnecessary fields (like `expectedMemberConfigs` and `assignments`) and assertions (like the redundant checks for leader and leader URL)
3. Add powerful, granular, and reusable utility methods that can provide stronger guarantees about the state of a cluster across successive rebalances without forcing people to track this state in their heads (accomplished by replacing the existing `assertAssignments` method with `assertWorkers`, `assertEmptyAssignment`, `assertConnectorAllocations`, and `assertTaskAllocations`, and by adding the new `assertBalancedAllocation` and `assertCompleteAllocation` methods)
4. Refactor common logic for testing utilities to be more concise and reduce the number of Java 8 streams statements that have to be understood in order to read through a test case
5. Fix a bug in the assertion logic for checking for duplicates currently present [here](https://github.com/apache/kafka/blob/b2cb6caa1e9267c720c00fa367a277ee8509baea/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java#L1447-L1451) and [here](https://github.com/apache/kafka/blob/b2cb6caa1e9267c720c00fa367a277ee8509baea/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java#L1456-L1460) ([`List::removeAll`](https://docs.oracle.com/javase/8/docs/api/java/util/List.html#removeAll-java.util.Collection-) removes _all_ occurrences of any element contained in the collection passed to the method)
6. Remove an incorrect assertion in the `assertNoReassignments` (now renamed to `assertNoRedundantAssignments`) method that there should be no duplicated connectors or tasks in the assignments reported by each worker to the leader during rebalance (this is unnecessary and even contradicts logic used for testing in cases like [this](https://github.com/apache/kafka/blob/b2cb6caa1e9267c720c00fa367a277ee8509baea/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java#L1112-L1125) where we intentionally simulate a worker with a duplicated set of connectors and/or tasks rejoining a cluster; the only reason this bug wasn't surfaced sooner is because the bug mentioned in the prior point covers it)

Once merged, this should allow for cleaner, faster test writing when adding new cases for incremental rebalancing, such as with https://github.com/apache/kafka/pull/10367.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
