### PR TITLE
KAFKA-13868: Replace YouTube embedded video with links on streams page

### DIFF
--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -50,7 +50,7 @@
                    <span class="video-number">3</span><a href="https://www.youtube.com/embed/7JYEEx7SBuE"><span class="video__text">Transforming Data Pt. 1</span></a>
                </p>
                <p class="video__item video_list_4 active">
-                   <span class="video-number">4</span><a href="https://www.youtube.com/embed/3kJgYIkAeHs"><span class="video__text">Transforming Data Pt. 11</span></a>
+                   <span class="video-number">4</span><a href="https://www.youtube.com/embed/3kJgYIkAeHs"><span class="video__text">Transforming Data Pt. 2</span></a>
                </p>
            </div>
          </div>

--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -35,32 +35,25 @@
     </div>
     <h3 class="streams_intro">The easiest way to write mission-critical real-time applications and microservices</h3>
        <p class="streams__description">Kafka Streams is a client library for building applications and microservices, where the input and output data are stored in Kafka clusters. It combines the simplicity of writing and deploying standard Java and Scala applications on the client side with the benefits of Kafka's server-side cluster technology.</p>
+       <hr class="separator">
+       <h3>VIDEO TOUR OF THE STREAMS API</h3>
        <div class="video__series__grid">
-          <div class="yt__video__block">
-            <div class="yt__video__inner__block">
-                <iframe  class="yt_series video_1 active" style="display:block" src="https://www.youtube.com/embed/Z3JKCLG3VP4?rel=0&showinfo=0&end=602" frameborder="0" allowfullscreen></iframe>
-                <iframe  class="yt_series video_2" src="https://www.youtube.com/embed/LxxeXI1mPKo?rel=0&showinfo=0&end=622" frameborder="0" allowfullscreen></iframe>
-                <iframe  class="yt_series video_3" src="https://www.youtube.com/embed/7JYEEx7SBuE?rel=0&showinfo=0end=557" frameborder="0" allowfullscreen></iframe>
-                <iframe  class="yt_series video_4" src="https://www.youtube.com/embed/3kJgYIkAeHs?rel=0&showinfo=0&end=564" frameborder="0" allowfullscreen></iframe>
-             </div>
-            </div>
-            <div class="video__block">
-                <h3>TOUR OF THE STREAMS API</h3>
-                <div class="video__list">
-                   <p class="video__item video_list_1 active" onclick="$('.video__item').removeClass('active'); $(this).addClass('active');$('.yt_series').hide();$('.video_1').show();">
-                      <span class="video-number">1</span><span class="video__text">Intro to Streams</span>
-                   </p>
-                   <p class="video__item video_list_2" onclick="$('.video__item').removeClass('active'); $(this).addClass('active');$('.yt_series').hide();$('.video_2').show();">
-                      <span class="video-number">2</span><span class="video__text">Creating a Streams Application</span>
-                   </p>
-                   <p class="video__item video_list_3" onclick="$('.video__item').removeClass('active'); $(this).addClass('active');$('.yt_series').hide();$('.video_3').show();">
-                      <span class="video-number">3</span><span class="video__text">Transforming Data Pt. 1</span>
-                   </p>
-                   <p class="video__item video_list_4" onclick="$('.video__item').removeClass('active'); $(this).addClass('active');$('.yt_series').hide();$('.video_4').show();">
-                      <span class="video-number">4</span><span class="video__text">Transforming Data Pt. 2</span>
-                   </p>
-                </div>
-            </div>
+         <div class="video__block">
+           <div class="video__list">
+               <p class="video__item video_list_1 active">
+                   <span class="video-number">1</span><a href="https://www.youtube.com/embed/Z3JKCLG3VP4"><span class="video__text">Intro to Streams</span></a>
+               </p>
+               <p class="video__item video_list_2 active">
+                   <span class="video-number">2</span><a href="https://www.youtube.com/embed/LxxeXI1mPKo"><span class="video__text">Creating a Streams Application</span></a>
+               </p>
+               <p class="video__item video_list_3 active">
+                   <span class="video-number">3</span><a href="https://www.youtube.com/embed/7JYEEx7SBuE"><span class="video__text">Transforming Data Pt. 1</span></a>
+               </p>
+               <p class="video__item video_list_4 active">
+                   <span class="video-number">4</span><a href="https://www.youtube.com/embed/3kJgYIkAeHs"><span class="video__text">Transforming Data Pt. 11</span></a>
+               </p>
+           </div>
+         </div>
        </div>
        <hr class="separator">
        <div class="use-item-section">


### PR DESCRIPTION
As per the [discussion in the community](https://lists.apache.org/thread/p24xvbf8nkvxpbj668vc0g3x3lojsnk4), we want to replace the embedded YouTube videos with hyperlinks to satisfy the [ASF privacy policy](https://privacy.apache.org/faq/committers.html).

This code change replaces the embedded videos from the streams web page on the website with hyperlinks.

**Before**
![Screenshot 2022-07-25 at 20 05 02](https://user-images.githubusercontent.com/71267/180844431-82f159de-51c2-4d84-895b-2b58efab3a85.png)

**After**
![Screenshot 2022-07-25 at 19 58 01](https://user-images.githubusercontent.com/71267/180844335-7d4cf22b-543f-4800-9eff-18389cf4318b.png)

