### PR TITLE
KAFKA-12699: Override the default handler for stream threads if the stream's handler is used

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -474,6 +474,13 @@ public class KafkaStreams implements AutoCloseable {
                         exception -> handleStreamsUncaughtException(exception, userStreamsUncaughtExceptionHandler, false)
                     );
                 }
+                processStreamThread(thread -> thread.setUncaughtExceptionHandler((t, e) -> { }
+                ));
+
+                if (globalStreamThread != null) {
+                    globalStreamThread.setUncaughtExceptionHandler((t, e) -> { }
+                    );
+                }
             } else {
                 throw new IllegalStateException("Can only set UncaughtExceptionHandler before calling start(). " +
                     "Current state is: " + state);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -220,6 +220,12 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
     }
 
     @Test
+    public void shouldReplaceThreadsWithoutJavaHandler() throws InterruptedException {
+        Thread.setDefaultUncaughtExceptionHandler((t ,e) -> fail("exception thrown"));
+        testReplaceThreads(2);
+    }
+
+    @Test
     public void shouldReplaceSingleThread() throws InterruptedException {
         testReplaceThreads(1);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -221,7 +221,7 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
 
     @Test
     public void shouldReplaceThreadsWithoutJavaHandler() throws InterruptedException {
-        Thread.setDefaultUncaughtExceptionHandler((t ,e) -> fail("exception thrown"));
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> fail("exception thrown"));
         testReplaceThreads(2);
     }
 


### PR DESCRIPTION
override the default handler for stream threads if the stream's handler is used. We do no want the java default handler triggering when a thread is replaced.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
