### PR TITLE
MINOR: Mention KAFKA-13748 in release notes

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -32,6 +32,9 @@
             by default in a future major release.</li>
         <li>Kafka has replaced log4j and slf4j-log4j12 with reload4j and slf4j-reload4j due to security concerns.
              More information can be found at <a href"https://reload4j.qos.ch">reload4j</a>.</li>
+        <li>The example connectors, <code>FileStreamSourceConnector</code> and <code>FileStreamSinkConnector</code>, have been 
+            removed from the default classpath. To use them in Kafka Connect standalone or distributed mode they need to be 
+            explicitly added, for example <code>CLASSPATH=./lib/connect-file-3.2.0.jar ./bin/connect-distributed.sh</code>.</li>
     </ul>
 
 <h4><a id="upgrade_3_1_0" href="#upgrade_3_1_0">Upgrading to 3.1.0 from any version 0.8.x through 3.0.x</a></h4>


### PR DESCRIPTION
KAFKA-13748 removed the FileStreamSinkConnector and FileStreamSinkConnector from the default classpath. Although these are provided for example purposes only, it makes sense to mention this in the release notes for users who use them in their own examples.