### PR TITLE
Minor: Remove extraneous code in LocalLogManager

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -243,11 +243,6 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
         }
 
         public synchronized long append(LocalBatch batch) {
-            try {
-                throw new RuntimeException("foo");
-            } catch (Exception e) {
-                log.info("WATERMELON: appending {}", batch, e);
-            }
             prevOffset += batch.size();
             log.debug("append(batch={}, prevOffset={})", batch, prevOffset);
             batches.put(prevOffset, batch);


### PR DESCRIPTION
Looks like this was some left over test code. 