### PR TITLE
MINOR: Pin ducktape version to < 0.9

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape>0.8", "requests==2.24.0"],
+      install_requires=["ducktape<0.9", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
With newer ducktape versions than < 0.9 system tests
may run into authentication issues with the AK system test
infrastructure.

The version will be bumped up once we have infrastructure
in place for newer paramiko versions brought in by ducktape
0.9.  

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
