### PR TITLE
KAFKA-10199: Expose tasks in state updater

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -86,7 +86,7 @@ public class DefaultStateUpdater implements StateUpdater {
         }
 
         public boolean onlyStandbyTasksLeft() {
-            return !updatingTasks.isEmpty() && updatingTasks.values().stream().noneMatch(Task::isActive);
+            return !updatingTasks.isEmpty() && updatingTasks.values().stream().allMatch(t -> !t.isActive());
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -35,7 +35,7 @@ public interface StateUpdater {
             this.exception = Objects.requireNonNull(exception);
         }
 
-        public Set<Task> tasks() {
+        public Set<Task> getTasks() {
             return Collections.unmodifiableSet(tasks);
         }
 
@@ -111,6 +111,50 @@ public interface StateUpdater {
      * @return list of failed tasks and the corresponding exceptions
      */
     List<ExceptionAndTasks> drainExceptionsAndFailedTasks();
+
+    /**
+     * Gets all tasks that are managed by the state updater.
+     *
+     * The state updater manages all tasks that were added with the {@link StateUpdater#add(Task)} and that have
+     * not been removed from the state updater with one of the following methods:
+     * <ul>
+     *   <li>{@link StateUpdater#drainRestoredActiveTasks(Duration)}</li>
+     *   <li>{@link StateUpdater#drainRemovedTasks()}</li>
+     *   <li>{@link StateUpdater#drainExceptionsAndFailedTasks()}</li>
+     * </ul>
+     *
+     * @return set of all tasks managed by the state updater
+     */
+    Set<Task> getTasks();
+
+    /**
+     * Gets active tasks that are managed by the state updater.
+     *
+     * The state updater manages all active tasks that were added with the {@link StateUpdater#add(Task)} and that have
+     * not been removed from the state updater with one of the following methods:
+     * <ul>
+     *   <li>{@link StateUpdater#drainRestoredActiveTasks(Duration)}</li>
+     *   <li>{@link StateUpdater#drainRemovedTasks()}</li>
+     *   <li>{@link StateUpdater#drainExceptionsAndFailedTasks()}</li>
+     * </ul>
+     *
+     * @return set of all tasks managed by the state updater
+     */
+    Set<StreamTask> getActiveTasks();
+
+    /**
+     * Gets standby tasks that are managed by the state updater.
+     *
+     * The state updater manages all standby tasks that were added with the {@link StateUpdater#add(Task)} and that have
+     * not been removed from the state updater with one of the following methods:
+     * <ul>
+     *   <li>{@link StateUpdater#drainRemovedTasks()}</li>
+     *   <li>{@link StateUpdater#drainExceptionsAndFailedTasks()}</li>
+     * </ul>
+     *
+     * @return set of all tasks managed by the state updater
+     */
+    Set<StandbyTask> getStandbyTasks();
 
     /**
      * Shuts down the state updater.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -58,6 +58,21 @@ public interface StateUpdater {
     }
 
     /**
+     * Starts the state updater.
+     */
+    void start();
+
+    /**
+     * Shuts down the state updater.
+     *
+     * @param timeout duration how long to wait until the state updater is shut down
+     *
+     * @throws
+     *     org.apache.kafka.streams.errors.StreamsException if the state updater thread cannot shutdown within the timeout
+     */
+    void shutdown(final Duration timeout);
+
+    /**
      * Adds a task (active or standby) to the state updater.
      *
      * This method does not block until the task is added to the state updater.
@@ -155,14 +170,4 @@ public interface StateUpdater {
      * @return set of all tasks managed by the state updater
      */
     Set<StandbyTask> getStandbyTasks();
-
-    /**
-     * Shuts down the state updater.
-     *
-     * @param timeout duration how long to wait until the state updater is shut down
-     *
-     * @throws
-     *     org.apache.kafka.streams.errors.StreamsException if the state updater thread cannot shutdown within the timeout
-     */
-    void shutdown(final Duration timeout);
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -694,11 +694,9 @@ class DefaultStateUpdaterTest {
         final StreamTask task2 = createActiveStatefulTaskInStateRestoring(TASK_0_2, Collections.singletonList(TOPIC_PARTITION_B_0));
         final StandbyTask task3 = createStandbyTaskInStateRunning(TASK_1_0, Collections.singletonList(TOPIC_PARTITION_C_0));
         final StandbyTask task4 = createStandbyTaskInStateRunning(TASK_1_1, Collections.singletonList(TOPIC_PARTITION_D_0));
-        when(changelogReader.completedChangelogs())
-                .thenReturn(Collections.emptySet());
-        when(changelogReader.allChangelogsCompleted())
-                .thenReturn(false);
-
+        when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        stateUpdater.start();
         stateUpdater.add(task1);
         stateUpdater.add(task2);
         stateUpdater.add(task3);
@@ -721,11 +719,9 @@ class DefaultStateUpdaterTest {
             final StreamTask task2 = createActiveStatefulTaskInStateRestoring(TASK_0_2, Collections.singletonList(TOPIC_PARTITION_B_0));
             final StandbyTask task3 = createStandbyTaskInStateRunning(TASK_1_0, Collections.singletonList(TOPIC_PARTITION_C_0));
             final StandbyTask task4 = createStandbyTaskInStateRunning(TASK_1_1, Collections.singletonList(TOPIC_PARTITION_D_0));
-            when(changelogReader.completedChangelogs())
-                    .thenReturn(Collections.emptySet());
-            when(changelogReader.allChangelogsCompleted())
-                    .thenReturn(false);
-
+            when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
+            when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+            stateUpdater.start();
             stateUpdater.add(task1);
             stateUpdater.add(task2);
             stateUpdater.add(task3);


### PR DESCRIPTION
This PR exposes the tasks managed by the state updater. The state
updater manages all tasks that were added to the state updater
and that have not yet been removed from it by draining one of the
output queues.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
