### PR TITLE
MINOR: Fix support for custom commit ids in the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,8 +154,8 @@ allprojects {
 
 def determineCommitId() {
   def takeFromHash = 16
-  if (project.hasProperty('commitId2')) {
-    commitId2.take(takeFromHash)
+  if (project.hasProperty('commitId')) {
+    commitId.take(takeFromHash)
   } else if (file("$rootDir/.git/HEAD").exists()) {
     def headRef = file("$rootDir/.git/HEAD").text
     if (headRef.contains('ref: ')) {


### PR DESCRIPTION
This regressed in ca375d8004c1 due to a typo. We need tests
for our builds. :)

I verified that passing the commitId via `-PcommitId=123`
works correctly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
