### PR TITLE
MINOR: parameter name fix for maxScalacThreads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
     )
 
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
-  maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacParallelism.toInteger() :
+  maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :
       Math.min(Runtime.runtime.availableProcessors(), 8)
   userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false
 


### PR DESCRIPTION
While running unitTest and integrationTest by tweaking the scala parallel threads parameter, hit this issue where the command `./gradlew -PmaxScalacThreads=4 unitTest` errored out, pointing to the bug of incorrect parameter name reference expected vs used. 

This commit is rectifying the parameter reference to be used. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
