### PR TITLE
HOTFIX: null check for ProducerRecord when computing sizeInBytes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -191,9 +191,9 @@ public class ClientUtils {
     }
 
     private static long recordSizeInBytes(final long keyBytes,
-                                         final long valueBytes,
-                                         final String topic,
-                                         final Headers headers) {
+                                          final long valueBytes,
+                                          final String topic,
+                                          final Headers headers) {
         long headerSizeInBytes = 0L;
 
         if (headers != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -174,7 +174,7 @@ public class ClientUtils {
 
     public static long producerRecordSizeInBytes(final ProducerRecord<byte[], byte[]> record) {
         return recordSizeInBytes(
-            record.key().length,
+            record.key() == null ? 0 : record.key().length,
             record.value() == null ? 0 : record.value().length,
             record.topic(),
             record.headers()
@@ -190,7 +190,7 @@ public class ClientUtils {
         );
     }
 
-    public static long recordSizeInBytes(final long keyBytes,
+    private static long recordSizeInBytes(final long keyBytes,
                                          final long valueBytes,
                                          final String topic,
                                          final Headers headers) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
@@ -86,6 +86,12 @@ public class ClientUtilsTest {
         HEADERS_BYTES +
         RECORD_METADATA_BYTES;
 
+    private static final long NULL_KEY_SIZE_IN_BYTES =
+        VALUE_BYTES +
+        TOPIC_BYTES +
+        HEADERS_BYTES +
+        RECORD_METADATA_BYTES;
+
     private static final long TOMBSTONE_SIZE_IN_BYTES =
         KEY_BYTES +
         TOPIC_BYTES +
@@ -230,7 +236,7 @@ public class ClientUtilsTest {
             VALUE,
             HEADERS
         );
-        assertThat(producerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+        assertThat(producerRecordSizeInBytes(record), equalTo(NULL_KEY_SIZE_IN_BYTES));
     }
 
     @Test
@@ -248,7 +254,7 @@ public class ClientUtilsTest {
             HEADERS,
             Optional.empty()
         );
-        assertThat(consumerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+        assertThat(consumerRecordSizeInBytes(record), equalTo(NULL_KEY_SIZE_IN_BYTES));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
@@ -86,12 +86,14 @@ public class ClientUtilsTest {
         HEADERS_BYTES +
         RECORD_METADATA_BYTES;
 
+    // 54 bytes
     private static final long NULL_KEY_SIZE_IN_BYTES =
         VALUE_BYTES +
         TOPIC_BYTES +
         HEADERS_BYTES +
         RECORD_METADATA_BYTES;
 
+    // 52 bytes
     private static final long TOMBSTONE_SIZE_IN_BYTES =
         KEY_BYTES +
         TOPIC_BYTES +
@@ -216,14 +218,14 @@ public class ClientUtilsTest {
             0,
             0L,
             TimestampType.CREATE_TIME,
-            KEY_BYTES,
             0,
-            KEY,
+            5,
             null,
+            VALUE,
             HEADERS,
             Optional.empty()
         );
-        assertThat(consumerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+        assertThat(consumerRecordSizeInBytes(record), equalTo(NULL_KEY_SIZE_IN_BYTES));
     }
 
     @Test
@@ -247,14 +249,14 @@ public class ClientUtilsTest {
             0,
             0L,
             TimestampType.CREATE_TIME,
+            KEY_BYTES,
             0,
-            0,
+            KEY,
             null,
-            VALUE,
             HEADERS,
             Optional.empty()
         );
-        assertThat(consumerRecordSizeInBytes(record), equalTo(NULL_KEY_SIZE_IN_BYTES));
+        assertThat(consumerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
@@ -73,6 +73,7 @@ public class ClientUtilsTest {
     ));    // 2 + 10 --> 12 bytes
     private static final int HEADERS_BYTES = 24;
 
+    // 20 bytes
     private static final int RECORD_METADATA_BYTES =
         8 + // timestamp
         8 + // offset

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
@@ -203,7 +203,7 @@ public class ClientUtilsTest {
     }
 
     @Test
-    public void shouldComputeSizeInBytesForConsumerRecordWithNullValue() {
+    public void shouldComputeSizeInBytesForConsumerRecordWithNullKey() {
         final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
             TOPIC,
             1,
@@ -214,6 +214,37 @@ public class ClientUtilsTest {
             0,
             KEY,
             null,
+            HEADERS,
+            Optional.empty()
+        );
+        assertThat(consumerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+    }
+
+    @Test
+    public void shouldComputeSizeInBytesForProducerRecordWithNullKey() {
+        final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+            TOPIC,
+            1,
+            0L,
+            null,
+            VALUE,
+            HEADERS
+        );
+        assertThat(producerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+    }
+
+    @Test
+    public void shouldComputeSizeInBytesForConsumerRecordWithNullValue() {
+        final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+            TOPIC,
+            1,
+            0,
+            0L,
+            TimestampType.CREATE_TIME,
+            0,
+            0,
+            null,
+            VALUE,
             HEADERS,
             Optional.empty()
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
@@ -69,8 +69,8 @@ public class ClientUtilsTest {
 
     private static final Headers HEADERS = new RecordHeaders(asList(
         new RecordHeader("h1", "headerVal1".getBytes()),   // 2 + 10 --> 12 bytes
-        new RecordHeader("h2", "headerVal2".getBytes())
-    ));    // 2 + 10 --> 12 bytes
+        new RecordHeader("h2", "headerVal2".getBytes())    // 2 + 10 --> 12 bytes
+    ));
     private static final int HEADERS_BYTES = 24;
 
     // 20 bytes

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -171,15 +171,13 @@ public class TestTopicsTest {
     }
 
     @Test
-    public void testPipeInputWithNullKey() {
+    public void testKeyValuesToMapWithNull() {
         final TestInputTopic<Long, String> inputTopic =
             testDriver.createInputTopic(INPUT_TOPIC, longSerde.serializer(), stringSerde.serializer());
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
-        final StreamsException exception = assertThrows(StreamsException.class, () -> inputTopic.pipeInput("value"));
-        assertThat(exception.getCause() instanceof NullPointerException, is(true));
-        assertThat(outputTopic.readKeyValuesToMap().isEmpty(), is(true));
-
+        inputTopic.pipeInput("value");
+        assertThrows(IllegalStateException.class, outputTopic::readKeyValuesToMap);
     }
 
     @Test

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -31,8 +31,6 @@ import org.apache.kafka.streams.test.TestRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -55,8 +55,6 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestTopicsTest {
-    private static final Logger log = LoggerFactory.getLogger(TestTopicsTest.class);
-
     private final static String INPUT_TOPIC = "input";
     private final static String OUTPUT_TOPIC = "output1";
     private final static String INPUT_TOPIC_MAP = OUTPUT_TOPIC;


### PR DESCRIPTION
Minor followup to #12235  that adds a null check on the record key in the new ClientUtils#producerRecordSizeInBytes utility method, as there are valid cases in which we might be sending records with null keys to the Producer, such as a simple `builder.stream("non-keyed-input-topic").filter(...).to("output-topic")`