### PR TITLE
KAFKA-13984: Fix TopicBasedRemoteLogMetadataManager#initializeResources should exit immediately when partition size of __remote_log_metadata  is not same as configured   

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -392,6 +392,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                         // If the existing topic partition size is not same as configured, mark initialization as failed and exit.
                         if (!isPartitionsCountSameAsConfigured(adminClient, topicName)) {
                             initializationFailed = true;
+                            return;
                         }
                     } catch (Exception e) {
                         log.info("Sleep for : {} ms before it is retried again.", rlmmConfig.initializationRetryIntervalMs());

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
@@ -63,11 +63,11 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
         // Call setup to start the cluster.
         super.setUp(new EmptyTestInfo());
 
-        initializeRemoteLogMetadataManager(topicIdPartitions, startConsumerThread);
+        initializeRemoteLogMetadataManager(topicIdPartitions, startConsumerThread, METADATA_TOPIC_PARTITIONS_COUNT);
     }
 
     public void initializeRemoteLogMetadataManager(Set<TopicIdPartition> topicIdPartitions,
-                                                   boolean startConsumerThread) {
+                                                   boolean startConsumerThread, int remoteLogMetadataTopicPartitionCount) {
         String logDir = TestUtils.tempDirectory("rlmm_segs_").getAbsolutePath();
         topicBasedRemoteLogMetadataManager = new TopicBasedRemoteLogMetadataManager(startConsumerThread) {
             @Override
@@ -94,7 +94,7 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
         configs.put(REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers(listenerName()));
         configs.put(BROKER_ID, 0);
         configs.put(LOG_DIR, logDir);
-        configs.put(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, METADATA_TOPIC_PARTITIONS_COUNT);
+        configs.put(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, remoteLogMetadataTopicPartitionCount);
         configs.put(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP, METADATA_TOPIC_REPLICATION_FACTOR);
         configs.put(REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_PROP, METADATA_TOPIC_RETENTION_MS);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -84,7 +84,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
         assertTrue(topicBasedRlmm().isInitialized());
 
         stopTopicBasedRemoteLogMetadataManagerHarness();
-        assertThrows(KafkaException.class, () -> startTopicBasedRemoteLogMetadataManagerHarness(false, 4));
+        assertThrows(KafkaException.class, () -> startTopicBasedRemoteLogMetadataManagerHarness(false, TopicBasedRemoteLogMetadataManagerHarness.METADATA_TOPIC_PARTITIONS_COUNT + 1));
         assertFalse(topicBasedRlmm().isInitialized());
 
         stopTopicBasedRemoteLogMetadataManagerHarness();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.server.log.remote.metadata.storage;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -44,6 +45,9 @@ import java.util.Optional;
 
 import static org.apache.kafka.server.log.remote.metadata.storage.ConsumerManager.COMMITTED_OFFSETS_FILE_NAME;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.LOG_DIR;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("deprecation") // Added for Scala 2.12 compatibility for usages of JavaConverters
 public class TopicBasedRemoteLogMetadataManagerRestartTest {
@@ -68,9 +72,26 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
         remoteLogMetadataManagerHarness.initialize(Collections.emptySet(), true);
     }
 
-    private void startTopicBasedRemoteLogMetadataManagerHarness(boolean startConsumerThread) {
-        remoteLogMetadataManagerHarness.initializeRemoteLogMetadataManager(Collections.emptySet(), startConsumerThread);
+    private void startTopicBasedRemoteLogMetadataManagerHarness(boolean startConsumerThread,
+                                                                int remoteLogMetadataTopicPartitionCount) {
+        remoteLogMetadataManagerHarness.initializeRemoteLogMetadataManager(Collections.emptySet(), startConsumerThread,
+                remoteLogMetadataTopicPartitionCount);
     }
+
+
+    @Test
+    public void testRLMMInitializeResources() throws Exception {
+        assertTrue(topicBasedRlmm().isInitialized());
+
+        stopTopicBasedRemoteLogMetadataManagerHarness();
+        assertThrows(KafkaException.class, () -> startTopicBasedRemoteLogMetadataManagerHarness(false, 4));
+        assertFalse(topicBasedRlmm().isInitialized());
+
+        stopTopicBasedRemoteLogMetadataManagerHarness();
+        startTopicBasedRemoteLogMetadataManagerHarness(false, 3);
+        assertTrue(topicBasedRlmm().isInitialized());
+    }
+
 
     @AfterEach
     public void teardown() throws IOException {
@@ -138,7 +159,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
 
         // Start TopicBasedRemoteLogMetadataManager but do not start consumer thread to check whether the stored metadata is
         // loaded successfully or not.
-        startTopicBasedRemoteLogMetadataManagerHarness(false);
+        startTopicBasedRemoteLogMetadataManagerHarness(false, TopicBasedRemoteLogMetadataManagerHarness.METADATA_TOPIC_PARTITIONS_COUNT);
 
         // Register these partitions to RLMM, which loads the respective metadata snapshots.
         topicBasedRlmm().onPartitionLeadershipChanges(Collections.singleton(leaderTopicIdPartition), Collections.singleton(followerTopicIdPartition));

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -88,7 +88,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
         assertFalse(topicBasedRlmm().isInitialized());
 
         stopTopicBasedRemoteLogMetadataManagerHarness();
-        startTopicBasedRemoteLogMetadataManagerHarness(false, 3);
+        startTopicBasedRemoteLogMetadataManagerHarness(false, TopicBasedRemoteLogMetadataManagerHarness.METADATA_TOPIC_PARTITIONS_COUNT);
         assertTrue(topicBasedRlmm().isInitialized());
     }
 


### PR DESCRIPTION
When  executing `TopicBasedRemoteLogMetadataManager.initializeResources()`, if the result of `TopicBasedRemoteLogMetadataManager.isPartitionsCountSameAsConfigured() `is false.

It means that the actual number of partitions in the internal topic __remote_log_metadata is inconsistent with the number of partitions configured in our configuration file
At this time, it is not reasonable to continue the subsequent initialization process.We should raise an error to exit.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
