### PR TITLE
[MINOR] Dead code from BrokerEndPoint removed

### DIFF
--- a/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
@@ -19,7 +19,6 @@ package kafka.cluster
 import java.nio.ByteBuffer
 
 import kafka.api.ApiUtils._
-import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.utils.Utils._
 
 object BrokerEndPoint {

--- a/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
@@ -35,13 +35,6 @@ object BrokerEndPoint {
       case _ => None
     }
   }
-
-  def readFrom(buffer: ByteBuffer): BrokerEndPoint = {
-    val brokerId = buffer.getInt()
-    val host = readShortString(buffer)
-    val port = buffer.getInt()
-    BrokerEndPoint(brokerId, host, port)
-  }
 }
 
 /**

--- a/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
@@ -36,16 +36,6 @@ object BrokerEndPoint {
       case _ => None
     }
   }
-  
-  /**
-   * BrokerEndPoint URI is host:port or [ipv6_host]:port
-   * Note that unlike EndPoint (or listener) this URI has no security information.
-   */
-  def createBrokerEndPoint(brokerId: Int, connectionString: String): BrokerEndPoint = {
-    parseHostPort(connectionString).map { case (host, port) => new BrokerEndPoint(brokerId, host, port) }.getOrElse {
-      throw new KafkaException("Unable to parse " + connectionString + " to a broker endpoint")
-    }
-  }
 
   def readFrom(buffer: ByteBuffer): BrokerEndPoint = {
     val brokerId = buffer.getInt()

--- a/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
@@ -16,11 +16,6 @@
  */
 package kafka.cluster
 
-import java.nio.ByteBuffer
-
-import kafka.api.ApiUtils._
-import org.apache.kafka.common.utils.Utils._
-
 object BrokerEndPoint {
 
   private val uriParseExp = """\[?([0-9a-zA-Z\-%._:]*)\]?:([0-9]+)""".r
@@ -45,20 +40,6 @@ object BrokerEndPoint {
  * This allows us to keep the wire protocol with the clients unchanged where the protocol is not needed.
  */
 case class BrokerEndPoint(id: Int, host: String, port: Int) {
-
-  def connectionString(): String = formatAddress(host, port)
-
-  def writeTo(buffer: ByteBuffer): Unit = {
-    buffer.putInt(id)
-    writeShortString(buffer, host)
-    buffer.putInt(port)
-  }
-
-  def sizeInBytes: Int =
-    4 + /* broker Id */
-    4 + /* port */
-    shortStringLength(host)
-
   override def toString: String = {
     s"BrokerEndPoint(id=$id, host=$host:$port)"
   }

--- a/core/src/test/scala/unit/kafka/cluster/BrokerEndPointTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/BrokerEndPointTest.scala
@@ -200,34 +200,6 @@ class BrokerEndPointTest {
   }
 
   @Test
-  def testBrokerEndpointFromUri(): Unit = {
-    var connectionString = "localhost:9092"
-    var endpoint = BrokerEndPoint.createBrokerEndPoint(1, connectionString)
-    assertEquals("localhost", endpoint.host)
-    assertEquals(9092, endpoint.port)
-    //KAFKA-3719
-    connectionString = "local_host:9092"
-    endpoint = BrokerEndPoint.createBrokerEndPoint(1, connectionString)
-    assertEquals("local_host", endpoint.host)
-    assertEquals(9092, endpoint.port)
-    // also test for ipv6
-    connectionString = "[::1]:9092"
-    endpoint = BrokerEndPoint.createBrokerEndPoint(1, connectionString)
-    assertEquals("::1", endpoint.host)
-    assertEquals(9092, endpoint.port)
-    // test for ipv6 with % character
-    connectionString = "[fe80::b1da:69ca:57f7:63d8%3]:9092"
-    endpoint = BrokerEndPoint.createBrokerEndPoint(1, connectionString)
-    assertEquals("fe80::b1da:69ca:57f7:63d8%3", endpoint.host)
-    assertEquals(9092, endpoint.port)
-    // add test for uppercase in hostname
-    connectionString = "MyHostname:9092"
-    endpoint = BrokerEndPoint.createBrokerEndPoint(1, connectionString)
-    assertEquals("MyHostname", endpoint.host)
-    assertEquals(9092, endpoint.port)
-  }
-
-  @Test
   def testEndpointFromUri(): Unit = {
     var connectionString = "PLAINTEXT://localhost:9092"
     var endpoint = EndPoint.createEndPoint(connectionString, None)


### PR DESCRIPTION
I found that several `BrokerEndPoint` methods nod used in production code.
It seems methods can be safely removed:

* `createBrokerEndPoint(Int, String)`
* `readFrom(buffer: ByteBuffer)`
* `connectionString(): String`
* `writeTo(buffer: ByteBuffer)`
* `sizeInBytes: Int`


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
