### PR TITLE
MINOR: Adding client Base64 serializer and deserializer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/Base64Deserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Base64Deserializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Base64;
+
+public class Base64Deserializer implements Deserializer<String> {
+    private final Base64.Encoder b64Encoder;
+
+    public Base64Deserializer() {
+        b64Encoder = Base64.getEncoder();
+    }
+
+    @Override
+    public String deserialize(String topic, byte[] data) {
+        return b64Encoder.encodeToString(data);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/Base64Serializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Base64Serializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Base64;
+
+public class Base64Serializer implements Serializer<String> {
+    private final Base64.Decoder b64Decoder;
+
+    public Base64Serializer() {
+        b64Decoder = Base64.getDecoder();
+    }
+
+    @Override
+    public byte[] serialize(String topic, String data) {
+        return b64Decoder.decode(data);
+    }
+}


### PR DESCRIPTION
Adding client serialization for Base64 which enables two use cases. First, these allow messages encoded in base64 to not incur the encoding penalty of a larger file size. Second, binary encoded messages may be used more simply on the command line.

This is a minor change. For testing the class files were added to an existing `kafka-client.jar` and exercised with `kafka-console-producer.sh` and `kafka-console-consumer.sh` in Windows and Ubuntu 20.04.

This is my own work and I license it to this project.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
