### PR TITLE
KAFKA-13843: Fix incorrect transactionManager state when receiving success response on an expired batch

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -671,11 +671,10 @@ public class Sender implements Runnable {
     }
 
     private void completeBatch(ProducerBatch batch, ProduceResponse.PartitionResponse response) {
-        if (transactionManager != null) {
-            transactionManager.handleCompletedBatch(batch, response);
-        }
-
         if (batch.complete(response.baseOffset, response.logAppendTime)) {
+            if (transactionManager != null) {
+                transactionManager.handleCompletedBatch(batch, response);
+            }
             maybeRemoveAndDeallocateBatch(batch);
         }
     }


### PR DESCRIPTION
When a batch's delivery timeout has expired but later receives a success response. Sender will call `transactionManager.handleCompletedBatch` without checking if it was completed before. And some states tracked in `topicPartitionBookkeeper` will be updated incorrectly. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
