### PR TITLE
KAFKA-14020: Performance regression in Producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1508,7 +1508,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         }
 
         public TopicPartition topicPartition() {
-            if (topicPartition == null) {
+            if (topicPartition == null && topic != null) {
                 if (partition != RecordMetadata.UNKNOWN_PARTITION)
                     topicPartition = new TopicPartition(topic, partition);
                 else if (recordPartition != null)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1473,7 +1473,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             this.userCallback = userCallback;
             this.interceptors = interceptors;
             this.record = record;
-            topic = record.topic();
+            // Note a record would be null only if the client application has a bug, but we don't want to
+            // have NPE here, because the interceptors would not be notified (see .doSend).
+            topic = record != null ? record.topic() : null;
         }
 
         @Override
@@ -1508,8 +1510,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             if (partition != RecordMetadata.UNKNOWN_PARTITION)
                 return new TopicPartition(topic, partition);
 
-            assert record != null;
-            return ProducerInterceptors.extractTopicPartition(record);
+            if (record != null)
+                return ProducerInterceptors.extractTopicPartition(record);
+
+            return null;
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1465,9 +1465,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     private class AppendCallbacks<K, V> implements RecordAccumulator.AppendCallbacks {
         private final Callback userCallback;
         private final ProducerInterceptors<K, V> interceptors;
-        private ProducerRecord<K, V> record;
         private final String topic;
-        protected int partition = RecordMetadata.UNKNOWN_PARTITION;
+        private volatile ProducerRecord<K, V> record;
+        private volatile int partition = RecordMetadata.UNKNOWN_PARTITION;
 
         private AppendCallbacks(Callback userCallback, ProducerInterceptors<K, V> interceptors, ProducerRecord<K, V> record) {
             this.userCallback = userCallback;
@@ -1507,6 +1507,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         }
 
         public TopicPartition topicPartition() {
+            // Note that this is called once in the success case (and maybe twice in error case)
+            // so there is not much benefit in caching the TopicPartition object.
             if (partition != RecordMetadata.UNKNOWN_PARTITION)
                 return new TopicPartition(topic, partition);
 


### PR DESCRIPTION
As part of KAFKA-10888 work, there were a couple regressions introduced:

- A call to time.milliseconds() got moved under the queue lock, moving it back outside the lock.  The call may be expensive and cause lock contention.  Now the call is moved back outside of the lock.

- The reference to ProducerRecord was held in the batch completion callback, so it was kept alive as long as the batch was alive, which may increase the amount of memory in certain scenario and cause excessive GC work.  Now the reference is reset early, so the ProducerRecord lifetime isn't bound to the batch lifetime.

Tested via manually crafted benchmark, lock profile shows ~15% lock contention on the ArrayQueue lock without the fix and ~5% lock contention with the fix (which is also consistent with pre-KAFKA-10888 profile).

Alloc profile shows ~10% spent in ProducerBatch.completeFutureAndFireCallbacks without the fix vs. ~0.25% with the fix (which is also consistent with pre-KAFKA-10888 profile).

Will add a proper jmh benchmark for producer (looks like we don't have one) in a follow-up change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
