### PR TITLE
MINOR: Displaying default entity name better in MetadataShell

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -45,6 +45,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.metadata.BrokerRegistrationFencingChange;
 import org.apache.kafka.metadata.BrokerRegistrationInControlledShutdownChange;
 import org.apache.kafka.queue.EventQueue;
@@ -215,7 +216,7 @@ public final class MetadataNodeManager implements AutoCloseable {
     }
 
     private void handleCommitImpl(MetadataRecordType type, ApiMessage message)
-            throws Exception {
+        throws Exception {
         switch (type) {
             case REGISTER_BROKER_RECORD: {
                 DirectoryNode brokersNode = data.root.mkdirs("brokers");
@@ -268,7 +269,7 @@ public final class MetadataNodeManager implements AutoCloseable {
                             "Can't handle ConfigResource.Type " + record.resourceType());
                 }
                 DirectoryNode configDirectory = data.root.mkdirs("configs").
-                    mkdirs(typeString).mkdirs(record.resourceName());
+                    mkdirs(typeString).mkdirs(Utils.isBlank(record.resourceName()) ? "<default>" : record.resourceName());
                 if (record.value() == null) {
                     configDirectory.rmrf(record.name());
                 } else {

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -45,7 +45,6 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.metadata.BrokerRegistrationFencingChange;
 import org.apache.kafka.metadata.BrokerRegistrationInControlledShutdownChange;
 import org.apache.kafka.queue.EventQueue;
@@ -269,7 +268,7 @@ public final class MetadataNodeManager implements AutoCloseable {
                             "Can't handle ConfigResource.Type " + record.resourceType());
                 }
                 DirectoryNode configDirectory = data.root.mkdirs("configs").
-                    mkdirs(typeString).mkdirs(Utils.isBlank(record.resourceName()) ? "<default>" : record.resourceName());
+                    mkdirs(typeString).mkdirs(record.resourceName().isEmpty() ? "<default>" : record.resourceName());
                 if (record.value() == null) {
                     configDirectory.rmrf(record.name());
                 } else {

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataNodeManagerTest.java
@@ -138,26 +138,32 @@ public class MetadataNodeManagerTest {
 
     @Test
     public void testValidConfigRecord() {
-        checkValidConfigRecord(ConfigResource.Type.BROKER.id(), "broker");
-        checkValidConfigRecord(ConfigResource.Type.TOPIC.id(), "topic");
+        checkValidConfigRecord(ConfigResource.Type.BROKER.id(), "broker", "0", "0");
+        checkValidConfigRecord(ConfigResource.Type.TOPIC.id(), "topic", "0", "0");
     }
 
-    private void checkValidConfigRecord(byte resourceType, String typeString) {
+    @Test
+    public void testDefaultBrokerRecord() {
+        checkValidConfigRecord(ConfigResource.Type.BROKER.id(), "broker", "", "<default>");
+        // Default topic resources are not allowed, so we don't test it.
+    }
+
+    private void checkValidConfigRecord(byte resourceType, String typeString, String resourceName, String resourceNameKey) {
         ConfigRecord configRecord = new ConfigRecord()
             .setResourceType(resourceType)
-            .setResourceName("0")
+            .setResourceName(resourceName)
             .setName("name")
             .setValue("kraft");
 
         metadataNodeManager.handleMessage(configRecord);
         assertEquals("kraft",
-            metadataNodeManager.getData().root().directory("configs", typeString, "0").file("name").contents());
+            metadataNodeManager.getData().root().directory("configs", typeString, resourceNameKey).file("name").contents());
 
         // null value indicates delete
         configRecord.setValue(null);
         metadataNodeManager.handleMessage(configRecord);
         assertFalse(
-            metadataNodeManager.getData().root().directory("configs", typeString, "0").children().containsKey("name"));
+            metadataNodeManager.getData().root().directory("configs", typeString, resourceNameKey).children().containsKey("name"));
     }
 
     @Test


### PR DESCRIPTION
*More detailed description of your change*
When debugging some bugs related to configs, I find we are unable to show default broker/topic configs since the resourceName="".
I changed it to <default> similar to how we trait default client quotas.

*Summary of testing strategy (including rationale)*
Unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
