### PR TITLE
MINOR: fix connect system test runs with JDK 10+

### DIFF
--- a/tests/kafkatest/services/kafka/util.py
+++ b/tests/kafkatest/services/kafka/util.py
@@ -22,7 +22,6 @@ TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
 new_jdk_not_supported = frozenset([str(LATEST_0_8_2), str(LATEST_0_9), str(LATEST_0_10_0), str(LATEST_0_10_1), str(LATEST_0_10_2), str(LATEST_0_11_0), str(LATEST_1_0)])
 
-
 def fix_opts_for_new_jvm(node):
     # Startup scripts for early versions of Kafka contains options
     # that not supported on latest versions of JVM like -XX:+PrintGCDateStamps or -XX:UseParNewGC.
@@ -33,9 +32,11 @@ def fix_opts_for_new_jvm(node):
         return ""
 
     cmd = ""
-    if node.version == LATEST_0_8_2 or node.version == LATEST_0_9 or node.version == LATEST_0_10_0 or node.version == LATEST_0_10_1 or node.version == LATEST_0_10_2 or node.version == LATEST_0_11_0 or node.version == LATEST_1_0:
-        cmd += "export KAFKA_GC_LOG_OPTS=\"-Xlog:gc*:file=kafka-gc.log:time,tags:filecount=10,filesize=102400\"; "
-        cmd += "export KAFKA_JVM_PERFORMANCE_OPTS=\"-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:MaxInlineLevel=15 -Djava.awt.headless=true\"; "
+    # check kafka version for kafka node types
+    if hasattr(node, 'version'):
+        if node.version == LATEST_0_8_2 or node.version == LATEST_0_9 or node.version == LATEST_0_10_0 or node.version == LATEST_0_10_1 or node.version == LATEST_0_10_2 or node.version == LATEST_0_11_0 or node.version == LATEST_1_0:
+            cmd += "export KAFKA_GC_LOG_OPTS=\"-Xlog:gc*:file=kafka-gc.log:time,tags:filecount=10,filesize=102400\"; "
+            cmd += "export KAFKA_JVM_PERFORMANCE_OPTS=\"-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:MaxInlineLevel=15 -Djava.awt.headless=true\"; "
     return cmd
 
 


### PR DESCRIPTION
When running system tests with JDK 10+, we hit the following error because util.py attempts to check the version variable for non-Kafka service objects.

```
[INFO:2022-05-23 18:43:04,741]: RunnerClient: kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=REMOTE_KRAFT: on run 1/1
[INFO:2022-05-23 18:43:04,775]: RunnerClient: kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=REMOTE_KRAFT: Setting up...
[INFO:2022-05-23 18:43:04,792]: RunnerClient: kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=REMOTE_KRAFT: Running...
[INFO:2022-05-23 18:43:53,154]: RunnerClient: kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=REMOTE_KRAFT: FAIL: AttributeError("'ClusterNode' object has no attribute 'version'")
Traceback (most recent call last):
  File "kafka/venv/lib/python3.7/site-packages/ducktape/tests/runner_client.py", line 175, in _do_run
    data = self.run_test()
  File "/kafka/venv/lib/python3.7/site-packages/ducktape/tests/runner_client.py", line 257, in run_test
    return self.test_context.function(self.test)
  File "kafka/venv/lib/python3.7/site-packages/ducktape/mark/_mark.py", line 433, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "kafka/tests/kafkatest/tests/connect/connect_test.py", line 109, in test_file_source_and_sink
    self.source.start()
  File "kafka/tests/kafkatest/services/connect.py", line 123, in start
    super(ConnectServiceBase, self).start()
  File "kafka/venv/lib/python3.7/site-packages/ducktape/services/service.py", line 265, in start
    self.start_node(node, **kwargs)
  File "kafka/tests/kafkatest/services/connect.py", line 332, in start_node
    self.start_and_wait_to_start_listening(node, 'standalone', remote_connector_configs)
  File "kafka/tests/kafkatest/services/connect.py", line 138, in start_and_wait_to_start_listening
    self.start_and_return_immediately(node, worker_type, remote_connector_configs)
  File "kafka/tests/kafkatest/services/connect.py", line 126, in start_and_return_immediately
    cmd = self.start_cmd(node, remote_connector_configs)
  File "kafka/tests/kafkatest/services/connect.py", line 300, in start_cmd
    cmd += fix_opts_for_new_jvm(node)
  File "/kafka/tests/kafkatest/services/kafka/util.py", line 36, in fix_opts_for_new_jvm
    if node.version == LATEST_0_8_2 or node.version == LATEST_0_9 or node.version == LATEST_0_10_0 or node.version == LATEST_0_10_1 or node.version == LATEST_0_10_2 or node.version == LATEST_0_11_0 or node.version == LATEST_1_0:
AttributeError: 'ClusterNode' object has no attribute 'version'
```