### PR TITLE
 KAFKA-13892: Dedupe RemoveAccessControlEntryRecord in deleteAcls response of AclControlManager

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -41,11 +41,13 @@ import org.apache.kafka.timeline.TimelineHashSet;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 /**
@@ -152,7 +154,11 @@ public class AclControlManager {
                 results.add(new AclDeleteResult(ApiError.fromThrowable(e).exception()));
             }
         }
-        return ControllerResult.atomicOf(records, results);
+        return ControllerResult.atomicOf(dedupeApiMessageAndVersion(records), results);
+    }
+
+    private List<ApiMessageAndVersion> dedupeApiMessageAndVersion(List<ApiMessageAndVersion> messages) {
+        return new HashSet<>(messages).stream().collect(Collectors.toList());
     }
 
     AclDeleteResult deleteAclsForFilter(AclBindingFilter filter,

--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -144,7 +145,7 @@ public class AclControlManager {
 
     ControllerResult<List<AclDeleteResult>> deleteAcls(List<AclBindingFilter> filters) {
         List<AclDeleteResult> results = new ArrayList<>();
-        List<ApiMessageAndVersion> records = new ArrayList<>();
+        Set<ApiMessageAndVersion> records = new HashSet<>();
         for (AclBindingFilter filter : filters) {
             try {
                 validateFilter(filter);
@@ -154,15 +155,11 @@ public class AclControlManager {
                 results.add(new AclDeleteResult(ApiError.fromThrowable(e).exception()));
             }
         }
-        return ControllerResult.atomicOf(dedupeApiMessageAndVersion(records), results);
-    }
-
-    private List<ApiMessageAndVersion> dedupeApiMessageAndVersion(List<ApiMessageAndVersion> messages) {
-        return new HashSet<>(messages).stream().collect(Collectors.toList());
+        return ControllerResult.atomicOf(records.stream().collect(Collectors.toList()), results);
     }
 
     AclDeleteResult deleteAclsForFilter(AclBindingFilter filter,
-                                        List<ApiMessageAndVersion> records) {
+                                        Set<ApiMessageAndVersion> records) {
         List<AclBindingDeleteResult> deleted = new ArrayList<>();
         for (Entry<Uuid, StandardAcl> entry : idToAcl.entrySet()) {
             Uuid id = entry.getKey();


### PR DESCRIPTION
## JIRA
https://issues.apache.org/jira/browse/KAFKA-13892

### Details
In https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java#L143 we loop through the ACL filters and and add `RemoveAccessControlEntryRecord` records to the response list for each matching ACL. There's a bug where if two (or more) filters match the same ACL, we create two (or more) `RemoveAccessControlEntryRecord` records for the same ACL. This is an issue because upon replay we throw an exception (https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java#L195) if the ACL is not in the in-memory data structures which will happen to the second `RemoveAccessControlEntryRecord`.

I don't think we need to dedupe `List<AclDeleteResult>`. It contains a list of results, where each result contains the ACLs that matched the filter. It should be OK for the same ACL to be in multiple AclDeleteResult results because it really could match multiple filters.


### Testing
- Added a unit test that tests the new behavior
- Ran pre-existing `AclControlManager` tests:
```
 kafka % ./gradlew metadata:test --tests org.apache.kafka.controller.AclControlManagerTest --rerun-tasks

> Configure project :
Starting build with version 3.3.0-SNAPSHOT (commit id 796b648d) using Gradle 7.4.2, Java 1.8 and Scala 2.13.6
Build properties: maxParallelForks=12, maxScalacThreads=8, maxTestRetries=0

> Task :raft:processMessages
MessageGenerator: processed 1 Kafka message JSON files(s).

> Task :metadata:processMessages
MessageGenerator: processed 19 Kafka message JSON files(s).

> Task :clients:processMessages
MessageGenerator: processed 144 Kafka message JSON files(s).

> Task :clients:processTestMessages
MessageGenerator: processed 2 Kafka message JSON files(s).

> Task :metadata:spotbugsMain
[main] INFO edu.umd.cs.findbugs.ExitCodes - Calculating exit code...

> Task :metadata:test

AclControlManagerTest > testValidateFilter() PASSED

AclControlManagerTest > testValidateNewAcl() PASSED

AclControlManagerTest > testLoadSnapshot() PASSED

AclControlManagerTest > testDeleteDedupe() PASSED

AclControlManagerTest > testCreateAclDeleteAcl() PASSED

AclControlManagerTest > testAddAndDelete() PASSED

BUILD SUCCESSFUL in 34s
29 actionable tasks: 29 executed
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
