### PR TITLE
KAFKA-14016: Revoke more partitions than expected in Cooperative rebalance

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -811,9 +811,6 @@ public abstract class AbstractCoordinator implements Closeable {
                 } else if (error == Errors.REBALANCE_IN_PROGRESS) {
                     log.info("SyncGroup failed: The group began another rebalance. Need to re-join the group. " +
                                  "Sent generation was {}", sentGeneration);
-                    // consumer didn't get assignment in this generation, so we need to reset generation
-                    // to avoid joinGroup with out-of-data ownedPartitions in cooperative rebalance
-                    resetStateOnResponseError(ApiKeys.SYNC_GROUP, error, false);
                     future.raise(error);
                 } else if (error == Errors.FENCED_INSTANCE_ID) {
                     // for sync-group request, even if the generation has changed we would not expect the instance id

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -767,7 +767,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     // if REBALANCE_IN_PROGRESS and have assignment data, need to apply it first
                     (error == Errors.REBALANCE_IN_PROGRESS &&
                             syncResponse.data().protocolName() != null &&
-                            syncResponse.data().protocolType() != null )) {
+                            syncResponse.data().protocolType() != null)) {
                 if (isProtocolTypeInconsistent(syncResponse.data().protocolType())) {
                     log.error("SyncGroup failed due to inconsistent Protocol Type, received {} but expected {}",
                         syncResponse.data().protocolType(), protocolType());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -490,54 +489,6 @@ public class AbstractCoordinatorTest {
     }
 
     @Test
-    public void testResetGenerationIdAfterSyncGroupFailedWithRebalanceInProgress() throws InterruptedException, ExecutionException {
-        setupCoordinator();
-
-        String memberId = "memberId";
-        int generation = 5;
-
-        // Rebalance once to initialize the generation and memberId
-        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
-        expectJoinGroup("", generation, memberId);
-        expectSyncGroup(generation, memberId);
-        ensureActiveGroup(generation, memberId);
-
-        // Force a rebalance
-        coordinator.requestRejoin("Manual test trigger");
-        assertTrue(coordinator.rejoinNeededOrPending());
-
-        ExecutorService executor = Executors.newFixedThreadPool(1);
-        try {
-            // Return RebalanceInProgress in syncGroup
-            int rejoinedGeneration = 10;
-            expectJoinGroup(memberId, rejoinedGeneration, memberId);
-            expectRebalanceInProgressForSyncGroup(rejoinedGeneration, memberId);
-            Future<Boolean> secondJoin = executor.submit(() ->
-                coordinator.ensureActiveGroup(mockTime.timer(Integer.MAX_VALUE)));
-
-            TestUtils.waitForCondition(() -> {
-                AbstractCoordinator.Generation currentGeneration = coordinator.generation();
-                return currentGeneration.generationId == AbstractCoordinator.Generation.NO_GENERATION.generationId &&
-                        currentGeneration.memberId.equals(memberId);
-            }, 2000, "Generation should be reset");
-
-            rejoinedGeneration = 20;
-            expectSyncGroup(rejoinedGeneration, memberId);
-            mockClient.respond(joinGroupFollowerResponse(
-                    rejoinedGeneration,
-                    memberId,
-                    "leaderId",
-                    Errors.NONE,
-                    PROTOCOL_TYPE
-            ));
-            assertTrue(secondJoin.get());
-        } finally {
-            executor.shutdownNow();
-            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    @Test
     public void testRejoinReason() {
         setupCoordinator();
 
@@ -613,22 +564,6 @@ public class AbstractCoordinatorTest {
                 && syncGroupRequest.protocolType().equals(PROTOCOL_TYPE)
                 && syncGroupRequest.protocolName().equals(PROTOCOL_NAME);
         }, null, true);
-    }
-
-    private void expectRebalanceInProgressForSyncGroup(
-            int expectedGeneration,
-            String expectedMemberId
-    ) {
-        mockClient.prepareResponse(body -> {
-            if (!(body instanceof SyncGroupRequest)) {
-                return false;
-            }
-            SyncGroupRequestData syncGroupRequest = ((SyncGroupRequest) body).data();
-            return syncGroupRequest.generationId() == expectedGeneration
-                    && syncGroupRequest.memberId().equals(expectedMemberId)
-                    && syncGroupRequest.protocolType().equals(PROTOCOL_TYPE)
-                    && syncGroupRequest.protocolName().equals(PROTOCOL_NAME);
-        }, syncGroupResponse(Errors.REBALANCE_IN_PROGRESS, PROTOCOL_TYPE, PROTOCOL_NAME));
     }
 
     private void expectDisconnectInJoinGroup(

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -592,9 +592,9 @@ class GroupCoordinator(val brokerId: Int,
             // if it join before leader syncGroup (from CompletingRebalance), return empty
             if (group.isPrevious(Stable)) {
               val memberMetadata = group.get(memberId)
-              responseCallback(SyncGroupResult(group.protocolType, group.protocolName, memberMetadata.assignment, Errors.REASSIGNMENT_IN_PROGRESS))
+              responseCallback(SyncGroupResult(group.protocolType, group.protocolName, memberMetadata.assignment, Errors.REBALANCE_IN_PROGRESS))
             } else {
-              responseCallback(SyncGroupResult(Errors.REASSIGNMENT_IN_PROGRESS))
+              responseCallback(SyncGroupResult(Errors.REBALANCE_IN_PROGRESS))
             }
 
           case CompletingRebalance =>

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -197,6 +197,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private[group] val lock = new ReentrantLock
 
   private var state: GroupState = initialState
+  private var previousState: Option[GroupState] = None
   var currentStateTimestamp: Option[Long] = Some(time.milliseconds())
   var protocolType: Option[String] = None
   var protocolName: Option[String] = None
@@ -225,6 +226,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def inLock[T](fun: => T): T = CoreUtils.inLock(lock)(fun)
 
   def is(groupState: GroupState): Boolean = state == groupState
+  def isPrevious(groupState: GroupState): Boolean = previousState.orNull == groupState
   def has(memberId: String): Boolean = members.contains(memberId)
   def get(memberId: String): MemberMetadata = members(memberId)
   def size: Int = members.size
@@ -436,6 +438,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def transitionTo(groupState: GroupState): Unit = {
     assertValidTransition(groupState)
+    previousState = Some(state)
     state = groupState
     currentStateTimestamp = Some(time.milliseconds())
   }


### PR DESCRIPTION
With latest trunk branch's code we found that in Cooperative rebalance consumer will revoke more partitions than expected. Details here https://issues.apache.org/jira/browse/KAFKA-14016

So i want to start a PR to discuss the fix code. test will be added later.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
