### PR TITLE
MINOR: Fix event output inconsistencies in TransactionalMessageCopier

### DIFF
--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -93,7 +93,7 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
                         self.consumed = int(data["consumed"])
                         self.logger.info("%s: consumed %d, remaining %d" %
                                          (self.transactional_id, self.consumed, self.remaining))
-                        if "shutdown_complete" in data:
+                        if data["stage"] == "ShutdownComplete":
                            if self.remaining == 0:
                                 # We are only finished if the remaining
                                 # messages at the time of shutdown is 0.

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -260,7 +260,7 @@ public class TransactionalMessageCopier {
         return json;
     }
 
-    private static synchronized String statusAsJson(
+    private static String statusAsJson(
         String stage,
         long totalProcessed,
         long consumedSinceLastRebalanced,

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -260,7 +260,7 @@ public class TransactionalMessageCopier {
         return json;
     }
 
-    private static String statusAsJson(
+    private static synchronized String statusAsJson(
         String stage,
         long totalProcessed,
         long consumedSinceLastRebalanced,

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -260,25 +260,21 @@ public class TransactionalMessageCopier {
         return json;
     }
 
-    private static synchronized String statusAsJson(long totalProcessed, long consumedSinceLastRebalanced, long remaining, String transactionalId, String stage) {
+    private static synchronized String statusAsJson(
+        String stage,
+        long totalProcessed,
+        long consumedSinceLastRebalanced,
+        long remaining,
+        String transactionalId
+    ) {
         Map<String, Object> statusData = new HashMap<>();
-        statusData.put("progress", transactionalId);
+        statusData.put("stage", stage);
+        statusData.put("transactionalId", transactionalId);
         statusData.put("totalProcessed", totalProcessed);
         statusData.put("consumed", consumedSinceLastRebalanced);
         statusData.put("remaining", remaining);
         statusData.put("time", FORMAT.format(new Date()));
-        statusData.put("stage", stage);
         return toJsonString(statusData);
-    }
-
-    private static synchronized String shutDownString(long totalProcessed, long consumedSinceLastRebalanced, long remaining, String transactionalId) {
-        Map<String, Object> shutdownData = new HashMap<>();
-        shutdownData.put("shutdown_complete", transactionalId);
-        shutdownData.put("totalProcessed", totalProcessed);
-        shutdownData.put("consumed", consumedSinceLastRebalanced);
-        shutdownData.put("remaining", remaining);
-        shutdownData.put("time", FORMAT.format(new Date()));
-        return toJsonString(shutdownData);
     }
 
     private static void abortTransactionAndResetPosition(
@@ -330,8 +326,13 @@ public class TransactionalMessageCopier {
                         .mapToLong(partition -> messagesRemaining(consumer, partition)).sum());
                     numMessagesProcessedSinceLastRebalance.set(0);
                     // We use message cap for remaining here as the remainingMessages are not set yet.
-                    System.out.println(statusAsJson(totalMessageProcessed.get(),
-                        numMessagesProcessedSinceLastRebalance.get(), remainingMessages.get(), transactionalId, "RebalanceComplete"));
+                    System.out.println(statusAsJson(
+                        "RebalanceComplete",
+                        totalMessageProcessed.get(),
+                        numMessagesProcessedSinceLastRebalance.get(),
+                        remainingMessages.get(),
+                        transactionalId
+                    ));
                 }
             });
         } else {
@@ -349,16 +350,26 @@ public class TransactionalMessageCopier {
         Exit.addShutdownHook("transactional-message-copier-shutdown-hook", () -> {
             isShuttingDown.set(true);
             consumer.wakeup();
-            System.out.println(shutDownString(totalMessageProcessed.get(),
-                numMessagesProcessedSinceLastRebalance.get(), remainingMessages.get(), transactionalId));
+            System.out.println(statusAsJson(
+                "ShutdownComplete",
+                totalMessageProcessed.get(),
+                numMessagesProcessedSinceLastRebalance.get(),
+                remainingMessages.get(),
+                transactionalId
+            ));
         });
 
         final boolean useGroupMetadata = parsedArgs.getBoolean("useGroupMetadata");
         try {
             Random random = new Random();
             while (!isShuttingDown.get() && remainingMessages.get() > 0) {
-                System.out.println(statusAsJson(totalMessageProcessed.get(),
-                    numMessagesProcessedSinceLastRebalance.get(), remainingMessages.get(), transactionalId, "ProcessLoop"));
+                System.out.println(statusAsJson(
+                    "ProcessLoop",
+                    totalMessageProcessed.get(),
+                    numMessagesProcessedSinceLastRebalance.get(),
+                    remainingMessages.get(),
+                    transactionalId
+                ));
 
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(200));
                 if (records.count() > 0) {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
@@ -267,13 +268,13 @@ public class TransactionalMessageCopier {
         long remaining,
         String transactionalId
     ) {
-        Map<String, Object> statusData = new HashMap<>();
-        statusData.put("stage", stage);
+        Map<String, Object> statusData = new LinkedHashMap<>();
         statusData.put("transactionalId", transactionalId);
+        statusData.put("stage", stage);
+        statusData.put("time", FORMAT.format(new Date()));
         statusData.put("totalProcessed", totalProcessed);
         statusData.put("consumed", consumedSinceLastRebalanced);
         statusData.put("remaining", remaining);
-        statusData.put("time", FORMAT.format(new Date()));
         return toJsonString(statusData);
     }
 


### PR DESCRIPTION
There is some strangeness and inconsistency in the messages written by `TransactionalMessageCopier` to stdout. Here is a sample of two messages.

Progress message:
```
{"consumed":33000,"stage":"ProcessLoop","totalProcessed":33000,"progress":"copier-0","time":"2022/04/24 05:40:31:649","remaining":333}
```
The `transactionalId` is set to the value of the `progress` key.

And a shutdown message:
```
{"consumed":33333,"shutdown_complete":"copier-0","totalProcessed":33333,"time":"2022/04/24 05:40:31:937","remaining":0}
```
The `transactionalId` this time is set to the `shutdown_complete` key and there is no `stage` key.

This patch fixes these issues with the following:

1. Use a separate key for the `transactionalId`.
2. Drop the `progress` and `shutdown_complete` fields.
3. Use `stage=ShutdownComplete` in the shutdown message.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
