### PR TITLE
MINOR: Followers should not have any remote replica states left over from previous leadership

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -579,7 +579,7 @@ class Partition(val topicPartition: TopicPartition,
       // Updating the assignment and ISR state is safe if the partition epoch is
       // larger or equal to the current partition epoch.
       updateAssignmentAndIsr(
-        assignment = replicas,
+        replicas = replicas,
         followers = replicas.filter(_ != localBrokerId),
         isr = isr,
         addingReplicas = addingReplicas,
@@ -674,7 +674,7 @@ class Partition(val topicPartition: TopicPartition,
       controllerEpoch = partitionState.controllerEpoch
 
       updateAssignmentAndIsr(
-        assignment = partitionState.replicas.asScala.iterator.map(_.toInt).toSeq,
+        replicas = partitionState.replicas.asScala.iterator.map(_.toInt).toSeq,
         followers = Seq.empty,
         isr = Set.empty,
         addingReplicas = partitionState.addingReplicas.asScala.map(_.toInt),
@@ -777,7 +777,7 @@ class Partition(val topicPartition: TopicPartition,
    *
    * Note: public visibility for tests.
    *
-   * @param assignment An ordered sequence of all the broker ids that were assigned to this
+   * @param replicas An ordered sequence of all the broker ids that were assigned to this
    *                   topic partition
    * @param followers An ordered sequence of all the followers (remote replicas)
    * @param isr The set of broker ids that are known to be insync with the leader
@@ -786,7 +786,7 @@ class Partition(val topicPartition: TopicPartition,
    * @param removingReplicas An ordered sequence of all broker ids that will be removed from
     *                         the assignment
    */
-  def updateAssignmentAndIsr(assignment: Seq[Int],
+  def updateAssignmentAndIsr(replicas: Seq[Int],
                              followers: Seq[Int],
                              isr: Set[Int],
                              addingReplicas: Seq[Int],
@@ -800,9 +800,9 @@ class Partition(val topicPartition: TopicPartition,
     remoteReplicasMap.removeAll(removedReplicas)
 
     if (addingReplicas.nonEmpty || removingReplicas.nonEmpty)
-      assignmentState = OngoingReassignmentState(addingReplicas, removingReplicas, assignment)
+      assignmentState = OngoingReassignmentState(addingReplicas, removingReplicas, replicas)
     else
-      assignmentState = SimpleAssignmentState(assignment)
+      assignmentState = SimpleAssignmentState(replicas)
     partitionState = CommittedPartitionState(isr, leaderRecoveryState)
   }
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1977,7 +1977,7 @@ class PartitionTest extends AbstractPartitionTest {
     // Test with ongoing reassignment
     partition.updateAssignmentAndIsr(
       replicas,
-      followers,
+      isLeader = true,
       isr,
       adding,
       removing,
@@ -1997,7 +1997,7 @@ class PartitionTest extends AbstractPartitionTest {
     val isr2 = Set(0, 3, 4, 5)
     partition.updateAssignmentAndIsr(
       replicas2,
-      followers2,
+      isLeader = true,
       isr2,
       Seq.empty,
       Seq.empty,
@@ -2013,7 +2013,7 @@ class PartitionTest extends AbstractPartitionTest {
     val replicas3 = Seq(1, 2, 3, 4)
     partition.updateAssignmentAndIsr(
       replicas3,
-      Seq.empty,
+      isLeader = false,
       Set.empty,
       Seq.empty,
       Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -85,7 +85,7 @@ class HighwatermarkPersistenceTest {
       partition0.setLog(log0, isFutureLog = false)
 
       partition0.updateAssignmentAndIsr(
-        assignment = Seq(configs.head.brokerId, configs.last.brokerId),
+        replicas = Seq(configs.head.brokerId, configs.last.brokerId),
         followers = Seq(configs.last.brokerId),
         isr = Set(configs.head.brokerId),
         addingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -86,7 +86,7 @@ class HighwatermarkPersistenceTest {
 
       partition0.updateAssignmentAndIsr(
         replicas = Seq(configs.head.brokerId, configs.last.brokerId),
-        followers = Seq(configs.last.brokerId),
+        isLeader = true,
         isr = Set(configs.head.brokerId),
         addingReplicas = Seq.empty,
         removingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -86,6 +86,7 @@ class HighwatermarkPersistenceTest {
 
       partition0.updateAssignmentAndIsr(
         assignment = Seq(configs.head.brokerId, configs.last.brokerId),
+        followers = Seq(configs.last.brokerId),
         isr = Set(configs.head.brokerId),
         addingReplicas = Seq.empty,
         removingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -227,7 +227,7 @@ class IsrExpirationTest {
 
     partition.updateAssignmentAndIsr(
       replicas = configs.map(_.brokerId),
-      followers = configs.tail.map(_.brokerId),
+      isLeader = true,
       isr = configs.map(_.brokerId).toSet,
       addingReplicas = Seq.empty,
       removingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -227,6 +227,7 @@ class IsrExpirationTest {
 
     partition.updateAssignmentAndIsr(
       assignment = configs.map(_.brokerId),
+      followers = configs.tail.map(_.brokerId),
       isr = configs.map(_.brokerId).toSet,
       addingReplicas = Seq.empty,
       removingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -226,7 +226,7 @@ class IsrExpirationTest {
     partition.setLog(localLog, isFutureLog = false)
 
     partition.updateAssignmentAndIsr(
-      assignment = configs.map(_.brokerId),
+      replicas = configs.map(_.brokerId),
       followers = configs.tail.map(_.brokerId),
       isr = configs.map(_.brokerId).toSet,
       addingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -332,6 +332,7 @@ class ReplicaManagerQuotasTest {
 
       partition.updateAssignmentAndIsr(
         assignment = Seq(leaderBrokerId, configs.last.brokerId),
+        followers = Seq(configs.last.brokerId),
         isr = if (bothReplicasInSync) Set(leaderBrokerId, configs.last.brokerId) else Set(leaderBrokerId),
         addingReplicas = Seq.empty,
         removingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -345,7 +345,7 @@ class ReplicaManagerQuotasTest {
       partition.setLog(log, isFutureLog = false)
 
       partition.updateAssignmentAndIsr(
-        assignment = Seq(leaderBrokerId, configs.last.brokerId),
+        replicas = Seq(leaderBrokerId, configs.last.brokerId),
         followers = Seq(configs.last.brokerId),
         isr = if (bothReplicasInSync) Set(leaderBrokerId, configs.last.brokerId) else Set(leaderBrokerId),
         addingReplicas = Seq.empty,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -346,7 +346,7 @@ class ReplicaManagerQuotasTest {
 
       partition.updateAssignmentAndIsr(
         replicas = Seq(leaderBrokerId, configs.last.brokerId),
-        followers = Seq(configs.last.brokerId),
+        isLeader = true,
         isr = if (bothReplicasInSync) Set(leaderBrokerId, configs.last.brokerId) else Set(leaderBrokerId),
         addingReplicas = Seq.empty,
         removingReplicas = Seq.empty,


### PR DESCRIPTION
While investigating https://github.com/apache/kafka/commit/4218fc61fedb02b78d35c88e56ab253baaf09f39, I noted that a follower doesn't clean up its remote replica states when it becomes a follower. So when it transition from leader to follower, remote replica states are kept around. This patch ensures that they are cleaned up.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
