### PR TITLE
MINOR: Include listener name in SocketServer acceptor and processor log context

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -84,9 +84,8 @@ class SocketServer(val config: KafkaConfig,
 
   protected val nodeId = config.brokerId
 
-  private val logContext = new LogContext(s"[SocketServer listenerType=${apiVersionManager.listenerType}, nodeId=$nodeId] ")
-
-  this.logIdent = logContext.logPrefix
+  private val logPrefix = s"SocketServer listenerType=${apiVersionManager.listenerType}, nodeId=$nodeId"
+  this.logIdent = s"[$logPrefix] "
 
   private val memoryPoolSensor = metrics.sensor("MemoryPoolUtilization")
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", MetricsGroup)
@@ -242,13 +241,14 @@ class SocketServer(val config: KafkaConfig,
   }
 
   private def endpoints = config.listeners.map(l => l.listenerName -> l).toMap
+  private def endpointLogContext(endpoint: EndPoint): LogContext = new LogContext(s"[$logPrefix, listener=${endpoint.listenerName.value}] ")
 
   protected def createDataPlaneAcceptor(endPoint: EndPoint, isPrivilegedListener: Boolean, requestChannel: RequestChannel): DataPlaneAcceptor = {
-    new DataPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, isPrivilegedListener, requestChannel, metrics, credentialProvider, logContext, memoryPool, apiVersionManager)
+    new DataPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, isPrivilegedListener, requestChannel, metrics, credentialProvider, endpointLogContext(endPoint), memoryPool, apiVersionManager)
   }
 
   private def createControlPlaneAcceptor(endPoint: EndPoint, requestChannel: RequestChannel): ControlPlaneAcceptor = {
-    new ControlPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, requestChannel, metrics, credentialProvider, logContext, memoryPool, apiVersionManager)
+    new ControlPlaneAcceptor(this, endPoint, config, nodeId, connectionQuotas, time, requestChannel, metrics, credentialProvider, endpointLogContext(endPoint), memoryPool, apiVersionManager)
   }
 
   /**
@@ -564,6 +564,7 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
   extends Runnable with Logging with KafkaMetricsGroup {
 
   val shouldRun = new AtomicBoolean(true)
+  this.logIdent = logContext.logPrefix
 
   def metricPrefix(): String
   def threadPrefix(): String
@@ -870,6 +871,7 @@ private[kafka] class Processor(
   val shouldRun = new AtomicBoolean(true)
 
   val thread = KafkaThread.nonDaemon(threadName, this)
+  this.logIdent = logContext.logPrefix
 
   private object ConnectionId {
     def fromString(s: String): Option[ConnectionId] = s.split("-") match {


### PR DESCRIPTION
Includes the listener name when logging out messages in the various network threads.

Before:
```
[2022-05-22 09:01:01,331] DEBUG Processor 2 listening to new connection from /127.0.0.1:64381 (kafka.network.Processor:62)
[2022-05-22 09:01:01,331] DEBUG Processor 1 listening to new connection from /127.0.0.1:64380 (kafka.network.Processor:62)
[2022-05-22 09:01:01,331] DEBUG Processor 0 listening to new connection from /127.0.0.1:64379 (kafka.network.Processor:62)
```

After:
```
[2022-05-22 09:15:47,772] DEBUG [SocketServer listenerType=ZK_BROKER, nodeId=0, listener=PLAINTEXT] Processor 0 listening to new connection from /127.0.0.1:64611 (kafka.network.Processor:62)
```

Tested by running a SocketServer unit test and verifying that messages were logged with an appropriate log prefix

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
