### PR TITLE
KAFKA-13889: Fix AclsDelta to handle ACCESS_CONTROL_ENTRY_RECORD quickly followed by REMOVE_ACCESS_CONTROL_ENTRY_RECORD for same ACL

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/AclsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/AclsDelta.java
@@ -44,6 +44,12 @@ public final class AclsDelta {
         this.image = image;
     }
 
+    /**
+     * Returns a Map of deltas from ACL ID to optional StandardAcl. An empty optional value indicates the ACL
+     * is for removal. An optional with a value indicates the ACL is to be added.
+     *
+     * @return Map of deltas.
+     */
     public Map<Uuid, Optional<StandardAcl>> changes() {
         return changes;
     }
@@ -65,13 +71,21 @@ public final class AclsDelta {
         changes.put(aclWithId.id(), Optional.of(aclWithId.acl()));
     }
 
+    /**
+     * This method replays a RemoveAccessControlEntryRecord record. If the current image contains the ACL
+     * the removal is stored as an Optional.empty() value in the Map. If the changes Map contains the ACL
+     * it means the ACL was recently applied and isn't in the image yet, in which case the ACL can be totally removed
+     * from the Map because there is no need to add it then delete it when the changes are applied.
+     *
+     * @param record Log metadata record to replay.
+     */
     public void replay(RemoveAccessControlEntryRecord record) {
         if (image.acls().containsKey(record.id())) {
             changes.put(record.id(), Optional.empty());
         } else if (changes.containsKey(record.id())) {
             changes.remove(record.id());
         } else {
-            throw new RuntimeException("Failed to find existing ACL with ID " + record.id() + " in either image or changes");
+            throw new IllegalStateException("Failed to find existing ACL with ID " + record.id() + " in either image or changes");
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/AclsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/AclsDelta.java
@@ -66,7 +66,13 @@ public final class AclsDelta {
     }
 
     public void replay(RemoveAccessControlEntryRecord record) {
-        changes.put(record.id(), Optional.empty());
+        if (image.acls().containsKey(record.id())) {
+            changes.put(record.id(), Optional.empty());
+        } else if (changes.containsKey(record.id())) {
+            changes.remove(record.id());
+        } else {
+            throw new RuntimeException("Failed to find existing ACL with ID " + record.id() + " in either image or changes");
+        }
     }
 
     public AclsImage apply() {

--- a/metadata/src/test/java/org/apache/kafka/image/AclsDeltaTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/AclsDeltaTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.AccessControlEntryRecord;
+import org.apache.kafka.common.metadata.RemoveAccessControlEntryRecord;
+import org.apache.kafka.metadata.authorizer.StandardAcl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Timeout(40)
+public class AclsDeltaTest {
+
+    private Uuid aclId = Uuid.fromString("iOZpss6VQUmD6blnqzl50g");
+
+    @Test
+    public void testRemovesDeleteIfNotInImage() {
+        AclsImage image = new AclsImage(Collections.emptyMap());
+        AclsDelta delta = new AclsDelta(image);
+        AccessControlEntryRecord inputAclRecord = testAccessControlEntryRecord();
+
+        assertEquals(0, delta.changes().size());
+
+        delta.replay(inputAclRecord);
+        assertTrue(delta.changes().containsKey(aclId));
+        assertTrue(delta.changes().get(aclId).isPresent());
+        assertEquals(testStandardAcl(), delta.changes().get(aclId).get());
+
+        RemoveAccessControlEntryRecord inputRemoveAclRecord = testRemoveAccessControlEntryRecord();
+        delta.replay(inputRemoveAclRecord);
+
+        assertFalse(delta.changes().containsKey(aclId));
+    }
+
+    @Test
+    public void testKeepsDeleteIfInImage() {
+        Map<Uuid, StandardAcl> initialImageMap = new HashMap<>();
+        initialImageMap.put(aclId, testStandardAcl());
+        AclsImage image = new AclsImage(initialImageMap);
+        AclsDelta delta = new AclsDelta(image);
+
+        assertEquals(0, delta.changes().size());
+
+        RemoveAccessControlEntryRecord removeAccessControlEntryRecord = testRemoveAccessControlEntryRecord();
+        delta.replay(removeAccessControlEntryRecord);
+
+        assertTrue(delta.changes().containsKey(aclId));
+        assertEquals(Optional.empty(), delta.changes().get(aclId));
+    }
+
+    @Test
+    public void testThrowsExceptionOnInvalidState() {
+        AclsImage image = new AclsImage(Collections.emptyMap());
+        AclsDelta delta = new AclsDelta(image);
+
+        RemoveAccessControlEntryRecord removeAccessControlEntryRecord = testRemoveAccessControlEntryRecord();
+        assertThrows(RuntimeException.class, () -> delta.replay(removeAccessControlEntryRecord));
+    }
+
+    private AccessControlEntryRecord testAccessControlEntryRecord() {
+        AccessControlEntryRecord record = new AccessControlEntryRecord();
+        record.setId(aclId);
+        record.setResourceType((byte) 1);
+        record.setResourceName("foo");
+        record.setPatternType((byte) 1);
+        record.setPrincipal("User:user");
+        record.setHost("host");
+        record.setOperation((byte) 1);
+        record.setPermissionType((byte) 1);
+        return record;
+    }
+
+    private RemoveAccessControlEntryRecord testRemoveAccessControlEntryRecord() {
+        RemoveAccessControlEntryRecord record = new RemoveAccessControlEntryRecord();
+        record.setId(aclId);
+        return record;
+    }
+
+    private StandardAcl testStandardAcl() {
+        return StandardAcl.fromRecord(testAccessControlEntryRecord());
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/AclsDeltaTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/AclsDeltaTest.java
@@ -48,8 +48,6 @@ public class AclsDeltaTest {
         assertEquals(0, delta.changes().size());
 
         delta.replay(inputAclRecord);
-        assertTrue(delta.changes().containsKey(aclId));
-        assertTrue(delta.changes().get(aclId).isPresent());
         assertEquals(Optional.of(testStandardAcl()), delta.changes().get(aclId));
 
         RemoveAccessControlEntryRecord inputRemoveAclRecord = testRemoveAccessControlEntryRecord();


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/KAFKA-13889

### Description
- Fixes `AclsDelta` to handle `ACCESS_CONTROL_ENTRY_RECORD` quickly followed by `REMOVE_ACCESS_CONTROL_ENTRY_RECORD` for same ACL
- As explained in the JIRA, in https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/image/AclsDelta.java#L64 we store the pending deletion in the `changes` Map. This could override a creation that might have just happened. This is an issue because in `BrokerMetadataPublisher` this results in us making a `removeAcl` call which finally results in https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java#L203 being executed and this code throws an exception if the ACL isnt in the Map yet. If the `ACCESS_CONTROL_ENTRY_RECORD` event never got processed by `BrokerMetadataPublisher` then the ACL wont be in the Map yet.
- So the fix here is to remove the entry from the `changes` Map if the ACL doesnt exist in the image yet. 

### Testing
- Added unit tests for new behavior


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
