### PR TITLE
MINOR: Include kafka record inside RecordDeserializationException

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -204,6 +204,11 @@
     <subpackage name="quotas">
       <allow pkg="org.apache.kafka.common" />
     </subpackage>
+
+    <subpackage name="errors">
+      <allow pkg="org.apache.kafka.common.record" />
+    </subpackage>
+    
   </subpackage>
 
   <subpackage name="controller">

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1430,7 +1430,7 @@ public class Fetcher<K, V> implements Closeable {
                                         valueByteArray == null ? ConsumerRecord.NULL_SIZE : valueByteArray.length,
                                         key, value, headers, leaderEpoch);
         } catch (RuntimeException e) {
-            throw new RecordDeserializationException(partition, record.offset(),
+            throw new RecordDeserializationException(partition, record, record.offset(),
                 "Error deserializing key/value for partition " + partition +
                     " at offset " + record.offset() + ". If needed, please seek past the record to continue consumption.", e);
         }

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.errors;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.Record;
 
 /**
  *  This exception is raised for any error that occurs while deserializing records received by the consumer using 
@@ -26,18 +27,22 @@ public class RecordDeserializationException extends SerializationException {
 
     private static final long serialVersionUID = 1L;
     private final TopicPartition partition;
+    private final Record record;
     private final long offset;
 
-    public RecordDeserializationException(TopicPartition partition, long offset, String message, Throwable cause) {
+    public RecordDeserializationException(TopicPartition partition, Record record, long offset, String message, Throwable cause) {
         super(message, cause);
         this.partition = partition;
+        this.record = record;
         this.offset = offset;
     }
 
     public TopicPartition topicPartition() {
         return partition;
     }
-
+    public Record record() {
+        return record;
+    }
     public long offset() {
         return offset;
     }


### PR DESCRIPTION
I want to handle the record where serialize Exception occurred in errorHandler. Shouldn't the exception include the record?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
