### PR TITLE
KAFKA-13217: Reconsider skipping the LeaveGroup on close() or add an overload that does so

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1542,7 +1542,7 @@ public class KafkaStreams implements AutoCloseable {
                 .groupMetadata()
                 .groupInstanceId();
 
-        final long remainingTimeMs = timeoutMs - (time.milliseconds() - startMs);
+        final long remainingTimeMs = Math.max(0, timeoutMs - (time.milliseconds() - startMs));
 
         if (options.leaveGroup && groupInstanceId.isPresent()) {
             log.debug("Sending leave group trigger to removing instance from consumer group");


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

[implementation overview - KIP](https://cwiki.apache.org/confluence/display/KAFKA/KIP-812%3A+Introduce+another+form+of+the+%60KafkaStreams.close%28%29%60+API+that+forces+the+member+to+leave+the+consumer+group)


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

@ableegoldman @guozhangwang