### PR TITLE
MINOR: Send kraft raft/controller logs to controller log in systests

### DIFF
--- a/tests/kafkatest/services/kafka/templates/log4j.properties
+++ b/tests/kafkatest/services/kafka/templates/log4j.properties
@@ -121,6 +121,8 @@ log4j.additivity.kafka.server.KafkaApis=false
 log4j.logger.kafka.request.logger={{ log_level|default("DEBUG") }}, requestInfoAppender, requestDebugAppender
 log4j.additivity.kafka.request.logger=false
 
+log4j.logger.org.apache.kafka.raft={{ log_level|default("DEBUG") }}, controllerInfoAppender, controllerDebugAppender
+log4j.logger.org.apache.kafka.controller={{ log_level|default("DEBUG") }}, controllerInfoAppender, controllerDebugAppender
 log4j.logger.kafka.controller={{ log_level|default("DEBUG") }}, controllerInfoAppender, controllerDebugAppender
 log4j.additivity.kafka.controller=false
 


### PR DESCRIPTION
Currently the only place we see controller/raft logging in system tests is `server-start-stdout-stderr.log` where they are mixed with all other logs. It is more convenient to send them to `controller.log` as we do for zk tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
