### PR TITLE
KAFKA-10199: Implement adding standby tasks to the state updater

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -46,6 +46,15 @@ public interface ChangelogReader extends ChangelogRegister {
      */
     Set<TopicPartition> completedChangelogs();
 
+    /**
+     * Returns whether all changelog partitions were completely read.
+     *
+     * Since changelog partitions for standby tasks are never completely read, this method will always return
+     * {@code false} if the changelog reader registered changelog partitions for standby tasks.
+     *
+     * @return {@code true} if all changelog partitions were completely read and no standby changelog partitions are read,
+     *         {@code false} otherwise
+     */
     boolean allChangelogsCompleted();
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -65,14 +65,24 @@ public interface StateUpdater {
     /**
      * Get all tasks (active and standby) that are managed by the state updater.
      *
-     * @return list of tasks managed by the state updater
+     * @return set of tasks managed by the state updater
      */
     Set<Task> getAllTasks();
+
+    /**
+     * Get standby tasks that are managed by the state updater.
+     *
+     * @return set of standby tasks managed by the state updater
+     */
+    Set<StandbyTask> getStandbyTasks();
 
     /**
      * Shuts down the state updater.
      *
      * @param timeout duration how long to wait until the state updater is shut down
+     *
+     * @throws
+     *     org.apache.kafka.streams.errors.StreamsException if the state updater thread cannot shutdown within the timeout
      */
     void shutdown(final Duration timeout);
 }


### PR DESCRIPTION
This PR adds adding of standby tasks to the default implementation
of the state updater.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
