### PR TITLE
KAFKA-13903: Queue size metric in QuorumController

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
@@ -18,7 +18,9 @@
 package org.apache.kafka.controller;
 
 
-public interface ControllerMetrics extends AutoCloseable {
+import org.apache.kafka.queue.EventQueueMetrics;
+
+public interface ControllerMetrics extends AutoCloseable, EventQueueMetrics {
     void setActive(boolean active);
 
     boolean active();
@@ -66,6 +68,10 @@ public interface ControllerMetrics extends AutoCloseable {
     void setLastAppliedRecordTimestamp(long timestamp);
 
     long lastAppliedRecordTimestamp();
+
+    void setQueueSize(int size);
+
+    int eventQueueSize();
 
     void close();
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -83,6 +83,7 @@ import org.apache.kafka.metadata.placement.ReplicaPlacer;
 import org.apache.kafka.metadata.placement.StripedReplicaPlacer;
 import org.apache.kafka.queue.EventQueue.EarliestDeadlineFunction;
 import org.apache.kafka.queue.EventQueue;
+import org.apache.kafka.queue.EventQueueMetrics;
 import org.apache.kafka.queue.KafkaEventQueue;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.BatchReader;
@@ -324,7 +325,7 @@ public final class QuorumController implements Controller {
 
             KafkaEventQueue queue = null;
             try {
-                queue = new KafkaEventQueue(time, logContext, threadNamePrefix + "QuorumController");
+                queue = new KafkaEventQueue(time, logContext, threadNamePrefix + "QuorumController", controllerMetrics);
                 return new QuorumController(
                     fatalFaultHandler,
                     logContext,

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -36,6 +36,9 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         "ControllerEventManager", "EventQueueTimeMs");
     private final static MetricName EVENT_QUEUE_PROCESSING_TIME_MS = getMetricName(
         "ControllerEventManager", "EventQueueProcessingTimeMs");
+
+    private final static MetricName EVENT_QUEUE_SIZE = getMetricName(
+            "ControllerEventManager", "EventQueueSize");
     private final static MetricName FENCED_BROKER_COUNT = getMetricName(
         "KafkaController", "FencedBrokerCount");
     private final static MetricName ACTIVE_BROKER_COUNT = getMetricName(
@@ -71,6 +74,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final AtomicLong lastAppliedRecordOffset = new AtomicLong(0);
     private final AtomicLong lastCommittedRecordOffset = new AtomicLong(0);
     private final AtomicLong lastAppliedRecordTimestamp = new AtomicLong(0);
+    private final AtomicInteger eventQueueSize = new AtomicInteger(0);
     private final Gauge<Integer> activeControllerCount;
     private final Gauge<Integer> fencedBrokerCountGauge;
     private final Gauge<Integer> activeBrokerCountGauge;
@@ -79,6 +83,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final Gauge<Integer> offlinePartitionCountGauge;
     private final Gauge<Integer> preferredReplicaImbalanceCountGauge;
     private final Gauge<Integer> metadataErrorCountGauge;
+    private final Gauge<Integer> eventQueueSizeGauge;
     private final Gauge<Long> lastAppliedRecordOffsetGauge;
     private final Gauge<Long> lastCommittedRecordOffsetGauge;
     private final Gauge<Long> lastAppliedRecordTimestampGauge;
@@ -103,6 +108,12 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
             @Override
             public Integer value() {
                 return active ? 1 : 0;
+            }
+        });
+        this.eventQueueSizeGauge = registry.newGauge(EVENT_QUEUE_SIZE, new Gauge<Integer>() {
+            @Override
+            public Integer value() {
+                return eventQueueSize.get();
             }
         });
         this.eventQueueTime = registry.newHistogram(EVENT_QUEUE_TIME_MS, true);
@@ -183,6 +194,16 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     @Override
     public boolean active() {
         return this.active;
+    }
+
+    @Override
+    public void setQueueSize(int size) {
+        eventQueueSize.set(size);
+    }
+
+    @Override
+    public int eventQueueSize() {
+        return eventQueueSize.get();
     }
 
     @Override
@@ -299,6 +320,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
             ACTIVE_CONTROLLER_COUNT,
             FENCED_BROKER_COUNT,
             ACTIVE_BROKER_COUNT,
+            EVENT_QUEUE_SIZE,
             EVENT_QUEUE_TIME_MS,
             EVENT_QUEUE_PROCESSING_TIME_MS,
             GLOBAL_TOPIC_COUNT,

--- a/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
@@ -31,6 +31,7 @@ public final class MockControllerMetrics implements ControllerMetrics {
     private volatile long lastAppliedRecordOffset = 0;
     private volatile long lastCommittedRecordOffset = 0;
     private volatile long lastAppliedRecordTimestamp = 0;
+    private volatile int eventQueueSize = 0;
 
     private volatile boolean closed = false;
 
@@ -152,6 +153,16 @@ public final class MockControllerMetrics implements ControllerMetrics {
     @Override
     public long lastAppliedRecordTimestamp() {
         return lastAppliedRecordTimestamp;
+    }
+
+    @Override
+    public void setQueueSize(int size) {
+        eventQueueSize = size;
+    }
+
+    @Override
+    public int eventQueueSize() {
+        return eventQueueSize;
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -55,6 +55,7 @@ public class QuorumControllerMetricsTest {
     public void testControllerEventManagerMetricNames() {
         String expectedType = "ControllerEventManager";
         Set<String> expectedMetricNames = Utils.mkSet(
+            "EventQueueSize",
             "EventQueueTimeMs",
             "EventQueueProcessingTimeMs");
         assertMetricsCreatedAndRemovedUponClose(expectedType, expectedMetricNames);

--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueueMetrics.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueueMetrics.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.queue;
+
+public interface EventQueueMetrics {
+    void setQueueSize(int size);
+
+    int eventQueueSize();
+}

--- a/server-common/src/test/java/org/apache/kafka/queue/MockEventQueueMetrics.java
+++ b/server-common/src/test/java/org/apache/kafka/queue/MockEventQueueMetrics.java
@@ -1,0 +1,15 @@
+package org.apache.kafka.queue;
+
+public final class MockEventQueueMetrics implements EventQueueMetrics {
+    private volatile int size = 0;
+
+    @Override
+    public void setQueueSize(int size) {
+        this.size = size;
+    }
+
+    @Override
+    public int eventQueueSize() {
+        return this.size;
+    }
+}


### PR DESCRIPTION
In order to stay in-line with existing queue metrics in ControllerEventManager
mbean, we need to include a queue size metric in KRaft mode.

The current size of the underlying queue in QuorumController
needs to be exposed as:

```
kafka.controller:type=ControllerEventManager,name=EventQueueSize
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)


[➡ Link to JIRA](https://issues.apache.org/jira/browse/KAFKA-13903)