### PR TITLE
KAFKA-13968: Fix 3 major bugs of KRaft snapshot generating

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -62,13 +62,8 @@ class BrokerSnapshotWriterBuilder(raftClient: RaftClient[ApiMessageAndVersion])
     extends SnapshotWriterBuilder {
   override def build(committedOffset: Long,
                      committedEpoch: Int,
-                     lastContainedLogTime: Long): SnapshotWriter[ApiMessageAndVersion] = {
-    raftClient.createSnapshot(committedOffset, committedEpoch, lastContainedLogTime).
-        asScala.getOrElse(
-      throw new RuntimeException("A snapshot already exists with " +
-        s"committedOffset=$committedOffset, committedEpoch=$committedEpoch, " +
-        s"lastContainedLogTime=$lastContainedLogTime")
-    )
+                     lastContainedLogTime: Long): Option[SnapshotWriter[ApiMessageAndVersion]] = {
+    raftClient.createSnapshot(committedOffset, committedEpoch, lastContainedLogTime).asScala
   }
 }
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -119,7 +119,7 @@ class BrokerMetadataListener(
       }
 
       _bytesSinceLastSnapshot = _bytesSinceLastSnapshot + results.numBytes
-      if (_publisher.nonEmpty && shouldSnapshot()) {
+      if (shouldSnapshot()) {
         maybeStartSnapshot()
       }
 
@@ -128,11 +128,13 @@ class BrokerMetadataListener(
   }
 
   private def shouldSnapshot(): Boolean = {
-    _bytesSinceLastSnapshot >= maxBytesBetweenSnapshots || metadataVersionChanged()
+    (_bytesSinceLastSnapshot >= maxBytesBetweenSnapshots) || metadataVersionChanged()
   }
 
-  private def metadataVersionChanged(): Boolean = Option(_delta.featuresDelta()).exists { featuresDelta =>
-    featuresDelta.metadataVersionChange().isPresent
+  private def metadataVersionChanged(): Boolean = {
+    _publisher.nonEmpty && Option(_delta.featuresDelta()).exists { featuresDelta =>
+      featuresDelta.metadataVersionChange().isPresent
+    }
   }
 
   private def maybeStartSnapshot(): Unit = {
@@ -248,7 +250,7 @@ class BrokerMetadataListener(
       _publisher = Some(publisher)
       log.info(s"Starting to publish metadata events at offset $highestMetadataOffset.")
       try {
-        if (shouldSnapshot()) {
+        if (metadataVersionChanged()) {
           maybeStartSnapshot()
         }
         publish(publisher)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -219,7 +219,7 @@ class BrokerMetadataListener(
             s" ${messageAndVersion.message}")
         }
 
-        _highestOffset  = lastCommittedOffset.getOrElse(batch.baseOffset() + index)
+        _highestOffset = lastCommittedOffset.getOrElse(batch.baseOffset() + index)
 
         delta.replay(highestMetadataOffset, epoch, messageAndVersion.message())
         numRecords += 1

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -132,6 +132,8 @@ class BrokerMetadataListener(
   }
 
   private def metadataVersionChanged(): Boolean = {
+    // The _publisher is empty before starting publishing, and we won't compute feature delta
+    // until we starting publishing
     _publisher.nonEmpty && Option(_delta.featuresDelta()).exists { featuresDelta =>
       featuresDelta.metadataVersionChange().isPresent
     }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
@@ -115,9 +115,4 @@ class BrokerMetadataSnapshotter(
     beginShutdown()
     eventQueue.close()
   }
-
-  // VisibleForTesting
-  def currentSnapshotOffset(): Long = {
-    _currentSnapshotOffset
-  }
 }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
@@ -46,7 +46,7 @@ class BrokerMetadataSnapshotter(
   private var _currentSnapshotOffset = -1L
 
   /**
-   * The offset of the newest snapshot, or -1 if there hasn't been one.Accessed only under
+   * The offset of the newest snapshot, or -1 if there hasn't been one. Accessed only under
    * the object lock.
    */
   private var _latestSnapshotOffset = -1L
@@ -61,9 +61,9 @@ class BrokerMetadataSnapshotter(
       warn(s"Declining to create a new snapshot at ${image.highestOffsetAndEpoch()} because " +
         s"there is already a snapshot in progress at offset ${_currentSnapshotOffset}")
       false
-    } else if (_latestSnapshotOffset >= image.highestOffsetAndEpoch().offset) {
+    } else if (_latestSnapshotOffset == image.highestOffsetAndEpoch().offset) {
       warn(s"Declining to create a new snapshot at ${image.highestOffsetAndEpoch()} because " +
-        s"there is a newer snapshot in progress at offset ${_latestSnapshotOffset}")
+        s"there is already a snapshot at offset ${_latestSnapshotOffset}")
       false
     } else {
       val writer = writerBuilder.build(
@@ -119,5 +119,10 @@ class BrokerMetadataSnapshotter(
   def close(): Unit = {
     beginShutdown()
     eventQueue.close()
+  }
+
+  // VisibleForTesting
+  def currentSnapshotOffset(): Long = {
+    _currentSnapshotOffset
   }
 }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
@@ -46,25 +46,36 @@ class BrokerMetadataSnapshotter(
   private var _currentSnapshotOffset = -1L
 
   /**
+   * The offset of the newest snapshot, or -1 if there hasn't been one.Accessed only under
+   * the object lock.
+   */
+  private var _latestSnapshotOffset = -1L
+
+  /**
    * The event queue which runs this listener.
    */
   val eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix.getOrElse(""))
 
   override def maybeStartSnapshot(lastContainedLogTime: Long, image: MetadataImage): Boolean = synchronized {
-    if (_currentSnapshotOffset == -1L) {
+    if (_currentSnapshotOffset != -1) {
+      warn(s"Declining to create a new snapshot at ${image.highestOffsetAndEpoch()} because " +
+        s"there is already a snapshot in progress at offset ${_currentSnapshotOffset}")
+      false
+    } else if (_latestSnapshotOffset >= image.highestOffsetAndEpoch().offset) {
+      warn(s"Declining to create a new snapshot at ${image.highestOffsetAndEpoch()} because " +
+        s"there is a newer snapshot in progress at offset ${_latestSnapshotOffset}")
+      false
+    } else {
       val writer = writerBuilder.build(
         image.highestOffsetAndEpoch().offset,
         image.highestOffsetAndEpoch().epoch,
         lastContainedLogTime
       )
       _currentSnapshotOffset = image.highestOffsetAndEpoch().offset
+      _latestSnapshotOffset = image.highestOffsetAndEpoch().offset
       info(s"Creating a new snapshot at offset ${_currentSnapshotOffset}...")
       eventQueue.append(new CreateSnapshotEvent(image, writer))
       true
-    } else {
-      warn(s"Declining to create a new snapshot at ${image.highestOffsetAndEpoch()} because " +
-           s"there is already a snapshot in progress at offset ${_currentSnapshotOffset}")
-      false
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -270,7 +270,7 @@ class BrokerMetadataListenerTest {
     listener.startPublishing(new MockMetadataPublisher()).get()
 
     val endOffset = 100L
-    updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_3_3_IV2.featureLevel(), endOffset)
+    updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, (MetadataVersion.latest().featureLevel() - 1).toShort, endOffset)
     listener.getImageRecords().get()
     assertEquals(endOffset, snapshotter.activeSnapshotOffset, "We should generate snapshot on feature update")
   }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -271,6 +271,7 @@ class BrokerMetadataListenerTest {
 
     val endOffset = 100L
     updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, (MetadataVersion.latest().featureLevel() - 1).toShort, endOffset)
+    // Waiting for the metadata version update to get processed
     listener.getImageRecords().get()
     assertEquals(endOffset, snapshotter.activeSnapshotOffset, "We should generate snapshot on feature update")
   }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -247,7 +247,7 @@ class BrokerMetadataListenerTest {
 
     updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, MetadataVersion.latest.featureLevel(), 100L)
     listener.getImageRecords().get()
-    assertEquals(-1L, snapshotter.activeSnapshotOffset, "We won't generate snapshot before starting publishing")
+    assertEquals(-1L, snapshotter.activeSnapshotOffset, "We won't generate snapshot on metadata version change before starting publishing")
   }
 
   @Test
@@ -256,9 +256,10 @@ class BrokerMetadataListenerTest {
     val listener = newBrokerMetadataListener(snapshotter = Some(snapshotter),
       maxBytesBetweenSnapshots = 1000L)
 
-    updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, MetadataVersion.latest.featureLevel(), 100L)
+    val endOffset = 100L
+    updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, MetadataVersion.latest.featureLevel(), endOffset)
     listener.startPublishing(new MockMetadataPublisher()).get()
-    assertEquals(100L, snapshotter.activeSnapshotOffset, "We should try to generate snapshot when starting publishing")
+    assertEquals(endOffset, snapshotter.activeSnapshotOffset, "We should try to generate snapshot when starting publishing")
   }
 
   @Test
@@ -268,9 +269,10 @@ class BrokerMetadataListenerTest {
       maxBytesBetweenSnapshots = 1000L)
     listener.startPublishing(new MockMetadataPublisher()).get()
 
-    updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_3_3_IV2.featureLevel(), 100L)
+    val endOffset = 100L
+    updateFeature(listener, feature = MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_3_3_IV2.featureLevel(), endOffset)
     listener.getImageRecords().get()
-    assertEquals(100L, snapshotter.activeSnapshotOffset, "We should generate snapshot on feature update")
+    assertEquals(endOffset, snapshotter.activeSnapshotOffset, "We should generate snapshot on feature update")
   }
 
   private def registerBrokers(


### PR DESCRIPTION
*More detailed description of your change*
There are 3 bugs when a broker generates a snapshot.

1. Broker should not generate snapshots until it starts publishing.
Before a broker starts publishing, `BrokerMetadataListener._publisher=None`,  so `_publisher.foreach(publish)` will do nothing, so `featuresDelta.metadataVersionChange().isPresent` is always true, so we will generating a snapshot on every commit since we believe metadata version has changed, here are the logs, note offset 1 is a LeaderChangeMessage so there is no snapshot:

```
[2022-06-08 13:07:43,010] INFO [BrokerMetadataSnapshotter id=0] Creating a new snapshot at offset 0... (kafka.server.metadata.BrokerMetadataSnapshotter:66)
[2022-06-08 13:07:43,222] INFO [BrokerMetadataSnapshotter id=0] Creating a new snapshot at offset 2... (kafka.server.metadata.BrokerMetadataSnapshotter:66)
[2022-06-08 13:07:43,727] INFO [BrokerMetadataSnapshotter id=0] Creating a new snapshot at offset 3... (kafka.server.metadata.BrokerMetadataSnapshotter:66)
[2022-06-08 13:07:44,228] INFO [BrokerMetadataSnapshotter id=0] Creating a new snapshot at offset 4... (kafka.server.metadata.BrokerMetadataSnapshotter:66)
```

2. We should compute `metadataVersionChanged` before `_publisher.foreach(publish)`
After `_publisher.foreach(publish)` the `BrokerMetadataListener_delta` is always Empty, so `metadataVersionChanged` is always false, this means we will never trigger snapshot generating even metadata version has changed.

3. We should try to generate a snapshot when starting publishing
When we started publishing, there may be a metadata version change, so we should try to generate a snapshot before first publishing.

*Summary of testing strategy (including rationale)*
A unit test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
