### PR TITLE
MINOR: Convert admin integration tests

### DIFF
--- a/core/src/test/java/kafka/test/ClusterInstance.java
+++ b/core/src/test/java/kafka/test/ClusterInstance.java
@@ -30,7 +30,7 @@ public interface ClusterInstance {
 
     enum ClusterType {
         ZK,
-        RAFT
+        KRAFT
     }
 
     /**
@@ -39,7 +39,7 @@ public interface ClusterInstance {
     ClusterType clusterType();
 
     default boolean isKRaftTest() {
-        return clusterType() == ClusterType.RAFT;
+        return clusterType() == ClusterType.KRAFT;
     }
 
     /**

--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -95,7 +95,7 @@ public class ClusterTestExtensionsTest {
         if (clusterInstance.clusterType().equals(ClusterInstance.ClusterType.ZK)) {
             Assertions.assertEquals(clusterInstance.config().serverProperties().getProperty("foo"), "bar");
             Assertions.assertEquals(clusterInstance.config().serverProperties().getProperty("spam"), "eggs");
-        } else if (clusterInstance.clusterType().equals(ClusterInstance.ClusterType.RAFT)) {
+        } else if (clusterInstance.clusterType().equals(ClusterInstance.ClusterType.KRAFT)) {
             Assertions.assertEquals(clusterInstance.config().serverProperties().getProperty("foo"), "baz");
             Assertions.assertEquals(clusterInstance.config().serverProperties().getProperty("spam"), "eggz");
         } else {

--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -170,7 +170,7 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
 
         @Override
         public ClusterType clusterType() {
-            return ClusterType.RAFT;
+            return ClusterType.KRAFT;
         }
 
         @Override

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -19,9 +19,10 @@ package kafka.api
 import java.util
 import java.util.Properties
 import java.util.concurrent.ExecutionException
+
 import kafka.security.authorizer.AclEntry
 import kafka.server.KafkaConfig
-import kafka.utils.Logging
+import kafka.utils.{Logging, TestInfoUtils}
 import kafka.utils.TestUtils._
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateTopicsOptions, CreateTopicsResult, DescribeClusterOptions, DescribeTopicsOptions, NewTopic, TopicDescription}
 import org.apache.kafka.common.Uuid
@@ -30,7 +31,9 @@ import org.apache.kafka.common.errors.{TopicExistsException, UnknownTopicOrParti
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.utils.Utils
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo, Timeout}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
@@ -66,8 +69,9 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
     super.tearDown()
   }
 
-  @Test
-  def testCreateDeleteTopics(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testCreateDeleteTopics(quorum: String): Unit = {
     client = Admin.create(createConfig)
     val topics = Seq("mytopic", "mytopic2", "mytopic3")
     val newTopics = Seq(
@@ -159,8 +163,9 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
     waitForTopics(client, List(), topics)
   }
 
-  @Test
-  def testAuthorizedOperations(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testAuthorizedOperations(quorum: String): Unit = {
     client = Admin.create(createConfig)
 
     // without includeAuthorizedOperations flag


### PR DESCRIPTION
This patch enables KRaft support in `PlaintextAdminIntegrationTest`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
