### PR TITLE
MINOR: Fix link to old doc in quickstart

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -277,8 +277,8 @@ KTable&lt;String, Long&gt; wordCounts = textLines
 wordCounts.toStream().to("output-topic", Produced.with(Serdes.String(), Serdes.Long()));</code></pre>
 
         <p>
-            The <a href="/25/documentation/streams/quickstart">Kafka Streams demo</a>
-            and the <a href="/25/documentation/streams/tutorial">app development tutorial</a>
+            The <a href="/documentation/streams/quickstart">Kafka Streams demo</a>
+            and the <a href="/documentation/streams/tutorial">app development tutorial</a>
             demonstrate how to code and run such a streaming application from start to finish.
         </p>
 


### PR DESCRIPTION
In Kafka's quickstart a link points to the 2.5 Kafka Streams demo.
This PR fixes this link.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
