### PR TITLE
KAFKA-13955: Fix failing KRaftClusterTest tests

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -82,7 +82,7 @@ object Defaults {
   val BrokerHeartbeatIntervalMs = 2000
   val BrokerSessionTimeoutMs = 9000
   val MetadataSnapshotMaxNewRecordBytes = 20 * 1024 * 1024
-  val MetadataMaxIdleIntervalMs = 500
+  val MetadataMaxIdleIntervalMs = 5000
 
   /** KRaft mode configs */
   val EmptyNodeId: Int = -1


### PR DESCRIPTION
*More detailed description of your change*
Will will generate NoOpRecord periodically to increase metadata LEO, however, when a broker startup, we will wait until its metadata LEO catches up with the controller LEO, we generate NoOpRecord every 500ms and send heartbeat request every 2000ms. 

It's almost impossible for a broker to catch up with the controller LEO if the broker sends a query request every 2000ms but the controller LEO increases every 500ms, so the tests in `KRaftClusterTest` will fail.

![image](https://user-images.githubusercontent.com/26023240/171584207-82a33962-a2f0-4af9-a0bb-09a42bb030e1.png)


*Summary of testing strategy (including rationale)*
After this change, the tests in `KRaftClusterTest` all succeed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
