### PR TITLE
MINOR: Reuse gradle daemon for scala compilation by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ def doValidation() {
   sh """
     ./retry_zinc ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
         spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-        --profile --no-daemon --continue -PxmlSpotBugsReport=true
+        --profile --continue -PxmlSpotBugsReport=true -PkeepAliveMode="session"
   """
 }
 
@@ -31,7 +31,7 @@ def isChangeRequest(env) {
 
 def doTest(env, target = "unitTest integrationTest") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
-      --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed \
+      --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
   junit '**/build/test-results/**/TEST-*.xml'
 }

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ available to the JVM. The value must be between 1 and 16 (inclusive).
 * `enableTestCoverage`: enables test coverage plugins and tasks, including bytecode enhancement of classes required to track said
 coverage. Note that this introduces some overhead when running tests and hence why it's disabled by default (the overhead
 varies, but 15-20% is a reasonable estimate).
+* `keepAliveMode`: configures the keep alive mode for the Gradle compilation daemon - reuse improves start-up time. The values should 
+be one of 'daemon' or `session` (the default is `daemon`). `daemon` keeps the daemon alive until it's explicitly stopped while
+`session` keeps it alive until the end of the build session. This currently only affects the Scala compiler, see
+https://github.com/gradle/gradle/pull/21034 for a PR that attempts to do the same for the Java compiler.
 * `scalaOptimizerMode`: configures the optimizing behavior of the scala compiler, the value should be one of `none`, `method`, `inline-kafka` or
 `inline-scala` (the default is `inline-kafka`). `none` is the scala compiler default, which only eliminates unreachable code. `method` also
 includes method-local optimizations. `inline-kafka` adds inlining of methods within the kafka packages. Finally, `inline-scala` also

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ available to the JVM. The value must be between 1 and 16 (inclusive).
 coverage. Note that this introduces some overhead when running tests and hence why it's disabled by default (the overhead
 varies, but 15-20% is a reasonable estimate).
 * `keepAliveMode`: configures the keep alive mode for the Gradle compilation daemon - reuse improves start-up time. The values should 
-be one of 'daemon' or `session` (the default is `daemon`). `daemon` keeps the daemon alive until it's explicitly stopped while
+be one of `daemon` or `session` (the default is `daemon`). `daemon` keeps the daemon alive until it's explicitly stopped while
 `session` keeps it alive until the end of the build session. This currently only affects the Scala compiler, see
 https://github.com/gradle/gradle/pull/21034 for a PR that attempts to do the same for the Java compiler.
 * `scalaOptimizerMode`: configures the optimizing behavior of the scala compiler, the value should be one of `none`, `method`, `inline-kafka` or

--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,18 @@ ext {
 
   userEnableTestCoverage = project.hasProperty("enableTestCoverage") ? enableTestCoverage : false
 
+  userKeepAliveModeString = project.hasProperty("keepAliveMode") ? keepAliveMode : "daemon"
+  userKeepAliveMode = KeepAliveMode.values().find(m -> m.name().toLowerCase().equals(userKeepAliveModeString))
+  if (userKeepAliveMode == null) {
+    def keepAliveValues = KeepAliveMode.values().collect(m -> m.name.toLowerCase())
+    throw new GradleException("Unexpected value for keepAliveMode property. Expected one of $keepAliveValues, but received: $userKeepAliveModeString")
+  }
+
   // See README.md for details on this option and the reasoning for the default
   userScalaOptimizerMode = project.hasProperty("scalaOptimizerMode") ? scalaOptimizerMode : "inline-kafka"
   def scalaOptimizerValues = ["none", "method", "inline-kafka", "inline-scala"]
   if (!scalaOptimizerValues.contains(userScalaOptimizerMode))
-    throw new GradleException("Unexpected value for scalaOptimizerMode property. Expected one of $scalaOptimizerValues), but received: $userScalaOptimizerMode")
+    throw new GradleException("Unexpected value for scalaOptimizerMode property. Expected one of $scalaOptimizerValues, but received: $userScalaOptimizerMode")
 
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
 
@@ -620,6 +627,8 @@ subprojects {
   }
 
   tasks.withType(ScalaCompile) {
+
+    scalaCompileOptions.keepAliveMode = userKeepAliveMode
 
     scalaCompileOptions.additionalParameters = [
       "-deprecation",


### PR DESCRIPTION
The time time to compile was reduced from 5.3 seconds to 0.9 seconds by
changing the keep alive mode from `SESSION` to `DAEMON`. We change the
default to the latter and allow the former to be set via a `keepAliveMode`
property.

Also update the Jenkins build to use `keepAliveMode="session"` instead of
`--no-daemon`.

./gradlew compileTestScala -PkeepAliveMode="daemon" --info:

> Task :streams:streams-scala:compileTestScala
> Watching 928 directories to track changes
> Caching disabled for task ':streams:streams-scala:compileTestScala' because:
>   Build cache is disabled
> Task ':streams:streams-scala:compileTestScala' is not up-to-date because:
>   Input property 'source' file /home/ijuma/src/kafka/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/JoinedTest.scala has changed.
> Watching 920 directories to track changes
> Watching 919 directories to track changes
> Compiling with Zinc Scala compiler.
> Prepared Zinc Scala inputs: 0.004 secs
> compiling 16 Scala sources to /home/ijuma/src/kafka/streams/streams-scala/build/classes/scala/test ...
> done compiling
> Completed Scala compilation: 0.925 secs

./gradlew compileTestScala -PkeepAliveMode="session" --info

> Task :streams:streams-scala:compileTestScala
> Watching 928 directories to track changes
> Caching disabled for task ':streams:streams-scala:compileTestScala' because:
>   Build cache is disabled
> Task ':streams:streams-scala:compileTestScala' is not up-to-date because:
>   Input property 'source' file /home/ijuma/src/kafka/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/JoinedTest.scala has changed.
> Watching 920 directories to track changes
> Watching 919 directories to track changes
> Starting process 'Gradle Worker Daemon 3'. Working directory: /home/ijuma/.gradle/workers Command: /usr/java/jdk-17.0.4.1+1/bin/java -Xss4m -XX:+UseParallelGC --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.nio.file=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.util.stream=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED @/home/ijuma/.gradle/.tmp/gradle-worker-classpath3305983246500958050txt -Xmx2048m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Worker Daemon 3'
> Successfully started process 'Gradle Worker Daemon 3'
> Started Gradle worker daemon (0.244 secs) with fork options DaemonForkOptions{executable=/usr/java/jdk-17.0.4.1+1/bin/java, minHeapSize=null, maxHeapSize=2048m, jvmArgs=[-Xss4m, -XX:+UseParallelGC, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.lang=ALL-UNNAMED, --add-opens=java.base/java.nio=ALL-UNNAMED, --add-opens=java.base/java.nio.file=ALL-UNNAMED, --add-opens=java.base/java.util=ALL-UNNAMED, --add-opens=java.base/java.util.concurrent=ALL-UNNAMED, --add-opens=java.base/java.util.regex=ALL-UNNAMED, --add-opens=java.base/java.util.stream=ALL-UNNAMED, --add-opens=java.base/java.text=ALL-UNNAMED, --add-opens=java.base/java.time=ALL-UNNAMED, --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED], keepAliveMode=SESSION}.
> Compiling with Zinc Scala compiler.
> Prepared Zinc Scala inputs: 0.187 secs
> compiling 16 Scala sources to /home/ijuma/src/kafka/streams/streams-scala/build/classes/scala/test ...
> done compiling
> Completed Scala compilation: 5.307 secs

See https://github.com/gradle/gradle/issues/20579 for more details.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
