### PR TITLE
MINOR: Stop leaking threads in BlockingConnectorTest

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -68,6 +68,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
 import static org.apache.kafka.connect.runtime.rest.RestServer.DEFAULT_REST_REQUEST_TIMEOUT_MS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -498,6 +499,10 @@ public class BlockingConnectorTest {
                 log.info("Will block on {}", block);
                 CountDownLatch blockLatch;
                 synchronized (Block.class) {
+                    assertNotNull(
+                            "Block was reset prematurely",
+                            awaitBlockLatch
+                    );
                     awaitBlockLatch.countDown();
                     blockLatch = newBlockLatch();
                     BLOCKED_THREADS.add(Thread.currentThread());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -468,6 +468,8 @@ public class OffsetsApiIntegrationTest {
         ConnectRestException e = assertThrows(ConnectRestException.class,
                 () -> connect.alterConnectorOffsets(connectorName, new ConnectorOffsets(offsetsToAlter)));
         assertThat(e.getMessage(), containsString("zombie sink task"));
+
+        BlockingConnectorTest.Block.reset();
     }
 
     @Test
@@ -807,6 +809,8 @@ public class OffsetsApiIntegrationTest {
         // Try to reset the offsets
         ConnectRestException e = assertThrows(ConnectRestException.class, () -> connect.resetConnectorOffsets(connectorName));
         assertThat(e.getMessage(), containsString("zombie sink task"));
+
+        BlockingConnectorTest.Block.reset();
     }
 
     @Test


### PR DESCRIPTION
These tests currently create threads that block forever until the JVM is shut down. This change unblocks those threads once their respective test cases are finished.

This is valuable not only for general code hygiene and resource utilization, but also for laying the groundwork for reusing an embedded Connect cluster across each of these test cases, which would drastically reduce test time. That's left for a follow-up PR, though.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
