### PR TITLE
KAFKA-14013: Limit the length of the `reason` field sent on the wire

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -218,6 +218,7 @@ import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
 import org.apache.kafka.common.requests.ExpireDelegationTokenResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
+import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
@@ -3756,7 +3757,7 @@ public class KafkaAdminClient extends AdminClient {
     public RemoveMembersFromConsumerGroupResult removeMembersFromConsumerGroup(String groupId,
                                                                                RemoveMembersFromConsumerGroupOptions options) {
         String reason = options.reason() == null || options.reason().isEmpty() ?
-            DEFAULT_LEAVE_GROUP_REASON : Utils.truncateIfRequired(options.reason());
+            DEFAULT_LEAVE_GROUP_REASON : JoinGroupRequest.maybeTruncateReason(options.reason());
 
         List<MemberIdentity> members;
         if (options.removeAll()) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3756,7 +3756,7 @@ public class KafkaAdminClient extends AdminClient {
     public RemoveMembersFromConsumerGroupResult removeMembersFromConsumerGroup(String groupId,
                                                                                RemoveMembersFromConsumerGroupOptions options) {
         String reason = options.reason() == null || options.reason().isEmpty() ?
-            DEFAULT_LEAVE_GROUP_REASON : options.reason();
+            DEFAULT_LEAVE_GROUP_REASON : Utils.truncateIfRequired(options.reason());
 
         List<MemberIdentity> members;
         if (options.removeAll()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -479,11 +479,10 @@ public abstract class AbstractCoordinator implements Closeable {
                 resetJoinGroupFuture();
                 synchronized (AbstractCoordinator.this) {
                     final String simpleName = exception.getClass().getSimpleName();
-                    final String shortReason = String.format("rebalance failed due to %s",
-                            simpleName);
+                    final String shortReason = String.format("rebalance failed due to %s", simpleName);
                     final String fullReason = String.format("rebalance failed due to '%s' (%s)",
-                            exception.getMessage(),
-                            simpleName);
+                        exception.getMessage(),
+                        simpleName);
                     requestRejoin(shortReason, fullReason);
                 }
 
@@ -560,7 +559,7 @@ public abstract class AbstractCoordinator implements Closeable {
                         .setProtocolType(protocolType())
                         .setProtocols(metadata())
                         .setRebalanceTimeoutMs(this.rebalanceConfig.rebalanceTimeoutMs)
-                        .setReason(Utils.truncateIfRequired(this.rejoinReason))
+                        .setReason(JoinGroupRequest.maybeTruncateReason(this.rejoinReason))
         );
 
         log.debug("Sending JoinGroup ({}) to coordinator {}", requestBuilder, this.coordinator);
@@ -1115,7 +1114,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 generation.memberId, coordinator, leaveReason);
             LeaveGroupRequest.Builder request = new LeaveGroupRequest.Builder(
                 rebalanceConfig.groupId,
-                Collections.singletonList(new MemberIdentity().setMemberId(generation.memberId).setReason(Utils.truncateIfRequired(leaveReason)))
+                Collections.singletonList(new MemberIdentity().setMemberId(generation.memberId).setReason(JoinGroupRequest.maybeTruncateReason(leaveReason)))
             );
 
             future = client.send(coordinator, request).compose(new LeaveGroupResponseHandler(generation));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -560,7 +560,7 @@ public abstract class AbstractCoordinator implements Closeable {
                         .setProtocolType(protocolType())
                         .setProtocols(metadata())
                         .setRebalanceTimeoutMs(this.rebalanceConfig.rebalanceTimeoutMs)
-                        .setReason(truncateIfRequired(this.rejoinReason))
+                        .setReason(Utils.truncateIfRequired(this.rejoinReason))
         );
 
         log.debug("Sending JoinGroup ({}) to coordinator {}", requestBuilder, this.coordinator);
@@ -1055,14 +1055,6 @@ public abstract class AbstractCoordinator implements Closeable {
         this.rejoinNeeded = true;
     }
 
-    private String truncateIfRequired(final String reason) {
-        if (reason.length() > 255) {
-            return reason.substring(0, 255);
-        } else {
-            return reason;
-        }
-    }
-
     private boolean isProtocolTypeInconsistent(String protocolType) {
         return protocolType != null && !protocolType.equals(protocolType());
     }
@@ -1123,7 +1115,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 generation.memberId, coordinator, leaveReason);
             LeaveGroupRequest.Builder request = new LeaveGroupRequest.Builder(
                 rebalanceConfig.groupId,
-                Collections.singletonList(new MemberIdentity().setMemberId(generation.memberId).setReason(truncateIfRequired(leaveReason)))
+                Collections.singletonList(new MemberIdentity().setMemberId(generation.memberId).setReason(Utils.truncateIfRequired(leaveReason)))
             );
 
             future = client.send(coordinator, request).compose(new LeaveGroupResponseHandler(generation));

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -73,8 +73,7 @@ public class JoinGroupRequest extends AbstractRequest {
     /**
      * Ensures that the provided {@code reason} remains within a range of 255 chars.
      * @param reason This is the reason that is sent to the broker over the wire
-     *               as a part of {@code JoinGroupRequest}, {@code LeaveGroupRequest}
-     *               or {@code RemoveMembersFromConsumerGroupOptions} messages.
+     *               as a part of {@code JoinGroupRequest} or {@code LeaveGroupRequest}.
      * @return a provided reason as is or truncated reason if it exceeds the 255 chars threshold.
      */
     public static String maybeTruncateReason(final String reason) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -73,7 +73,7 @@ public class JoinGroupRequest extends AbstractRequest {
     /**
      * Ensures that the provided {@code reason} remains within a range of 255 chars.
      * @param reason This is the reason that is sent to the broker over the wire
-     *               as a part of {@code JoinGroupRequest} or {@code LeaveGroupRequest}.
+     *               as a part of {@code JoinGroupRequest} or {@code LeaveGroupRequest} messages.
      * @return a provided reason as is or truncated reason if it exceeds the 255 chars threshold.
      */
     public static String maybeTruncateReason(final String reason) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -70,6 +70,21 @@ public class JoinGroupRequest extends AbstractRequest {
         });
     }
 
+    /**
+     * Ensures that the provided {@code reason} remains within a range of 255 chars.
+     * @param reason This is the reason that is sent to the broker over the wire
+     *               as a part of {@code JoinGroupRequest}, {@code LeaveGroupRequest}
+     *               or {@code RemoveMembersFromConsumerGroupOptions} messages.
+     * @return a provided reason as is or truncated reason if it exceeds the 255 chars threshold.
+     */
+    public static String maybeTruncateReason(final String reason) {
+        if (reason.length() > 255) {
+            return reason.substring(0, 255);
+        } else {
+            return reason;
+        }
+    }
+
     public JoinGroupRequest(JoinGroupRequestData data, short version) {
         super(ApiKeys.JOIN_GROUP, version);
         this.data = data;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1432,4 +1432,17 @@ public final class Utils {
                 .toArray(String[]::new);
     }
 
+    /**
+     * Ensures that the provided {@code reason} remains within a range of 255 chars.
+     * @param reason This is the reason that is sent to the broker over the wire
+     *               as a part of {@code JoinGroupRequest}, {@code LeaveGroupRequest} or {@code RemoveMembersFromConsumerGroupOptions} messages.
+     * @return a provided reason as is or truncated reason if it exceeds the 255 chars threshold.
+     */
+    public static String truncateIfRequired(final String reason) {
+        if (reason.length() > 255) {
+            return reason.substring(0, 255);
+        } else {
+            return reason;
+        }
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1432,17 +1432,4 @@ public final class Utils {
                 .toArray(String[]::new);
     }
 
-    /**
-     * Ensures that the provided {@code reason} remains within a range of 255 chars.
-     * @param reason This is the reason that is sent to the broker over the wire
-     *               as a part of {@code JoinGroupRequest}, {@code LeaveGroupRequest} or {@code RemoveMembersFromConsumerGroupOptions} messages.
-     * @return a provided reason as is or truncated reason if it exceeds the 255 chars threshold.
-     */
-    public static String truncateIfRequired(final String reason) {
-        if (reason.length() > 255) {
-            return reason.substring(0, 255);
-        } else {
-            return reason;
-        }
-    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4085,7 +4085,7 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testRemoveMembersFromGroupReasonAndTruncateReason() throws Exception {
+    public void testRemoveMembersFromGroupTruncatesReason() throws Exception {
         final String reason = "Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong reason that is 271 characters long to make sure that length limit logic handles the scenario nicely";
         final String truncatedReason = reason.substring(0, 255);
         testRemoveMembersFromGroup(reason, truncatedReason);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4085,6 +4085,13 @@ public class KafkaAdminClientTest {
     }
 
     @Test
+    public void testRemoveMembersFromGroupReasonAndTruncateReason() throws Exception {
+        final String reason = "Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong reason that is 271 characters long to make sure that length limit logic handles the scenario nicely";
+        final String truncatedReason = reason.substring(0, 255);
+        testRemoveMembersFromGroup(reason, truncatedReason);
+    }
+
+    @Test
     public void testRemoveMembersFromGroupDefaultReason() throws Exception {
         testRemoveMembersFromGroup(null, DEFAULT_LEAVE_GROUP_REASON);
         testRemoveMembersFromGroup("", DEFAULT_LEAVE_GROUP_REASON);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -571,6 +571,11 @@ public class AbstractCoordinatorTest {
         expectSyncGroup(generation, memberId);
         ensureActiveGroup(generation, memberId);
         assertEquals("", coordinator.rejoinReason());
+
+        // check limit length of reason field
+        mockClient.prepareResponse(joinGroupFollowerResponse(defaultGeneration, memberId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.GROUP_MAX_SIZE_REACHED));
+        coordinator.requestRejoin("Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong reason that is 271 characters long to make sure that length limit logic handles the scenario nicely");
+        assertEquals("Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong reason that is 271 characters long to make sure that length limit logic handles the", coordinator.rejoinReason());
     }
 
     private void ensureActiveGroup(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -1176,7 +1176,7 @@ public class AbstractCoordinatorTest {
         LeaveGroupResponse response =
                 leaveGroupResponse(Collections.singletonList(memberResponse));
         String leaveReason = "Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong leaveReason that is 271 characters long to make sure that length limit logic handles the scenario nicely";
-        RequestFuture<Void> leaveGroupFuture = setupLeaveGroup(response, leaveReason.substring(0, 255), leaveReason);
+        RequestFuture<Void> leaveGroupFuture = setupLeaveGroup(response, leaveReason, leaveReason.substring(0, 255));
         assertNotNull(leaveGroupFuture);
         assertTrue(leaveGroupFuture.succeeded());
     }
@@ -1219,8 +1219,8 @@ public class AbstractCoordinatorTest {
     }
 
     private RequestFuture<Void> setupLeaveGroup(LeaveGroupResponse leaveGroupResponse,
-                                                String expectedLeaveReason,
-                                                String actualLeaveReason) {
+                                                String leaveReason,
+                                                String expectedLeaveReason) {
         setupCoordinator(RETRY_BACKOFF_MS, Integer.MAX_VALUE, Optional.empty());
 
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
@@ -1232,11 +1232,11 @@ public class AbstractCoordinatorTest {
             }
             LeaveGroupRequestData leaveGroupRequest = ((LeaveGroupRequest) body).data();
             return leaveGroupRequest.members().get(0).memberId().equals(memberId) &&
-                    leaveGroupRequest.members().get(0).reason().equals(expectedLeaveReason);
+                   leaveGroupRequest.members().get(0).reason().equals(expectedLeaveReason);
         }, leaveGroupResponse);
 
         coordinator.ensureActiveGroup();
-        return coordinator.maybeLeaveGroup(actualLeaveReason);
+        return coordinator.maybeLeaveGroup(leaveReason);
     }
 
     @Test


### PR DESCRIPTION
Hello David @dajac , James @jnh5y 
I found an open JIRA ticket - https://issues.apache.org/jira/browse/KAFKA-14013
and decided to come up with a suggestion.
Could you please take a look if you have a spare minute?
Happy to adjust the changes if that's required.

--
Regards, Eugene 
