### PR TITLE
KAFKA-13620: Use different metric name for KRaft SocketServer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -101,8 +101,7 @@ public class Metrics implements Closeable {
         this(defaultConfig, new ArrayList<>(0), time);
     }
 
-
-  /**
+    /**
      * Create a metrics repository with no reporters and the given default config. This config will be used for any
      * metric that doesn't override its own config. Expiration of Sensors is disabled.
      * @param defaultConfig The default config to use for all metrics that don't override their config

--- a/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
@@ -43,7 +43,7 @@ trait KafkaMetricsGroup extends Logging {
 
 
   def explicitMetricName(group: String, typeName: String, name: String,
-                                   tags: scala.collection.Map[String, String]): MetricName = {
+                         tags: scala.collection.Map[String, String]): MetricName = {
 
     val nameBuilder: StringBuilder = new StringBuilder
 

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -143,7 +143,9 @@ class ControllerServer(
         metrics,
         time,
         credentialProvider,
-        apiVersionManager)
+        apiVersionManager,
+        DataPlaneAcceptor.ControllerServerMetricPrefix,
+        DataPlaneAcceptor.ControllerServerThreadPrefix)
       socketServer.startup(startProcessingRequests = false, controlPlaneListener = None, config.controllerListeners)
 
       if (config.controllerListeners.nonEmpty) {
@@ -211,8 +213,8 @@ class ControllerServer(
         controllerApis,
         time,
         config.numIoThreads,
-        s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent",
-        DataPlaneAcceptor.ThreadPrefix)
+        s"${DataPlaneAcceptor.ControllerServerMetricPrefix}RequestHandlerAvgIdlePercent",
+        DataPlaneAcceptor.ControllerServerThreadPrefix)
       socketServer.startProcessingRequests(authorizerFutures)
     } catch {
       case e: Throwable =>

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -73,7 +73,7 @@ class TestRaftServer(
     credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
 
     val apiVersionManager = new SimpleApiVersionManager(ListenerType.CONTROLLER)
-    socketServer = new SocketServer(config, metrics, time, credentialProvider, apiVersionManager)
+    socketServer = new SocketServer(config, metrics, time, credentialProvider, apiVersionManager, DataPlaneAcceptor.ControllerServerMetricPrefix, DataPlaneAcceptor.ControllerServerThreadPrefix)
     socketServer.startup(startProcessingRequests = false)
 
     val metaProperties = MetaProperties(

--- a/core/src/test/scala/unit/kafka/server/BrokerServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerServerTest.scala
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.network.{DataPlaneAcceptor, SocketServer}
+import kafka.server.Server.STARTED
+import kafka.utils.{TestInfoUtils, TestUtils}
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.metadata.BrokerState
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertNull}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Created by dengziming on 4/19/22.
+ */
+class BrokerServerTest extends KafkaServerTestHarness {
+
+  override def generateConfigs: Seq[KafkaConfig] = {
+    TestUtils.createBrokerConfigs(3, null).map(KafkaConfig.fromProps).toSeq
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft"))
+  def testBrokerServerStarted(quorum: String): Unit = {
+    for (server <- brokers) {
+      assertEquals(STARTED, server.asInstanceOf[BrokerServer].status)
+      TestUtils.waitUntilTrue(() => BrokerState.RUNNING == server.brokerState, "Timeout waiting for BrokerServer starting")
+    }
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft"))
+  def testSocketServerMetricNames(quorum: String): Unit = {
+    for (server <- brokers) {
+      TestUtils.waitUntilTrue(() => BrokerState.RUNNING == server.brokerState, "Timeout waiting for BrokerServer starting")
+      checkMetricNames(server.metrics, server.socketServer)
+    }
+  }
+
+  private def checkMetricNames(metrics: Metrics, server: SocketServer): Unit = {
+    assertNull(metrics.metric(metrics.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}NotExists", SocketServer.MetricsGroup)))
+
+    // SocketServer metric
+    assertNotNull(metrics.sensor(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}MemoryPoolUtilization"))
+    assertNotNull(metrics.metric(metrics.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}MemoryPoolAvgDepletedPercent", SocketServer.MetricsGroup)))
+    assertNotNull(metrics.metric(metrics.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}MemoryPoolDepletedTimeTotal", SocketServer.MetricsGroup)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}${DataPlaneAcceptor.MetricPrefix}NetworkProcessorAvgIdlePercent", Map.empty)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}MemoryPoolAvailable", Map.empty)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}MemoryPoolUsed", Map.empty)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}${DataPlaneAcceptor.MetricPrefix}ExpiredConnectionsKilledCount", Map.empty)))
+
+    // KafkaRequestHandlerPool metric
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.KafkaServerMetricPrefix}RequestHandlerAvgIdlePercent", Map.empty)))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/ControllerServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerServerTest.scala
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.network.{DataPlaneAcceptor, SocketServer}
+import kafka.server.Server.STARTED
+import kafka.utils.{TestInfoUtils, TestUtils}
+import org.apache.kafka.common.metrics.Metrics
+import org.junit.jupiter.api.Assertions.{assertNotNull, assertNull}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Created by dengziming on 4/19/22.
+ */
+class ControllerServerTest extends KafkaServerTestHarness {
+
+  override def generateConfigs: Seq[KafkaConfig] = {
+    TestUtils.createBrokerConfigs(3, null).map(KafkaConfig.fromProps).toSeq
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft"))
+  def testControllerServerStarted(quorum: String): Unit = {
+    for (server <- controllerServers) {
+      TestUtils.waitUntilTrue(() => server.status == STARTED, "Timeout waiting for ControllerServer starting")
+    }
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft"))
+  def testSocketServerMetricNames(quorum: String): Unit = {
+    for (server <- controllerServers) {
+      TestUtils.waitUntilTrue(() => server.status == STARTED, "Timeout waiting for ControllerServer starting")
+      checkMetricNames(server.metrics, server.socketServer)
+    }
+  }
+
+  private def checkMetricNames(metrics: Metrics, server: SocketServer): Unit = {
+    assertNull(metrics.metric(metrics.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}NotExists", SocketServer.MetricsGroup)))
+
+    // SocketServer metric
+    assertNotNull(metrics.sensor(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}MemoryPoolUtilization"))
+    assertNotNull(metrics.metric(metrics.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}MemoryPoolAvgDepletedPercent", SocketServer.MetricsGroup)))
+    assertNotNull(metrics.metric(metrics.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}MemoryPoolDepletedTimeTotal", SocketServer.MetricsGroup)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}${DataPlaneAcceptor.MetricPrefix}NetworkProcessorAvgIdlePercent", Map.empty)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}MemoryPoolAvailable", Map.empty)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}MemoryPoolUsed", Map.empty)))
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}${DataPlaneAcceptor.MetricPrefix}ExpiredConnectionsKilledCount", Map.empty)))
+
+    // KafkaRequestHandlerPool metric
+    assertNotNull(TestUtils.metric(server.metricName(s"${DataPlaneAcceptor.ControllerServerMetricPrefix}RequestHandlerAvgIdlePercent", Map.empty)))
+  }
+}

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -28,8 +28,8 @@ import java.util
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.{Callable, CompletableFuture, ExecutionException, Executors, TimeUnit}
 import java.util.{Arrays, Collections, Optional, Properties}
+import com.yammer.metrics.core.{Gauge, Meter, Metric, MetricName}
 
-import com.yammer.metrics.core.{Gauge, Meter}
 import javax.net.ssl.X509TrustManager
 import kafka.api._
 import kafka.cluster.{Broker, EndPoint, IsrChangeListener}
@@ -1936,6 +1936,10 @@ object TestUtils extends Logging {
     val total = allMetrics.values().asScala.filter(_.metricName().name() == metricName)
       .foldLeft(0.0)((total, metric) => total + metric.metricValue.asInstanceOf[Double])
     total.toLong
+  }
+
+  def metric(metricName: MetricName): Option[Metric] = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.find { case (k, _) => k.equals(metricName) }.map(_._2)
   }
 
   def yammerGaugeValue[T](metricName: String): Option[T] = {


### PR DESCRIPTION
*More detailed description of your change*
In traditional we only have one SocketServer and one KafkaRequestHandlerPool in a process. In KRaft cluster, especially in co-resident mode, there may be multiple SocketServer and KafkaRequestHandlerPool, so we should avoid using the same MetricName.
I just added a prefix for the SocketServer and KafkaRequestHandlerPool in ControllerServer, to differentiate between the ones in BrokerServer.

Note that I didn't change Acceptor and Processor, since their metric name tags contain a listenerName, which will always be different for ControllerServer and BrokerServer.

*Summary of testing strategy (including rationale)*
1. integration tests.
2. Tested locally, now there are 2 KafkaRequestHandlerPool metrics in KRaft co-resident mode, compared to only one before.
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/26023240/164959514-7966937b-0e63-4ebe-a601-888c93949f17.png">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
