### PR TITLE
KAFKA-14017: Implement new KIP-618 APIs in FileStreamSourceConnector

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.source.ExactlyOnceSupport;
 import org.apache.kafka.connect.source.SourceConnector;
 
 import java.util.ArrayList;
@@ -95,4 +96,18 @@ public class FileStreamSourceConnector extends SourceConnector {
     public ConfigDef config() {
         return CONFIG_DEF;
     }
+
+    @Override
+    public ExactlyOnceSupport exactlyOnceSupport(Map<String, String> props) {
+        AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, props);
+        filename = parsedConfig.getString(FILE_CONFIG);
+        // We can provide exactly-once guarantees if reading from a "real" file
+        // (as long as the file is only appended to over the lifetime of the connector)
+        // If we're reading from stdin, we can't provide exactly-once guarantees
+        // since we don't even track offsets
+        return filename != null && !filename.isEmpty()
+                ? ExactlyOnceSupport.SUPPORTED
+                : ExactlyOnceSupport.UNSUPPORTED;
+    }
+
 }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.connect.file;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.source.ConnectorTransactionBoundaries;
+import org.apache.kafka.connect.source.ExactlyOnceSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +60,23 @@ public class FileStreamSourceConnectorTest {
         for (ConfigValue val : configValues) {
             assertEquals(0, val.errorMessages().size(), "Config property errors: " + val.errorMessages());
         }
+    }
+
+    @Test
+    public void testExactlyOnceSupport() {
+        sourceProperties.put(FileStreamSourceConnector.FILE_CONFIG, FILENAME);
+        assertEquals(ExactlyOnceSupport.SUPPORTED, connector.exactlyOnceSupport(sourceProperties));
+
+        sourceProperties.put(FileStreamSourceConnector.FILE_CONFIG, " ");
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(sourceProperties));
+
+        sourceProperties.remove(FileStreamSourceConnector.FILE_CONFIG);
+        assertEquals(ExactlyOnceSupport.UNSUPPORTED, connector.exactlyOnceSupport(sourceProperties));
+    }
+
+    @Test
+    public void testTransactionBoundaryDefinition() {
+        assertEquals(ConnectorTransactionBoundaries.UNSUPPORTED, connector.canDefineTransactionBoundaries(sourceProperties));
     }
 
     @Test


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14017)

Implements the new `SourceConnector::exactlyOnceSupport` method in the file source connector
- When reading from stdin, returns `ExactlyOnceSupport.UNSUPPORTED` as we do not track offsets
- When reading from a file, returns `ExactlyOnceSupport.SUPPORTED` as we do track offsets and, as long as the only modifications to the file after the connector is created are appends, those offsets should be perfectly accurate

Does not implement the new `SourceConnector::canDefineTransactionBoundaries` method as the default is to return `ConnectorTransactionBoundaries.UNSUPPORTED`, which is correct for this connector as it is incapable of defining its own transaction boundaries

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
