### PR TITLE
KAFKA-13845: Add support for reading KRaft snapshots in kafka-dump-log

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordUtils.java
@@ -28,9 +28,9 @@ import java.nio.ByteBuffer;
  */
 public class ControlRecordUtils {
 
-    public static final short LEADER_CHANGE_SCHEMA_HIGHEST_VERSION = new LeaderChangeMessage().highestSupportedVersion();
-    public static final short SNAPSHOT_HEADER_HIGHEST_VERSION = new SnapshotHeaderRecord().highestSupportedVersion();
-    public static final short SNAPSHOT_FOOTER_HIGHEST_VERSION = new SnapshotFooterRecord().highestSupportedVersion();
+    public static final short LEADER_CHANGE_SCHEMA_HIGHEST_VERSION = LeaderChangeMessage.HIGHEST_SUPPORTED_VERSION;
+    public static final short SNAPSHOT_HEADER_HIGHEST_VERSION = SnapshotHeaderRecord.HIGHEST_SUPPORTED_VERSION;
+    public static final short SNAPSHOT_FOOTER_HIGHEST_VERSION = SnapshotFooterRecord.HIGHEST_SUPPORTED_VERSION;
 
     public static LeaderChangeMessage deserializeLeaderChangeMessage(Record record) {
         ControlRecordType recordType = ControlRecordType.parse(record.key());

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -25,7 +25,7 @@ import kafka.log._
 import kafka.serializer.Decoder
 import kafka.utils._
 import kafka.utils.Implicits._
-import org.apache.kafka.common.message.{SnapshotFooterRecord, SnapshotFooterRecordJsonConverter, SnapshotHeaderRecord, SnapshotHeaderRecordJsonConverter}
+import org.apache.kafka.common.message.{SnapshotFooterRecordJsonConverter, SnapshotHeaderRecordJsonConverter}
 import org.apache.kafka.common.metadata.{MetadataJsonConverters, MetadataRecordType}
 import org.apache.kafka.common.protocol.ByteBufferAccessor
 import org.apache.kafka.common.record._
@@ -296,10 +296,10 @@ object DumpLogSegments {
                     print(s" endTxnMarker: ${endTxnMarker.controlType} coordinatorEpoch: ${endTxnMarker.coordinatorEpoch}")
                   case ControlRecordType.SNAPSHOT_HEADER =>
                     val header = ControlRecordUtils.deserializedSnapshotHeaderRecord(record)
-                    print(s" SnapshotHeader ${SnapshotHeaderRecordJsonConverter.write(header, SnapshotHeaderRecord.HIGHEST_SUPPORTED_VERSION)}")
+                    print(s" SnapshotHeader ${SnapshotHeaderRecordJsonConverter.write(header, header.version())}")
                   case ControlRecordType.SNAPSHOT_FOOTER =>
                     val footer = ControlRecordUtils.deserializedSnapshotFooterRecord(record)
-                    print(s" SnapshotFooter ${SnapshotFooterRecordJsonConverter.write(footer, SnapshotFooterRecord.HIGHEST_SUPPORTED_VERSION)}")
+                    print(s" SnapshotFooter ${SnapshotFooterRecordJsonConverter.write(footer, footer.version())}")
                   case controlType =>
                     print(s" controlType: $controlType($controlTypeId)")
                 }

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -21,18 +21,21 @@ import java.io.{ByteArrayOutputStream, File, PrintWriter}
 import java.nio.ByteBuffer
 import java.util
 import java.util.Properties
-
-import kafka.log.{AppendOrigin, UnifiedLog, LogConfig, LogManager, LogTestUtils}
-import kafka.server.{BrokerTopicStats, FetchLogEnd, LogDirFailureChannel}
+import kafka.log.{AppendOrigin, Defaults, LogConfig, LogManager, LogTestUtils, UnifiedLog}
+import kafka.raft.{KafkaMetadataLog, MetadataLogConfig}
+import kafka.server.{BrokerTopicStats, FetchLogEnd, KafkaRaftServer, LogDirFailureChannel}
 import kafka.tools.DumpLogSegments.TimeIndexDumpErrors
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.metadata.{PartitionChangeRecord, RegisterBrokerRecord, TopicRecord}
 import org.apache.kafka.common.protocol.{ByteBufferAccessor, ObjectSerializationCache}
 import org.apache.kafka.common.record.{CompressionType, ControlRecordType, EndTransactionMarker, MemoryRecords, RecordVersion, SimpleRecord}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.MetadataRecordSerde
+import org.apache.kafka.raft.{KafkaRaftClient, OffsetAndEpoch}
 import org.apache.kafka.server.common.ApiMessageAndVersion
+import org.apache.kafka.snapshot.RecordsSnapshotWriter
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
@@ -49,6 +52,7 @@ class DumpLogSegmentsTest {
   val logDir = TestUtils.randomPartitionLogDir(tmpDir)
   val segmentName = "00000000000000000000"
   val logFilePath = s"$logDir/$segmentName.log"
+  val snapshotPath = s"$logDir/00000000000000000000-0000000000.checkpoint"
   val indexFilePath = s"$logDir/$segmentName.index"
   val timeIndexFilePath = s"$logDir/$segmentName.timeindex"
   val time = new MockTime(0, 0)
@@ -257,12 +261,12 @@ class DumpLogSegmentsTest {
     log.flush(false)
 
     var output = runDumpLogSegments(Array("--cluster-metadata-decoder", "false", "--files", logFilePath))
-    assert(output.contains("TOPIC_RECORD"))
-    assert(output.contains("BROKER_RECORD"))
+    assertTrue(output.contains("TOPIC_RECORD"))
+    assertTrue(output.contains("BROKER_RECORD"))
 
     output = runDumpLogSegments(Array("--cluster-metadata-decoder", "--skip-record-metadata", "false", "--files", logFilePath))
-    assert(output.contains("TOPIC_RECORD"))
-    assert(output.contains("BROKER_RECORD"))
+    assertTrue(output.contains("TOPIC_RECORD"))
+    assertTrue(output.contains("BROKER_RECORD"))
 
     // Bogus metadata record
     val buf = ByteBuffer.allocate(4)
@@ -273,9 +277,73 @@ class DumpLogSegmentsTest {
     log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, records:_*), leaderEpoch = 2)
 
     output = runDumpLogSegments(Array("--cluster-metadata-decoder", "--skip-record-metadata", "false", "--files", logFilePath))
-    assert(output.contains("TOPIC_RECORD"))
-    assert(output.contains("BROKER_RECORD"))
-    assert(output.contains("skipping"))
+    assertTrue(output.contains("TOPIC_RECORD"))
+    assertTrue(output.contains("BROKER_RECORD"))
+    assertTrue(output.contains("skipping"))
+  }
+
+  @Test
+  def testDumpMetadataSnapshot(): Unit = {
+    val metadataRecords = Seq(
+      new ApiMessageAndVersion(
+        new RegisterBrokerRecord().setBrokerId(0).setBrokerEpoch(10), 0.toShort),
+      new ApiMessageAndVersion(
+        new RegisterBrokerRecord().setBrokerId(1).setBrokerEpoch(20), 0.toShort),
+      new ApiMessageAndVersion(
+        new TopicRecord().setName("test-topic").setTopicId(Uuid.randomUuid()), 0.toShort),
+      new ApiMessageAndVersion(
+        new PartitionChangeRecord().setTopicId(Uuid.randomUuid()).setLeader(1).
+          setPartitionId(0).setIsr(util.Arrays.asList(0, 1, 2)), 0.toShort)
+    )
+
+    val metadataLog = KafkaMetadataLog(
+      KafkaRaftServer.MetadataPartition,
+      KafkaRaftServer.MetadataTopicId,
+      logDir,
+      time,
+      time.scheduler,
+      MetadataLogConfig(
+        logSegmentBytes = 100 * 1024,
+        logSegmentMinBytes = 100 * 1024,
+        logSegmentMillis = 10 * 1000,
+        retentionMaxBytes = 100 * 1024,
+        retentionMillis = 60 * 1000,
+        maxBatchSizeInBytes = KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+        maxFetchSizeInBytes = KafkaRaftClient.MAX_FETCH_SIZE_BYTES,
+        fileDeleteDelayMs = Defaults.FileDeleteDelayMs,
+        nodeId = 1
+      )
+    )
+
+    val lastContainedLogTimestamp = 10000
+
+    val snapshotWriter = RecordsSnapshotWriter.createWithHeader(
+      () => metadataLog.createNewSnapshot(new OffsetAndEpoch(0, 0)),
+      1024,
+      MemoryPool.NONE,
+      new MockTime,
+      lastContainedLogTimestamp,
+      CompressionType.NONE,
+      new MetadataRecordSerde
+    ).get()
+
+    snapshotWriter.append(metadataRecords.asJava)
+    snapshotWriter.freeze()
+    snapshotWriter.close()
+
+    var output = runDumpLogSegments(Array("--cluster-metadata-decoder", "false", "--files", snapshotPath))
+    assertTrue(output.contains("TOPIC_RECORD"))
+    assertTrue(output.contains("BROKER_RECORD"))
+    assertTrue(output.contains("SnapshotHeader"))
+    assertTrue(output.contains("SnapshotFooter"))
+    assertTrue(output.contains(s"lastContainedLogTimestamp: $lastContainedLogTimestamp"))
+
+    output = runDumpLogSegments(Array("--cluster-metadata-decoder", "--skip-record-metadata", "false", "--files", snapshotPath))
+    assertTrue(output.contains("TOPIC_RECORD"))
+    assertTrue(output.contains("BROKER_RECORD"))
+    assertFalse(output.contains("SnapshotHeader"))
+    assertFalse(output.contains("SnapshotFooter"))
+    assertFalse(output.contains(s"lastContainedLogTimestamp: $lastContainedLogTimestamp"))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -340,7 +340,7 @@ class DumpLogSegmentsTest {
     assertTrue(output.contains("BROKER_RECORD"))
     assertTrue(output.contains("SnapshotHeader"))
     assertTrue(output.contains("SnapshotFooter"))
-    assertTrue(output.contains(s"\"lastContainedLogTimestamp\":$lastContainedLogTimestamp"))
+    assertTrue(output.contains(s""""lastContainedLogTimestamp":$lastContainedLogTimestamp"""))
 
     output = runDumpLogSegments(Array("--cluster-metadata-decoder", "--skip-record-metadata", "--files", snapshotPath))
     assertTrue(output.contains("Snapshot end offset: 0, epoch: 0"))
@@ -348,7 +348,7 @@ class DumpLogSegmentsTest {
     assertTrue(output.contains("BROKER_RECORD"))
     assertFalse(output.contains("SnapshotHeader"))
     assertFalse(output.contains("SnapshotFooter"))
-    assertFalse(output.contains(s"\"lastContainedLogTimestamp\": $lastContainedLogTimestamp"))
+    assertFalse(output.contains(s""""lastContainedLogTimestamp": $lastContainedLogTimestamp"""))
   }
 
   @Test

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 public final class Snapshots {
     private static final Logger log = LoggerFactory.getLogger(Snapshots.class);
-    private static final String SUFFIX = ".checkpoint";
+    public static final String SUFFIX = ".checkpoint";
     private static final String PARTIAL_SUFFIX = String.format("%s.part", SUFFIX);
     private static final String DELETE_SUFFIX = String.format("%s.deleted", SUFFIX);
 

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
@@ -238,7 +238,7 @@ final public class SnapshotWriterReaderTest {
         assertTrue(batch.isControlBatch());
 
         SnapshotFooterRecord footerRecord = ControlRecordUtils.deserializedSnapshotFooterRecord(record);
-        assertEquals(footerRecord.version(), ControlRecordUtils.SNAPSHOT_HEADER_HIGHEST_VERSION);
+        assertEquals(footerRecord.version(), ControlRecordUtils.SNAPSHOT_FOOTER_HIGHEST_VERSION);
 
         return countRecords;
     }


### PR DESCRIPTION
*More detailed description of your change*

1. Support metadata snapshot suffix ".checkpoint"
2. print metadata snapshot header and footer 

Here is the output of the command:
```
kafka-dump-log.sh --cluster-metadata-decoder --files path/to/logs/00000000000000000000-0000000000.checkpoint

Dumping /var/folders/xs/1lh3bwpj2674ch_3wyqbcv6c0000gn/T/kafka-3001968433464842910/kafka-269189/00000000000000000000-0000000000.checkpoint
Snapshot end offset: 0, epoch: 0
baseOffset: 0 lastOffset: 0 count: 1 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: true deleteHorizonMs: OptionalLong.empty position: 0 CreateTime: 1653548892941 size: 83 magic: 2 compresscodec: none crc: 3406426388 isvalid: true
| offset: 0 CreateTime: 1653548892941 keySize: 4 valueSize: 11 sequence: -1 headerKeys: [] SnapshotHeader {"version":0,"lastContainedLogTimestamp":10000}
baseOffset: 1 lastOffset: 4 count: 4 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: false deleteHorizonMs: OptionalLong.empty position: 83 CreateTime: 1653548892941 size: 237 magic: 2 compresscodec: none crc: 2671055946 isvalid: true
| offset: 1 CreateTime: 1653548892941 keySize: -1 valueSize: 36 sequence: -1 headerKeys: [] payload: {"type":"REGISTER_BROKER_RECORD","version":0,"data":{"brokerId":0,"incarnationId":"AAAAAAAAAAAAAAAAAAAAAA","brokerEpoch":10,"endPoints":[],"features":[],"rack":"","fenced":true}}
| offset: 2 CreateTime: 1653548892941 keySize: -1 valueSize: 36 sequence: -1 headerKeys: [] payload: {"type":"REGISTER_BROKER_RECORD","version":0,"data":{"brokerId":1,"incarnationId":"AAAAAAAAAAAAAAAAAAAAAA","brokerEpoch":20,"endPoints":[],"features":[],"rack":"","fenced":true}}
| offset: 3 CreateTime: 1653548892941 keySize: -1 valueSize: 31 sequence: -1 headerKeys: [] payload: {"type":"TOPIC_RECORD","version":0,"data":{"name":"test-topic","topicId":"is0zVR4mQQmbu-3eNwcUJA"}}
| offset: 4 CreateTime: 1653548892941 keySize: -1 valueSize: 45 sequence: -1 headerKeys: [] payload: {"type":"PARTITION_CHANGE_RECORD","version":0,"data":{"partitionId":0,"topicId":"onrG6joYREqEnYDbNzxIXA","isr":[0,1,2],"leader":1}}
baseOffset: 5 lastOffset: 5 count: 1 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: true deleteHorizonMs: OptionalLong.empty position: 320 CreateTime: 1653548892941 size: 75 magic: 2 compresscodec: none crc: 581232483 isvalid: true
| offset: 5 CreateTime: 1653548892941 keySize: 4 valueSize: 3 sequence: -1 headerKeys: [] SnapshotFooter {"version":0}
```

we can skip record metadata
```
kafka-dump-log.sh --cluster-metadata-decoder --skip-record-metadata --files path/to/logs/00000000000000000000-0000000000.checkpoint

Dumping /var/folders/xs/1lh3bwpj2674ch_3wyqbcv6c0000gn/T/kafka-3001968433464842910/kafka-269189/00000000000000000000-0000000000.checkpoint
Snapshot end offset: 0, epoch: 0
baseOffset: 0 lastOffset: 0 count: 1 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: true deleteHorizonMs: OptionalLong.empty position: 0 CreateTime: 1653548892941 size: 83 magic: 2 compresscodec: none crc: 3406426388 isvalid: true

baseOffset: 1 lastOffset: 4 count: 4 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: false deleteHorizonMs: OptionalLong.empty position: 83 CreateTime: 1653548892941 size: 237 magic: 2 compresscodec: none crc: 2671055946 isvalid: true
 payload: {"type":"REGISTER_BROKER_RECORD","version":0,"data":{"brokerId":0,"incarnationId":"AAAAAAAAAAAAAAAAAAAAAA","brokerEpoch":10,"endPoints":[],"features":[],"rack":"","fenced":true}}
 payload: {"type":"REGISTER_BROKER_RECORD","version":0,"data":{"brokerId":1,"incarnationId":"AAAAAAAAAAAAAAAAAAAAAA","brokerEpoch":20,"endPoints":[],"features":[],"rack":"","fenced":true}}
 payload: {"type":"TOPIC_RECORD","version":0,"data":{"name":"test-topic","topicId":"is0zVR4mQQmbu-3eNwcUJA"}}
 payload: {"type":"PARTITION_CHANGE_RECORD","version":0,"data":{"partitionId":0,"topicId":"onrG6joYREqEnYDbNzxIXA","isr":[0,1,2],"leader":1}}
baseOffset: 5 lastOffset: 5 count: 1 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 0 isTransactional: false isControl: true deleteHorizonMs: OptionalLong.empty position: 320 CreateTime: 1653548892941 size: 75 magic: 2 compresscodec: none crc: 581232483 isvalid: true
```

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
Unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
