### PR TITLE
KAFKA-13788: Use AdminClient.incrementalAlterConfigs in ConfigCommand

### DIFF
--- a/core/src/test/scala/integration/kafka/admin/ConfigCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ConfigCommandIntegrationTest.scala
@@ -279,6 +279,9 @@ class ConfigCommandIntegrationTest extends KafkaServerTestHarness with Logging {
         "--entity-type", "brokers")
         ++ entityNameParams
     ))
+    TestUtils.waitUntilTrue(
+      () => brokers.forall(broker => broker.config.getInt("log.cleaner.threads") == 2),
+      "Timeout waiting for topic config propagating to broker")
 
     val describeResult = TestUtils.grabConsoleOutput(
       ConfigCommand.describeConfig(adminClient, new ConfigCommandOptions(
@@ -297,6 +300,9 @@ class ConfigCommandIntegrationTest extends KafkaServerTestHarness with Logging {
         "--entity-type", "brokers")
         ++ entityNameParams
     ))
+    TestUtils.waitUntilTrue(
+      () => brokers.forall(broker => broker.config.getInt("log.cleaner.threads") != 2),
+      "Timeout waiting for topic config propagating to broker")
 
     assertFalse(TestUtils.grabConsoleOutput(
       ConfigCommand.describeConfig(adminClient, new ConfigCommandOptions(
@@ -318,6 +324,9 @@ class ConfigCommandIntegrationTest extends KafkaServerTestHarness with Logging {
         "--entity-type", "topics",
         "--entity-name", "test-config-topic")
     ))
+    TestUtils.waitUntilTrue(
+      () => brokers.forall(broker => broker.logManager.logsByTopic("test-config-topic").head.config.getInt("segment.bytes") == 10240000),
+      "Timeout waiting for topic config propagating to broker")
 
     val describeResult = TestUtils.grabConsoleOutput(
       ConfigCommand.describeConfig(adminClient, new ConfigCommandOptions(
@@ -336,6 +345,9 @@ class ConfigCommandIntegrationTest extends KafkaServerTestHarness with Logging {
         "--entity-type", "topics",
         "--entity-name", "test-config-topic")
     ))
+    TestUtils.waitUntilTrue(
+      () => brokers.forall(broker => broker.logManager.logsByTopic("test-config-topic").head.config.getInt("segment.bytes") != 10240000),
+      "Timeout waiting for topic config propagating to broker")
 
     assertFalse(TestUtils.grabConsoleOutput(
       ConfigCommand.describeConfig(adminClient, new ConfigCommandOptions(

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -1077,13 +1077,13 @@ class ConfigCommandTest extends Logging {
         describeResult
       }
 
-      override def alterConfigs(configs: util.Map[ConfigResource, Config], options: AlterConfigsOptions): AlterConfigsResult = {
+      override def incrementalAlterConfigs(configs: util.Map[ConfigResource, util.Collection[AlterConfigOp]], options: AlterConfigsOptions): AlterConfigsResult = {
         assertEquals(1, configs.size)
         val entry = configs.entrySet.iterator.next
         val resource = entry.getKey
         val config = entry.getValue
         assertEquals(ConfigResource.Type.BROKER, resource.`type`)
-        config.entries.forEach { e => brokerConfigs.put(e.name, e.value) }
+        config.asScala.map(_.configEntry()).foreach { e => brokerConfigs.put(e.name, e.value) }
         alterResult
       }
     }


### PR DESCRIPTION
*More detailed description of your change*
The bug can be reproduced following KAFKA-13788, when creating an invalid broker config, we wouldn't treat it as invalid and will treat it as sensitive, and if we want to create a valid broker config, we will fail since the deprecated `AdminClient.alterConfigs` requires we specify all sensitive configs.

1. If we user `AdminClient.incrementalAlterConfigs`, this can be avoided.
2. I find we lack integration tests for altering topic and broker configs, so I added a bunch of test cases.
3. As a convenience, I added KRaft support for `ConfigCommandIntegrationTest`

*Summary of testing strategy (including rationale)*
A integration test `testUpdateConfigNotAffectedByInvalidConfig`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
