### PR TITLE
KAFKA-13835: Fix two bugs related to dynamic broker configs in KRaft

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -127,6 +127,8 @@ class BrokerServer(
 
   var forwardingManager: ForwardingManager = null
 
+  @volatile var featureCache: FinalizedFeatureCache = null
+
   var alterIsrManager: AlterIsrManager = null
 
   var autoTopicCreationManager: AutoTopicCreationManager = null
@@ -221,7 +223,7 @@ class BrokerServer(
       clientToControllerChannelManager.start()
       forwardingManager = new ForwardingManagerImpl(clientToControllerChannelManager)
 
-      val featureCache: FinalizedFeatureCache = new FinalizedFeatureCache(brokerFeatures)
+      featureCache = new FinalizedFeatureCache(brokerFeatures)
 
       val apiVersionManager = ApiVersionManager(
         ListenerType.BROKER,

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -248,6 +248,24 @@ class BrokerMetadataListener(
     }
   }
 
+  // This is used in tests to alter the publisher that is in use by the broker.
+  def alterPublisher(publisher: MetadataPublisher): CompletableFuture[Void] = {
+    val event = new AlterPublisherEvent(publisher)
+    eventQueue.append(event)
+    event.future
+  }
+
+  class AlterPublisherEvent(publisher: MetadataPublisher)
+    extends EventQueue.FailureLoggingEvent(log) {
+    val future = new CompletableFuture[Void]()
+
+    override def run(): Unit = {
+      _publisher = Some(publisher)
+      log.info(s"Set publisher to ${publisher}")
+      future.complete(null)
+    }
+  }
+
   private def publish(publisher: MetadataPublisher): Unit = {
     val delta = _delta
     _image = _delta.apply()

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -17,6 +17,8 @@
 
 package kafka.server.metadata
 
+import java.util.Properties
+
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.{LogManager, UnifiedLog}
@@ -187,21 +189,26 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
                 toLoggableProps(resource, props).mkString(","))
               dynamicConfigHandlers(ConfigType.Topic).
                 processConfigChanges(resource.name(), props)
-              conf.dynamicConfig.reloadUpdatedFilesWithoutConfigChange(props)
-            case BROKER => if (resource.name().isEmpty) {
-              // Apply changes to "cluster configs" (also known as default BROKER configs).
-              // These are stored in KRaft with an empty name field.
-              info(s"Updating cluster configuration : " +
-                toLoggableProps(resource, props).mkString(","))
-              dynamicConfigHandlers(ConfigType.Broker).
-                processConfigChanges(ConfigEntityName.Default, props)
-            } else if (resource.name().equals(brokerId.toString)) {
-              // Apply changes to this broker's dynamic configuration.
-              info(s"Updating broker ${brokerId} with new configuration : " +
-                toLoggableProps(resource, props).mkString(","))
-              dynamicConfigHandlers(ConfigType.Broker).
-                processConfigChanges(resource.name(), props)
-            }
+            case BROKER =>
+              if (resource.name().isEmpty) {
+                // Apply changes to "cluster configs" (also known as default BROKER configs).
+                // These are stored in KRaft with an empty name field.
+                info("Updating cluster configuration : " +
+                  toLoggableProps(resource, props).mkString(","))
+                dynamicConfigHandlers(ConfigType.Broker).
+                  processConfigChanges(ConfigEntityName.Default, props)
+              } else if (resource.name().equals(brokerId.toString)) {
+                // Apply changes to this broker's dynamic configuration.
+                info(s"Updating broker ${brokerId} with new configuration : " +
+                  toLoggableProps(resource, props).mkString(","))
+                dynamicConfigHandlers(ConfigType.Broker).
+                  processConfigChanges(resource.name(), props)
+                // When applying a per broker config (not a cluster config), we also
+                // reload any associated file. For example, if the ssl.keystore is still
+                // set to /tmp/foo, we still want to reload /tmp/foo in case its contents
+                // have changed. This doesn't apply to topic configs or cluster configs.
+                reloadUpdatedFilesWithoutConfigChange(props)
+              }
             case _ => // nothing to do
           }
         }
@@ -248,6 +255,10 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
     } finally {
       _firstPublish = false
     }
+  }
+
+  def reloadUpdatedFilesWithoutConfigChange(props: Properties): Unit = {
+    conf.dynamicConfig.reloadUpdatedFilesWithoutConfigChange(props)
   }
 
   /**

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -197,7 +197,7 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
                   toLoggableProps(resource, props).mkString(","))
                 dynamicConfigHandlers(ConfigType.Broker).
                   processConfigChanges(ConfigEntityName.Default, props)
-              } else if (resource.name().equals(brokerId.toString)) {
+              } else if (resource.name() == brokerId.toString) {
                 // Apply changes to this broker's dynamic configuration.
                 info(s"Updating broker ${brokerId} with new configuration : " +
                   toLoggableProps(resource, props).mkString(","))


### PR DESCRIPTION
The first bug is that we are calling reloadUpdatedFilesWithoutConfigChange when a topic
configuration is changed, but not when a broker configuration is changed. This is backwards.
This function must be called only for BROKER configs, and never for TOPIC configs. (Also, this
function is called only for specific broker configs, not for cluster configs.)

The second bug is that there were several configurations such as `max.connections` which are
related to broker listeners, but which do not involve creating or removing new listeners. We should
support these configurations in KRaft. Only adding or removing listeners is unsupported, not
changes to existing listeners. This PR fixes the configuration change validation to support this.
(This also removes a very puzzling error mesage stating that we are adding or removing listeners,
when we are not).