### PR TITLE
MINOR: Fail if Logging controller bean is not correctly registered

### DIFF
--- a/core/src/main/scala/kafka/metrics/KafkaMetricsReporter.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsReporter.scala
@@ -69,11 +69,9 @@ object KafkaMetricsReporter {
             reporter.init(verifiableProps)
             reporters += reporter
             reporter match {
-              case bean: KafkaMetricsReporterMBean =>
-                val success = CoreUtils.registerMBean(reporter, bean.getMBeanName)
-                if (!success) {
-                  throw new IllegalArgumentException(s"Couldn't register ${bean.getMBeanName} MBean")
-                }
+              // Note that we are silently ignoring if registration is not successful since we do not check the return
+              // type of `CoreUtils.registerMBean`
+              case bean: KafkaMetricsReporterMBean => CoreUtils.registerMBean(reporter, bean.getMBeanName)
               case _ =>
             }
           })

--- a/core/src/main/scala/kafka/metrics/KafkaMetricsReporter.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsReporter.scala
@@ -21,8 +21,9 @@
 package kafka.metrics
 
 import kafka.utils.{CoreUtils, VerifiableProperties}
-import java.util.concurrent.atomic.AtomicBoolean
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
 
@@ -53,11 +54,13 @@ trait KafkaMetricsReporter {
 
 object KafkaMetricsReporter {
   val ReporterStarted: AtomicBoolean = new AtomicBoolean(false)
-  private var reporters: ArrayBuffer[KafkaMetricsReporter] = null
+  val reporterStartedLatch: CountDownLatch = new CountDownLatch(1)
+
+  private var reporters: ArrayBuffer[KafkaMetricsReporter] = _
 
   def startReporters(verifiableProps: VerifiableProperties): Seq[KafkaMetricsReporter] = {
-    ReporterStarted synchronized {
-      if (!ReporterStarted.get()) {
+    if (!ReporterStarted.getAndSet(true)) {
+      try {
         reporters = ArrayBuffer[KafkaMetricsReporter]()
         val metricsConfig = new KafkaMetricsConfig(verifiableProps)
         if (metricsConfig.reporters.nonEmpty) {
@@ -66,13 +69,20 @@ object KafkaMetricsReporter {
             reporter.init(verifiableProps)
             reporters += reporter
             reporter match {
-              case bean: KafkaMetricsReporterMBean => CoreUtils.registerMBean(reporter, bean.getMBeanName)
+              case bean: KafkaMetricsReporterMBean =>
+                val success = CoreUtils.registerMBean(reporter, bean.getMBeanName)
+                if (!success) {
+                  throw new IllegalArgumentException(s"Couldn't register ${bean.getMBeanName} MBean")
+                }
               case _ =>
             }
           })
-          ReporterStarted.set(true)
         }
+      } finally {
+        reporterStartedLatch.countDown()
       }
+    } else {
+      reporterStartedLatch.await()
     }
     reporters
   }

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -119,7 +119,7 @@ object CoreUtils {
    */
   def registerMBean(mbean: Object, name: String): Boolean = {
     try {
-      val mbs = ManagementFactory.getPlatformMBeanServer()
+      val mbs = ManagementFactory.getPlatformMBeanServer
       mbs synchronized {
         val objName = new ObjectName(name)
         if (mbs.isRegistered(objName))
@@ -139,7 +139,7 @@ object CoreUtils {
    * @param name The mbean name to unregister
    */
   def unregisterMBean(name: String): Unit = {
-    val mbs = ManagementFactory.getPlatformMBeanServer()
+    val mbs = ManagementFactory.getPlatformMBeanServer
     mbs synchronized {
       val objName = new ObjectName(name)
       if (mbs.isRegistered(objName))

--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -27,10 +27,13 @@ object Log4jControllerRegistration {
   try {
     val log4jController = Class.forName("kafka.utils.Log4jController").asInstanceOf[Class[Object]]
     val instance = log4jController.getDeclaredConstructor().newInstance()
-    CoreUtils.registerMBean(instance, "kafka:type=kafka.Log4jController")
+    val success = CoreUtils.registerMBean(instance, "kafka:type=kafka.Log4jController")
+    if (!success) {
+      throw new IllegalArgumentException()
+    }
     logger.info("Registered kafka:type=kafka.Log4jController MBean")
   } catch {
-    case _: Exception => logger.info("Couldn't register kafka:type=kafka.Log4jController MBean")
+    case _: Exception => logger.info("Couldn't register kafka:type=kafka.Log4jController MBean", Exception)
   }
 }
 

--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -29,11 +29,11 @@ object Log4jControllerRegistration {
     val instance = log4jController.getDeclaredConstructor().newInstance()
     val success = CoreUtils.registerMBean(instance, "kafka:type=kafka.Log4jController")
     if (!success) {
-      throw new IllegalArgumentException()
+      throw new IllegalArgumentException
     }
     logger.info("Registered kafka:type=kafka.Log4jController MBean")
   } catch {
-    case _: Exception => logger.info("Couldn't register kafka:type=kafka.Log4jController MBean", Exception)
+    case _: Exception => logger.info("Couldn't register kafka:type=kafka.Log4jController MBean")
   }
 }
 
@@ -43,7 +43,7 @@ private object Logging {
 
 trait Logging {
 
-  protected lazy val logger = Logger(LoggerFactory.getLogger(loggerName))
+  protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(loggerName))
 
   protected var logIdent: String = _
 


### PR DESCRIPTION
Two changes in this PR.

1. Remove synchronized block and simplify it by using a latch.

2. Do not ignore the return value for `CoreUtils.registerMBean`. Since the method does not throw an exception, the return type tells us whether the registration was successful or not.

Note that after this change we are throwing an exception if we fail to load the log4j controller BUT we do not fail if we fail to load a metrics reporter bean (existing behaviour).
