### PR TITLE
KAFKA-13792: Fix UncleanLeaderElectionTest package path

### DIFF
--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package kafka.integration
+package unit.kafka.integration
 
 import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}


### PR DESCRIPTION
Change `UncleanLeaderElectionTest` class package path.

`original`: kafka.integration

`fix`: unit.kafka.integration

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
