### PR TITLE
MINOR: set UNKNOWN_MEMBER_ID explicitly when deleting group instance id

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -218,6 +218,7 @@ import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
 import org.apache.kafka.common.requests.ExpireDelegationTokenResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
+import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
@@ -3742,7 +3743,8 @@ public class KafkaAdminClient extends AdminClient {
             MemberIdentity memberIdentity = new MemberIdentity().setReason(reason);
 
             if (member.groupInstanceId().isPresent()) {
-                memberIdentity.setGroupInstanceId(member.groupInstanceId().get());
+                memberIdentity.setGroupInstanceId(member.groupInstanceId().get())
+                        .setMemberId(JoinGroupRequest.UNKNOWN_MEMBER_ID);
             } else {
                 memberIdentity.setMemberId(member.consumerId());
             }


### PR DESCRIPTION
This is not a bug fix, but it makes code more readable. We expect the member id to be undefined(`UNKNOWN_MEMBER_ID`) when we are removing group instance id. Hence, it would be better to set `UNKNOWN_MEMBER_ID` explicitly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
