### PR TITLE
KAFKA-14012: Add warning to closeQuietly documentation about method references of null objects

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -997,9 +997,15 @@ public final class Utils {
     }
 
     /**
-     * Closes {@code closeable} and if an exception is thrown, it is logged at the WARN level. Note that, if
-     * a method reference of null object is passed as closeable to this method, then that leads to NPE and
-     * the close() doesn't happen as expected.
+     * Closes {@code closeable} and if an exception is thrown, it is logged at the WARN level.
+     * <b>Be cautious when passing method references as an argument.</b> For example:
+     * <p>
+     * {@code closeQuietly(task::stop, "source task");}
+     * <p>
+     * Although this method gracefully handles null {@link AutoCloseable} objects, attempts to take a method
+     * reference from a null object will result in a {@link NullPointerException}. In the example code above,
+     * it would be the caller's responsibility to ensure that {@code task} was non-null before attempting to
+     * use a method reference from it.
      */
     public static void closeQuietly(AutoCloseable closeable, String name) {
         if (closeable != null) {
@@ -1011,10 +1017,16 @@ public final class Utils {
         }
     }
 
-    /*
+    /**
     * Closes {@code closeable} and if an exception is thrown, it is registered to the firstException parameter.
-    * Note that, if a method reference of null object is passed as closeable to this method, then that leads to NPE and
-    * * the close() doesn't happen as expected.
+    * <b>Be cautious when passing method references as an argument.</b> For example:
+    * <p>
+    * {@code closeQuietly(task::stop, "source task");}
+    * <p>
+    * Although this method gracefully handles null {@link AutoCloseable} objects, attempts to take a method
+    * reference from a null object will result in a {@link NullPointerException}. In the example code above,
+    * it would be the caller's responsibility to ensure that {@code task} was non-null before attempting to
+    * use a method reference from it.
     */
     public static void closeQuietly(AutoCloseable closeable, String name, AtomicReference<Throwable> firstException) {
         if (closeable != null) {
@@ -1028,8 +1040,7 @@ public final class Utils {
     }
 
     /**
-     * close all closable objects even if one of them throws exception. Have care when passing method references as a
-     * closeable as a method reference on a null object would throw an NPE and the close won't happen as expected.
+     * close all closable objects even if one of them throws exception.
      * @param firstException keeps the first exception
      * @param name message of closing those objects
      * @param closeables closable objects

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -997,7 +997,9 @@ public final class Utils {
     }
 
     /**
-     * Closes {@code closeable} and if an exception is thrown, it is logged at the WARN level.
+     * Closes {@code closeable} and if an exception is thrown, it is logged at the WARN level. Note that, if
+     * a method reference of null object is passed as closeable to this method, then that leads to NPE and
+     * the close() doesn't happen as expected.
      */
     public static void closeQuietly(AutoCloseable closeable, String name) {
         if (closeable != null) {
@@ -1009,6 +1011,11 @@ public final class Utils {
         }
     }
 
+    /*
+    * Closes {@code closeable} and if an exception is thrown, it is registered to the firstException parameter.
+    * Note that, if a method reference of null object is passed as closeable to this method, then that leads to NPE and
+    * * the close() doesn't happen as expected.
+    */
     public static void closeQuietly(AutoCloseable closeable, String name, AtomicReference<Throwable> firstException) {
         if (closeable != null) {
             try {
@@ -1021,7 +1028,8 @@ public final class Utils {
     }
 
     /**
-     * close all closable objects even if one of them throws exception.
+     * close all closable objects even if one of them throws exception. Have care when passing method references as a
+     * closeable as a method reference on a null object would throw an NPE and the close won't happen as expected.
      * @param firstException keeps the first exception
      * @param name message of closing those objects
      * @param closeables closable objects

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -234,7 +234,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
         this.admin = admin;
         this.offsetReader = offsetReader;
         this.offsetWriter = offsetWriter;
-        this.offsetStore = offsetStore;
+        this.offsetStore = Objects.requireNonNull(offsetStore, "offset store cannot be null for source tasks");
         this.closeExecutor = closeExecutor;
         this.sourceTaskContext = sourceTaskContext;
 
@@ -242,7 +242,6 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
         this.sourceTaskMetricsGroup = new SourceTaskMetricsGroup(id, connectMetrics);
         this.topicTrackingEnabled = workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG);
         this.topicCreation = TopicCreation.newTopicCreation(workerConfig, topicGroups);
-        Objects.requireNonNull(this.offsetStore);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -241,6 +242,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
         this.sourceTaskMetricsGroup = new SourceTaskMetricsGroup(id, connectMetrics);
         this.topicTrackingEnabled = workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG);
         this.topicCreation = TopicCreation.newTopicCreation(workerConfig, topicGroups);
+        Objects.requireNonNull(this.offsetStore);
     }
 
     @Override
@@ -298,7 +300,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
 
     @Override
     protected void close() {
-        if (started && task != null) {
+        if (started) {
             Utils.closeQuietly(task::stop, "source task");
         }
 
@@ -310,9 +312,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
         Utils.closeQuietly(transformationChain, "transformation chain");
         Utils.closeQuietly(retryWithToleranceOperator, "retry operator");
         Utils.closeQuietly(offsetReader, "offset reader");
-        if (offsetReader != null) {
-            Utils.closeQuietly(offsetStore::stop, "offset backing store");
-        }
+        Utils.closeQuietly(offsetStore::stop, "offset backing store");
     }
 
     private void closeProducer(Duration duration) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -298,7 +298,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
 
     @Override
     protected void close() {
-        if (started) {
+        if (started && task != null) {
             Utils.closeQuietly(task::stop, "source task");
         }
 
@@ -310,7 +310,9 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
         Utils.closeQuietly(transformationChain, "transformation chain");
         Utils.closeQuietly(retryWithToleranceOperator, "retry operator");
         Utils.closeQuietly(offsetReader, "offset reader");
-        Utils.closeQuietly(offsetStore::stop, "offset backing store");
+        if (offsetReader != null) {
+            Utils.closeQuietly(offsetStore::stop, "offset backing store");
+        }
     }
 
     private void closeProducer(Duration duration) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -357,7 +357,10 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
         relinquishWritePrivileges();
         Utils.closeQuietly(ownTopicAdmin, "admin for config topic");
-        Utils.closeQuietly(configLog::stop, "KafkaBasedLog for config topic");
+
+        if (configLog != null) {
+            Utils.closeQuietly(configLog::stop, "KafkaBasedLog for config topic");
+        }
 
         log.info("Closed KafkaConfigBackingStore");
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -357,10 +357,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
         relinquishWritePrivileges();
         Utils.closeQuietly(ownTopicAdmin, "admin for config topic");
-
-        if (configLog != null) {
-            Utils.closeQuietly(configLog::stop, "KafkaBasedLog for config topic");
-        }
+        Utils.closeQuietly(configLog::stop, "KafkaBasedLog for config topic");
 
         log.info("Closed KafkaConfigBackingStore");
     }


### PR DESCRIPTION
Utils.closeQuietly method accepts `AutoCloseable` object, and close it and sometimes, method references of null objects are passed to it which causes npes. This PR fixes it..