### PR TITLE
[BUG] Remove duplicate common.message.* from clients:test jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1325,7 +1325,7 @@ project(':clients') {
     }
     test {
       java {
-        srcDirs = ["src/generated/java", "src/generated-test/java", "src/test/java"]
+        srcDirs = ["src/generated-test/java", "src/test/java"]
       }
     }
   }


### PR DESCRIPTION
When consuming both `kafka-client:3.0.1` and `kafka-client:3.0.1:test`
through maven a hygene tool was detecting multiple instances of the same
class loaded into the classpath.

Verified this change by building locally with a before and after build with `./gradlew clients:publishToMavenLocal`, then used beyond compare to verify the contents.

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
   - Minor change to existing build process, the java classes was duplicated and unused.
- [X] Verify test coverage and CI build status
   - There should be no changes in test coverage and CI build status.
- [X] Verify documentation (including upgrade notes)
   - No documentation updates need to be made