### PR TITLE
MINOR: Make TopicPartitionBookkeeper and TopicPartitionEntry top level

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -181,7 +181,7 @@ public class TransactionManager {
         // See https://github.com/apache/kafka/pull/12096#pullrequestreview-955554191 for details.
         private static final Comparator<ProducerBatch> PRODUCER_BATCH_COMPARATOR =
             Comparator.comparingLong(ProducerBatch::producerId)
-                .thenComparing(ProducerBatch::producerEpoch)
+                .thenComparingInt(ProducerBatch::producerEpoch)
                 .thenComparingInt(ProducerBatch::baseSequence);
 
         TopicPartitionEntry() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionBookkeeper.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionBookkeeper.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.producer.internals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.utils.PrimitiveRef;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
+
+class TxnPartitionBookkeeper {
+
+    final Map<TopicPartition, TxnPartitionEntry> topicPartitions = new HashMap<>();
+
+    TxnPartitionEntry getPartition(TopicPartition topicPartition) {
+        TxnPartitionEntry ent = topicPartitions.get(topicPartition);
+        if (ent == null) {
+            throw new IllegalStateException("Trying to get the sequence number for " + topicPartition +
+                ", but the sequence number was never set for this partition.");
+        }
+        return ent;
+    }
+
+    TxnPartitionEntry getOrCreatePartition(TopicPartition topicPartition) {
+        return topicPartitions.computeIfAbsent(topicPartition, tp -> new TxnPartitionEntry());
+    }
+
+    boolean contains(TopicPartition topicPartition) {
+        return topicPartitions.containsKey(topicPartition);
+    }
+
+    void reset() {
+        topicPartitions.clear();
+    }
+
+    OptionalLong lastAckedOffset(TopicPartition topicPartition) {
+        TxnPartitionEntry entry = topicPartitions.get(topicPartition);
+        if (entry != null && entry.lastAckedOffset != ProduceResponse.INVALID_OFFSET) {
+            return OptionalLong.of(entry.lastAckedOffset);
+        } else {
+            return OptionalLong.empty();
+        }
+    }
+
+    OptionalInt lastAckedSequence(TopicPartition topicPartition) {
+        TxnPartitionEntry entry = topicPartitions.get(topicPartition);
+        if (entry != null && entry.lastAckedSequence != TransactionManager.NO_LAST_ACKED_SEQUENCE_NUMBER) {
+            return OptionalInt.of(entry.lastAckedSequence);
+        } else {
+            return OptionalInt.empty();
+        }
+    }
+
+    void startSequencesAtBeginning(TopicPartition topicPartition, ProducerIdAndEpoch newProducerIdAndEpoch) {
+        final PrimitiveRef.IntRef sequence = PrimitiveRef.ofInt(0);
+        TxnPartitionEntry topicPartitionEntry = getPartition(topicPartition);
+        topicPartitionEntry.resetSequenceNumbers(inFlightBatch -> {
+            inFlightBatch.resetProducerState(newProducerIdAndEpoch, sequence.value, inFlightBatch.isTransactional());
+            sequence.value += inFlightBatch.recordCount;
+        });
+        topicPartitionEntry.producerIdAndEpoch = newProducerIdAndEpoch;
+        topicPartitionEntry.nextSequence = sequence.value;
+        topicPartitionEntry.lastAckedSequence = TransactionManager.NO_LAST_ACKED_SEQUENCE_NUMBER;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionEntry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionEntry.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.producer.internals;
+
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
+
+class TxnPartitionEntry {
+
+    // The producer id/epoch being used for a given partition.
+    ProducerIdAndEpoch producerIdAndEpoch;
+
+    // The base sequence of the next batch bound for a given partition.
+    int nextSequence;
+
+    // The sequence number of the last record of the last ack'd batch from the given partition. When there are no
+    // in flight requests for a partition, the lastAckedSequence(topicPartition) == nextSequence(topicPartition) - 1.
+    int lastAckedSequence;
+
+    // Keep track of the in flight batches bound for a partition, ordered by sequence. This helps us to ensure that
+    // we continue to order batches by the sequence numbers even when the responses come back out of order during
+    // leader failover. We add a batch to the queue when it is drained, and remove it when the batch completes
+    // (either successfully or through a fatal failure).
+    SortedSet<ProducerBatch> inflightBatchesBySequence;
+
+    // We keep track of the last acknowledged offset on a per partition basis in order to disambiguate UnknownProducer
+    // responses which are due to the retention period elapsing, and those which are due to actual lost data.
+    long lastAckedOffset;
+
+    // `inflightBatchesBySequence` should only have batches with the same producer id and producer
+    // epoch, but there is an edge case where we may remove the wrong batch if the comparator
+    // only takes `baseSequence` into account.
+    // See https://github.com/apache/kafka/pull/12096#pullrequestreview-955554191 for details.
+    private static final Comparator<ProducerBatch> PRODUCER_BATCH_COMPARATOR =
+        Comparator.comparingLong(ProducerBatch::producerId)
+            .thenComparingInt(ProducerBatch::producerEpoch)
+            .thenComparingInt(ProducerBatch::baseSequence);
+
+    TxnPartitionEntry() {
+        this.producerIdAndEpoch = ProducerIdAndEpoch.NONE;
+        this.nextSequence = 0;
+        this.lastAckedSequence = TransactionManager.NO_LAST_ACKED_SEQUENCE_NUMBER;
+        this.lastAckedOffset = ProduceResponse.INVALID_OFFSET;
+        this.inflightBatchesBySequence = new TreeSet<>(PRODUCER_BATCH_COMPARATOR);
+    }
+
+    void resetSequenceNumbers(Consumer<ProducerBatch> resetSequence) {
+        TreeSet<ProducerBatch> newInflights = new TreeSet<>(PRODUCER_BATCH_COMPARATOR);
+        for (ProducerBatch inflightBatch : inflightBatchesBySequence) {
+            resetSequence.accept(inflightBatch);
+            newInflights.add(inflightBatch);
+        }
+        inflightBatchesBySequence = newInflights;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionMap.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionMap.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.PrimitiveRef;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 
-class TxnPartitionBookkeeper {
+class TxnPartitionMap {
 
     final Map<TopicPartition, TxnPartitionEntry> topicPartitions = new HashMap<>();
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionMap.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TxnPartitionMap.java
@@ -30,7 +30,7 @@ class TxnPartitionMap {
 
     final Map<TopicPartition, TxnPartitionEntry> topicPartitions = new HashMap<>();
 
-    TxnPartitionEntry getPartition(TopicPartition topicPartition) {
+    TxnPartitionEntry get(TopicPartition topicPartition) {
         TxnPartitionEntry ent = topicPartitions.get(topicPartition);
         if (ent == null) {
             throw new IllegalStateException("Trying to get the sequence number for " + topicPartition +
@@ -39,7 +39,7 @@ class TxnPartitionMap {
         return ent;
     }
 
-    TxnPartitionEntry getOrCreatePartition(TopicPartition topicPartition) {
+    TxnPartitionEntry getOrCreate(TopicPartition topicPartition) {
         return topicPartitions.computeIfAbsent(topicPartition, tp -> new TxnPartitionEntry());
     }
 
@@ -71,7 +71,7 @@ class TxnPartitionMap {
 
     void startSequencesAtBeginning(TopicPartition topicPartition, ProducerIdAndEpoch newProducerIdAndEpoch) {
         final PrimitiveRef.IntRef sequence = PrimitiveRef.ofInt(0);
-        TxnPartitionEntry topicPartitionEntry = getPartition(topicPartition);
+        TxnPartitionEntry topicPartitionEntry = get(topicPartition);
         topicPartitionEntry.resetSequenceNumbers(inFlightBatch -> {
             inFlightBatch.resetProducerState(newProducerIdAndEpoch, sequence.value, inFlightBatch.isTransactional());
             sequence.value += inFlightBatch.recordCount;


### PR DESCRIPTION
This is the first step towards refactoring the `TransactionManager` so
that it's easier to understand and test. The high level idea is to push
down behavior to `TopicPartitionEntry` and `TopicPartitionBookkeeper`
and to encapsulate the state so that the mutations can only be done via
the appropriate methods.

Inner classes have no mechanism to limit access from the outer class,
which presents a challenge when mutability is widespread (like we do
here).

As a first step, we make `TopicPartitionBookkeeper` and
`TopicPartitionEntry` top level and rename them and a couple
of methods to make the intended usage clear and avoid
redundancy.

To make the review easier, we don't change anything else
except access changes required for the code to compile.
The next PR will contain the rest of the refactoring.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
