### PR TITLE
MINOR: Fix options for old-style Admin.listConsumerGroupOffsets

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -921,12 +921,13 @@ public interface Admin extends AutoCloseable {
      * @return The ListGroupOffsetsResult
      */
     default ListConsumerGroupOffsetsResult listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options) {
-        ListConsumerGroupOffsetsOptions listOptions = new ListConsumerGroupOffsetsOptions()
-            .requireStable(options.requireStable());
         @SuppressWarnings("deprecation")
         ListConsumerGroupOffsetsSpec groupSpec = new ListConsumerGroupOffsetsSpec()
             .topicPartitions(options.topicPartitions());
-        return listConsumerGroupOffsets(Collections.singletonMap(groupId, groupSpec), listOptions);
+
+        // We can use the provided options with the batched API, which uses topic partitions from
+        // the group spec and ignores any topic partitions set in the options.
+        return listConsumerGroupOffsets(Collections.singletonMap(groupId, groupSpec), options);
     }
 
     /**


### PR DESCRIPTION
This fixes the options set in commit https://github.com/apache/kafka/commit/beac86f049385932309158c1cb49c8657e53f45f for the old style API. Timeout was not being copied to the new options. The copy is error-prone, so changing to use the provided options directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
