### PR TITLE
KAFKA-13907: Fix hanging ServerShutdownTest.testCleanShutdownWithKRaftControllerUnavailable

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -53,6 +53,7 @@ import org.apache.kafka.server.util.timer.{SystemTimer, SystemTimerReaper}
 import org.apache.kafka.server.util.{Deadline, FutureUtils, KafkaScheduler}
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel
 
+import java.time.Duration
 import java.util
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicBoolean
@@ -623,9 +624,10 @@ class BrokerServer(
     }
   }
 
-  override def shutdown(): Unit = {
+  override def shutdown(timeout: Duration): Unit = {
     if (!maybeChangeStatus(STARTED, SHUTTING_DOWN)) return
     try {
+      val deadline = time.milliseconds() + timeout.toMillis;
       info("shutting down")
 
       if (config.controlledShutdownEnable) {
@@ -634,7 +636,8 @@ class BrokerServer(
 
         lifecycleManager.beginControlledShutdown()
         try {
-          lifecycleManager.controlledShutdownFuture.get(5L, TimeUnit.MINUTES)
+          val controlledShutdownTimeoutMs = deadline - time.milliseconds()
+          lifecycleManager.controlledShutdownFuture.get(controlledShutdownTimeoutMs, TimeUnit.MILLISECONDS)
         } catch {
           case _: TimeoutException =>
             error("Timed out waiting for the controller to approve controlled shutdown")

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -37,6 +37,7 @@ import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 import org.apache.kafka.server.util.Scheduler
 
+import java.time.Duration
 import java.util
 import scala.collection.Seq
 import scala.jdk.CollectionConverters._
@@ -92,7 +93,8 @@ trait KafkaBroker extends Logging {
   def boundPort(listenerName: ListenerName): Int
   def startup(): Unit
   def awaitShutdown(): Unit
-  def shutdown(): Unit
+  def shutdown(): Unit = shutdown(Duration.ofMinutes(5))
+  def shutdown(timeout: Duration): Unit
   def brokerTopicStats: BrokerTopicStats
   def credentialProvider: CredentialProvider
   def clientToControllerChannelManager: NodeToControllerChannelManager

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -68,6 +68,7 @@ import org.apache.zookeeper.client.ZKClientConfig
 import java.io.{File, IOException}
 import java.net.{InetAddress, SocketTimeoutException}
 import java.nio.file.{Files, Paths}
+import java.time.Duration
 import java.util
 import java.util.{Optional, OptionalInt, OptionalLong}
 import java.util.concurrent._
@@ -947,7 +948,7 @@ class KafkaServer(
    * Shutdown API for shutting down a single instance of the Kafka server.
    * Shuts down the LogManager, the SocketServer and the log cleaner scheduler thread
    */
-  override def shutdown(): Unit = {
+  override def shutdown(timeout: Duration): Unit = {
     try {
       info("shutting down")
 

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -597,7 +597,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 int brokerId = entry.getKey();
                 BrokerServer broker = entry.getValue();
                 futureEntries.add(new SimpleImmutableEntry<>("broker" + brokerId,
-                    executorService.submit(broker::shutdown)));
+                    executorService.submit((Runnable) broker::shutdown)));
             }
             waitForAllFutures(futureEntries);
             futureEntries.clear();

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEX
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 
 import java.io.File
+import java.time.Duration
 import java.util
 import java.util.{Arrays, Collections, Properties}
 import scala.collection.{Seq, mutable}
@@ -259,9 +260,21 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     index
   }
 
+  /**
+   * Kill the broker at the specified index.
+   * A controlled shutdown is attempted, with a timeout of 5 minutes.
+   */
   def killBroker(index: Int): Unit = {
-    if (alive(index)) {
-      _brokers(index).shutdown()
+    killBroker(index, Duration.ofMinutes(5))
+  }
+
+  /**
+   * Kill the broker at the specified index.
+   * A controlled shutdown is attempted, with the specified timeout.
+   */
+  def killBroker(index: Int, timeout: Duration): Unit = {
+    if(alive(index)) {
+      _brokers(index).shutdown(timeout)
       _brokers(index).awaitShutdown()
       alive(index) = false
     }

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -39,12 +39,13 @@ import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerial
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.config.ZkConfigs
-import org.junit.jupiter.api.{BeforeEach, Disabled, TestInfo, Timeout}
+import org.junit.jupiter.api.{BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import java.time.Duration
 import java.util.Properties
 import scala.collection.Seq
 import scala.jdk.CollectionConverters._
@@ -197,12 +198,11 @@ class ServerShutdownTest extends KafkaServerTestHarness {
     verifyNonDaemonThreadsStatus()
   }
 
-  @Disabled
   @ParameterizedTest
   @ValueSource(strings = Array("kraft"))
-  def testCleanShutdownWithKRaftControllerUnavailable(quorum: String): Unit = {
+  def testShutdownWithKRaftControllerUnavailable(quorum: String): Unit = {
     shutdownKRaftController()
-    shutdownBroker()
+    killBroker(0, Duration.ofSeconds(1))
     CoreUtils.delete(broker.config.logDirs)
     verifyNonDaemonThreadsStatus()
   }


### PR DESCRIPTION
When a controlled shutdown is requested the broker tries to communicate the state change to the controller via a heartbeat request. [1]

In this test, the controller is not available so the request will fail. The current timeout behavior in a heartbeat request is to just keep retrying — which generally makes sense, just not in the context of a controlled shutdown.

When a heartbeat request times out, if we are in the middle of a controlled shutdown, we shouldn't just retry forever but rather just give up on trying to contact the controller and proceed with the controlled shutdown.

[1] https://github.com/apache/kafka/blob/f2d6282668a31b9a554563338f9178e2bba2833f/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala#L217

*Summary of testing strategy*
The test no longer fails

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
