### PR TITLE
KAFKA-14053: Transactional producer should bump the epoch and skip ab…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -302,7 +302,7 @@ public class Sender implements Runnable {
                 transactionManager.maybeResolveSequences();
 
                 // do not continue sending if the transaction manager is in a failed state
-                if (transactionManager.hasFatalError()) {
+                if (transactionManager.hasFatalError() || transactionManager.hasFatalBumpableError()) {
                     RuntimeException lastError = transactionManager.lastError();
                     if (lastError != null)
                         maybeAbortBatches(lastError);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1063,8 +1063,8 @@ public class TransactionManager {
 
     private boolean maybeTerminateRequestWithError(TxnRequestHandler requestHandler) {
         if (hasError()) {
-            if (hasAbortableError() && requestHandler instanceof FindCoordinatorHandler)
-                // No harm letting the FindCoordinator request go through if we're expecting to abort
+            if ((hasAbortableError() || hasFatalBumpableError()) && requestHandler instanceof FindCoordinatorHandler)
+                // No harm letting the FindCoordinator request go through if we're expecting to abort or bump
                 return false;
             if (hasFatalBumpableError() && requestHandler instanceof InitProducerIdHandler)
                 // Should allow the fencing bump to complete

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1533,7 +1533,7 @@ public class SenderTest {
     }
 
     @Test
-    public void testUnresolvedSequencesAreNotFatal() throws Exception {
+    public void testUnresolvedSequencesAreFatalBumpable() throws Exception {
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
         TransactionManager txnManager = new TransactionManager(logContext, "testUnresolvedSeq", 60000, 100, apiVersions);
@@ -1570,7 +1570,7 @@ public class SenderTest {
 
         // Loop once and confirm that the transaction manager does not enter a fatal error state
         sender.runOnce();
-        assertTrue(txnManager.hasAbortableError());
+        assertTrue(txnManager.hasFatalBumpableError());
     }
 
     @Test


### PR DESCRIPTION
…orting when a delivery timeout is encountered

When a transactional batch encounters delivery or request timeout, it can still be in-flight. In this situation, if the transaction is aborted, the abort marker might get appended to the log earlier than the in-flight batch. This can cause the LSO of a partition to be blocked infinitely, or can violate the processing guarantees.
To avoid this situation, on a client side timeout, the transactional producer should skip aborting (EndTxnRequest), and bump the epoch instead. Since this is a fencing bump, the producer cannot safely continue, resulting in a fatal error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
