### PR TITLE
KAKFA-13410 Generate snapshot prior to metadata.version upgrade

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1768,7 +1768,7 @@ public final class QuorumController implements Controller {
             // the controller purgatory. See QuorumMetaLogListener#handleCommit. Since this callback is synchronous,
             // we can safely create a snapshot of the prior offset before it gets cleaned up by the Raft thread.
             long offset = offsetToSnapshot.get();
-            if (offset > 0) {
+            if (offset > 0 && snapshotGeneratorManager.generator == null) {
                 log.info("Generating a snapshot prior to a metadata.version update that includes (epoch={}, offset={}) after {}.",
                     lastCommittedEpoch, lastCommittedOffset, newBytesSinceLastSnapshot);
                 snapshotGeneratorManager.createSnapshotGenerator(offset, lastCommittedEpoch, lastCommittedTimestamp);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -112,6 +112,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -644,10 +645,10 @@ public final class QuorumController implements Controller {
 
         /**
          * Once we've passed the records to the Raft layer, we will invoke this function
-         * with the end offset at which those records were placed.  If there were no
-         * records to write, we'll just pass the last write offset.
+         * with the previous batch end offset and the end offset at which those records were placed.
+         * If there were no records to write, both of these values will be the last write offset.
          */
-        default void processBatchEndOffset(long offset) {
+        default void processBatchEndOffset(long previousBatchEndOffset, long offset) {
         }
     }
 
@@ -684,7 +685,7 @@ public final class QuorumController implements Controller {
             startProcessingTimeNs = OptionalLong.of(now);
             ControllerResult<T> result = op.generateRecordsAndResult();
             if (result.records().isEmpty()) {
-                op.processBatchEndOffset(writeOffset);
+                op.processBatchEndOffset(writeOffset, writeOffset);
                 // If the operation did not return any records, then it was actually just
                 // a read after all, and not a read + write.  However, this read was done
                 // from the latest in-memory state, which might contain uncommitted data.
@@ -714,7 +715,7 @@ public final class QuorumController implements Controller {
                 } else {
                     offset = raftClient.scheduleAppend(controllerEpoch, result.records());
                 }
-                op.processBatchEndOffset(offset);
+                op.processBatchEndOffset(writeOffset, offset);
                 writeOffset = offset;
                 resultAndOffset = ControllerResultAndOffset.of(offset, result);
                 for (ApiMessageAndVersion message : result.records()) {
@@ -758,9 +759,10 @@ public final class QuorumController implements Controller {
         }
     }
 
-    private <T> CompletableFuture<T> appendWriteEvent(String name,
-                                                      OptionalLong deadlineNs,
-                                                      ControllerWriteOperation<T> op) {
+    // Visible for testing
+    <T> CompletableFuture<T> appendWriteEvent(String name,
+                                              OptionalLong deadlineNs,
+                                              ControllerWriteOperation<T> op) {
         ControllerWriteEvent<T> event = new ControllerWriteEvent<>(name, op);
         if (deadlineNs.isPresent()) {
             queue.appendWithDeadline(deadlineNs.getAsLong(), event);
@@ -1008,6 +1010,11 @@ public final class QuorumController implements Controller {
         } else {
             log.trace("maybeCompleteAuthorizerInitialLoad: highWatermark not set.");
         }
+    }
+
+    // Visible for testing
+    MetadataVersion currentMetadataVersion() {
+        return featureControl.metadataVersion();
     }
 
     private void renounce() {
@@ -1675,7 +1682,7 @@ public final class QuorumController implements Controller {
                 }
 
                 @Override
-                public void processBatchEndOffset(long offset) {
+                public void processBatchEndOffset(long previousBatchEndOffset, long offset) {
                     if (inControlledShutdown) {
                         clusterControl.heartbeatManager().
                             updateControlledShutdownOffset(brokerId, offset);
@@ -1735,17 +1742,38 @@ public final class QuorumController implements Controller {
         ControllerRequestContext context,
         UpdateFeaturesRequestData request
     ) {
-        return appendWriteEvent("updateFeatures", context.deadlineNs(), () -> {
-            Map<String, Short> updates = new HashMap<>();
-            Map<String, FeatureUpdate.UpgradeType> upgradeTypes = new HashMap<>();
-            request.featureUpdates().forEach(featureUpdate -> {
-                String featureName = featureUpdate.feature();
-                upgradeTypes.put(featureName, FeatureUpdate.UpgradeType.fromCode(featureUpdate.upgradeType()));
-                updates.put(featureName, featureUpdate.maxVersionLevel());
-            });
-            return featureControl.updateFeatures(updates, upgradeTypes, clusterControl.brokerSupportedVersions(),
-                request.validateOnly());
+        final AtomicLong offsetToSnapshot = new AtomicLong(0L);
+        return appendWriteEvent("updateFeatures", context.deadlineNs(), new ControllerWriteOperation<Map<String, ApiError>>() {
+            @Override
+            public ControllerResult<Map<String, ApiError>> generateRecordsAndResult() throws Exception {
+                Map<String, Short> updates = new HashMap<>();
+                Map<String, FeatureUpdate.UpgradeType> upgradeTypes = new HashMap<>();
+                request.featureUpdates().forEach(featureUpdate -> {
+                    String featureName = featureUpdate.feature();
+                    upgradeTypes.put(featureName, FeatureUpdate.UpgradeType.fromCode(featureUpdate.upgradeType()));
+                    updates.put(featureName, featureUpdate.maxVersionLevel());
+                });
+                return featureControl.updateFeatures(updates, upgradeTypes, clusterControl.brokerSupportedVersions(),
+                        request.validateOnly());
+            }
+
+            @Override
+            public void processBatchEndOffset(long previousBatchEndOffset, long offset) {
+                log.debug("Offset before metadata.version update {}. Offset after update {}", previousBatchEndOffset, offset);
+                offsetToSnapshot.set(previousBatchEndOffset);
+            }
+
         }).thenApply(result -> {
+            // The future that this chained callback is attached to is completed synchronously from the Raft thread via
+            // the controller purgatory. See QuorumMetaLogListener#handleCommit. Since this callback is synchronous,
+            // we can safely create a snapshot of the prior offset before it gets cleaned up by the Raft thread.
+            long offset = offsetToSnapshot.get();
+            if (offset > 0) {
+                log.info("Generating a snapshot prior to a metadata.version update that includes (epoch={}, offset={}) after {}.",
+                    lastCommittedEpoch, lastCommittedOffset, newBytesSinceLastSnapshot);
+                snapshotGeneratorManager.createSnapshotGenerator(offset, lastCommittedEpoch, lastCommittedTimestamp);
+            }
+
             UpdateFeaturesResponseData responseData = new UpdateFeaturesResponseData();
             responseData.setResults(new UpdateFeaturesResponseData.UpdatableFeatureResultCollection(result.size()));
             result.forEach((featureName, error) -> responseData.results().add(

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -1165,7 +1165,7 @@ public class QuorumControllerTest {
                 controller.updateFeatures(ANONYMOUS_CONTEXT, data).get();
 
                 SnapshotReader<ApiMessageAndVersion> snapshot = createSnapshotReader(
-                    logEnv.waitForSnapshot(previousEndOffset.get())
+                    logEnv.waitForLatestSnapshot()
                 );
 
                 // The previous version should appear in a snapshot

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -39,9 +39,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
+import org.apache.kafka.clients.admin.FeatureUpdate;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.BrokerIdNotRegisteredException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.config.ConfigResource;
@@ -1127,6 +1129,54 @@ public class QuorumControllerTest {
         for (int i = 0; i < authorizers.size(); i++) {
             assertFalse(authorizers.get(i).initialLoadFuture().isDone(),
                 "authorizer " + i + " should not have completed loading.");
+        }
+    }
+
+    @Test
+    public void testMetadataVersionUpgradeSnapshot() throws Throwable {
+        try (LocalLogManagerTestEnv logEnv = new LocalLogManagerTestEnv(3, Optional.empty())) {
+            try (QuorumControllerTestEnv controlEnv = new QuorumControllerTestEnv(logEnv, b -> b.setConfigSchema(SCHEMA),
+                    OptionalLong.empty(), OptionalLong.empty(), MetadataVersion.IBP_3_0_IV0)) {
+                QuorumController controller = controlEnv.activeController();
+
+                // Capture the offset just prior to running an upgrade
+                final AtomicLong previousEndOffset = new AtomicLong();
+                controller.appendWriteEvent("getOffset", OptionalLong.empty(), new QuorumController.ControllerWriteOperation<Void>() {
+                    @Override
+                    public ControllerResult<Void> generateRecordsAndResult() {
+                        return ControllerResult.of(Collections.emptyList(), null);
+                    }
+
+                    @Override
+                    public void processBatchEndOffset(long previousBatchEndOffset, long offset) {
+                        previousEndOffset.set(previousBatchEndOffset);
+                    }
+                }).get();
+
+                // Do the upgrade
+                UpdateFeaturesRequestData data = new UpdateFeaturesRequestData().setFeatureUpdates(
+                    new UpdateFeaturesRequestData.FeatureUpdateKeyCollection());
+                data.featureUpdates().add(
+                    new UpdateFeaturesRequestData.FeatureUpdateKey()
+                        .setFeature(MetadataVersion.FEATURE_NAME)
+                        .setMaxVersionLevel(MetadataVersion.IBP_3_1_IV0.featureLevel())
+                        .setUpgradeType(FeatureUpdate.UpgradeType.UPGRADE.code()));
+
+                controller.updateFeatures(ANONYMOUS_CONTEXT, data).get();
+
+                SnapshotReader<ApiMessageAndVersion> snapshot = createSnapshotReader(
+                    logEnv.waitForSnapshot(previousEndOffset.get())
+                );
+
+                // The previous version should appear in a snapshot
+                List<ApiMessageAndVersion> expectedSnapshot = Collections.singletonList(
+                    new ApiMessageAndVersion(new FeatureLevelRecord().
+                        setName(MetadataVersion.FEATURE_NAME).
+                        setFeatureLevel(MetadataVersion.IBP_3_0_IV0.featureLevel()), (short) 0));
+                checkSnapshotContent(expectedSnapshot, snapshot);
+
+                assertEquals(MetadataVersion.IBP_3_1_IV0, controller.currentMetadataVersion());
+            }
         }
     }
 }


### PR DESCRIPTION
When we update the `metadata.version` in KRaft, we want to take a snapshot of the metadata just prior to the record batch that includes the upgrade. By creating a snapshot, we have a convenient way of manually restoring the metadata to a previous state that does not include an upgrade. This is not required for correctness, but more so as a hedge against bugs encountered by an upgrade. 