### PR TITLE
KAFKA-13702: Connect RestClient overrides response status code on request failure

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -157,6 +157,8 @@ public class RestClient {
             log.error("IO error forwarding REST request: ", e);
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "IO Error trying to forward REST request: " + e.getMessage(), e);
         } catch (ConnectRestException e) {
+            // catching any explicitly thrown ConnectRestException-s to preserve its status code
+            // and to avoid getting it overridden by the more generic catch (Throwable) clause down below
             log.error("Error forwarding REST request", e);
             throw e;
         } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -19,10 +19,6 @@ package org.apache.kafka.connect.runtime.rest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import javax.crypto.SecretKey;
-import javax.ws.rs.core.HttpHeaders;
-
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
@@ -37,6 +33,8 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.crypto.SecretKey;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -101,6 +99,21 @@ public class RestClient {
         }
 
         try {
+            return httpRequest(client, url, method, headers, requestBodyData, responseFormat, sessionKey, requestSignatureAlgorithm);
+        } finally {
+            try {
+                client.stop();
+            } catch (Exception e) {
+                log.error("Failed to stop HTTP client", e);
+            }
+        }
+    }
+
+    static <T> HttpResponse<T> httpRequest(HttpClient client, String url, String method,
+                                           HttpHeaders headers, Object requestBodyData,
+                                           TypeReference<T> responseFormat, SecretKey sessionKey,
+                                           String requestSignatureAlgorithm) {
+        try {
             String serializedBody = requestBodyData == null ? null : JSON_SERDE.writeValueAsString(requestBodyData);
             log.trace("Sending {} with input {} to {}", method, serializedBody, url);
 
@@ -143,15 +156,12 @@ public class RestClient {
         } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
             log.error("IO error forwarding REST request: ", e);
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "IO Error trying to forward REST request: " + e.getMessage(), e);
+        } catch (ConnectRestException e) {
+            log.error("Error forwarding REST request", e);
+            throw e;
         } catch (Throwable t) {
             log.error("Error forwarding REST request", t);
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "Error trying to forward REST request: " + t.getMessage(), t);
-        } finally {
-            try {
-                client.stop();
-            } catch (Exception e) {
-                log.error("Failed to stop HTTP client", e);
-            }
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -22,34 +22,32 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
-import org.junit.jupiter.api.BeforeEach;
+import org.jose4j.keys.HmacKey;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.niceMock;
-import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RestClientTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<TestDTO> TEST_TYPE = new TypeReference<TestDTO>() {
     };
-    private HttpClient httpClient;
+
+    private final HttpClient httpClient = mock(HttpClient.class);
 
     private static String toJsonString(Object obj) {
         try {
@@ -59,58 +57,103 @@ public class RestClientTest {
         }
     }
 
-    private static <T> RestClient.HttpResponse<T> httpRequest(HttpClient httpClient, TypeReference<T> typeReference) {
+    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient, String requestSignatureAlgorithm) {
         return RestClient.httpRequest(
-                httpClient, null, null, null, null, typeReference, null, null);
+                httpClient,
+                "https://localhost:1234/api/endpoint",
+                "GET",
+                null,
+                new TestDTO("requestBodyData"),
+                TEST_TYPE,
+                new HmacKey("HMAC".getBytes(StandardCharsets.UTF_8)),
+                requestSignatureAlgorithm);
     }
 
-    @BeforeEach
-    public void mockSetup() {
-        httpClient = niceMock(HttpClient.class);
+    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient) {
+        String validRequestSignatureAlgorithm = "HmacMD5";
+        return RestClient.httpRequest(
+                httpClient,
+                "https://localhost:1234/api/endpoint",
+                "GET",
+                null,
+                new TestDTO("requestBodyData"),
+                TEST_TYPE,
+                new HmacKey("HMAC".getBytes(StandardCharsets.UTF_8)),
+                validRequestSignatureAlgorithm);
+
+    }
+
+    private static void assertIsInternalServerError(ConnectRestException e) {
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.statusCode());
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.errorCode());
     }
 
     @Test
-    public void testSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    public void testSuccess() throws Exception {
         int statusCode = Response.Status.OK.getStatusCode();
-        String expectedResponse = toJsonString(new TestDTO("someContent"));
-        setupHttpClient(statusCode, expectedResponse);
+        TestDTO expectedResponse = new TestDTO("someContent");
+        setupHttpClient(statusCode, toJsonString(expectedResponse));
 
-        RestClient.HttpResponse<TestDTO> httpResp = httpRequest(httpClient, TEST_TYPE);
-        assertEquals(httpResp.status(), statusCode);
-        assertEquals(toJsonString(httpResp.body()), expectedResponse);
+        RestClient.HttpResponse<TestDTO> httpResp = httpRequest(httpClient);
+        assertEquals(statusCode, httpResp.status());
+        assertEquals(expectedResponse, httpResp.body());
     }
 
     @Test
-    public void testNoContent() throws ExecutionException, InterruptedException, TimeoutException {
+    public void testNoContent() throws Exception {
         int statusCode = Response.Status.NO_CONTENT.getStatusCode();
         setupHttpClient(statusCode, null);
 
-        RestClient.HttpResponse<TestDTO> httpResp = httpRequest(httpClient, TEST_TYPE);
-        assertEquals(httpResp.status(), statusCode);
+        RestClient.HttpResponse<TestDTO> httpResp = httpRequest(httpClient);
+        assertEquals(statusCode, httpResp.status());
         assertNull(httpResp.body());
     }
 
     @Test
-    public void testError() throws ExecutionException, InterruptedException, TimeoutException {
+    public void testStatusCodeAndErrorMessagePreserved() throws Exception {
         int statusCode = Response.Status.CONFLICT.getStatusCode();
         ErrorMessage errorMsg = new ErrorMessage(Response.Status.GONE.getStatusCode(), "Some Error Message");
         setupHttpClient(statusCode, toJsonString(errorMsg));
-        ConnectRestException e = assertThrows(ConnectRestException.class, () -> httpRequest(httpClient, TEST_TYPE));
-        assertEquals(e.statusCode(), statusCode);
-        assertEquals(e.errorCode(), errorMsg.errorCode());
-        assertEquals(e.getMessage(), errorMsg.message());
+        ConnectRestException e = assertThrows(ConnectRestException.class, () -> httpRequest(httpClient));
+        assertEquals(statusCode, e.statusCode());
+        assertEquals(errorMsg.errorCode(), e.errorCode());
+        assertEquals(errorMsg.message(), e.getMessage());
     }
 
-    private void setupHttpClient(int responseCode, String responseJsonString) throws ExecutionException, InterruptedException, TimeoutException {
-        WorkerConfig workerConf = niceMock(WorkerConfig.class);
-        expect(workerConf.originals()).andReturn(Collections.emptyMap());
-        Request req = niceMock(Request.class);
-        ContentResponse resp = niceMock(ContentResponse.class);
-        expect(resp.getStatus()).andReturn(responseCode);
-        expect(resp.getContentAsString()).andReturn(responseJsonString);
-        expect(req.send()).andReturn(resp);
-        expect(httpClient.newRequest(anyString())).andReturn(req);
-        replay(workerConf, httpClient, req, resp);
+    @Test
+    public void testUnexpectedHttpResponseCausesInternalServerError() throws Exception {
+        int statusCode = Response.Status.NOT_MODIFIED.getStatusCode(); // never thrown explicitly -
+        // should be treated as an unexpected error and translated into 500 INTERNAL_SERVER_ERROR
+
+        setupHttpClient(statusCode, null);
+        ConnectRestException e = assertThrows(ConnectRestException.class, () -> httpRequest(httpClient));
+        assertIsInternalServerError(e);
+    }
+
+    @Test
+    public void testRuntimeExceptionCausesInternalServerError() {
+        when(httpClient.newRequest(anyString())).thenThrow(new RuntimeException());
+
+        ConnectRestException e = assertThrows(ConnectRestException.class, () -> httpRequest(httpClient));
+        assertIsInternalServerError(e);
+    }
+
+    @Test
+    public void testRequestSignatureFailureCausesInternalServerError() throws Exception {
+        setupHttpClient(0, null);
+        String invalidRequestSignatureAlgorithm = "Foo";
+        ConnectRestException e = assertThrows(ConnectRestException.class, () -> httpRequest(httpClient, invalidRequestSignatureAlgorithm));
+        assertIsInternalServerError(e);
+    }
+
+    private void setupHttpClient(int responseCode, String responseJsonString) throws Exception {
+        Request req = mock(Request.class);
+        ContentResponse resp = mock(ContentResponse.class);
+        when(resp.getStatus()).thenReturn(responseCode);
+        when(resp.getContentAsString()).thenReturn(responseJsonString);
+        when(req.send()).thenReturn(resp);
+        when(req.header(anyString(), anyString())).thenReturn(req);
+        when(httpClient.newRequest(anyString())).thenReturn(req);
     }
 
     private static class TestDTO {
@@ -123,6 +166,19 @@ public class RestClientTest {
 
         public String getContent() {
             return content;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestDTO testDTO = (TestDTO) o;
+            return content.equals(testDTO.content);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(content);
         }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.runtime.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
+import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RestClientTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<TestDTO> TEST_TYPE = new TypeReference<TestDTO>() {
+    };
+    private HttpClient httpClient;
+
+    private static String toJsonString(Object obj) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T> RestClient.HttpResponse<T> httpRequest(HttpClient httpClient, TypeReference<T> typeReference) {
+        return RestClient.httpRequest(
+                httpClient, null, null, null, null, typeReference, null, null);
+    }
+
+    @BeforeEach
+    public void mockSetup() {
+        httpClient = niceMock(HttpClient.class);
+    }
+
+    @Test
+    public void testSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+        int statusCode = Response.Status.OK.getStatusCode();
+        String expectedResponse = toJsonString(new TestDTO("someContent"));
+        setupHttpClient(statusCode, expectedResponse);
+
+        RestClient.HttpResponse<TestDTO> httpResp = httpRequest(httpClient, TEST_TYPE);
+        assertEquals(httpResp.status(), statusCode);
+        assertEquals(toJsonString(httpResp.body()), expectedResponse);
+    }
+
+    @Test
+    public void testNoContent() throws ExecutionException, InterruptedException, TimeoutException {
+        int statusCode = Response.Status.NO_CONTENT.getStatusCode();
+        setupHttpClient(statusCode, null);
+
+        RestClient.HttpResponse<TestDTO> httpResp = httpRequest(httpClient, TEST_TYPE);
+        assertEquals(httpResp.status(), statusCode);
+        assertNull(httpResp.body());
+    }
+
+    @Test
+    public void testError() throws ExecutionException, InterruptedException, TimeoutException {
+        int statusCode = Response.Status.CONFLICT.getStatusCode();
+        ErrorMessage errorMsg = new ErrorMessage(Response.Status.GONE.getStatusCode(), "Some Error Message");
+        setupHttpClient(statusCode, toJsonString(errorMsg));
+        ConnectRestException e = assertThrows(ConnectRestException.class, () -> httpRequest(httpClient, TEST_TYPE));
+        assertEquals(e.statusCode(), statusCode);
+        assertEquals(e.errorCode(), errorMsg.errorCode());
+        assertEquals(e.getMessage(), errorMsg.message());
+    }
+
+    private void setupHttpClient(int responseCode, String responseJsonString) throws ExecutionException, InterruptedException, TimeoutException {
+        WorkerConfig workerConf = niceMock(WorkerConfig.class);
+        expect(workerConf.originals()).andReturn(Collections.emptyMap());
+        Request req = niceMock(Request.class);
+        ContentResponse resp = niceMock(ContentResponse.class);
+        expect(resp.getStatus()).andReturn(responseCode);
+        expect(resp.getContentAsString()).andReturn(responseJsonString);
+        expect(req.send()).andReturn(resp);
+        expect(httpClient.newRequest(anyString())).andReturn(req);
+        replay(workerConf, httpClient, req, resp);
+    }
+
+    private static class TestDTO {
+        private final String content;
+
+        @JsonCreator
+        private TestDTO(@JsonProperty(value = "content") String content) {
+            this.content = content;
+        }
+
+        public String getContent() {
+            return content;
+        }
+    }
+}


### PR DESCRIPTION

In case the submitted request status is >=400, the connect RestClient [throws](https://github.com/apache/kafka/blob/8047ba3800436d6162d0f8eb707e28857ab9eb68/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java#L133) a ConnectRestException with the proper response code, but it gets intercepted and [rethrown with 500 status code](https://github.com/apache/kafka/blob/8047ba3800436d6162d0f8eb707e28857ab9eb68/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java#L147), effectively overriding the actual failure status.

Includes a new unit-test class for the RestClient

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
