### PR TITLE
KAFKA-13609: Use INVALID_CONFIG when config value is null or broker config validation fails

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -130,7 +130,7 @@ class ConfigAdminManager(nodeId: Int,
             }
           }
           if (!nullUpdates.isEmpty()) {
-            throw new InvalidRequestException("Null value not supported for : " +
+            throw new InvalidConfigurationException("Null value not supported for : " +
               String.join(", ", nullUpdates))
           }
           resourceType match {
@@ -200,11 +200,7 @@ class ConfigAdminManager(nodeId: Int,
       conf.dynamicConfig.validate(props, !configResource.name().isEmpty)
     } catch {
       case e: ApiException => throw e
-      //KAFKA-13609: InvalidRequestException is not really the right exception here if the
-      // configuration fails validation. The configuration is still well-formed, but just
-      // can't be applied. It should probably throw InvalidConfigurationException. However,
-      // we should probably only change this in a KIP since it has compatibility implications.
-      case e: Throwable => throw new InvalidRequestException(e.getMessage)
+      case e: Throwable => throw new InvalidConfigurationException(e.getMessage)
     }
  }
 
@@ -242,7 +238,7 @@ class ConfigAdminManager(nodeId: Int,
             }
           }
           if (!nullUpdates.isEmpty()) {
-            throw new InvalidRequestException("Null value not supported for : " +
+            throw new InvalidConfigurationException("Null value not supported for : " +
               String.join(", ", nullUpdates))
           }
           resourceType match {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -838,7 +838,7 @@ object KafkaConfig {
   val LogCleanerEnableDoc = "Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size."
   val LogCleanerDeleteRetentionMsDoc = "The amount of time to retain delete tombstone markers for log compacted topics. This setting also gives a bound " +
     "on the time in which a consumer must complete a read if they begin from offset 0 to ensure that they get a valid snapshot of the final stage (otherwise delete " +
-    "tombstones may be collected before they complete their scan).";
+    "tombstones may be collected before they complete their scan)."
   val LogCleanerMinCompactionLagMsDoc = "The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted."
   val LogCleanerMaxCompactionLagMsDoc = "The maximum time a message will remain ineligible for compaction in the log. Only applicable for logs that are being compacted."
   val LogIndexSizeMaxBytesDoc = "The maximum size in bytes of the offset index"
@@ -878,7 +878,7 @@ object KafkaConfig {
     "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface."
   val AlterConfigPolicyClassNameDoc = "The alter configs policy class that should be used for validation. The class should " +
     "implement the <code>org.apache.kafka.server.policy.AlterConfigPolicy</code> interface."
-  val LogMessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC;
+  val LogMessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC
 
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsDoc = "The socket timeout for controller-to-broker channels"

--- a/core/src/test/scala/integration/kafka/api/AdminClientWithPoliciesIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientWithPoliciesIntegrationTest.scala
@@ -23,7 +23,7 @@ import kafka.utils.TestUtils.assertFutureExceptionTypeEquals
 import kafka.utils.{Logging, TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigsOptions, Config, ConfigEntry}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
-import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException, PolicyViolationException}
+import org.apache.kafka.common.errors.{InvalidConfigurationException, PolicyViolationException}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.policy.AlterConfigPolicy
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNull}
@@ -146,7 +146,7 @@ class AdminClientWithPoliciesIntegrationTest extends KafkaServerTestHarness with
     assertFutureExceptionTypeEquals(alterResult.values.get(topicResource1), classOf[PolicyViolationException])
     alterResult.values.get(topicResource2).get
     assertFutureExceptionTypeEquals(alterResult.values.get(topicResource3), classOf[InvalidConfigurationException])
-    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidRequestException])
+    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidConfigurationException])
 
     // Verify that the second resource was updated and the others were not
     ensureConsistentKRaftMetadata()
@@ -175,7 +175,7 @@ class AdminClientWithPoliciesIntegrationTest extends KafkaServerTestHarness with
     assertFutureExceptionTypeEquals(alterResult.values.get(topicResource1), classOf[PolicyViolationException])
     alterResult.values.get(topicResource2).get
     assertFutureExceptionTypeEquals(alterResult.values.get(topicResource3), classOf[InvalidConfigurationException])
-    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidRequestException])
+    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidConfigurationException])
 
     // Verify that no resources are updated since validate_only = true
     ensureConsistentKRaftMetadata()

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2185,8 +2185,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   @ValueSource(strings = Array("zk", "kraft"))
   def testLongTopicNames(quorum: String): Unit = {
     val client = Admin.create(createConfig)
-    val longTopicName = String.join("", Collections.nCopies(249, "x"));
-    val invalidTopicName = String.join("", Collections.nCopies(250, "x"));
+    val longTopicName = String.join("", Collections.nCopies(249, "x"))
+    val invalidTopicName = String.join("", Collections.nCopies(250, "x"))
     val newTopics2 = Seq(new NewTopic(invalidTopicName, 3, 3.toShort),
                          new NewTopic(longTopicName, 3, 3.toShort))
     val results = client.createTopics(newTopics2.asJava).values()
@@ -2243,7 +2243,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     )
     assertFutureExceptionTypeEquals(
       client.incrementalAlterConfigs(Map(topicResource -> alterOps.asJavaCollection).asJava).all,
-      classOf[InvalidRequestException],
+      classOf[InvalidConfigurationException],
       Some("Null value not supported for : retention.bytes")
     )
     validateLogConfig(compressionType = "producer")
@@ -2665,7 +2665,7 @@ object PlaintextAdminIntegrationTest {
     assertEquals(Set(topicResource1, topicResource2, brokerResource).asJava, alterResult.values.keySet)
     assertFutureExceptionTypeEquals(alterResult.values.get(topicResource1), classOf[InvalidConfigurationException])
     alterResult.values.get(topicResource2).get
-    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidRequestException])
+    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidConfigurationException])
 
     // Verify that first and third resources were not updated and second was updated
     test.ensureConsistentKRaftMetadata()
@@ -2694,7 +2694,7 @@ object PlaintextAdminIntegrationTest {
     assertEquals(Set(topicResource1, topicResource2, brokerResource).asJava, alterResult.values.keySet)
     assertFutureExceptionTypeEquals(alterResult.values.get(topicResource1), classOf[InvalidConfigurationException])
     alterResult.values.get(topicResource2).get
-    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidRequestException])
+    assertFutureExceptionTypeEquals(alterResult.values.get(brokerResource), classOf[InvalidConfigurationException])
 
     // Verify that no resources are updated since validate_only = true
     test.ensureConsistentKRaftMetadata()

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -26,7 +26,6 @@ import java.time.Duration
 import java.util
 import java.util.{Collections, Properties}
 import java.util.concurrent._
-
 import javax.management.ObjectName
 import com.yammer.metrics.core.MetricName
 import kafka.admin.ConfigCommand
@@ -50,7 +49,7 @@ import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.config.SslConfigs._
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.config.provider.FileConfigProvider
-import org.apache.kafka.common.errors.{AuthenticationException, InvalidRequestException}
+import org.apache.kafka.common.errors.{AuthenticationException, InvalidConfigurationException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricsContext, MetricsReporter, Quota}
 import org.apache.kafka.common.network.{ListenerName, Mode}
@@ -1014,7 +1013,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val props = new Properties
     props.put(KafkaConfig.InterBrokerListenerNameProp, SecureExternal)
     val e = assertThrows(classOf[ExecutionException], () => reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.InterBrokerListenerNameProp, SecureExternal)))
-    assertTrue(e.getCause.isInstanceOf[InvalidRequestException], s"Unexpected exception ${e.getCause}")
+    assertTrue(e.getCause.isInstanceOf[InvalidConfigurationException], s"Unexpected exception ${e.getCause}")
     servers.foreach(server => assertEquals(SecureInternal, server.config.interBrokerListenerName.value))
   }
 
@@ -1432,7 +1431,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
         Seq(new ConfigResource(ConfigResource.Type.BROKER, ""))
       brokerResources.foreach { brokerResource =>
         val exception = assertThrows(classOf[ExecutionException], () => alterResult.values.get(brokerResource).get)
-        assertEquals(classOf[InvalidRequestException], exception.getCause().getClass())
+        assertEquals(classOf[InvalidConfigurationException], exception.getCause().getClass())
       }
       servers.foreach { server =>
         assertEquals(oldProps, server.config.values.asScala.filter { case (k, _) => newProps.containsKey(k) })

--- a/core/src/test/scala/unit/kafka/server/ConfigAdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConfigAdminManagerTest.scala
@@ -38,7 +38,7 @@ import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{Alter
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterableConfigCollection => IAlterableConfigCollection}
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.{AlterConfigsResourceResponse => IAlterConfigsResourceResponse}
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.protocol.Errors.{INVALID_REQUEST, NONE}
+import org.apache.kafka.common.protocol.Errors.{INVALID_CONFIG, INVALID_REQUEST, NONE}
 import org.apache.kafka.common.requests.ApiError
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{Assertions, Test}
@@ -333,7 +333,7 @@ class ConfigAdminManagerTest {
     val manager = newConfigAdminManager(2)
     val brokerLogger2 = brokerLogger2Incremental()
     assertEquals(Collections.singletonMap(brokerLogger2,
-      new ApiError(INVALID_REQUEST, s"Null value not supported for : ${logger.getName}")),
+      new ApiError(INVALID_CONFIG, s"Null value not supported for : ${logger.getName}")),
       manager.preprocess(new IncrementalAlterConfigsRequestData().
         setResources(new IAlterConfigsResourceCollection(util.Arrays.asList(
           brokerLogger2).iterator())),
@@ -397,7 +397,7 @@ class ConfigAdminManagerTest {
     val manager = newConfigAdminManager(2)
     val brokerLogger2 = broker2Legacy()
     assertEquals(Collections.singletonMap(brokerLogger2,
-      new ApiError(INVALID_REQUEST, s"Null value not supported for : ${logger.getName}")),
+      new ApiError(INVALID_CONFIG, s"Null value not supported for : ${logger.getName}")),
       manager.preprocess(new AlterConfigsRequestData().
         setResources(new LAlterConfigsResourceCollection(util.Arrays.asList(
           brokerLogger2).iterator()))))

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4085,7 +4085,7 @@ class KafkaApisTest {
     val capturedResponse = verifyNoThrottling(request)
     assertEquals(new AlterConfigsResponseData().setResponses(asList(
       new LAlterConfigsResourceResponse().
-        setErrorCode(Errors.INVALID_REQUEST.code()).
+        setErrorCode(Errors.INVALID_CONFIG.code()).
         setErrorMessage("Null value not supported for : foo").
         setResourceName(brokerId.toString).
         setResourceType(BROKER.id()))),


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*
1. Use INVALID_CONFIG when the config value is null 
2. Use INVALID_CONFIG when broker config validation fails

*Summary of testing strategy (including rationale)*
Existing test cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
