### PR TITLE
MINOR:Metric clear when ReplicaManager shutdown

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1949,6 +1949,9 @@ class ReplicaManager(val config: KafkaConfig,
     removeMetric("AtMinIsrPartitionCount")
     removeMetric("ReassigningPartitions")
     removeMetric("PartitionsWithLateTransactionsCount")
+    removeMetric("IsrExpandsPerSec")
+    removeMetric("IsrShrinksPerSec")
+    removeMetric("FailedIsrUpdatesPerSec")
   }
 
   // High watermark do not need to be checkpointed only when under unit tests


### PR DESCRIPTION
The following metrics also need to be closed when replicaManager shutdown
```
"IsrExpandsPerSec"
"IsrShrinksPerSec"
"FailedIsrUpdatesPerSec"
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
