### PR TITLE
KAFKA-13957: Fix flaky shouldQuerySpecificActivePartitionStores test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -233,7 +233,7 @@ public class StoreQueryIntegrationTest {
                     assertThat(store2.get(key), is(notNullValue()));
                     assertThat(getStore(kafkaStreams1, storeQueryParam2).get(key), is(nullValue()));
                     final InvalidStateStoreException exception =
-                            assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams2, storeQueryParam2).get(key));
+                        assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams2, storeQueryParam2).get(key));
                     assertThat(
                         exception.getMessage(),
                         containsString("The specified partition 1 for store source-table does not exist.")

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -532,14 +532,14 @@ public class StoreQueryIntegrationTest {
         });
     }
 
-    private Matcher<String> retrievableException() {
+    private Matcher<String> retriableException() {
         return is(
-                anyOf(
-                        containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING"),
-                        containsString("The state store, source-table, may have migrated to another instance"),
-                        containsString("Cannot get state store source-table because the stream thread is STARTING, not RUNNING"),
-                        containsString("The specified partition 1 for store source-table does not exist.")
-                )
+            anyOf(
+                containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING"),
+                containsString("The state store, source-table, may have migrated to another instance"),
+                containsString("Cannot get state store source-table because the stream thread is STARTING, not RUNNING"),
+                containsString("The specified partition 1 for store source-table does not exist.")
+            )
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -223,7 +223,6 @@ public class StoreQueryIntegrationTest {
                 assertThat(getStore(kafkaStreams2, storeQueryParam2).get(key), is(nullValue()));
                 final InvalidStateStoreException exception =
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
-
                 assertThat(
                     exception.getMessage(),
                     containsString("The specified partition 1 for store source-table does not exist.")

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -225,8 +225,8 @@ public class StoreQueryIntegrationTest {
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
 
                 assertThat(
-                        exception.getMessage(),
-                        containsString("The specified partition 1 for store source-table does not exist.")
+                    exception.getMessage(),
+                    containsString("The specified partition 1 for store source-table does not exist.")
                 );
             } else {
                 assertThat(store2.get(key), is(notNullValue()));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -213,8 +213,8 @@ public class StoreQueryIntegrationTest {
             }
 
             final StoreQueryParameters<ReadOnlyKeyValueStore<Integer, Integer>> storeQueryParam2 =
-                    StoreQueryParameters.<ReadOnlyKeyValueStore<Integer, Integer>>fromNameAndType(TABLE_NAME, keyValueStore())
-                            .withPartition(keyDontBelongPartition);
+                StoreQueryParameters.<ReadOnlyKeyValueStore<Integer, Integer>>fromNameAndType(TABLE_NAME, keyValueStore())
+                    .withPartition(keyDontBelongPartition);
 
             try {
                 // Assert that key is not served when wrong specific partition is requested

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -235,8 +235,8 @@ public class StoreQueryIntegrationTest {
                     final InvalidStateStoreException exception =
                             assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams2, storeQueryParam2).get(key));
                     assertThat(
-                            exception.getMessage(),
-                            containsString("The specified partition 1 for store source-table does not exist.")
+                        exception.getMessage(),
+                        containsString("The specified partition 1 for store source-table does not exist.")
                     );
                 }
                 return true;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -226,8 +226,8 @@ public class StoreQueryIntegrationTest {
                     final InvalidStateStoreException exception =
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
                     assertThat(
-                            exception.getMessage(),
-                            containsString("The specified partition 1 for store source-table does not exist.")
+                        exception.getMessage(),
+                        containsString("The specified partition 1 for store source-table does not exist.")
                     );
                 } else {
                     assertThat(store2.get(key), is(notNullValue()));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,8 +61,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -180,7 +183,7 @@ public class StoreQueryIntegrationTest {
 
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
-        until(() -> {
+        retryUntil(() -> {
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
 
             //key belongs to this partition
@@ -210,39 +213,33 @@ public class StoreQueryIntegrationTest {
             }
 
             final StoreQueryParameters<ReadOnlyKeyValueStore<Integer, Integer>> storeQueryParam2 =
-                StoreQueryParameters.<ReadOnlyKeyValueStore<Integer, Integer>>fromNameAndType(TABLE_NAME, keyValueStore())
-                .withPartition(keyDontBelongPartition);
-
-            try {
-                // Assert that key is not served when wrong specific partition is requested
-                // If kafkaStreams1 is active for keyPartition, kafkaStreams2 would be active for keyDontBelongPartition
-                // So, in that case, store3 would be null and the store4 would not return the value for key as wrong partition was requested
-                if (kafkaStreams1IsActive) {
-                    assertThat(store1.get(key), is(notNullValue()));
-                    assertThat(getStore(kafkaStreams2, storeQueryParam2).get(key), is(nullValue()));
-                    final InvalidStateStoreException exception =
+                    StoreQueryParameters.<ReadOnlyKeyValueStore<Integer, Integer>>fromNameAndType(TABLE_NAME, keyValueStore())
+                            .withPartition(keyDontBelongPartition);
+            // Assert that key is not served when wrong specific partition is requested
+            // If kafkaStreams1 is active for keyPartition, kafkaStreams2 would be active for keyDontBelongPartition
+            // So, in that case, store3 would be null and the store4 would not return the value for key as wrong partition was requested
+            if (kafkaStreams1IsActive) {
+                assertThat(store1.get(key), is(notNullValue()));
+                assertThat(getStore(kafkaStreams2, storeQueryParam2).get(key), is(nullValue()));
+                final InvalidStateStoreException exception =
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
-                    assertThat(
+
+                assertThat(
                         exception.getMessage(),
                         containsString("The specified partition 1 for store source-table does not exist.")
-                    );
-                } else {
-                    assertThat(store2.get(key), is(notNullValue()));
-                    assertThat(getStore(kafkaStreams1, storeQueryParam2).get(key), is(nullValue()));
-                    final InvalidStateStoreException exception =
+                );
+            } else {
+                assertThat(store2.get(key), is(notNullValue()));
+                assertThat(getStore(kafkaStreams1, storeQueryParam2).get(key), is(nullValue()));
+                final InvalidStateStoreException exception =
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams2, storeQueryParam2).get(key));
-                    assertThat(
+                assertThat(
                         exception.getMessage(),
                         containsString("The specified partition 1 for store source-table does not exist.")
-                    );
-                }
-                return true;
-            } catch (final InvalidStateStoreException exception) {
-                verifyRetrievableException(exception);
-                LOG.info("Either streams wasn't running or a re-balancing took place. Will try again.");
-                return false;
+                );
             }
-        });
+            return true;
+        }, this::retryableException);
     }
 
     @Test
@@ -535,17 +532,26 @@ public class StoreQueryIntegrationTest {
         });
     }
 
+    private Matcher<String> retrievableException() {
+        return is(
+                anyOf(
+                        containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING"),
+                        containsString("The state store, source-table, may have migrated to another instance"),
+                        containsString("Cannot get state store source-table because the stream thread is STARTING, not RUNNING"),
+                        containsString("The specified partition 1 for store source-table does not exist.")
+                )
+        );
+    }
+
+    private boolean retryableException(final Exception exception) {
+        return retrievableException().matches(exception.getMessage());
+    }
+
     private void verifyRetrievableException(final Exception exception) {
         assertThat(
             "Unexpected exception thrown while getting the value from store.",
             exception.getMessage(),
-            is(
-                anyOf(
-                    containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING"),
-                    containsString("The state store, source-table, may have migrated to another instance"),
-                    containsString("Cannot get state store source-table because the stream thread is STARTING, not RUNNING")
-                )
-            )
+            retrievableException()
         );
     }
 
@@ -560,6 +566,27 @@ public class StoreQueryIntegrationTest {
                 throw e;
             } catch (final Exception e) {
                 throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static void retryUntil(final Callable<Boolean> callable, final Predicate<Exception> exceptionPredicate) throws Exception {
+        boolean success = false;
+        final long deadline = System.currentTimeMillis() + IntegrationTestUtils.DEFAULT_TIMEOUT;
+        while (!success && System.currentTimeMillis() < deadline) {
+            try {
+                success = callable.call();
+                Thread.sleep(500L);
+            } catch (final Exception e) {
+                if (exceptionPredicate.test(e)) {
+                    LOG.info("Retryable exception detected, retrying", e);
+                } else {
+                    if (e instanceof RuntimeException) {
+                        throw e;
+                    } else {
+                        throw new RuntimeException(e);
+                    }
+                }
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -61,10 +61,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -214,7 +212,7 @@ public class StoreQueryIntegrationTest {
 
             final StoreQueryParameters<ReadOnlyKeyValueStore<Integer, Integer>> storeQueryParam2 =
                 StoreQueryParameters.<ReadOnlyKeyValueStore<Integer, Integer>>fromNameAndType(TABLE_NAME, keyValueStore())
-                    .withPartition(keyDontBelongPartition);
+                .withPartition(keyDontBelongPartition);
 
             try {
                 // Assert that key is not served when wrong specific partition is requested

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -157,7 +157,7 @@ public class StoreQueryIntegrationTest {
                 }
                 return true;
             } catch (final InvalidStateStoreException exception) {
-                verifyRetrievableException(exception);
+                verifyRetriableException(exception);
                 LOG.info("Either streams wasn't running or a re-balancing took place. Will try again.");
                 return false;
             }
@@ -238,7 +238,7 @@ public class StoreQueryIntegrationTest {
                 );
             }
             return true;
-        }, this::retryableException);
+        }, this::retriableException);
     }
 
     @Test
@@ -503,7 +503,7 @@ public class StoreQueryIntegrationTest {
                 assertThat(store1.get(key3), is(notNullValue()));
                 return true;
             } catch (final InvalidStateStoreException exception) {
-                verifyRetrievableException(exception);
+                verifyRetriableException(exception);
                 LOG.info("Either streams wasn't running or a re-balancing took place. Will try again.");
                 return false;
             }
@@ -524,7 +524,7 @@ public class StoreQueryIntegrationTest {
                 assertThat(store1.get(key3), is(notNullValue()));
                 return true;
             } catch (final InvalidStateStoreException exception) {
-                verifyRetrievableException(exception);
+                verifyRetriableException(exception);
                 LOG.info("Either streams wasn't running or a re-balancing took place. Will try again.");
                 return false;
             }
@@ -542,15 +542,15 @@ public class StoreQueryIntegrationTest {
         );
     }
 
-    private boolean retryableException(final Exception exception) {
-        return retrievableException().matches(exception.getMessage());
+    private boolean retriableException(final Exception exception) {
+        return retriableException().matches(exception.getMessage());
     }
 
-    private void verifyRetrievableException(final Exception exception) {
+    private void verifyRetriableException(final Exception exception) {
         assertThat(
             "Unexpected exception thrown while getting the value from store.",
             exception.getMessage(),
-            retrievableException()
+            retriableException()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -81,6 +81,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.anyOf;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Category({IntegrationTest.class})
 public class StoreQueryIntegrationTest {
@@ -562,7 +563,8 @@ public class StoreQueryIntegrationTest {
     private static void until(final TestCondition condition) {
         boolean success = false;
         final long deadline = System.currentTimeMillis() + IntegrationTestUtils.DEFAULT_TIMEOUT;
-        while (!success && System.currentTimeMillis() < deadline) {
+        boolean deadlineExceeded = System.currentTimeMillis() >= deadline;
+        while (!success && !deadlineExceeded) {
             try {
                 success = condition.conditionMet();
                 Thread.sleep(500L);
@@ -570,7 +572,12 @@ public class StoreQueryIntegrationTest {
                 throw e;
             } catch (final Exception e) {
                 throw new RuntimeException(e);
+            } finally {
+                deadlineExceeded = System.currentTimeMillis() >= deadline;
             }
+        }
+        if (deadlineExceeded) {
+            fail("Test execution timed out");
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -224,7 +224,7 @@ public class StoreQueryIntegrationTest {
                     assertThat(store1.get(key), is(notNullValue()));
                     assertThat(getStore(kafkaStreams2, storeQueryParam2).get(key), is(nullValue()));
                     final InvalidStateStoreException exception =
-                            assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
+                        assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
                     assertThat(
                             exception.getMessage(),
                             containsString("The specified partition 1 for store source-table does not exist.")

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -548,10 +548,6 @@ public class StoreQueryIntegrationTest {
         );
     }
 
-    private boolean retriableException(final Exception exception) {
-        return retriableException().matches(exception.getMessage());
-    }
-
     private void verifyRetriableException(final Exception exception) {
         assertThat(
             "Unexpected exception thrown while getting the value from store.",


### PR DESCRIPTION
Currently the tests fail because there is a missing predicate in the `retrievableException` which causes the test to fail, i.e. the current predicates

```java
containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING"),
containsString("The state store, source-table, may have migrated to another instance"),
containsString("Cannot get state store source-table because the stream thread is STARTING, not RUNNING")
```
wasn't complete. Another one needed to be added, namely "The specified partition 1 for store source-table does not exist.". This is because its possible for 

```java
assertThat(getStore(kafkaStreams2, storeQueryParam2).get(key), is(nullValue()));
```         
or

```java
assertThat(getStore(kafkaStreams1, storeQueryParam2).get(key), is(nullValue()));
```

(depending on which branch) to be thrown, i.e. see
```
org.apache.kafka.streams.errors.InvalidStateStorePartitionException: The specified partition 1 for store source-table does not exist.

	at org.apache.kafka.streams.state.internals.WrappingStoreProvider.stores(WrappingStoreProvider.java:63)
	at org.apache.kafka.streams.state.internals.CompositeReadOnlyKeyValueStore.get(CompositeReadOnlyKeyValueStore.java:53)
	at org.apache.kafka.streams.integration.StoreQueryIntegrationTest.lambda$shouldQuerySpecificActivePartitionStores$5(StoreQueryIntegrationTest.java:223)
	at org.apache.kafka.streams.integration.StoreQueryIntegrationTest.retryUntil(StoreQueryIntegrationTest.java:579)
	at org.apache.kafka.streams.integration.StoreQueryIntegrationTest.shouldQuerySpecificActivePartitionStores(StoreQueryIntegrationTest.java:186)
```

This happens when the stream hasn't been initialized yet. I have run the test around 12k times using Intellij's JUnit testing framework without any flaky failures. The PR also does some minor refactoring regarding moving the list of predicates into their own functions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
