### PR TITLE
KAFKA-14063: Prevent malicious tiny payloads from causing OOMs with variably sized collections

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -583,6 +583,12 @@ public final class MessageDataGenerator implements MessageClassGenerator {
                 }
             }).
             generate(buffer);
+        // Fix for KAFKA-14063, defend against antagonistic payloads.
+        buffer.printf("if (%s > _readable.remaining()) {%n", lengthVar);
+        buffer.incrementIndent();
+        buffer.printf("throw new RuntimeException(\"field length for %s is longer than remaining reader data\");%n", name);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
         buffer.printf("if (%s < 0) {%n", lengthVar);
         buffer.incrementIndent();
         VersionConditional.forVersions(nullableVersions, possibleVersions).


### PR DESCRIPTION
When parsing code receives a payload for a variable length field where the length is specified in the code as some arbitrarily large number (assume INT32_MAX for example) this will immediately try to allocate an ArrayList to hold this many elements, before checking whether this is a reasonable array size given the available data. 

The fix for this is to instead throw a runtime exception if the length of a variably sized container exceeds the amount of remaining data. Then, the worst a user can do is force the server to allocate 8x the size of the actual delivered data (if they claim there are N elements for a container of Objects (i.e. not a byte string) and each Object bottoms out in an 8 byte pointer in the ArrayList's backing array).

This was identified by fuzzing the kafka request parsing code.