### PR TITLE
KAFKA-14107: Upgrade Jetty version for CVE fixes

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jacksonDatabind: "2.13.3",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",
-  jetty: "9.4.44.v20210927",
+  jetty: "9.4.48.v20220622",
   jersey: "2.34",
   jline: "3.21.0",
   jmh: "1.35",


### PR DESCRIPTION
KAFKA-14107 Upgrade Jetty for CVE fixes.

Jetty: [CVE-2022-2048](https://nvd.nist.gov/vuln/detail/CVE-2022-2048)
and [CVE-2022-2047](https://nvd.nist.gov/vuln/detail/CVE-2022-2047)
- Fixed by upgrading to 9.4.48.v20220622

Signed-off-by: Andrew Borley <BORLEY@uk.ibm.com>
