### PR TITLE
MINOR: Remove ARM/PowerPC builds from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,15 +169,6 @@ pipeline {
             SCALA_VERSION=2.12
           }
           stages {
-            stage('Check ARM Agent') {
-              agent { label 'arm4' }
-              options {
-                timeout(time: 5, unit: 'MINUTES')
-              }
-              steps {
-                echo 'ARM ok'
-              }
-            }
             stage('Run ARM Build') {
               agent { label 'arm4' }
               options {
@@ -202,15 +193,6 @@ pipeline {
             SCALA_VERSION=2.12
           }
           stages {
-            stage('Check PowerPC Agent') {
-              agent { label 'ppc64le' }
-              options {
-                timeout(time: 5, unit: 'MINUTES')
-              }
-              steps {
-                echo 'PowerPC ok'
-              }
-            }
             stage('Run PowerPC Build') {
               agent { label 'ppc64le' }
               options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,54 +160,6 @@ pipeline {
             echo 'Skipping Kafka Streams archetype test for Java 17'
           }
         }
-
-        stage('ARM') {
-          options {
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.12
-          }
-          stages {
-            stage('Run ARM Build') {
-              agent { label 'arm4' }
-              options {
-                timeout(time: 2, unit: 'HOURS')
-              }
-              steps {
-                doValidation()
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                  doTest(env, 'unitTest')
-                }
-                echo 'Skipping Kafka Streams archetype test for ARM build'
-              }
-            }
-          }
-        }
-
-        stage('PowerPC') {
-          options {
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.12
-          }
-          stages {
-            stage('Run PowerPC Build') {
-              agent { label 'ppc64le' }
-              options {
-                timeout(time: 2, unit: 'HOURS')
-              }
-              steps {
-                doValidation()
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                  doTest(env, 'unitTest')
-                }
-                echo 'Skipping Kafka Streams archetype test for PowerPC build'
-              }
-            }
-          }
-        }
         
         // To avoid excessive Jenkins resource usage, we only run the stages
         // above at the PR stage. The ones below are executed after changes


### PR DESCRIPTION
We see the ARM agent check timing out frequently. I think the 5 minute timeout might be too aggressive. I think the original intent of this check was to prevent one of these agent check timeouts from propagating to the top level, but that never really worked. So perhaps we don't need these.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
