### PR TITLE
KAFKA-12828 Remove deprecated methods in KeyQueryMetadata

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -53,39 +53,6 @@ public class KeyQueryMetadata {
      * Get the active Kafka Streams instance for given key.
      *
      * @return active instance's {@link HostInfo}
-     * @deprecated Use {@link #activeHost()} instead.
-     */
-    @Deprecated
-    public HostInfo getActiveHost() {
-        return activeHost;
-    }
-
-    /**
-     * Get the Kafka Streams instances that host the key as standbys.
-     *
-     * @return set of standby {@link HostInfo} or a empty set, if no standbys are configured
-     * @deprecated Use {@link #standbyHosts()} instead.
-     */
-    @Deprecated
-    public Set<HostInfo> getStandbyHosts() {
-        return standbyHosts;
-    }
-
-    /**
-     * Get the store partition corresponding to the key.
-     *
-     * @return store partition number
-     * @deprecated Use {@link #partition()} instead.
-     */
-    @Deprecated
-    public int getPartition() {
-        return partition;
-    }
-
-    /**
-     * Get the active Kafka Streams instance for given key.
-     *
-     * @return active instance's {@link HostInfo}
      */
     public HostInfo activeHost() {
         return activeHost;


### PR DESCRIPTION
*Remove the deprecated `getActiveHost()`, `getStandbyHosts()` and `getPartition()` methods in `KeyQueryMetadata`*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
