### PR TITLE
MINOR: Fix TestDowngrade.test_upgrade_and_downgrade

### DIFF
--- a/tests/kafkatest/tests/core/downgrade_test.py
+++ b/tests/kafkatest/tests/core/downgrade_test.py
@@ -139,14 +139,15 @@ class TestDowngrade(EndToEndTest):
 
         self.logger.info("First pass bounce - rolling upgrade")
         self.upgrade_from(kafka_version)
+        self.await_consumed_records(min_records=5000)
 
         upgrade_topic_id = self.kafka.topic_id(self.topic)
         assert start_topic_id == upgrade_topic_id
 
         self.logger.info("Second pass bounce - rolling downgrade")
+        num_records_acked = self.producer.num_acked
         self.downgrade_to(kafka_version)
-
-        self.run_validation()
+        self.run_validation(min_records=num_records_acked+5000)
 
         downgrade_topic_id = self.kafka.topic_id(self.topic)
         assert upgrade_topic_id == downgrade_topic_id

--- a/tests/kafkatest/tests/core/downgrade_test.py
+++ b/tests/kafkatest/tests/core/downgrade_test.py
@@ -139,13 +139,13 @@ class TestDowngrade(EndToEndTest):
 
         self.logger.info("First pass bounce - rolling upgrade")
         self.upgrade_from(kafka_version)
-        self.run_validation()
 
         upgrade_topic_id = self.kafka.topic_id(self.topic)
         assert start_topic_id == upgrade_topic_id
 
         self.logger.info("Second pass bounce - rolling downgrade")
         self.downgrade_to(kafka_version)
+
         self.run_validation()
 
         downgrade_topic_id = self.kafka.topic_id(self.topic)

--- a/tests/kafkatest/tests/end_to_end.py
+++ b/tests/kafkatest/tests/end_to_end.py
@@ -87,7 +87,13 @@ class EndToEndTest(Test):
         self.last_consumed_offsets[partition] = offset
         self.records_consumed.append(record_id)
 
-    def await_consumed_offsets(self, last_acked_offsets, timeout_sec):
+    def await_produced_records(self, min_records, timeout_sec=30):
+        wait_until(lambda: self.producer.num_acked > min_records,
+                   timeout_sec=timeout_sec,
+                   err_msg="Producer failed to produce messages for %ds." %\
+                   timeout_sec)
+
+    def await_consumed_offsets(self, last_acked_offsets, timeout_sec=30):
         def has_finished_consuming():
             for partition, offset in last_acked_offsets.items():
                 if not partition in self.last_consumed_offsets:
@@ -102,6 +108,10 @@ class EndToEndTest(Test):
                    err_msg="Consumer failed to consume up to offsets %s after waiting %ds." %\
                    (str(last_acked_offsets), timeout_sec))
 
+    def await_consumed_records(self, min_records, producer_timeout_sec=30,
+                               consumer_timeout_sec=30):
+        self.await_produced_records(min_records=min_records)
+        self.await_consumed_offsets(self.producer.last_acked_offsets)
 
     def _collect_all_logs(self):
         for s in self.test_context.services:
@@ -120,11 +130,7 @@ class EndToEndTest(Test):
     def run_validation(self, min_records=5000, producer_timeout_sec=30,
                        consumer_timeout_sec=30, enable_idempotence=False):
         try:
-            wait_until(lambda: self.producer.num_acked > min_records,
-                       timeout_sec=producer_timeout_sec,
-                       err_msg="Producer failed to produce messages for %ds." %\
-                       producer_timeout_sec)
-
+            await_produced_records(min_records, producer_timeout_sec)
             self.logger.info("Stopping producer after writing up to offsets %s" %\
                          str(self.producer.last_acked_offsets))
             self.producer.stop()

--- a/tests/kafkatest/tests/end_to_end.py
+++ b/tests/kafkatest/tests/end_to_end.py
@@ -130,7 +130,7 @@ class EndToEndTest(Test):
     def run_validation(self, min_records=5000, producer_timeout_sec=30,
                        consumer_timeout_sec=30, enable_idempotence=False):
         try:
-            await_produced_records(min_records, producer_timeout_sec)
+            self.await_produced_records(min_records, producer_timeout_sec)
             self.logger.info("Stopping producer after writing up to offsets %s" %\
                          str(self.producer.last_acked_offsets))
             self.producer.stop()


### PR DESCRIPTION
The second validation does not verify the second bounce because the verified producer and the verified consumer are stopped in `self.run_validation`. This means that the second `run_validation` just spit out the same information as the first one. It seems to me that we should just run the validation at the end.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
