### PR TITLE
KAFKA-13861: Fix the validateOnly behavior for CreatePartitions requests in KRaft mode

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -740,6 +740,7 @@ class ControllerApis(val requestChannel: RequestChannel,
     request: CreatePartitionsRequestData,
     getAlterAuthorizedTopics: Iterable[String] => Set[String]
   ): CompletableFuture[util.List[CreatePartitionsTopicResult]] = {
+    debug(s"Processing createPartitions request $request")
     val responses = new util.ArrayList[CreatePartitionsTopicResult]()
     val duplicateTopicNames = new util.HashSet[String]()
     val topicNames = new util.HashSet[String]()

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -740,7 +740,6 @@ class ControllerApis(val requestChannel: RequestChannel,
     request: CreatePartitionsRequestData,
     getAlterAuthorizedTopics: Iterable[String] => Set[String]
   ): CompletableFuture[util.List[CreatePartitionsTopicResult]] = {
-    debug(s"Processing createPartitions request $request")
     val responses = new util.ArrayList[CreatePartitionsTopicResult]()
     val duplicateTopicNames = new util.HashSet[String]()
     val topicNames = new util.HashSet[String]()

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -767,7 +767,7 @@ class ControllerApis(val requestChannel: RequestChannel,
           setErrorCode(TOPIC_AUTHORIZATION_FAILED.code))
       }
     }
-    controller.createPartitions(context, topics, request.validateOnly()).thenApply { results =>
+    controller.createPartitions(context, topics, request.validateOnly).thenApply { results =>
       results.forEach(response => responses.add(response))
       responses
     }

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -767,7 +767,7 @@ class ControllerApis(val requestChannel: RequestChannel,
           setErrorCode(TOPIC_AUTHORIZATION_FAILED.code))
       }
     }
-    controller.createPartitions(context, topics).thenApply { results =>
+    controller.createPartitions(context, topics, request.validateOnly()).thenApply { results =>
       results.forEach(response => responses.add(response))
       responses
     }

--- a/core/src/test/java/kafka/test/MockController.java
+++ b/core/src/test/java/kafka/test/MockController.java
@@ -410,10 +410,16 @@ public class MockController implements Controller {
         throw new UnsupportedOperationException();
     }
 
+    boolean lastCreatePartitionsValidateOnly = false;
+    public boolean isLastCreatePartitionsValidateOnly() {
+        return this.lastCreatePartitionsValidateOnly;
+    }
+
     @Override
     synchronized public CompletableFuture<List<CreatePartitionsTopicResult>> createPartitions(
         ControllerRequestContext context,
-        List<CreatePartitionsTopic> topicList
+        List<CreatePartitionsTopic> topicList,
+        boolean validateOnly
     ) {
         if (!active) {
             CompletableFuture<List<CreatePartitionsTopicResult>> future = new CompletableFuture<>();
@@ -432,6 +438,7 @@ public class MockController implements Controller {
                     setErrorMessage("No such topic as " + topic.name()));
             }
         }
+        lastCreatePartitionsValidateOnly = validateOnly;
         return CompletableFuture.completedFuture(results);
     }
 

--- a/core/src/test/java/kafka/test/MockController.java
+++ b/core/src/test/java/kafka/test/MockController.java
@@ -410,11 +410,6 @@ public class MockController implements Controller {
         throw new UnsupportedOperationException();
     }
 
-    boolean lastCreatePartitionsValidateOnly = false;
-    public boolean isLastCreatePartitionsValidateOnly() {
-        return this.lastCreatePartitionsValidateOnly;
-    }
-
     @Override
     synchronized public CompletableFuture<List<CreatePartitionsTopicResult>> createPartitions(
         ControllerRequestContext context,
@@ -438,7 +433,6 @@ public class MockController implements Controller {
                     setErrorMessage("No such topic as " + topic.name()));
             }
         }
-        lastCreatePartitionsValidateOnly = validateOnly;
         return CompletableFuture.completedFuture(results);
     }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -25,12 +25,11 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit}
 import java.util.{Collections, Optional, Properties}
 import java.{time, util}
-
 import kafka.log.LogConfig
 import kafka.security.authorizer.AclEntry
 import kafka.server.{Defaults, DynamicConfig, KafkaConfig, KafkaServer}
 import kafka.utils.TestUtils._
-import kafka.utils.{Log4jController, TestUtils}
+import kafka.utils.{Log4jController, TestInfoUtils, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.HostResolver
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
@@ -425,8 +424,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     checkValidAlterConfigs(client, topicResource1, topicResource2)
   }
 
-  @Test
-  def testCreatePartitions(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testCreatePartitions(quorum: String): Unit = {
     client = Admin.create(createConfig)
 
     // Create topics
@@ -490,7 +490,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       var e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidPartitionsException when newCount is a decrease")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      assertEquals("Topic currently has 3 partitions, which is higher than the requested 1.", e.getCause.getMessage, desc)
+      var exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "The topic create-partitions-topic-1 currently has 3 partition(s); 1 would not be an increase."
+      } else {
+        "Topic currently has 3 partitions, which is higher than the requested 1."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try a newCount which would be a noop (without assignment)
@@ -499,7 +504,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get,
         () => s"$desc: Expect InvalidPartitionsException when requesting a noop")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      assertEquals("Topic already has 3 partitions.", e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "Topic already has 3 partition(s)."
+      } else {
+        "Topic already has 3 partitions."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic2, Some(3)), desc)
 
       // try a newCount which would be a noop (where the assignment matches current state)
@@ -507,7 +517,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         NewPartitions.increaseTo(3, newPartition2Assignments)).asJava, option)
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get)
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      assertEquals("Topic already has 3 partitions.", e.getCause.getMessage, desc)
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic2, Some(3)), desc)
 
       // try a newCount which would be a noop (where the assignment doesn't match current state)
@@ -515,7 +525,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         NewPartitions.increaseTo(3, newPartition2Assignments.asScala.reverse.toList.asJava)).asJava, option)
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get)
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      assertEquals("Topic already has 3 partitions.", e.getCause.getMessage, desc)
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic2, Some(3)), desc)
 
       // try a bad topic name
@@ -525,7 +535,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(unknownTopic).get,
         () => s"$desc: Expect InvalidTopicException when using an unknown topic")
       assertTrue(e.getCause.isInstanceOf[UnknownTopicOrPartitionException], desc)
-      assertEquals("The topic 'an-unknown-topic' does not exist.", e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "This server does not host this topic-partition."
+      } else {
+        "The topic 'an-unknown-topic' does not exist."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
 
       // try an invalid newCount
       alterResult = client.createPartitions(Map(topic1 ->
@@ -533,7 +548,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidPartitionsException when newCount is invalid")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      assertEquals("Topic currently has 3 partitions, which is higher than the requested -22.", e.getCause.getMessage,
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "The topic create-partitions-topic-1 currently has 3 partition(s); -22 would not be an increase."
+      } else {
+        "Topic currently has 3 partitions, which is higher than the requested -22."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage,
         desc)
       assertEquals(3, numPartitions(topic1), desc)
 
@@ -543,9 +563,14 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidPartitionsException when #brokers != replication factor")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Inconsistent replication factor between partitions, partition 0 has 1 " +
-        "while partitions [3] have replication factors [2], respectively.",
-        e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "The manual partition assignment includes a partition with 2 replica(s), but this is not " +
+          "consistent with previous partitions, which have 1 replica(s)."
+      } else {
+        "Inconsistent replication factor between partitions, partition 0 has 1 while partitions [3] " +
+          "have replication factors [2], respectively."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try #assignments < with the increase
@@ -554,7 +579,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when #assignments != newCount - oldCount")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Increasing the number of partitions by 3 but 1 assignments provided.", e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "Attempted to add 3 additional partition(s), but only 1 assignment(s) were specified."
+      } else {
+        "Increasing the number of partitions by 3 but 1 assignments provided."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try #assignments > with the increase
@@ -562,8 +592,13 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         NewPartitions.increaseTo(4, asList(asList(1), asList(2)))).asJava, option)
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when #assignments != newCount - oldCount")
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "Attempted to add 1 additional partition(s), but only 2 assignment(s) were specified."
+      } else {
+        "Increasing the number of partitions by 1 but 2 assignments provided."
+      }
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Increasing the number of partitions by 1 but 2 assignments provided.", e.getCause.getMessage, desc)
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try with duplicate brokers in assignments
@@ -572,8 +607,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments has duplicate brokers")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Duplicate brokers not allowed in replica assignment: 1, 1 for partition id 3.",
-        e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "The manual partition assignment includes the broker 1 more than once."
+      } else {
+        "Duplicate brokers not allowed in replica assignment: 1, 1 for partition id 3."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try assignments with differently sized inner lists
@@ -582,8 +621,14 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments have differently sized inner lists")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Inconsistent replication factor between partitions, partition 0 has 1 " +
-        "while partitions [4] have replication factors [2], respectively.", e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "The manual partition assignment includes a partition with 2 replica(s), but this is not " +
+          "consistent with previous partitions, which have 1 replica(s)."
+      } else {
+        "Inconsistent replication factor between partitions, partition 0 has 1 " +
+          "while partitions [4] have replication factors [2], respectively."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try assignments with unknown brokers
@@ -592,7 +637,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments contains an unknown broker")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Unknown broker(s) in replica assignment: 12.", e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "The manual partition assignment includes broker 12, but no such broker is registered."
+      } else {
+        "Unknown broker(s) in replica assignment: 12."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
 
       // try with empty assignments
@@ -601,7 +651,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments is empty")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      assertEquals("Increasing the number of partitions by 1 but 0 assignments provided.", e.getCause.getMessage, desc)
+      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+        "Attempted to add 1 additional partition(s), but only 0 assignment(s) were specified."
+      } else {
+        "Increasing the number of partitions by 1 but 0 assignments provided."
+      }
+      assertEquals(exceptionMsgStr, e.getCause.getMessage, desc)
       assertEquals(3, numPartitions(topic1), desc)
     }
 
@@ -614,7 +669,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     TestUtils.waitUntilTrue(() => numPartitions(topic1) == 4, "Timed out waiting for new partitions to appear")
     var e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get)
     assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException])
-    assertEquals("Topic currently has 3 partitions, which is higher than the requested 2.", e.getCause.getMessage)
+    val exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      "The topic create-partitions-topic-2 currently has 3 partition(s); 2 would not be an increase."
+    } else {
+      "Topic currently has 3 partitions, which is higher than the requested 2."
+    }
+    assertEquals(exceptionMsgStr, e.getCause.getMessage)
     assertEquals(3, numPartitions(topic2))
 
     // finally, try to add partitions to a topic queued for deletion
@@ -623,9 +683,14 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     alterResult = client.createPartitions(Map(topic1 ->
       NewPartitions.increaseTo(4)).asJava, validateOnly)
     e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
-      () => "Expect InvalidTopicException when the topic is queued for deletion")
-    assertTrue(e.getCause.isInstanceOf[InvalidTopicException])
-    assertEquals("The topic is queued for deletion.", e.getCause.getMessage)
+      () => "Expect InvalidTopicException or UnknownTopicOrPartitionException when the topic is queued for deletion")
+    if (TestInfoUtils.isKRaft(testInfo)) {
+      assertTrue(e.getCause.isInstanceOf[UnknownTopicOrPartitionException], e.toString)
+      assertEquals("This server does not host this topic-partition.", e.getCause.getMessage)
+    } else {
+      assertTrue(e.getCause.isInstanceOf[InvalidTopicException], e.toString)
+      assertEquals("The topic is queued for deletion.", e.getCause.getMessage)
+    }
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -677,7 +677,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     assertEquals(exceptionMsgStr, e.getCause.getMessage)
     assertEquals(3, numPartitions(topic2))
 
-    // finally, try to add partitions to a topic queued for deletion
+    // Delete the topic. Verify addition of partitions to deleted topic is not possible. In
+    // Zookeeper mode, the topic is queued for deletion. In KRaft, the deletion occurs
+    // immediately and hence we have a different Exception thrown in the response.
     val deleteResult = client.deleteTopics(asList(topic1))
     deleteResult.topicNameValues.get(topic1).get
     alterResult = client.createPartitions(Map(topic1 ->

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -490,7 +490,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       var e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidPartitionsException when newCount is a decrease")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      var exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      var exceptionMsgStr = if (isKRaftTest()) {
         "The topic create-partitions-topic-1 currently has 3 partition(s); 1 would not be an increase."
       } else {
         "Topic currently has 3 partitions, which is higher than the requested 1."
@@ -504,7 +504,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get,
         () => s"$desc: Expect InvalidPartitionsException when requesting a noop")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "Topic already has 3 partition(s)."
       } else {
         "Topic already has 3 partitions."
@@ -535,7 +535,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(unknownTopic).get,
         () => s"$desc: Expect InvalidTopicException when using an unknown topic")
       assertTrue(e.getCause.isInstanceOf[UnknownTopicOrPartitionException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "This server does not host this topic-partition."
       } else {
         "The topic 'an-unknown-topic' does not exist."
@@ -548,7 +548,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidPartitionsException when newCount is invalid")
       assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "The topic create-partitions-topic-1 currently has 3 partition(s); -22 would not be an increase."
       } else {
         "Topic currently has 3 partitions, which is higher than the requested -22."
@@ -563,7 +563,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidPartitionsException when #brokers != replication factor")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "The manual partition assignment includes a partition with 2 replica(s), but this is not " +
           "consistent with previous partitions, which have 1 replica(s)."
       } else {
@@ -579,7 +579,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when #assignments != newCount - oldCount")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "Attempted to add 3 additional partition(s), but only 1 assignment(s) were specified."
       } else {
         "Increasing the number of partitions by 3 but 1 assignments provided."
@@ -592,7 +592,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         NewPartitions.increaseTo(4, asList(asList(1), asList(2)))).asJava, option)
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when #assignments != newCount - oldCount")
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "Attempted to add 1 additional partition(s), but only 2 assignment(s) were specified."
       } else {
         "Increasing the number of partitions by 1 but 2 assignments provided."
@@ -607,7 +607,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments has duplicate brokers")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "The manual partition assignment includes the broker 1 more than once."
       } else {
         "Duplicate brokers not allowed in replica assignment: 1, 1 for partition id 3."
@@ -621,7 +621,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments have differently sized inner lists")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "The manual partition assignment includes a partition with 2 replica(s), but this is not " +
           "consistent with previous partitions, which have 1 replica(s)."
       } else {
@@ -637,7 +637,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments contains an unknown broker")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "The manual partition assignment includes broker 12, but no such broker is registered."
       } else {
         "Unknown broker(s) in replica assignment: 12."
@@ -651,7 +651,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
         () => s"$desc: Expect InvalidReplicaAssignmentException when assignments is empty")
       assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException], desc)
-      exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+      exceptionMsgStr = if (isKRaftTest()) {
         "Attempted to add 1 additional partition(s), but only 0 assignment(s) were specified."
       } else {
         "Increasing the number of partitions by 1 but 0 assignments provided."
@@ -669,7 +669,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     TestUtils.waitUntilTrue(() => numPartitions(topic1) == 4, "Timed out waiting for new partitions to appear")
     var e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic2).get)
     assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException])
-    val exceptionMsgStr = if (TestInfoUtils.isKRaft(testInfo)) {
+    val exceptionMsgStr = if (isKRaftTest()) {
       "The topic create-partitions-topic-2 currently has 3 partition(s); 2 would not be an increase."
     } else {
       "Topic currently has 3 partitions, which is higher than the requested 2."
@@ -686,7 +686,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       NewPartitions.increaseTo(4)).asJava, validateOnly)
     e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
       () => "Expect InvalidTopicException or UnknownTopicOrPartitionException when the topic is queued for deletion")
-    if (TestInfoUtils.isKRaft(testInfo)) {
+    if (isKRaftTest()) {
       assertTrue(e.getCause.isInstanceOf[UnknownTopicOrPartitionException], e.toString)
       assertEquals("This server does not host this topic-partition.", e.getCause.getMessage)
     } else {

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -729,17 +729,27 @@ class ControllerApisTest {
     request.topics().add(new CreatePartitionsTopic().setName("bar").setAssignments(null).setCount(5))
     request.topics().add(new CreatePartitionsTopic().setName("bar").setAssignments(null).setCount(5))
     request.topics().add(new CreatePartitionsTopic().setName("baz").setAssignments(null).setCount(5))
-    assertEquals(Set(new CreatePartitionsTopicResult().setName("foo").
-        setErrorCode(NONE.code()).
-        setErrorMessage(null),
+    request.setValidateOnly(true)
+    val expectedResult = Set(new CreatePartitionsTopicResult().setName("foo").
+      setErrorCode(NONE.code()).
+      setErrorMessage(null),
       new CreatePartitionsTopicResult().setName("bar").
         setErrorCode(INVALID_REQUEST.code()).
         setErrorMessage("Duplicate topic name."),
       new CreatePartitionsTopicResult().setName("baz").
         setErrorCode(TOPIC_AUTHORIZATION_FAILED.code()).
-        setErrorMessage(null)),
+        setErrorMessage(null))
+    assertEquals(expectedResult,
       controllerApis.createPartitions(ANONYMOUS_CONTEXT, request,
         _ => Set("foo", "bar")).get().asScala.toSet)
+    assertTrue(controller.isLastCreatePartitionsValidateOnly)
+
+    // Remove the validateOnly flag in the request.
+    request.setValidateOnly(false)
+    assertEquals(expectedResult,
+      controllerApis.createPartitions(ANONYMOUS_CONTEXT, request,
+        _ => Set("foo", "bar")).get().asScala.toSet)
+    assertFalse(controller.isLastCreatePartitionsValidateOnly)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -729,11 +729,9 @@ class ControllerApisTest {
     request.topics().add(new CreatePartitionsTopic().setName("bar").setAssignments(null).setCount(5))
     request.topics().add(new CreatePartitionsTopic().setName("bar").setAssignments(null).setCount(5))
     request.topics().add(new CreatePartitionsTopic().setName("baz").setAssignments(null).setCount(5))
-
-    // Set the validateOnly flag and check the controller just validates the request.
     request.setValidateOnly(validateOnly)
 
-    // Check if the controller is called correctly with the 'validateOnly' field set.
+    // Check if the controller is called correctly with the 'validateOnly' field set appropriately.
     when(controller.createPartitions(
       any(),
       ArgumentMatchers.eq(

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -328,8 +328,7 @@ public interface Controller extends AclMutator, AutoCloseable {
      * Create partitions on certain topics.
      *
      * @param topics        The list of topics to create partitions for.
-     * @param validateOnly  If true, create partitions is just validated and returns response
-     *                      without actually creating partitions.
+     * @param validateOnly  If true, the request is validated, but no partitions will be created.
      *
      * @return              A future yielding per-topic results.
      */

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -328,11 +328,15 @@ public interface Controller extends AclMutator, AutoCloseable {
      * Create partitions on certain topics.
      *
      * @param topics        The list of topics to create partitions for.
+     * @param validateOnly  If true, create partitions is just validated and returns response
+     *                      without actually creating partitions.
+     *
      * @return              A future yielding per-topic results.
      */
     CompletableFuture<List<CreatePartitionsTopicResult>> createPartitions(
         ControllerRequestContext context,
-        List<CreatePartitionsTopic> topics
+        List<CreatePartitionsTopic> topics,
+        boolean validateOnly
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1664,13 +1664,14 @@ public final class QuorumController implements Controller {
     @Override
     public CompletableFuture<List<CreatePartitionsTopicResult>> createPartitions(
         ControllerRequestContext context,
-        List<CreatePartitionsTopic> topics
+        List<CreatePartitionsTopic> topics,
+        boolean validateOnly
     ) {
         if (topics.isEmpty()) {
             return CompletableFuture.completedFuture(Collections.emptyList());
         }
         return appendWriteEvent("createPartitions", context.deadlineNs(),
-            () -> replicationControl.createPartitions(topics));
+            () -> replicationControl.createPartitions(topics, validateOnly));
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1673,7 +1673,13 @@ public final class QuorumController implements Controller {
 
         return appendWriteEvent("createPartitions", context.deadlineNs(), () -> {
             final ControllerResult<List<CreatePartitionsTopicResult>> result = replicationControl.createPartitions(topics);
-            return validateOnly ? result.withoutRecords() : result;
+            if (validateOnly) {
+                log.debug("Validate-only CreatePartitions result(s): {}", result.response());
+                return result.withoutRecords();
+            } else {
+                log.debug("CreatePartitions result(s): {}", result.response());
+                return result;
+            }
         });
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1670,8 +1670,11 @@ public final class QuorumController implements Controller {
         if (topics.isEmpty()) {
             return CompletableFuture.completedFuture(Collections.emptyList());
         }
-        return appendWriteEvent("createPartitions", context.deadlineNs(),
-            () -> replicationControl.createPartitions(topics, validateOnly));
+
+        return appendWriteEvent("createPartitions", context.deadlineNs(), () -> {
+            final ControllerResult<List<CreatePartitionsTopicResult>> result = replicationControl.createPartitions(topics);
+            return validateOnly ? result.withoutRecords() : result;
+        });
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1346,7 +1346,7 @@ public class ReplicationControlManager {
     }
 
     ControllerResult<List<CreatePartitionsTopicResult>>
-            createPartitions(List<CreatePartitionsTopic> topics, boolean validateOnly) {
+            createPartitions(List<CreatePartitionsTopic> topics) {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         List<CreatePartitionsTopicResult> results = new ArrayList<>();
         for (CreatePartitionsTopic topic : topics) {
@@ -1364,25 +1364,8 @@ public class ReplicationControlManager {
                 setErrorCode(apiError.error().code()).
                 setErrorMessage(apiError.message()));
         }
-        StringBuilder resultsBuilder = new StringBuilder();
-        String resultsPrefix = "";
-        for (CreatePartitionsTopicResult result : results) {
-            resultsBuilder.append(resultsPrefix).append(result.name()).append(": ");
-            Errors error = Errors.forCode(result.errorCode());
-            if (error == Errors.NONE) {
-                resultsBuilder.append("SUCCESS");
-            } else {
-                resultsBuilder.append(error).append(" (").append(result.errorMessage()).append(")");
-            }
-            resultsPrefix = ", ";
-        }
-        if (validateOnly) {
-            log.info("Validate-only CreatePartitions result(s): {}", resultsBuilder);
-            return ControllerResult.atomicOf(Collections.emptyList(), results);
-        } else {
-            log.info("CreatePartitions result(s): {}", resultsBuilder);
-            return ControllerResult.atomicOf(records, results);
-        }
+        log.debug("CreatePartitions result(s): {}", results);
+        return ControllerResult.atomicOf(records, results);
     }
 
     void createPartitions(CreatePartitionsTopic topic,

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1364,7 +1364,6 @@ public class ReplicationControlManager {
                 setErrorCode(apiError.error().code()).
                 setErrorMessage(apiError.message()));
         }
-        log.debug("CreatePartitions result(s): {}", results);
         return ControllerResult.atomicOf(records, results);
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -808,7 +808,7 @@ public class QuorumControllerTest {
                     controller.findTopicNames(context0, Collections.singletonList(Uuid.ZERO_UUID));
                 CompletableFuture<List<CreatePartitionsTopicResult>> createPartitionsFuture =
                     controller.createPartitions(context0, Collections.singletonList(
-                        new CreatePartitionsTopic()));
+                        new CreatePartitionsTopic()), false);
                 CompletableFuture<ElectLeadersResponseData> electLeadersFuture =
                     controller.electLeaders(context0, new ElectLeadersRequestData().setTimeoutMs(0).
                         setTopicPartitions(null));
@@ -862,7 +862,7 @@ public class QuorumControllerTest {
                 CompletableFuture<Map<Uuid, ResultOrError<String>>> findTopicNamesFuture =
                     controller.findTopicNames(ANONYMOUS_CONTEXT, Collections.emptyList());
                 CompletableFuture<List<CreatePartitionsTopicResult>> createPartitionsFuture =
-                    controller.createPartitions(ANONYMOUS_CONTEXT, Collections.emptyList());
+                    controller.createPartitions(ANONYMOUS_CONTEXT, Collections.emptyList(), false);
                 CompletableFuture<ElectLeadersResponseData> electLeadersFuture =
                     controller.electLeaders(ANONYMOUS_CONTEXT, new ElectLeadersRequestData());
                 CompletableFuture<AlterPartitionReassignmentsResponseData> alterReassignmentsFuture =

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1009,7 +1009,8 @@ public class ReplicationControlManagerTest {
             new CreatePartitionsTopicResult().
                 setName("quux").
                 setErrorCode(INVALID_PARTITIONS.code()).
-                setErrorMessage("Topic already has 2 partition(s).")), createPartitionsResult.response());
+                setErrorMessage("Topic already has 2 partition(s).")),
+            createPartitionsResult.response());
         ctx.replay(createPartitionsResult.records());
         List<CreatePartitionsTopic> topics2 = new ArrayList<>();
         topics2.add(new CreatePartitionsTopic().

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -242,7 +242,7 @@ public class ReplicationControlManagerTest {
                     setBrokerIds(Replicas.toList(replicas[i])));
             }
             ControllerResult<List<CreatePartitionsTopicResult>> result =
-                replicationControl.createPartitions(Collections.singletonList(topic), false);
+                replicationControl.createPartitions(Collections.singletonList(topic));
             assertEquals(1, result.response().size());
             CreatePartitionsTopicResult topicResult = result.response().get(0);
             assertEquals(name, topicResult.name());
@@ -992,7 +992,9 @@ public class ReplicationControlManagerTest {
             setName("baz").setCount(3).setAssignments(null));
         topics.add(new CreatePartitionsTopic().
             setName("quux").setCount(2).setAssignments(null));
-        List<CreatePartitionsTopicResult> expectedResult = asList(new CreatePartitionsTopicResult().
+        ControllerResult<List<CreatePartitionsTopicResult>> createPartitionsResult =
+            replicationControl.createPartitions(topics);
+        assertEquals(asList(new CreatePartitionsTopicResult().
                 setName("foo").
                 setErrorCode(NONE.code()).
                 setErrorMessage(null),
@@ -1007,17 +1009,7 @@ public class ReplicationControlManagerTest {
             new CreatePartitionsTopicResult().
                 setName("quux").
                 setErrorCode(INVALID_PARTITIONS.code()).
-                setErrorMessage("Topic already has 2 partition(s)."));
-        ControllerResult<List<CreatePartitionsTopicResult>> createPartitionsResult =
-            replicationControl.createPartitions(topics, true);
-        assertEquals(expectedResult, createPartitionsResult.response());
-        assertTrue(createPartitionsResult.records().isEmpty(), "Found records for validateOnly " +
-            "CreatePartitions request");
-        ctx.replay(createPartitionsResult.records());
-        createPartitionsResult = replicationControl.createPartitions(topics, false);
-        assertEquals(expectedResult, createPartitionsResult.response());
-        assertFalse(createPartitionsResult.records().isEmpty(), "Found no records for " +
-            "CreatePartitions request");
+                setErrorMessage("Topic already has 2 partition(s).")), createPartitionsResult.response());
         ctx.replay(createPartitionsResult.records());
         List<CreatePartitionsTopic> topics2 = new ArrayList<>();
         topics2.add(new CreatePartitionsTopic().
@@ -1033,7 +1025,7 @@ public class ReplicationControlManagerTest {
             setName("foo2").setCount(3).setAssignments(asList(
             new CreatePartitionsAssignment().setBrokerIds(asList(2, 0)))));
         ControllerResult<List<CreatePartitionsTopicResult>> createPartitionsResult2 =
-            replicationControl.createPartitions(topics2, false);
+            replicationControl.createPartitions(topics2);
         assertEquals(asList(new CreatePartitionsTopicResult().
                 setName("foo").
                 setErrorCode(NONE.code()).


### PR DESCRIPTION
KAFKA-13861: Fix the validateOnly behavior for `CreatePartitions` requests in KRaft mode

The KRaft implementation of the `CreatePartitions` ignores the `validateOnly` flag in the
request and creates the partitions if the validations are successful. Fixed the behavior
not to create partitions upon validation if the `validateOnly` flag is true.

Add ControllerApi and ReplicationControlManager tests to verify the correct behavior.
