### PR TITLE
KAFKA-7509: Clean up incorrect warnings logged by Connect

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Configurations shared by Kafka client applications: producer, consumer, connect, etc.
@@ -181,6 +182,15 @@ public class CommonClientConfigs {
     public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = "default.api.timeout.ms";
     public static final String DEFAULT_API_TIMEOUT_MS_DOC = "Specifies the timeout (in milliseconds) for client APIs. " +
             "This configuration is used as the default timeout for all client operations that do not specify a <code>timeout</code> parameter.";
+
+    public static final String CONNECT_KAFKA_CLUSTER_ID = "connect.kafka.cluster.id";
+    public static final String CONNECT_GROUP_ID = "connect.group.id";
+
+    public static void ignoreAutoPopulatedMetricsContextProperties(AbstractConfig config) {
+        Stream.of(CONNECT_KAFKA_CLUSTER_ID, CONNECT_GROUP_ID)
+                .map(property -> METRICS_CONTEXT_PREFIX + property)
+                .forEach(config::ignore);
+    }
 
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -218,6 +218,8 @@ public class AdminClientConfig extends AbstractConfig {
                                 .withClientSaslSupport();
     }
 
+    final boolean isSubConfig;
+
     @Override
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
@@ -229,6 +231,7 @@ public class AdminClientConfig extends AbstractConfig {
 
     protected AdminClientConfig(Map<?, ?> props, boolean doLog) {
         super(CONFIG, props, doLog);
+        this.isSubConfig = props instanceof RecordingMap;
     }
 
     public static Set<String> configNames() {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.SecurityConfig;
+import org.apache.kafka.common.config.internals.RecordingMap;
 import org.apache.kafka.common.metrics.Sensor;
 
 import java.util.Map;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -592,7 +592,9 @@ public class KafkaAdminClient extends AdminClient {
             new TimeoutProcessorFactory() : timeoutProcessorFactory;
         this.maxRetries = config.getInt(AdminClientConfig.RETRIES_CONFIG);
         this.retryBackoffMs = config.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG);
-        config.logUnused();
+        CommonClientConfigs.ignoreAutoPopulatedMetricsContextProperties(config);
+        if (!config.isSubConfig)
+            config.logUnused();
         AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
         log.debug("Kafka admin client initialized");
         thread.start();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.SecurityConfig;
+import org.apache.kafka.common.config.internals.RecordingMap;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.requests.JoinGroupRequest;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -577,6 +577,8 @@ public class ConsumerConfig extends AbstractConfig {
                                 .withClientSaslSupport();
     }
 
+    final boolean isSubConfig;
+
     @Override
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         Map<String, Object> refinedConfigs = CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
@@ -601,7 +603,9 @@ public class ConsumerConfig extends AbstractConfig {
     protected static Map<String, Object> appendDeserializerToConfig(Map<String, Object> configs,
                                                                     Deserializer<?> keyDeserializer,
                                                                     Deserializer<?> valueDeserializer) {
-        Map<String, Object> newConfigs = new HashMap<>(configs);
+        Map<String, Object> newConfigs = configs instanceof RecordingMap ?
+                ((RecordingMap<Object>) configs).copy() :
+                new HashMap<>(configs);
         if (keyDeserializer != null)
             newConfigs.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
         if (valueDeserializer != null)
@@ -624,14 +628,17 @@ public class ConsumerConfig extends AbstractConfig {
 
     public ConsumerConfig(Properties props) {
         super(CONFIG, props);
+        this.isSubConfig = false;
     }
 
     public ConsumerConfig(Map<String, Object> props) {
         super(CONFIG, props);
+        this.isSubConfig = props instanceof RecordingMap;
     }
 
     protected ConsumerConfig(Map<?, ?> props, boolean doLog) {
         super(CONFIG, props, doLog);
+        this.isSubConfig = props instanceof RecordingMap;
     }
 
     public static Set<String> configNames() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.serialization.Deserializer;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -604,9 +603,7 @@ public class ConsumerConfig extends AbstractConfig {
     protected static Map<String, Object> appendDeserializerToConfig(Map<String, Object> configs,
                                                                     Deserializer<?> keyDeserializer,
                                                                     Deserializer<?> valueDeserializer) {
-        Map<String, Object> newConfigs = configs instanceof RecordingMap ?
-                ((RecordingMap<Object>) configs).copy() :
-                new HashMap<>(configs);
+        Map<String, Object> newConfigs = RecordingMap.copyAndPreserve(configs);
         if (keyDeserializer != null)
             newConfigs.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
         if (valueDeserializer != null)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -812,7 +812,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, metricGrpPrefix);
 
-            config.logUnused();
+            CommonClientConfigs.ignoreAutoPopulatedMetricsContextProperties(config);
+
+            if (!config.isSubConfig)
+                config.logUnused();
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
             log.debug("Kafka consumer initialized");
         } catch (Throwable t) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -429,7 +429,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             String ioThreadName = NETWORK_THREAD_PREFIX + " | " + clientId;
             this.ioThread = new KafkaThread(ioThreadName, this.sender, true);
             this.ioThread.start();
-            config.logUnused();
+            CommonClientConfigs.ignoreAutoPopulatedMetricsContextProperties(config);
+            if (!config.isSubConfig)
+                config.logUnused();
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
             log.debug("Kafka producer started");
         } catch (Throwable t) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -453,6 +453,8 @@ public class ProducerConfig extends AbstractConfig {
                                         TRANSACTIONAL_ID_DOC);
     }
 
+    final boolean isSubConfig;
+
     @Override
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         Map<String, Object> refinedConfigs = CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
@@ -537,7 +539,9 @@ public class ProducerConfig extends AbstractConfig {
     static Map<String, Object> appendSerializerToConfig(Map<String, Object> configs,
             Serializer<?> keySerializer,
             Serializer<?> valueSerializer) {
-        Map<String, Object> newConfigs = new HashMap<>(configs);
+        Map<String, Object> newConfigs = configs instanceof RecordingMap ?
+                ((RecordingMap<Object>) configs).copy() :
+                new HashMap<>(configs);
         if (keySerializer != null)
             newConfigs.put(KEY_SERIALIZER_CLASS_CONFIG, keySerializer.getClass());
         if (valueSerializer != null)
@@ -547,14 +551,17 @@ public class ProducerConfig extends AbstractConfig {
 
     public ProducerConfig(Properties props) {
         super(CONFIG, props);
+        this.isSubConfig = false;
     }
 
     public ProducerConfig(Map<String, Object> props) {
         super(CONFIG, props);
+        this.isSubConfig = props instanceof RecordingMap;
     }
 
     ProducerConfig(Map<?, ?> props, boolean doLog) {
         super(CONFIG, props, doLog);
+        this.isSubConfig = props instanceof RecordingMap;
     }
 
     public static Set<String> configNames() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -540,9 +539,7 @@ public class ProducerConfig extends AbstractConfig {
     static Map<String, Object> appendSerializerToConfig(Map<String, Object> configs,
             Serializer<?> keySerializer,
             Serializer<?> valueSerializer) {
-        Map<String, Object> newConfigs = configs instanceof RecordingMap ?
-                ((RecordingMap<Object>) configs).copy() :
-                new HashMap<>(configs);
+        Map<String, Object> newConfigs = RecordingMap.copyAndPreserve(configs);
         if (keySerializer != null)
             newConfigs.put(KEY_SERIALIZER_CLASS_CONFIG, keySerializer.getClass());
         if (valueSerializer != null)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SecurityConfig;
+import org.apache.kafka.common.config.internals.RecordingMap;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -382,7 +382,7 @@ public class AbstractConfig {
     public void logUnused() {
         Set<String> unusedkeys = unused();
         if (!unusedkeys.isEmpty()) {
-            log.warn("These configurations '{}' were supplied but are not used yet.", unusedkeys);
+            log.warn("These configurations were supplied but are not used yet: {}", unusedkeys);
         }
     }
 
@@ -609,7 +609,7 @@ public class AbstractConfig {
      * Marks keys retrieved via `get` as used. This is needed because `Configurable.configure` takes a `Map` instead
      * of an `AbstractConfig` and we can't change that without breaking public API like `Partitioner`.
      */
-    private class RecordingMap<V> extends HashMap<String, V> {
+    protected class RecordingMap<V> extends HashMap<String, V> {
 
         private final String prefix;
         private final boolean withIgnoreFallback;
@@ -649,6 +649,11 @@ public class AbstractConfig {
             }
             return super.get(key);
         }
+
+        public RecordingMap<V> copy() {
+            return new RecordingMap<>(this);
+        }
+
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/config/internals/RecordingMap.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/internals/RecordingMap.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.config.internals;
+
+import org.apache.kafka.common.config.AbstractConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Marks keys retrieved via `get` as used. This is needed because `Configurable.configure` takes a `Map` instead
+ * of an `AbstractConfig` and we can't change that without breaking public API like `Partitioner`.
+ */
+public class RecordingMap<V> extends HashMap<String, V> {
+
+    private static final long serialVersionUID = 8756361579758562482L;
+
+    private final String prefix;
+    private final boolean withIgnoreFallback;
+    private final transient AbstractConfig config;
+
+    public RecordingMap(AbstractConfig config) {
+        this(config, "", false);
+    }
+
+    public RecordingMap(AbstractConfig config, String prefix, boolean withIgnoreFallback) {
+        this.config = config;
+        this.prefix = Objects.requireNonNull(prefix);
+        this.withIgnoreFallback = withIgnoreFallback;
+    }
+
+    public RecordingMap(AbstractConfig config, Map<String, ? extends V> m) {
+        this(config, m, "", false);
+    }
+
+    public RecordingMap(AbstractConfig config, Map<String, ? extends V> m, String prefix, boolean withIgnoreFallback) {
+        super(m);
+        this.config = config;
+        this.prefix = Objects.requireNonNull(prefix);
+        this.withIgnoreFallback = withIgnoreFallback;
+    }
+
+    @Override
+    public V get(Object key) {
+        if (key instanceof String) {
+            String stringKey = (String) key;
+            String keyWithPrefix;
+            if (prefix.isEmpty()) {
+                keyWithPrefix = stringKey;
+            } else {
+                keyWithPrefix = prefix + stringKey;
+            }
+            record(keyWithPrefix);
+            if (withIgnoreFallback)
+                record(stringKey);
+        }
+        return super.get(key);
+    }
+
+    public RecordingMap<V> copy() {
+        return new RecordingMap<>(config, this);
+    }
+
+    private void record(String key) {
+        if (config != null)
+            config.ignore(key);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/config/internals/RecordingMap.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/internals/RecordingMap.java
@@ -55,6 +55,15 @@ public class RecordingMap<V> extends HashMap<String, V> {
         this.withIgnoreFallback = withIgnoreFallback;
     }
 
+    public static <V> Map<String, V> copyAndPreserve(Map<String, V> map) {
+        if (map instanceof RecordingMap) {
+            RecordingMap<V> recordingMap = (RecordingMap<V>) map;
+            return new RecordingMap<>(recordingMap.config, recordingMap, recordingMap.prefix, recordingMap.withIgnoreFallback);
+        } else {
+            return new HashMap<>(map);
+        }
+    }
+
     @Override
     public V get(Object key) {
         if (key instanceof String) {
@@ -70,10 +79,6 @@ public class RecordingMap<V> extends HashMap<String, V> {
                 record(stringKey);
         }
         return super.get(key);
-    }
-
-    public RecordingMap<V> copy() {
-        return new RecordingMap<>(config, this);
     }
 
     private void record(String key) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -104,7 +103,7 @@ public class ConnectDistributed {
         String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
 
         // Create the admin client to be shared by all backing stores.
-        Map<String, Object> adminProps = new HashMap<>(config.originals());
+        Map<String, Object> adminProps = config.originals();
         ConnectUtils.addMetricsContextProperties(adminProps, config, kafkaClusterId);
         SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(adminProps);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -94,7 +94,7 @@ public class ConnectStandalone {
             Worker worker = new Worker(workerId, time, plugins, config, new FileOffsetBackingStore(),
                                        connectorClientConfigOverridePolicy);
 
-            Herder herder = new StandaloneHerder(worker, kafkaClusterId, connectorClientConfigOverridePolicy);
+            Herder herder = new StandaloneHerder(worker, kafkaClusterId, connectorClientConfigOverridePolicy, config);
             final Connect connect = new Connect(herder, rest);
             log.info("Kafka Connect standalone worker initialization took {}ms", time.hiResClockMs() - initStart);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -104,6 +104,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     protected final ConfigBackingStore configBackingStore;
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
     protected volatile boolean running = false;
+    private final WorkerConfig config;
     private final ExecutorService connectorExecutor;
 
     private final ConcurrentMap<String, Connector> tempConnectors = new ConcurrentHashMap<>();
@@ -113,7 +114,8 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                           String kafkaClusterId,
                           StatusBackingStore statusBackingStore,
                           ConfigBackingStore configBackingStore,
-                          ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy) {
+                          ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
+                          WorkerConfig config) {
         this.worker = worker;
         this.worker.herder = this;
         this.workerId = workerId;
@@ -121,6 +123,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.statusBackingStore = statusBackingStore;
         this.configBackingStore = configBackingStore;
         this.connectorClientConfigOverridePolicy = connectorClientConfigOverridePolicy;
+        this.config = config;
         this.connectorExecutor = Executors.newCachedThreadPool();
     }
 
@@ -135,6 +138,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.worker.start();
         this.statusBackingStore.start();
         this.configBackingStore.start();
+        config.logUnused();
     }
 
     protected void stopServices() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -87,10 +87,10 @@ public class ConnectMetrics {
 
         Map<String, Object> contextLabels = new HashMap<>();
         contextLabels.putAll(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
-        contextLabels.put(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID, clusterId);
+        contextLabels.put(CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID, clusterId);
         Object groupId = config.originals().get(DistributedConfig.GROUP_ID_CONFIG);
         if (groupId != null) {
-            contextLabels.put(WorkerConfig.CONNECT_GROUP_ID, groupId);
+            contextLabels.put(CommonClientConfigs.CONNECT_GROUP_ID, groupId);
         }
         MetricsContext metricsContext = new KafkaMetricsContext(JMX_PREFIX, contextLabels);
         this.metrics = new Metrics(metricConfig, reporters, time, metricsContext);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -29,6 +29,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import java.security.InvalidParameterException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -399,6 +400,13 @@ public class DistributedConfig extends WorkerConfig {
     @Override
     public Integer getRebalanceTimeout() {
         return getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+    }
+
+    @Override
+    protected List<String> subConfigPrefixes() {
+        List<String> result = super.subConfigPrefixes();
+        result.addAll(Arrays.asList(CONFIG_STORAGE_PREFIX, OFFSET_STORAGE_PREFIX, STATUS_STORAGE_PREFIX));
+        return result;
     }
 
     public DistributedConfig(Map<String, String> props) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -241,7 +241,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                       Time time,
                       ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
                       AutoCloseable... uponShutdown) {
-        super(worker, workerId, kafkaClusterId, statusBackingStore, configBackingStore, connectorClientConfigOverridePolicy);
+        super(worker, workerId, kafkaClusterId, statusBackingStore, configBackingStore, connectorClientConfigOverridePolicy, config);
 
         this.time = time;
         this.herderMetrics = new HerderMetrics(metrics);
@@ -1250,7 +1250,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
         } else {
             if (configState.offset() < assignment.offset()) {
-                log.warn("Catching up to assignment's config offset.");
+                log.info("Catching up to assignment's config offset.");
                 needsReadToEnd = true;
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -37,7 +37,6 @@ import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
@@ -98,8 +97,8 @@ public class WorkerGroupMember {
 
             Map<String, Object> contextLabels = new HashMap<>();
             contextLabels.putAll(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
-            contextLabels.put(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID, ConnectUtils.lookupKafkaClusterId(config));
-            contextLabels.put(WorkerConfig.CONNECT_GROUP_ID, config.getString(DistributedConfig.GROUP_ID_CONFIG));
+            contextLabels.put(CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID, ConnectUtils.lookupKafkaClusterId(config));
+            contextLabels.put(CommonClientConfigs.CONNECT_GROUP_ID, config.getString(DistributedConfig.GROUP_ID_CONFIG));
             MetricsContext metricsContext = new KafkaMetricsContext(JMX_PREFIX, contextLabels);
 
             this.metrics = new Metrics(metricConfig, reporters, time, metricsContext);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -71,13 +71,15 @@ public class StandaloneHerder extends AbstractHerder {
     private ClusterConfigState configState;
 
     public StandaloneHerder(Worker worker, String kafkaClusterId,
-                            ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy) {
+                            ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
+                            StandaloneConfig config) {
         this(worker,
                 worker.workerId(),
                 kafkaClusterId,
                 new MemoryStatusBackingStore(),
                 new MemoryConfigBackingStore(worker.configTransformer()),
-             connectorClientConfigOverridePolicy);
+                connectorClientConfigOverridePolicy,
+                config);
     }
 
     // visible for testing
@@ -86,8 +88,9 @@ public class StandaloneHerder extends AbstractHerder {
                      String kafkaClusterId,
                      StatusBackingStore statusBackingStore,
                      MemoryConfigBackingStore configBackingStore,
-                     ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy) {
-        super(worker, workerId, kafkaClusterId, statusBackingStore, configBackingStore, connectorClientConfigOverridePolicy);
+                     ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
+                     StandaloneConfig config) {
+        super(worker, workerId, kafkaClusterId, statusBackingStore, configBackingStore, connectorClientConfigOverridePolicy, config);
         this.configState = ClusterConfigState.EMPTY;
         this.requestExecutorService = Executors.newSingleThreadScheduledExecutor();
         configBackingStore.setUpdateListener(new ConfigUpdateListener());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -506,8 +506,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
     // package private for testing
     KafkaBasedLog<String, byte[]> setupAndCreateKafkaBasedLog(String topic, final WorkerConfig config) {
         String clusterId = ConnectUtils.lookupKafkaClusterId(config);
-        Map<String, Object> originals = config.originals();
-        Map<String, Object> producerProps = new HashMap<>(originals);
+        Map<String, Object> producerProps = config.originals();
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
@@ -519,12 +518,12 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "false");
         ConnectUtils.addMetricsContextProperties(producerProps, config, clusterId);
 
-        Map<String, Object> consumerProps = new HashMap<>(originals);
+        Map<String, Object> consumerProps = config.originals();
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
 
-        Map<String, Object> adminProps = new HashMap<>(originals);
+        Map<String, Object> adminProps = config.originals();
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
         Supplier<TopicAdmin> adminSupplier;
         if (topicAdminSupplier != null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -86,8 +86,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         String clusterId = ConnectUtils.lookupKafkaClusterId(config);
         data = new HashMap<>();
 
-        Map<String, Object> originals = config.originals();
-        Map<String, Object> producerProps = new HashMap<>(originals);
+        Map<String, Object> producerProps = config.originals();
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
@@ -99,12 +98,12 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "false");
         ConnectUtils.addMetricsContextProperties(producerProps, config, clusterId);
 
-        Map<String, Object> consumerProps = new HashMap<>(originals);
+        Map<String, Object> consumerProps = config.originals();
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
 
-        Map<String, Object> adminProps = new HashMap<>(originals);
+        Map<String, Object> adminProps = config.originals();
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
         Supplier<TopicAdmin> adminSupplier;
         if (topicAdminSupplier != null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -165,8 +165,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
             throw new ConfigException("Must specify topic for connector status.");
 
         String clusterId = ConnectUtils.lookupKafkaClusterId(config);
-        Map<String, Object> originals = config.originals();
-        Map<String, Object> producerProps = new HashMap<>(originals);
+        Map<String, Object> producerProps = config.originals();
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.RETRIES_CONFIG, 0); // we handle retries in this class
@@ -178,12 +177,12 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "false"); // disable idempotence since retries is force to 0
         ConnectUtils.addMetricsContextProperties(producerProps, config, clusterId);
 
-        Map<String, Object> consumerProps = new HashMap<>(originals);
+        Map<String, Object> consumerProps = config.originals();
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
 
-        Map<String, Object> adminProps = new HashMap<>(originals);
+        Map<String, Object> adminProps = config.originals();
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
         Supplier<TopicAdmin> adminSupplier;
         if (topicAdminSupplier != null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -145,10 +145,10 @@ public final class ConnectUtils {
         //add all properties predefined with "metrics.context."
         prop.putAll(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX, false));
         //add connect properties
-        prop.put(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_KAFKA_CLUSTER_ID, clusterId);
+        prop.put(CommonClientConfigs.METRICS_CONTEXT_PREFIX + CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID, clusterId);
         Object groupId = config.originals().get(DistributedConfig.GROUP_ID_CONFIG);
         if (groupId != null) {
-            prop.put(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_GROUP_ID, groupId);
+            prop.put(CommonClientConfigs.METRICS_CONTEXT_PREFIX + CommonClientConfigs.CONNECT_GROUP_ID, groupId);
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -50,6 +50,7 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.easymock.Mock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
@@ -146,6 +147,7 @@ public class AbstractHerderTest {
     @MockStrict private ClassLoader classLoader;
     @MockStrict private ConfigBackingStore configStore;
     @MockStrict private StatusBackingStore statusStore;
+    @Mock private WorkerConfig config;
 
     @Test
     public void testConnectors() {
@@ -156,9 +158,10 @@ public class AbstractHerderTest {
                 String.class,
                 StatusBackingStore.class,
                 ConfigBackingStore.class,
-                ConnectorClientConfigOverridePolicy.class
+                ConnectorClientConfigOverridePolicy.class,
+                WorkerConfig.class
             )
-            .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+            .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
             .addMockedMethod("generation")
             .createMock();
 
@@ -180,9 +183,10 @@ public class AbstractHerderTest {
                 String.class,
                 StatusBackingStore.class,
                 ConfigBackingStore.class,
-                ConnectorClientConfigOverridePolicy.class
+                ConnectorClientConfigOverridePolicy.class,
+                WorkerConfig.class
             )
-            .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+            .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
             .addMockedMethod("generation")
             .createMock();
 
@@ -205,8 +209,8 @@ public class AbstractHerderTest {
 
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                                 ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                                 ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
 
@@ -246,8 +250,8 @@ public class AbstractHerderTest {
 
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                                 ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                                 ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
 
@@ -278,8 +282,8 @@ public class AbstractHerderTest {
         RestartRequest restartRequest = new RestartRequest(connectorName, false, true);
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                        ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                        ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
 
@@ -345,8 +349,8 @@ public class AbstractHerderTest {
 
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                        ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                        ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
 
@@ -387,8 +391,8 @@ public class AbstractHerderTest {
 
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                        ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                        ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
 
@@ -913,9 +917,10 @@ public class AbstractHerderTest {
                         String.class,
                         StatusBackingStore.class,
                         ConfigBackingStore.class,
-                        ConnectorClientConfigOverridePolicy.class
+                        ConnectorClientConfigOverridePolicy.class,
+                        WorkerConfig.class
                 )
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
 
@@ -963,8 +968,8 @@ public class AbstractHerderTest {
         String connName = "AnotherPlugin";
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                        ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                        ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
         EasyMock.expect(worker.getPlugins()).andStubReturn(plugins);
@@ -978,8 +983,8 @@ public class AbstractHerderTest {
         String connName = "AnotherPlugin";
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                        ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                        ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
         EasyMock.expect(worker.getPlugins()).andStubReturn(plugins);
@@ -1049,8 +1054,8 @@ public class AbstractHerderTest {
 
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
-                                 ConnectorClientConfigOverridePolicy.class)
-                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, connectorClientConfigOverridePolicy)
+                                 ConnectorClientConfigOverridePolicy.class, WorkerConfig.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, connectorClientConfigOverridePolicy, config)
                 .addMockedMethod("generation")
                 .createMock();
         EasyMock.expect(herder.generation()).andStubReturn(generation);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.ThreadedTest;
 import org.easymock.Capture;
@@ -30,8 +29,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -59,19 +56,12 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
 
     private SourceTaskOffsetCommitter committer;
 
-    private static final long DEFAULT_OFFSET_COMMIT_INTERVAL_MS = 1000;
+    private static final long OFFSET_COMMIT_INTERVAL_MS = 1000;
 
     @Override
     public void setup() {
         super.setup();
-        Map<String, String> workerProps = new HashMap<>();
-        workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
-        workerProps.put("offset.flush.interval.ms",
-                Long.toString(DEFAULT_OFFSET_COMMIT_INTERVAL_MS));
-        WorkerConfig config = new StandaloneConfig(workerProps);
-        committer = new SourceTaskOffsetCommitter(config, executor, committers);
+        committer = new SourceTaskOffsetCommitter(OFFSET_COMMIT_INTERVAL_MS, executor, committers);
         Whitebox.setInternalState(SourceTaskOffsetCommitter.class, "log", mockLog);
     }
 
@@ -81,8 +71,8 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
         Capture<Runnable> taskWrapper = EasyMock.newCapture();
 
         EasyMock.expect(executor.scheduleWithFixedDelay(
-                EasyMock.capture(taskWrapper), eq(DEFAULT_OFFSET_COMMIT_INTERVAL_MS),
-                eq(DEFAULT_OFFSET_COMMIT_INTERVAL_MS), eq(TimeUnit.MILLISECONDS))
+                EasyMock.capture(taskWrapper), eq(OFFSET_COMMIT_INTERVAL_MS),
+                eq(OFFSET_COMMIT_INTERVAL_MS), eq(TimeUnit.MILLISECONDS))
         ).andReturn((ScheduledFuture) commitFuture);
 
         PowerMock.replayAll();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -88,6 +88,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.DEFAULT_TOPIC_CREATION_PREFIX;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_FACTOR_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_CREATION_ENABLE_CONFIG;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -196,6 +197,7 @@ public class WorkerTest extends ThreadedTest {
                                 .strictness(Strictness.STRICT_STUBS)
                                 .startMocking();
 
+        workerProps.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
@@ -1163,7 +1165,7 @@ public class WorkerTest extends ThreadedTest {
             if (reporter instanceof MockMetricsReporter) {
                 MockMetricsReporter mockMetricsReporter = (MockMetricsReporter) reporter;
                 //verify connect cluster is set in MetricsContext
-                assertEquals(CLUSTER_ID, mockMetricsReporter.getMetricsContext().contextLabels().get(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID));
+                assertEquals(CLUSTER_ID, mockMetricsReporter.getMetricsContext().contextLabels().get(CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID));
             }
         }
         //verify metric is created with correct jmx prefix

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.MockConnectMetrics;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.ConnectUtils;
@@ -82,8 +81,8 @@ public class WorkerGroupMemberTest {
             if (reporter instanceof MockConnectMetrics.MockMetricsReporter) {
                 entered = true;
                 MockConnectMetrics.MockMetricsReporter mockMetricsReporter = (MockConnectMetrics.MockMetricsReporter) reporter;
-                assertEquals("cluster-1", mockMetricsReporter.getMetricsContext().contextLabels().get(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID));
-                assertEquals("group-1", mockMetricsReporter.getMetricsContext().contextLabels().get(WorkerConfig.CONNECT_GROUP_ID));
+                assertEquals("cluster-1", mockMetricsReporter.getMetricsContext().contextLabels().get(CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID));
+                assertEquals("group-1", mockMetricsReporter.getMetricsContext().contextLabels().get(CommonClientConfigs.CONNECT_GROUP_ID));
             }
         }
         assertTrue("Failed to verify MetricsReporter", entered);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -118,6 +118,7 @@ public class StandaloneHerderTest {
     private DelegatingClassLoader delegatingLoader;
     protected FutureCallback<Herder.Created<ConnectorInfo>> createCallback;
     @Mock protected StatusBackingStore statusBackingStore;
+    @Mock private StandaloneConfig config;
 
     private final ConnectorClientConfigOverridePolicy
         noneConnectorClientConfigOverridePolicy = new NoneConnectorClientConfigOverridePolicy();
@@ -128,7 +129,7 @@ public class StandaloneHerderTest {
         worker = PowerMock.createMock(Worker.class);
         String[] methodNames = new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/, "buildRestartPlan", "recordRestarting"};
         herder = PowerMock.createPartialMock(StandaloneHerder.class, methodNames,
-                worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
+                worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy, config);
         createCallback = new FutureCallback<>();
         plugins = PowerMock.createMock(Plugins.class);
         pluginLoader = PowerMock.createMock(PluginClassLoader.class);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.junit.Test;
@@ -84,8 +83,8 @@ public class ConnectUtilsTest {
 
         Map<String, Object> prop = new HashMap<>();
         ConnectUtils.addMetricsContextProperties(prop, config, "cluster-1");
-        assertEquals("connect-cluster", prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_GROUP_ID));
-        assertEquals("cluster-1", prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_KAFKA_CLUSTER_ID));
+        assertEquals("connect-cluster", prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + CommonClientConfigs.CONNECT_GROUP_ID));
+        assertEquals("cluster-1", prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID));
     }
 
     @Test
@@ -99,8 +98,8 @@ public class ConnectUtilsTest {
 
         Map<String, Object> prop = new HashMap<>();
         ConnectUtils.addMetricsContextProperties(prop, config, "cluster-1");
-        assertNull(prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_GROUP_ID));
-        assertEquals("cluster-1", prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_KAFKA_CLUSTER_ID));
+        assertNull(prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + CommonClientConfigs.CONNECT_GROUP_ID));
+        assertEquals("cluster-1", prop.get(CommonClientConfigs.METRICS_CONTEXT_PREFIX + CommonClientConfigs.CONNECT_KAFKA_CLUSTER_ID));
 
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-7509)

### Summary of changes

- Skip the calls to `AbstractConfig::logUnused` made by [KafkaConsumer](https://github.com/apache/kafka/blob/62ea4c46a9be7388baeaef1c505d3e5798a9066f/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L815), [KafkaProducer](https://github.com/apache/kafka/blob/62ea4c46a9be7388baeaef1c505d3e5798a9066f/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L432), and [KafkaAdminClient](https://github.com/apache/kafka/blob/62ea4c46a9be7388baeaef1c505d3e5798a9066f/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java#L595) instances when the original config map is an instance of a [RecordingMap](https://github.com/apache/kafka/blob/62ea4c46a9be7388baeaef1c505d3e5798a9066f/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java#L608-L612)
- Modify `ConsumerConfig::appendDeserializerToConfig` and `ProducerConfig::appendSerializerToConfig` to preserve `RecordingMap` instances passed in to their constructors (or more precisely, create clones of those instances that retain the "recording" behavior of the original) so that all properties used by those consumers/producers are marked as used with the original `RecordingMap`
- Use `WorkerConfig::originals` as the baseline when constructing configs to pass to Kafka clients that are used by the worker to manage its internal Kafka topics, so that all properties in the worker config that are used by those Kafka clients are marked as used in the `WorkerConfig`
- Ignore all properties in the worker config that are transparently passed through to configurations for other components that:
- - Perform their own logging for unused properties (such as producers and consumers used by connector instances, whose properties can be specified in a worker config with the `producer.` and `consumer.` prefixes, respectively)
- - Are used transparently by the worker without accessing via either `AbstractConfig::get` (or one of its strongly-typed variants) or by invoking `Map::get` on the result of `AbstractConfig::originals` (or one of its prefixed variants) (such as internal topic settings)
- - Are not constructed during worker startup, but instead brought up later (such as the default key, value, and header converters, which are instantiated on a case-by-case basis when bringing up connectors)
- Log warnings for all unused (and non-ignored) properties in the `WorkerConfig` after worker startup has taken place
- Disable all warnings for unused properties when constructing admin clients used by connectors as those include the top-level worker config, which is guaranteed to contain properties like `key.converter` that are not used by the admin client
- Permit all warnings for unused properties when constructing producers and consumers used by connectors as those do not include the top-level worker config and unused properties should not be expected in these cases
- Automatically ignore all automatically-injected metrics context properties that are added by the Connect framework when configuring Kafka clients since these are always provided (when Connect brings up Kafka clients) but are not always used

I also fixed a bug introduced in https://github.com/apache/kafka/pull/8455 that causes a spurious warning to be logged when the worker config doesn't include a value for the `plugin.path` property.

### Testing

I've verified this locally with a variety of cases including typos in the worker config (`gorup.id` instead of `group.id`), typos in connector client properties included in the worker config (`producer.clinet.id` instead of `producer.client.id`), correctly-skipped connector client properties included in the worker config (`consumer.max.poll.records`), connector client interceptor properties included in the worker config (`producer.interceptor.classes`, `some.interceptor.property.that.is.used`, `some.interceptor.property.that.is.not.used`), use of the DLQ topic in a sink connector, and use of automatic topic creation in a source connector. If this approach looks reasonable, I can automate these tests, probably by capturing logging output during an integration test run and asserting that warnings were issued only for the expected set of properties.

### Edge cases

Note that the `RecordingMap` class is subtly broken at the moment in that it doesn't take into account calls to `Map::forEach`, `Map::entrySet`, `Map::keySet`, `Map::values`, `Map::getOrDefault`, `Map::compute`, `Map::computeIfPresent`, etc. This comes into play with cases like when custom settings are specified for internal topics (see [TopicAdmin.NewTopicBuilder::config](https://github.com/apache/kafka/blob/62ea4c46a9be7388baeaef1c505d3e5798a9066f/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java#L224-L240)). We may not want to invest too heavily into this approach for controlling warning messages if we want to develop a truly flexible solution that can be easily used by both internal and external components.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
