### PR TITLE
MINOR: Fix DSL typo in streams docs

### DIFF
--- a/docs/streams/developer-guide/dsl-topology-naming.html
+++ b/docs/streams/developer-guide/dsl-topology-naming.html
@@ -41,7 +41,7 @@
 		   you are required to explicitly name each one.
 	    </p>
 		<p>
-		   At the DLS layer, there are operators.  A single DSL operator may
+		   At the DSL layer, there are operators.  A single DSL operator may
 		   compile down to multiple <code>Processors</code> and <code>State Stores</code>, and
 		   if required <code>repartition topics</code>. But with the Kafka Streams
 		   DSL, all these names are generated for you. There is a relationship between


### PR DESCRIPTION
Minor typo.

