### PR TITLE
KAFKA-4279: REST API for filtering Connector plugins by type

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginType.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginType.java
@@ -59,6 +59,10 @@ public enum PluginType {
         return klass.getSimpleName();
     }
 
+    public Class<?> getKlass() {
+        return klass;
+    }
+
     @Override
     public String toString() {
         return super.toString().toLowerCase(Locale.ROOT);


### PR DESCRIPTION
https://cwiki.apache.org/confluence/display/KAFKA/KIP-850%3A+REST+API+for+filtering+Connector+plugins+by+type

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
