### PR TITLE
MINOR: Fix flaky testClientDisconnectionUpdatesRequestMetrics()

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1125,12 +1125,12 @@ class SocketServerTest {
 
       val requestMetrics = channel.metrics(request.header.apiKey.name)
       def totalTimeHistCount(): Long = requestMetrics.totalTimeHist.count
+      val expectedTotalTimeCount = totalTimeHistCount() + 1
       val send = new NetworkSend(request.context.connectionId, ByteBufferSend.sizePrefixed(ByteBuffer.allocate(responseBufferSize)))
       val headerLog = new ObjectNode(JsonNodeFactory.instance)
       headerLog.set("response", new TextNode("someResponse"))
       channel.sendResponse(new RequestChannel.SendResponse(request, send, Some(headerLog), None))
 
-      val expectedTotalTimeCount = totalTimeHistCount() + 1
       TestUtils.waitUntilTrue(() => totalTimeHistCount() == expectedTotalTimeCount,
         s"request metrics not updated, expected: $expectedTotalTimeCount, actual: ${totalTimeHistCount()}")
 


### PR DESCRIPTION
This PR fixes the flaky SocketServerTest.testClientDisconnectionUpdatesRequestMetrics() test. When a response is sent, the request metrics get updated. But if the metrics get updated before expectedTotalTimeCount is defined, the expected count gets defined with an inaccurate value.

It looks like the order was accidentally swapped in this commit https://github.com/apache/kafka/commit/16d36f1674f4867b4dc498464df20a0e8e18eb3f.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
