### PR TITLE
MINOR: adjust logging levels in Stream tests

### DIFF
--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -22,6 +22,7 @@ log4j.logger.kafka=ERROR
 log4j.logger.state.change.logger=ERROR
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.apache.kafka.clients=ERROR
 
 # These are the only logs we will likely ever find anything useful in to debug Streams test failures
 log4j.logger.org.apache.kafka.clients.consumer=INFO

--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -23,13 +23,14 @@ log4j.logger.state.change.logger=ERROR
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 
+# These are the only logs we will likely ever find anything useful in to debug Streams test failures
+log4j.logger.org.apache.kafka.clients.consumer=INFO
+log4j.logger.org.apache.kafka.clients.producer=INFO
+log4j.logger.org.apache.kafka.streams=INFO
+
 # printing out the configs takes up a huge amount of the allotted characters,
 # and provides little value as we can always figure out the test configs without the logs
 log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
 log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
 log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
 log4j.logger.org.apache.kafka.streams.StreamsConfig=ERROR
-
-# These are the only logs we will likely ever find anything useful in to debug Streams test failures
-log4j.logger.org.apache.kafka.clients=INFO
-log4j.logger.org.apache.kafka.streams=INFO


### PR DESCRIPTION
Now that we've turned off logging in the brokers/zookeeper/config classes we can finally see at least some of the logs where Streams is actually doing something when trying to debug tests from a failed PR build. But I've noticed we still have some flooding of warnings from the `NetworkClient` and info-level junk from `Metadata`, so to maximize the visible useful logs we should filter out everything bu the producer/consumer client themselves (in addition to Streams) fine-grained logging 