### PR TITLE
KAFKA-13792: Fix wrong package name in Scala test files

### DIFF
--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-package kafka.server
+package integration.kafka.server
 
 import java.io.{ByteArrayOutputStream, File, PrintStream}
 import java.net.InetSocketAddress
 import java.util
 import java.util.{Collections, Properties}
 import java.util.concurrent.CompletableFuture
-
 import javax.security.auth.login.Configuration
 import kafka.raft.KafkaRaftManager
+import kafka.server.{BrokerServer, ControllerServer, KafkaBroker, KafkaConfig, KafkaRaftServer, KafkaServer, MetaProperties}
 import kafka.tools.StorageTool
 import kafka.utils.{CoreUtils, Logging, TestInfoUtils, TestUtils}
 import kafka.zk.{AdminZkClient, EmbeddedZookeeper, KafkaZkClient}

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package kafka.integration
+package unit.kafka.integration
 
 import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}


### PR DESCRIPTION
- Fix wrong package name in `QuorumImplementation` and `UncleanLeaderElectionTest` files.
- import classes

[Related Jira ticket](https://issues.apache.org/jira/browse/KAFKA-13792)

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
