### PR TITLE
KIP-829: (console consumer) add print.topic property

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -235,6 +235,7 @@ object ConsoleConsumer extends Logging {
       | print.partition=true|false
       | print.headers=true|false
       | print.value=true|false
+      | print.topic=true|false
       | key.separator=<key.separator>
       | line.separator=<line.separator>
       | headers.separator=<line.separator>
@@ -490,6 +491,7 @@ class DefaultMessageFormatter extends MessageFormatter {
   var printPartition = false
   var printOffset = false
   var printHeaders = false
+  var printTopic = false
   var keySeparator = utfBytes("\t")
   var lineSeparator = utfBytes("\n")
   var headersSeparator = utfBytes(",")
@@ -506,6 +508,7 @@ class DefaultMessageFormatter extends MessageFormatter {
     getPropertyIfExists(configs, "print.partition", getBoolProperty).foreach(printPartition = _)
     getPropertyIfExists(configs, "print.headers", getBoolProperty).foreach(printHeaders = _)
     getPropertyIfExists(configs, "print.value", getBoolProperty).foreach(printValue = _)
+    getPropertyIfExists(configs, "print.topic", getBoolProperty).foreach(printTopic = _)
     getPropertyIfExists(configs, "key.separator", getByteProperty).foreach(keySeparator = _)
     getPropertyIfExists(configs, "line.separator", getByteProperty).foreach(lineSeparator = _)
     getPropertyIfExists(configs, "headers.separator", getByteProperty).foreach(headersSeparator = _)
@@ -540,20 +543,27 @@ class DefaultMessageFormatter extends MessageFormatter {
         output.write(utfBytes(s"$timestampType:$timestamp"))
       else
         output.write(utfBytes("NO_TIMESTAMP"))
-      writeSeparator(columnSeparator =  printOffset || printPartition || printHeaders || printKey || printValue)
+      writeSeparator(columnSeparator =  printOffset || printPartition || printTopic || printHeaders || printKey || printValue)
     }
 
     if (printPartition) {
       output.write(utfBytes("Partition:"))
       output.write(utfBytes(partition().toString))
-      writeSeparator(columnSeparator = printOffset || printHeaders || printKey || printValue)
+      writeSeparator(columnSeparator = printOffset || printTopic || printHeaders || printKey || printValue)
     }
 
     if (printOffset) {
       output.write(utfBytes("Offset:"))
       output.write(utfBytes(offset().toString))
+      writeSeparator(columnSeparator = printTopic || printHeaders || printKey || printValue)
+    }
+
+    if (printTopic) {
+      output.write(utfBytes("Topic:"))
+      output.write(utfBytes(topic()))
       writeSeparator(columnSeparator = printHeaders || printKey || printValue)
     }
+
 
     if (printHeaders) {
       val headersIt = headers().iterator.asScala

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -584,6 +584,13 @@ class ConsoleConsumerTest {
       new RecordHeaders(), Optional.empty[Integer])
     formatter.writeTo(record2, new PrintStream(out))
     assertEquals("CreateTime:123\tPartition:0\tOffset:123\tkey\tvalue\n", out.toString)
+
+    configs.put("print.topic", "true")
+    formatter.configure(configs)
+    out = new ByteArrayOutputStream()
+    formatter.writeTo(record, new PrintStream(out))
+    assertEquals("NO_TIMESTAMP\tPartition:0\tOffset:123\tTopic:topic\tkey\tvalue\n", out.toString)
+
     formatter.close()
   }
 


### PR DESCRIPTION
```
Usage:
./kafka-console-consumer.sh --bootstrap-server kafka:9092 --include '.*'  --property print.topic=true

Example output:
Topic:hello.world	{"msg": "abc"}
```

Purpose:
Until now, there is no way to print all messages from all topics while maintaining the topic information. This PR adds this functionallity.

[KIP-829](https://cwiki.apache.org/confluence/display/KAFKA/KIP-829%3A+%28console-consumer%29+add+print.topic+property)