### PR TITLE
KAFKA-10199: Add methods to add and remove tasks to task manager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -82,7 +82,7 @@ public class TaskExecutor {
                 }
             } catch (final Throwable t) {
                 taskExecutionMetadata.registerTaskError(task, t, now);
-                tasks.removeTaskFromCuccessfullyProcessedBeforeClosing(lastProcessed);
+                tasks.removeTaskFromSuccessfullyProcessedBeforeClosing(lastProcessed);
                 commitSuccessfullyProcessedTasks();
                 throw t;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -798,12 +798,12 @@ public class TaskManager {
         } catch (final RuntimeException swallow) {
             log.error("Error suspending dirty task {} ", task.id(), swallow);
         }
-        tasks.removeTaskBeforeClosing(task.id());
+        tasks.removeTask(task.id());
         task.closeDirty();
     }
 
     private void completeTaskCloseClean(final Task task) {
-        tasks.removeTaskBeforeClosing(task.id());
+        tasks.removeTask(task.id());
         task.closeClean();
     }
 
@@ -1175,7 +1175,7 @@ public class TaskManager {
             final Set<TaskId> allRemovedTasks =
                 union(HashSet::new, activeTasksToRemove, standbyTasksToRemove).stream().map(Task::id).collect(Collectors.toSet());
             closeAndCleanUpTasks(activeTasksToRemove, standbyTasksToRemove, true);
-            allRemovedTasks.forEach(tasks::removeTaskBeforeClosing);
+            allRemovedTasks.forEach(tasks::removeTask);
             releaseLockedDirectoriesForTasks(allRemovedTasks);
         } catch (final Exception e) {
             // TODO KAFKA-12648: for now just swallow the exception to avoid interfering with the other topologies
@@ -1322,8 +1322,11 @@ public class TaskManager {
         return tasks().values().stream().anyMatch(Task::needsInitializationOrRestoration);
     }
 
-    // for testing only
-    void addTask(final Task task) {
+    public Task removeTask(final TaskId taskId) {
+        return tasks.removeTask(taskId);
+    }
+
+    public void addTask(final Task task) {
         tasks.addTask(task);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -17,31 +17,49 @@
 
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.test.StreamsTestUtils.createStandbyTask;
+import static org.apache.kafka.test.StreamsTestUtils.createStatefulTask;
+import static org.apache.kafka.test.StreamsTestUtils.createStatelessTask;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TasksTest {
+
+    private final static TaskId TASK_0_0 = new TaskId(0, 0);
+    private final static TopicPartition TOPIC_PARTITION_A_0 = new TopicPartition("topicA", 0);
+
+    private final TopologyMetadata topologyMetadata = mock(TopologyMetadata.class);
+
+    private final Tasks tasks = new Tasks(
+        new LogContext(),
+        topologyMetadata,
+        mock(ActiveTaskCreator.class),
+        mock(StandbyTaskCreator.class)
+    );
+
     @Test
     public void testNotPausedTasks() {
-        final TopologyMetadata topologyMetadata = mock(TopologyMetadata.class);
         final String unnamedTopologyName = null;
         when(topologyMetadata.isPaused(unnamedTopologyName))
             .thenReturn(false)
             .thenReturn(false).thenReturn(false)
             .thenReturn(true)
             .thenReturn(true).thenReturn(true);
-
-        final Tasks tasks = new Tasks(
-            new LogContext(),
-            topologyMetadata,
-            mock(ActiveTaskCreator.class),
-            mock(StandbyTaskCreator.class)
-        );
 
         final TaskId taskId1 = new TaskId(0, 1);
         final TaskId taskId2 = new TaskId(0, 2);
@@ -61,5 +79,139 @@ public class TasksTest {
 
         Assert.assertEquals(tasks.notPausedActiveTasks().size(), 0);
         Assert.assertEquals(tasks.notPausedTasks().size(), 0);
+    }
+
+    @Test
+    public void shouldAddStatelessTaskToTasks() {
+        final Task task = createStatelessTask(TASK_0_0);
+        when(task.inputPartitions())
+            .thenReturn(mkSet(new TopicPartition("input1", 0), new TopicPartition("input2", 0)));
+        shouldAddActiveTaskToTasks(task);
+    }
+
+    @Test
+    public void shouldAddStatefulTaskToTasks() {
+        final Task task = createStatefulTask(TASK_0_0, Collections.singleton(TOPIC_PARTITION_A_0));
+        when(task.inputPartitions())
+            .thenReturn(mkSet(new TopicPartition("input1", 0), new TopicPartition("input2", 0)));
+        shouldAddActiveTaskToTasks(task);
+    }
+
+    private void shouldAddActiveTaskToTasks(final Task task) {
+        tasks.addTask(task);
+
+        final Collection<Task> allTasks = tasks.allTasks();
+        assertEquals(1, allTasks.size());
+        assertTrue(allTasks.contains(task));
+        final Collection<Task> activeTasks = tasks.activeTasks();
+        assertEquals(1, activeTasks.size());
+        assertTrue(activeTasks.contains(task));
+        final Map<TaskId, Task> tasksPerId = tasks.tasksPerId();
+        assertEquals(1, tasksPerId.size());
+        assertEquals(task, tasksPerId.get(task.id()));
+        assertEquals(task, tasks.task(task.id()));
+        final Collection<Task> foundTasks = tasks.tasks(mkSet(task.id()));
+        assertEquals(1, foundTasks.size());
+        assertTrue(foundTasks.contains(task));
+        final Collection<Task> nonPausedActiveTasks = tasks.notPausedActiveTasks();
+        assertEquals(1, nonPausedActiveTasks.size());
+        assertTrue(nonPausedActiveTasks.contains(task));
+        final Collection<Task> nonPausedTasks = tasks.notPausedTasks();
+        assertEquals(1, nonPausedTasks.size());
+        assertTrue(nonPausedTasks.contains(task));
+        for (final TopicPartition topicPartition : task.inputPartitions()) {
+            assertEquals(task, tasks.activeTasksForInputPartition(topicPartition));
+        }
+        assertTrue(tasks.standbyTasks().isEmpty());
+    }
+
+    @Test
+    public void shouldAddStandbyTaskToTasks() {
+        final Task task = createStandbyTask(TASK_0_0, Collections.singleton(TOPIC_PARTITION_A_0));
+
+        tasks.addTask(task);
+
+        final Collection<Task> allTasks = tasks.allTasks();
+        assertEquals(1, allTasks.size());
+        assertTrue(allTasks.contains(task));
+        final Map<TaskId, Task> tasksPerId = tasks.tasksPerId();
+        assertEquals(1, tasksPerId.size());
+        assertEquals(task, tasksPerId.get(task.id()));
+        assertEquals(task, tasks.task(task.id()));
+        final Collection<Task> foundTasks = tasks.tasks(mkSet(task.id()));
+        assertEquals(1, foundTasks.size());
+        assertTrue(foundTasks.contains(task));
+        final Collection<Task> nonPausedTasks = tasks.notPausedTasks();
+        assertEquals(1, nonPausedTasks.size());
+        assertTrue(nonPausedTasks.contains(task));
+        final Collection<Task> standbyTasks = tasks.standbyTasks();
+        assertEquals(1, standbyTasks.size());
+        assertTrue(standbyTasks.contains(task));
+        assertTrue(tasks.notPausedActiveTasks().isEmpty());
+        assertTrue(tasks.activeTasks().isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveStatelessTaskFromTasks() {
+        final Task task = createStatelessTask(TASK_0_0);
+        when(task.inputPartitions())
+            .thenReturn(mkSet(new TopicPartition("input1", 0), new TopicPartition("input2", 0)));
+        shouldRemoveActiveTaskFromTasks(task);
+    }
+
+    @Test
+    public void shouldRemoveStatefulTaskFromTasks() {
+        final Task task = createStatefulTask(TASK_0_0, Collections.singleton(TOPIC_PARTITION_A_0));
+        when(task.inputPartitions())
+            .thenReturn(mkSet(new TopicPartition("input1", 0), new TopicPartition("input2", 0)));
+        shouldRemoveActiveTaskFromTasks(task);
+    }
+
+    private void shouldRemoveActiveTaskFromTasks(final Task task) {
+        tasks.addTask(task);
+
+        final Task removedTask = tasks.removeTask(task.id());
+
+        assertEquals(task, removedTask);
+        assertTrue(tasks.allTasks().isEmpty());
+        assertTrue(tasks.activeTasks().isEmpty());
+        assertTrue(tasks.tasksPerId().isEmpty());
+        final String expectedMessage = "Task unknown: " + task.id();
+        final Exception exceptionGetSingleTask = assertThrows(IllegalStateException.class, () -> tasks.task(task.id()));
+        assertEquals(expectedMessage, exceptionGetSingleTask.getMessage());
+        final Exception exceptionGetMultipleTask =
+            assertThrows(IllegalStateException.class, () -> tasks.tasks(mkSet(task.id())));
+        assertEquals(expectedMessage, exceptionGetMultipleTask.getMessage());
+        assertTrue(tasks.notPausedActiveTasks().isEmpty());
+        assertTrue(tasks.notPausedTasks().isEmpty());
+        for (final TopicPartition topicPartition : task.inputPartitions()) {
+            assertNull(tasks.activeTasksForInputPartition(topicPartition));
+        }
+        assertTrue(tasks.standbyTasks().isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveStandbyTaskFromTasks() {
+        final Task task = createStandbyTask(TASK_0_0, Collections.singleton(TOPIC_PARTITION_A_0));
+        tasks.addTask(task);
+
+        final Task removedTask = tasks.removeTask(task.id());
+
+        assertEquals(task, removedTask);
+        assertTrue(tasks.allTasks().isEmpty());
+        assertTrue(tasks.activeTasks().isEmpty());
+        assertTrue(tasks.tasksPerId().isEmpty());
+        final String expectedMessage = "Task unknown: " + task.id();
+        final Exception exceptionGetSingleTask = assertThrows(IllegalStateException.class, () -> tasks.task(task.id()));
+        assertEquals(expectedMessage, exceptionGetSingleTask.getMessage());
+        final Exception exceptionGetMultipleTask =
+            assertThrows(IllegalStateException.class, () -> tasks.tasks(mkSet(task.id())));
+        assertEquals(expectedMessage, exceptionGetMultipleTask.getMessage());
+        assertTrue(tasks.notPausedActiveTasks().isEmpty());
+        assertTrue(tasks.notPausedTasks().isEmpty());
+        for (final TopicPartition topicPartition : task.inputPartitions()) {
+            assertNull(tasks.activeTasksForInputPartition(topicPartition));
+        }
+        assertTrue(tasks.standbyTasks().isEmpty());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -18,6 +18,7 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
@@ -25,12 +26,19 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.StandbyTask;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.mockito.Mockito;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -48,6 +56,8 @@ import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class StreamsTestUtils {
     private StreamsTestUtils() {}
@@ -272,5 +282,36 @@ public final class StreamsTestUtils {
     public static boolean isCheckSupplierCall() {
         return Arrays.stream(Thread.currentThread().getStackTrace())
                 .anyMatch(caller -> "org.apache.kafka.streams.internals.ApiUtils".equals(caller.getClassName()) && "checkSupplier".equals(caller.getMethodName()));
+    }
+
+    public static StreamTask createStatelessTask(final TaskId taskId) {
+        final StreamTask task = Mockito.mock(StreamTask.class);
+        when(task.changelogPartitions()).thenReturn(Collections.emptySet());
+        when(task.isActive()).thenReturn(true);
+        when(task.id()).thenReturn(taskId);
+        return task;
+    }
+
+    public static StreamTask createStatefulTask(final TaskId taskId,
+                                                final Collection<TopicPartition> changelogPartitions) {
+        final StreamTask task = mock(StreamTask.class);
+        setupStatefulTask(task, taskId, changelogPartitions);
+        when(task.isActive()).thenReturn(true);
+        return task;
+    }
+
+    public static StandbyTask createStandbyTask(final TaskId taskId,
+                                         final Collection<TopicPartition> changelogPartitions) {
+        final StandbyTask task = mock(StandbyTask.class);
+        setupStatefulTask(task, taskId, changelogPartitions);
+        when(task.isActive()).thenReturn(false);
+        return task;
+    }
+
+    private static void setupStatefulTask(final Task task,
+                                   final TaskId taskId,
+                                   final Collection<TopicPartition> changelogPartitions) {
+        when(task.changelogPartitions()).thenReturn(changelogPartitions);
+        when(task.id()).thenReturn(taskId);
     }
 }


### PR DESCRIPTION
To integrate the state updater into the current code, we need the
ability to add and remove tasks from the task manager. This
functionality is needed to ensure that a task is managed either
by the task manager or by the state updater but not by both.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
