### PR TITLE
(draft) Kafka-12319: Improve rate calculation for first sample window

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
@@ -31,7 +31,7 @@ public class Avg extends SampledStat {
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value += value;
+        sample.setValue(sample.getValue() + value);
     }
 
     @Override
@@ -39,8 +39,8 @@ public class Avg extends SampledStat {
         double total = 0.0;
         long count = 0;
         for (Sample s : samples) {
-            total += s.value;
-            count += s.eventCount;
+            total += s.getValue();
+            count += s.getEventCount();
         }
         return count == 0 ? Double.NaN : total / count;
     }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Frequencies.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Frequencies.java
@@ -133,7 +133,7 @@ public class Frequencies extends SampledStat implements CompoundStat {
         purgeObsoleteSamples(config, now);
         long totalCount = 0;
         for (Sample sample : samples) {
-            totalCount += sample.eventCount;
+            totalCount += sample.getEventCount();
         }
         if (totalCount == 0) {
             return 0.0d;
@@ -153,7 +153,7 @@ public class Frequencies extends SampledStat implements CompoundStat {
     double totalCount() {
         long count = 0;
         for (Sample sample : samples) {
-            count += sample.eventCount;
+            count += sample.getEventCount();
         }
         return count;
     }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
@@ -31,7 +31,7 @@ public final class Max extends SampledStat {
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value = Math.max(sample.value, value);
+        sample.setValue(Math.max(sample.getValue(), value));
     }
 
     @Override
@@ -39,8 +39,8 @@ public final class Max extends SampledStat {
         double max = Double.NEGATIVE_INFINITY;
         long count = 0;
         for (Sample sample : samples) {
-            max = Math.max(max, sample.value);
-            count += sample.eventCount;
+            max = Math.max(max, sample.getValue());
+            count += sample.getEventCount();
         }
         return count == 0 ? Double.NaN : max;
     }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
@@ -31,7 +31,7 @@ public class Min extends SampledStat {
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value = Math.min(sample.value, value);
+        sample.setValue(Math.min(sample.getValue(), value));
     }
 
     @Override
@@ -39,8 +39,8 @@ public class Min extends SampledStat {
         double min = Double.MAX_VALUE;
         long count = 0;
         for (Sample sample : samples) {
-            min = Math.min(min, sample.value);
-            count += sample.eventCount;
+            min = Math.min(min, sample.getValue());
+            count += sample.getEventCount();
         }
         return count == 0 ? Double.NaN : min;
     }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Percentiles.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Percentiles.java
@@ -82,7 +82,7 @@ public class Percentiles extends SampledStat implements CompoundStat {
         purgeObsoleteSamples(config, now);
         float count = 0.0f;
         for (Sample sample : this.samples)
-            count += sample.eventCount;
+            count += sample.getEventCount();
         if (count == 0.0f)
             return Double.NaN;
         float sum = 0.0f;

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Rate.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Rate.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.metrics.stats;
 
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.metrics.MeasurableStat;
@@ -52,10 +51,6 @@ public class Rate implements MeasurableStat {
         this.unit = unit;
     }
 
-    public String unitName() {
-        return unit.name().substring(0, unit.name().length() - 2).toLowerCase(Locale.ROOT);
-    }
-
     @Override
     public void record(MetricConfig config, double value, long timeMs) {
         this.stat.record(config, value, timeMs);
@@ -68,31 +63,74 @@ public class Rate implements MeasurableStat {
     }
 
     public long windowSize(MetricConfig config, long now) {
-        // purge old samples before we compute the window size
+        // Purge obsolete samples. Obsolete samples are the ones which are not relevant to the current calculation
+        // because their creation time is outside (before) the duration of time window used to calculate rate.
         stat.purgeObsoleteSamples(config, now);
 
         /*
          * Here we check the total amount of time elapsed since the oldest non-obsolete window.
-         * This give the total windowSize of the batch which is the time used for Rate computation.
-         * However, there is an issue if we do not have sufficient data for e.g. if only 1 second has elapsed in a 30 second
-         * window, the measured rate will be very high.
-         * Hence we assume that the elapsed time is always N-1 complete windows plus whatever fraction of the final window is complete.
+         * This gives the duration of computation time window which used to calculate Rate.
          *
-         * Note that we could simply count the amount of time elapsed in the current window and add n-1 windows to get the total time,
-         * but this approach does not account for sleeps. SampledStat only creates samples whenever record is called,
-         * if no record is called for a period of time that time is not accounted for in windowSize and produces incorrect results.
+         * For scenarios when rate computation is performed after at least `config.samples` have completed,
+         * the duration of computation time window is determined by:
+         *      window duration = (now - start time of oldest non-obsolete window)
+         *
+         * Note that, alternatively window duration could be determined by:
+         *      `window duration = duration of (config.samples() - 1) windows + amount of time elapsed in the current window`
+         * But this approach would be incorrect because it does not consider the situations where a slice of time will
+         * not be part of any window. Since, SampledStat only creates samples whenever record is called, the following
+         * scenario can occur.
+         *      Time = T1: Window#1 start with config.timeWindowMs = 1s
+         *      Time = T1 + 0.9s: Last observed record call
+         *      Time = T1 + 1.7s: New record call
+         * Here, Window#1 duration is from T1 to T1 + 1s. There is no window that exists from T1+1s to T1+1.7s.
+         * Window#2 starts from T1 + 1.7s. If we calculate duration of computation time window using the method above
+         * it would ignore the slice of time which belongs to no window.
+         *
+         * ## Special case: First ever window
+         * A special scenario occurs when rate calculation is performed before at least `config.samples` have completed
+         * (e.g. if only 1 second has elapsed in a 30 second). In such a scenario, window duration would be equal to the
+         * time elapsed in the current window (since oldest non-obsolete window is current window). This leads to an
+         * incorrect value for rate. Consider the following example:
+         *      config.timeWindowMs() = 1s
+         *      config.samples() = 2
+         *      Record events (E) at timestamps:
+         *          E1 = CurrentTimeStamp (T1)
+         *          E2 = T1 + 30ms
+         *          E2 = T1 + 60ms
+         *      Rate calculated at T1 + 20ms = 1/0.02s = 50 events per second
+         *      Rate calculated at T1 + 50ms = 2/0.05s = 40 events per second
+         *      Rate calculated at T2 + 60ms = 3/0.06s = 50 events per second
+         * These incorrect/inflated rate calculations leads the system to provide artificially high rate than actual.
+         * The algorithm in this function has a special handling for such cases.
+         *
+         * ## Special case: First window after prolonged period of no record events
+         * Another special scenario occurs when a record event is received after multiples of `config.timeWindowMs`
+         * have elapsed since the last record event. In such a scenario, all the older samples would have been
+         * considered obsolete and would have been removed at the beginning of this function. Note that this scenario is
+         * different from Special Case of First ever window because unlike first ever window (where prior window is
+         * missing), this scenario genuinely has a prior window with zero events. The algorithm in this function has a
+         * special handling for such cases.
+         *
          */
-        long totalElapsedTimeMs = now - stat.oldest(now).lastWindowMs;
+        long totalElapsedTimeMs = now - stat.oldest(now).getLastWindowMs();
+
         // Check how many full windows of data we have currently retained
         int numFullWindows = (int) (totalElapsedTimeMs / config.timeWindowMs());
-        int minFullWindows = config.samples() - 1;
 
-        if (numFullWindows < 1) {
+        // Special case: First ever window
+        // Detect this scenario by checking if the current sample belong to the first window AND the time at which
+        // we are calculating the rate belongs to first window.
+        if (stat.isCurrentSampleInFirstWindow() && numFullWindows == 0) {
             return config.timeWindowMs();
         }
+
+        int minFullWindows = config.samples() - 1;
+        // ## Special case: First window after prolonged period of no record events
         // If the available windows are less than the minimum required, add the difference to the totalElapsedTime
-        if (numFullWindows < minFullWindows)
+        if (numFullWindows < minFullWindows) {
             totalElapsedTimeMs += (minFullWindows - numFullWindows) * config.timeWindowMs();
+        }
 
         return totalElapsedTimeMs;
     }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Rate.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Rate.java
@@ -87,6 +87,9 @@ public class Rate implements MeasurableStat {
         int numFullWindows = (int) (totalElapsedTimeMs / config.timeWindowMs());
         int minFullWindows = config.samples() - 1;
 
+        if (numFullWindows < 1) {
+            return config.timeWindowMs();
+        }
         // If the available windows are less than the minimum required, add the difference to the totalElapsedTime
         if (numFullWindows < minFullWindows)
             totalElapsedTimeMs += (minFullWindows - numFullWindows) * config.timeWindowMs();

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/SampledStat.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/SampledStat.java
@@ -34,8 +34,9 @@ import org.apache.kafka.common.metrics.MetricConfig;
  */
 public abstract class SampledStat implements MeasurableStat {
 
-    private double initialValue;
+    private final double initialValue;
     private int current = 0;
+
     protected List<Sample> samples;
 
     public SampledStat(double initialValue) {
@@ -49,7 +50,7 @@ public abstract class SampledStat implements MeasurableStat {
         if (sample.isComplete(timeMs, config))
             sample = advance(config, timeMs);
         update(sample, config, value, timeMs);
-        sample.eventCount += 1;
+        sample.setEventCount(sample.getEventCount() + 1);
     }
 
     private Sample advance(MetricConfig config, long timeMs) {
@@ -81,13 +82,28 @@ public abstract class SampledStat implements MeasurableStat {
         return this.samples.get(this.current);
     }
 
+    /**
+     * Determines if the latest sample belongs to the first ever window.
+     *
+     * This scenario is true iff all of the following are true:
+     * 1. There is only 1 sample available. Since each window produces one sample, presence of more than one sample
+     *    means that other windows have been processed, hence, current cannot be the first window.
+     * 2. The current sample is active i.e. it has not been reset.
+     * 3. The current sample has not been reused by another window.
+     */
+    public boolean isCurrentSampleInFirstWindow() {
+        return this.samples.size() == 1 && // should have exactly one sample
+                this.samples.get(0).isActive() && // sample should be active
+                !this.samples.get(0).isObjectReused(); // sample should never have been reused
+    }
+
     public Sample oldest(long now) {
         if (samples.size() == 0)
             this.samples.add(newSample(now));
         Sample oldest = this.samples.get(0);
         for (int i = 1; i < this.samples.size(); i++) {
             Sample curr = this.samples.get(i);
-            if (curr.lastWindowMs < oldest.lastWindowMs)
+            if (curr.getLastWindowMs() < oldest.getLastWindowMs())
                 oldest = curr;
         }
         return oldest;
@@ -110,32 +126,96 @@ public abstract class SampledStat implements MeasurableStat {
     protected void purgeObsoleteSamples(MetricConfig config, long now) {
         long expireAge = config.samples() * config.timeWindowMs();
         for (Sample sample : samples) {
-            if (now - sample.lastWindowMs >= expireAge)
+            if (now - sample.getLastWindowMs() >= expireAge)
                 sample.reset(now);
         }
     }
 
     protected static class Sample {
-        public double initialValue;
-        public long eventCount;
-        public long lastWindowMs;
-        public double value;
+        private double initialValue;
+        private long eventCount;
+        private long lastWindowMs;
+        private double value;
+        private boolean isReused = false;
+
+        /**
+         * A Sample object could be re-used to store future samples for space efficiency. Thus, a sample could be in
+         * either of the following lifecycle states:
+         * NOT_INITIALIZED: Sample has not been initialized.
+         * ACTIVE: Sample has values and is currently
+         * RESET: Sample has been reset and the object is not destroyed so that it could be used for storing future
+         *        samples.
+         */
+        private enum LifecycleState {
+            NOT_INITIALIZED, ACTIVE, RESET
+        }
+        private LifecycleState currentLifecycleState;
 
         public Sample(double initialValue, long now) {
             this.initialValue = initialValue;
             this.eventCount = 0;
             this.lastWindowMs = now;
             this.value = initialValue;
+            this.currentLifecycleState = LifecycleState.ACTIVE;
         }
 
         public void reset(long now) {
+            this.currentLifecycleState = LifecycleState.RESET;
             this.eventCount = 0;
             this.lastWindowMs = now;
+            this.isReused = true;
             this.value = initialValue;
+        }
+
+        /**
+         * Has this sample object ever been re-used
+         */
+        public boolean isObjectReused() {
+            return isReused;
         }
 
         public boolean isComplete(long timeMs, MetricConfig config) {
             return timeMs - lastWindowMs >= config.timeWindowMs() || eventCount >= config.eventWindow();
+        }
+
+        public boolean isActive() {
+            return currentLifecycleState == LifecycleState.ACTIVE;
+        }
+
+        public double getInitialValue() {
+            return initialValue;
+        }
+
+        public void setInitialValue(final double initialValue) {
+            this.currentLifecycleState = LifecycleState.ACTIVE;
+            this.initialValue = initialValue;
+        }
+
+        public long getEventCount() {
+            return eventCount;
+        }
+
+        public void setEventCount(final long eventCount) {
+            this.currentLifecycleState = LifecycleState.ACTIVE;
+            this.eventCount = eventCount;
+        }
+
+        public long getLastWindowMs() {
+            return lastWindowMs;
+        }
+
+        public void setLastWindowMs(final long lastWindowMs) {
+            this.currentLifecycleState = LifecycleState.ACTIVE;
+            this.lastWindowMs = lastWindowMs;
+        }
+
+        public double getValue() {
+            return value;
+        }
+
+        public void setValue(final double value) {
+            this.currentLifecycleState = LifecycleState.ACTIVE;
+            this.value = value;
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/SimpleRate.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/SimpleRate.java
@@ -33,7 +33,7 @@ public class SimpleRate extends Rate {
     @Override
     public long windowSize(MetricConfig config, long now) {
         stat.purgeObsoleteSamples(config, now);
-        long elapsed = now - stat.oldest(now).lastWindowMs;
+        long elapsed = now - stat.oldest(now).getLastWindowMs();
         return Math.max(elapsed, config.timeWindowMs());
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/WindowedSum.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/WindowedSum.java
@@ -34,14 +34,14 @@ public class WindowedSum extends SampledStat {
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value += value;
+        sample.setValue(sample.getValue() + value);
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
         double total = 0.0;
         for (Sample sample : samples)
-            total += sample.value;
+            total += sample.getValue();
         return total;
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -608,7 +608,7 @@ public class MetricsTest {
         time.sleep(cfg.timeWindowMs() / 2);
 
         // prior to any time passing
-        double elapsedSecs = (cfg.timeWindowMs() * (cfg.samples() - 1) + (((double)cfg.timeWindowMs()) / 2.0d)) / 1000.0d;
+        double elapsedSecs = (cfg.timeWindowMs() * (cfg.samples() - 1) + (((double) cfg.timeWindowMs()) / 2.0d)) / 1000.0d;
 
         KafkaMetric rateMetric = metrics.metrics().get(rateMetricName);
         KafkaMetric countRateMetric = metrics.metrics().get(countRateMetricName);

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -145,18 +145,18 @@ public class MetricsTest {
         // pretend 2 seconds passed...
         long sleepTimeMs = 2;
         time.sleep(sleepTimeMs * 1000);
-        elapsedSecs += sleepTimeMs;
 
         assertEquals(5.0, metricValueFunc.apply(metrics.metric(metrics.metricName("s2.total", "grp1"))), EPS,
             "s2 reflects the constant value");
-        assertEquals(4.5, metricValueFunc.apply(metrics.metric(metrics.metricName("test.avg", "grp1"))), EPS,
+        assertEquals(sum / (double) count, metricValueFunc.apply(metrics.metric(metrics.metricName("test.avg", "grp1"))), EPS,
             "Avg(0...9) = 4.5");
         assertEquals(count - 1,  metricValueFunc.apply(metrics.metric(metrics.metricName("test.max", "grp1"))), EPS,
             "Max(0...9) = 9");
         assertEquals(0.0, metricValueFunc.apply(metrics.metric(metrics.metricName("test.min", "grp1"))), EPS,
             "Min(0...9) = 0");
+        // rate is calculated over the first ever window. Hence, we don't assume presence of prior
         assertEquals(sum / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.rate", "grp1"))), EPS,
-            "Rate(0...9) = 1.40625");
+            "Rate(0...9) = 1.5");
         assertEquals(count / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.occurences", "grp1"))), EPS,
             String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
         assertEquals(count, metricValueFunc.apply(metrics.metric(metrics.metricName("test.count", "grp1"))), EPS,

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
@@ -69,14 +69,14 @@ public class MetricsTest {
     private static final Logger log = LoggerFactory.getLogger(MetricsTest.class);
 
     private static final double EPS = 0.000001;
-    private MockTime time = new MockTime();
-    private MetricConfig config = new MetricConfig();
+    private final MockTime time = new MockTime();
+    private final MetricConfig config = new MetricConfig();
     private Metrics metrics;
     private ExecutorService executorService;
 
     @BeforeEach
     public void setup() {
-        this.metrics = new Metrics(config, Arrays.asList(new JmxReporter()), time, true);
+        this.metrics = new Metrics(config, singletonList(new JmxReporter()), time, true);
     }
 
     @AfterEach
@@ -91,7 +91,7 @@ public class MetricsTest {
     @Test
     public void testMetricName() {
         MetricName n1 = metrics.metricName("name", "group", "description", "key1", "value1", "key2", "value2");
-        Map<String, String> tags = new HashMap<String, String>();
+        Map<String, String> tags = new HashMap<>();
         tags.put("key1", "value1");
         tags.put("key2", "value2");
         MetricName n2 = metrics.metricName("name", "group", "description", tags);
@@ -106,7 +106,7 @@ public class MetricsTest {
     }
 
     @Test
-    public void testSimpleStats() throws Exception {
+    public void testSimpleStats() {
         verifyStats(m -> (double) m.metricValue());
     }
 
@@ -196,7 +196,7 @@ public class MetricsTest {
         assertEquals(1.0 + c1, p2, EPS);
         assertEquals(1.0 + c1 + c2, p1, EPS);
         assertEquals(Arrays.asList(child1, child2), metrics.childrenSensors().get(parent1));
-        assertEquals(Arrays.asList(child1), metrics.childrenSensors().get(parent2));
+        assertEquals(singletonList(child1), metrics.childrenSensors().get(parent2));
         assertNull(metrics.childrenSensors().get(grandchild));
     }
 
@@ -450,11 +450,11 @@ public class MetricsTest {
         final Quota quota1 = Quota.upperBound(10.5);
         final Quota quota2 = Quota.lowerBound(10.5);
 
-        assertFalse(quota1.equals(quota2), "Quota with different upper values shouldn't be equal");
+        assertNotEquals(quota1, quota2, "Quota with different upper values shouldn't be equal");
 
         final Quota quota3 = Quota.lowerBound(10.5);
 
-        assertTrue(quota2.equals(quota3), "Quota with same upper and bound values should be equal");
+        assertEquals(quota2, quota3, "Quota with same upper and bound values should be equal");
     }
 
     @Test
@@ -608,14 +608,14 @@ public class MetricsTest {
         time.sleep(cfg.timeWindowMs() / 2);
 
         // prior to any time passing
-        double elapsedSecs = (cfg.timeWindowMs() * (cfg.samples() - 1) + cfg.timeWindowMs() / 2) / 1000.0;
+        double elapsedSecs = (cfg.timeWindowMs() * (cfg.samples() - 1) + (((double)cfg.timeWindowMs()) / 2.0d)) / 1000.0d;
 
         KafkaMetric rateMetric = metrics.metrics().get(rateMetricName);
         KafkaMetric countRateMetric = metrics.metrics().get(countRateMetricName);
         assertEquals(sum / elapsedSecs, (Double) rateMetric.metricValue(), EPS, "Rate(0...2) = 2.666");
         assertEquals(count / elapsedSecs, (Double) countRateMetric.metricValue(), EPS, "Count rate(0...2) = 0.02666");
         assertEquals(elapsedSecs,
-                ((Rate) rateMetric.measurable()).windowSize(cfg, time.milliseconds()) / 1000, EPS, "Elapsed Time = 75 seconds");
+                ((Rate) rateMetric.measurable()).windowSize(cfg, time.milliseconds()) / 1000.0, EPS, "Elapsed Time = 75 seconds");
         assertEquals(sum, (Double) totalMetric.metricValue(), EPS);
         assertEquals(count, (Double) countTotalMetric.metricValue(), EPS);
 
@@ -625,6 +625,79 @@ public class MetricsTest {
         assertEquals(0, (Double) countRateMetric.metricValue(), EPS);
         assertEquals(sum, (Double) totalMetric.metricValue(), EPS);
         assertEquals(count, (Double) countTotalMetric.metricValue(), EPS);
+    }
+
+    /**
+     * This test validates the "Special case: First ever window" defined in {@link Rate#windowSize(MetricConfig, long)}
+     */
+    @Test
+    public void testRateForFirstWindow() {
+        Rate rate = new Rate();
+
+        //Given
+        MetricConfig config = new MetricConfig().timeWindow(1, TimeUnit.SECONDS).samples(2);
+
+        //In the first window the rate is a fraction of the whole (1s) window
+        //So when we record 1000 at t0, the rate should be 1000 until the window completes, or more data is recorded.
+        record(rate, config, 1000);
+        assertEquals(1000, measure(rate, config), 0);
+        time.sleep(100);
+        assertEquals(1000, measure(rate, config), 0); // 1000B / 0.1s
+        time.sleep(100);
+        assertEquals(1000, measure(rate, config), 0); // 1000B / 0.2s
+        time.sleep(200);
+        assertEquals(1000, measure(rate, config), 0); // 1000B / 0.4s
+
+        //In the second (and subsequent) window(s), the rate will be in proportion to the elapsed time
+        //So the rate will degrade over time, as the time between measurement and the initial recording grows.
+        time.sleep(600);
+        assertEquals(1000, measure(rate, config), 0); // 1000B / 1.0s
+        time.sleep(200);
+        assertEquals(1000 / 1.2, measure(rate, config), 0); // 1000B / 1.2s
+        time.sleep(200);
+        assertEquals(1000 / 1.4, measure(rate, config), 0); // 1000B / 1.4s
+    }
+
+    /**
+     * This test validates the "Special case: First window after prolonged period of no record events"
+     * defined in {@link Rate#windowSize(MetricConfig, long)}
+     */
+    @Test
+    public void testRateWhenMultipleWindowsAreMissingRecords() {
+        Rate rate = new Rate();
+
+        //Given
+        MetricConfig config = new MetricConfig().timeWindow(1, TimeUnit.SECONDS).samples(2);
+
+        //In the first window the rate is a fraction of the whole (1s) window
+        //So when we record 1000 at t0, the rate should be 1000 until the window completes, or more data is recorded.
+        record(rate, config, 1000);
+        assertEquals(1000, measure(rate, config), 0);
+        time.sleep(100);
+        assertEquals(1000, measure(rate, config), 0); // 1000B
+        time.sleep(100);
+        assertEquals(1000, measure(rate, config), 0); // 1000B
+        time.sleep(200);
+        assertEquals(1000, measure(rate, config), 0); // 1000B
+        time.sleep(600);
+        // Time elapsed = 1s. Start of window#2.
+        // Window#2 has no record events but the rate will be in proportion to the elapsed time
+        // So the rate will degrade over time, as the time between measurement and the initial recording grows.
+        assertEquals(1000, measure(rate, config), 0); // 1000B / 1.0s
+        time.sleep(200);
+        assertEquals(1000 / 1.2, measure(rate, config), 0); // 1000B / 1.2s
+        time.sleep(200);
+        assertEquals(1000 / 1.4, measure(rate, config), 0); // 1000B / 1.4s
+        time.sleep(600);
+        // Window#3 and Window#4 have no record events.
+        time.sleep(2000);
+        // Time elapsed = 4s. Start of Window#5
+        // Rate is zero since no recorded events in the window duration used for calculation of rate
+        assertEquals(0, measure(rate, config), 0);
+        time.sleep(200);
+        record(rate, config, 1000);
+        // Unlike the case of first window, the rate is calculated assuming no events in previous window.
+        assertEquals(1000 / 1.2, measure(rate, config), 0); // 1000B / 1.2s
     }
 
     public static class ConstantMeasurable implements Measurable {
@@ -676,9 +749,9 @@ public class MetricsTest {
 
         //Sleeping for another 6.5 windows also should be the same
         time.sleep(6500);
-        assertEquals(3000 / 9, measure(rate, config), 1); // 3000B / 9s
+        assertEquals(3000.0 / 9.0, measure(rate, config), 1); // 3000B / 9s
         record(rate, config, 1000);
-        assertEquals(4000 / 9, measure(rate, config), 1); // 4000B / 9s
+        assertEquals(4000.0 / 9.0, measure(rate, config), 1); // 4000B / 9s
 
         //Going over the 10 window boundary should cause the first window's values (1000) will be purged.
         //So the rate is calculated based on the oldest reading, which is inside the second window, at 1.4s
@@ -699,7 +772,7 @@ public class MetricsTest {
     @Test
     public void testMetricInstances() {
         MetricName n1 = metrics.metricInstance(SampleMetrics.METRIC1, "key1", "value1", "key2", "value2");
-        Map<String, String> tags = new HashMap<String, String>();
+        Map<String, String> tags = new HashMap<>();
         tags.put("key1", "value1");
         tags.put("key2", "value2");
         MetricName n2 = metrics.metricInstance(SampleMetrics.METRIC2, tags);
@@ -718,7 +791,7 @@ public class MetricsTest {
         Map<String, String> childTagsWithValues = new HashMap<>();
         childTagsWithValues.put("child-tag", "child-tag-value");
 
-        try (Metrics inherited = new Metrics(new MetricConfig().tags(parentTagsWithValues), Arrays.asList(new JmxReporter()), time, true)) {
+        try (Metrics inherited = new Metrics(new MetricConfig().tags(parentTagsWithValues), singletonList(new JmxReporter()), time, true)) {
             MetricName inheritedMetric = inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, childTagsWithValues);
 
             Map<String, String> filledOutTags = inheritedMetric.tags();
@@ -760,14 +833,15 @@ public class MetricsTest {
         final AtomicBoolean alive = new AtomicBoolean(true);
         executorService = Executors.newSingleThreadExecutor();
         executorService.submit(new ConcurrentMetricOperation(alive, "record",
-            () -> sensors.forEach(sensor -> sensor.record(random.nextInt(10000)))));
+                () -> sensors.forEach(sensor -> sensor.record(random.nextInt(10000)))));
 
         for (int i = 0; i < 10000; i++) {
             if (sensors.size() > 5) {
                 Sensor sensor = random.nextBoolean() ? sensors.removeFirst() : sensors.removeLast();
                 metrics.removeSensor(sensor.name());
             }
-            StatType statType = StatType.forId(random.nextInt(StatType.values().length));
+            final StatType statType = StatType.forId(random.nextInt(StatType.values().length));
+            assertNotNull(statType);
             sensors.add(sensorCreator.createSensor(statType, i));
             for (Sensor sensor : sensors) {
                 for (KafkaMetric metric : sensor.metrics()) {
@@ -783,10 +857,10 @@ public class MetricsTest {
      * that synchronizes on every reporter method doesn't result in errors or deadlock.
      */
     @Test
-    public void testConcurrentReadUpdateReport() throws Exception {
+    public void testConcurrentReadUpdateReport() {
 
         class LockingReporter implements MetricsReporter {
-            Map<MetricName, KafkaMetric> activeMetrics = new HashMap<>();
+            final Map<MetricName, KafkaMetric> activeMetrics = new HashMap<>();
             @Override
             public synchronized void init(List<KafkaMetric> metrics) {
             }
@@ -818,7 +892,7 @@ public class MetricsTest {
 
         final LockingReporter reporter = new LockingReporter();
         this.metrics.close();
-        this.metrics = new Metrics(config, Arrays.asList(reporter), new MockTime(10), true);
+        this.metrics = new Metrics(config, singletonList(reporter), new MockTime(10), true);
         final Deque<Sensor> sensors = new ConcurrentLinkedDeque<>();
         SensorCreator sensorCreator = new SensorCreator(metrics);
 
@@ -827,10 +901,10 @@ public class MetricsTest {
         executorService = Executors.newFixedThreadPool(3);
 
         Future<?> writeFuture = executorService.submit(new ConcurrentMetricOperation(alive, "record",
-            () -> sensors.forEach(sensor -> sensor.record(random.nextInt(10000)))));
+                () -> sensors.forEach(sensor -> sensor.record(random.nextInt(10000)))));
         Future<?> readFuture = executorService.submit(new ConcurrentMetricOperation(alive, "read",
-            () -> sensors.forEach(sensor -> sensor.metrics().forEach(metric ->
-                assertNotNull(metric.metricValue(), "Invalid metric value")))));
+                () -> sensors.forEach(sensor -> sensor.metrics().forEach(metric ->
+                        assertNotNull(metric.metricValue(), "Invalid metric value")))));
         Future<?> reportFuture = executorService.submit(new ConcurrentMetricOperation(alive, "report",
                 reporter::processMetrics));
 
@@ -840,6 +914,7 @@ public class MetricsTest {
                 metrics.removeSensor(sensor.name());
             }
             StatType statType = StatType.forId(random.nextInt(StatType.values().length));
+            assertNotNull(statType);
             sensors.add(sensorCreator.createSensor(statType, i));
         }
         assertFalse(readFuture.isDone(), "Read failed");
@@ -849,7 +924,7 @@ public class MetricsTest {
         alive.set(false);
     }
 
-    private class ConcurrentMetricOperation implements Runnable {
+    private static class ConcurrentMetricOperation implements Runnable {
         private final AtomicBoolean alive;
         private final String opName;
         private final Runnable op;
@@ -883,7 +958,7 @@ public class MetricsTest {
         PERCENTILES(9),
         METER(10);
 
-        int id;
+        final int id;
         StatType(int id) {
             this.id = id;
         }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -154,8 +154,8 @@ public class MetricsTest {
             "Max(0...9) = 9");
         assertEquals(0.0, metricValueFunc.apply(metrics.metric(metrics.metricName("test.min", "grp1"))), EPS,
             "Min(0...9) = 0");
-        // rate is calculated over the first ever window. Hence, we don't assume presence of prior
-        assertEquals(sum / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.rate", "grp1"))), EPS,
+        // rate is calculated over the first ever window. Hence, we don't assume presence of prior windows with 0 recorded events.
+        assertEquals(sum / config.timeWindowMs(), metricValueFunc.apply(metrics.metric(metrics.metricName("test.rate", "grp1"))), EPS,
             "Rate(0...9) = 1.5");
         assertEquals(count / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.occurences", "grp1"))), EPS,
             String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -155,7 +155,7 @@ public class MetricsTest {
         assertEquals(0.0, metricValueFunc.apply(metrics.metric(metrics.metricName("test.min", "grp1"))), EPS,
             "Min(0...9) = 0");
         // rate is calculated over the first ever window. Hence, we don't assume presence of prior windows with 0 recorded events.
-        assertEquals(sum / config.timeWindowMs(), metricValueFunc.apply(metrics.metric(metrics.metricName("test.rate", "grp1"))), EPS,
+        assertEquals((double) sum / (config.timeWindowMs() / 1000.0), metricValueFunc.apply(metrics.metric(metrics.metricName("test.rate", "grp1"))), EPS,
             "Rate(0...9) = 1.5");
         assertEquals(count / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.occurences", "grp1"))), EPS,
             String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));

--- a/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
@@ -262,10 +262,10 @@ public class SensorTest {
         assertTrue(sensor.add(metricName, new Rate()));
         final KafkaMetric rateMetric = metrics.metric(metricName);
 
-        // Recording a first value at T+0 to bring the avg rate to 3 which is already
+        // Recording a first value at T+0 to bring the avg rate to 30 which is already
         // above the quota.
         strictRecord(sensor, 30, time.milliseconds());
-        assertEquals(3, rateMetric.measurableValue(time.milliseconds()), 0.1);
+        assertEquals(30, rateMetric.measurableValue(time.milliseconds()), 0.1);
 
         // Theoretically, we should wait 5s to bring back the avg rate to the define quota:
         // ((30 / 10) - 2) / 2 * 10 = 5s

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1453,7 +1453,11 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   private val interBrokerListenerName = config.interBrokerListenerName
   private val counts = mutable.Map[InetAddress, Int]()
 
-  // Listener counts and configs are synchronized on `counts`
+  /**
+   * Number of accepted connections per listener.
+   *
+   * Note: Listener counts and configs are synchronized on `counts`
+   */
   private val listenerCounts = mutable.Map[ListenerName, Int]()
   private[network] val maxConnectionsPerListener = mutable.Map[ListenerName, ListenerConnectionQuota]()
   @volatile private var totalCount = 0
@@ -1471,6 +1475,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
       recordIpConnectionMaybeThrottle(listenerName, address)
       val count = counts.getOrElseUpdate(address, 0)
       counts.put(address, count + 1)
+
       totalCount += 1
       if (listenerCounts.contains(listenerName)) {
         listenerCounts.put(listenerName, listenerCounts(listenerName) + 1)
@@ -1615,17 +1620,17 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   private def waitForConnectionSlot(listenerName: ListenerName,
                                     acceptorBlockedPercentMeter: com.yammer.metrics.core.Meter): Unit = {
     counts.synchronized {
-      val startThrottleTimeMs = time.milliseconds
-      val throttleTimeMs = math.max(recordConnectionAndGetThrottleTimeMs(listenerName, startThrottleTimeMs), 0)
+      val startThrottleTimestampMs = time.milliseconds
+      val throttleTimeDurationMs = math.max(recordConnectionAndGetThrottleTimeMs(listenerName, startThrottleTimestampMs), 0)
 
-      if (throttleTimeMs > 0 || !connectionSlotAvailable(listenerName)) {
+      if (throttleTimeDurationMs > 0 || !connectionSlotAvailable(listenerName)) {
         val startNs = time.nanoseconds
-        val endThrottleTimeMs = startThrottleTimeMs + throttleTimeMs
-        var remainingThrottleTimeMs = throttleTimeMs
+        val endThrottleTimestampMs = startThrottleTimestampMs + throttleTimeDurationMs
+        var remainingThrottleTimeDurationMs = math.max(throttleTimeDurationMs - (time.milliseconds - startThrottleTimestampMs), 0)
         do {
-          counts.wait(remainingThrottleTimeMs)
-          remainingThrottleTimeMs = math.max(endThrottleTimeMs - time.milliseconds, 0)
-        } while (remainingThrottleTimeMs > 0 || !connectionSlotAvailable(listenerName))
+          counts.wait(remainingThrottleTimeDurationMs)
+          remainingThrottleTimeDurationMs = math.max(endThrottleTimestampMs - time.milliseconds, 0)
+        } while (remainingThrottleTimeDurationMs > 0 || !connectionSlotAvailable(listenerName))
         acceptorBlockedPercentMeter.mark(time.nanoseconds - startNs)
       }
     }
@@ -1654,7 +1659,10 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
 
   /**
    * Calculates the delay needed to bring the observed connection creation rate to listener-level limit or to broker-wide
-   * limit, whichever the longest. The delay is capped to the quota window size defined by QuotaWindowSizeSecondsProp
+   * limit, whichever the longest. The delay is capped to the quota window size defined by QuotaWindowSizeSecondsProp.
+   *
+   * Calls to this function must be performed with the counts lock to ensure that reading the listener/broker
+   * connection rate quota and creating the sensor's metric config is atomic.
    *
    * @param listenerName listener for which calculate the delay
    * @param timeMs current time in milliseconds

--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -415,7 +415,7 @@ class ConnectionQuotasTest extends Logging {
     val futures = listeners.values.map { listener =>
       executor.submit((() =>
         // epsilon is set to account for the worst-case where the measurement is taken just before or after the quota window
-        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 3)): Runnable)
+        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 7)): Runnable)
     }
     futures.foreach(_.get(40, TimeUnit.SECONDS))
 

--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -26,7 +26,7 @@ import kafka.metrics.KafkaMetricsGroup
 import kafka.network.Processor.ListenerMetricTag
 import kafka.server.KafkaConfig
 import kafka.utils.Implicits.MapExtensionMethods
-import kafka.utils.{Logging, MockTime, TestUtils}
+import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.config.internals.QuotaConfigs
 import org.apache.kafka.common.metrics.internals.MetricsUtils
@@ -40,7 +40,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection.{Map, mutable}
 import scala.concurrent.TimeoutException
 
-class ConnectionQuotasTest extends Logging {
+class ConnectionQuotasTest {
   private var metrics: Metrics = _
   private var executor: ExecutorService = _
   private var connectionQuotas: ConnectionQuotas = _
@@ -187,7 +187,8 @@ class ConnectionQuotasTest extends Logging {
 
     // connections on the same listener but from a different IP should be accepted
     executor.submit((() =>
-      acceptConnections(connectionQuotas, externalListener.listenerName, knownHost, maxConnectionsPerIp, 0, expectIpThrottle = false)): Runnable
+      acceptConnections(connectionQuotas, externalListener.listenerName, knownHost, maxConnectionsPerIp,
+        0, expectIpThrottle = false)): Runnable
     ).get(5, TimeUnit.SECONDS)
 
     // remove two "rejected" connections and remove 2 more connections to free up the space for another 2 connections

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -46,7 +46,7 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
         "Should return the overridden value (4000)")
 
       // p1 should be throttled using the overridden quota
-      var throttleTimeMs = maybeRecord(clientQuotaManager, client1.user, client1.clientId, 2500 * config.numQuotaSamples)
+      var throttleTimeMs = maybeRecord(clientQuotaManager, client1.user, client1.clientId, 2500)
       assertTrue(throttleTimeMs > 0, s"throttleTimeMs should be > 0. was $throttleTimeMs")
 
       // Case 2: Change quota again. The quota should be updated within KafkaMetrics as well since the sensor was created.
@@ -69,7 +69,7 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
       clientQuotaManager.updateQuota(defaultConfigClient.configUser, defaultConfigClient.configClientId, defaultConfigClient.sanitizedConfigClientId, Some(new Quota(4000, true)))
       assertEquals(4000, clientQuotaManager.quota(client1.user, client1.clientId).bound, 0.0, "Should return the newly overridden value (4000)")
 
-      throttleTimeMs = maybeRecord(clientQuotaManager, client1.user, client1.clientId, 1000 * config.numQuotaSamples)
+      throttleTimeMs = maybeRecord(clientQuotaManager, client1.user, client1.clientId, 1000)
       assertEquals(0, throttleTimeMs, s"throttleTimeMs should be 0. was $throttleTimeMs")
 
     } finally {
@@ -150,7 +150,7 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
       else Double.MaxValue
     assertEquals(expectedMaxValueInQuotaWindow, quotaManager.getMaxValueInQuotaWindow(session, clientId), 0.01)
 
-    val throttleTimeMs = maybeRecord(quotaManager, user, clientId, value * config.numQuotaSamples)
+    val throttleTimeMs = maybeRecord(quotaManager, user, clientId, value)
     if (expectThrottle)
       assertTrue(throttleTimeMs > 0, s"throttleTimeMs should be > 0. was $throttleTimeMs")
     else

--- a/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
@@ -60,7 +60,7 @@ class QuotaUtilsTest {
   def testThrottleTimeObservedRateAboveQuota(): Unit = {
     val quota = 50.0
     val observedValue = 100.0
-    assertEquals(2000, throttleTime(observedValue, quota, 3))
+    assertEquals(1000, throttleTime(observedValue, quota, 3))
   }
 
   @Test


### PR DESCRIPTION
## Background
Apache Kafka's rate-limiting algorithm uses a variation of fixed window algorithm where the duration of time window is controlled by two configurations: [quota.window.num](https://kafka.apache.org/documentation/#brokerconfigs_quota.window.num) and [quota.window.size.seconds](https://kafka.apache.org/documentation/#brokerconfigs_quota.window.size.seconds). When a client connection is received, rate of connections at that timestamp is calculated by observing the number of requests in the duration of time window defined using the configurable parameters. If the rate is above the acceptable threshold, the connection is made to wait for a duration calculated to ensure that when a connection is accepted, the overall rate should be less than (or equal to) acceptable threshold.

This algorithm has certain edge cases to handle rate calculation, such as the scenarios where 1\ extended period of time when no connections are received or when 2\ the rate calculation is occurring within the first ever window with no prior samples. Currently, both these cases are handled in the same manner. When no prior windows are available, an assumption is made that a prior window exists with 0 data points. This is an effective way to solve scenario 1 but it leads to problems for scenario 2. Let us demonstrate using examples.

Consider configuration as `config.timeWindowMs() = 1s`, `config.samples() = 2`, max connection create rate = 30/s. A workload with a uniform rate of 40/s (1  connection per 25 ms) is started.

Record events (E) at timestamps:
E1 = CurrentTimeStamp (T1)
E2 = T1 + 25ms
E3 = T1 + 50ms
...
...
E30 = T1 + 725ms

The rate calculated as per the current algorithm (assuming a pre-existing window with 0 events) would be:
- Rate T1 + 20ms = 1/ (prior window size + current window elapsed time) = 1 / (1 + 0.02) = 0.98 events per second
- Rate calculated at T1 + 90ms = 3/1.09s = 2.75 events per second
- Rate calculated at T1 + 730ms = 30/1.73s = 17.34 events per second

Note that even after 30 events in that window, the rate is still set to ~17 events per second, which would prevent the throttling to kick-in. This would lead to a situation where the first window allows more requests than acceptable limit to pass through and thus, to compensate, the second window serves less traffic, the third window again increases the traffic and so on.... 
This leads to an uneven distribution traffic across windows.

Note that this un-even distribution is the primary cause of flakiness of `ConnectionQuotasTest.testListenerConnectionRateLimitWhenActualRateAboveLimit()`

## Solution 
As a solution, this PR distinguishes between the scenario 1 and 2 above. During the `Rate` calculation, windowSize method has been modified to treat the case of first window separately from the case when no traffic has been received in prior windows. For the first window, the windowSize is calculated as the overall length of first window. Using the new change, the above calculation changes to:

The rate calculated as per the new algorithm (assuming a pre-existing window with 0 events) would be:
- Rate T1 + 20ms = 1/ (current window size) = 1 / 1 = 1 events per second
- Rate calculated at T1 + 90ms = 3/1s = 3 events per second
- Rate calculated at T1 + 730ms = 30/1s = 30 events per second

Note how the throttling kicks-in as expected after 30 events and thus leading to a smoother distribution of traffic across windows.
## Code Changes
1. Modifications in `Rate.java#windowSize()` method to distinguish between scenario 1 and 2.
2. Add a method `isCurrentSampleInFirstWindow` in 
3. Fix the `ConnectionQuotasTest.testListenerConnectionRateLimitWhenActualRateAboveLimit()` test to run for 20s as expected (earlier, there was a difference between what )
4. Add new tests for scenario 1 and scenario 2 in `MetricsTest.java`
5. Modified existing tests for throttling / quota management to remove the assumptions of calculation based on prior empty windows
## Testing
All unit test pass using `./gradlew unitTest`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
