### PR TITLE
KAFKA-13804: output the reason why broker exit unexpectedly during startup

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -108,9 +108,9 @@ object Kafka extends Logging {
 
       try server.startup()
       catch {
-        case _: Throwable =>
+        case e: Throwable =>
           // KafkaServer.startup() calls shutdown() in case of exceptions, so we invoke `exit` to set the status code
-          fatal("Exiting Kafka.")
+          fatal("Exiting Kafka due to fatal exception", e)
           Exit.exit(1)
       }
 

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -110,7 +110,7 @@ object Kafka extends Logging {
       catch {
         case e: Throwable =>
           // KafkaServer.startup() calls shutdown() in case of exceptions, so we invoke `exit` to set the status code
-          fatal("Exiting Kafka due to fatal exception", e)
+          fatal("Exiting Kafka due to fatal exception during startup.", e)
           Exit.exit(1)
       }
 


### PR DESCRIPTION
JIRA: [KAFKA-13804](https://issues.apache.org/jira/browse/KAFKA-13804)

improve the log readability by adding the exception why broker exit during startup at the end of logs.

The updated log output will be like this:
```
...
[2022-04-07 18:19:33,005] ERROR [KafkaServer id=0] Fatal error during KafkaServer startup. Prepare to shutdown (kafka.server.KafkaServer)
java.io.IOException: No space left on device
  at kafka.server.KafkaServer.startup(KafkaServer.scala:461)
  at kafka.Kafka$.main(Kafka.scala:110)
  at kafka.Kafka.main(Kafka.scala)
[2022-04-07 18:19:33,007] INFO [KafkaServer id=0] shutting down (kafka.server.KafkaServer)
[2022-04-07 18:19:33,008] INFO [KafkaServer id=0] Starting controlled shutdown (kafka.server.KafkaServer)
[2022-04-07 18:19:33,016] INFO [KafkaServer id=0] Controlled shutdown request returned successfully after 6ms (kafka.server.KafkaServer)
....
[2022-04-07 18:19:33,227] INFO Broker and topic stats closed (kafka.server.BrokerTopicStats)
[2022-04-07 18:19:33,227] INFO App info kafka.server for 0 unregistered (org.apache.kafka.common.utils.AppInfoParser)
[2022-04-07 18:19:33,227] INFO [KafkaServer id=0] shut down completed 

// old log
[2022-04-11 15:06:27,405] ERROR Exiting Kafka (kafka.Kafka$)

// updated log
[2022-04-11 15:06:27,405] ERROR Exiting Kafka due to fatal exception during startup (kafka.Kafka$)
java.io.IOException: No space left on device
  at kafka.server.KafkaServer.startup(KafkaServer.scala:461)   
  at kafka.Kafka$.main(Kafka.scala:110)   
  at kafka.Kafka.main(Kafka.scala)

[2022-04-12 11:07:08,466] INFO [KafkaServer id=0] shutting down (kafka.server.KafkaServer)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
