### PR TITLE
KAFKA-13941: Reenable ARM in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,10 +162,6 @@ pipeline {
         }
 
         stage('ARM') {
-          // Remove this once infra is fixed. See INFRA-23305 and KAFKA-13941
-          when {
-            expression { false }
-          }
           options {
             timestamps()
           }


### PR DESCRIPTION
Since https://issues.apache.org/jira/browse/INFRA-23305 appears to have been resolved, we should be able to reenable the ARM build.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
