### PR TITLE
MINOR:Remove repeated variable reset in KafkaController.scala

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -467,14 +467,6 @@ class KafkaController(val config: KafkaConfig,
 
     // shutdown leader rebalance scheduler
     kafkaScheduler.shutdown()
-    offlinePartitionCount = 0
-    preferredReplicaImbalanceCount = 0
-    globalTopicCount = 0
-    globalPartitionCount = 0
-    topicsToDeleteCount = 0
-    replicasToDeleteCount = 0
-    ineligibleTopicsToDeleteCount = 0
-    ineligibleReplicasToDeleteCount = 0
 
     // stop token expiry check scheduler
     if (tokenCleanScheduler.isStarted)


### PR DESCRIPTION
…s onControllerResignation
The following variables  in kafkaController.scala are used for metric statistics：
```
   offlinePartitionCount 
    preferredReplicaImbalanceCount
    globalTopicCount 
    globalPartitionCount
    topicsToDeleteCount 
    replicasToDeleteCount 
    ineligibleTopicsToDeleteCount 
    ineligibleReplicasToDeleteCount 
```

when execute the  KafkaController.process().updateMetrics() method, If the controller is not active, will reset the following values   
```
.....
globalTopicCount = if (!isActive) 0 else controllerContext.allTopics.size
globalPartitionCount = if (!isActive) 0 else controllerContext.partitionWithLeadersCount
....
```

So we don't need to reset again when executing kafkaController.onControllerResignation()

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
