### PR TITLE
KAFKA-13863: Prevent null config value when create topic in KRaft mode

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -24,7 +24,7 @@ import kafka.log.LogConfig
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, TOPIC}
 import org.apache.kafka.controller.ConfigurationValidator
-import org.apache.kafka.common.errors.InvalidRequestException
+import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException}
 import org.apache.kafka.common.internals.Topic
 
 import scala.collection.mutable
@@ -104,7 +104,7 @@ class ControllerConfigurationValidator extends ConfigurationValidator {
           }
         })
         if (nullTopicConfigs.nonEmpty) {
-          throw new InvalidRequestException("Null value not supported for topic configs : " +
+          throw new InvalidConfigurationException("Null value not supported for topic configs: " +
             nullTopicConfigs.mkString(","))
         }
         LogConfig.validate(properties)

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -158,7 +158,7 @@ class ZkAdminManager(val config: KafkaConfig,
 
         val nullConfigs = topic.configs.asScala.filter(_.value == null).map(_.name)
         if (nullConfigs.nonEmpty)
-          throw new ConfigException(s"Null value not supported for topic configs: ${nullConfigs.mkString(",")}")
+          throw new InvalidConfigurationException(s"Null value not supported for topic configs: ${nullConfigs.mkString(",")}")
 
         if ((topic.numPartitions != NO_NUM_PARTITIONS || topic.replicationFactor != NO_REPLICATION_FACTOR)
             && !topic.assignments().isEmpty) {

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -158,7 +158,7 @@ class ZkAdminManager(val config: KafkaConfig,
 
         val nullConfigs = topic.configs.asScala.filter(_.value == null).map(_.name)
         if (nullConfigs.nonEmpty)
-          throw new InvalidRequestException(s"Null value not supported for topic configs : ${nullConfigs.mkString(",")}")
+          throw new ConfigException(s"Null value not supported for topic configs: ${nullConfigs.mkString(",")}")
 
         if ((topic.numPartitions != NO_NUM_PARTITIONS || topic.replicationFactor != NO_REPLICATION_FACTOR)
             && !topic.assignments().isEmpty) {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2233,8 +2233,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val newTopic = new NewTopic(topic, 2, brokerCount.toShort)
     assertFutureExceptionTypeEquals(
       client.createTopics(Collections.singletonList(newTopic.configs(invalidConfigs))).all,
-      classOf[InvalidRequestException],
-      Some("Null value not supported for topic configs : retention.bytes")
+      classOf[InvalidConfigurationException],
+      Some("Null value not supported for topic configs: retention.bytes")
     )
 
     val validConfigs = Map[String, String](LogConfig.CompressionTypeProp -> "producer")

--- a/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
@@ -58,8 +58,8 @@ class ControllerConfigurationValidatorTest {
     config.put(SEGMENT_JITTER_MS_CONFIG, "10")
     config.put(SEGMENT_BYTES_CONFIG, null)
     config.put(SEGMENT_MS_CONFIG, null)
-    assertEquals("Null value not supported for topic configs : segment.bytes,segment.ms",
-      assertThrows(classOf[InvalidRequestException], () => validator.validate(
+    assertEquals("Null value not supported for topic configs: segment.bytes,segment.ms",
+      assertThrows(classOf[InvalidConfigurationException], () => validator.validate(
         new ConfigResource(TOPIC, "foo"), config)). getMessage())
   }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -773,10 +773,18 @@ public class ReplicationControlManager {
         for (CreatableTopic topic : topics) {
             if (topicErrors.containsKey(topic.name())) continue;
             Map<String, Entry<OpType, String>> topicConfigs = new HashMap<>();
+            List<String> nullConfigs = new ArrayList<>();
             for (CreateTopicsRequestData.CreateableTopicConfig config : topic.configs()) {
-                topicConfigs.put(config.name(), new SimpleImmutableEntry<>(SET, config.value()));
+                if (config.value() == null) {
+                    nullConfigs.add(config.name());
+                } else {
+                    topicConfigs.put(config.name(), new SimpleImmutableEntry<>(SET, config.value()));
+                }
             }
-            if (!topicConfigs.isEmpty()) {
+            if (!nullConfigs.isEmpty()) {
+                topicErrors.put(topic.name(), new ApiError(Errors.INVALID_REQUEST,
+                    "Null value not supported for topic configs : " + String.join(",", nullConfigs)));
+            } else if (!topicConfigs.isEmpty()) {
                 configChanges.put(new ConfigResource(TOPIC, topic.name()), topicConfigs);
             }
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -782,8 +782,8 @@ public class ReplicationControlManager {
                 }
             }
             if (!nullConfigs.isEmpty()) {
-                topicErrors.put(topic.name(), new ApiError(Errors.INVALID_REQUEST,
-                    "Null value not supported for topic configs : " + String.join(",", nullConfigs)));
+                topicErrors.put(topic.name(), new ApiError(Errors.INVALID_CONFIG,
+                    "Null value not supported for topic configs: " + String.join(",", nullConfigs)));
             } else if (!topicConfigs.isEmpty()) {
                 configChanges.put(new ConfigResource(TOPIC, topic.name()), topicConfigs);
             }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -487,9 +487,9 @@ public class ReplicationControlManagerTest {
 
         ControllerResult<CreateTopicsResponseData> result2 =
             replicationControl.createTopics(request2, Collections.singleton("bar"));
-        assertEquals(Errors.INVALID_REQUEST.code(), result2.response().topics().find("bar").errorCode());
+        assertEquals(Errors.INVALID_CONFIG.code(), result2.response().topics().find("bar").errorCode());
         assertEquals(
-            "Null value not supported for topic configs : foo",
+            "Null value not supported for topic configs: foo",
             result2.response().topics().find("bar").errorMessage()
         );
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -445,6 +445,56 @@ public class ReplicationControlManagerTest {
     }
 
     @Test
+    public void testCreateTopicsWithConfigs() throws Exception {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+
+        CreateTopicsRequestData.CreateableTopicConfigCollection validConfigs =
+            new CreateTopicsRequestData.CreateableTopicConfigCollection();
+        validConfigs.add(
+            new CreateTopicsRequestData.CreateableTopicConfig()
+                .setName("foo")
+                .setValue("notNull")
+        );
+        CreateTopicsRequestData request1 = new CreateTopicsRequestData();
+        request1.topics().add(new CreatableTopic().setName("foo")
+            .setNumPartitions(-1).setReplicationFactor((short) -1)
+            .setConfigs(validConfigs));
+
+        ControllerResult<CreateTopicsResponseData> result1 =
+            replicationControl.createTopics(request1, Collections.singleton("foo"));
+        assertEquals((short) 0, result1.response().topics().find("foo").errorCode());
+
+        ctx.replay(result1.records());
+        assertEquals(
+            "notNull",
+            ctx.configurationControl.getConfigs(new ConfigResource(ConfigResource.Type.TOPIC, "foo")).get("foo")
+        );
+
+        CreateTopicsRequestData.CreateableTopicConfigCollection invalidConfigs =
+            new CreateTopicsRequestData.CreateableTopicConfigCollection();
+        invalidConfigs.add(
+            new CreateTopicsRequestData.CreateableTopicConfig()
+                .setName("foo")
+                .setValue(null)
+        );
+        CreateTopicsRequestData request2 = new CreateTopicsRequestData();
+        request2.topics().add(new CreatableTopic().setName("bar")
+            .setNumPartitions(-1).setReplicationFactor((short) -1)
+            .setConfigs(invalidConfigs));
+
+        ControllerResult<CreateTopicsResponseData> result2 =
+            replicationControl.createTopics(request2, Collections.singleton("bar"));
+        assertEquals(Errors.INVALID_REQUEST.code(), result2.response().topics().find("bar").errorCode());
+        assertEquals(
+            "Null value not supported for topic configs : foo",
+            result2.response().topics().find("bar").errorMessage()
+        );
+    }
+
+    @Test
     public void testBrokerCountMetrics() throws Exception {
         ReplicationControlTestContext ctx = new ReplicationControlTestContext();
         ReplicationControlManager replicationControl = ctx.replicationControl;


### PR DESCRIPTION
*More detailed description of your change*
When creating topics with customized configs, we should keep consistency with behavior in zk mode.

*Summary of testing strategy (including rationale)*
Change `PlaintextAdminIntegrationTest.testCreateTopicsReturnsConfigs` to support KRaft mode.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
