### PR TITLE
remove min_cluster_size() calls

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
@@ -27,6 +27,7 @@ from kafkatest.version import DEV_BRANCH, LATEST_0_10_0, LATEST_0_10_1, LATEST_0
     LATEST_1_1, LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, LATEST_2_7, \
     LATEST_2_8, LATEST_3_0, LATEST_3_1, LATEST_3_2, KafkaVersion
 
+
 class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     """
     These tests validate that we can use a new client to produce and consume from older brokers.
@@ -51,10 +52,6 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     def setUp(self):
         if self.zk:
             self.zk.start()
-
-    def min_cluster_size(self):
-        # Override this since we're adding services outside of the constructor
-        return super(ClientCompatibilityProduceConsumeTest, self).min_cluster_size() + self.num_producers + self.num_consumers
 
     @cluster(num_nodes=9)
     @matrix(broker_version=[str(DEV_BRANCH)], metadata_quorum=quorum.all_non_upgrade)

--- a/tests/kafkatest/tests/client/compression_test.py
+++ b/tests/kafkatest/tests/client/compression_test.py
@@ -51,10 +51,6 @@ class CompressionTest(ProduceConsumeValidateTest):
         if self.zk:
             self.zk.start()
 
-    def min_cluster_size(self):
-        # Override this since we're adding services outside of the constructor
-        return super(CompressionTest, self).min_cluster_size() + self.num_producers + self.num_consumers
-
     @cluster(num_nodes=8)
     @matrix(compression_types=[COMPRESSION_TYPES], metadata_quorum=quorum.all_non_upgrade)
     def test_compressed_topic(self, compression_types, metadata_quorum=quorum.zk):

--- a/tests/kafkatest/tests/client/quota_test.py
+++ b/tests/kafkatest/tests/client/quota_test.py
@@ -122,10 +122,6 @@ class QuotaTest(Test):
     def setUp(self):
         self.zk.start()
 
-    def min_cluster_size(self):
-        """Override this since we're adding services outside of the constructor"""
-        return super(QuotaTest, self).min_cluster_size() + self.num_producers + self.num_consumers
-
     @cluster(num_nodes=5)
     @matrix(quota_type=[QuotaConfig.CLIENT_ID, QuotaConfig.USER, QuotaConfig.USER_CLIENT], override_quota=[True, False])
     @parametrize(quota_type=QuotaConfig.CLIENT_ID, consumer_num=2)

--- a/tests/kafkatest/tests/core/fetch_from_follower_test.py
+++ b/tests/kafkatest/tests/core/fetch_from_follower_test.py
@@ -61,9 +61,6 @@ class FetchFromFollowerTest(ProduceConsumeValidateTest):
         self.num_producers = 1
         self.num_consumers = 1
 
-    def min_cluster_size(self):
-        return super(FetchFromFollowerTest, self).min_cluster_size() + self.num_producers * 2 + self.num_consumers * 2
-
     def setUp(self):
         if self.zk:
             self.zk.start()

--- a/tests/kafkatest/tests/core/log_dir_failure_test.py
+++ b/tests/kafkatest/tests/core/log_dir_failure_test.py
@@ -86,10 +86,6 @@ class LogDirFailureTest(ProduceConsumeValidateTest):
     def setUp(self):
         self.zk.start()
 
-    def min_cluster_size(self):
-        """Override this since we're adding services outside of the constructor"""
-        return super(LogDirFailureTest, self).min_cluster_size() + self.num_producers * 2 + self.num_consumers * 2
-
     @cluster(num_nodes=9)
     @matrix(bounce_broker=[False, True], broker_type=["leader", "follower"], security_protocol=["PLAINTEXT"])
     def test_replication_with_disk_failure(self, bounce_broker, security_protocol, broker_type):

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -69,10 +69,6 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         if self.zk:
             self.zk.start()
 
-    def min_cluster_size(self):
-        # Override this since we're adding services outside of the constructor
-        return super(ReassignPartitionsTest, self).min_cluster_size() + self.num_producers + self.num_consumers
-
     def clean_bounce_some_brokers(self):
         """Bounce every other broker"""
         for node in self.kafka.nodes[::2]:

--- a/tests/kafkatest/tests/core/replication_test.py
+++ b/tests/kafkatest/tests/core/replication_test.py
@@ -114,10 +114,6 @@ class ReplicationTest(EndToEndTest):
         """:type test_context: ducktape.tests.test.TestContext"""
         super(ReplicationTest, self).__init__(test_context=test_context, topic_config=self.TOPIC_CONFIG)
 
-    def min_cluster_size(self):
-        """Override this since we're adding services outside of the constructor"""
-        return super(ReplicationTest, self).min_cluster_size() + self.num_producers + self.num_consumers
-
     @cluster(num_nodes=7)
     @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
             broker_type=["leader"],

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -81,11 +81,6 @@ class ThrottlingTest(ProduceConsumeValidateTest):
     def setUp(self):
         self.zk.start()
 
-    def min_cluster_size(self):
-        # Override this since we're adding services outside of the constructor
-        return super(ThrottlingTest, self).min_cluster_size() +\
-            self.num_producers + self.num_consumers
-
     def clean_bounce_some_brokers(self):
         """Bounce every other broker"""
         for node in self.kafka.nodes[::2]:

--- a/tests/kafkatest/tests/verifiable_consumer_test.py
+++ b/tests/kafkatest/tests/verifiable_consumer_test.py
@@ -49,10 +49,6 @@ class VerifiableConsumerTest(KafkaTest):
         partitions = self._partitions(assignment)
         return len(partitions) == num_partitions and set(partitions) == all_partitions
 
-    def min_cluster_size(self):
-        """Override this since we're adding services outside of the constructor"""
-        return super(VerifiableConsumerTest, self).min_cluster_size() + self.num_consumers + self.num_producers
-
     def setup_consumer(self, topic, static_membership=False, enable_autocommit=False,
                        assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor", **kwargs):
         return VerifiableConsumer(self.test_context, self.num_consumers, self.kafka,


### PR DESCRIPTION
This ducktape PR - https://github.com/confluentinc/ducktape/pull/336 - deprecates min_cluster_spec() method which was the only method in ducktape framework which was actually calling min_cluster_size() method (which, in turn, has been deprecated for a while).

This PR removes all usages of min_cluster_size() since it won't be used for anything useful in ducktape in the future.
If we want to be on the safe side, we should only merge this one after we release new ducktape version with that PR, though it's probably ok either way.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
