### PR TITLE
MINOR: change Streams topic-level metrics tag from 'topic-name' to 'topic'

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -219,12 +219,13 @@ public class RecordCollectorImpl implements RecordCollector {
                 }
 
                 if (!topic.endsWith("-changelog")) {
-                    // we may not have created a sensor yet if the node uses dynamic topic routing
                     final Map<String, Sensor> producedSensorByTopic = sinkNodeToProducedSensorByTopic.get(processorNodeId);
                     if (producedSensorByTopic == null) {
                         log.error("Unable to records bytes produced to topic {} by sink node {} as the node is not recognized.\n"
                                       + "Known sink nodes are {}.", topic, processorNodeId, sinkNodeToProducedSensorByTopic.keySet());
                     } else {
+                        // we may not have created a sensor during initialization if the node uses dynamic topic routing,
+                        // as all topics are not known up front, so create the sensor for that topic if absent
                         final Sensor topicProducedSensor = producedSensorByTopic.computeIfAbsent(
                             topic,
                             t -> TopicMetrics.producedSensor(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -117,7 +117,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String THREAD_ID_TAG = "thread-id";
     public static final String TASK_ID_TAG = "task-id";
     public static final String PROCESSOR_NODE_ID_TAG = "processor-node-id";
-    public static final String TOPIC_NAME_TAG = "topic-name";
+    public static final String TOPIC_NAME_TAG = "topic";
     public static final String STORE_ID_TAG = "state-id";
     public static final String RECORD_CACHE_ID_TAG = "record-cache-id";
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TopicMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TopicMetricsTest.java
@@ -39,7 +39,7 @@ public class TopicMetricsTest {
     private static final String THREAD_ID = "test-thread";
     private static final String TASK_ID = "test-task";
     private static final String PROCESSOR_NODE_ID = "test-processor";
-    private static final String TOPIC_NAME = "topic";
+    private static final String TOPIC = "topic";
 
     private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
 
@@ -59,14 +59,14 @@ public class TopicMetricsTest {
         final String descriptionOfRecordsTotal = "The total number of records consumed from this topic";
         final String descriptionOfBytesTotal = "The total number of bytes consumed from this topic";
 
-        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME, "consumed", RecordingLevel.INFO))
+        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC, "consumed", RecordingLevel.INFO))
             .thenReturn(expectedSensor);
-        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME, "consumed", RecordingLevel.INFO))
+        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC, "consumed", RecordingLevel.INFO))
             .thenReturn(expectedSensor);
-        when(streamsMetrics.topicLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME)).thenReturn(tagMap);
+        when(streamsMetrics.topicLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC)).thenReturn(tagMap);
 
         verifySensor(
-            () -> TopicMetrics.consumedSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME, streamsMetrics)
+            () -> TopicMetrics.consumedSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC, streamsMetrics)
         );
 
         STREAMS_METRICS_STATIC_MOCK.verify(
@@ -89,13 +89,13 @@ public class TopicMetricsTest {
         final String descriptionOfRecordsTotal = "The total number of records produced to this topic";
         final String descriptionOfBytesTotal = "The total number of bytes produced to this topic";
 
-        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME, "produced", RecordingLevel.INFO))
+        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC, "produced", RecordingLevel.INFO))
             .thenReturn(expectedSensor);
-        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME, "produced", RecordingLevel.INFO))
+        when(streamsMetrics.topicLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC, "produced", RecordingLevel.INFO))
             .thenReturn(expectedSensor);
-        when(streamsMetrics.topicLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME)).thenReturn(tagMap);
+        when(streamsMetrics.topicLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC)).thenReturn(tagMap);
 
-        verifySensor(() -> TopicMetrics.producedSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC_NAME, streamsMetrics));
+        verifySensor(() -> TopicMetrics.producedSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, TOPIC, streamsMetrics));
 
         STREAMS_METRICS_STATIC_MOCK.verify(
             () -> StreamsMetricsImpl.addTotalCountAndSumMetricsToSensor(

--- a/streams/src/test/java/org/apache/kafka/test/MockRecordCollector.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockRecordCollector.java
@@ -50,12 +50,14 @@ public class MockRecordCollector implements RecordCollector {
                             final Serializer<V> valueSerializer,
                             final String processorNodeId,
                             final InternalProcessorContext<Void, Void> context) {
-        collected.add(new ProducerRecord<>(topic,
-                                           partition,
-                                           timestamp,
-                                           key,
-                                           value,
-                                           headers));
+        collected.add(new ProducerRecord<>(
+            topic,
+            partition,
+            timestamp,
+            key,
+            value,
+            headers)
+        );
     }
 
     @Override
@@ -69,12 +71,14 @@ public class MockRecordCollector implements RecordCollector {
                             final String processorNodeId,
                             final InternalProcessorContext<Void, Void> context,
                             final StreamPartitioner<? super K, ? super V> partitioner) {
-        collected.add(new ProducerRecord<>(topic,
+        collected.add(new ProducerRecord<>(
+            topic,
             0, // partition id
             timestamp,
             key,
             value,
-            headers));
+            headers)
+        );
     }
 
     @Override

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamSplitTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamSplitTest.scala
@@ -35,7 +35,7 @@ class KStreamSplitTest extends TestDriver {
     val sinkTopic = Array("default", "even", "three");
 
     val m = builder
-      .stream[Int, Int](sourceTopic)
+      .stream[Integer, Integer](sourceTopic)
       .split(Named.as("_"))
       .branch((_, v) => v % 2 == 0)
       .branch((_, v) => v % 3 == 0)
@@ -46,14 +46,14 @@ class KStreamSplitTest extends TestDriver {
     m("_2").to(sinkTopic(2))
 
     val testDriver = createTestDriver(builder)
-    val testInput = testDriver.createInput[Int, Int](sourceTopic)
-    val testOutput = sinkTopic.map(name => testDriver.createOutput[Int, Int](name))
+    val testInput = testDriver.createInput[Integer, Integer](sourceTopic)
+    val testOutput = sinkTopic.map(name => testDriver.createOutput[Integer, Integer](name))
 
     testInput.pipeValueList(
       List(1, 2, 3, 4, 5)
+        .map(Integer.valueOf)
         .asJava
     )
-
     assertEquals(List(1, 5), testOutput(0).readValuesToList().asScala)
     assertEquals(List(2, 4), testOutput(1).readValuesToList().asScala)
     assertEquals(List(3), testOutput(2).readValuesToList().asScala)
@@ -67,7 +67,7 @@ class KStreamSplitTest extends TestDriver {
     val sourceTopic = "source"
 
     val m = builder
-      .stream[Int, Int](sourceTopic)
+      .stream[Integer, Integer](sourceTopic)
       .split(Named.as("_"))
       .branch((_, v) => v % 2 == 0, Branched.withConsumer(ks => ks.to("even"), "consumedEvens"))
       .branch((_, v) => v % 3 == 0, Branched.withFunction(ks => ks.mapValues(x => x * x), "mapped"))
@@ -76,14 +76,15 @@ class KStreamSplitTest extends TestDriver {
     m("_mapped").to("mapped")
 
     val testDriver = createTestDriver(builder)
-    val testInput = testDriver.createInput[Int, Int](sourceTopic)
+    val testInput = testDriver.createInput[Integer, Integer](sourceTopic)
     testInput.pipeValueList(
       List(1, 2, 3, 4, 5, 9)
+        .map(Integer.valueOf)
         .asJava
     )
 
-    val even = testDriver.createOutput[Int, Int]("even")
-    val mapped = testDriver.createOutput[Int, Int]("mapped")
+    val even = testDriver.createOutput[Integer, Integer]("even")
+    val mapped = testDriver.createOutput[Integer, Integer]("mapped")
 
     assertEquals(List(2, 4), even.readValuesToList().asScala)
     assertEquals(List(9, 81), mapped.readValuesToList().asScala)
@@ -97,7 +98,7 @@ class KStreamSplitTest extends TestDriver {
     val sourceTopic = "source"
 
     val m = builder
-      .stream[Int, Int](sourceTopic)
+      .stream[Integer, Integer](sourceTopic)
       .split(Named.as("_"))
       .branch((_, v) => v % 2 == 0, Branched.withConsumer(ks => ks.to("even")))
       .branch((_, v) => v % 3 == 0, Branched.withFunction(ks => ks.mapValues(x => x * x)))
@@ -106,19 +107,19 @@ class KStreamSplitTest extends TestDriver {
     m("_2").to("mapped")
 
     val testDriver = createTestDriver(builder)
-    val testInput = testDriver.createInput[Int, Int](sourceTopic)
+    val testInput = testDriver.createInput[Integer, Integer](sourceTopic)
     testInput.pipeValueList(
       List(1, 2, 3, 4, 5, 9)
+        .map(Integer.valueOf)
         .asJava
     )
 
-    val even = testDriver.createOutput[Int, Int]("even")
-    val mapped = testDriver.createOutput[Int, Int]("mapped")
+    val even = testDriver.createOutput[Integer, Integer]("even")
+    val mapped = testDriver.createOutput[Integer, Integer]("mapped")
 
     assertEquals(List(2, 4), even.readValuesToList().asScala)
     assertEquals(List(9, 81), mapped.readValuesToList().asScala)
 
     testDriver.close()
   }
-
 }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamSplitTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamSplitTest.scala
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.scala.kstream
 
 import org.apache.kafka.streams.kstream.Named
-import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.serialization.Serdes._
@@ -50,13 +49,10 @@ class KStreamSplitTest extends TestDriver {
     val testInput = testDriver.createInput[Int, Int](sourceTopic)
     val testOutput = sinkTopic.map(name => testDriver.createOutput[Int, Int](name))
 
-    testInput pipeKeyValueList List(
-      new KeyValue(1, 1),
-      new KeyValue(1, 2),
-      new KeyValue(1, 3),
-      new KeyValue(1, 4),
-      new KeyValue(1, 5)
-    ).asJava
+    testInput.pipeValueList(
+      List(1, 2, 3, 4, 5)
+        .asJava
+    )
 
     assertEquals(List(1, 5), testOutput(0).readValuesToList().asScala)
     assertEquals(List(2, 4), testOutput(1).readValuesToList().asScala)
@@ -81,14 +77,10 @@ class KStreamSplitTest extends TestDriver {
 
     val testDriver = createTestDriver(builder)
     val testInput = testDriver.createInput[Int, Int](sourceTopic)
-    testInput pipeKeyValueList List(
-      new KeyValue(1, 1),
-      new KeyValue(1, 2),
-      new KeyValue(1, 3),
-      new KeyValue(1, 4),
-      new KeyValue(1, 5),
-      new KeyValue(1, 9)
-    ).asJava
+    testInput.pipeValueList(
+      List(1, 2, 3, 4, 5, 9)
+        .asJava
+    )
 
     val even = testDriver.createOutput[Int, Int]("even")
     val mapped = testDriver.createOutput[Int, Int]("mapped")
@@ -115,14 +107,10 @@ class KStreamSplitTest extends TestDriver {
 
     val testDriver = createTestDriver(builder)
     val testInput = testDriver.createInput[Int, Int](sourceTopic)
-    testInput pipeKeyValueList List(
-      new KeyValue(1, 1),
-      new KeyValue(1, 2),
-      new KeyValue(1, 3),
-      new KeyValue(1, 4),
-      new KeyValue(1, 5),
-      new KeyValue(1, 9)
-    ).asJava
+    testInput.pipeValueList(
+      List(1, 2, 3, 4, 5, 9)
+        .asJava
+    )
 
     val even = testDriver.createOutput[Int, Int]("even")
     val mapped = testDriver.createOutput[Int, Int]("mapped")


### PR DESCRIPTION
Changes the tag name from `topic-name` to just `topic` to conform to the way this tag is named elsewhere (ie in the clients)

Also addresses the [followup feedback](https://github.com/apache/kafka/pull/12235#pullrequestreview-997922994) from @cadonna on the [original PR](https://github.com/apache/kafka/pull/12235):

1. fixes a comment about dynamic topic routing
2. fixes some indentation in `MockRecordCollector`
3. Undoes the changes to `KStreamSplitTest.scala` and `TestTopicsTest` which are no longer necessary after [this hotfix](https://github.com/apache/kafka/pull/12288)
