### PR TITLE
KAFKA-10199: Bookkeep tasks during assignment for use with state updater

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -63,6 +63,11 @@ class Tasks {
 
     private final Set<Task> pendingTasksToRestore = new HashSet<>();
 
+    private final Set<TaskId> pendingActiveTasksToRecycle = new HashSet<>();
+    private final Set<TaskId> pendingStandbyTasksToRecycle = new HashSet<>();
+    private final Set<TaskId> pendingTasksThatNeedInputPartitionUpdate = new HashSet<>();
+    private final Set<TaskId> pendingTasksToClose = new HashSet<>();
+
     // TODO: change type to `StreamTask`
     private final Map<TopicPartition, Task> activeTasksPerPartition = new HashMap<>();
 
@@ -81,6 +86,22 @@ class Tasks {
 
     void addPendingStandbyTasks(final Map<TaskId, Set<TopicPartition>> pendingTasks) {
         pendingStandbyTasksToCreate.putAll(pendingTasks);
+    }
+
+    void addPendingActiveTaskToRecycle(final TaskId taskId) {
+        pendingActiveTasksToRecycle.add(taskId);
+    }
+
+    void addPendingStandbyTaskToRecycle(final TaskId taskId) {
+        pendingStandbyTasksToRecycle.add(taskId);
+    }
+
+    void addPendingTaskThatNeedsInputPartitionsUpdate(final TaskId taskId) {
+        pendingTasksThatNeedInputPartitionUpdate.add(taskId);
+    }
+
+    void addPendingTaskToClose(final TaskId taskId) {
+        pendingTasksToClose.add(taskId);
     }
 
     void addPendingTaskToRestore(final Collection<Task> tasks) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -757,7 +757,7 @@ public class StreamThreadTest {
             topologyMetadata,
             null,
             null,
-            config
+            null
         ) {
             @Override
             int commit(final Collection<Task> tasksToCommit) {
@@ -860,7 +860,7 @@ public class StreamThreadTest {
             topologyMetadata,
             null,
             null,
-            config
+            null
         ) {
             @Override
             int commit(final Collection<Task> tasksToCommit) {

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -282,29 +282,6 @@ public final class StreamsTestUtils {
                 .anyMatch(caller -> "org.apache.kafka.streams.internals.ApiUtils".equals(caller.getClassName()) && "checkSupplier".equals(caller.getMethodName()));
     }
 
-    public static StreamTask createStatefulTask(final TaskId taskId,
-                                                final Set<TopicPartition> changelogPartitions) {
-        final StreamTask task = mock(StreamTask.class);
-        setupStatefulTask(task, taskId, changelogPartitions);
-        when(task.isActive()).thenReturn(true);
-        return task;
-    }
-
-    public static StandbyTask createStandbyTask(final TaskId taskId,
-                                                final Set<TopicPartition> changelogPartitions) {
-        final StandbyTask task = mock(StandbyTask.class);
-        setupStatefulTask(task, taskId, changelogPartitions);
-        when(task.isActive()).thenReturn(false);
-        return task;
-    }
-
-    private static void setupStatefulTask(final Task task,
-                                          final TaskId taskId,
-                                          final Set<TopicPartition> changelogPartitions) {
-        when(task.changelogPartitions()).thenReturn(changelogPartitions);
-        when(task.id()).thenReturn(taskId);
-    }
-
     public static class TaskBuilder<T extends Task> {
         private final T task;
 


### PR DESCRIPTION
Bookkeeps tasks to be recycled, closed, and updated during handling of
the assignment. The bookkeeping is needed for integrating the
state updater.

These change is hidden behind internal config STATE_UPDATER_ENABLED.
If the config is false Streams should not use the state updater
and behave as usual.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
