### PR TITLE
Kafka 13816: Downgrading Connect rebalancing protocol from incremental to eager causes duplicate task instances

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1523,12 +1523,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 log.warn("Catching up to assignment's config offset.");
                 needsReadToEnd = true;
             }
-
-            // We had a successful rebalance which should mark the toggle
-            // happening successfully. Unsetting the flag now.
-            if (member.eagerProtocolDowngradeRequested()) {
-                member.toggleEagerProtocolDowngradeRequest(false);
-            }
         }
 
         long now = time.milliseconds();
@@ -1573,6 +1567,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // guarantees we'll attempt to rejoin before executing this method again.
         herderMetrics.rebalanceSucceeded(time.milliseconds());
         rebalanceResolved = true;
+
+        // We had a successful rebalance which should mark the downgrade
+        // happening successfully. Unsetting the flag now.
+        member.toggleEagerProtocolDowngradeRequest(false);
 
         if (!assignment.revokedConnectors().isEmpty() || !assignment.revokedTasks().isEmpty()) {
             assignment.revokedConnectors().clear();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1502,7 +1502,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // 2. Assignment succeeded.
         //  2a. We are caught up on configs. Awesome! We can proceed to run our assigned work.
         //  2b. We need to try to catch up - try reading configs for reasonable amount of time.
-        //  Also, if there was a protocol downgrade to eager requested, that flag would be unset here successfully
+        //  Also, if there was a protocol downgrade to eager requested, that flag would be unset at the end successfully
         //  marking the downgrade to eager.
 
         boolean needsReadToEnd = false;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/RevokingAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/RevokingAssignor.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.distributed;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.slf4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember;
+import static org.apache.kafka.connect.runtime.distributed.ConnectProtocol.Assignment;
+
+/**
+ * An assignor that always revokes every connector and task from every worker in the cluster.
+ */
+public class RevokingAssignor implements ConnectAssignor {
+
+    private final Logger log;
+
+    public RevokingAssignor(LogContext logContext) {
+        this.log = logContext.logger(RevokingAssignor.class);
+    }
+
+    @Override
+    public Map<String, ByteBuffer> performAssignment(String leaderId, String protocol,
+                                                     List<JoinGroupResponseMember> allMemberMetadata,
+                                                     WorkerCoordinator coordinator) {
+        Map<String, ExtendedWorkerState> memberConfigs = new HashMap<>();
+        for (JoinGroupResponseMember member : allMemberMetadata) {
+            memberConfigs.put(
+                    member.memberId(),
+                    IncrementalCooperativeConnectProtocol.deserializeMetadata(ByteBuffer.wrap(member.metadata())));
+        }
+        log.debug("Member configs: {}", memberConfigs);
+
+        short protocolVersion = ConnectProtocolCompatibility.fromProtocol(protocol).protocolVersion();
+        String leaderUrl = memberConfigs.get(leaderId).url();
+
+        // The new config offset is the maximum seen by any member. We always perform assignment using this offset,
+        // even if some members have fallen behind. The config offset used to generate the assignment is included in
+        // the response so members that have fallen behind will not use the assignment until they have caught up.
+        long maxOffset = memberConfigs.values().stream().map(ExtendedWorkerState::offset).max(Long::compare).get();
+        log.debug("Max config offset root: {}, local snapshot config offsets root: {}",
+                maxOffset, coordinator.configSnapshot().offset());
+        Long leaderOffset = ensureLeaderConfig(maxOffset, coordinator);
+
+        Map<String, ExtendedAssignment> assignments;
+        if (leaderOffset == null) {
+            assignments = fillFailedAssignments(maxOffset, leaderId, leaderUrl, memberConfigs.keySet(), protocolVersion, Assignment.CONFIG_MISMATCH);
+        } else {
+            assignments = fillRevokingAssignments(maxOffset, leaderId, leaderUrl, memberConfigs, protocolVersion);
+        }
+        return serializeAssignments(assignments);
+    }
+
+    private Long ensureLeaderConfig(long maxOffset, WorkerCoordinator coordinator) {
+        // If this leader is behind some other members, we can't do assignment
+        if (coordinator.configSnapshot().offset() < maxOffset) {
+            // We might be able to take a new snapshot to catch up immediately and avoid another round of syncing here.
+            // Alternatively, if this node has already passed the maximum reported by any other member of the group, it
+            // is also safe to use this newer state.
+            ClusterConfigState updatedSnapshot = coordinator.configFreshSnapshot();
+            if (updatedSnapshot.offset() < maxOffset) {
+                log.info("Was selected to perform assignments, but do not have latest config found in sync request. "
+                        + "Returning an empty configuration to trigger re-sync.");
+                return null;
+            } else {
+                coordinator.configSnapshot(updatedSnapshot);
+                return updatedSnapshot.offset();
+            }
+        }
+        return maxOffset;
+    }
+
+    // Revoke all assignments
+    private Map<String, ExtendedAssignment> fillRevokingAssignments(
+            long maxOffset,
+            String leaderId,
+            String leaderUrl,
+            Map<String, ExtendedWorkerState> memberConfigs,
+            short protocolVersion
+    ) {
+        Map<String, ExtendedAssignment> groupAssignment = new HashMap<>();
+        memberConfigs.forEach((member, memberState) -> {
+            Collection<String> revokedConnectors = memberState.assignment().connectors();
+            Collection<ConnectorTaskId> revokedTasks = memberState.assignment().tasks();
+            ExtendedAssignment assignment = new ExtendedAssignment(
+                    protocolVersion, Assignment.NO_ERROR, leaderId, leaderUrl, maxOffset,
+                    Collections.emptySet(), Collections.emptySet(), revokedConnectors, revokedTasks,
+                    0
+            );
+            log.debug("Filling assignment: {} -> {}", member, assignment);
+            groupAssignment.put(member, assignment);
+        });
+        log.debug("Finished assignment");
+        return groupAssignment;
+    }
+
+    // Fail all assignments
+    private Map<String, ExtendedAssignment> fillFailedAssignments(
+            long maxOffset,
+            String leaderId,
+            String leaderUrl,
+            Collection<String> members,
+            short protocolVersion,
+            short error
+    ) {
+        Map<String, ExtendedAssignment> groupAssignment = new HashMap<>();
+        members.forEach(member -> {
+            ExtendedAssignment assignment = new ExtendedAssignment(
+                    protocolVersion, error, leaderId, leaderUrl, maxOffset,
+                    Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
+                    0
+            );
+            log.debug("Filling assignment: {} -> {}", member, assignment);
+            groupAssignment.put(member, assignment);
+        });
+        log.debug("Finished assignment");
+        return groupAssignment;
+    }
+
+    /**
+     * From a map of workers to assignment object generate the equivalent map of workers to byte
+     * buffers of serialized assignments.
+     *
+     * @param assignments the map of worker assignments
+     * @return the serialized map of assignments to workers
+     */
+    protected Map<String, ByteBuffer> serializeAssignments(Map<String, ExtendedAssignment> assignments) {
+        return assignments.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        Entry::getKey,
+                        e -> IncrementalCooperativeConnectProtocol.serializeAssignment(e.getValue())));
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/RevokingAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/RevokingAssignor.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.runtime.distributed;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.connect.storage.ClusterConfigState;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.slf4j.Logger;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/RevokingAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/RevokingAssignor.java
@@ -149,11 +149,12 @@ public class RevokingAssignor implements ConnectAssignor {
      * @return the serialized map of assignments to workers
      */
     protected Map<String, ByteBuffer> serializeAssignments(Map<String, ExtendedAssignment> assignments) {
+        // sessioned could just be set to false as the new protocol is EAGER which doesn't support sessioning.
         return assignments.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
                         Entry::getKey,
-                        e -> IncrementalCooperativeConnectProtocol.serializeAssignment(e.getValue())));
+                        e -> IncrementalCooperativeConnectProtocol.serializeAssignment(e.getValue(), false)));
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 
 import static org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import static org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember;
+import static org.apache.kafka.connect.runtime.distributed.ConnectProtocolCompatibility.COMPATIBLE;
 import static org.apache.kafka.connect.runtime.distributed.ConnectProtocolCompatibility.EAGER;
 
 /**
@@ -64,6 +65,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
     private volatile int lastCompletedGenerationId;
     private final ConnectAssignor eagerAssignor;
     private final ConnectAssignor incrementalAssignor;
+    private final ConnectAssignor revokingAssignor;
     private final int coordinatorDiscoveryTimeoutMs;
 
     /**
@@ -96,6 +98,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         this.protocolCompatibility = protocolCompatibility;
         this.incrementalAssignor = new IncrementalCooperativeAssignor(logContext, time, maxDelay);
         this.eagerAssignor = new EagerAssignor(logContext);
+        this.revokingAssignor = new RevokingAssignor(logContext);
         this.currentConnectProtocol = protocolCompatibility;
         this.coordinatorDiscoveryTimeoutMs = config.heartbeatIntervalMs;
         this.lastCompletedGenerationId = Generation.NO_GENERATION.generationId;
@@ -188,19 +191,23 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         currentConnectProtocol = ConnectProtocolCompatibility.fromProtocol(protocol);
         // At this point we always consider ourselves to be a member of the cluster, even if there was an assignment
         // error (the leader couldn't make the assignment) or we are behind the config and cannot yet work on our assigned
-        // tasks. It's the responsibility of the code driving this process to decide how to react (e.g. trying to get
+        // tasks. It's the responsibility of the code driving this process(DistributedHerder) to decide how to react (e.g. trying to get
         // up to date, try to rejoin again, leaving the group and backing off, etc.).
         rejoinRequested = false;
-        if (currentConnectProtocol != EAGER) {
-            if (!newAssignment.revokedConnectors().isEmpty() || !newAssignment.revokedTasks().isEmpty()) {
-                listener.onRevoked(newAssignment.leader(), newAssignment.revokedConnectors(), newAssignment.revokedTasks());
-            }
+        final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
 
-            final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+        // if there's a CONFIG_MISMATCH error, then nothing would be revoked.
+        if (!newAssignment.revokedConnectors().isEmpty() || !newAssignment.revokedTasks().isEmpty()) {
+            listener.onRevoked(newAssignment.leader(), newAssignment.revokedConnectors(), newAssignment.revokedTasks());
             if (localAssignmentSnapshot != null) {
                 localAssignmentSnapshot.connectors().removeAll(newAssignment.revokedConnectors());
                 localAssignmentSnapshot.tasks().removeAll(newAssignment.revokedTasks());
                 log.debug("After revocations snapshot of assignment: {}", localAssignmentSnapshot);
+            }
+        }
+
+        if (currentConnectProtocol != EAGER) {
+            if (localAssignmentSnapshot != null) {
                 newAssignment.connectors().addAll(localAssignmentSnapshot.connectors());
                 newAssignment.tasks().addAll(localAssignmentSnapshot.tasks());
             }
@@ -219,10 +226,15 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         if (skipAssignment)
             throw new IllegalStateException("Can't skip assignment because Connect does not support static membership.");
 
-        return ConnectProtocolCompatibility.fromProtocol(protocol) == EAGER
-               ? eagerAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this)
-               : incrementalAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this);
-    }
+        ConnectProtocolCompatibility newConnectProtocol = ConnectProtocolCompatibility.fromProtocol(protocol);
+        if (currentConnectProtocol.protocolVersion() >= COMPATIBLE.protocolVersion() && newConnectProtocol == EAGER) {
+            log.info("Downgraded from incremental to eager assignment during this round; revoking all tasks and connectors from all workers in the cluster");
+            return revokingAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this);
+        } else {
+            return ConnectProtocolCompatibility.fromProtocol(protocol) == EAGER
+                    ? eagerAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this)
+                    : incrementalAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this);
+        }    }
 
     @Override
     protected boolean onJoinPrepare(int generation, String memberId) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -229,8 +229,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             throw new IllegalStateException("Can't skip assignment because Connect does not support static membership.");
 
         ConnectProtocolCompatibility newConnectProtocol = ConnectProtocolCompatibility.fromProtocol(protocol);
-        if ((currentConnectProtocol.protocolVersion() >= COMPATIBLE.protocolVersion() && newConnectProtocol == EAGER)
-                || eagerProtocolDowngradeRequested) {
+        if (connectProtocolDowngraded(newConnectProtocol) || eagerProtocolDowngradeRequested) {
             log.info("Downgraded from incremental to eager assignment or previous downgrade didn't succeed. " +
                     "Revoking all tasks and connectors from all workers in the cluster");
             eagerProtocolDowngradeRequested = true;
@@ -240,6 +239,10 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
                     ? eagerAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this)
                     : incrementalAssignor.performAssignment(leaderId, protocol, allMemberMetadata, this);
         }
+    }
+
+    private boolean connectProtocolDowngraded(ConnectProtocolCompatibility newConnectProtocol) {
+        return currentConnectProtocol.protocolVersion() >= COMPATIBLE.protocolVersion() && newConnectProtocol == EAGER;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -213,6 +213,12 @@ public class WorkerGroupMember {
         return coordinator.ownerUrl(task);
     }
 
+    public boolean eagerProtocolDowngradeRequested() { return coordinator.eagerProtocolDowngradeRequested(); }
+
+    public void toggleEagerProtocolDowngradeRequest(boolean newStatus) {
+        coordinator.toggleEagerProtocolDowngradeRequest(newStatus);
+    }
+
     /**
      * Get the version of the connect protocol that is currently active in the group of workers.
      *

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -284,6 +284,8 @@ public class DistributedHerderTest extends ThreadedTest {
         });
         member.wakeup();
         PowerMock.expectLastCall();
+        EasyMock.expect(member.eagerProtocolDowngradeRequested()).andReturn(false);
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         PowerMock.expectLastCall();
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -284,8 +284,6 @@ public class DistributedHerderTest extends ThreadedTest {
         });
         member.wakeup();
         PowerMock.expectLastCall();
-        EasyMock.expect(member.eagerProtocolDowngradeRequested()).andReturn(false);
-        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         PowerMock.expectLastCall();
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
@@ -294,6 +292,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -347,6 +348,9 @@ public class DistributedHerderTest extends ThreadedTest {
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -402,6 +406,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         time.sleep(1000L);
@@ -436,6 +443,12 @@ public class DistributedHerderTest extends ThreadedTest {
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -507,6 +520,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         time.sleep(1000L);
@@ -565,6 +581,9 @@ public class DistributedHerderTest extends ThreadedTest {
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -668,6 +687,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -740,6 +762,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         // No immediate action besides this -- change will be picked up via the config log
 
         PowerMock.replayAll();
@@ -797,6 +822,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         // No immediate action besides this -- change will be picked up via the config log
 
@@ -1105,6 +1133,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         // No immediate action besides this -- change will be picked up via the config log
 
         PowerMock.replayAll();
@@ -1164,6 +1195,10 @@ public class DistributedHerderTest extends ThreadedTest {
         expectConfigRefreshAndSnapshot(ClusterConfigState.EMPTY);
         member.requestRejoin();
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.deleteConnectorConfig(CONN1, putConnectorCallback);
@@ -1226,6 +1261,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -1254,6 +1292,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1288,6 +1329,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1326,6 +1370,9 @@ public class DistributedHerderTest extends ThreadedTest {
 
         String ownerUrl = "ownerUrl";
         EasyMock.expect(member.ownerUrl(CONN1)).andReturn(ownerUrl);
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1373,6 +1420,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -1405,6 +1455,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1440,6 +1493,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.ensureActive();
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
         PowerMock.expectLastCall();
 
         PowerMock.replayAll();
@@ -1481,6 +1537,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1658,6 +1717,9 @@ public class DistributedHerderTest extends ThreadedTest {
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
         PowerMock.expectLastCall().andReturn(true);
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -1685,6 +1747,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1734,6 +1799,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -1770,6 +1838,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1828,6 +1899,9 @@ public class DistributedHerderTest extends ThreadedTest {
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -1896,6 +1970,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick(); // join
@@ -1957,6 +2034,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -2021,6 +2101,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick(); // join
@@ -2057,6 +2140,9 @@ public class DistributedHerderTest extends ThreadedTest {
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -2105,6 +2191,9 @@ public class DistributedHerderTest extends ThreadedTest {
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -2162,6 +2251,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick(); // join
@@ -2201,6 +2293,9 @@ public class DistributedHerderTest extends ThreadedTest {
         PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -2254,6 +2349,9 @@ public class DistributedHerderTest extends ThreadedTest {
         expectRebalance(1, Collections.emptyList(), Collections.emptyList(), true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -2340,6 +2438,9 @@ public class DistributedHerderTest extends ThreadedTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
 
         PowerMock.replayAll();
 
@@ -2439,6 +2540,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         assertStatistics(0, 0, 0, Double.POSITIVE_INFINITY);
@@ -2496,6 +2600,10 @@ public class DistributedHerderTest extends ThreadedTest {
 
 
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         FutureCallback<Collection<String>> listConnectorsCb = new FutureCallback<>();
@@ -2592,6 +2700,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         // Should pick up original config
@@ -2653,6 +2764,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.captureLong(pollTimeout));
         EasyMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -2688,6 +2802,12 @@ public class DistributedHerderTest extends ThreadedTest {
         // Second rebalance: poll indefinitely as worker is no longer leader, so key expiration doesn't come into play
         member.poll(Long.MAX_VALUE);
         EasyMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall();
 
         PowerMock.replayAll(initialSecretKey);
 
@@ -2826,6 +2946,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        member.toggleEagerProtocolDowngradeRequest(false);
+        PowerMock.expectLastCall().anyTimes();
+
         PowerMock.replayAll();
 
         herder.tick();
@@ -2870,6 +2993,9 @@ public class DistributedHerderTest extends ThreadedTest {
         member.ensureActive();
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
+        member.toggleEagerProtocolDowngradeRequest(false);
         PowerMock.expectLastCall();
 
         PowerMock.replayAll(secretKey);
@@ -3628,8 +3754,6 @@ public class DistributedHerderTest extends ThreadedTest {
         EasyMock.expectLastCall().anyTimes();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall().anyTimes();
-        EasyMock.expect(member.eagerProtocolDowngradeRequested()).andReturn(false);
-        PowerMock.expectLastCall();
     }
 
     private SessionKey expectNewSessionKey() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3628,6 +3628,8 @@ public class DistributedHerderTest extends ThreadedTest {
         EasyMock.expectLastCall().anyTimes();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall().anyTimes();
+        EasyMock.expect(member.eagerProtocolDowngradeRequested()).andReturn(false);
+        PowerMock.expectLastCall();
     }
 
     private SessionKey expectNewSessionKey() {


### PR DESCRIPTION
Downgrading Connect rebalancing protocol from incremental to eager causes duplicate task instances. This PR aims to address this issue .