### PR TITLE
MINOR: Fix QueryResult Javadocs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.query;
 
-
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.query.internals.FailedQueryResult;
 import org.apache.kafka.streams.query.internals.SucceededQueryResult;
@@ -31,7 +30,7 @@ import java.util.List;
 public interface QueryResult<R> {
     /**
      * Static factory method to create a result object for a successful query. Used by StateStores
-     * to respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
+     * to respond to a {@link StateStore#query(Query, PositionBound, QueryConfig)}.
      */
     static <R> QueryResult<R> forResult(final R result) {
         return new SucceededQueryResult<>(result);
@@ -39,7 +38,7 @@ public interface QueryResult<R> {
 
     /**
      * Static factory method to create a result object for a failed query. Used by StateStores to
-     * respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
+     * respond to a {@link StateStore#query(Query, PositionBound, QueryConfig)}.
      */
     static <R> QueryResult<R> forFailure(
         final FailureReason failureReason,
@@ -52,7 +51,7 @@ public interface QueryResult<R> {
      * Static factory method to create a failed query result object to indicate that the store does
      * not know how to handle the query.
      * <p>
-     * Used by StateStores to respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
+     * Used by StateStores to respond to a {@link StateStore#query(Query, PositionBound, QueryConfig)}.
      */
     static <R> QueryResult<R> forUnknownQueryType(
         final Query<R> query,
@@ -69,7 +68,7 @@ public interface QueryResult<R> {
      * Static factory method to create a failed query result object to indicate that the store has
      * not yet caught up to the requested position bound.
      * <p>
-     * Used by StateStores to respond to a {@link StateStore#query(Query, PositionBound, boolean)}.
+     * Used by StateStores to respond to a {@link StateStore#query(Query, PositionBound, QueryConfig)}.
      */
     static <R> QueryResult<R> notUpToBound(
         final Position currentPosition,


### PR DESCRIPTION
Fixes the `QueryResult` javadocs. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
