### PR TITLE
MINOR: fix no_op_record exception when running /bin/kafka-metadata-shell.sh

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -333,6 +333,8 @@ public final class MetadataNodeManager implements AutoCloseable {
                 producerIds.create("nextBlockStartId").setContents(record.nextProducerId() + "");
                 break;
             }
+            case NO_OP_RECORD:
+                break;
             default:
                 throw new RuntimeException("Unhandled metadata record type");
         }


### PR DESCRIPTION
Fixes exception that appears due to record type of NO_OP_RECORD when running /bin/kafka-metadata-shell.sh