### PR TITLE
KAFKA-13998: JoinGroupRequestData 'reason' can be too large

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -479,7 +479,6 @@ public abstract class AbstractCoordinator implements Closeable {
                 resetJoinGroupFuture();
                 synchronized (AbstractCoordinator.this) {
                     final String shortReason = String.format("rebalance failed due to an exception: (%s)",
-                        exception.getMessage(),
                         exception.getClass().getSimpleName());
                     final String fullReason = String.format("rebalance failed due to '%s' (%s)",
                         exception.getMessage(),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -478,7 +478,7 @@ public abstract class AbstractCoordinator implements Closeable {
 
                 resetJoinGroupFuture();
                 synchronized (AbstractCoordinator.this) {
-                    final String shortReason = String.format("rebalance failed due to an exception: (%s)",
+                    final String shortReason = String.format("rebalance failed due to %s",
                         exception.getClass().getSimpleName());
                     final String fullReason = String.format("rebalance failed due to '%s' (%s)",
                         exception.getMessage(),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -478,8 +478,13 @@ public abstract class AbstractCoordinator implements Closeable {
 
                 resetJoinGroupFuture();
                 synchronized (AbstractCoordinator.this) {
-                    rejoinReason = String.format("rebalance failed due to '%s' (%s)", exception.getMessage(), exception.getClass().getSimpleName());
-                    rejoinNeeded = true;
+                    final String shortReason = String.format("rebalance failed due to an exception: (%s)",
+                        exception.getMessage(),
+                        exception.getClass().getSimpleName());
+                    final String fullReason = String.format("rebalance failed due to '%s' (%s)",
+                        exception.getMessage(),
+                        exception.getClass().getSimpleName());
+                    requestRejoin(shortReason, fullReason);
                 }
 
                 if (exception instanceof UnknownMemberIdException ||

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -553,7 +553,7 @@ public class AbstractCoordinatorTest {
         ensureActiveGroup(generation, memberId);
         assertEquals("", coordinator.rejoinReason());
 
-        // Force a rebalance
+        // force a rebalance
         expectJoinGroup(memberId, "Manual test trigger", generation, memberId);
         expectSyncGroup(generation, memberId);
         coordinator.requestRejoin("Manual test trigger");
@@ -567,7 +567,7 @@ public class AbstractCoordinatorTest {
                 () -> coordinator.joinGroupIfNeeded(mockTime.timer(100L)));
 
         // next join group request should contain exception message
-        expectJoinGroup(memberId, String.format("rebalance failed due to '%s' (%s)", e.getMessage(), e.getClass().getSimpleName()), generation, memberId);
+        expectJoinGroup(memberId, String.format("rebalance failed due to %s", e.getClass().getSimpleName()), generation, memberId);
         expectSyncGroup(generation, memberId);
         ensureActiveGroup(generation, memberId);
         assertEquals("", coordinator.rejoinReason());


### PR DESCRIPTION
This fix follows the pattern which is established in `AbstractCoordinator.java` of setting the request reason with the method `requestRejoin`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
