### PR TITLE
KAFKA-13572 Fix negative preferred replica imbalanced count metric

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -328,8 +328,9 @@ class ControllerContext {
   }
 
   def queueTopicDeletion(topics: Set[String]): Unit = {
+    val newlyDeletedTopics = topics.diff(topicsToBeDeleted)
     topicsToBeDeleted ++= topics
-    topics.foreach(cleanPreferredReplicaImbalanceMetric)
+    newlyDeletedTopics.foreach(cleanPreferredReplicaImbalanceMetric)
   }
 
   def beginTopicDeletion(topics: Set[String]): Unit = {

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -327,9 +327,15 @@ class ControllerContext {
     }
   }
 
-  def queueTopicDeletion(topics: Set[String]): Unit = {
-    val newlyDeletedTopics = topics.diff(topicsToBeDeleted)
-    topicsToBeDeleted ++= topics
+  def queueTopicDeletion(topicToBeAddedIntoDeletionList: Set[String]): Unit = {
+    // queueTopicDeletion could be called multiple times for same topic.
+    // e.g. 1) delete topic-A => 2) delete topic-B before A's deletion completes.
+    // In this case, at 2), queueTopicDeletion will be called with Set(topic-A, topic-B).
+    // However we should call cleanPreferredReplicaImbalanceMetric only once for same topic
+    // because otherwise, preferredReplicaImbalanceCount could be decremented wrongly at 2nd call.
+    // So we need to take a diff with already queued topics here.
+    val newlyDeletedTopics = topicToBeAddedIntoDeletionList.diff(topicsToBeDeleted)
+    topicsToBeDeleted ++= newlyDeletedTopics
     newlyDeletedTopics.foreach(cleanPreferredReplicaImbalanceMetric)
   }
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
@@ -206,18 +206,22 @@ class ControllerContextTest {
 
   @Test
   def testPreferredReplicaImbalanceMetricOnConcurrentTopicDeletion(): Unit = {
-    context.updatePartitionFullReplicaAssignment(tp1, ReplicaAssignment(Seq(1, 2, 3)))
-    context.updatePartitionFullReplicaAssignment(tp3, ReplicaAssignment(Seq(1, 2, 3)))
+    val topicA = "A"
+    val topicB = "B"
+    val tpA = new TopicPartition(topicA, 0)
+    val tpB = new TopicPartition(topicB, 0)
+    context.updatePartitionFullReplicaAssignment(tpA, ReplicaAssignment(Seq(1, 2, 3)))
+    context.updatePartitionFullReplicaAssignment(tpB, ReplicaAssignment(Seq(1, 2, 3)))
     assertEquals(0, context.preferredReplicaImbalanceCount)
 
-    context.queueTopicDeletion(Set(tp1.topic))
+    context.queueTopicDeletion(Set(topicA))
     // All partitions in topic will be marked as Offline during deletion procedure
-    context.putPartitionLeadershipInfo(tp1, LeaderIsrAndControllerEpoch(LeaderAndIsr(LeaderAndIsr.NoLeader, List(1, 2, 3)), 0))
+    context.putPartitionLeadershipInfo(tpA, LeaderIsrAndControllerEpoch(LeaderAndIsr(LeaderAndIsr.NoLeader, List(1, 2, 3)), 0))
     assertEquals(0, context.preferredReplicaImbalanceCount)
 
-    // Initiate tp3's topic deletion before tp1's deletion completes.
-    // Since tp1's delete-topic ZK node still exists, context.queueTopicDeletion will be called with Set(tp1, tp3)
-    context.queueTopicDeletion(Set(tp1.topic, tp3.topic))
+    // Initiate topicB's topic deletion before topicA's deletion completes.
+    // Since topicA's delete-topic ZK node still exists, context.queueTopicDeletion will be called with Set(topicA, topicB)
+    context.queueTopicDeletion(Set(topicA, topicB))
     assertEquals(0, context.preferredReplicaImbalanceCount)
   }
 }


### PR DESCRIPTION
* Currently, `preferredReplicaImbalanceCount` calculation has a race that becomes negative when topic deletion is initiated simultaneously.
    * Please refer [KAFKA-13572's comment](https://issues.apache.org/jira/browse/KAFKA-13572?focusedCommentId=17566872&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17566872) for the details
* This PR addresses the problem by fixing `cleanPreferredReplicaImbalanceMetric` to be called only once per topic-deletion procedure

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
