### PR TITLE
MINOR: Change groupInstanceId type from Optional<String> to String in ConsumerGroupMetadata and GroupRebalanceConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/GroupRebalanceConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/GroupRebalanceConfig.java
@@ -41,9 +41,10 @@ public class GroupRebalanceConfig {
     public final int rebalanceTimeoutMs;
     public final int heartbeatIntervalMs;
     public final String groupId;
-    public final Optional<String> groupInstanceId;
     public final long retryBackoffMs;
     public final boolean leaveGroupOnClose;
+
+    private final String groupInstanceId;
 
     public GroupRebalanceConfig(AbstractConfig config, ProtocolType protocolType) {
         this.sessionTimeoutMs = config.getInt(CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG);
@@ -63,12 +64,10 @@ public class GroupRebalanceConfig {
             String groupInstanceId = config.getString(CommonClientConfigs.GROUP_INSTANCE_ID_CONFIG);
             if (groupInstanceId != null) {
                 JoinGroupRequest.validateGroupInstanceId(groupInstanceId);
-                this.groupInstanceId = Optional.of(groupInstanceId);
-            } else {
-                this.groupInstanceId = Optional.empty();
             }
+            this.groupInstanceId = groupInstanceId;
         } else {
-            this.groupInstanceId = Optional.empty();
+            this.groupInstanceId = null;
         }
 
         this.retryBackoffMs = config.getLong(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG);
@@ -86,7 +85,7 @@ public class GroupRebalanceConfig {
                                 final int rebalanceTimeoutMs,
                                 final int heartbeatIntervalMs,
                                 String groupId,
-                                Optional<String> groupInstanceId,
+                                String groupInstanceId,
                                 long retryBackoffMs,
                                 boolean leaveGroupOnClose) {
         this.sessionTimeoutMs = sessionTimeoutMs;
@@ -96,5 +95,9 @@ public class GroupRebalanceConfig {
         this.groupInstanceId = groupInstanceId;
         this.retryBackoffMs = retryBackoffMs;
         this.leaveGroupOnClose = leaveGroupOnClose;
+    }
+
+    public Optional<String> groupInstanceId() {
+        return Optional.ofNullable(groupInstanceId);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -29,23 +29,27 @@ public class ConsumerGroupMetadata {
     final private String groupId;
     final private int generationId;
     final private String memberId;
-    final private Optional<String> groupInstanceId;
+    final private String groupInstanceId;
 
     public ConsumerGroupMetadata(String groupId,
                                  int generationId,
                                  String memberId,
-                                 Optional<String> groupInstanceId) {
+                                 String groupInstanceId) {
         this.groupId = Objects.requireNonNull(groupId, "group.id can't be null");
         this.generationId = generationId;
         this.memberId = Objects.requireNonNull(memberId, "member.id can't be null");
-        this.groupInstanceId = Objects.requireNonNull(groupInstanceId, "group.instance.id can't be null");
+        this.groupInstanceId = groupInstanceId;
+    }
+
+    public ConsumerGroupMetadata(String groupId, int generationId, String memberId) {
+        this(groupId, generationId, memberId, null);
     }
 
     public ConsumerGroupMetadata(String groupId) {
         this(groupId,
             JoinGroupRequest.UNKNOWN_GENERATION_ID,
             JoinGroupRequest.UNKNOWN_MEMBER_ID,
-            Optional.empty());
+            null);
     }
 
     public String groupId() {
@@ -61,7 +65,7 @@ public class ConsumerGroupMetadata {
     }
 
     public Optional<String> groupInstanceId() {
-        return groupInstanceId;
+        return Optional.ofNullable(groupInstanceId);
     }
 
     @Override
@@ -70,7 +74,7 @@ public class ConsumerGroupMetadata {
             groupId,
             generationId,
             memberId,
-            groupInstanceId.orElse(""));
+            groupInstanceId);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -679,8 +679,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             LogContext logContext;
 
             // If group.instance.id is set, we will append it to the log context.
-            if (groupRebalanceConfig.groupInstanceId.isPresent()) {
-                logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
+            if (groupRebalanceConfig.groupInstanceId().isPresent()) {
+                logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId().get() +
                         ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
             } else {
                 logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -555,7 +555,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public ConsumerGroupMetadata groupMetadata() {
-        return new ConsumerGroupMetadata("dummy.group.id", 1, "1", Optional.empty());
+        return new ConsumerGroupMetadata("dummy.group.id", 1, "1");
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,7 +38,7 @@ public class ConsumerGroupMetadataTest {
         String groupInstanceId = "instance";
 
         ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId,
-            generationId, memberId, Optional.of(groupInstanceId));
+            generationId, memberId, groupInstanceId);
 
         assertEquals(groupId, groupMetadata.groupId());
         assertEquals(generationId, groupMetadata.generationId());
@@ -62,7 +63,7 @@ public class ConsumerGroupMetadataTest {
         int generationId = 2;
 
         assertThrows(NullPointerException.class, () -> new ConsumerGroupMetadata(
-            null, generationId, memberId, Optional.empty())
+            null, generationId, memberId)
         );
     }
 
@@ -71,17 +72,29 @@ public class ConsumerGroupMetadataTest {
         int generationId = 2;
 
         assertThrows(NullPointerException.class, () -> new ConsumerGroupMetadata(
-            groupId, generationId, null, Optional.empty())
+            groupId, generationId, null)
         );
     }
 
     @Test
-    public void testInvalidInstanceId() {
+    public void testNullGroupInstanceId() {
         String memberId = "member";
         int generationId = 2;
 
-        assertThrows(NullPointerException.class, () -> new ConsumerGroupMetadata(
-            groupId, generationId, memberId, null)
-        );
+        ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId, generationId, memberId, null);
+
+        assertInstanceOf(Optional.class, groupMetadata.groupInstanceId());
+        assertFalse(groupMetadata.groupInstanceId().isPresent());
+    }
+
+    @Test
+    public void testWithoutGroupInstanceId() {
+        String memberId = "member";
+        int generationId = 2;
+
+        ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId, generationId, memberId);
+
+        assertInstanceOf(Optional.class, groupMetadata.groupInstanceId());
+        assertFalse(groupMetadata.groupInstanceId().isPresent());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -50,7 +50,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
     @Override
     public Subscription buildSubscriptionWithGeneration(List<String> topics, List<TopicPartition> partitions, int generation) {
-        assignor.onAssignment(null, new ConsumerGroupMetadata("dummy-group-id", generation, "dummy-member-id", Optional.empty()));
+        assignor.onAssignment(null, new ConsumerGroupMetadata("dummy-group-id", generation, "dummy-member-id"));
         return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions);
     }
 
@@ -63,7 +63,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         assertEquals(encodedGeneration.get(), DEFAULT_GENERATION);
 
         int generation = 10;
-        assignor.onAssignment(null, new ConsumerGroupMetadata("dummy-group-id", generation, "dummy-member-id", Optional.empty()));
+        assignor.onAssignment(null, new ConsumerGroupMetadata("dummy-group-id", generation, "dummy-member-id"));
 
         subscription = new Subscription(topics(topic), assignor.subscriptionUserData(new HashSet<>(topics(topic))));
         encodedGeneration = ((CooperativeStickyAssignor) assignor).memberData(subscription).generation;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -176,7 +176,7 @@ public class KafkaConsumerTest {
     private final String groupId = "mock-group";
     private final String memberId = "memberId";
     private final String leaderId = "leaderId";
-    private final Optional<String> groupInstanceId = Optional.of("mock-instance");
+    private final String groupInstanceId = "mock-instance";
     private Map<String, Uuid> topicIds = Stream.of(
             new AbstractMap.SimpleEntry<>(topic, topicId),
             new AbstractMap.SimpleEntry<>(topic2, topicId2),
@@ -834,7 +834,7 @@ public class KafkaConsumerTest {
         initMetadata(client, Collections.singletonMap(topic, 1));
 
         KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, metadata, assignor,
-                true, groupId, Optional.empty(), false);
+                true, groupId, null, false);
         consumer.assign(singletonList(tp0));
         consumer.seek(tp0, 20L);
         consumer.poll(Duration.ZERO);
@@ -1737,7 +1737,7 @@ public class KafkaConsumerTest {
         initMetadata(client, Collections.singletonMap(topic, 1));
         Node node = metadata.fetch().nodes().get(0);
 
-        final KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, metadata, assignor, false, Optional.empty());
+        final KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, metadata, assignor, false, null);
         consumer.subscribe(singleton(topic), getConsumerRebalanceListener(consumer));
         Node coordinator = prepareRebalance(client, node, assignor, singletonList(tp0), null);
 
@@ -2143,7 +2143,7 @@ public class KafkaConsumerTest {
         assertEquals(groupId, groupMetadataOnStart.groupId());
         assertEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, groupMetadataOnStart.memberId());
         assertEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, groupMetadataOnStart.generationId());
-        assertEquals(groupInstanceId, groupMetadataOnStart.groupInstanceId());
+        assertEquals(groupInstanceId, groupMetadataOnStart.groupInstanceId().get());
 
         consumer.subscribe(singleton(topic), getConsumerRebalanceListener(consumer));
         prepareRebalance(client, node, assignor, singletonList(tp0), null);
@@ -2156,7 +2156,7 @@ public class KafkaConsumerTest {
         assertEquals(groupId, groupMetadataAfterPoll.groupId());
         assertEquals(memberId, groupMetadataAfterPoll.memberId());
         assertEquals(1, groupMetadataAfterPoll.generationId());
-        assertEquals(groupInstanceId, groupMetadataAfterPoll.groupInstanceId());
+        assertEquals(groupInstanceId, groupMetadataAfterPoll.groupInstanceId().get());
     }
 
     @Test
@@ -2507,7 +2507,7 @@ public class KafkaConsumerTest {
                                                       ConsumerMetadata metadata,
                                                       ConsumerPartitionAssignor assignor,
                                                       boolean autoCommitEnabled,
-                                                      Optional<String> groupInstanceId) {
+                                                      String groupInstanceId) {
         return newConsumer(time, client, subscription, metadata, assignor, autoCommitEnabled, groupId, groupInstanceId, false);
     }
 
@@ -2525,7 +2525,7 @@ public class KafkaConsumerTest {
                                                       ConsumerPartitionAssignor assignor,
                                                       boolean autoCommitEnabled,
                                                       String groupId,
-                                                      Optional<String> groupInstanceId,
+                                                      String groupInstanceId,
                                                       boolean throwOnStableOffsetNotSupported) {
         return newConsumer(time, client, subscription, metadata, assignor, autoCommitEnabled, groupId, groupInstanceId,
         Optional.of(new StringDeserializer()), throwOnStableOffsetNotSupported);
@@ -2538,7 +2538,7 @@ public class KafkaConsumerTest {
                                                       ConsumerPartitionAssignor assignor,
                                                       boolean autoCommitEnabled,
                                                       String groupId,
-                                                      Optional<String> groupInstanceId,
+                                                      String groupInstanceId,
                                                       Optional<Deserializer<String>> valueDeserializer,
                                                       boolean throwOnStableOffsetNotSupported) {
         String clientId = "mock-consumer";

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
@@ -92,7 +92,7 @@ public class MockConsumerTest {
         assertEquals(2L, consumer.position(tp));
         consumer.commitSync();
         assertEquals(2L, consumer.committed(Collections.singleton(tp)).get(tp).offset());
-        assertEquals(new ConsumerGroupMetadata("dummy.group.id", 1, "1", Optional.empty()),
+        assertEquals(new ConsumerGroupMetadata("dummy.group.id", 1, "1"),
             consumer.groupMetadata());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -65,7 +65,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -114,16 +113,14 @@ public class AbstractCoordinatorTest {
     }
 
     private void setupCoordinator() {
-        setupCoordinator(RETRY_BACKOFF_MS, REBALANCE_TIMEOUT_MS,
-            Optional.empty());
+        setupCoordinator(RETRY_BACKOFF_MS, REBALANCE_TIMEOUT_MS, null);
     }
 
     private void setupCoordinator(int retryBackoffMs) {
-        setupCoordinator(retryBackoffMs, REBALANCE_TIMEOUT_MS,
-            Optional.empty());
+        setupCoordinator(retryBackoffMs, REBALANCE_TIMEOUT_MS, null);
     }
 
-    private void setupCoordinator(int retryBackoffMs, int rebalanceTimeoutMs, Optional<String> groupInstanceId) {
+    private void setupCoordinator(int retryBackoffMs, int rebalanceTimeoutMs, String groupInstanceId) {
         LogContext logContext = new LogContext();
         this.mockTime = new MockTime();
         ConsumerMetadata metadata = new ConsumerMetadata(retryBackoffMs, 60 * 60 * 1000L,
@@ -150,7 +147,7 @@ public class AbstractCoordinatorTest {
                                                                         GROUP_ID,
                                                                         groupInstanceId,
                                                                         retryBackoffMs,
-                                                                        !groupInstanceId.isPresent());
+                                                                        groupInstanceId == null);
         this.coordinator = new DummyCoordinator(rebalanceConfig,
                                                 consumerClient,
                                                 metrics,
@@ -315,8 +312,7 @@ public class AbstractCoordinatorTest {
 
     @Test
     public void testJoinGroupRequestTimeout() {
-        setupCoordinator(RETRY_BACKOFF_MS, REBALANCE_TIMEOUT_MS,
-            Optional.empty());
+        setupCoordinator(RETRY_BACKOFF_MS, REBALANCE_TIMEOUT_MS, null);
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
@@ -333,7 +329,7 @@ public class AbstractCoordinatorTest {
     @Test
     public void testJoinGroupRequestTimeoutLowerBoundedByDefaultRequestTimeout() {
         int rebalanceTimeoutMs = REQUEST_TIMEOUT_MS - 10000;
-        setupCoordinator(RETRY_BACKOFF_MS, rebalanceTimeoutMs, Optional.empty());
+        setupCoordinator(RETRY_BACKOFF_MS, rebalanceTimeoutMs, null);
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
@@ -352,8 +348,7 @@ public class AbstractCoordinatorTest {
     public void testJoinGroupRequestMaxTimeout() {
         // Ensure we can handle the maximum allowed rebalance timeout
 
-        setupCoordinator(RETRY_BACKOFF_MS, Integer.MAX_VALUE,
-            Optional.empty());
+        setupCoordinator(RETRY_BACKOFF_MS, Integer.MAX_VALUE, null);
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(0));
 
@@ -1047,11 +1042,11 @@ public class AbstractCoordinatorTest {
 
     @Test
     public void testLeaveGroupSentWithGroupInstanceIdUnSet() {
-        checkLeaveGroupRequestSent(Optional.empty());
-        checkLeaveGroupRequestSent(Optional.of("groupInstanceId"));
+        checkLeaveGroupRequestSent(null);
+        checkLeaveGroupRequestSent("groupInstanceId");
     }
 
-    private void checkLeaveGroupRequestSent(Optional<String> groupInstanceId) {
+    private void checkLeaveGroupRequestSent(String groupInstanceId) {
         setupCoordinator(RETRY_BACKOFF_MS, Integer.MAX_VALUE, groupInstanceId);
 
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
@@ -1128,7 +1123,7 @@ public class AbstractCoordinatorTest {
     }
 
     private RequestFuture<Void> setupLeaveGroup(LeaveGroupResponse leaveGroupResponse) {
-        setupCoordinator(RETRY_BACKOFF_MS, Integer.MAX_VALUE, Optional.empty());
+        setupCoordinator(RETRY_BACKOFF_MS, Integer.MAX_VALUE, null);
 
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         mockClient.prepareResponse(joinGroupFollowerResponse(1, memberId, leaderId, Errors.NONE));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
@@ -22,8 +22,6 @@ import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,7 +41,7 @@ public class HeartbeatTest {
                                                                         maxPollIntervalMs,
                                                                         heartbeatIntervalMs,
                                                                         "group_id",
-                                                                        Optional.empty(),
+                                                                        null,
                                                                         retryBackoffMs,
                                                                         true);
         heartbeat = new Heartbeat(rebalanceConfig, time);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -98,7 +98,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
@@ -1554,7 +1553,7 @@ public class KafkaProducerTest {
             producer.initTransactions();
             producer.beginTransaction();
             ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId,
-                generationId, memberId, Optional.of(groupInstanceId));
+                generationId, memberId, groupInstanceId);
 
             producer.sendOffsetsToTransaction(Collections.emptyMap(), groupMetadata);
             producer.commitTransaction();
@@ -1568,7 +1567,7 @@ public class KafkaProducerTest {
 
     @Test
     public void testInvalidGenerationIdAndMemberIdCombinedInSendOffsets() {
-        verifyInvalidGroupMetadata(new ConsumerGroupMetadata("group", 2, JoinGroupRequest.UNKNOWN_MEMBER_ID, Optional.empty()));
+        verifyInvalidGroupMetadata(new ConsumerGroupMetadata("group", 2, JoinGroupRequest.UNKNOWN_MEMBER_ID));
     }
 
     private void verifyInvalidGroupMetadata(ConsumerGroupMetadata groupMetadata) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -929,7 +929,7 @@ public class TransactionManagerTest {
 
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
             singletonMap(tp, new OffsetAndMetadata(39L)),
-            new ConsumerGroupMetadata(consumerGroupId, 5, fencedMemberId, Optional.of(groupInstanceId)));
+            new ConsumerGroupMetadata(consumerGroupId, 5, fencedMemberId, groupInstanceId));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, producerId, epoch);
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
@@ -963,7 +963,7 @@ public class TransactionManagerTest {
 
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
             singletonMap(tp, new OffsetAndMetadata(39L)),
-            new ConsumerGroupMetadata(consumerGroupId, 5, unknownMemberId, Optional.empty()));
+            new ConsumerGroupMetadata(consumerGroupId, 5, unknownMemberId));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, producerId, epoch);
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
@@ -996,8 +996,7 @@ public class TransactionManagerTest {
 
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
             singletonMap(tp, new OffsetAndMetadata(39L)),
-            new ConsumerGroupMetadata(consumerGroupId, illegalGenerationId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
-                Optional.empty()));
+            new ConsumerGroupMetadata(consumerGroupId, illegalGenerationId, JoinGroupRequest.UNKNOWN_MEMBER_ID));
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, producerId, epoch);
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
@@ -2335,7 +2334,7 @@ public class TransactionManagerTest {
         offsets.put(tp1, new OffsetAndMetadata(1));
 
         TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(
-            offsets, new ConsumerGroupMetadata(consumerGroupId, generationId, memberId, Optional.of(groupInstanceId)));
+            offsets, new ConsumerGroupMetadata(consumerGroupId, generationId, memberId, groupInstanceId));
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, producerId, epoch);
 
         sender.runOnce();  // send AddOffsetsToTxnResult


### PR DESCRIPTION
- There is Optional<String> groupInstanceId field in ConsumerGroupMetadata class and GroupRebalanceConfig class and that is one of the Optional anti-patterns so I changes to String and use getter method to return Optional type.
- Add new ConsumerGroupMetadata constructor for if groupInstanceId not used.