### PR TITLE
MINOR: Update unit/integration tests to work with the IBM Semeru JDK

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -44,6 +44,10 @@ public final class Java {
         return System.getProperty("java.vendor").contains("IBM");
     }
 
+    public static boolean isIbmJdkSemeru() {
+        return isIbmJdk() && System.getProperty("java.runtime.name", "").contains("Semeru");
+    }
+
     // Package private for testing
     static class Version {
         public final int majorVersion;

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -27,15 +27,18 @@ import org.junit.jupiter.api.Test;
 public class JavaTest {
 
     private String javaVendor;
+    private String javaRuntimeName;
 
     @BeforeEach
     public void before() {
         javaVendor = System.getProperty("java.vendor");
+        javaRuntimeName = System.getProperty("java.runtime.name");
     }
 
     @AfterEach
     public void after() {
         System.setProperty("java.vendor", javaVendor);
+        System.setProperty("java.runtime.name", javaRuntimeName);
     }
 
     @Test
@@ -47,8 +50,21 @@ public class JavaTest {
     }
 
     @Test
+    public void testIsIBMJdkSemeru() {
+        System.setProperty("java.vendor", "Oracle Corporation");
+        assertFalse(Java.isIbmJdkSemeru());
+        System.setProperty("java.vendor", "IBM Corporation");
+        System.setProperty("java.runtime.name", "Java(TM) SE Runtime Environment");
+        assertFalse(Java.isIbmJdkSemeru());
+        System.setProperty("java.vendor", "IBM Corporation");
+        System.setProperty("java.runtime.name", "IBM Semeru Runtime Certified Edition");
+        assertTrue(Java.isIbmJdkSemeru());
+    }
+
+    @Test
     public void testLoadKerberosLoginModule() throws ClassNotFoundException {
-        String clazz = Java.isIbmJdk()
+        // IBM Semeru JDKs use the OpenJDK security providers
+        String clazz = Java.isIbmJdk() && !Java.isIbmJdkSemeru()
                 ? "com.ibm.security.auth.module.Krb5LoginModule"
                 : "com.sun.security.auth.module.Krb5LoginModule";
         Class.forName(clazz);

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -260,17 +260,11 @@ class MiniKdc(config: Properties, workDir: File) extends Logging {
   }
 
   private def refreshJvmKerberosConfig(): Unit = {
-    // Newer IBM JDKs use the OpenJDK security providers so try that first
-    val klass = try {
-      Class.forName("sun.security.krb5.Config")
-    } catch {
-      case ex: Exception => {
-        if (Java.isIbmJdk)
-          Class.forName("com.ibm.security.krb5.internal.Config")
-        else
-          throw ex
-      }
-    }
+    val klass =
+      if (Java.isIbmJdk && !Java.isIbmJdkSemeru)
+        Class.forName("com.ibm.security.krb5.internal.Config")
+      else
+        Class.forName("sun.security.krb5.Config")
     klass.getMethod("refresh").invoke(klass)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -31,16 +31,17 @@ object JaasTestUtils {
                              keyTab: String,
                              principal: String,
                              debug: Boolean,
-                             serviceName: Option[String]) extends JaasModule {
+                             serviceName: Option[String],
+                             isIbmSecurity: Boolean) extends JaasModule {
 
     def name =
-      if (Java.isIbmJdk)
+      if (isIbmSecurity)
         "com.ibm.security.auth.module.Krb5LoginModule"
       else
         "com.sun.security.auth.module.Krb5LoginModule"
 
     def entries: Map[String, String] =
-      if (Java.isIbmJdk)
+      if (isIbmSecurity)
         Map(
           "principal" -> principal,
           "credsType" -> "both"
@@ -119,6 +120,18 @@ object JaasTestUtils {
     }
   }
 
+  private val isIbmSecurity = try {
+      Class.forName("sun.security.krb5.Config"); false
+    } catch {
+      case ex: Exception => {
+        if (Java.isIbmJdk) {
+          Class.forName("com.ibm.security.krb5.internal.Config"); true
+        } else {
+          throw ex
+        }
+      }
+    }
+
   private val ZkServerContextName = "Server"
   private val ZkClientContextName = "Client"
   private val ZkUserSuperPasswd = "adminpasswd"
@@ -158,7 +171,7 @@ object JaasTestUtils {
     val result = saslProperties.getOrElse(new Properties)
     // IBM Kerberos module doesn't support the serviceName JAAS property, hence it needs to be
     // passed as a Kafka property
-    if (Java.isIbmJdk && !result.contains(KafkaConfig.SaslKerberosServiceNameProp))
+    if (isIbmSecurity && !result.contains(KafkaConfig.SaslKerberosServiceNameProp))
       result.put(KafkaConfig.SaslKerberosServiceNameProp, serviceName)
     result
   }
@@ -215,7 +228,8 @@ object JaasTestUtils {
           keyTab = keytabLocation.getOrElse(throw new IllegalArgumentException("Keytab location not specified for GSSAPI")).getAbsolutePath,
           principal = KafkaServerPrincipal,
           debug = true,
-          serviceName = Some(serviceName))
+          serviceName = Some(serviceName),
+          isIbmSecurity)
       case "PLAIN" =>
         PlainLoginModule(
           KafkaPlainAdmin,
@@ -256,7 +270,8 @@ object JaasTestUtils {
           keyTab = keytabLocation.getOrElse(throw new IllegalArgumentException("Keytab location not specified for GSSAPI")).getAbsolutePath,
           principal = clientPrincipal,
           debug = true,
-          serviceName = Some(serviceName)
+          serviceName = Some(serviceName),
+          isIbmSecurity
         )
       case "PLAIN" =>
         PlainLoginModule(

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -120,17 +120,7 @@ object JaasTestUtils {
     }
   }
 
-  private val isIbmSecurity = try {
-      Class.forName("sun.security.krb5.Config"); false
-    } catch {
-      case ex: Exception => {
-        if (Java.isIbmJdk) {
-          Class.forName("com.ibm.security.krb5.internal.Config"); true
-        } else {
-          throw ex
-        }
-      }
-    }
+  private val isIbmSecurity = Java.isIbmJdk && !Java.isIbmJdkSemeru
 
   private val ZkServerContextName = "Server"
   private val ZkClientContextName = "Client"

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -276,6 +276,7 @@ class SecurityConfig(TemplateRenderer):
         node.account.ssh("mkdir -p %s" % SecurityConfig.CONFIG_DIR, allow_fail=False)
         jaas_conf_file = "jaas.conf"
         java_version = node.account.ssh_capture("java -version")
+        is_ibm_security = any('IBM' in line for line in java_version) and not any('Semeru' in line for line in java_version)
 
         jaas_conf = None
         if 'sasl.jaas.config' not in self.properties:
@@ -283,7 +284,7 @@ class SecurityConfig(TemplateRenderer):
                 jaas_conf_file,
                 {
                     'node': node,
-                    'is_ibm_jdk': any('IBM' in line for line in java_version),
+                    'is_ibm_security': is_ibm_security,
                     'SecurityConfig': SecurityConfig,
                     'client_sasl_mechanism': self.client_sasl_mechanism,
                     'enabled_sasl_mechanisms': self.enabled_sasl_mechanisms
@@ -299,7 +300,7 @@ class SecurityConfig(TemplateRenderer):
                                          "admin_client_as_broker_jaas.conf",
                                          {
                                              'node': node,
-                                             'is_ibm_jdk': any('IBM' in line for line in java_version),
+                                             'is_ibm_security': is_ibm_security,
                                              'SecurityConfig': SecurityConfig,
                                              'client_sasl_mechanism': self.client_sasl_mechanism,
                                              'enabled_sasl_mechanisms': self.enabled_sasl_mechanisms

--- a/tests/kafkatest/services/security/templates/admin_client_as_broker_jaas.conf
+++ b/tests/kafkatest/services/security/templates/admin_client_as_broker_jaas.conf
@@ -14,7 +14,7 @@
 
 KafkaClient {
 {% if "GSSAPI" in enabled_sasl_mechanisms %}
-{% if is_ibm_jdk %}
+{% if is_ibm_security %}
     com.ibm.security.auth.module.Krb5LoginModule required debug=false
     credsType=both
     useKeytab="file:/mnt/security/keytab"

--- a/tests/kafkatest/services/security/templates/jaas.conf
+++ b/tests/kafkatest/services/security/templates/jaas.conf
@@ -16,7 +16,7 @@
 KafkaClient {
 {% endif %}
 {% if "GSSAPI" in client_sasl_mechanism %}
-{% if is_ibm_jdk %}
+{% if is_ibm_security %}
     com.ibm.security.auth.module.Krb5LoginModule required debug=false
     credsType=both
     useKeytab="file:/mnt/security/keytab"
@@ -44,7 +44,7 @@ KafkaClient {
 
 KafkaServer {
 {% if "GSSAPI" in enabled_sasl_mechanisms %}
-{% if is_ibm_jdk %}
+{% if is_ibm_security %}
     com.ibm.security.auth.module.Krb5LoginModule required debug=false
     credsType=both
     useKeytab="file:/mnt/security/keytab"
@@ -74,7 +74,7 @@ KafkaServer {
 
 {% if zk_sasl %}
 Client {
-{% if is_ibm_jdk %}
+{% if is_ibm_security %}
     com.ibm.security.auth.module.Krb5LoginModule required debug=false
     credsType=both
     useKeytab="file:/mnt/security/keytab"
@@ -90,7 +90,7 @@ Client {
 };
 
 Server {
-{% if is_ibm_jdk %}
+{% if is_ibm_security %}
    com.ibm.security.auth.module.Krb5LoginModule required debug=false
    credsType=both
    useKeyTab="file:/mnt/security/keytab"


### PR DESCRIPTION
The IBM Semeru JDK use the OpenJDK security providers instead of the IBM
security providers so test for the OpenJDK classes first where possible
and test for Semeru in the java.runtime.name system property otherwise.

Use a real but empty KafkaThread object in KafkaProducerTest instead of
a mock because the Semeru Thread class implementation has some extra
checks that are called and fail when the mock is used.

Tested with IBM and Temurin JDKs. Added a unit test for the new Java.isIbmSemeru() method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
