### PR TITLE
MINOR: fix number of nodes used in test_compatible_brokers_eos_v2_enabled

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
@@ -115,6 +115,7 @@ class StreamsBrokerCompatibility(Test):
         self.consumer.stop()
         self.kafka.stop()
 
+    @cluster(num_nodes=4)
     @parametrize(broker_version=str(LATEST_2_8))
     @parametrize(broker_version=str(LATEST_2_7))
     @parametrize(broker_version=str(LATEST_2_6))


### PR DESCRIPTION
```
14:26:43 [WARNING - 2022-05-14 21:26:43,595 - runner_client - log - lineno:305]: RunnerClient:
kafkatest.tests.streams.streams_broker_compatibility_test.StreamsBrokerCompatibility.test_compatible_brokers_eos_v2_enabled.broker_version=2.7.1:
Test requested 30 nodes, used only 4
14:26:43 [WARNING:2022-05-14 21:26:43,614]: RunnerClient:
kafkatest.tests.streams.streams_broker_compatibility_test.StreamsBrokerCompatibility.test_compatible_brokers_eos_v2_enabled.broker_version=2.7.1:
Test requested 30 nodes, used only 4
14:26:43 [INFO:2022-05-14 21:26:43,634]: RunnerClient:
kafkatest.tests.streams.streams_broker_compatibility_test.StreamsBrokerCompatibility.test_compatible_brokers_eos_v2_enabled.broker_version=2.7.1:
Summary:
14:26:43 [INFO:2022-05-14 21:26:43,653]: RunnerClient:
kafkatest.tests.streams.streams_broker_compatibility_test.StreamsBrokerCompatibility.test_compatible_brokers_eos_v2_enabled.broker_version=2.7.1:
Data: None
14:26:43 [WARNING:2022-05-14 21:26:43,678]: Test
kafkatest.tests.streams.streams_broker_compatibility_test.StreamsBrokerCompatibility.test_compatible_brokers_eos_v2_enabled.broker_version=2.8.1
is using entire cluster. It's possible this test has no
associated cluster metadata.
```