### PR TITLE
KAFKA-14146: Config file option for MessageReader/MessageFormatter in ConsoleProducer/ConsoleConsumer (KIP-840)

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -248,6 +248,10 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("prop")
       .ofType(classOf[String])
+    val messageFormatterConfigOpt = parser.accepts("formatter-config", s"Config properties file to initialize the message formatter. Note that $messageFormatterArgOpt takes precedence over this config.")
+      .withRequiredArg
+      .describedAs("config file")
+      .ofType(classOf[String])
     val resetBeginningOpt = parser.accepts("from-beginning", "If the consumer does not already have an established offset to consume from, " +
       "start with the earliest message present in the log rather than the latest message.")
     val maxMessagesOpt = parser.accepts("max-messages", "The maximum number of messages to consume before exiting. If not set, consumption is continual.")
@@ -307,7 +311,11 @@ object ConsoleConsumer extends Logging {
     val partitionArg = if (options.has(partitionIdOpt)) Some(options.valueOf(partitionIdOpt).intValue) else None
     val skipMessageOnError = options.has(skipMessageOnErrorOpt)
     val messageFormatterClass = Class.forName(options.valueOf(messageFormatterOpt))
-    val formatterArgs = CommandLineUtils.parseKeyValueArgs(options.valuesOf(messageFormatterArgOpt).asScala)
+    val formatterArgs = if (options.has(messageFormatterConfigOpt))
+      Utils.loadProps(options.valueOf(messageFormatterConfigOpt))
+    else
+      new Properties()
+    formatterArgs ++= CommandLineUtils.parseKeyValueArgs(options.valuesOf(messageFormatterArgOpt).asScala)
     val maxMessages = if (options.has(maxMessagesOpt)) options.valueOf(maxMessagesOpt).intValue else -1
     val timeoutMs = if (options.has(timeoutMsOpt)) options.valueOf(timeoutMsOpt).intValue else -1
     val bootstrapServer = options.valueOf(bootstrapServerOpt)

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -71,7 +71,10 @@ object ConsoleProducer {
   }
 
   def getReaderProps(config: ProducerConfig): Properties = {
-    val props = new Properties
+    val props =
+      if (config.options.has(config.readerConfigOpt))
+        Utils.loadProps(config.options.valueOf(config.readerConfigOpt))
+      else new Properties
     props.put("topic", config.topic)
     props ++= config.cmdLineProps
     props
@@ -240,6 +243,10 @@ object ConsoleProducer {
       )
       .withRequiredArg
       .describedAs("prop")
+      .ofType(classOf[String])
+    val readerConfigOpt = parser.accepts("reader-config", s"Config properties file for the message reader. Note that $propertyOpt takes precedence over this config.")
+      .withRequiredArg
+      .describedAs("config file")
       .ofType(classOf[String])
     val producerPropertyOpt = parser.accepts("producer-property", "A mechanism to pass user-defined properties in the form key=value to the producer. ")
             .withRequiredArg

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -483,9 +483,36 @@ class ConsoleConsumerTest {
     assertTrue(config.formatterArgs.containsKey("key.deserializer.my-props"))
     val formatter = config.formatter.asInstanceOf[DefaultMessageFormatter]
     assertTrue(formatter.keyDeserializer.get.isInstanceOf[MockDeserializer])
-    assertEquals(1, formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].configs.size)
-    assertEquals("abc", formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].configs.get("my-props"))
-    assertTrue(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isKey)
+    val keyDeserializer = formatter.keyDeserializer.get.asInstanceOf[MockDeserializer]
+    assertEquals(1, keyDeserializer.configs.size)
+    assertEquals("abc", keyDeserializer.configs.get("my-props"))
+    assertTrue(keyDeserializer.isKey)
+  }
+
+  @Test
+  def testCustomConfigShouldBePassedToConfigureMethod(): Unit = {
+    val propsFile = TestUtils.tempFile()
+    val propsStream = Files.newOutputStream(propsFile.toPath)
+    propsStream.write("key.deserializer.my-props=abc\n".getBytes())
+    propsStream.write("print.key=false".getBytes())
+    propsStream.close()
+
+    val args = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--property", "print.key=true",
+      "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+      "--formatter-config", propsFile.getAbsolutePath
+    )
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+    assertTrue(config.formatter.isInstanceOf[DefaultMessageFormatter])
+    assertTrue(config.formatterArgs.containsKey("key.deserializer.my-props"))
+    val formatter = config.formatter.asInstanceOf[DefaultMessageFormatter]
+    assertTrue(formatter.keyDeserializer.get.isInstanceOf[MockDeserializer])
+    val keyDeserializer = formatter.keyDeserializer.get.asInstanceOf[MockDeserializer]
+    assertEquals(1, keyDeserializer.configs.size)
+    assertEquals("abc", keyDeserializer.configs.get("my-props"))
+    assertTrue(keyDeserializer.isKey)
   }
 
   @Test


### PR DESCRIPTION
[KIP-840](https://cwiki.apache.org/confluence/x/bBqhD) [KAFKA-14146](https://issues.apache.org/jira/browse/KAFKA-14146)

`kafka-console-producer.sh` & `kafka-console-consumer.sh` scripts have a `--property` that can be set multiple times. This PR allows to set those properties through a config file with `--config` instead of multiple `--property` options.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
