### PR TITLE
MINOR: KRaft nodes not shutdown correctly when using one controller in colocated mode

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -18,6 +18,7 @@ import os.path
 import re
 import signal
 import time
+import math
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -872,7 +873,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         cluster_has_colocated_controllers = self.quorum_info.has_brokers and self.quorum_info.has_controllers
         force_sigkill_due_to_too_few_colocated_controllers =\
             clean_shutdown and cluster_has_colocated_controllers\
-            and self.colocated_nodes_started < round(self.num_nodes_controller_role / 2)
+            and self.colocated_nodes_started < math.ceil(self.num_nodes_controller_role / 2)
         if force_sigkill_due_to_too_few_colocated_controllers:
             self.logger.info("Forcing node to stop via SIGKILL due to too few co-located KRaft controllers: %i/%i" %\
                              (self.colocated_nodes_started, self.num_nodes_controller_role))


### PR DESCRIPTION
Found a bug in `KafkaService.stop_node`. `round(self.num_nodes_controller_role / 2)` rounds to the closest even choice. When only one controller is used in colocated mode, it rounds to zero. If the colocated controller is the first node shutdown, the remaining ones fails to stop within the 60s timeout because they are stuck in controlled shutdown. Those nodes are eventually killed. It is better to use `match.ceil` here.

We don't have any system tests affected by this though. It is still worth fixing in my opinion.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
