### PR TITLE
KAFKA-13648: KRaft ClusterInstance does not allow for deferred start

### DIFF
--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -103,12 +103,15 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
                 KafkaClusterTestKit cluster = builder.build();
                 clusterReference.set(cluster);
                 cluster.format();
-                cluster.startup();
-                kafka.utils.TestUtils.waitUntilTrue(
-                    () -> cluster.brokers().get(0).brokerState() == BrokerState.RUNNING,
-                    () -> "Broker never made it to RUNNING state.",
-                    org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS,
-                    100L);
+                if (clusterConfig.isAutoStart()) {
+                    cluster.startup();
+                    kafka.utils.TestUtils.waitUntilTrue(
+                            () -> cluster.brokers().get(0).brokerState() == BrokerState.RUNNING,
+                            () -> "Broker never made it to RUNNING state.",
+                            org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS,
+                            100L);
+                }
+
             },
             (AfterTestExecutionCallback) context -> clusterInstance.stop(),
             new ClusterInstanceParameterResolver(clusterInstance),


### PR DESCRIPTION
This issue happens cause the `cluster.startup()` invoked already and the solution is just check the `clusterConfig.isAutoStart` in the  `BeforeTestExecutionCallback`.

In addition I believe checking just a broker state is not sufficient  and it's better to invoke `cluster.waitForReadyBrokers()` instead but I didn't change it, cause it was out of scope of the issue.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
