### PR TITLE
KAFKA-13946: setMetadataDirectory() method in builder for ControllerNode has no parameters

### DIFF
--- a/core/src/test/java/kafka/testkit/ControllerNode.java
+++ b/core/src/test/java/kafka/testkit/ControllerNode.java
@@ -27,7 +27,7 @@ public class ControllerNode implements TestKitNode {
             return this;
         }
 
-        public Builder setMetadataDirectory() {
+        public Builder setMetadataDirectory(String metadataDirectory) {
             this.metadataDirectory = metadataDirectory;
             return this;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-13946

Added parameter `metadataDirectory` to `setMetadataDirectory()` so that `this.metadataDirectory` would not be set to itself.