### PR TITLE
MINOR: replace ACL_AUTHORIZER attribute with ZK_ACL_AUTHORIZER

### DIFF
--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -71,7 +71,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.set_authorizer_and_bounce(client_protocol, broker_protocol)
 
     def set_authorizer_and_bounce(self, client_protocol, broker_protocol):
-        self.kafka.authorizer_class_name = KafkaService.ACL_AUTHORIZER
+        self.kafka.authorizer_class_name = KafkaService.ZK_ACL_AUTHORIZER
         # Force use of direct ZooKeeper access due to SecurityDisabledException: No Authorizer is configured on the broker.
         self.acls.set_acls(client_protocol, self.kafka, self.topic, self.group, force_use_zk_connection=True)
         self.acls.set_acls(broker_protocol, self.kafka, self.topic, self.group, force_use_zk_connection=True)

--- a/tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
@@ -95,7 +95,7 @@ class ZooKeeperSecurityUpgradeTest(ProduceConsumeValidateTest):
 
         # set acls
         if self.is_secure:
-            self.kafka.authorizer_class_name = KafkaService.ACL_AUTHORIZER
+            self.kafka.authorizer_class_name = KafkaService.ZK_ACL_AUTHORIZER
             # Force use of direct ZooKeeper access because Kafka is not yet started
             self.acls.set_acls(security_protocol, self.kafka, self.topic, self.group, force_use_zk_connection=True,
                                additional_cluster_operations_to_grant=['Create'])


### PR DESCRIPTION
Replace ACL_AUTHORIZER attribute with ZK_ACL_AUTHORIZER in tests. Required after the changes merged with https://github.com/apache/kafka/pull/12190

Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)