### PR TITLE
MINOR: Use right enum value for broker registration change

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -422,7 +422,7 @@ public class ClusterControlManager {
             record,
             record.id(),
             record.epoch(),
-            BrokerRegistrationFencingChange.UNFENCE.asBoolean(),
+            BrokerRegistrationFencingChange.FENCE.asBoolean(),
             BrokerRegistrationInControlledShutdownChange.NONE.asBoolean()
         );
     }
@@ -432,7 +432,7 @@ public class ClusterControlManager {
             record,
             record.id(),
             record.epoch(),
-            BrokerRegistrationFencingChange.FENCE.asBoolean(),
+            BrokerRegistrationFencingChange.UNFENCE.asBoolean(),
             BrokerRegistrationInControlledShutdownChange.NONE.asBoolean()
         );
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1162,7 +1162,7 @@ public class ReplicationControlManager {
         if (featureControl.metadataVersion().isBrokerRegistrationChangeRecordSupported()) {
             records.add(new ApiMessageAndVersion(new BrokerRegistrationChangeRecord().
                     setBrokerId(brokerId).setBrokerEpoch(brokerRegistration.epoch()).
-                    setFenced(BrokerRegistrationFencingChange.UNFENCE.value()),
+                    setFenced(BrokerRegistrationFencingChange.FENCE.value()),
                     (short) 0));
         } else {
             records.add(new ApiMessageAndVersion(new FenceBrokerRecord().
@@ -1205,7 +1205,7 @@ public class ReplicationControlManager {
         if (featureControl.metadataVersion().isBrokerRegistrationChangeRecordSupported()) {
             records.add(new ApiMessageAndVersion(new BrokerRegistrationChangeRecord().
                 setBrokerId(brokerId).setBrokerEpoch(brokerEpoch).
-                setFenced(BrokerRegistrationFencingChange.FENCE.value()),
+                setFenced(BrokerRegistrationFencingChange.UNFENCE.value()),
                 (short) 0));
         } else {
             records.add(new ApiMessageAndVersion(new UnfenceBrokerRecord().setId(brokerId).

--- a/metadata/src/main/java/org/apache/kafka/image/ClusterDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterDelta.java
@@ -94,7 +94,7 @@ public final class ClusterDelta {
     public void replay(FenceBrokerRecord record) {
         BrokerRegistration curRegistration = getBrokerOrThrow(record.id(), record.epoch(), "fence");
         changedBrokers.put(record.id(), Optional.of(curRegistration.cloneWith(
-            BrokerRegistrationFencingChange.UNFENCE.asBoolean(),
+            BrokerRegistrationFencingChange.FENCE.asBoolean(),
             Optional.empty()
         )));
     }
@@ -102,7 +102,7 @@ public final class ClusterDelta {
     public void replay(UnfenceBrokerRecord record) {
         BrokerRegistration curRegistration = getBrokerOrThrow(record.id(), record.epoch(), "unfence");
         changedBrokers.put(record.id(), Optional.of(curRegistration.cloneWith(
-            BrokerRegistrationFencingChange.FENCE.asBoolean(),
+            BrokerRegistrationFencingChange.UNFENCE.asBoolean(),
             Optional.empty()
         )));
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistrationFencingChange.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistrationFencingChange.java
@@ -25,9 +25,9 @@ import java.util.stream.Collectors;
 
 
 public enum BrokerRegistrationFencingChange {
-    FENCE(-1, Optional.of(false)),
+    FENCE(1, Optional.of(true)),
     NONE(0, Optional.empty()),
-    UNFENCE(1, Optional.of(true));
+    UNFENCE(-1, Optional.of(false));
 
     private final byte value;
 

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -111,7 +111,7 @@ public class ClusterControlManagerTest {
             clusterControl.replay(unfenceBrokerRecord);
         } else {
             BrokerRegistrationChangeRecord changeRecord =
-                    new BrokerRegistrationChangeRecord().setBrokerId(1).setBrokerEpoch(100).setFenced((byte) -1);
+                    new BrokerRegistrationChangeRecord().setBrokerId(1).setBrokerEpoch(100).setFenced(BrokerRegistrationFencingChange.UNFENCE.value());
             clusterControl.replay(changeRecord);
         }
         assertFalse(clusterControl.unfenced(0));
@@ -123,7 +123,7 @@ public class ClusterControlManagerTest {
             clusterControl.replay(fenceBrokerRecord);
         } else {
             BrokerRegistrationChangeRecord changeRecord =
-                    new BrokerRegistrationChangeRecord().setBrokerId(1).setBrokerEpoch(100).setFenced((byte) 1);
+                    new BrokerRegistrationChangeRecord().setBrokerId(1).setBrokerEpoch(100).setFenced(BrokerRegistrationFencingChange.FENCE.value());
             clusterControl.replay(changeRecord);
         }
         assertFalse(clusterControl.unfenced(0));
@@ -234,7 +234,7 @@ public class ClusterControlManagerTest {
         registrationChangeRecord = new BrokerRegistrationChangeRecord()
             .setBrokerId(0)
             .setBrokerEpoch(100)
-            .setFenced(BrokerRegistrationFencingChange.FENCE.value());
+            .setFenced(BrokerRegistrationFencingChange.UNFENCE.value());
         clusterControl.replay(registrationChangeRecord);
 
         assertTrue(clusterControl.unfenced(0));

--- a/metadata/src/test/java/org/apache/kafka/metadata/BrokerRegistrationInControlledShutdownChangeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/BrokerRegistrationInControlledShutdownChangeTest.java
@@ -24,27 +24,25 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 @Timeout(40)
-public class BrokerRegistrationFencingChangeTest {
+public class BrokerRegistrationInControlledShutdownChangeTest {
+
     @Test
     public void testValues() {
-        assertEquals((byte) 1, BrokerRegistrationFencingChange.FENCE.value());
-        assertEquals((byte) 0, BrokerRegistrationFencingChange.NONE.value());
-        assertEquals((byte) -1, BrokerRegistrationFencingChange.UNFENCE.value());
+        assertEquals((byte) 0, BrokerRegistrationInControlledShutdownChange.NONE.value());
+        assertEquals((byte) 1, BrokerRegistrationInControlledShutdownChange.IN_CONTROLLED_SHUTDOWN.value());
     }
 
     @Test
     public void testAsBoolean() {
-        assertEquals(Optional.of(true), BrokerRegistrationFencingChange.FENCE.asBoolean());
-        assertEquals(Optional.empty(), BrokerRegistrationFencingChange.NONE.asBoolean());
-        assertEquals(Optional.of(false), BrokerRegistrationFencingChange.UNFENCE.asBoolean());
+        assertEquals(Optional.empty(), BrokerRegistrationInControlledShutdownChange.NONE.asBoolean());
+        assertEquals(Optional.of(true), BrokerRegistrationInControlledShutdownChange.IN_CONTROLLED_SHUTDOWN.asBoolean());
     }
 
     @Test
     public void testValueRoundTrip() {
-        for (BrokerRegistrationFencingChange change : BrokerRegistrationFencingChange.values()) {
-            assertEquals(Optional.of(change), BrokerRegistrationFencingChange.fromValue(change.value()));
+        for (BrokerRegistrationInControlledShutdownChange change : BrokerRegistrationInControlledShutdownChange.values()) {
+            assertEquals(Optional.of(change), BrokerRegistrationInControlledShutdownChange.fromValue(change.value()));
         }
     }
 }


### PR DESCRIPTION
*More detailed description of your change*
In `ClusterControlManager.replay` and `ReplicationControlManager`, we use `BrokerRegistrationFencingChange.FENCE` when unfencing a broker and use `BrokerRegistrationFencingChange.UNFENCE` when fencing a broker, this is confusing.

*Summary of testing strategy (including rationale)*
Didn't change any logic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
