### PR TITLE
KAFKA-14024: Consumer keeps Commit offset in onJoinPrepare in Cooperative rebalance

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -187,6 +187,7 @@ public abstract class AbstractCoordinator implements Closeable {
     /**
      * Invoked prior to each group join or rejoin. This is typically used to perform any
      * cleanup from the previous generation (such as committing offsets for the consumer)
+     * @param timer Timer bounding how long this method can block
      * @param generation The previous generation or -1 if there was none
      * @param memberId The identifier of this member in the previous group or "" if there was none
      * @return true If onJoinPrepare async commit succeeded, false otherwise

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -191,7 +191,7 @@ public abstract class AbstractCoordinator implements Closeable {
      * @param memberId The identifier of this member in the previous group or "" if there was none
      * @return true If onJoinPrepare async commit succeeded, false otherwise
      */
-    protected abstract boolean onJoinPrepare(int generation, String memberId);
+    protected abstract boolean onJoinPrepare(Timer timer, int generation, String memberId);
 
     /**
      * Invoked when the leader is elected. This is used by the leader to perform the assignment
@@ -426,7 +426,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 // exception, in which case upon retry we should not retry onJoinPrepare either.
                 needsJoinPrepare = false;
                 // return false when onJoinPrepare is waiting for committing offset
-                if (!onJoinPrepare(generation.generationId, generation.memberId)) {
+                if (!onJoinPrepare(timer, generation.generationId, generation.memberId)) {
                     needsJoinPrepare = true;
                     //should not initiateJoinGroup if needsJoinPrepare still is true
                     return false;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -747,6 +747,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         log.debug("Executing onJoinPrepare with generation {} and memberId {}", generation, memberId);
         if (joinPrepareTimer == null) {
             joinPrepareTimer = time.timer(rebalanceConfig.rebalanceTimeoutMs);
+        } else {
+            joinPrepareTimer.update();
         }
         // async commit offsets prior to rebalance if auto-commit enabled
         if (autoCommitEnabled && autoCommitOffsetRequestFuture == null) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -745,6 +745,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         boolean onJoinPrepareAsyncCommitCompleted = false;
         // async commit offsets prior to rebalance if auto-commit enabled
         RequestFuture<Void> future = maybeAutoCommitOffsetsAsync();
+        // wait for commit offset response if future exist
+        if (future != null) {
+            client.poll(future, time.timer(rebalanceConfig.rebalanceTimeoutMs));
+        }
         // return true when
         // 1. future is null, which means no commit request sent, so it is still considered completed
         // 2. offset commit completed

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -1698,7 +1698,7 @@ public class AbstractCoordinatorTest {
         }
 
         @Override
-        protected boolean onJoinPrepare(int generation, String memberId) {
+        protected boolean onJoinPrepare(Timer timer, int generation, String memberId) {
             onJoinPrepareInvokes++;
             return true;
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1300,7 +1300,7 @@ public abstract class ConsumerCoordinatorTest {
     }
 
     @Test
-    public void testRejoinGroupWithCooperativeRebalance() throws InterruptedException {
+    public void testOnJoinPrepareWithOffsetCommit() throws InterruptedException {
         rebalanceConfig = buildRebalanceConfig(Optional.of("group-id"));
         ConsumerCoordinator coordinator = buildCoordinator(rebalanceConfig,
                 new Metrics(),

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -225,7 +225,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
     }
 
     @Override
-    protected boolean onJoinPrepare(int generation, String memberId) {
+    protected boolean onJoinPrepare(Timer timer, int generation, String memberId) {
         log.info("Rebalance started");
         leaderState(null);
         final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -1032,9 +1032,9 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val consumerPoller2 = subscribeConsumerAndStartPolling(consumer2, List(topic))
     TestUtils.waitUntilTrue(() => consumerPoller1.consumerAssignment().size == 1,
-      s"Timed out while awaiting expected assignment change to 1.")
+      s"Timed out while awaiting expected assignment size change to 1.")
     TestUtils.waitUntilTrue(() => consumerPoller2.consumerAssignment().size == 1,
-      s"Timed out while awaiting expected assignment change to 1.")
+      s"Timed out while awaiting expected assignment size change to 1.")
 
     if (!lock.tryLock(3000, TimeUnit.MILLISECONDS)) {
       fail(s"Time out while awaiting for lock.")
@@ -1044,7 +1044,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
         // cooperative rebalance should rebalance twice before finally stable
         assertEquals(stableGeneration + 2, generationId1)
       } else {
-        // eager rebalance should rebalance once once before finally stable
+        // eager rebalance should rebalance once before finally stable
         assertEquals(stableGeneration + 1, generationId1)
       }
       assertEquals(stableMemberId1, memberId1)


### PR DESCRIPTION
I think this is introduce in https://issues.apache.org/jira/browse/KAFKA-13310.  

https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L752

we didn't wait for client to receive commit offset response here, so onJoinPrepareAsyncCommitCompleted will be false in cooperative rebalance, and client will loop in invoking onJoinPrepare.

i think EAGER mode don't have this problem because it will revoke the partitions even if onJoinPrepareAsyncCommitCompleted=false and will not try to commit next round.

Besides, there's also another bug found during fixing this bug. Before [KAFKA-13310](https://issues.apache.org/jira/browse/KAFKA-13310), we commitOffset sync with rebalanceTimeout, which will retry when retriable error until timeout. After [KAFKA-13310](https://issues.apache.org/jira/browse/KAFKA-13310), we thought we have retry, but we'll retry after partitions revoking. That is, even though the retried offset commit successfully, it still causes some partitions offsets un-committed, and after rebalance, other consumers will consume overlapping records.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
