### PR TITLE
KAFKA-14101: Improve documentation for consuming from embedded Kafka cluster topics in Connect integration testing framework

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
@@ -88,23 +88,23 @@ public class IdentityReplicationIntegrationTest extends MirrorConnectorsIntegrat
                 "topic config was not synced");
         createAndTestNewTopicWithConfigFilter();
 
-        assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
                 "Records were not produced to primary cluster.");
-        assertEquals(NUM_RECORDS_PRODUCED, backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED, backup.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
                 "Records were not replicated to backup cluster.");
 
-        assertTrue(primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
+        assertTrue(primary.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
                 "Heartbeats were not emitted to primary cluster.");
-        assertTrue(backup.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
+        assertTrue(backup.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
                 "Heartbeats were not emitted to backup cluster.");
-        assertTrue(backup.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "primary.heartbeats").count() > 0,
+        assertTrue(backup.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "primary.heartbeats").count() > 0,
                 "Heartbeats were not replicated downstream to backup cluster.");
-        assertTrue(primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
+        assertTrue(primary.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
                 "Heartbeats were not replicated downstream to primary cluster.");
 
         assertTrue(backupClient.upstreamClusters().contains(PRIMARY_CLUSTER_ALIAS), "Did not find upstream primary cluster.");
         assertEquals(1, backupClient.replicationHops(PRIMARY_CLUSTER_ALIAS), "Did not calculate replication hops correctly.");
-        assertTrue(backup.kafka().consume(1, CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0,
+        assertTrue(backup.kafka().consumeAtLeast(1, CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0,
                 "Checkpoints were not emitted downstream to backup cluster.");
 
         Map<TopicPartition, OffsetAndMetadata> backupOffsets = backupClient.remoteConsumerOffsets(consumerGroupName, PRIMARY_CLUSTER_ALIAS,
@@ -138,9 +138,9 @@ public class IdentityReplicationIntegrationTest extends MirrorConnectorsIntegrat
         produceMessages(primary, "test-topic-2", 1);
 
         // expect total consumed messages equals to NUM_RECORDS_PER_PARTITION
-        assertEquals(NUM_RECORDS_PER_PARTITION, primary.kafka().consume(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-2").count(),
+        assertEquals(NUM_RECORDS_PER_PARTITION, primary.kafka().consumeAtLeast(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-2").count(),
                 "Records were not produced to primary cluster.");
-        assertEquals(NUM_RECORDS_PER_PARTITION, backup.kafka().consume(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "test-topic-2").count(),
+        assertEquals(NUM_RECORDS_PER_PARTITION, backup.kafka().consumeAtLeast(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "test-topic-2").count(),
                 "New topic was not replicated to backup cluster.");
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -266,34 +266,34 @@ public class MirrorConnectorsIntegrationBaseTest {
                 "topic config was not synced");
         createAndTestNewTopicWithConfigFilter();
 
-        assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
             "Records were not produced to primary cluster.");
-        assertEquals(NUM_RECORDS_PRODUCED, backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED, backup.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1").count(),
             "Records were not replicated to backup cluster.");
-        assertEquals(NUM_RECORDS_PRODUCED, backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED, backup.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count(),
             "Records were not produced to backup cluster.");
-        assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED, primary.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1").count(),
             "Records were not replicated to primary cluster.");
         
-        assertEquals(NUM_RECORDS_PRODUCED * 2, primary.kafka().consume(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1", "test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED * 2, primary.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1", "test-topic-1").count(),
             "Primary cluster doesn't have all records from both clusters.");
-        assertEquals(NUM_RECORDS_PRODUCED * 2, backup.kafka().consume(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1", "test-topic-1").count(),
+        assertEquals(NUM_RECORDS_PRODUCED * 2, backup.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1", "test-topic-1").count(),
             "Backup cluster doesn't have all records from both clusters.");
         
-        assertTrue(primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
+        assertTrue(primary.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
             "Heartbeats were not emitted to primary cluster.");
-        assertTrue(backup.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
+        assertTrue(backup.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0,
             "Heartbeats were not emitted to backup cluster.");
-        assertTrue(backup.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "primary.heartbeats").count() > 0,
+        assertTrue(backup.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "primary.heartbeats").count() > 0,
             "Heartbeats were not replicated downstream to backup cluster.");
-        assertTrue(primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "backup.heartbeats").count() > 0,
+        assertTrue(primary.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "backup.heartbeats").count() > 0,
             "Heartbeats were not replicated downstream to primary cluster.");
         
         assertTrue(backupClient.upstreamClusters().contains(PRIMARY_CLUSTER_ALIAS), "Did not find upstream primary cluster.");
         assertEquals(1, backupClient.replicationHops(PRIMARY_CLUSTER_ALIAS), "Did not calculate replication hops correctly.");
         assertTrue(primaryClient.upstreamClusters().contains(BACKUP_CLUSTER_ALIAS), "Did not find upstream backup cluster.");
         assertEquals(1, primaryClient.replicationHops(BACKUP_CLUSTER_ALIAS), "Did not calculate replication hops correctly.");
-        assertTrue(backup.kafka().consume(1, CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0,
+        assertTrue(backup.kafka().consumeAtLeast(1, CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0,
             "Checkpoints were not emitted downstream to backup cluster.");
 
         Map<TopicPartition, OffsetAndMetadata> backupOffsets = backupClient.remoteConsumerOffsets(consumerGroupName, PRIMARY_CLUSTER_ALIAS,
@@ -312,7 +312,7 @@ public class MirrorConnectorsIntegrationBaseTest {
             assertTrue(primaryConsumer.position(new TopicPartition("primary.test-topic-1", 0)) > 0, "Consumer failedover to zero offset.");
             assertTrue(primaryConsumer.position(
                 new TopicPartition("primary.test-topic-1", 0)) <= NUM_RECORDS_PRODUCED, "Consumer failedover beyond expected offset.");
-            assertTrue(primary.kafka().consume(1, CHECKPOINT_DURATION_MS, "backup.checkpoints.internal").count() > 0,
+            assertTrue(primary.kafka().consumeAtLeast(1, CHECKPOINT_DURATION_MS, "backup.checkpoints.internal").count() > 0,
                 "Checkpoints were not emitted upstream to primary cluster.");
         }
 
@@ -350,14 +350,14 @@ public class MirrorConnectorsIntegrationBaseTest {
         produceMessages(backup, "test-topic-3", 1);
         
         // expect total consumed messages equals to NUM_RECORDS_PER_PARTITION
-        assertEquals(NUM_RECORDS_PER_PARTITION, primary.kafka().consume(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-2").count(),
+        assertEquals(NUM_RECORDS_PER_PARTITION, primary.kafka().consumeAtLeast(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-2").count(),
             "Records were not produced to primary cluster.");
-        assertEquals(NUM_RECORDS_PER_PARTITION, backup.kafka().consume(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-3").count(),
+        assertEquals(NUM_RECORDS_PER_PARTITION, backup.kafka().consumeAtLeast(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-3").count(),
             "Records were not produced to backup cluster.");
 
-        assertEquals(NUM_RECORDS_PER_PARTITION, primary.kafka().consume(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "backup.test-topic-3").count(),
+        assertEquals(NUM_RECORDS_PER_PARTITION, primary.kafka().consumeAtLeast(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "backup.test-topic-3").count(),
             "New topic was not replicated to primary cluster.");
-        assertEquals(NUM_RECORDS_PER_PARTITION, backup.kafka().consume(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "primary.test-topic-2").count(),
+        assertEquals(NUM_RECORDS_PER_PARTITION, backup.kafka().consumeAtLeast(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "primary.test-topic-2").count(),
             "New topic was not replicated to backup cluster.");
     }
     

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -217,6 +217,9 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
         if (failed) {
             log.debug("Skipping final offset commit as task has failed");
             return;
+        } else if (isCancelled()) {
+            log.debug("Skipping final offset commit as task has been cancelled and its producer has already been closed");
+            return;
         }
 
         // It should be safe to commit here even if we were in the middle of retrying on RetriableExceptions in the

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -218,7 +218,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
             log.debug("Skipping final offset commit as task has failed");
             return;
         } else if (isCancelled()) {
-            log.debug("Skipping final offset commit as task has been cancelled and its producer has already been closed");
+            log.debug("Skipping final offset commit as task has been cancelled");
             return;
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -128,7 +128,7 @@ public class ErrorHandlingIntegrationTest {
         props.put(DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, "true");
         props.put(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
 
-        // tolerate all erros
+        // tolerate all errors
         props.put(ERRORS_TOLERANCE_CONFIG, "all");
 
         // retry for up to one second
@@ -180,7 +180,6 @@ public class ErrorHandlingIntegrationTest {
         connect.deleteConnector(CONNECTOR_NAME);
         connect.assertions().assertConnectorAndTasksAreStopped(CONNECTOR_NAME,
                 "Connector tasks did not stop in time.");
-
     }
 
     @Test
@@ -205,7 +204,7 @@ public class ErrorHandlingIntegrationTest {
         props.put(DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, "true");
         props.put(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
 
-        // tolerate all erros
+        // tolerate all errors
         props.put(ERRORS_TOLERANCE_CONFIG, "all");
 
         // retry for up to one second

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -153,7 +153,7 @@ public class ErrorHandlingIntegrationTest {
         // consume all records from test topic
         log.info("Consuming records from test topic");
         int i = 0;
-        for (ConsumerRecord<byte[], byte[]> rec : connect.kafka().consume(NUM_RECORDS_PRODUCED, CONSUME_MAX_DURATION_MS, "test-topic")) {
+        for (ConsumerRecord<byte[], byte[]> rec : connect.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, CONSUME_MAX_DURATION_MS, "test-topic")) {
             String k = new String(rec.key());
             String v = new String(rec.value());
             log.debug("Consumed record (key='{}', value='{}') from topic {}", k, v, rec.topic());
@@ -167,7 +167,7 @@ public class ErrorHandlingIntegrationTest {
 
         // consume failed records from dead letter queue topic
         log.info("Consuming records from test topic");
-        ConsumerRecords<byte[], byte[]> messages = connect.kafka().consume(EXPECTED_INCORRECT_RECORDS, CONSUME_MAX_DURATION_MS, DLQ_TOPIC);
+        ConsumerRecords<byte[], byte[]> messages = connect.kafka().consumeAtLeast(EXPECTED_INCORRECT_RECORDS, CONSUME_MAX_DURATION_MS, DLQ_TOPIC);
         for (ConsumerRecord<byte[], byte[]> recs : messages) {
             log.debug("Consumed record (key={}, value={}) from dead letter queue topic {}",
                     new String(recs.key()), new String(recs.value()), DLQ_TOPIC);
@@ -230,7 +230,7 @@ public class ErrorHandlingIntegrationTest {
         // consume all records from test topic
         log.info("Consuming records from test topic");
         int i = 0;
-        for (ConsumerRecord<byte[], byte[]> rec : connect.kafka().consume(NUM_RECORDS_PRODUCED, CONSUME_MAX_DURATION_MS, "test-topic")) {
+        for (ConsumerRecord<byte[], byte[]> rec : connect.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, CONSUME_MAX_DURATION_MS, "test-topic")) {
             String k = new String(rec.key());
             String v = new String(rec.value());
             log.debug("Consumed record (key='{}', value='{}') from topic {}", k, v, rec.topic());
@@ -244,7 +244,7 @@ public class ErrorHandlingIntegrationTest {
 
         // consume failed records from dead letter queue topic
         log.info("Consuming records from test topic");
-        ConsumerRecords<byte[], byte[]> messages = connect.kafka().consume(EXPECTED_INCORRECT_RECORDS, CONSUME_MAX_DURATION_MS, DLQ_TOPIC);
+        ConsumerRecords<byte[], byte[]> messages = connect.kafka().consumeAtLeast(EXPECTED_INCORRECT_RECORDS, CONSUME_MAX_DURATION_MS, DLQ_TOPIC);
 
         connect.deleteConnector(CONNECTOR_NAME);
         connect.assertions().assertConnectorAndTasksAreStopped(CONNECTOR_NAME,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -426,7 +426,7 @@ public class ExactlyOnceSourceIntegrationTest {
             lastExpectedOffsetSeqno = nextExpectedOffsetSeqno - lastExpectedOffsetSeqno;
         }
         ConsumerRecords<byte[], byte[]> offsetRecords = connect.kafka()
-                .consume(
+                .consumeAtLeast(
                         expectedOffsetSeqnos.size(),
                         TimeUnit.MINUTES.toMillis(1),
                         consumerProps,
@@ -771,7 +771,7 @@ public class ExactlyOnceSourceIntegrationTest {
 
             // consume at least the expected number of records from the source topic or fail, to ensure that they were correctly produced
             int recordNum = connectorTargetedCluster
-                    .consume(
+                    .consumeAtLeast(
                             recordsProduced,
                             TimeUnit.MINUTES.toMillis(1),
                             Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -433,8 +433,7 @@ public class ExactlyOnceSourceIntegrationTest {
                         offsetsTopic
                 );
 
-        List<Long> actualOffsetSeqnos = new ArrayList<>();
-        offsetRecords.forEach(record -> actualOffsetSeqnos.add(parseAndAssertOffsetForSingleTask(record)));
+        List<Long> actualOffsetSeqnos = parseAndAssertOffsetsForSingleTask(offsetRecords);
 
         assertEquals("Committed offsets should match connector-defined transaction boundaries",
                 expectedOffsetSeqnos, actualOffsetSeqnos.subList(0, expectedOffsetSeqnos.size()));
@@ -768,27 +767,32 @@ public class ExactlyOnceSourceIntegrationTest {
                     recordNum >= recordsProduced);
 
             // also consume from the connector's dedicated offsets topic; just need to read one offset record
-            ConsumerRecord<byte[], byte[]> offsetRecord = connectorTargetedCluster
-                    .consume(
-                            1,
+            ConsumerRecords<byte[], byte[]> offsetRecords = connectorTargetedCluster
+                    .consumeAll(
                             TimeUnit.MINUTES.toMillis(1),
                             Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
+                            null,
                             offsetsTopic
-                    ).iterator().next();
-            long seqno = parseAndAssertOffsetForSingleTask(offsetRecord);
-            assertEquals("Offset commits should occur on connector-defined poll boundaries, which happen every " + recordsProduced + " records",
-                    0, seqno % recordsProduced);
+                    );
+            List<Long> seqnos = parseAndAssertOffsetsForSingleTask(offsetRecords);
+            seqnos.forEach(seqno ->
+                assertEquals("Offset commits should occur on connector-defined poll boundaries, which happen every " + recordsProduced + " records",
+                        0, seqno % recordsProduced)
+            );
 
             // also consume from the cluster's global offsets topic; again, just need to read one offset record
-            offsetRecord = connect.kafka()
-                    .consume(
-                            1,
+            offsetRecords = connect.kafka()
+                    .consumeAll(
                             TimeUnit.MINUTES.toMillis(1),
+                            null,
+                            null,
                             globalOffsetsTopic
-                    ).iterator().next();
-            seqno = parseAndAssertOffsetForSingleTask(offsetRecord);
-            assertEquals("Offset commits should occur on connector-defined poll boundaries, which happen every " + recordsProduced + " records",
-                    0, seqno % recordsProduced);
+                    );
+            seqnos = parseAndAssertOffsetsForSingleTask(offsetRecords);
+            seqnos.forEach(seqno ->
+                assertEquals("Offset commits should occur on connector-defined poll boundaries, which happen every " + recordsProduced + " records",
+                        0, seqno % recordsProduced)
+            );
 
             // Shut down the whole cluster
             connect.workers().forEach(connect::removeWorker);
@@ -826,15 +830,22 @@ public class ExactlyOnceSourceIntegrationTest {
             assertConnectorStopped(connectorStop);
 
             // consume all records from the source topic or fail, to ensure that they were correctly produced
-            ConsumerRecords<byte[], byte[]> records = connectorTargetedCluster.consumeAll(
+            ConsumerRecords<byte[], byte[]> sourceRecords = connectorTargetedCluster.consumeAll(
                     CONSUME_RECORDS_TIMEOUT_MS,
                     Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
                     null,
                     topic
             );
-            assertTrue("Not enough records produced by source connector. Expected at least: " + recordsProduced + " + but got " + records.count(),
-                    records.count() >= recordsProduced);
-            assertExactlyOnceSeqnos(records, numTasks);
+            assertTrue("Not enough records produced by source connector. Expected at least: " + recordsProduced + " + but got " + sourceRecords.count(),
+                    sourceRecords.count() >= recordsProduced);
+            // also have to check which offsets have actually been committed, since we no longer have exactly-once guarantees
+            offsetRecords = connectorTargetedCluster.consumeAll(
+                    CONSUME_RECORDS_TIMEOUT_MS,
+                    Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
+                    null,
+                    offsetsTopic
+            );
+            assertAtLeastOnceSeqnos(sourceRecords, offsetRecords, numTasks);
         }
     }
 
@@ -891,27 +902,10 @@ public class ExactlyOnceSourceIntegrationTest {
                 .orElseThrow(() -> new AssertionError("Failed to find configuration validation result for property '" + property + "'"));
     }
 
-    @SuppressWarnings("unchecked")
-    private long parseAndAssertOffsetForSingleTask(ConsumerRecord<byte[], byte[]> offsetRecord) {
-        JsonConverter offsetsConverter = new JsonConverter();
-        // The JSON converter behaves identically for keys and values. If that ever changes, we may need to update this test to use
-        // separate converter instances.
-
-        offsetsConverter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false"), false);
-        Object keyObject = offsetsConverter.toConnectData("topic name is not used by converter", offsetRecord.key()).value();
-        Object valueObject = offsetsConverter.toConnectData("topic name is not used by converter", offsetRecord.value()).value();
-
-        assertNotNull("Offset value should not be null", valueObject);
-
-        assertEquals("Serialized source partition should match expected format",
-                Arrays.asList(CONNECTOR_NAME, MonitorableSourceConnector.sourcePartition(MonitorableSourceConnector.taskId(CONNECTOR_NAME, 0))),
-                keyObject);
-
-        Map<String, Object> value = assertAndCast(valueObject, Map.class, "Value");
-
-        Object seqnoObject = value.get("saved");
-        assertNotNull("Serialized source offset should contain 'seqno' field from MonitorableSourceConnector", seqnoObject);
-        return assertAndCast(seqnoObject, Long.class, "Seqno offset field");
+    private List<Long> parseAndAssertOffsetsForSingleTask(ConsumerRecords<byte[], byte[]> offsetRecords) {
+        Map<Integer, List<Long>> parsedOffsets = parseOffsetForTasks(offsetRecords);
+        assertEquals("Expected records to only be produced from a single task", Collections.singleton(0), parsedOffsets.keySet());
+        return parsedOffsets.get(0);
     }
 
     private List<Long> parseAndAssertValuesForSingleTask(ConsumerRecords<byte[], byte[]> sourceRecords) {
@@ -922,6 +916,25 @@ public class ExactlyOnceSourceIntegrationTest {
 
     private void assertExactlyOnceSeqnos(ConsumerRecords<byte[], byte[]> sourceRecords, int numTasks) {
         Map<Integer, List<Long>> parsedValues = parseValuesForTasks(sourceRecords);
+        assertSeqnos(parsedValues, numTasks);
+    }
+
+    private void assertAtLeastOnceSeqnos(ConsumerRecords<byte[], byte[]> sourceRecords, ConsumerRecords<byte[], byte[]> offsetRecords, int numTasks) {
+        Map<Integer, List<Long>> parsedValues = parseValuesForTasks(sourceRecords);
+        Map<Integer, Long> lastCommittedValues = parseOffsetForTasks(offsetRecords)
+                .entrySet().stream().collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> Collections.max(e.getValue())
+                ));
+        parsedValues.replaceAll((task, values) -> {
+            Long committedValue = lastCommittedValues.get(task);
+            assertNotNull("No committed offset found for task " + task, committedValue);
+            return values.stream().filter(v -> v <= committedValue).collect(Collectors.toList());
+        });
+        assertSeqnos(parsedValues, numTasks);
+    }
+
+    private void assertSeqnos(Map<Integer, List<Long>> parsedValues, int numTasks) {
         Set<Integer> expectedKeys = IntStream.range(0, numTasks).boxed().collect(Collectors.toSet());
         assertEquals("Expected records to be produced by each task", expectedKeys, parsedValues.keySet());
 
@@ -930,10 +943,19 @@ public class ExactlyOnceSourceIntegrationTest {
             // which makes in-order consumption impossible
             Set<Long> expectedSeqnos = LongStream.range(1, seqnos.size() + 1).boxed().collect(Collectors.toSet());
             Set<Long> actualSeqnos = new HashSet<>(seqnos);
-            assertEquals(
-                    "Seqnos for task " + taskId + " should start at 1 and increase strictly by 1 with each record",
-                    expectedSeqnos,
-                    actualSeqnos
+
+            Set<Long> missingSeqnos = new HashSet<>(expectedSeqnos);
+            missingSeqnos.removeAll(actualSeqnos);
+            Set<Long> extraSeqnos = new HashSet<>(actualSeqnos);
+            extraSeqnos.removeAll(expectedSeqnos);
+
+            // Try to provide the most friendly error message possible if this test fails
+            assertTrue(
+                    "Seqnos for task " + taskId + " should start at 1 and increase strictly by 1 with each record, " +
+                            "but the actual seqnos did not.\n" +
+                            "Seqnos that should have been emitted but were not: " + missingSeqnos + "\n" +
+                            "seqnos that should not have been emitted but were: " + extraSeqnos,
+                    missingSeqnos.isEmpty() && extraSeqnos.isEmpty()
             );
         });
     }
@@ -977,6 +999,54 @@ public class ExactlyOnceSourceIntegrationTest {
             }
 
             result.computeIfAbsent(taskId, t -> new ArrayList<>()).add(seqno);
+        }
+        return result;
+    }
+
+    private Map<Integer, List<Long>> parseOffsetForTasks(ConsumerRecords<byte[], byte[]> offsetRecords) {
+        JsonConverter offsetsConverter = new JsonConverter();
+        // The JSON converter behaves identically for keys and values. If that ever changes, we may need to update this test to use
+        // separate converter instances.
+        offsetsConverter.configure(Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false"), false);
+
+        Map<Integer, List<Long>> result = new HashMap<>();
+        for (ConsumerRecord<byte[], byte[]> offsetRecord : offsetRecords) {
+            Object keyObject = offsetsConverter.toConnectData("topic name is not used by converter", offsetRecord.key()).value();
+            Object valueObject = offsetsConverter.toConnectData("topic name is not used by converter", offsetRecord.value()).value();
+
+            assertNotNull("Offset key should not be null", keyObject);
+            assertNotNull("Offset value should not be null", valueObject);
+
+            @SuppressWarnings("unchecked")
+            List<Object> key = assertAndCast(keyObject, List.class, "Key");
+            assertEquals(
+                    "Offset topic key should be a list containing two elements: the name of the connector, and the connector-provided source partition",
+                    2,
+                    key.size()
+            );
+            assertEquals(CONNECTOR_NAME, key.get(0));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> partition = assertAndCast(key.get(1), Map.class, "Key[1]");
+            Object taskIdObject = partition.get("task.id");
+            assertNotNull("Serialized source partition should contain 'task.id' field from MonitorableSourceConnector", taskIdObject);
+            String taskId = assertAndCast(taskIdObject, String.class, "task ID");
+            assertTrue("task ID should match pattern '<connectorName>-<taskId>", taskId.startsWith(CONNECTOR_NAME + "-"));
+            String taskIdRemainder = taskId.substring(CONNECTOR_NAME.length() + 1);
+            int taskNum;
+            try {
+                taskNum = Integer.parseInt(taskIdRemainder);
+            } catch (NumberFormatException e) {
+                throw new AssertionError("task ID should match pattern '<connectorName>-<taskId>', where <taskId> is an integer", e);
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> value = assertAndCast(valueObject, Map.class, "Value");
+
+            Object seqnoObject = value.get("saved");
+            assertNotNull("Serialized source offset should contain 'seqno' field from MonitorableSourceConnector", seqnoObject);
+            long seqno = assertAndCast(seqnoObject, Long.class, "Seqno offset field");
+
+            result.computeIfAbsent(taskNum, t -> new ArrayList<>()).add(seqno);
         }
         return result;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -157,7 +157,7 @@ public class ExampleConnectIntegrationTest {
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals("Unexpected number of records consumed", NUM_RECORDS_PRODUCED,
-                connect.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count());
+                connect.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count());
 
         // wait for the connector tasks to consume all records.
         connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
@@ -216,7 +216,7 @@ public class ExampleConnectIntegrationTest {
         connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced
-        int recordNum = connect.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count();
+        int recordNum = connect.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + NUM_RECORDS_PRODUCED + " + but got " + recordNum,
                 recordNum >= NUM_RECORDS_PRODUCED);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -215,7 +215,7 @@ public class ExampleConnectIntegrationTest {
         // wait for the connector tasks to commit enough records
         connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
 
-        // consume all records from the source topic or fail, to ensure that they were correctly produced
+        // consume all expected records from the source topic or fail, to ensure that they were correctly produced
         int recordNum = connect.kafka().consumeAtLeast(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + NUM_RECORDS_PRODUCED + " + but got " + recordNum,
                 recordNum >= NUM_RECORDS_PRODUCED);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -172,7 +172,7 @@ public class MonitorableSourceConnector extends SampleSourceConnector {
             batchSize = Integer.parseInt(props.getOrDefault(MESSAGES_PER_POLL_CONFIG, "1"));
             taskHandle = RuntimeHandles.get().connectorHandle(connectorName).taskHandle(taskId);
             Map<String, Object> offset = Optional.ofNullable(
-                    context.offsetStorageReader().offset(Collections.singletonMap("task.id", taskId)))
+                    context.offsetStorageReader().offset(sourcePartition(taskId)))
                     .orElse(Collections.emptyMap());
             startingSeqno = Optional.ofNullable((Long) offset.get("saved")).orElse(0L);
             seqno = startingSeqno;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -160,7 +160,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         int numRecordsProduced = 100;
         long recordTransferDurationMs = TimeUnit.SECONDS.toMillis(30);
 
-        // consume all records from the source topic or fail, to ensure that they were correctly produced
+        // consume all expected records from the source topic or fail, to ensure that they were correctly produced
         int recordNum = connect.kafka().consumeAtLeast(numRecordsProduced, recordTransferDurationMs, TOPIC_NAME).count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + numRecordsProduced + " + but got " + recordNum,
                 recordNum >= numRecordsProduced);
@@ -181,7 +181,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        // consume all records from the source topic or fail, to ensure that they were correctly produced
+        // consume all expected records from the source topic or fail, to ensure that they were correctly produced
         recordNum = connect.kafka().consumeAtLeast(numRecordsProduced, recordTransferDurationMs, anotherTopic).count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + numRecordsProduced + " + but got " + recordNum,
                 recordNum >= numRecordsProduced);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -161,7 +161,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         long recordTransferDurationMs = TimeUnit.SECONDS.toMillis(30);
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced
-        int recordNum = connect.kafka().consume(numRecordsProduced, recordTransferDurationMs, TOPIC_NAME).count();
+        int recordNum = connect.kafka().consumeAtLeast(numRecordsProduced, recordTransferDurationMs, TOPIC_NAME).count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + numRecordsProduced + " + but got " + recordNum,
                 recordNum >= numRecordsProduced);
 
@@ -182,7 +182,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 "Connector tasks did not start in time.");
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced
-        recordNum = connect.kafka().consume(numRecordsProduced, recordTransferDurationMs, anotherTopic).count();
+        recordNum = connect.kafka().consumeAtLeast(numRecordsProduced, recordTransferDurationMs, anotherTopic).count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + numRecordsProduced + " + but got " + recordNum,
                 recordNum >= numRecordsProduced);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -162,9 +162,9 @@ public class TransformationIntegrationTest {
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals("Unexpected number of records consumed", numFooRecords,
-                connect.kafka().consume(numFooRecords, RECORD_TRANSFER_DURATION_MS, fooTopic).count());
+                connect.kafka().consumeAtLeast(numFooRecords, RECORD_TRANSFER_DURATION_MS, fooTopic).count());
         assertEquals("Unexpected number of records consumed", numBarRecords,
-                connect.kafka().consume(numBarRecords, RECORD_TRANSFER_DURATION_MS, barTopic).count());
+                connect.kafka().consumeAtLeast(numBarRecords, RECORD_TRANSFER_DURATION_MS, barTopic).count());
 
         // wait for the connector tasks to consume all records.
         connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
@@ -250,7 +250,7 @@ public class TransformationIntegrationTest {
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals("Unexpected number of records consumed", numRecords,
-                connect.kafka().consume(numRecords, RECORD_TRANSFER_DURATION_MS, topic).count());
+                connect.kafka().consumeAtLeast(numRecords, RECORD_TRANSFER_DURATION_MS, topic).count());
 
         // wait for the connector tasks to consume all records.
         connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
@@ -316,7 +316,7 @@ public class TransformationIntegrationTest {
         connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced
-        for (ConsumerRecord<byte[], byte[]> record : connect.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "test-topic")) {
+        for (ConsumerRecord<byte[], byte[]> record : connect.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "test-topic")) {
             assertNotNull("Expected header to exist",
                     record.headers().lastHeader("header-8"));
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -315,7 +315,7 @@ public class TransformationIntegrationTest {
         // wait for the connector tasks to commit enough records
         connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
 
-        // consume all records from the source topic or fail, to ensure that they were correctly produced
+        // consume a record from the source topic or fail, to ensure that the task could successfully produce
         for (ConsumerRecord<byte[], byte[]> record : connect.kafka().consumeAtLeast(1, RECORD_TRANSFER_DURATION_MS, "test-topic")) {
             assertNotNull("Expected header to exist",
                     record.headers().lastHeader("header-8"));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -444,18 +444,32 @@ public class EmbeddedKafkaCluster {
 
     /**
      * Consume at least n records in a given duration or throw an exception.
+     * <p>
+     * Be cautious when verifying data produced to multi-partition topics, as ordering is only
+     * guaranteed within a single partition. The set of records consumed from multi-partition
+     * topics may be returned in a different order than they were produced in, and may only
+     * contain data from a subset of the partitions on the topic, even if none of the partitions
+     * are empty. If desired, {@link #consumeAll(long, Map, Map, String...)} can be used to
+     * ensure that all currently-available records across all partitions on each topic are read.
      *
      * @param n the number of expected records in this topic.
      * @param maxDuration the max duration to wait for these records (in milliseconds).
      * @param topics the topics to subscribe and consume records from.
      * @return a {@link ConsumerRecords} collection containing at least n records.
      */
-    public ConsumerRecords<byte[], byte[]> consume(int n, long maxDuration, String... topics) {
-        return consume(n, maxDuration, Collections.emptyMap(), topics);
+    public ConsumerRecords<byte[], byte[]> consumeAtLeast(int n, long maxDuration, String... topics) {
+        return consumeAtLeast(n, maxDuration, Collections.emptyMap(), topics);
     }
 
     /**
      * Consume at least n records in a given duration or throw an exception.
+     * <p>
+     * Be cautious when verifying data produced to multi-partition topics, as ordering is only
+     * guaranteed within a single partition. The set of records consumed from multi-partition
+     * topics may be returned in a different order than they were produced in, and may only
+     * contain data from a subset of the partitions on the topic, even if none of the partitions
+     * are empty. If desired, {@link #consumeAll(long, Map, Map, String...)} can be used to
+     * ensure that all currently-available records across all partitions on each topic are read.
      *
      * @param n the number of expected records in this topic.
      * @param maxDuration the max duration to wait for these records (in milliseconds).
@@ -464,7 +478,7 @@ public class EmbeddedKafkaCluster {
      *                      may not be null
      * @return a {@link ConsumerRecords} collection containing at least n records.
      */
-    public ConsumerRecords<byte[], byte[]> consume(int n, long maxDuration, Map<String, Object> consumerProps, String... topics) {
+    public ConsumerRecords<byte[], byte[]> consumeAtLeast(int n, long maxDuration, Map<String, Object> consumerProps, String... topics) {
         Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
         int consumedRecords = 0;
         try (KafkaConsumer<byte[], byte[]> consumer = createConsumerAndSubscribeTo(consumerProps, topics)) {


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14101)

Depends on https://github.com/apache/kafka/pull/12429, which should implement a logical fix for KAFKA-14101. This follow-up PR is intended to help harden our integration tests against the mistakes that caused KAFKA-14101 by:
1. Renaming `EmbeddedKafkaCluster::consume` to `EmbeddedKafkaCluster::consumeAtLeast` in order to clarify behavior and help distinguish between it and `EmbeddedKafkaCluster::consumeAll`.
2. Adding a note to the Javadocs for `EmbeddedKafkaCluster::consumeAtLeast` warning about out-of-order consumption and data missing from topic partitions.

Though ready for review now, this PR should not be merged until https://github.com/apache/kafka/pull/12429 is merged.