### PR TITLE
MINOR: Use parameterized logging in StandardAuthorizer and StandardAuthorizerData

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
@@ -166,8 +166,7 @@ public class StandardAuthorizer implements ClusterMetadataAuthorizer {
             nodeId = -1;
         }
         this.data = data.copyWithNewConfig(nodeId, superUsers, defaultResult);
-        this.data.log.info("set super.users=" + String.join(",", superUsers) +
-            ", default result=" + defaultResult);
+        this.data.log.info("set super.users={}, default result={}", String.join(",", superUsers), defaultResult);
     }
 
     // VisibleForTesting

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -198,7 +198,7 @@ public class StandardAuthorizerData {
         for (Entry<Uuid, StandardAcl> entry : aclEntries) {
             newData.addAcl(entry.getKey(), entry.getValue());
         }
-        log.info("Applied " + aclEntries.size() + "acl(s) from image.");
+        log.info("Applied {} acl(s) from image.", aclEntries.size());
         return newData;
     }
 
@@ -213,9 +213,7 @@ public class StandardAuthorizerData {
                 throw new RuntimeException("Unable to add the ACL with ID " + id +
                     " to aclsByResource");
             }
-            if (log.isTraceEnabled()) {
-                log.trace("Added ACL " + id + ": " + acl);
-            }
+            log.trace("Added ACL {}: {}", id, acl);
         } catch (Throwable e) {
             log.error("addAcl error", e);
             throw e;
@@ -232,9 +230,7 @@ public class StandardAuthorizerData {
                 throw new RuntimeException("Unable to remove the ACL with ID " + id +
                     " from aclsByResource");
             }
-            if (log.isTraceEnabled()) {
-                log.trace("Removed ACL " + id + ": " + acl);
-            }
+            log.trace("Removed ACL {}: {}", id, acl);
         } catch (Throwable e) {
             log.error("removeAcl error", e);
             throw e;


### PR DESCRIPTION
This updates StandardAuthorizer and StandardAuthorizerData to use parameterized logging per the SLF4J recommendation (see https://www.slf4j.org/faq.html). This also removes a couple if statements that explicitly check if trace is enabled, but the logger should handle not publishing the message and not constructing the String if trace is not enabled.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
