### PR TITLE
KAFKA-13651; Add audit logging to `StandardAuthorizer`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1136,6 +1136,8 @@ project(':metadata') {
     compileOnly libs.log4j
     testImplementation libs.junitJupiter
     testImplementation libs.hamcrest
+    testImplementation libs.mockitoCore
+    testImplementation libs.mockitoInline
     testImplementation libs.slf4jlog4j
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':raft').sourceSets.test.output

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourcePattern.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourcePattern.java
@@ -89,7 +89,7 @@ public class ResourcePattern {
 
     @Override
     public String toString() {
-        return "ResourcePattern(resourceType=" + resourceType + ", name=" + ((name == null) ? "<any>" : name) + ", patternType=" + patternType + ")";
+        return "ResourcePattern(resourceType=" + resourceType + ", name=" + name + ", patternType=" + patternType + ")";
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.metadata.AccessControlEntryRecord;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import java.util.Objects;
 
@@ -94,6 +95,13 @@ final public class StandardAcl implements Comparable<StandardAcl> {
 
     public String principal() {
         return principal;
+    }
+
+    public KafkaPrincipal kafkaPrincipal() {
+        int colonIndex = principal.indexOf(":");
+        String principalType = principal.substring(0, colonIndex);
+        String principalName = principal.substring(colonIndex + 1);
+        return new KafkaPrincipal(principalType, principalName);
     }
 
     public String host() {

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
@@ -99,6 +99,10 @@ final public class StandardAcl implements Comparable<StandardAcl> {
 
     public KafkaPrincipal kafkaPrincipal() {
         int colonIndex = principal.indexOf(":");
+        if (colonIndex == -1) {
+            throw new IllegalStateException("Could not parse principal from `" + principal + "` " +
+                "(no colon is present separating the principal type from the principal name)");
+        }
         String principalType = principal.substring(0, colonIndex);
         String principalName = principal.substring(colonIndex + 1);
         return new KafkaPrincipal(principalType, principalName);

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -32,6 +32,12 @@ import org.apache.kafka.server.authorizer.Action;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.Arrays;
@@ -40,7 +46,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -118,8 +123,6 @@ public class StandardAuthorizerTest {
         return new Action(aclOperation,
             new ResourcePattern(resourceType, resourceName, LITERAL), 1, false, false);
     }
-
-    private final static AtomicLong NEXT_ID = new AtomicLong(0);
 
     static StandardAcl newFooAcl(AclOperation op, AclPermissionType permission) {
         return new StandardAcl(
@@ -428,4 +431,85 @@ public class StandardAuthorizerTest {
                     newAction(WRITE, GROUP, "arbitrary"),
                     newAction(READ, TOPIC, "ala"))));
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testDenyAuditLogging(boolean logIfDenied) throws Exception {
+        try (MockedStatic<LoggerFactory> mockedLoggerFactory = Mockito.mockStatic(LoggerFactory.class)) {
+            Logger otherLog = Mockito.mock(Logger.class);
+            Logger auditLog = Mockito.mock(Logger.class);
+            mockedLoggerFactory
+                .when(() -> LoggerFactory.getLogger("kafka.authorizer.logger"))
+                .thenReturn(auditLog);
+
+            mockedLoggerFactory
+                .when(() -> LoggerFactory.getLogger(Mockito.any(Class.class)))
+                .thenReturn(otherLog);
+
+            Mockito.when(auditLog.isDebugEnabled()).thenReturn(true);
+            Mockito.when(auditLog.isTraceEnabled()).thenReturn(true);
+
+            StandardAuthorizer authorizer = createAuthorizerWithManyAcls();
+            ResourcePattern topicResource = new ResourcePattern(TOPIC, "alpha", LITERAL);
+            Action action = new Action(READ, topicResource, 1, false, logIfDenied);
+            MockAuthorizableRequestContext requestContext = new MockAuthorizableRequestContext.Builder()
+                .setPrincipal(new KafkaPrincipal(USER_TYPE, "bob"))
+                .build();
+
+            assertEquals(singletonList(DENIED), authorizer.authorize(requestContext, singletonList(action)));
+
+            String expectedAuditLog = "Principal = User:bob is Denied operation = READ " +
+                "from host = 127.0.0.1 on resource = Topic:LITERAL:alpha for request = Fetch " +
+                "with resourceRefCount = 1 based on rule MatchingAcl(acl=StandardAcl(resourceType=TOPIC, " +
+                "resourceName=alp, patternType=PREFIXED, principal=User:bob, host=*, operation=READ, " +
+                "permissionType=DENY))";
+
+            if (logIfDenied) {
+                Mockito.verify(auditLog).info(expectedAuditLog);
+            } else {
+                Mockito.verify(auditLog).trace(expectedAuditLog);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAllowAuditLogging(boolean logIfAllowed) throws Exception {
+        try (MockedStatic<LoggerFactory> mockedLoggerFactory = Mockito.mockStatic(LoggerFactory.class)) {
+            Logger otherLog = Mockito.mock(Logger.class);
+            Logger auditLog = Mockito.mock(Logger.class);
+            mockedLoggerFactory
+                .when(() -> LoggerFactory.getLogger("kafka.authorizer.logger"))
+                .thenReturn(auditLog);
+
+            mockedLoggerFactory
+                .when(() -> LoggerFactory.getLogger(Mockito.any(Class.class)))
+                .thenReturn(otherLog);
+
+            Mockito.when(auditLog.isDebugEnabled()).thenReturn(true);
+            Mockito.when(auditLog.isTraceEnabled()).thenReturn(true);
+
+            StandardAuthorizer authorizer = createAuthorizerWithManyAcls();
+            ResourcePattern topicResource = new ResourcePattern(TOPIC, "green1", LITERAL);
+            Action action = new Action(READ, topicResource, 1, logIfAllowed, false);
+            MockAuthorizableRequestContext requestContext = new MockAuthorizableRequestContext.Builder()
+                .setPrincipal(new KafkaPrincipal(USER_TYPE, "bob"))
+                .build();
+
+            assertEquals(singletonList(ALLOWED), authorizer.authorize(requestContext, singletonList(action)));
+
+            String expectedAuditLog = "Principal = User:bob is Allowed operation = READ " +
+                "from host = 127.0.0.1 on resource = Topic:LITERAL:green1 for request = Fetch " +
+                "with resourceRefCount = 1 based on rule MatchingAcl(acl=StandardAcl(resourceType=TOPIC, " +
+                "resourceName=green, patternType=PREFIXED, principal=User:bob, host=*, operation=READ, " +
+                "permissionType=ALLOW))";
+
+            if (logIfAllowed) {
+                Mockito.verify(auditLog).debug(expectedAuditLog);
+            } else {
+                Mockito.verify(auditLog).trace(expectedAuditLog);
+            }
+        }
+    }
+
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -454,6 +454,7 @@ public class StandardAuthorizerTest {
             Action action = new Action(READ, topicResource, 1, false, logIfDenied);
             MockAuthorizableRequestContext requestContext = new MockAuthorizableRequestContext.Builder()
                 .setPrincipal(new KafkaPrincipal(USER_TYPE, "bob"))
+                .setClientAddress(InetAddress.getByName("127.0.0.1"))
                 .build();
 
             assertEquals(singletonList(DENIED), authorizer.authorize(requestContext, singletonList(action)));
@@ -494,6 +495,7 @@ public class StandardAuthorizerTest {
             Action action = new Action(READ, topicResource, 1, logIfAllowed, false);
             MockAuthorizableRequestContext requestContext = new MockAuthorizableRequestContext.Builder()
                 .setPrincipal(new KafkaPrincipal(USER_TYPE, "bob"))
+                .setClientAddress(InetAddress.getByName("127.0.0.1"))
                 .build();
 
             assertEquals(singletonList(ALLOWED), authorizer.authorize(requestContext, singletonList(action)));


### PR DESCRIPTION
This patch adds audit support through the `kafka.authorizer.logger` logger  to `StandardAuthorizer`. It follows the same conventions as `AclAuthorizer` with a similarly formatted log message. When `logIfAllowed` is set in the `Action`, then the log message is at DEBUG level; otherwise, we log at trace. When `logIfDenied` is set, then the log message is at INFO level; otherwise, we again log at TRACE.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
