### PR TITLE
MINOR: Disable ARM builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,6 @@ pipeline {
         stage('ARM') {
           agent { label 'arm4' }
           options {
-            timeout(time: 2, unit: 'HOURS') 
             timestamps()
           }
           environment {
@@ -173,7 +172,9 @@ pipeline {
           steps {
             doValidation()
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', catchInterruptions: true) {
-              doTest(env, 'unitTest')
+              timeout(time: 5, unit: 'MINUTES') {
+                doTest(env, 'unitTest')
+              } 
             }
             echo 'Skipping Kafka Streams archetype test for ARM build'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,7 +163,7 @@ pipeline {
 
         stage('ARM') {
           when {
-            false
+            expression { false }
           }
           options {
             timestamps()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ pipeline {
           }
           steps {
             doValidation()
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', catchInterruptions: true) {
               doTest(env, 'unitTest')
             }
             echo 'Skipping Kafka Streams archetype test for ARM build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,9 +183,11 @@ pipeline {
               options {
                 timeout(time: 2, unit: 'HOURS')
               }
-              doValidation()
-              doTest(env, 'unitTest')
-              echo 'Skipping Kafka Streams archetype test for ARM build'
+              steps {
+                doValidation()
+                doTest(env, 'unitTest')
+                echo 'Skipping Kafka Streams archetype test for ARM build'
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,6 +162,9 @@ pipeline {
         }
 
         stage('ARM') {
+          when {
+            false
+          }
           options {
             timestamps()
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,8 +162,9 @@ pipeline {
         }
 
         stage('ARM') {
+          // Remove this once infra is fixed. See INFRA-23305 and KAFKA-13941
           when {
-            expression { false }
+            expression { true }
           }
           options {
             timestamps()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,21 +162,31 @@ pipeline {
         }
 
         stage('ARM') {
-          agent { label 'arm4' }
           options {
             timestamps()
           }
           environment {
             SCALA_VERSION=2.12
           }
-          steps {
-            doValidation()
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', catchInterruptions: true) {
-              timeout(time: 5, unit: 'MINUTES') {
-                doTest(env, 'unitTest')
-              } 
+          stages {
+            stage('Check ARM') {
+              agent { label 'arm4' }
+              options {
+                timeout(time: 5, unit: 'MINUTES')
+              }
+              steps {
+                echo 'ok'
+              }
             }
-            echo 'Skipping Kafka Streams archetype test for ARM build'
+            stage('Run ARM Build') {
+              agent { label 'arm4' }
+              options {
+                timeout(time: 2, unit: 'HOURS')
+              }
+              doValidation()
+              doTest(env, 'unitTest')
+              echo 'Skipping Kafka Streams archetype test for ARM build'
+            }
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,13 +173,13 @@ pipeline {
             SCALA_VERSION=2.12
           }
           stages {
-            stage('Check ARM') {
+            stage('Check ARM Agent') {
               agent { label 'arm4' }
               options {
                 timeout(time: 5, unit: 'MINUTES')
               }
               steps {
-                echo 'ok'
+                echo 'ARM ok'
               }
             }
             stage('Run ARM Build') {
@@ -189,7 +189,9 @@ pipeline {
               }
               steps {
                 doValidation()
-                doTest(env, 'unitTest')
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                  doTest(env, 'unitTest')
+                }
                 echo 'Skipping Kafka Streams archetype test for ARM build'
               }
             }
@@ -197,20 +199,35 @@ pipeline {
         }
 
         stage('PowerPC') {
-          agent { label 'ppc64le' }
           options {
-            timeout(time: 2, unit: 'HOURS')
             timestamps()
           }
           environment {
             SCALA_VERSION=2.12
           }
-          steps {
-            doValidation()
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              doTest(env, 'unitTest')
+          stages {
+            stage('Check PowerPC Agent') {
+              agent { label 'ppc64le' }
+              options {
+                timeout(time: 5, unit: 'MINUTES')
+              }
+              steps {
+                echo 'PowerPC ok'
+              }
             }
-            echo 'Skipping Kafka Streams archetype test for PowerPC build'
+            stage('Run PowerPC Build') {
+              agent { label 'ppc64le' }
+              options {
+                timeout(time: 2, unit: 'HOURS')
+              }
+              steps {
+                doValidation()
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                  doTest(env, 'unitTest')
+                }
+                echo 'Skipping Kafka Streams archetype test for PowerPC build'
+              }
+            }
           }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
         stage('ARM') {
           // Remove this once infra is fixed. See INFRA-23305 and KAFKA-13941
           when {
-            expression { true }
+            expression { false }
           }
           options {
             timestamps()


### PR DESCRIPTION
Recently, the ARM nodes have not been schedulable in our PR builds which leads to the ARM stage hanging for 2 hours until it is timed out. 

https://ci-builds.apache.org/job/Kafka/job/kafka-pr/view/change-requests/job/PR-12213/3/

This patch adds a no-op stage with a shorter timeout to check if the agent is available. This will give faster feedback on the state of the ARM build.

Also, this patch disables the ARM build.