### PR TITLE
MINOR: Fix RecordContext Javadoc

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/RecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/RecordContext.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 
 /**
  * The context associated with the current record being processed by
- * an {@link org.apache.kafka.streams.processor.api.Processor}
+ * a {@link org.apache.kafka.streams.processor.Processor}
  */
 public interface RecordContext {
 


### PR DESCRIPTION
A prior commit accidentally changed the javadoc for RecordContext.
In reality, it is not reachable from api.Processor, only Processor.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
