### PR TITLE
MINOR: Clean up tmp files created by tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.security.ssl.mock.TestTrustManagerFactory;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -66,7 +67,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testSslFactoryConfiguration() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -122,7 +123,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testSslFactoryWithoutPasswordConfiguration() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -138,7 +139,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testClientMode() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
@@ -152,7 +153,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void staleSslEngineFactoryShouldBeClosed() throws IOException, GeneralSecurityException {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
@@ -164,7 +165,7 @@ public abstract class SslFactoryTest {
         assertNotNull(sslEngineFactory);
         assertFalse(sslEngineFactory.closed);
 
-        trustStoreFile = File.createTempFile("truststore", ".jks");
+        trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         clientSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -178,7 +179,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testReconfiguration() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -193,7 +194,7 @@ public abstract class SslFactoryTest {
         assertSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory recreated unnecessarily");
 
         // Verify that the SslEngineFactory is recreated on reconfigure() if config is changed
-        trustStoreFile = File.createTempFile("truststore", ".jks");
+        trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -230,7 +231,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testReconfigurationWithoutTruststore() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -258,7 +259,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testReconfigurationWithoutKeystore() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -273,7 +274,7 @@ public abstract class SslFactoryTest {
                 "SSL context recreated unnecessarily");
         assertFalse(sslFactory.createSslEngine("localhost", 0).getUseClientMode());
 
-        File newTrustStoreFile = File.createTempFile("truststore", ".jks");
+        File newTrustStoreFile = TestUtils.tempFile("truststore", ".jks");
         sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(newTrustStoreFile)
                 .build();
@@ -338,7 +339,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testKeyStoreTrustStoreValidation() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
@@ -349,8 +350,8 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testUntrustedKeyStoreValidationFails() throws Exception {
-        File trustStoreFile1 = File.createTempFile("truststore1", ".jks");
-        File trustStoreFile2 = File.createTempFile("truststore2", ".jks");
+        File trustStoreFile1 = TestUtils.tempFile("truststore1", ".jks");
+        File trustStoreFile2 = TestUtils.tempFile("truststore2", ".jks");
         Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile1)
                 .build();
@@ -419,12 +420,12 @@ public abstract class SslFactoryTest {
     }
 
     private void verifyCertificateEntriesValidation(boolean usePem, String tlsProtocol) throws Exception {
-        File trustStoreFile = usePem ? null : File.createTempFile("truststore", ".jks");
+        File trustStoreFile = usePem ? null : TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .usePem(usePem)
                 .build();
-        File newTrustStoreFile = usePem ? null : File.createTempFile("truststore", ".jks");
+        File newTrustStoreFile = usePem ? null : TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> newCnConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(newTrustStoreFile)
                 .cn("Another CN")
@@ -447,7 +448,7 @@ public abstract class SslFactoryTest {
      */
     @Test
     public void testClientSpecifiedSslEngineFactoryUsed() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
@@ -461,7 +462,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testEngineFactoryClosed() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
@@ -480,7 +481,7 @@ public abstract class SslFactoryTest {
      */
     @Test
     public void testServerSpecifiedSslEngineFactoryUsed() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
@@ -497,7 +498,7 @@ public abstract class SslFactoryTest {
      */
     @Test
     public void testInvalidSslEngineFactory() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
@@ -510,7 +511,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testUsedConfigs() throws IOException, GeneralSecurityException {
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
-                .createNewTrustStore(File.createTempFile("truststore", ".jks"))
+                .createNewTrustStore(TestUtils.tempFile("truststore", ".jks"))
                 .useClientCert(false)
                 .build();
         serverSslConfig.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestKeyManagerFactory.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestKeyManagerFactory.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestSslUtils.CertificateBuilder;
+import org.apache.kafka.test.TestUtils;
 
 public class TestKeyManagerFactory extends KeyManagerFactorySpi {
     public static final String ALGORITHM = "TestAlgorithm";
@@ -70,7 +71,7 @@ public class TestKeyManagerFactory extends KeyManagerFactorySpi {
                 this.certificate = certBuilder.generate("CN=" + CN + ", O=A server", this.keyPair);
                 Map<String, X509Certificate> certificates = new HashMap<>();
                 certificates.put(ALIAS, certificate);
-                File trustStoreFile = File.createTempFile("testTrustStore", ".jks");
+                File trustStoreFile = TestUtils.tempFile("testTrustStore", ".jks");
                 mockTrustStoreFile = trustStoreFile.getPath();
                 TestSslUtils.createTrustStore(mockTrustStoreFile, new Password(TestSslUtils.TRUST_STORE_PASSWORD), certificates);
             } catch (IOException | GeneralSecurityException e) {

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -216,7 +216,7 @@ public class TestSslUtils {
         }
         if (trustCerts != null) {
             if (tsPath == null) {
-                tsPath = File.createTempFile("truststore", ".pem").getPath();
+                tsPath = TestUtils.tempFile("truststore", ".pem").getPath();
                 sslProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, tsPath);
             }
             sslProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
@@ -504,13 +504,13 @@ public class TestSslUtils {
             File keyStoreFile = null;
 
             if (mode == Mode.CLIENT && useClientCert) {
-                keyStoreFile = File.createTempFile("clientKS", ".jks");
+                keyStoreFile = TestUtils.tempFile("clientKS", ".jks");
                 KeyPair cKP = generateKeyPair(algorithm);
                 X509Certificate cCert = certBuilder.generate("CN=" + cn + ", O=A client", cKP);
                 createKeyStore(keyStoreFile.getPath(), keyStorePassword, keyPassword, "client", cKP.getPrivate(), cCert);
                 certs.put(certAlias, cCert);
             } else if (mode == Mode.SERVER) {
-                keyStoreFile = File.createTempFile("serverKS", ".jks");
+                keyStoreFile = TestUtils.tempFile("serverKS", ".jks");
                 KeyPair sKP = generateKeyPair(algorithm);
                 X509Certificate sCert = certBuilder.generate("CN=" + cn + ", O=A server", sKP);
                 createKeyStore(keyStoreFile.getPath(), keyStorePassword, keyPassword, "server", sKP.getPrivate(), sCert);

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -29,16 +29,15 @@ import org.apache.kafka.common.record.UnalignedRecords;
 import org.apache.kafka.common.requests.ByteBufferChannel;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.Exit;
-import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -176,13 +175,7 @@ public class TestUtils {
      */
     public static File tempFile(final String contents) throws IOException {
         final File file = tempFile();
-        if (Java.IS_JAVA11_COMPATIBLE) {
-            Files.writeString(file.toPath(), contents);
-        } else {
-            try(final FileWriter writer = new FileWriter(file)) {
-                writer.write(contents);
-            }
-        }
+        Files.write(file.toPath(), contents.getBytes(StandardCharsets.UTF_8));
         return file;
     }
 

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -29,11 +29,13 @@ import org.apache.kafka.common.record.UnalignedRecords;
 import org.apache.kafka.common.requests.ByteBufferChannel;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -174,7 +176,13 @@ public class TestUtils {
      */
     public static File tempFile(final String contents) throws IOException {
         final File file = tempFile();
-        Files.writeString(file.toPath(), contents);
+        if (Java.IS_JAVA11_COMPATIBLE) {
+            Files.writeString(file.toPath(), contents);
+        } else {
+            try(final FileWriter writer = new FileWriter(file)) {
+                writer.write(contents);
+            }
+        }
         return file;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.tests;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.KafkaThread;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -38,10 +37,8 @@ import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.test.TestUtils;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Properties;
@@ -64,28 +61,6 @@ public class SmokeTestClient extends SmokeTestUtil {
         } else {
             Runtime.getRuntime().addShutdownHook(new Thread(runnable));
         }
-    }
-
-    private static File tempDirectory() {
-        final String prefix = "kafka-";
-        final File file;
-        try {
-            file = Files.createTempDirectory(prefix).toFile();
-        } catch (final IOException ex) {
-            throw new RuntimeException("Failed to create a temp dir", ex);
-        }
-        file.deleteOnExit();
-
-        addShutdownHook("delete-temp-file-shutdown-hook", () -> {
-            try {
-                Utils.delete(file);
-            } catch (final IOException e) {
-                System.out.println("Error deleting " + file.getAbsolutePath());
-                e.printStackTrace(System.out);
-            }
-        });
-
-        return file;
     }
 
     public SmokeTestClient(final String name) {
@@ -156,7 +131,7 @@ public class SmokeTestClient extends SmokeTestUtil {
         final Properties fullProps = new Properties(props);
         fullProps.put(StreamsConfig.APPLICATION_ID_CONFIG, "SmokeTest");
         fullProps.put(StreamsConfig.CLIENT_ID_CONFIG, "SmokeTest-" + name);
-        fullProps.put(StreamsConfig.STATE_DIR_CONFIG, tempDirectory().getAbsolutePath());
+        fullProps.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         fullProps.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
         fullProps.putAll(props);
         return fullProps;


### PR DESCRIPTION
# Problem
There are a bunch of tests which do not clean up after themselves. This leads to accumulation of files in the tmp directory of the system on which the tests are running. 

# Change
This code change fixes some of the main culprit tests which leak the files in the temporary directory.