### PR TITLE
KAFKA-13971: Fix atomicity violations caused by improper usage of ConcurrentHashMap - part2

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -222,14 +222,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     private <T> void addPlugins(Collection<PluginDesc<T>> plugins, ClassLoader loader) {
         for (PluginDesc<T> plugin : plugins) {
             String pluginClassName = plugin.className();
-            SortedMap<PluginDesc<?>, ClassLoader> inner = pluginLoaders.get(pluginClassName);
-            if (inner == null) {
-                inner = new TreeMap<>();
-                pluginLoaders.put(pluginClassName, inner);
-                // TODO: once versioning is enabled this line should be moved outside this if branch
-                log.info("Added plugin '{}'", pluginClassName);
-            }
-            inner.put(plugin, loader);
+            pluginLoaders.computeIfAbsent(pluginClassName, k -> new TreeMap<>()).put(plugin, loader);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -222,10 +222,14 @@ public class DelegatingClassLoader extends URLClassLoader {
     private <T> void addPlugins(Collection<PluginDesc<T>> plugins, ClassLoader loader) {
         for (PluginDesc<T> plugin : plugins) {
             String pluginClassName = plugin.className();
-            pluginLoaders.computeIfAbsent(pluginClassName, k -> {
+            SortedMap<PluginDesc<?>, ClassLoader> inner = pluginLoaders.get(pluginClassName);
+            if (inner == null) {
+                inner = new TreeMap<>();
+                pluginLoaders.put(pluginClassName, inner);
+                // TODO: once versioning is enabled this line should be moved outside this if branch
                 log.info("Added plugin '{}'", pluginClassName);
-                return new TreeMap<>();
-            }).put(plugin, loader);
+            }
+            inner.put(plugin, loader);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -222,7 +222,10 @@ public class DelegatingClassLoader extends URLClassLoader {
     private <T> void addPlugins(Collection<PluginDesc<T>> plugins, ClassLoader loader) {
         for (PluginDesc<T> plugin : plugins) {
             String pluginClassName = plugin.className();
-            pluginLoaders.computeIfAbsent(pluginClassName, k -> new TreeMap<>()).put(plugin, loader);
+            pluginLoaders.computeIfAbsent(pluginClassName, k -> {
+                log.info("Added plugin '{}'", pluginClassName);
+                return new TreeMap<>();
+            }).put(plugin, loader);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTrigger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTrigger.java
@@ -32,12 +32,12 @@ public class RocksDBMetricsRecordingTrigger implements Runnable {
 
     public void addMetricsRecorder(final RocksDBMetricsRecorder metricsRecorder) {
         final String metricsRecorderName = metricsRecorderName(metricsRecorder);
-        if (metricsRecordersToTrigger.containsKey(metricsRecorderName)) {
+        final RocksDBMetricsRecorder existingRocksDBMetricsRecorder = metricsRecordersToTrigger.putIfAbsent(metricsRecorderName, metricsRecorder);
+        if (existingRocksDBMetricsRecorder != null) {
             throw new IllegalStateException("RocksDB metrics recorder for store \"" + metricsRecorder.storeName() +
                 "\" of task " + metricsRecorder.taskId().toString() + " has already been added. "
                 + "This is a bug in Kafka Streams.");
         }
-        metricsRecordersToTrigger.put(metricsRecorderName, metricsRecorder);
     }
 
     public void removeMetricsRecorder(final RocksDBMetricsRecorder metricsRecorder) {


### PR DESCRIPTION
~~## Problem #1 in DelegatingClassLoader.java
Atomicity violation in example such as:
Consider thread T1 reaches line 228, but before executing context switches to thread T2 which also reaches line 228. Again context switches to T1 which reaches line 232 and adds a value to the map. T2 will execute line 228 and creates a new map which overwrites the value written by T1, hence change done by T1 would be lost. This code change ensures that two threads cannot initiate the TreeMap, instead only one of them will.~~

## Problem #2 in RocksDBMetricsRecordingTrigger.java
Atomicity violation in example such as:
Consider thread T1 reaches line 40 but before executing it context switches to thread T2 which also reaches line 40. In a serialized execution order, thread T2 should have thrown the exception but it won't in this case. The code change fixes that.

Note that some other problems associated with use of concurrent hashmap has been fixed in https://github.com/apache/kafka/pull/12277