### PR TITLE
KAFKA-13559: Fix issue where responses intermittently takes 300+ ms to respond, even when the server is idle.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -594,8 +594,8 @@ public class Selector implements Selectable, AutoCloseable {
 
                     // Following is to fix KAFKA-13559. This will prevent poll() from blocking for 300 ms when the
                     // socket has no data but the buffer has data. Only happens when using SSL.
-                    //if (channel.hasBytesBuffered())
-                    //    madeReadProgressLastPoll = true;
+                    if (channel.hasBytesBuffered())
+                        madeReadProgressLastPoll = true;
                 } catch (Exception e) {
                     sendFailed = true;
                     throw e;

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -591,11 +591,6 @@ public class Selector implements Selectable, AutoCloseable {
                 long nowNanos = channelStartTimeNanos != 0 ? channelStartTimeNanos : currentTimeNanos;
                 try {
                     attemptWrite(key, channel, nowNanos);
-
-                    // Following is to fix KAFKA-13559. This will prevent poll() from blocking for 300 ms when the
-                    // socket has no data but the buffer has data. Only happens when using SSL.
-                    if (channel.hasBytesBuffered())
-                        madeReadProgressLastPoll = true;
                 } catch (Exception e) {
                     sendFailed = true;
                     throw e;
@@ -762,6 +757,7 @@ public class Selector implements Selectable, AutoCloseable {
             explicitlyMutedChannels.remove(channel);
             if (channel.hasBytesBuffered()) {
                 keysWithBufferedRead.add(channel.selectionKey());
+                madeReadProgressLastPoll = true;
             }
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -652,6 +652,11 @@ public class Selector implements Selectable, AutoCloseable {
             if (send != null) {
                 this.completedSends.add(send);
                 this.sensors.recordCompletedSend(nodeId, send.size(), currentTimeMs);
+
+                // To fix KAFKA-13559, i.e. select(timeout) blocks for 300 ms when the socket has no data but the buffer
+                // has data. Only happens when using SSL.
+                if (channel.hasBytesBuffered())
+                    madeReadProgressLastPoll = true;
             }
         }
     }

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1890,7 +1890,7 @@ class SocketServerTest {
     testableServer.enableRequestProcessing(Map.empty)
     val testableSelector = testableServer.testableSelector
     val proxyServer = new ProxyServer(testableServer)
-    val selectTimeoutMs = 1000
+    val selectTimeoutMs = 500
     // set pollTimeoutOverride to "selectTimeoutMs" to ensure poll() timeout is distinct and can be identified
     testableSelector.pollTimeoutOverride = Some(selectTimeoutMs)
 
@@ -1921,9 +1921,7 @@ class SocketServerTest {
 
       // process the first request in the server side
       // this would move bytes from netReadBuffer to appReadBuffer, then process only the first request
-      // we call wakeup() so Selector.poll() does not block in this step (because we artificially add data into netReadBuffer)
-      testableSelector.wakeup()
-      val req1 = receiveRequest(testableServer.dataPlaneRequestChannel, selectTimeoutMs + 1000)
+      val req1 = receiveRequest(testableServer.dataPlaneRequestChannel, 60000)
       processRequest(testableServer.dataPlaneRequestChannel, req1)
 
       // receive response in the client side
@@ -1933,7 +1931,7 @@ class SocketServerTest {
       // NOTE 1: this should not block because the data is already in the buffer
       // NOTE 2: we do not call wakeup() here so Selector.poll() would block if the fix is not in place
       val processTimeStartNanos = System.nanoTime()
-      receiveRequest(testableServer.dataPlaneRequestChannel, selectTimeoutMs + 1000)
+      receiveRequest(testableServer.dataPlaneRequestChannel, 60000)
       val processTimeEndNanos = System.nanoTime()
 
       // check the duration of processing the second request

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1890,7 +1890,7 @@ class SocketServerTest {
     testableServer.enableRequestProcessing(Map.empty)
     val testableSelector = testableServer.testableSelector
     val proxyServer = new ProxyServer(testableServer)
-    val selectTimeoutMs = 5000
+    val selectTimeoutMs = 1000
     // set pollTimeoutOverride to "selectTimeoutMs" to ensure poll() timeout is distinct and can be identified
     testableSelector.pollTimeoutOverride = Some(selectTimeoutMs)
 

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1902,13 +1902,8 @@ class SocketServerTest {
   def testLatencyWithBufferedDataAndNoSocketData(): Unit = {
     shutdownServerAndMetrics(server)
 
-    // to ensure we only have 1 connection (channel)
-    val props = sslServerProps
-    val numConnections = 1
-    props.put("max.connections.per.ip", numConnections.toString)
-
     // create server with SSL listener
-    val testableServer = new TestableSocketServer(KafkaConfig.fromProps(props))
+    val testableServer = new TestableSocketServer(KafkaConfig.fromProps(sslServerProps))
     testableServer.enableRequestProcessing(Map.empty)
     val testableSelector = testableServer.testableSelector
     val proxyServer = new ProxyServer(testableServer)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1891,7 +1891,7 @@ class SocketServerTest {
     val testableSelector = testableServer.testableSelector
     val proxyServer = new ProxyServer(testableServer)
     val selectTimeoutMs = 5000
-    // set pollTimeoutOverride to "selectTimeout" to ensure poll() timeout is distinct and can be identified
+    // set pollTimeoutOverride to "selectTimeoutMs" to ensure poll() timeout is distinct and can be identified
     testableSelector.pollTimeoutOverride = Some(selectTimeoutMs)
 
     try {
@@ -1923,7 +1923,7 @@ class SocketServerTest {
       // this would move bytes from netReadBuffer to appReadBuffer, then process only the first request
       // we call wakeup() so Selector.poll() does not block in this step (because we artificially add data into netReadBuffer)
       testableSelector.wakeup()
-      val req1 = receiveRequest(testableServer.dataPlaneRequestChannel, 1000)
+      val req1 = receiveRequest(testableServer.dataPlaneRequestChannel, selectTimeoutMs + 1000)
       processRequest(testableServer.dataPlaneRequestChannel, req1)
 
       // receive response in the client side

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -590,15 +590,18 @@ class SocketServerTest {
     val netReadBuffer: ByteBuffer = JTestUtils.fieldValue(transportLayer, classOf[SslTransportLayer], "netReadBuffer")
 
     proxyServer.enableBuffering(netReadBuffer)
+    proxyServer.setBufferedDataCount(numBufferedRequests)
     (1 to numBufferedRequests).foreach { _ => sendRequest(socket, requestBytes) }
 
     val keysWithBufferedRead: util.Set[SelectionKey] = JTestUtils.fieldValue(serverSelector, classOf[Selector], "keysWithBufferedRead")
     keysWithBufferedRead.add(channel.selectionKey)
     JTestUtils.setFieldValue(transportLayer, "hasBytesBuffered", true)
 
-    TestUtils.waitUntilTrue(() => !proxyServer.bufferDataAvailable,
-      "Data is still being transferred from proxy server to kafka broker even after 10000 ms",
-      10000)
+    // wait until the first request is transferred to netReadBuffer
+    // the second request will be transferred after we call receiveRequest
+    TestUtils.waitUntilTrue(() => proxyServer.getBufferedDataCount == (numBufferedRequests - 1),
+      "The first request is still being transferred from proxy server to netReadBuffer even after 60000 ms",
+      60000)
 
     (socket, request1)
   }
@@ -1907,7 +1910,9 @@ class SocketServerTest {
       processRequest(testableServer.dataPlaneRequestChannel, req1)
 
       // process the requests in the netReadBuffer, this should not block
+      kafkaLogger.info("BADAI - testLatencyWithBufferedDataAndNoSocketData - BEFORE receiveRequest")
       val req2 = receiveRequest(testableServer.dataPlaneRequestChannel)
+      kafkaLogger.info("BADAI - testLatencyWithBufferedDataAndNoSocketData - AFTER receiveRequest")
       processRequest(testableServer.dataPlaneRequestChannel, req2)
 
       sslSocket.close()
@@ -2226,6 +2231,7 @@ class SocketServerTest {
 
     def runOp[T](operation: SelectorOperation, connectionId: Option[String],
                  onFailure: => Unit = {})(code: => T): T = {
+      kafkaLogger.info("BADAI - runOp - operation=" + operation)
       // If a failure is set on `operation`, throw that exception even if `code` fails
       try code
       finally onOperation(operation, connectionId, onFailure)
@@ -2342,8 +2348,7 @@ class SocketServerTest {
     val executor = Executors.newFixedThreadPool(2)
     @volatile var clientConnSocket: Socket = _
     @volatile var buffer: Option[ByteBuffer] = None
-    // this flag is only relevant after buffering is enabled via enableBuffering
-    @volatile var bufferDataAvailable: Boolean = true
+    val bufferedDataCount = new AtomicInteger(0)
 
     executor.submit((() => {
       try {
@@ -2351,16 +2356,19 @@ class SocketServerTest {
         val serverOut = serverConnSocket.getOutputStream
         val clientIn = clientConnSocket.getInputStream
         var b: Int = -1
+        var count: Int = 0
         while ({b = clientIn.read(); b != -1}) {
           buffer match {
             case Some(buf) =>
-              if (bufferDataAvailable == false) bufferDataAvailable = true
-              if (clientIn.available() == 0) bufferDataAvailable = false
+              if (clientIn.available() == 0)
+                bufferedDataCount.decrementAndGet()
+              count += 1
               buf.put(b.asInstanceOf[Byte])
             case None =>
               serverOut.write(b)
               serverOut.flush()
           }
+          kafkaLogger.info("BADAI - ProxyServer - buffer=" + buffer + " count=" + count + " bufferedDataCount=" + bufferedDataCount.get())
         }
       } finally {
         clientConnSocket.close()
@@ -2376,6 +2384,10 @@ class SocketServerTest {
     }): Runnable)
 
     def enableBuffering(buffer: ByteBuffer): Unit = this.buffer = Some(buffer)
+
+    def setBufferedDataCount(count: Int): Unit = this.bufferedDataCount.set(count)
+
+    def getBufferedDataCount: Int = this.bufferedDataCount.get()
 
     def close(): Unit = {
       serverSocket.close()


### PR DESCRIPTION
KAFKA-13559: Fix issue where responses intermittently takes 300+ ms to respond, even when the server is idle.

Processing request got delayed by 300 ms in the following condition:
1. Client-Server communication uses SSL socket
2. More than one requests are in the same network packet

This 300 ms delay occurs because the socket has no data but the buffer has data. And the sequence of events that leads to this situation is the following (high level):

Step 1 - Client sends more than one requests in the same network packet.
Step 2 - Server processes the 1st request. While doing this, SslTransportLayer reads all of the bytes (containing multiple requests) from the socket and stores it in the buffer.
Step 3 - Server sends the response for the 1st request.
Step 4 - Server processes the 2nd request. This request is taken from the SslTransportLayer buffer, instead of the socket. Because of this, "select(timeout)" blocks for 300 ms. THIS IS WHERE THE DELAY IS.

From producer side, this happens when you produce continuous records in a tight loop and then suddenly stop for more than 300 ms.

To fix this, Selector set "madeReadProgressLastPoll" to "true" after unmuting the channel, if there's data in the buffer.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
