### PR TITLE
KAFKA-1194: changes needed to run on Windows

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.utils.Utils;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -461,13 +460,11 @@ public class FileRecords extends AbstractRecords implements Closeable {
                                            int initFileSize,
                                            boolean preallocate) throws IOException {
         if (mutable) {
-            if (fileAlreadyExists || !preallocate) {
+            if (preallocate && !fileAlreadyExists) {
+                return Utils.createPreallocatedFile(file.toPath(), initFileSize);
+            } else {
                 return FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.READ,
                         StandardOpenOption.WRITE);
-            } else {
-                RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
-                randomAccessFile.setLength(initFileSize);
-                return randomAccessFile.getChannel();
             }
         } else {
             return FileChannel.open(file.toPath());

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -663,7 +663,7 @@ object KafkaMetadataLog extends Logging {
       }
 
       snapshotsToDelete.foreach { snapshotPath =>
-        Files.deleteIfExists(snapshotPath.path)
+        Snapshots.makeWritableAndDeleteIfExists(snapshotPath.path)
         info(s"Deleted unneeded snapshot file with path $snapshotPath")
       }
     } finally {

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -116,7 +116,7 @@ public final class Snapshots {
         Path immutablePath = snapshotPath(logDir, snapshotId);
         Path deletedPath = deleteRenamePath(immutablePath, snapshotId);
         try {
-            boolean deleted = Files.deleteIfExists(immutablePath) | Files.deleteIfExists(deletedPath);
+            boolean deleted = makeWritableAndDeleteIfExists(immutablePath) | makeWritableAndDeleteIfExists(deletedPath);
             if (deleted) {
                 log.info("Deleted snapshot files for snapshot {}.", snapshotId);
             } else {
@@ -149,6 +149,15 @@ public final class Snapshots {
                 ),
                 e
             );
+        }
+    }
+
+    public static boolean makeWritableAndDeleteIfExists(Path path) throws IOException {
+        try {
+            path.toFile().setWritable(true);
+            return Files.deleteIfExists(path);
+        } catch (IOException ex) {
+            throw ex;
         }
     }
 }


### PR DESCRIPTION
Hi,

  I have come across [this comment](https://issues.apache.org/jira/browse/KAFKA-2170?focusedCommentId=17477226&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17477226) by [Maksim Zinal](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=mzinal).

> I've created a quick patch which seems to fix the issue on my system and on the Kafka version I use (2.8.0).
> 
> I believe that the reason of lock failures is the use of RandomAccessFile Java API to open the files in some cases, while in other cases FileChannel.open() is used instead. When opening files with RandomAccessFile under Windows, FILE_SHARE_DELETE flag is not set, which leads to "access denied" errors when trying to rename or delete the open files. FileChannel.open() sets the FILE_SHARE_DELETE by default, as I checked on JDK 8 and 11.
> 
> Here's the link to the branch based on tag 2.8.0: https://github.com/zinal/kafka/tree/2.8.0_KAFKA-1194
> 
> Here are the exact changes implemented: https://github.com/zinal/kafka/compare/2.8.0...zinal:2.8.0_KAFKA-1194 (plus jcenter and grgit stuff needed to run the build).

This change addresses some "access denied" errors which occur on Windows.
[KAFKA-1194](https://issues.apache.org/jira/browse/KAFKA-1194), [KAFKA-2427](https://issues.apache.org/jira/browse/KAFKA-2427), [KAFKA-6059](https://issues.apache.org/jira/browse/KAFKA-6059), [KAFKA-6188](https://issues.apache.org/jira/browse/KAFKA-6188), [KAFKA-6200](https://issues.apache.org/jira/browse/KAFKA-6200), [KAFKA-7575](https://issues.apache.org/jira/browse/KAFKA-7575), [KAFKA-8145](https://issues.apache.org/jira/browse/KAFKA-8145), [KAFKA-9458](https://issues.apache.org/jira/browse/KAFKA-9458)

Stackowerflow
[45141541](https://stackoverflow.com/questions/45141541/kafka-topic-data-is-not-getting-deleted-in-windows), [45599625](https://stackoverflow.com/questions/45599625/kafka-unable-to-start-kafka-process-can-not-access-file-00000000000000000000), [48114040](https://stackoverflow.com/questions/48114040/exception-during-topic-deletion-when-kafka-is-hosted-in-docker-in-windows), [50755827](https://stackoverflow.com/questions/50755827/accessdeniedexception-when-deleting-a-topic-on-windows-kafka), [67555122](https://stackoverflow.com/questions/67555122/getting-java-nio-file-accessdeniedexception-on-kafka-on-windows)

**Testing**
I deployed Kafka 2.8.1. with the original patch provided by [Maksim Zinal](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=mzinal) in January on ~50 Windows servers. Each Kafka instance has only one queue. Several processes per Kafka instance write their logs in to the queue and one process reads the queue and processed the data.

It seems that [these issues mentioned on stackowerflow](https://stackoverflow.com/questions/45599625/kafka-unable-to-start-kafka-process-can-not-access-file-00000000000000000000) by Windows users are gone.

I am currently testing Kafka 3.3. with the latest version of the patch which was modified according to @divijvaidya requests.

Kafka 3.3. log files

- [controller.log](https://github.com/apache/kafka/files/9072570/controller.log)
- [server.log](https://github.com/apache/kafka/files/9072571/server.log)
- [log-cleaner.log](https://github.com/apache/kafka/files/9072572/log-cleaner.log)

You can see in the logs that Kafka managed to delete timeindex files. 

Thank you for your time.
