### PR TITLE
KAFKA-10199: Further refactor task lifecycle management

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -43,10 +43,11 @@ public abstract class AbstractTask implements Task {
     private Task.State state = CREATED;
     private long deadlineMs = NO_DEADLINE;
 
-    protected Set<TopicPartition> inputPartitions;
     protected final Logger log;
-    protected final LogContext logContext;
     protected final String logPrefix;
+    protected final LogContext logContext;
+
+    protected Set<TopicPartition> inputPartitions;
 
     /**
      * If the checkpoint has not been loaded from the file yet (null), then we should not overwrite the checkpoint;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -221,6 +221,9 @@ class ActiveTaskCreator {
             log.warn("Detected unmatched input partitions for task {} when recycling it from standby to active", standbyTask.id);
         }
 
+        standbyTask.prepareRecycle();
+        standbyTask.stateMgr.transitionTaskType(Task.TaskType.ACTIVE);
+
         final RecordCollector recordCollector = createRecordCollector(standbyTask.id, getLogContext(standbyTask.id), standbyTask.topology);
         final StreamTask task = new StreamTask(
             standbyTask.id,
@@ -238,7 +241,7 @@ class ActiveTaskCreator {
             standbyTask.logContext
         );
 
-        log.trace("Recycled active task {} from recycled standby with assigned partitions {}", task.id, inputPartitions);
+        log.trace("Created active task {} from recycled standby task with assigned partitions {}", task.id, inputPartitions);
         createTaskSensor.record();
         return task;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -135,11 +135,9 @@ class ActiveTaskCreator {
         return threadProducer;
     }
 
-    // TODO: change return type to `StreamTask`
-    public Collection<Task> createTasks(final Consumer<byte[], byte[]> consumer,
-                                 final Map<TaskId, Set<TopicPartition>> tasksToBeCreated) {
-        // TODO: change type to `StreamTask`
-        final List<Task> createdTasks = new ArrayList<>();
+    public Collection<StreamTask> createTasks(final Consumer<byte[], byte[]> consumer,
+                                              final Map<TaskId, Set<TopicPartition>> tasksToBeCreated) {
+        final List<StreamTask> createdTasks = new ArrayList<>();
 
         for (final Map.Entry<TaskId, Set<TopicPartition>> newTaskAndPartitions : tasksToBeCreated.entrySet()) {
             final TaskId taskId = newTaskAndPartitions.getKey();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -227,7 +227,6 @@ public class StandbyTask extends AbstractTask implements Task {
         streamsMetrics.removeAllTaskLevelSensors(Thread.currentThread().getName(), id.toString());
         if (state() == State.SUSPENDED) {
             stateMgr.recycle();
-            stateMgr.transitionTaskType(TaskType.ACTIVE);
         } else {
             throw new IllegalStateException("Illegal state " + state() + " while closing standby task " + id);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -92,7 +92,7 @@ public class StandbyTask extends AbstractTask implements Task {
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public boolean initializeIfNeeded() {
+    public void initializeIfNeeded() {
         if (state() == State.CREATED) {
             StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
 
@@ -109,13 +109,9 @@ public class StandbyTask extends AbstractTask implements Task {
             processorContext.initialize();
 
             log.info("Initialized");
-
-            return true;
         } else if (state() == State.RESTORING) {
             throw new IllegalStateException("Illegal state " + state() + " while initializing standby task " + id);
         }
-
-        return false;
     }
 
     @Override
@@ -227,7 +223,7 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void recycleAndConvert() {
+    public void prepareRecycle() {
         streamsMetrics.removeAllTaskLevelSensors(Thread.currentThread().getName(), id.toString());
         if (state() == State.SUSPENDED) {
             stateMgr.recycle();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -92,7 +92,7 @@ public class StandbyTask extends AbstractTask implements Task {
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public void initializeIfNeeded() {
+    public boolean initializeIfNeeded() {
         if (state() == State.CREATED) {
             StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
 
@@ -109,9 +109,13 @@ public class StandbyTask extends AbstractTask implements Task {
             processorContext.initialize();
 
             log.info("Initialized");
+
+            return true;
         } else if (state() == State.RESTORING) {
             throw new IllegalStateException("Illegal state " + state() + " while initializing standby task " + id);
         }
+
+        return false;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -16,12 +16,10 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -41,10 +39,12 @@ import java.util.Set;
  * A StandbyTask
  */
 public class StandbyTask extends AbstractTask implements Task {
-    private final Sensor closeTaskSensor;
     private final boolean eosEnabled;
-    private final InternalProcessorContext processorContext;
+    private final Sensor closeTaskSensor;
     private final StreamsMetricsImpl streamsMetrics;
+
+    @SuppressWarnings("rawtypes")
+    protected final InternalProcessorContext processorContext;
 
     /**
      * @param id              the ID of this task
@@ -55,6 +55,7 @@ public class StandbyTask extends AbstractTask implements Task {
      * @param stateMgr        the {@link ProcessorStateManager} for this task
      * @param stateDirectory  the {@link StateDirectory} created by the thread
      */
+    @SuppressWarnings("rawtypes")
     StandbyTask(final TaskId id,
                 final Set<TopicPartition> inputPartitions,
                 final ProcessorTopology topology,
@@ -222,10 +223,11 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void closeCleanAndRecycleState() {
+    public void recycleAndConvert() {
         streamsMetrics.removeAllTaskLevelSensors(Thread.currentThread().getName(), id.toString());
         if (state() == State.SUSPENDED) {
             stateMgr.recycle();
+            stateMgr.transitionTaskType(TaskType.ACTIVE);
         } else {
             throw new IllegalStateException("Illegal state " + state() + " while closing standby task " + id);
         }
@@ -233,44 +235,7 @@ public class StandbyTask extends AbstractTask implements Task {
         closeTaskSensor.record();
         transitionTo(State.CLOSED);
 
-        log.info("Closed clean and recycled state");
-    }
-
-    /**
-     * Create an active task from this standby task without closing and re-initializing the state stores.
-     * The task should have been in suspended state when calling this function
-     *
-     * TODO: we should be able to not need the input partitions as input param in future but always reuse
-     *       the task's input partitions when we have fixed partitions -> tasks mapping
-     */
-    public StreamTask recycle(final Time time,
-                              final ThreadCache cache,
-                              final RecordCollector recordCollector,
-                              final Set<TopicPartition> inputPartitions,
-                              final Consumer<byte[], byte[]> mainConsumer) {
-        if (!inputPartitions.equals(this.inputPartitions)) {
-            log.warn("Detected unmatched input partitions for task {} when recycling it from active to standby", id);
-        }
-
-        stateMgr.transitionTaskType(TaskType.ACTIVE);
-
-        log.debug("Recycling standby task {} to active", id);
-
-        return new StreamTask(
-            id,
-            inputPartitions,
-            topology,
-            mainConsumer,
-            config,
-            streamsMetrics,
-            stateDirectory,
-            cache,
-            time,
-            stateMgr,
-            recordCollector,
-            processorContext,
-            logContext
-        );
+        log.info("Closed and recycled state, and converted type to active");
     }
 
     private void close(final boolean clean) {
@@ -342,6 +307,7 @@ public class StandbyTask extends AbstractTask implements Task {
         throw new IllegalStateException("Attempted to add records to task " + id() + " for invalid input partition " + partition);
     }
 
+    @SuppressWarnings("rawtypes")
     InternalProcessorContext processorContext() {
         return processorContext;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -118,6 +118,9 @@ class StandbyTaskCreator {
             log.warn("Detected unmatched input partitions for task {} when recycling it from active to standby", streamTask.id);
         }
 
+        streamTask.prepareRecycle();
+        streamTask.stateMgr.transitionTaskType(Task.TaskType.STANDBY);
+
         final StandbyTask task = new StandbyTask(
             streamTask.id,
             inputPartitions,
@@ -130,7 +133,7 @@ class StandbyTaskCreator {
             streamTask.processorContext
         );
 
-        log.trace("Recycled standby task {} from recycled active with assigned partitions {}", task.id, inputPartitions);
+        log.trace("Created standby task {} from recycled active task with assigned partitions {}", task.id, inputPartitions);
         createTaskSensor.record();
         return task;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -67,10 +67,8 @@ class StandbyTaskCreator {
         );
     }
 
-    // TODO: change return type to `StandbyTask`
-    Collection<Task> createTasks(final Map<TaskId, Set<TopicPartition>> tasksToBeCreated) {
-        // TODO: change type to `StandbyTask`
-        final List<Task> createdTasks = new ArrayList<>();
+    Collection<StandbyTask> createTasks(final Map<TaskId, Set<TopicPartition>> tasksToBeCreated) {
+        final List<StandbyTask> createdTasks = new ArrayList<>();
 
         for (final Map.Entry<TaskId, Set<TopicPartition>> newTaskAndPartitions : tasksToBeCreated.entrySet()) {
             final TaskId taskId = newTaskAndPartitions.getKey();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -219,7 +219,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public boolean initializeIfNeeded() {
+    public void initializeIfNeeded() {
         if (state() == State.CREATED) {
             recordCollector.initialize();
 
@@ -233,11 +233,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             transitionTo(State.RESTORING);
 
             log.info("Initialized");
-
-            return true;
         }
-
-        return false;
     }
 
     public void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
@@ -548,7 +544,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     }
 
     @Override
-    public void recycleAndConvert() {
+    public void prepareRecycle() {
         validateClean();
         removeAllSensors();
         clearCommitStatuses();
@@ -557,7 +553,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 stateMgr.recycle();
                 partitionGroup.close();
                 recordCollector.closeClean();
-                stateMgr.transitionTaskType(TaskType.STANDBY);
 
                 break;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -83,7 +83,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private final Map<TopicPartition, Long> committedOffsets;
     private final Map<TopicPartition, Long> highWatermark;
     private final Set<TopicPartition> resetOffsetsForPartitions;
-    private Optional<Long> timeCurrentIdlingStarted;
     private final PunctuationQueue streamTimePunctuationQueue;
     private final PunctuationQueue systemTimePunctuationQueue;
     private final StreamsMetricsImpl streamsMetrics;
@@ -97,15 +96,16 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private final Sensor bufferedRecordsSensor;
     private final Map<String, Sensor> e2eLatencySensors = new HashMap<>();
 
-    @SuppressWarnings("rawtypes")
-    private final InternalProcessorContext processorContext;
-
     private final RecordQueueCreator recordQueueCreator;
+
+    @SuppressWarnings("rawtypes")
+    protected final InternalProcessorContext processorContext;
 
     private StampedRecord record;
     private boolean commitNeeded = false;
     private boolean commitRequested = false;
     private boolean hasPendingTxCommit = false;
+    private Optional<Long> timeCurrentIdlingStarted;
 
     @SuppressWarnings("rawtypes")
     public StreamTask(final TaskId id,
@@ -544,7 +544,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     }
 
     @Override
-    public void closeCleanAndRecycleState() {
+    public void recycleAndConvert() {
         validateClean();
         removeAllSensors();
         clearCommitStatuses();
@@ -553,6 +553,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 stateMgr.recycle();
                 partitionGroup.close();
                 recordCollector.closeClean();
+                stateMgr.transitionTaskType(TaskType.STANDBY);
 
                 break;
 
@@ -566,49 +567,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         }
 
         closeTaskSensor.record();
-
         transitionTo(State.CLOSED);
 
-        log.info("Closed clean and recycled state");
-    }
-
-    /**
-     * Create a standby task from this active task without closing and re-initializing the state stores.
-     * The task should have been in suspended state when calling this function
-     *
-     * TODO: we should be able to not need the input partitions as input param in future but always reuse
-     *       the task's input partitions when we have fixed partitions -> tasks mapping
-     */
-    public StandbyTask recycle(final Set<TopicPartition> inputPartitions) {
-        if (state() != Task.State.CLOSED) {
-            throw new IllegalStateException("Attempted to convert an active task that's not closed: " + id);
-        }
-
-        if (!inputPartitions.equals(this.inputPartitions)) {
-            log.warn("Detected unmatched input partitions for task {} when recycling it from active to standby", id);
-        }
-
-        stateMgr.transitionTaskType(TaskType.STANDBY);
-
-        final ThreadCache dummyCache = new ThreadCache(
-            new LogContext(String.format("stream-thread [%s] ", Thread.currentThread().getName())),
-            0,
-            streamsMetrics
-        );
-
-        log.debug("Recycling active task {} to standby", id);
-
-        return new StandbyTask(
-            id,
-            inputPartitions,
-            topology,
-            config,
-            streamsMetrics,
-            stateMgr,
-            stateDirectory,
-            dummyCache,
-            processorContext
-        );
+        log.info("Closed and recycled state, and converted type to standby");
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -219,7 +219,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public void initializeIfNeeded() {
+    public boolean initializeIfNeeded() {
         if (state() == State.CREATED) {
             recordCollector.initialize();
 
@@ -233,7 +233,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             transitionTo(State.RESTORING);
 
             log.info("Initialized");
+
+            return true;
         }
+
+        return false;
     }
 
     public void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -155,10 +155,9 @@ public interface Task {
     void revive();
 
     /**
-     * Attempt a clean close but do not close the underlying state
+     * Recycle the task's state while closing, and convert its type (from active to standby, and vice versa)
      */
-    void closeCleanAndRecycleState();
-
+    void recycleAndConvert();
 
     // runtime methods (using in RUNNING state)
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -105,7 +105,7 @@ public interface Task {
      * @throws LockException    could happen when multi-threads within the single instance, could retry
      * @throws StreamsException fatal error, should close the thread
      */
-    boolean initializeIfNeeded();
+    void initializeIfNeeded();
 
     default void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
         throw new UnsupportedOperationException();
@@ -155,9 +155,9 @@ public interface Task {
     void revive();
 
     /**
-     * Recycle the task's state while closing, and convert its type (from active to standby, and vice versa)
+     * Close the task except the state, so that the states can be later recycled
      */
-    void recycleAndConvert();
+    void prepareRecycle();
 
     // runtime methods (using in RUNNING state)
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -105,7 +105,7 @@ public interface Task {
      * @throws LockException    could happen when multi-threads within the single instance, could retry
      * @throws StreamsException fatal error, should close the thread
      */
-    void initializeIfNeeded();
+    boolean initializeIfNeeded();
 
     default void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
         throw new UnsupportedOperationException();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutionMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutionMetadata.java
@@ -17,8 +17,11 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.TaskId;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,12 +39,25 @@ public class TaskExecutionMetadata {
 
     private final boolean hasNamedTopologies;
     private final Set<String> pausedTopologies;
+    private final ProcessingMode processingMode;
+    private final Collection<Task> successfullyProcessed = new HashSet<>();
     // map of topologies experiencing errors/currently under backoff
     private final ConcurrentHashMap<String, NamedTopologyMetadata> topologyNameToErrorMetadata = new ConcurrentHashMap<>();
 
-    public TaskExecutionMetadata(final Set<String> allTopologyNames, final Set<String> pausedTopologies) {
+    public TaskExecutionMetadata(final Set<String> allTopologyNames,
+                                 final Set<String> pausedTopologies,
+                                 final ProcessingMode processingMode) {
         this.hasNamedTopologies = !(allTopologyNames.size() == 1 && allTopologyNames.contains(UNNAMED_TOPOLOGY));
         this.pausedTopologies = pausedTopologies;
+        this.processingMode = processingMode;
+    }
+
+    public boolean hasNamedTopologies() {
+        return hasNamedTopologies;
+    }
+
+    public ProcessingMode processingMode() {
+        return processingMode;
     }
 
     public boolean canProcessTask(final Task task, final long now) {
@@ -77,6 +93,22 @@ public class TaskExecutionMetadata {
         }
     }
 
+    Collection<Task> successfullyProcessed() {
+        return successfullyProcessed;
+    }
+
+    void addToSuccessfullyProcessed(final Task task) {
+        successfullyProcessed.add(task);
+    }
+
+    void removeTaskFromSuccessfullyProcessedBeforeClosing(final Task task) {
+        successfullyProcessed.remove(task);
+    }
+
+    void clearSuccessfullyProcessed() {
+        successfullyProcessed.clear();
+    }
+
     private class NamedTopologyMetadata {
         private final Logger log;
         private final Map<TaskId, Long> tasksToErrorTime = new ConcurrentHashMap<>();
@@ -109,7 +141,7 @@ public class TaskExecutionMetadata {
         }
 
         public synchronized void registerTaskError(final Task task, final Throwable t, final long now) {
-            log.info("Begin backoff for unhealthy task {} at t={}", task.id(), now);
+            log.info("Begin backoff for unhealthy task {} at t={} due to {}", task.id(), now, t.getClass().getName());
             tasksToErrorTime.put(task.id(), now);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -113,7 +113,7 @@ public class TopologyMetadata {
         } else {
             builders.put(UNNAMED_TOPOLOGY, builder);
         }
-        this.taskExecutionMetadata = new TaskExecutionMetadata(builders.keySet(), pausedTopologies);
+        this.taskExecutionMetadata = new TaskExecutionMetadata(builders.keySet(), pausedTopologies, processingMode);
     }
 
     public TopologyMetadata(final ConcurrentNavigableMap<String, InternalTopologyBuilder> builders,
@@ -128,7 +128,7 @@ public class TopologyMetadata {
         if (builders.isEmpty()) {
             log.info("Created an empty KafkaStreams app with no topology");
         }
-        this.taskExecutionMetadata = new TaskExecutionMetadata(builders.keySet(), pausedTopologies);
+        this.taskExecutionMetadata = new TaskExecutionMetadata(builders.keySet(), pausedTopologies, processingMode);
     }
 
     // Need to (re)set the log here to pick up the `processId` part of the clientId in the prefix

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -571,13 +571,13 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // CREATED
+        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // CREATED
 
         task.initializeIfNeeded();
-        assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RUNNING
+        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // RUNNING
 
         task.suspend();
-        task.closeCleanAndRecycleState(); // SUSPENDED
+        task.recycleAndConvert(); // SUSPENDED
 
         // Currently, there are no metrics registered for standby tasks.
         // This is a regression test so that, if we add some, we will be sure to deregister them.

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -571,13 +571,13 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // CREATED
+        assertThrows(IllegalStateException.class, () -> task.prepareRecycle()); // CREATED
 
         task.initializeIfNeeded();
-        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // RUNNING
+        assertThrows(IllegalStateException.class, () -> task.prepareRecycle()); // RUNNING
 
         task.suspend();
-        task.recycleAndConvert(); // SUSPENDED
+        task.prepareRecycle(); // SUSPENDED
 
         // Currently, there are no metrics registered for standby tasks.
         // This is a regression test so that, if we add some, we will be sure to deregister them.

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2187,7 +2187,7 @@ public class StreamTaskTest {
 
         task.suspend();
         assertThat(getTaskMetrics(), not(empty()));
-        task.recycleAndConvert();
+        task.prepareRecycle();
         assertThat(getTaskMetrics(), empty());
     }
 
@@ -2266,7 +2266,7 @@ public class StreamTaskTest {
         task.process(0L);
         assertTrue(task.commitNeeded());
 
-        assertThrows(TaskMigratedException.class, () -> task.recycleAndConvert());
+        assertThrows(TaskMigratedException.class, () -> task.prepareRecycle());
     }
 
     @Test
@@ -2277,16 +2277,16 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager, recordCollector);
 
         task = createStatefulTask(createConfig("100"), true);
-        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // CREATED
+        assertThrows(IllegalStateException.class, () -> task.prepareRecycle()); // CREATED
 
         task.initializeIfNeeded();
-        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // RESTORING
+        assertThrows(IllegalStateException.class, () -> task.prepareRecycle()); // RESTORING
 
         task.completeRestoration(noOpResetter -> { });
-        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // RUNNING
+        assertThrows(IllegalStateException.class, () -> task.prepareRecycle()); // RUNNING
 
         task.suspend();
-        task.recycleAndConvert(); // SUSPENDED
+        task.prepareRecycle(); // SUSPENDED
 
         EasyMock.verify(stateManager, recordCollector);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2187,7 +2187,7 @@ public class StreamTaskTest {
 
         task.suspend();
         assertThat(getTaskMetrics(), not(empty()));
-        task.closeCleanAndRecycleState();
+        task.recycleAndConvert();
         assertThat(getTaskMetrics(), empty());
     }
 
@@ -2266,7 +2266,7 @@ public class StreamTaskTest {
         task.process(0L);
         assertTrue(task.commitNeeded());
 
-        assertThrows(TaskMigratedException.class, () -> task.closeCleanAndRecycleState());
+        assertThrows(TaskMigratedException.class, () -> task.recycleAndConvert());
     }
 
     @Test
@@ -2277,16 +2277,16 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager, recordCollector);
 
         task = createStatefulTask(createConfig("100"), true);
-        assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // CREATED
+        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // CREATED
 
         task.initializeIfNeeded();
-        assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RESTORING
+        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // RESTORING
 
         task.completeRestoration(noOpResetter -> { });
-        assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RUNNING
+        assertThrows(IllegalStateException.class, () -> task.recycleAndConvert()); // RUNNING
 
         task.suspend();
-        task.closeCleanAndRecycleState(); // SUSPENDED
+        task.recycleAndConvert(); // SUSPENDED
 
         EasyMock.verify(stateManager, recordCollector);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -841,6 +841,7 @@ public class StreamThreadTest {
         expect(activeTaskCreator.producerClientIds()).andStubReturn(Collections.singleton("producerClientId"));
 
         final StandbyTaskCreator standbyTaskCreator = mock(StandbyTaskCreator.class);
+        expect(standbyTaskCreator.createTasks(anyObject())).andStubReturn(Collections.emptySet());
 
         EasyMock.replay(consumer, consumerGroupMetadata, task, activeTaskCreator, standbyTaskCreator);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutionMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutionMetadataTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class TaskExecutionMetadataTest {
         final Set<String> topologies = Collections.singleton(UNNAMED_TOPOLOGY);
         final Set<String> pausedTopologies = new HashSet<>();
 
-        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(topologies, pausedTopologies);
+        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(topologies, pausedTopologies, ProcessingMode.AT_LEAST_ONCE);
 
         final Task mockTask = createMockTask(UNNAMED_TOPOLOGY);
 
@@ -55,7 +56,7 @@ public class TaskExecutionMetadataTest {
     @Test
     public void testNamedTopologiesCanBePausedIndependently() {
         final Set<String> pausedTopologies = new HashSet<>();
-        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(NAMED_TOPOLOGIES, pausedTopologies);
+        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(NAMED_TOPOLOGIES, pausedTopologies, ProcessingMode.AT_LEAST_ONCE);
 
         final Task mockTask1 = createMockTask(TOPOLOGY1);
         final Task mockTask2 = createMockTask(TOPOLOGY2);
@@ -77,8 +78,7 @@ public class TaskExecutionMetadataTest {
         final Set<String> pausedTopologies = new HashSet<>();
         pausedTopologies.add(TOPOLOGY1);
 
-        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(NAMED_TOPOLOGIES,
-            pausedTopologies);
+        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(NAMED_TOPOLOGIES, pausedTopologies, ProcessingMode.AT_LEAST_ONCE);
 
         final Task mockTask1 = createMockTask(TOPOLOGY1);
         final Task mockTask2 = createMockTask(TOPOLOGY2);
@@ -95,8 +95,7 @@ public class TaskExecutionMetadataTest {
     public void testNamedTopologiesCanBackoff() {
         final Set<String> pausedTopologies = new HashSet<>();
 
-        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(NAMED_TOPOLOGIES,
-            pausedTopologies);
+        final TaskExecutionMetadata metadata = new TaskExecutionMetadata(NAMED_TOPOLOGIES, pausedTopologies, ProcessingMode.AT_LEAST_ONCE);
 
         final Task mockTask1 = createMockTask(TOPOLOGY1);
         final Task mockTask2 = createMockTask(TOPOLOGY2);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
@@ -28,10 +27,10 @@ public class TaskExecutorTest {
     @Test
     public void testPunctuateWithPause() {
         final Tasks tasks = mock(Tasks.class);
+        final TaskManager taskManager = mock(TaskManager.class);
         final TaskExecutionMetadata metadata = mock(TaskExecutionMetadata.class);
 
-        final TaskExecutor taskExecutor =
-            new TaskExecutor(tasks, metadata, ProcessingMode.AT_LEAST_ONCE, false, new LogContext());
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
 
         taskExecutor.punctuate();
         verify(tasks).activeTasks();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -3198,7 +3198,7 @@ public class TaskManagerTest {
             .andReturn(singletonList(activeTask));
         activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(taskId00);
         expectLastCall().anyTimes();
-        activeTask.closeCleanAndRecycleState();
+        activeTask.recycleAndConvert();
         expectLastCall().once();
 
         expect(standbyTaskCreator.createStandbyTaskFromActive(anyObject(), eq(taskId00Partitions)))
@@ -3222,7 +3222,7 @@ public class TaskManagerTest {
         expectLastCall().anyTimes();
         standbyTask.postCommit(true);
         expectLastCall().anyTimes();
-        standbyTask.closeCleanAndRecycleState();
+        standbyTask.recycleAndConvert();
         expectLastCall().once();
 
         final StreamTask activeTask = mock(StreamTask.class);
@@ -3434,7 +3434,7 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void closeCleanAndRecycleState() {
+        public void recycleAndConvert() {
             transitionTo(State.CLOSED);
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -28,10 +28,7 @@ import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public class TasksTest {
 
@@ -42,41 +39,10 @@ public class TasksTest {
     private final static TaskId TASK_1_0 = new TaskId(1, 0);
 
     private final LogContext logContext = new LogContext();
-    private final ActiveTaskCreator activeTaskCreator = mock(ActiveTaskCreator.class);
-    private final StandbyTaskCreator standbyTaskCreator = mock(StandbyTaskCreator.class);
 
     @Test
-    public void shouldCreateTasksWithStateUpdater() {
-        final Tasks tasks = new Tasks(logContext, activeTaskCreator, standbyTaskCreator);
-        final StreamTask statefulTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).build();
-        final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_1)).build();
-        final StreamTask statelessTask = statelessTask(TASK_1_0).build();
-
-        tasks.addNewActiveTasks(mkSet(statefulTask, statelessTask));
-        tasks.addNewStandbyTasks(Collections.singletonList(standbyTask));
-
-        final Exception exceptionForStatefulTaskOnTask = assertThrows(IllegalStateException.class, () -> tasks.task(statefulTask.id()));
-        assertEquals("Task unknown: " + statefulTask.id(), exceptionForStatefulTaskOnTask.getMessage());
-        assertFalse(tasks.activeTasks().contains(statefulTask));
-        assertFalse(tasks.allTasks().contains(statefulTask));
-        final Exception exceptionForStatefulTaskOnTasks = assertThrows(IllegalStateException.class, () -> tasks.tasks(mkSet(statefulTask.id())));
-        assertEquals("Task unknown: " + statefulTask.id(), exceptionForStatefulTaskOnTasks.getMessage());
-        final Exception exceptionForStatelessTaskOnTask = assertThrows(IllegalStateException.class, () -> tasks.task(statelessTask.id()));
-        assertEquals("Task unknown: " + statelessTask.id(), exceptionForStatelessTaskOnTask.getMessage());
-        assertFalse(tasks.activeTasks().contains(statelessTask));
-        assertFalse(tasks.allTasks().contains(statelessTask));
-        final Exception exceptionForStatelessTaskOnTasks = assertThrows(IllegalStateException.class, () -> tasks.tasks(mkSet(statelessTask.id())));
-        assertEquals("Task unknown: " + statelessTask.id(), exceptionForStatelessTaskOnTasks.getMessage());
-        final Exception exceptionForStandbyTaskOnTask = assertThrows(IllegalStateException.class, () -> tasks.task(standbyTask.id()));
-        assertEquals("Task unknown: " + standbyTask.id(), exceptionForStandbyTaskOnTask.getMessage());
-        assertFalse(tasks.allTasks().contains(standbyTask));
-        final Exception exceptionForStandByTaskOnTasks = assertThrows(IllegalStateException.class, () -> tasks.tasks(mkSet(standbyTask.id())));
-        assertEquals("Task unknown: " + standbyTask.id(), exceptionForStandByTaskOnTasks.getMessage());
-    }
-
-    @Test
-    public void shouldCreateTasksWithoutStateUpdater() {
-        final Tasks tasks = new Tasks(logContext, activeTaskCreator, standbyTaskCreator);
+    public void shouldCreateTasks() {
+        final Tasks tasks = new Tasks(logContext);
         final StreamTask statefulTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_1)).build();
         final StreamTask statelessTask = statelessTask(TASK_1_0).build();


### PR DESCRIPTION
1. Consolidate the task recycle procedure into a single function within the task. The current procedure now becomes: a) task.recycleStateAndConvert, at end of it the task is in `closed` while its stateManager is retained, and the manager type has been converted; 2) create the new task with old task's fields and the stateManager inside the creators.
2. Move the task execution related metadata into the corresponding `TaskExecutionMetadata` class, including the task idle related metadata (e.g. successfully processed tasks); reduce the number of params needed for `TaskExecutor` as well as `Tasks`.
3. Move the task execution related fields (embedded producer and consumer) and task creators out of `Tasks` and migrated into `TaskManager`. Now the `Tasks` is only a bookkeeping place without any task mutation logic.
4. When adding tests, I realized that we should not add task to state updater right after creation, since it was not initialized yet, while state updater would validate that the task's state is already `restoring / running`. So I updated that logic while adding unit tests.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
