### PR TITLE
KAFKA-13410; Add a --release-version flag for storage-tool

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -97,12 +97,9 @@ object StorageTool extends Logging {
       help("The cluster ID to use.")
     formatParser.addArgument("--ignore-formatted", "-g").
       action(storeTrue())
-    formatParser.addArgument("--metadata-version", "-v").
-      action(store()).
-      help(s"The initial metadata.version feature flag level to use. Cannot be specified with --release-version.")
     formatParser.addArgument("--release-version", "-r").
       action(store()).
-      help(s"A release version to use for the initial metadata.version. Cannot be specified with --metadata-version. The default is (${MetadataVersion.latest().version()})")
+      help(s"A release version to use for the initial metadata.version. The default is (${MetadataVersion.latest().version()})")
 
     parser.parseArgsOrFail(args)
   }
@@ -117,17 +114,9 @@ object StorageTool extends Logging {
   def configToSelfManagedMode(config: KafkaConfig): Boolean = config.processRoles.nonEmpty
 
   def getMetadataVersion(namespace: Namespace): MetadataVersion = {
-    val mv = Option(namespace.getString("metadata_version"))
-    val rv = Option(namespace.getString("release_version"))
-    if (mv.isDefined && rv.isDefined) {
-      throw new TerseFailure(s"Cannot specify both --metadata-version and --release-version.")
-    } else if (mv.isDefined) {
-      mv.map(level => MetadataVersion.fromFeatureLevel(level.toShort)).get
-    } else if (rv.isDefined) {
-      rv.map(ver => MetadataVersion.fromVersionString(ver)).get
-    } else {
-      MetadataVersion.latest()
-    }
+    Option(namespace.getString("release_version"))
+      .map(ver => MetadataVersion.fromVersionString(ver))
+      .getOrElse(MetadataVersion.latest())
   }
 
   def infoCommand(stream: PrintStream, selfManagedMode: Boolean, directories: Seq[String]): Int = {

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -22,13 +22,14 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util
 import java.util.Properties
-
 import kafka.server.{KafkaConfig, MetaProperties}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.common.MetadataVersion
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.{Test, Timeout}
+
+import scala.collection.mutable
 
 
 @Timeout(value = 40)
@@ -162,7 +163,7 @@ Found problem:
       val stream = new ByteArrayOutputStream()
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, MetadataVersion.latest(), ignoreFormatted = false))
-      assertEquals("Formatting %s%n".format(tempDir), stream.toString())
+      assertTrue(stream.toString().startsWith("Formatting %s".format(tempDir)))
 
       try assertEquals(1, StorageTool.
         formatCommand(new PrintStream(new ByteArrayOutputStream()), Seq(tempDir.toString), metaProperties, MetadataVersion.latest(), ignoreFormatted = false)) catch {
@@ -189,16 +190,33 @@ Found problem:
 
   @Test
   def testDefaultMetadataVersion(): Unit = {
-    var namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ"))
-    var mv = StorageTool.getMetadataVersion(namespace)
+    val namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ"))
+    val mv = StorageTool.getMetadataVersion(namespace)
     assertEquals(MetadataVersion.latest().featureLevel(), mv.featureLevel(),
       "Expected the default metadata.version to be the latest version")
+  }
 
-    namespace = StorageTool.parseArguments(Array("format", "-c", "config.props",
-      "--metadata-version", MetadataVersion.latest().featureLevel().toString, "-t", "XcZZOzUqS4yHOjhMQB6JLQ"))
-    mv = StorageTool.getMetadataVersion(namespace)
-    assertEquals(MetadataVersion.latest().featureLevel(), mv.featureLevel(),
-      "Expected the default metadata.version to be the latest version")
+  @Test
+  def testMetadataVersionFlags(): Unit = {
+    def parseMetadataVersion(strings: String*): MetadataVersion = {
+      var args = mutable.Seq("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ")
+      args ++= strings
+      val namespace = StorageTool.parseArguments(args.toArray)
+      StorageTool.getMetadataVersion(namespace)
+    }
 
+    var mv = parseMetadataVersion("--metadata-version", "1")
+    assertEquals(1, mv.featureLevel())
+
+    mv = parseMetadataVersion("--metadata-version", "3")
+    assertEquals(3, mv.featureLevel())
+
+    assertThrows(classOf[TerseFailure], () => parseMetadataVersion("--metadata-version", "3", "--release-version", "3.0"))
+
+    mv = parseMetadataVersion("--release-version", "3.0")
+    assertEquals("3.0", mv.shortVersion())
+
+    mv = parseMetadataVersion("--release-version", "3.0-IV1")
+    assertEquals(MetadataVersion.IBP_3_0_IV1, mv)
   }
 }

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -205,18 +205,12 @@ Found problem:
       StorageTool.getMetadataVersion(namespace)
     }
 
-    var mv = parseMetadataVersion("--metadata-version", "1")
-    assertEquals(1, mv.featureLevel())
-
-    mv = parseMetadataVersion("--metadata-version", "3")
-    assertEquals(3, mv.featureLevel())
-
-    assertThrows(classOf[TerseFailure], () => parseMetadataVersion("--metadata-version", "3", "--release-version", "3.0"))
-
-    mv = parseMetadataVersion("--release-version", "3.0")
+    var mv = parseMetadataVersion("--release-version", "3.0")
     assertEquals("3.0", mv.shortVersion())
 
     mv = parseMetadataVersion("--release-version", "3.0-IV1")
     assertEquals(MetadataVersion.IBP_3_0_IV1, mv)
+
+    assertThrows(classOf[IllegalArgumentException], () => parseMetadataVersion("--release-version", "0.0"))
   }
 }


### PR DESCRIPTION
This patch removes the `--metadata-version` and adds a `--release-version` to the kafka-storage tool. Format command help:

```
usage: kafka-storage format [-h] --config CONFIG --cluster-id CLUSTER_ID [--ignore-formatted] [--release-version RELEASE_VERSION]

optional arguments:
  -h, --help             show this help message and exit
  --config CONFIG, -c CONFIG
                         The Kafka configuration file to use.
  --cluster-id CLUSTER_ID, -t CLUSTER_ID
                         The cluster ID to use.
  --ignore-formatted, -g
  --release-version RELEASE_VERSION, -r RELEASE_VERSION
                         A release version to use for the initial metadata.version. The default is (3.3-IV2)
```

This change is somewhat breaking since we are removing `--metadata-version` which was introduced in 1135f22eaf on May 18, but it has not been released yet.