### PR TITLE
KAFKA-13166 Fix missing ControllerApis error handling

### DIFF
--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -24,14 +24,16 @@ import org.apache.kafka.common.acl.AclOperation._
 import org.apache.kafka.common.acl.AclBinding
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.message.CreateAclsResponseData.AclCreationResult
+import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsFilterResult
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.server.authorizer._
-import java.util
 
+import java.util
+import java.util.concurrent.CompletableFuture
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable
 import scala.compat.java8.OptionConverters._
@@ -53,7 +55,7 @@ class AclApis(authHelper: AuthHelper,
 
   def close(): Unit = alterAclsPurgatory.shutdown()
 
-  def handleDescribeAcls(request: RequestChannel.Request): Unit = {
+  def handleDescribeAcls(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, DESCRIBE)
     val describeAclsRequest = request.body[DescribeAclsRequest]
     authorizer match {
@@ -74,9 +76,10 @@ class AclApis(authHelper: AuthHelper,
             .setResources(DescribeAclsResponse.aclsResources(returnedAcls)),
           describeAclsRequest.version))
     }
+    CompletableFuture.completedFuture[Unit](())
   }
 
-  def handleCreateAcls(request: RequestChannel.Request): Unit = {
+  def handleCreateAcls(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, ALTER)
     val createAclsRequest = request.body[CreateAclsRequest]
 
@@ -84,6 +87,7 @@ class AclApis(authHelper: AuthHelper,
       case None => requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
         createAclsRequest.getErrorResponse(requestThrottleMs,
           new SecurityDisabledException("No Authorizer is configured.")))
+        CompletableFuture.completedFuture[Unit](())
       case Some(auth) =>
         val allBindings = createAclsRequest.aclCreations.asScala.map(CreateAclsRequest.aclBinding)
         val errorResults = mutable.Map[AclBinding, AclCreateResult]()
@@ -103,6 +107,7 @@ class AclApis(authHelper: AuthHelper,
             validBindings += acl
         }
 
+        val future = new CompletableFuture[util.List[AclCreationResult]]()
         val createResults = auth.createAcls(request.context, validBindings.asJava).asScala.map(_.toCompletableFuture)
 
         def sendResponseCallback(): Unit = {
@@ -117,17 +122,20 @@ class AclApis(authHelper: AuthHelper,
             }
             creationResult
           }
+          future.complete(aclCreationResults.asJava)
+        }
+        alterAclsPurgatory.tryCompleteElseWatch(config.connectionsMaxIdleMs, createResults, sendResponseCallback)
+
+        future.thenApply[Unit] { aclCreationResults =>
           requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
             new CreateAclsResponse(new CreateAclsResponseData()
               .setThrottleTimeMs(requestThrottleMs)
-              .setResults(aclCreationResults.asJava)))
+              .setResults(aclCreationResults)))
         }
-
-        alterAclsPurgatory.tryCompleteElseWatch(config.connectionsMaxIdleMs, createResults, sendResponseCallback)
     }
   }
 
-  def handleDeleteAcls(request: RequestChannel.Request): Unit = {
+  def handleDeleteAcls(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, ALTER)
     val deleteAclsRequest = request.body[DeleteAclsRequest]
     authorizer match {
@@ -135,13 +143,20 @@ class AclApis(authHelper: AuthHelper,
         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
           deleteAclsRequest.getErrorResponse(requestThrottleMs,
             new SecurityDisabledException("No Authorizer is configured.")))
+        CompletableFuture.completedFuture[Unit](())
       case Some(auth) =>
 
+        val future = new CompletableFuture[util.List[DeleteAclsFilterResult]]()
         val deleteResults = auth.deleteAcls(request.context, deleteAclsRequest.filters)
           .asScala.map(_.toCompletableFuture).toList
 
         def sendResponseCallback(): Unit = {
           val filterResults = deleteResults.map(_.get).map(DeleteAclsResponse.filterResult).asJava
+          future.complete(filterResults)
+        }
+
+        alterAclsPurgatory.tryCompleteElseWatch(config.connectionsMaxIdleMs, deleteResults, sendResponseCallback)
+        future.thenApply[Unit] { filterResults =>
           requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
             new DeleteAclsResponse(
               new DeleteAclsResponseData()
@@ -149,7 +164,6 @@ class AclApis(authHelper: AuthHelper,
                 .setFilterResults(filterResults),
               deleteAclsRequest.version))
         }
-        alterAclsPurgatory.tryCompleteElseWatch(config.connectionsMaxIdleMs, deleteResults, sendResponseCallback)
     }
   }
-}
+ }


### PR DESCRIPTION
In ControllerApis, we are making use of the CompletableFuture-s returned by QuorumController to add callbacks via `whenComplete`. Since these chained methods on CompletableFuture return a _new_ CompletableFuture instance, the ControllerPurgatory does not capture any of downstream exceptions when completing the original instance. The only way to see these errors is to call `get` on the chained future, or to add additional completion stages to handle the error explicitly. However, we do not want to call `get` since that would block the request threads.

This patch changes the signature of the request handlers in ControllerApis to all return CompletableFuture. It also converts all of the `CompletableFuture#whenComplete` callbacks to `CompletableFuture#handle`. This allows us to directly handle exceptions thrown by the controller in the individual request handlers. A single `whenComplete` error handler is added in `ControllerApis#handle` which will ensure we log exceptions thrown by the response builders (or other logic in the chained `handle` calls). 

The resulting future chain now looks like:

```scala
controller.doStuff()
    .handle { (result, exception) => 
      // Transform result or exception into a response 
    }
    .whenComplete { (result, exception) => 
      // Handle errors thrown in "handle"
    }
```

The future is still completed by ControllerPurgatory, and that is when the completion stages are run. We do not call `get` in ControllerApis to avoid blocking the request threads.

There is some opportunity for cleanup and consolidation of error handling in ControllerApis, but I'd rather make a separate PR for that.