### PR TITLE
MINOR : Handle javax.ws.rs.NotFoundException in  ConnectExceptionMapper

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/errors/ConnectExceptionMapper.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/errors/ConnectExceptionMapper.java
@@ -45,7 +45,7 @@ public class ConnectExceptionMapper implements ExceptionMapper<Exception> {
                     .build();
         }
 
-        if (exception instanceof NotFoundException) {
+        if (exception instanceof NotFoundException || exception instanceof javax.ws.rs.NotFoundException) {
             return Response.status(Response.Status.NOT_FOUND)
                     .entity(new ErrorMessage(Response.Status.NOT_FOUND.getStatusCode(), exception.getMessage()))
                     .build();


### PR DESCRIPTION
Proposal to catch valid 404 exceptions, triggered by any HTTP request to a non existent path on the Connect REST API, higher in the code, not to log an ERROR log  on line 61 which can be seen as a false alarm

I was not able to find any existing unit test for this exception mapper

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
