### PR TITLE
KAFKA-13950: Fix resource leak in error scenarios

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
@@ -34,6 +34,7 @@ public interface ChannelBuilder extends AutoCloseable, Configurable {
      * @param  key SelectionKey
      * @param  maxReceiveSize max size of a single receive buffer to allocate
      * @param  memoryPool memory pool from which to allocate buffers, or null for none
+     * @param  metadataRegistry registry which stores the metadata about the channels
      * @return KafkaChannel
      */
     KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize,

--- a/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.common.network;
 
 
+import org.apache.kafka.common.memory.MemoryPool;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -78,6 +80,10 @@ public interface Selectable {
 
     /**
      * The collection of receives that completed on the last {@link #poll(long) poll()} call.
+     *
+     * Note that the caller of this method assumes responsibility to close the NetworkReceive resources which may be
+     * backed by a {@link MemoryPool}. In such scenarios (when NetworkReceive uses a {@link MemoryPool}, it is necessary
+     * to close the {@link NetworkReceive} to prevent any memory leaks.
      */
     Collection<NetworkReceive> completedReceives();
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -334,9 +334,10 @@ public class Selector implements Selectable, AutoCloseable {
     }
 
     private KafkaChannel buildAndAttachKafkaChannel(SocketChannel socketChannel, String id, SelectionKey key) throws IOException {
+        ChannelMetadataRegistry metadataRegistry = null;
         try {
-            KafkaChannel channel = channelBuilder.buildChannel(id, key, maxReceiveSize, memoryPool,
-                new SelectorChannelMetadataRegistry());
+            metadataRegistry = new SelectorChannelMetadataRegistry();
+            KafkaChannel channel = channelBuilder.buildChannel(id, key, maxReceiveSize, memoryPool, metadataRegistry);
             key.attach(channel);
             return channel;
         } catch (Exception e) {
@@ -345,6 +346,9 @@ public class Selector implements Selectable, AutoCloseable {
             } finally {
                 key.cancel();
             }
+            // Ideally, these resources are closed by the KafkaChannel but if the KafkaChannel is not created to an
+            // error, this builder should close the resources it has created instead.
+            Utils.closeQuietly(metadataRegistry, "metadataRegistry");
             throw new IOException("Channel could not be created for socket " + socketChannel, e);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
@@ -385,8 +385,7 @@ public final class LegacyRecord {
                               ByteBuffer value,
                               CompressionType compressionType,
                               TimestampType timestampType) {
-        try {
-            DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer));
+        try (DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer))) {
             write(out, magic, timestamp, key, value, compressionType, timestampType);
         } catch (IOException e) {
             throw new KafkaException(e);

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -181,12 +181,15 @@ public class ReplicaManagerBuilder {
 
     public ReplicaManager build() {
         if (config == null) config = new KafkaConfig(Collections.emptyMap());
-        if (metrics == null) metrics = new Metrics();
         if (logManager == null) throw new RuntimeException("You must set logManager");
         if (metadataCache == null) throw new RuntimeException("You must set metadataCache");
         if (logDirFailureChannel == null) throw new RuntimeException("You must set logDirFailureChannel");
         if (alterPartitionManager == null) throw new RuntimeException("You must set alterIsrManager");
         if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(Optional.of(config));
+        // Initialize metrics in the end just before passing it to ReplicaManager to ensure ReplicaManager closes the
+        // metrics correctly. There might be a resource leak if it is initialized and an exception occurs between
+        // its initialization and creation of ReplicaManager.
+        if (metrics == null) metrics = new Metrics();
         return new ReplicaManager(config,
                              metrics,
                              time,

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -48,7 +48,7 @@ import static java.util.Collections.singleton;
 /**
  * This class implements a read-process-write application.
  */
-public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebalanceListener {
+public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebalanceListener, AutoCloseable {
     private final String bootstrapServers;
     private final String inputTopic;
     private final String outputTopic;
@@ -213,5 +213,16 @@ public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebal
                 return 0;
             }
         }).sum();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (producer != null) {
+            producer.close();
+        }
+
+        if (consumer != null) {
+            consumer.close();
+        }
     }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -165,7 +165,7 @@ versions += [
   spotbugs: "4.8.0",
   zinc: "1.9.2",
   zookeeper: "3.8.3",
-  zstd: "1.5.5-6"
+  zstd: "1.5.5-9"
 ]
 
 libs += [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -165,7 +165,7 @@ versions += [
   spotbugs: "4.8.0",
   zinc: "1.9.2",
   zookeeper: "3.8.3",
-  zstd: "1.5.5-9"
+  zstd: "1.5.5-6"
 ]
 
 libs += [

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -60,7 +60,7 @@ import static org.apache.kafka.streams.processor.internals.StateManagerUtil.pars
  * stored. Handles creation/locking/unlocking/cleaning of the Task Directories. This class is not
  * thread-safe.
  */
-public class StateDirectory {
+public class StateDirectory implements AutoCloseable {
 
     private static final Pattern TASK_DIR_PATH_NAME = Pattern.compile("\\d+_\\d+");
     private static final Pattern NAMED_TOPOLOGY_DIR_PATH_NAME = Pattern.compile("__.+__"); // named topology dirs follow '__Topology-Name__'
@@ -377,6 +377,7 @@ public class StateDirectory {
         }
     }
 
+    @Override
     public void close() {
         if (hasPersistentStores) {
             try {


### PR DESCRIPTION
# Problem
We are not properly closing Closeable resources in the code base at multiple places especially when we have an exception.

# Change
This code change fixes multiple of these leaks. Note that `Utils.closeQuietly` is used in this code change where author thinks that propagation of original exception is essential.