### PR TITLE
KAFKA-13980: Upgrade from Scala 2.12.15 to 2.12.17

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,7 +27,7 @@ ext {
 }
 
 // Add Scala version
-def defaultScala212Version = '2.12.15'
+def defaultScala212Version = '2.12.17'
 def defaultScala213Version = '2.13.8'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {


### PR DESCRIPTION
This PR updates from Scala 2.12.15 to 2.12.16. Since its a binary compatible change there shouldn't be any problems.

Release notes can be found here https://github.com/scala/scala/releases/tag/v2.12.16

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
