### PR TITLE
MINOR: Fix SubscriptionInfoData name in exception message

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -60,10 +60,10 @@ public class SubscriptionInfo {
 
     static {
         // Just statically check to make sure that the generated code always stays in sync with the overall protocol
-        final int subscriptionInfoLatestVersion = SubscriptionInfoData.SCHEMAS.length - 1;
+        final int subscriptionInfoLatestVersion = SubscriptionInfoData.HIGHEST_SUPPORTED_VERSION;
         if (subscriptionInfoLatestVersion != LATEST_SUPPORTED_VERSION) {
             throw new IllegalArgumentException(
-                "streams/src/main/resources/common/message/SubscriptionInfo.json needs to be updated to match the " +
+                "streams/src/main/resources/common/message/SubscriptionInfoData.json needs to be updated to match the " +
                     "latest assignment protocol version. SubscriptionInfo only supports up to  ["
                     + subscriptionInfoLatestVersion + "] but needs to support up to [" + LATEST_SUPPORTED_VERSION + "].");
         }


### PR DESCRIPTION
*More detailed description of your change*
A small fix because of SubscriptionInfo.json has been renamed to SubscriptionInfoData.json

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
