### PR TITLE
KAFKA-13851: Add integration tests for DeleteRecords API

### DIFF
--- a/core/src/test/scala/unit/kafka/server/DeleteRecordsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteRecordsRequestTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 import kafka.utils.TestUtils

--- a/core/src/test/scala/unit/kafka/server/DeleteRecordsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteRecordsRequestTest.scala
@@ -1,0 +1,152 @@
+package kafka.server
+
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.{IsolationLevel, TopicPartition}
+import org.apache.kafka.common.message.DeleteRecordsRequestData
+import org.apache.kafka.common.message.DeleteRecordsRequestData.{DeleteRecordsPartition, DeleteRecordsTopic}
+import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{DeleteRecordsRequest, DeleteRecordsResponse, ListOffsetsRequest, ListOffsetsResponse}
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+
+import java.util.Collections
+import scala.collection.Seq
+import scala.jdk.CollectionConverters._
+
+class DeleteRecordsRequestTest extends BaseRequestTest {
+  private val TIMEOUT_MS = 1000
+  private val MESSAGES_PRODUCED_PER_PARTITION = 10
+  private var producer: KafkaProducer[String, String] = null
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    super.setUp(testInfo)
+    producer = TestUtils.createProducer(bootstrapServers(),
+      keySerializer = new StringSerializer, valueSerializer = new StringSerializer)
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    if (producer != null)
+      producer.close()
+    super.tearDown()
+  }
+
+  @Test
+  def testDeleteRecordsHappyCase(): Unit = {
+    val (topicPartition: TopicPartition, leaderId: Int) = createTopicAndSendRecords
+
+    // Create the DeleteRecord request requesting deletion of offset which is not present
+    val offsetToDelete = Math.max(MESSAGES_PRODUCED_PER_PARTITION - 8, 0)
+    val request: DeleteRecordsRequest = createDeleteRecordsRequestForTopicPartition(topicPartition, offsetToDelete)
+
+    // call the API
+    val response = sendDeleteRecordsRequest(request, leaderId)
+    val partitionResult = response.data.topics.find(topicPartition.topic).partitions.find(topicPartition.partition)
+
+    // Validate the expected error code in the response
+    assertEquals(Errors.NONE.code(), partitionResult.errorCode(),
+      s"Unexpected error code received: ${Errors.forCode(partitionResult.errorCode).name()}")
+
+    // Validate the expected lowWaterMark in the response
+    assertEquals(offsetToDelete, partitionResult.lowWatermark(),
+      s"Unexpected lowWatermark received: ${partitionResult.lowWatermark}")
+
+    // Validate that the records have actually deleted
+    validateRecordsAreDeleted(topicPartition, leaderId, offsetToDelete)
+  }
+
+  @Test
+  def testErrorWhenDeletingRecordsWithInvalidOffset(): Unit = {
+    val (topicPartition: TopicPartition, leaderId: Int) = createTopicAndSendRecords
+
+    // Create the DeleteRecord request requesting deletion of offset which is not present
+    val offsetToDelete = MESSAGES_PRODUCED_PER_PARTITION + 5
+    val request: DeleteRecordsRequest = createDeleteRecordsRequestForTopicPartition(topicPartition, offsetToDelete)
+
+    // call the API
+    val response = sendDeleteRecordsRequest(request, leaderId)
+    val partitionResult = response.data.topics.find(topicPartition.topic).partitions.find(topicPartition.partition)
+
+    // Validate the expected error code in the response
+    assertEquals(Errors.OFFSET_OUT_OF_RANGE.code(), partitionResult.errorCode(),
+      s"Unexpected error code received: ${Errors.forCode(partitionResult.errorCode()).name()}")
+  }
+
+  @Test
+  def testErrorWhenDeletingRecordsWithInvalidTopic(): Unit = {
+    val (_, leaderId: Int) = createTopicAndSendRecords
+
+    val invalidTopicPartition = new TopicPartition("invalid-topic", 0)
+    // Create the DeleteRecord request requesting deletion of offset which is not present
+    val offsetToDelete = 1
+    val request: DeleteRecordsRequest = createDeleteRecordsRequestForTopicPartition(invalidTopicPartition, offsetToDelete)
+
+    // call the API
+    val response = sendDeleteRecordsRequest(request, leaderId)
+    val partitionResult = response.data.topics.find(invalidTopicPartition.topic).partitions.find(invalidTopicPartition.partition)
+
+    // Validate the expected error code in the response
+    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), partitionResult.errorCode(),
+      s"Unexpected error code received: ${Errors.forCode(partitionResult.errorCode()).name()}")
+  }
+
+  private def createTopicAndSendRecords = {
+    // Single topic
+    val topic1 = "topic-1"
+    val topicPartition = new TopicPartition(topic1, 0)
+    val partitionToLeader = createTopic(topic1)
+    assertTrue(partitionToLeader.contains(topicPartition.partition), "Topic creation did not succeed")
+    // Write records
+    produceData(Seq(topicPartition), MESSAGES_PRODUCED_PER_PARTITION)
+    (topicPartition, partitionToLeader(topicPartition.partition))
+  }
+
+  private def createDeleteRecordsRequestForTopicPartition(topicPartition: TopicPartition, offsetToDelete: Int) = {
+    val requestData = new DeleteRecordsRequestData()
+      .setTopics(Collections.singletonList(new DeleteRecordsTopic()
+        .setName(topicPartition.topic())
+        .setPartitions(Collections.singletonList(new DeleteRecordsPartition()
+          .setOffset(offsetToDelete)
+          .setPartitionIndex(topicPartition.partition())))))
+      .setTimeoutMs(TIMEOUT_MS)
+    val request = new DeleteRecordsRequest.Builder(requestData).build()
+    request
+  }
+
+  private def sendDeleteRecordsRequest(request: DeleteRecordsRequest, leaderId: Int): DeleteRecordsResponse = {
+    connectAndReceive[DeleteRecordsResponse](request, destination = brokerSocketServer(leaderId))
+  }
+
+  private def produceData(topicPartitions: Iterable[TopicPartition], numMessagesPerPartition: Int): Seq[RecordMetadata] = {
+    val records = for {
+      tp <- topicPartitions.toSeq
+      messageIndex <- 0 until numMessagesPerPartition
+    } yield {
+      val suffix = s"$tp-$messageIndex"
+      new ProducerRecord(tp.topic, tp.partition, s"key $suffix", s"value $suffix")
+    }
+    records.map(producer.send(_).get)
+  }
+
+  private def validateRecordsAreDeleted(topicPartition: TopicPartition, leaderId: Int, expectedOffset: Long): Unit = {
+    val targetTimes = List(new ListOffsetsTopic()
+      .setName(topicPartition.topic)
+      .setPartitions(List(new ListOffsetsPartition()
+        .setPartitionIndex(topicPartition.partition)
+        .setTimestamp(0L)).asJava)).asJava
+
+    val request = ListOffsetsRequest.Builder
+      .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false)
+      .setTargetTimes(targetTimes).build()
+
+    val listOffsetsPartitionResponse = connectAndReceive[ListOffsetsResponse](request, destination = brokerSocketServer(leaderId)).topics.asScala.find(_.name == topicPartition.topic).get
+      .partitions.asScala.find(_.partitionIndex == topicPartition.partition).get
+
+    assertEquals(expectedOffset, listOffsetsPartitionResponse.offset)
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/DeleteRecordsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteRecordsRequestTest.scala
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.Collections
-import java.util.concurrent.{Future, TimeUnit}
+import java.util.concurrent.TimeUnit
 import scala.collection.Seq
 
 class DeleteRecordsRequestTest extends BaseRequestTest {
@@ -164,14 +164,7 @@ class DeleteRecordsRequestTest extends BaseRequestTest {
     val logForTopicPartition = brokers.flatMap(_.replicaManager.logManager.getLog(topicPartition)).headOption
     // logManager should exist for the provided partition
     assertTrue(logForTopicPartition.isDefined)
-    // assert that log start offset has been reset i.e. deleteRecords has correctly deleted the records until the
-    // provided offset.
+    // assert that log start offset is equal to the expectedStartOffset after DeleteRecords has been called.
     assertEquals(expectedStartOffset, logForTopicPartition.get.logStartOffset)
   }
-
-  def verifySendSuccess(future: Future[RecordMetadata]): Unit = {
-    val recordMetadata = future.get(30, TimeUnit.SECONDS)
-    assertTrue(recordMetadata.offset >= 0, s"Invalid offset $recordMetadata")
-  }
-
 }


### PR DESCRIPTION
## Changes
Added integration tests to test the DeleteRecords API for the following scenarios:
1. Happy case when the records are deleted
2. Error case when an invalid topic is provided
3. Error case when an invalid offset is provided

## Testing
`./gradlew unitTest` is successful locally


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
