### PR TITLE
MINOR: Expose client information on RequestContext as additional public API beyond request logs (continuation of KIP 511)

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -264,6 +264,7 @@
     <allow pkg="org.apache.kafka.image" />
     <allow pkg="org.apache.kafka.metadata" />
     <allow pkg="org.apache.kafka.metalog" />
+    <allow pkg="org.apache.kafka.network" />
     <allow pkg="org.apache.kafka.queue" />
     <allow pkg="org.apache.kafka.raft" />
     <allow pkg="org.apache.kafka.server.authorizer" />

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -136,6 +136,7 @@ public class RequestContext implements AuthorizableRequestContext {
         return header.apiVersion();
     }
 
+    @Override
     public ClientInformation clientInformation() {
         return clientInformation;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -136,6 +136,10 @@ public class RequestContext implements AuthorizableRequestContext {
         return header.apiVersion();
     }
 
+    public ClientInformation clientInformation() {
+        return clientInformation;
+    }
+
     @Override
     public String listenerName() {
         return listenerName.value();

--- a/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.authorizer;
 
 import java.net.InetAddress;
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
@@ -69,4 +70,9 @@ public interface AuthorizableRequestContext {
      * Returns the correlation id from the request header.
      */
     int correlationId();
+
+    /**
+     * Returns client information for the connection on which the request was received.
+     */
+    ClientInformation clientInformation();
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -44,6 +44,7 @@ public class RequestContextTest {
         RequestContext context = new RequestContext(header, "0", InetAddress.getLocalHost(), KafkaPrincipal.ANONYMOUS,
                 new ListenerName("ssl"), SecurityProtocol.SASL_SSL, ClientInformation.EMPTY, false);
         assertEquals(0, context.apiVersion());
+        assertEquals(ClientInformation.EMPTY, context.clientInformation());
 
         // Write some garbage to the request buffer. This should be ignored since we will treat
         // the unknown version type as v0 which has an empty request body.

--- a/core/src/main/scala/kafka/security/authorizer/AuthorizerUtils.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AuthorizerUtils.scala
@@ -23,6 +23,7 @@ import kafka.network.RequestChannel.Session
 import org.apache.kafka.common.resource.Resource
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.network.ClientInformation
 import org.apache.kafka.server.authorizer.{AuthorizableRequestContext, Authorizer}
 
 
@@ -42,6 +43,7 @@ object AuthorizerUtils {
       override def securityProtocol(): SecurityProtocol = null
       override def correlationId(): Int = -1
       override def requestVersion(): Int = -1
+      override def clientInformation(): ClientInformation = ClientInformation.EMPTY;
     }
   }
 }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -2133,6 +2133,7 @@ object TestUtils extends Logging {
     override def requestVersion(): Int = 0
     override def clientId(): String = ""
     override def correlationId(): Int = 0
+    override def clientInformation(): ClientInformation = ClientInformation.EMPTY
   }
 
   def addAndVerifyAcls[B <: KafkaBroker](

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MockAuthorizableRequestContext.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MockAuthorizableRequestContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.metadata.authorizer;
 
+import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -35,6 +36,7 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
         private short requestVersion = ApiKeys.FETCH.latestVersion();
         private String clientId = "myClientId";
         private int correlationId = 123;
+        private ClientInformation clientInformation = ClientInformation.EMPTY;
 
         public Builder() throws Exception {
             this.clientAddress = InetAddress.getLocalHost();
@@ -80,6 +82,11 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
             return this;
         }
 
+        public Builder setClientInformation(ClientInformation clientInformation) {
+            this.clientInformation = clientInformation;
+            return this;
+        }
+
         public MockAuthorizableRequestContext build() {
             return new MockAuthorizableRequestContext(listenerName,
                 securityProtocol,
@@ -88,7 +95,8 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
                 requestType,
                 requestVersion,
                 clientId,
-                correlationId);
+                correlationId,
+                clientInformation);
         }
     }
 
@@ -100,6 +108,7 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
     private final short requestVersion;
     private final String clientId;
     private final int correlationId;
+    private final ClientInformation clientInformation;
 
     private MockAuthorizableRequestContext(String listenerName,
             SecurityProtocol securityProtocol,
@@ -108,7 +117,8 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
             ApiKeys requestType,
             short requestVersion,
             String clientId,
-            int correlationId) {
+            int correlationId,
+            ClientInformation clientInformation) {
         this.listenerName = listenerName;
         this.securityProtocol = securityProtocol;
         this.principal = principal;
@@ -117,6 +127,7 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
         this.requestVersion = requestVersion;
         this.clientId = clientId;
         this.correlationId = correlationId;
+        this.clientInformation = clientInformation;
     }
 
     @Override
@@ -157,5 +168,10 @@ public class MockAuthorizableRequestContext implements AuthorizableRequestContex
     @Override
     public int correlationId() {
         return correlationId;
+    }
+
+    @Override
+    public ClientInformation clientInformation() {
+        return clientInformation;
     }
 }


### PR DESCRIPTION
[KIP 511](https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers) introduced a [ClientInformation](https://github.com/apache/kafka/blob/99b9b3e84f4e98c3f07714e1de6a139a004cbc5b/clients/src/main/java/org/apache/kafka/common/network/ClientInformation.java) class that wraps software (client) name and version and is also set as a property on [RequestContext](https://github.com/apache/kafka/blob/99b9b3e84f4e98c3f07714e1de6a139a004cbc5b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java), except unfortunately there's no getter to retrieve this information.

The [KIP](https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers) implemented protocol support, a registry to set it at the network layer per session and integrated with [RequestContext](https://github.com/apache/kafka/blob/d35283f011a797902fc9c4d896a1a6f039eb7d06/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java#L101), but unfortunately the only "public API" for this information is the broker request logs.

This change exposes client information to custom authorisers as well via `RequestConext`, where it can be programatically used in a pluggable fashion as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
