### PR TITLE
MINOR: Add the change statement of reload4j in Notable changes of 3.1.1

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -65,7 +65,7 @@
     <ul>
         <li>Idempotence for the producer is enabled by default if no conflicting configurations are set. In 3.0.0 and 3.1.0, a bug prevented this default from being applied,
             which meant that idempotence remained disabled unless the user had explicitly set <code>enable.idempotence</code> to true
-            (See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details).
+            (See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details).
             This issue was fixed and the default is properly applied in 3.0.1, 3.1.1, and 3.2.0.</li>
         <li>A notable exception is Connect that by default disables idempotent behavior for all of its
             producers in order to uniformly support using a wide range of Kafka broker versions. 
@@ -131,13 +131,21 @@
 <ul>
     <li>Idempotence for the producer is enabled by default if no conflicting configurations are set.
         A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
-	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
+	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details.
         This issue was fixed and the default is properly applied.</li>
     <li>A notable exception is Connect that by default disables idempotent behavior for all of its
         producers in order to uniformly support using a wide range of Kafka broker versions.
         Users can change this behavior to enable idempotence for some or all producers
         via Connect worker and/or connector configuration. Connect may enable idempotent producers
         by default in a future major release.</li>
+    <li>Kafka has replaced log4j with reload4j due to security concerns.
+        This only affects modules that specify a logging backend (<code>connect-runtime</code> and <code>kafka-tools</code> are two such examples).
+        A number of modules, including <code>kafka-clients</code>, leave it to the application to specify the logging backend.
+        More information can be found at <a href="https://reload4j.qos.ch">reload4j</a>.
+        Projects that depend on the affected modules from the Kafka project should use
+        <a href="https://www.slf4j.org/manual.html#swapping">slf4j-log4j12 version 1.7.35 or above</a> or
+        slf4j-reload4j to avoid
+        <a href="https://www.slf4j.org/codes.html#no_tlm">possible compatibility issues originating from the logging framework</a>.</li>
 </ul>
 
 <h5><a id="upgrade_310_notable" href="#upgrade_310_notable">Notable changes in 3.1.0</a></h5>
@@ -207,7 +215,7 @@
 <ul>
     <li>Idempotence for the producer is enabled by default if no conflicting configurations are set.
         A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
-	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
+	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details.
         This issue was fixed and the default is properly applied.</li>
 </ul>
 
@@ -216,7 +224,7 @@
     <li>The producer has stronger delivery guarantees by default: <code>idempotence</code> is enabled and <code>acks</code> is set to <code>all</code> instead of <code>1</code>.
         See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default">KIP-679</a> for details.
 	In 3.0.0 and 3.1.0, a bug prevented the idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
-	<code>enable.idempotence</code> to true. Note that the bug did not affect the <code>acks=all</code> change. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
+	<code>enable.idempotence</code> to true. Note that the bug did not affect the <code>acks=all</code> change. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details.
         This issue was fixed and the default is properly applied in 3.0.1, 3.1.1, and 3.2.0.</li>
     <li>Java 8 and Scala 2.12 support have been deprecated since Apache Kafka 3.0 and will be removed in Apache Kafka 4.0.
         See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223">KIP-750</a>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -65,7 +65,7 @@
     <ul>
         <li>Idempotence for the producer is enabled by default if no conflicting configurations are set. In 3.0.0 and 3.1.0, a bug prevented this default from being applied,
             which meant that idempotence remained disabled unless the user had explicitly set <code>enable.idempotence</code> to true
-            (See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details).
+            (See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details).
             This issue was fixed and the default is properly applied in 3.0.1, 3.1.1, and 3.2.0.</li>
         <li>A notable exception is Connect that by default disables idempotent behavior for all of its
             producers in order to uniformly support using a wide range of Kafka broker versions. 
@@ -131,7 +131,7 @@
 <ul>
     <li>Idempotence for the producer is enabled by default if no conflicting configurations are set.
         A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
-	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details.
+	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
         This issue was fixed and the default is properly applied.</li>
     <li>A notable exception is Connect that by default disables idempotent behavior for all of its
         producers in order to uniformly support using a wide range of Kafka broker versions.
@@ -215,7 +215,7 @@
 <ul>
     <li>Idempotence for the producer is enabled by default if no conflicting configurations are set.
         A bug prevented the producer idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
-	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details.
+	<code>enable.idempotence</code> to true. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
         This issue was fixed and the default is properly applied.</li>
 </ul>
 
@@ -224,7 +224,7 @@
     <li>The producer has stronger delivery guarantees by default: <code>idempotence</code> is enabled and <code>acks</code> is set to <code>all</code> instead of <code>1</code>.
         See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default">KIP-679</a> for details.
 	In 3.0.0 and 3.1.0, a bug prevented the idempotence default from being applied which meant that it remained disabled unless the user had explicitly set
-	<code>enable.idempotence</code> to true. Note that the bug did not affect the <code>acks=all</code> change. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a> for more details.
+	<code>enable.idempotence</code> to true. Note that the bug did not affect the <code>acks=all</code> change. See <a href="https://issues.apache.org/jira/browse/KAFKA-13598">KAFKA-13598</a>for more details.
         This issue was fixed and the default is properly applied in 3.0.1, 3.1.1, and 3.2.0.</li>
     <li>Java 8 and Scala 2.12 support have been deprecated since Apache Kafka 3.0 and will be removed in Apache Kafka 4.0.
         See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223">KIP-750</a>


### PR DESCRIPTION
Referring to KAFKA-13660, reload4j is a very important change that solves the security problem of log4j. It was declared in Notable changes in 3.2.0, but missing in Notable changes in 3.1.1

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
