### PR TITLE
MINOR: Improve Javadoc for OffsetCommitCallback-consuming commitAsync…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1095,7 +1095,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * should not be used.
      * <p>
      * This is an asynchronous call and will not block. Any errors encountered are either passed to the callback
-     * (if provided) or discarded.
+     * (if provided) or discarded. As the consumer does not wait for the response to underlying request in this call,
+     * the callback will only be invoked on future interaction with the broker (e.g. {@link #poll(Duration)}).
      * <p>
      * Offsets committed through multiple calls to this API are guaranteed to be sent in the same order as
      * the invocations. Corresponding commit callbacks are also invoked in the same order. Additionally note that
@@ -1121,7 +1122,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * then the committed offsets must belong to the currently auto-assigned partitions.
      * <p>
      * This is an asynchronous call and will not block. Any errors encountered are either passed to the callback
-     * (if provided) or discarded.
+     * (if provided) or discarded. As the consumer does not wait for the response to underlying request in this call,
+     * the callback will only be invoked on future interaction with the broker (e.g. {@link #poll(Duration)}).
      * <p>
      * Offsets committed through multiple calls to this API are guaranteed to be sent in the same order as
      * the invocations. Corresponding commit callbacks are also invoked in the same order. Additionally note that


### PR DESCRIPTION
… methods

Having "async" in Kafka consumer API might encourage users to expect that there is some other internal thread that might deliver offset-commit confirmation, but actually it's usercode that needs to `poll()` to get the response. This PR attempts to add some disclaimer to cover this situation.

In example, the following blocks infinitely:
```
final Consumer<byte[], byte[]> kc = ....
kc.assign(Collections.singleton(new TopicPartition("mytopic", 0)));
kc.poll(2000);
final CountDownLatch latch = new CountDownLatch(1); // The latch should be released when we get a response.  
kc.commitAsync(new OffsetCommitCallback() {
    @Override
    public void onComplete(final Map<TopicPartition, OffsetAndMetadata> offsets, final Exception exception) {
        latch.countDown();
    }
});
latch.await(); // <- Never releases; adding something trivial like `kc.poll(300)`
               // before the await does help, as then we kick off the NetworkClient to do the polling for responses.
```

In detail:
`KafkaConsumer.commitAsync` calls only send the OFFSET_COMMIT requests, but do not wait for response (as they should be, as they are asynchronous after all) (the "in-flight" request is kept in NetworkClient's `inFlightRequests` collection).
However, compared to Producer's asynchronous send API, there is no underlying worker thread that is going to get the data and invoke the callback - it is going to happen on the next NetworkClient interaction with remote (AFAICT anything that should finally invoke `NetworkClient.poll`).



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
