### PR TITLE
rename isDone to hasComplete

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestFuture.java
@@ -55,7 +55,7 @@ public class RequestFuture<T> implements ConsumerNetworkClient.PollCondition {
      * Check whether the response is ready to be handled
      * @return true if the response is ready, false otherwise
      */
-    public boolean isDone() {
+    public boolean hasComplete() {
         return result.get() != INCOMPLETE_SENTINEL;
     }
 
@@ -80,7 +80,7 @@ public class RequestFuture<T> implements ConsumerNetworkClient.PollCondition {
      * @return true if the request completed and was successful
      */
     public boolean succeeded() {
-        return isDone() && !failed();
+        return hasComplete() && !failed();
     }
 
     /**


### PR DESCRIPTION
I used deep learning to discover that the method 'isDone' changed in 4af50bb8600c37ee2e3597fba9a54a29cef94afa.
The code snippet before and after the change is as follows.
```
public boolean isDone() {
        return isDone;
    }
```

```
public boolean isDone() {
        return result.get() != INCOMPLETE_SENTINEL;
    }
```
We thought we could rename `isDone` to `hasComplete` with a more specific meaning.

We are actually looking at analysing the reasons for renaming  identifiers and we would like to get advice from more experienced people, so would appreciate your feedback from one of the following perspectives.
 1. `(merge)`you accept this renaming opportunity and agree with the recommended name
 2. `(agree and not recommend)`you accept the renaming but disagree with the recommended name, do you think the recommended name means the same thing or is the recommended name simply not suitable?
3. `(not agree and useful)`Would our suggested renaming opportunity be useful for your other refactoring activities?
4. `(not agree and not fix) `You do not think our suggested renaming opportunity is appropriate. Is this because you think the identifier meaning does not need to be renamed or is it some other issue?
We look forward to your feedback!

Thank you!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
