### PR TITLE
KAFKA-13791: Fix FetchResponse#`fetchData` and `forgottenTopics`: Assignment of lazy-initialized members should be the last step with double-checked locking

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -100,7 +100,7 @@ public class FetchResponse extends AbstractResponse {
         if (responseData == null) {
             synchronized (this) {
                 if (responseData == null) {
-                    // Assigning the lazy-initialized responseData in the last step
+                    // Assigning the lazy-initialized `responseData` in the last step
                     // to avoid other threads accessing a half-initialized object.
                     final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseDataTmp =
                             new LinkedHashMap<>();


### PR DESCRIPTION
Double-checked locking can be used for lazy initialization of volatile fields, but only if field assignment is the last step in the synchronized block. Otherwise, you run the risk of threads accessing a half-initialized object.

The problem is consistent with [KAFKA-13777](https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-13777)

#https://github.com/apache/kafka/pull/11963