### PR TITLE
MINOR: Avoid possibly resolvable name in tests

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -441,14 +441,14 @@ class ConfigCommandTest extends Logging {
   @Test
   def shouldFailIfUnresolvableHost(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
-      "--entity-name", "name-that-should-be-unresolvable", "--entity-type", "ips", "--describe"))
+      "--entity-name", "RFC2606.invalid", "--entity-type", "ips", "--describe"))
     assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
   @Test
   def shouldFailIfUnresolvableHostUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
-      "--entity-name", "name-that-should-be-unresolvable", "--entity-type", "ips", "--describe"))
+      "--entity-name", "RFC2606.invalid", "--entity-type", "ips", "--describe"))
     assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -441,14 +441,14 @@ class ConfigCommandTest extends Logging {
   @Test
   def shouldFailIfUnresolvableHost(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
-      "--entity-name", "admin", "--entity-type", "ips", "--describe"))
+      "--entity-name", "name-that-should-be-unresolvable", "--entity-type", "ips", "--describe"))
     assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
   @Test
   def shouldFailIfUnresolvableHostUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
-      "--entity-name", "admin", "--entity-type", "ips", "--describe"))
+      "--entity-name", "name-that-should-be-unresolvable", "--entity-type", "ips", "--describe"))
     assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -66,7 +66,7 @@ class DynamicConfigTest extends QuorumTestHarness {
 
   @Test
   def shouldFailIpConfigsWithBadHost(): Unit = {
-    assertThrows(classOf[AdminOperationException], () => adminZkClient.changeIpConfig("name-that-should-be-unresolvable",
+    assertThrows(classOf[AdminOperationException], () => adminZkClient.changeIpConfig("RFC2606.invalid",
       propsWith(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG, "2")))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -66,7 +66,7 @@ class DynamicConfigTest extends QuorumTestHarness {
 
   @Test
   def shouldFailIpConfigsWithBadHost(): Unit = {
-    assertThrows(classOf[AdminOperationException], () => adminZkClient.changeIpConfig("ip",
+    assertThrows(classOf[AdminOperationException], () => adminZkClient.changeIpConfig("name-that-should-be-unresolvable",
       propsWith(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG, "2")))
   }
 }


### PR DESCRIPTION
There is a reasonable chance that the name `admin` might actually be
resolvable in certain corporate development environments.

*Summary of testing strategy*
These two tests started passing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
