### PR TITLE
MINOR: fix html generation syntax errors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -241,7 +241,7 @@ public enum ApiKeys {
             b.append("</td>");
             b.append("</tr>\n");
         }
-        b.append("</table>\n");
+        b.append("</tbody></table>\n");
         return b.toString();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -500,7 +500,7 @@ public enum Errors {
             b.append("</td>");
             b.append("</tr>\n");
         }
-        b.append("</table>\n");
+        b.append("</tbody></table>\n");
         return b.toString();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -112,7 +112,7 @@ public class Protocol {
             b.append("</td>");
             b.append("</tr>\n");
         }
-        b.append("</table>\n");
+        b.append("</tbody></table>\n");
     }
 
     public static String toHtml() {
@@ -148,7 +148,7 @@ public class Protocol {
                 Schema schema = requests[i];
                 // Schema
                 if (schema != null) {
-                    b.append("<p>");
+                    b.append("<div>");
                     // Version header
                     b.append("<pre>");
                     b.append(key.name);
@@ -159,7 +159,7 @@ public class Protocol {
                     b.append("</pre>");
                     schemaToFieldTableHtml(requests[i], b);
                 }
-                b.append("</p>\n");
+                b.append("</div>\n");
             }
 
             // Responses
@@ -169,7 +169,7 @@ public class Protocol {
                 Schema schema = responses[i];
                 // Schema
                 if (schema != null) {
-                    b.append("<p>");
+                    b.append("<div>");
                     // Version header
                     b.append("<pre>");
                     b.append(key.name);
@@ -180,7 +180,7 @@ public class Protocol {
                     b.append("</pre>");
                     schemaToFieldTableHtml(responses[i], b);
                 }
-                b.append("</p>\n");
+                b.append("</div>\n");
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -1120,7 +1120,7 @@ public abstract class Type {
             b.append("</td>");
             b.append("</tr>\n");
         }
-        b.append("</table>\n");
+        b.append("</tbody></table>\n");
         return b.toString();
     }
 


### PR DESCRIPTION
*More detailed description of your change,
The html document generation has some errors in it, specifically related to protocols. The two issues identified and resolved are:

- Missing `</tbody>` closing tags added
- Invalid usage of a `<p>` tag as a wrapper element for `<table>` elements. Changed the `<p>` tag to be a `<div>`. 

*Summary of testing strategy (including rationale)
Tested by running `./gradlew siteDocsTar` and observing that the output was properly formed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
