### PR TITLE
HOTFIX: Fix NPE in StreamTask#shouldCheckpointState

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1951,7 +1951,9 @@ public class StreamTaskTest {
         EasyMock.expectLastCall().once();
         stateManager.checkpoint();
         EasyMock.expectLastCall().once();
-        EasyMock.replay(stateManager);
+        EasyMock.expect(stateManager.changelogOffsets()).andStubReturn(Collections.emptyMap());
+        EasyMock.expect(recordCollector.offsets()).andStubReturn(Collections.emptyMap());
+        EasyMock.replay(stateManager, recordCollector);
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 


### PR DESCRIPTION
The mocks were not setup correctly in StreamTask#shouldCheckpointState
which caused a null pointer exception during test execution.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
