### PR TITLE
KAFKA-13972; Ensure that replicas are stopped after cancelled reassignment

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -404,7 +404,6 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
   def addStopReplicaRequestForBrokers(brokerIds: Seq[Int],
                                       topicPartition: TopicPartition,
                                       deletePartition: Boolean): Unit = {
-    stateChangeLogger.info(s"Sending StopReplica to $brokerIds for $topicPartition")
     // A sentinel (-2) is used as an epoch if the topic is queued for deletion. It overrides
     // any existing epoch.
     val leaderEpoch = if (controllerContext.isTopicQueuedUpForDeletion(topicPartition.topic)) {

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -404,6 +404,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
   def addStopReplicaRequestForBrokers(brokerIds: Seq[Int],
                                       topicPartition: TopicPartition,
                                       deletePartition: Boolean): Unit = {
+    stateChangeLogger.info(s"Sending StopReplica to $brokerIds for $topicPartition")
     // A sentinel (-2) is used as an epoch if the topic is queued for deletion. It overrides
     // any existing epoch.
     val leaderEpoch = if (controllerContext.isTopicQueuedUpForDeletion(topicPartition.topic)) {

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -159,12 +159,12 @@ object Election {
       leaderOpt match {
         case Some(newLeader) =>
           val newLeaderAndIsr = leaderAndIsr.newLeader(newLeader)
-          LeaderAndIsrUpdateResult.Successful(partition, newLeaderAndIsr, assignment, Seq.empty)
+          LeaderAndIsrUpdateResult.Successful(partition, newLeaderAndIsr, liveReplicas = liveReplicas)
         case None =>
-          // TODO: Perhaps we want to distinguish the cases
+          val reason = if (!leaderAndIsr.isr.contains(assignment.head)) "offline" else "not in the ISR"
           LeaderAndIsrUpdateResult.Failed(partition, new StateChangeFailedException(
-            s"Failed to elect preferred replica for partition $partition since the preferred replica " +
-              s"${assignment.head} is not live or not in the ISR"
+            s"Failed to elect preferred leader ${assignment.head} for partition $partition since " +
+              s"it is $reason"
           ))
       }
     }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -725,7 +725,11 @@ class KafkaController(val config: KafkaConfig,
     maybeUpdateCurrentAssignment(topicPartition, assignment)
 
     if (!assignment.isBeingReassigned) {
+      // If a reassignment is cancelled or if a new reassignment is just changing the
+      // preferred leader, then it can be completed without additional replica movements.
+      // We do still need to send `UpdateMetadata` though for the replica changes.
       removePartitionFromReassigningPartitions(topicPartition, assignment)
+      sendUpdateMetadataRequest(controllerContext.liveOrShuttingDownBrokerIds.toSeq, Set(topicPartition))
       return
     }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2653,7 +2653,7 @@ case class PartitionAndReplica(topicPartition: TopicPartition, replica: Int) {
   def partition: Int = topicPartition.partition
 
   override def toString: String = {
-    s"[Topic=$topic,Partition=$partition,Replica=$replica]"
+    s"[TopicPartition=$topicPartition,Replica=$replica]"
   }
 }
 

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -325,12 +325,12 @@ class ZkReplicaStateMachine(config: KafkaConfig,
     partitions: Seq[TopicPartition]
   ): Map[TopicPartition, LeaderIsrAndControllerEpoch] = {
     var results = Map.empty[TopicPartition, LeaderIsrAndControllerEpoch]
-    var remainingPartitions = partitions
-    while (remainingPartitions.nonEmpty) {
-      val (finishedPartitions, partitionsToRetry) = tryRemoveReplicasFromIsr(replicaId, remainingPartitions)
-      remainingPartitions = partitionsToRetry
+    var remaining = partitions
+    while (remaining.nonEmpty) {
+      val (finishedRemoval, removalsToRetry) = tryRemoveReplicasFromIsr(replicaId, remaining)
+      remaining = removalsToRetry
 
-      finishedPartitions.foreach {
+      finishedRemoval.foreach {
         case (partition, Left(e)) =>
           val replica = PartitionAndReplica(partition, replicaId)
           val currentState = controllerContext.replicaState(replica)

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -152,6 +152,9 @@ class ZkReplicaStateMachine(config: KafkaConfig,
    * ReplicaDeletionSuccessful -> NonExistentReplica
    * -- remove the replica from the in memory partition replica assignment cache
    *
+   * NewReplica,OnlineReplica,OfflineReplica -> UnassignedReplicas
+   * -- Following completion or cancellation of a reassignment, remove the replica state
+   *
    * @param replicaId The replica for which the state transition is invoked
    * @param replicas The partitions on this replica for which the state transition is invoked
    * @param targetState The end state that the replica should be moved to
@@ -221,7 +224,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
         val (replicasWithLeadershipInfo, replicasWithoutLeadershipInfo) = validReplicas.partition { replica =>
           controllerContext.partitionLeadershipInfo(replica.topicPartition).isDefined
         }
-        val updatedLeaderIsrAndControllerEpochs = fenceReplicas(replicaId, replicasWithLeadershipInfo.map(_.topicPartition))
+        val updatedLeaderIsrAndControllerEpochs = removeReplicasFromIsr(replicaId, replicasWithLeadershipInfo.map(_.topicPartition))
         updatedLeaderIsrAndControllerEpochs.forKeyValue { (partition, leaderIsrAndControllerEpoch) =>
           stateLogger.info(s"Partition $partition state changed to $leaderIsrAndControllerEpoch " +
             s"after transitioning replica $replicaId to $OfflineReplica")
@@ -296,24 +299,35 @@ class ZkReplicaStateMachine(config: KafkaConfig,
             logSuccessfulTransition(stateLogger, replicaId, replica.topicPartition, currentState, NonExistentReplica)
           controllerContext.removeReplicaState(replica)
         }
+      case UnassignedReplica =>
+        // For the case of a replica which has been removed following reassignment,
+        // replicas will be stopped and deleted as part of the final transition to `OnlinePartition`.
+        // The replica assignment also will be updated as part of the reassignment completion.
+        // So here we just need to remove the replica state.
+        validReplicas.foreach { replica =>
+          val currentState = controllerContext.replicaState(replica)
+          if (traceEnabled)
+            logSuccessfulTransition(stateLogger, replicaId, replica.topicPartition, currentState, UnassignedReplica)
+          controllerContext.removeReplicaState(replica)
+        }
     }
   }
 
   /**
-   * Repeatedly attempt to fence a replica of multiple partitions until there are no more remaining partitions
+   * Repeatedly attempt to remove a replica from the isr of multiple partitions until there are no more remaining partitions
    * to retry.
-   * @param replicaId The replica being fenced from multiple partitions
-   * @param partitions The partitions from which we're trying to fence the replica from
-   * @return The updated LeaderIsrAndControllerEpochs of all partitions for which we successfully fenced
+   * @param replicaId The replica being removed from isr of multiple partitions
+   * @param partitions The partitions from which we're trying to remove the replica from isr
+   * @return The updated LeaderIsrAndControllerEpochs of all partitions for which we successfully removed the replica from isr.
    */
-  private def fenceReplicas(
+  private def removeReplicasFromIsr(
     replicaId: Int,
     partitions: Seq[TopicPartition]
   ): Map[TopicPartition, LeaderIsrAndControllerEpoch] = {
     var results = Map.empty[TopicPartition, LeaderIsrAndControllerEpoch]
     var remainingPartitions = partitions
     while (remainingPartitions.nonEmpty) {
-      val (finishedPartitions, partitionsToRetry) = tryFenceReplicas(replicaId, remainingPartitions)
+      val (finishedPartitions, partitionsToRetry) = tryRemoveReplicasFromIsr(replicaId, remainingPartitions)
       remainingPartitions = partitionsToRetry
 
       finishedPartitions.foreach {
@@ -329,43 +343,35 @@ class ZkReplicaStateMachine(config: KafkaConfig,
   }
 
   /**
-   * Fence an existing replica by bumping the leader epoch. The bumped leader epoch
-   * ensures 1) that the follower can no longer fetch with the old epoch, and 2)
-   * that it will accept a `StopReplica` request with the bumped epoch.
+   * Try to remove a replica from the isr of multiple partitions.
+   * Removing a replica from isr updates partition state in zookeeper.
    *
-   * - If the replica is the current leader, then the leader will be changed to
-   *   [[LeaderAndIsr.NoLeader]], and it will remain in the ISR.
-   * - If the replica is not the current leader and it is in the ISR, then it
-   *   will be removed from the ISR.
-   * - Otherwise, the epoch will be bumped and the leader and ISR will be unchanged.
-   *
-   * Fencing a replica updates partition state in zookeeper.
-   *
-   * @param replicaId The replica being fenced from multiple partitions
-   * @param partitions The partitions from which we're trying to fence the replica from
+   * @param replicaId The replica being removed from isr of multiple partitions
+   * @param partitions The partitions from which we're trying to remove the replica from isr
    * @return A tuple of two elements:
    *         1. The updated Right[LeaderIsrAndControllerEpochs] of all partitions for which we successfully
-   *         fenced the replica. Or Left[Exception] for failures which need to be retries
+   *         removed the replica from isr. Or Left[Exception] corresponding to failed removals that should
+   *         not be retried
    *         2. The partitions that we should retry due to a zookeeper BADVERSION conflict. Version conflicts can occur if
    *         the partition leader updated partition state while the controller attempted to update partition state.
    */
-  private def tryFenceReplicas(
+  private def tryRemoveReplicasFromIsr(
     replicaId: Int,
     partitions: Seq[TopicPartition]
   ): (Map[TopicPartition, Either[Exception, LeaderIsrAndControllerEpoch]], Seq[TopicPartition]) = {
     val (leaderAndIsrs, partitionsWithNoLeaderAndIsrInZk) = getTopicPartitionStatesFromZk(partitions)
-    val adjustedLeaderAndIsrs: Map[TopicPartition, LeaderAndIsr] = leaderAndIsrs.flatMap {
+    val (leaderAndIsrsWithReplica, leaderAndIsrsWithoutReplica) = leaderAndIsrs.partition { case (_, result) =>
+      result.map { leaderAndIsr =>
+        leaderAndIsr.isr.contains(replicaId)
+      }.getOrElse(false)
+    }
+
+    val adjustedLeaderAndIsrs: Map[TopicPartition, LeaderAndIsr] = leaderAndIsrsWithReplica.flatMap {
       case (partition, result) =>
         result.toOption.map { leaderAndIsr =>
-          if (leaderAndIsr.isr.contains(replicaId)) {
-            val newLeader = if (replicaId == leaderAndIsr.leader) LeaderAndIsr.NoLeader else leaderAndIsr.leader
-            val adjustedIsr = if (leaderAndIsr.isr.size == 1) leaderAndIsr.isr else leaderAndIsr.isr.filter(_ != replicaId)
-            partition -> leaderAndIsr.newLeaderAndIsr(newLeader, adjustedIsr)
-          } else {
-            // Even if the replica is not in the ISR. We must bump the epoch to ensure the replica
-            // is fenced from replication and the `StopReplica` can be sent with a bumped epoch.
-            partition -> leaderAndIsr.newEpoch
-          }
+          val newLeader = if (replicaId == leaderAndIsr.leader) LeaderAndIsr.NoLeader else leaderAndIsr.leader
+          val adjustedIsr = if (leaderAndIsr.isr.size == 1) leaderAndIsr.isr else leaderAndIsr.isr.filter(_ != replicaId)
+          partition -> leaderAndIsr.newLeaderAndIsr(newLeader, adjustedIsr)
         }
     }
 
@@ -384,13 +390,13 @@ class ZkReplicaStateMachine(config: KafkaConfig,
       }.toMap
 
     val leaderIsrAndControllerEpochs: Map[TopicPartition, Either[Exception, LeaderIsrAndControllerEpoch]] =
-      finishedPartitions.map { case (partition, result) =>
+      (leaderAndIsrsWithoutReplica ++ finishedPartitions).map { case (partition, result) =>
         (partition, result.map { leaderAndIsr =>
           val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerContext.epoch)
           controllerContext.putPartitionLeadershipInfo(partition, leaderIsrAndControllerEpoch)
           leaderIsrAndControllerEpoch
         })
-      }.toMap
+      }
 
     if (isDebugEnabled) {
       updatesToRetry.foreach { partition =>
@@ -510,4 +516,9 @@ case object ReplicaDeletionIneligible extends ReplicaState {
 case object NonExistentReplica extends ReplicaState {
   val state: Byte = 7
   val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionSuccessful)
+}
+
+case object UnassignedReplica extends ReplicaState {
+  val state: Byte = 8
+  val validPreviousStates: Set[ReplicaState] = Set(NewReplica, OnlineReplica, OfflineReplica)
 }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -584,7 +584,6 @@ class KafkaServer(
       var shutdownSucceeded: Boolean = false
 
       try {
-
         var remainingRetries = retries
         var prevController: Node = null
         var ioException = false

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1535,7 +1535,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           s"Unexpected message: ${exception.getMessage}")
       } else {
         assertTrue(exception.getMessage.contains(
-          s"Failed to elect leader for partition $topicPartition under strategy PreferredReplicaPartitionLeaderElectionStrategy"),
+          s"Failed to elect preferred leader"),
           s"Unexpected message: ${exception.getMessage}")
       }
     }

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1562,8 +1562,10 @@ class ControllerIntegrationTest extends QuorumTestHarness {
 
   private def preferredReplicaLeaderElection(controllerId: Int, otherBroker: KafkaServer, tp: TopicPartition,
                                              replicas: Set[Int], leaderEpoch: Int): Unit = {
+    println(s"Shutting down ${otherBroker.config.brokerId}")
     otherBroker.shutdown()
     otherBroker.awaitShutdown()
+
     waitForPartitionState(tp, firstControllerEpoch, controllerId, leaderEpoch + 1,
       "failed to get expected partition state upon broker shutdown")
     otherBroker.startup()

--- a/core/src/test/scala/unit/kafka/controller/ElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ElectionTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.controller
 
 import kafka.api.LeaderAndIsr

--- a/core/src/test/scala/unit/kafka/controller/ElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ElectionTest.scala
@@ -1,0 +1,812 @@
+package kafka.controller
+
+import kafka.api.LeaderAndIsr
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.metadata.LeaderRecoveryState
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, fail}
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+import scala.collection.mutable
+
+class ElectionTest {
+  private val topicPartition = new TopicPartition("foo", 15)
+
+  @Test
+  def testControlledShutdownIfAnotherLiveReplicaIsInIsr(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1, 2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(2, 3),
+      shuttingDownBrokerIds = Seq(1)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 6,
+      isr = List(2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(2, 3),
+      replicasToStop = Seq(1)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownIfShuttingDownBrokerIsOnlyMemberOfIsr(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertFailedUpdate(controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(2, 3),
+      shuttingDownBrokerIds = Seq(1)
+    ))
+  }
+
+  @Test
+  def testControlledShutdownIfNoActiveLeader(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 5,
+      isr = List(2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3),
+      shuttingDownBrokerIds = Seq(1)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 6,
+      isr = List(2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(3),
+      replicasToStop = Seq(1)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownIfShuttingDownBrokerNotInIsr(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 5,
+      isr = List(2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(2, 3),
+      shuttingDownBrokerIds = Seq(1)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 6,
+      isr = List(2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(2, 3),
+      replicasToStop = Seq(1)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownMultipleBrokersInIsr(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3),
+      shuttingDownBrokerIds = Seq(1, 2)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 3,
+      leaderEpoch = 6,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(3),
+      replicasToStop = Seq(1, 2)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownMultipleBrokersOnlyMembersInIsr(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 5,
+      isr = List(1, 2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3),
+      shuttingDownBrokerIds = Seq(1, 2)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 6,
+      isr = List(2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(3, 2),
+      replicasToStop = Seq(1)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownMultipleBrokersAndNoCurrentLeader(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 5,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(),
+      shuttingDownBrokerIds = Seq(1, 2)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 6,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(),
+      replicasToStop = Seq(1, 2)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownMultipleBrokersNotInIsr(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 3,
+      leaderEpoch = 5,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3),
+      shuttingDownBrokerIds = Seq(1, 2)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 3,
+      leaderEpoch = 6,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(3),
+      replicasToStop = Seq(1, 2)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownMultipleBrokersOneInIsrAndOneNot(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 3,
+      leaderEpoch = 5,
+      isr = List(2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3),
+      shuttingDownBrokerIds = Seq(1, 2)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 3,
+      leaderEpoch = 6,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(3),
+      replicasToStop = Seq(1, 2)
+    ), result)
+  }
+
+  @Test
+  def testControlledShutdownSingleReplica(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertFailedUpdate(controlledShutdown(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(),
+      shuttingDownBrokerIds = Seq(1)
+    ))
+  }
+
+  @Test
+  def testCancelReassignmentNoAddingReplicasInIsr(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 6,
+      isr = List(1, 2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(1, 2, 3),
+      replicasToDelete = Seq(4, 5)
+    ), result)
+  }
+
+  @Test
+  def testCancelReassignmentWithAddingReplicasInIsr(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3, 5),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 6,
+      isr = List(1, 2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(1, 2, 3),
+      replicasToDelete = Seq(4, 5)
+    ), result)
+  }
+
+  @Test
+  def testCancelReassignmentWithLeaderInTargetReplicas(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 4,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3, 4),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 6,
+      isr = List(1, 2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(1, 2, 3),
+      replicasToDelete = Seq(4, 5)
+    ), result)
+  }
+
+  @Test
+  def testCancelReassignmentWithPreferredLeaderOffline(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 4,
+      leaderEpoch = 5,
+      isr = List(3, 4),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3, 4, 5)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 3,
+      leaderEpoch = 6,
+      isr = List(3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(3),
+      replicasToDelete = Seq(4, 5)
+    ), result)
+  }
+
+  @Test
+  def testCancelReassignmentWithNoOriginalReplicasInIsr(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 4,
+      leaderEpoch = 5,
+      isr = List(4),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertFailedUpdate(cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3, 4, 5)
+    ))
+  }
+
+  @Test
+  def testCancelReassignmentWithNoLiveOriginalReplicasInIsr(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2),
+      addingReplicas = Seq(2),
+      removingReplicas = Seq(1)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 5,
+      isr = List(1),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertFailedUpdate(cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(2)
+    ))
+  }
+
+  @Test
+  def testCancelReassignmentWithNoReassignmentInProgress(): Unit = {
+    val assignment = ReplicaAssignment(Seq(1, 2, 3))
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertThrows(classOf[IllegalStateException], () => cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(3, 4, 5)
+    ))
+  }
+
+  @Test
+  def testCancelReassignmentWithNoAddingReplicas(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(),
+      removingReplicas = Seq(4, 5)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 4,
+      leaderEpoch = 5,
+      isr = List(3, 4),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = cancelReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.NotNeeded(
+      topicPartition,
+      initialLeaderAndIsr
+    ), result)
+  }
+
+  @Test
+  def testCompleteReassignmentCurrentLeaderNotInTargetReplicas(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 2,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3, 4, 5),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = completeReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 6,
+      isr = List(1, 4, 5),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(1, 4, 5),
+      replicasToDelete = Seq(2, 3)
+    ), result)
+  }
+
+  @Test
+  def testCompleteReassignmentCurrentLeaderInTargetReplicas(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 4,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3, 4, 5),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = completeReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    val expectedLeaderAndIsr = LeaderAndIsr(
+      leader = 4,
+      leaderEpoch = 6,
+      isr = List(1, 4, 5),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.Successful(
+      topicPartition,
+      expectedLeaderAndIsr,
+      liveReplicas = Seq(1, 4, 5),
+      replicasToDelete = Seq(2, 3)
+    ), result)
+  }
+
+  @Test
+  def testCompleteReassignmentWithNoReplicasToRemove(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq()
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = 1,
+      leaderEpoch = 5,
+      isr = List(1, 2, 3, 4, 5),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    val result = completeReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    )
+
+    assertEquals(LeaderAndIsrUpdateResult.NotNeeded(
+      topicPartition,
+      initialLeaderAndIsr
+    ), result)
+  }
+
+  @Test
+  def testCompleteReassignmentWithSomeTargetReplicasOutOfIsr(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2, 3, 4, 5),
+      addingReplicas = Seq(4, 5),
+      removingReplicas = Seq(2, 3)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 1,
+      isr = List(1, 2, 3, 4),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertFailedUpdate(completeReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1, 2, 3, 4, 5)
+    ))
+  }
+
+  @Test
+  def testCompleteReassignmentWithNoLiveTargetReplicasInIsr(): Unit = {
+    val assignment = ReplicaAssignment(
+      replicas = Seq(1, 2),
+      addingReplicas = Seq(2),
+      removingReplicas = Seq(1)
+    )
+
+    val initialLeaderAndIsr = LeaderAndIsr(
+      leader = LeaderAndIsr.NoLeader,
+      leaderEpoch = 5,
+      isr = List(2),
+      LeaderRecoveryState.RECOVERED,
+      partitionEpoch = 79
+    )
+
+    assertFailedUpdate(completeReassignment(
+      initialLeaderAndIsr,
+      assignment,
+      liveBrokerIds = Seq(1)
+    ))
+  }
+
+  private def assertFailedUpdate(
+    result: LeaderAndIsrUpdateResult
+  ): Unit = {
+    result match {
+      case LeaderAndIsrUpdateResult.Failed(topicPartition, _) =>
+        assertEquals(this.topicPartition, topicPartition)
+      case _ =>
+        fail(s"Unexpected result: $result")
+    }
+  }
+
+  private def cancelReassignment(
+    initialLeaderAndIsr: LeaderAndIsr,
+    assignment: ReplicaAssignment,
+    liveBrokerIds: Seq[Int],
+    shuttingDownBrokerIds: Seq[Int] = Seq()
+  ): LeaderAndIsrUpdateResult = {
+    val controllerContext = mockedControllerContext(
+      topicPartition,
+      assignment,
+      liveBrokerIds,
+      shuttingDownBrokerIds
+    )
+
+    val results = Election.processReassignmentCancellation(
+      controllerContext = controllerContext,
+      Seq(topicPartition -> initialLeaderAndIsr)
+    )
+    assertEquals(1, results.size)
+    assertEquals(topicPartition, results.head.topicPartition)
+    results.head
+  }
+
+  private def completeReassignment(
+    initialLeaderAndIsr: LeaderAndIsr,
+    assignment: ReplicaAssignment,
+    liveBrokerIds: Seq[Int],
+    shuttingDownBrokerIds: Seq[Int] = Seq()
+  ): LeaderAndIsrUpdateResult = {
+    val controllerContext = mockedControllerContext(
+      topicPartition,
+      assignment,
+      liveBrokerIds,
+      shuttingDownBrokerIds
+    )
+
+    val results = Election.processReassignmentCompletion(
+      controllerContext = controllerContext,
+      Seq(topicPartition -> initialLeaderAndIsr)
+    )
+    assertEquals(1, results.size)
+    assertEquals(topicPartition, results.head.topicPartition)
+    results.head
+  }
+  private def controlledShutdown(
+    initialLeaderAndIsr: LeaderAndIsr,
+    assignment: ReplicaAssignment,
+    liveBrokerIds: Seq[Int],
+    shuttingDownBrokerIds: Seq[Int]
+
+  ): LeaderAndIsrUpdateResult = {
+    val controllerContext = mockedControllerContext(
+      topicPartition,
+      assignment,
+      liveBrokerIds,
+      shuttingDownBrokerIds
+    )
+
+    val results = Election.processControlledShutdown(
+      controllerContext = controllerContext,
+      Seq(topicPartition -> initialLeaderAndIsr)
+    )
+    assertEquals(1, results.size)
+    assertEquals(topicPartition, results.head.topicPartition)
+    results.head
+  }
+
+  private def mockedControllerContext(
+    topicPartition: TopicPartition,
+    assignment: ReplicaAssignment,
+    liveBrokerIds: Seq[Int],
+    shuttingDownBrokerIds: Seq[Int]
+  ): ControllerContext = {
+    val controllerContext = Mockito.mock(classOf[ControllerContext])
+    Mockito.when(controllerContext.partitionReplicaAssignment(topicPartition))
+      .thenReturn(assignment.replicas)
+    Mockito.when(controllerContext.partitionFullReplicaAssignment(topicPartition))
+      .thenReturn(assignment)
+
+    Mockito.when(controllerContext.shuttingDownBrokerIds)
+      .thenReturn(mutable.Set.from(shuttingDownBrokerIds))
+
+    assignment.replicas.foreach { replicaId =>
+      Mockito.when(controllerContext.isReplicaOnline(replicaId, topicPartition, includeShuttingDownBrokers = false))
+        .thenReturn(liveBrokerIds.contains(replicaId))
+    }
+
+    controllerContext
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/controller/ElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ElectionTest.scala
@@ -799,7 +799,7 @@ class ElectionTest {
       .thenReturn(assignment)
 
     Mockito.when(controllerContext.shuttingDownBrokerIds)
-      .thenReturn(mutable.Set.from(shuttingDownBrokerIds))
+      .thenReturn(mutable.Set(shuttingDownBrokerIds: _*))
 
     assignment.replicas.foreach { replicaId =>
       Mockito.when(controllerContext.isReplicaOnline(replicaId, topicPartition, includeShuttingDownBrokers = false))

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -71,7 +71,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     assertEquals(NonExistentPartition, partitionState(partition))
   }
@@ -93,7 +93,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).addLeaderAndIsrRequestForBrokers(Seq(brokerId),
@@ -114,7 +114,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).sendRequestsToBrokers(controllerEpoch)
@@ -133,7 +133,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).sendRequestsToBrokers(controllerEpoch)
@@ -174,7 +174,7 @@ class PartitionStateMachineTest {
     when(mockZkClient.updateLeaderAndIsr(Map(partition -> leaderAndIsrAfterElection), controllerEpoch, controllerContext.epochZkVersion))
       .thenReturn(UpdateLeaderAndIsrResult(Map(partition -> Right(updatedLeaderAndIsr)), Seq.empty))
 
-    partitionStateMachine.handleStateChanges(partitions, OnlinePartition, Option(PreferredReplicaPartitionLeaderElectionStrategy))
+    partitionStateMachine.handleStateChanges(partitions, OnlinePartition, Option(PreferredLeaderElectionStrategy))
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).addLeaderAndIsrRequestForBrokers(Seq(brokerId),
       partition, LeaderIsrAndControllerEpoch(updatedLeaderAndIsr, controllerEpoch), replicaAssignment(Seq(brokerId)), isNew = false)
@@ -209,7 +209,7 @@ class PartitionStateMachineTest {
     when(mockZkClient.updateLeaderAndIsr(Map(partition -> leaderAndIsrAfterElection), controllerEpoch, controllerContext.epochZkVersion))
       .thenReturn(UpdateLeaderAndIsrResult(Map(partition -> Right(updatedLeaderAndIsr)), Seq.empty))
 
-    partitionStateMachine.handleStateChanges(partitions, OnlinePartition, Option(ControlledShutdownPartitionLeaderElectionStrategy))
+    partitionStateMachine.handleStateChanges(partitions, OnlinePartition, Option(ControlledShutdownStrategy))
     verify(mockControllerBrokerRequestBatch).newBatch()
     // The leaderAndIsr request should be sent to both brokers, including the shutting down one
     verify(mockControllerBrokerRequestBatch).addLeaderAndIsrRequestForBrokers(Seq(brokerId, otherBrokerId),
@@ -266,7 +266,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).addLeaderAndIsrRequestForBrokers(Seq(brokerId),
@@ -343,7 +343,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(true))
+      Option(OfflineLeaderElectionStrategy(true))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).addLeaderAndIsrRequestForBrokers(
@@ -373,7 +373,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).sendRequestsToBrokers(controllerEpoch)
@@ -398,7 +398,7 @@ class PartitionStateMachineTest {
     partitionStateMachine.handleStateChanges(
       partitions,
       OnlinePartition,
-      Option(OfflinePartitionLeaderElectionStrategy(false))
+      Option(OfflineLeaderElectionStrategy(false))
     )
     verify(mockControllerBrokerRequestBatch).newBatch()
     verify(mockControllerBrokerRequestBatch).sendRequestsToBrokers(controllerEpoch)
@@ -469,7 +469,7 @@ class PartitionStateMachineTest {
     assertEquals(partitions.size, controllerContext.offlinePartitionCount,
       s"There should be ${partitions.size} offline partition(s)")
 
-    partitionStateMachine.handleStateChanges(partitions, OnlinePartition, Some(OfflinePartitionLeaderElectionStrategy(false)))
+    partitionStateMachine.handleStateChanges(partitions, OnlinePartition, Some(OfflineLeaderElectionStrategy(false)))
     assertEquals(0, controllerContext.offlinePartitionCount,
       s"There should be no offline partition(s)")
   }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1094,9 +1094,7 @@ object TestUtils extends Logging {
       timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
     val expectedBrokerIds = brokers.map(_.config.brokerId).toSet
     waitUntilTrue(() => brokers.forall { server =>
-      val aliveBrokers = server.dataPlaneRequestProcessor.metadataCache.getAliveBrokers().map(_.id).toSet
-      println(s"Expected: $expectedBrokerIds, Actual: $aliveBrokers")
-      expectedBrokerIds == aliveBrokers
+      expectedBrokerIds == server.dataPlaneRequestProcessor.metadataCache.getAliveBrokers().map(_.id).toSet
     }, "Timed out waiting for broker metadata to propagate to all servers", timeout)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1889,16 +1889,22 @@ object TestUtils extends Logging {
     )
   }
 
+  def currentIsr(admin: Admin, partition: TopicPartition): Set[Int] = {
+    val description = admin.describeTopics(Set(partition.topic).asJava)
+      .allTopicNames
+      .get
+      .asScala
+    description
+      .values
+      .flatMap(_.partitions.asScala.flatMap(_.isr.asScala))
+      .map(_.id)
+      .toSet
+  }
+
   def waitForBrokersInIsr(client: Admin, partition: TopicPartition, brokerIds: Set[Int]): Unit = {
     waitUntilTrue(
       () => {
-        val description = client.describeTopics(Set(partition.topic).asJava).allTopicNames.get.asScala
-        val isr = description
-          .values
-          .flatMap(_.partitions.asScala.flatMap(_.isr.asScala))
-          .map(_.id)
-          .toSet
-
+        val isr = currentIsr(client, partition)
         brokerIds.subsetOf(isr)
       },
       s"Expected brokers $brokerIds to be in the ISR for $partition"

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1093,9 +1093,11 @@ object TestUtils extends Logging {
       brokers: Seq[B],
       timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
     val expectedBrokerIds = brokers.map(_.config.brokerId).toSet
-    waitUntilTrue(() => brokers.forall(server =>
-      expectedBrokerIds == server.dataPlaneRequestProcessor.metadataCache.getAliveBrokers().map(_.id).toSet
-    ), "Timed out waiting for broker metadata to propagate to all servers", timeout)
+    waitUntilTrue(() => brokers.forall { server =>
+      val aliveBrokers = server.dataPlaneRequestProcessor.metadataCache.getAliveBrokers().map(_.id).toSet
+      println(s"Expected: $expectedBrokerIds, Actual: $aliveBrokers")
+      expectedBrokerIds == aliveBrokers
+    }, "Timed out waiting for broker metadata to propagate to all servers", timeout)
   }
 
   /**


### PR DESCRIPTION
When a reassignment is cancelled, the controller must send `StopReplica` to all Adding replicas to ensure that the partition state is removed. Currently, this does not necessarily result in a bump to the leader epoch, which means that the `StopReplica` may be ignored by the Adding replica due to [KIP-570](https://cwiki.apache.org/confluence/display/KAFKA/KIP-570%3A+Add+leader+epoch+in+StopReplicaRequest). When this happens, the partition becomes stray and must be manually cleaned up.

We fix the problem here by ensuring that the leader epoch is bumped when a replica transitions to `OfflineReplica` even if the replica is not a leader or in the current ISR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
