### PR TITLE
MINOR: Update release versions for upgrade tests with 3.1.1 release

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -99,7 +99,7 @@ versions += [
   kafka_27: "2.7.1",
   kafka_28: "2.8.1",
   kafka_30: "3.0.1",
-  kafka_31: "3.1.0",
+  kafka_31: "3.1.1",
   kafka_32: "3.2.0",
   lz4: "1.8.0",
   mavenArtifact: "3.8.4",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN mkdir -p "/opt/kafka-2.6.2" && chmod a+rw /opt/kafka-2.6.2 && curl -s "$KAFK
 RUN mkdir -p "/opt/kafka-2.7.1" && chmod a+rw /opt/kafka-2.7.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.7.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.7.1"
 RUN mkdir -p "/opt/kafka-2.8.1" && chmod a+rw /opt/kafka-2.8.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.8.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.8.1"
 RUN mkdir -p "/opt/kafka-3.0.1" && chmod a+rw /opt/kafka-3.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.0.1"
-RUN mkdir -p "/opt/kafka-3.1.0" && chmod a+rw /opt/kafka-3.1.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.0"
+RUN mkdir -p "/opt/kafka-3.1.1" && chmod a+rw /opt/kafka-3.1.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.1"
 RUN mkdir -p "/opt/kafka-3.2.0" && chmod a+rw /opt/kafka-3.2.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.2.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.2.0"
 
 # Streams test dependencies
@@ -84,8 +84,8 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.6.2-test.jar" -o /opt/kafka-2.6.2/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.7.1-test.jar" -o /opt/kafka-2.7.1/libs/kafka-streams-2.7.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.8.1-test.jar" -o /opt/kafka-2.8.1/libs/kafka-streams-2.8.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.0.1-test.jar" -o /opt/kafka-3.0.1/libs/kafka-streams-3.0.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.1.0-test.jar" -o /opt/kafka-3.1.0/libs/kafka-streams-3.1.0-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.2.0-test.jar" -o /opt/kafka-3.1.0/libs/kafka-streams-3.2.0-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.1.1-test.jar" -o /opt/kafka-3.1.1/libs/kafka-streams-3.1.1-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.2.0-test.jar" -o /opt/kafka-3.2.0/libs/kafka-streams-3.2.0-test.jar
 
 # The version of Kibosh to use for testing.
 # If you update this, also update vagrant/base.sh

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -219,7 +219,8 @@ LATEST_3_0 = V_3_0_1
 
 # 3.1.x versions
 V_3_1_0 = KafkaVersion("3.1.0")
-LATEST_3_1 = V_3_1_0
+V_3_1_1 = KafkaVersion("3.1.1")
+LATEST_3_1 = V_3_1_1
 
 # 3.2.x versions
 V_3_2_0 = KafkaVersion("3.2.0")

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -150,8 +150,8 @@ get_kafka 2.8.1 2.12
 chmod a+rw /opt/kafka-2.8.1
 get_kafka 3.0.1 2.12
 chmod a+rw /opt/kafka-3.0.1
-get_kafka 3.1.0 2.12
-chmod a+rw /opt/kafka-3.1.0
+get_kafka 3.1.1 2.12
+chmod a+rw /opt/kafka-3.1.1
 get_kafka 3.2.0 2.12
 chmod a+rw /opt/kafka-3.2.0
 


### PR DESCRIPTION
Updates release versions in files that are used for upgrade test with the 3.1.1 release version.

(Also fixes a mistaken kafka-3.1.0 → kafka-3.2.0 in the Dockerfile)