### PR TITLE
MINOR: Fix flaky testDescribeUnderReplicatedPartitions

### DIFF
--- a/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
@@ -588,7 +588,7 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
       val aliveServers = brokers.filterNot(_.config.brokerId == 0)
 
       if (isKRaftTest()) {
-        TestUtils.waitForKRaftBrokerMetadataCatchupController(
+        TestUtils.ensureConsistentKRaftMetadata(
           aliveServers,
           controllerServer,
           "Timeout waiting for partition metadata propagating to brokers"

--- a/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
@@ -586,11 +586,14 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
     try {
       killBroker(0)
       val aliveServers = brokers.filterNot(_.config.brokerId == 0)
-      TestUtils.waitForPartitionMetadata(aliveServers, testTopicName, 0)
+      TestUtils.waitUntilTrue(
+        () => aliveServers.forall(broker => broker.metadataCache.getPartitionInfo(testTopicName, 0).exists(_.isr().size() < 6)),
+        "Timeout waiting for partition metadata propagating to brokers"
+      )
       val output = TestUtils.grabConsoleOutput(
         topicService.describeTopic(new TopicCommandOptions(Array("--under-replicated-partitions"))))
       val rows = output.split("\n")
-      assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
+      assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"), s"Unexpected output: ${rows(0)}")
     } finally {
       restartDeadBrokers()
     }


### PR DESCRIPTION
*More detailed description of your change*
Currently, we are waiting for metadataCache to bookkeeper the partition info, this isn't enough, we should wait until the partition ISR is less than AR.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
