### PR TITLE
KAFKA-14114: Adding Metadata Log Processing Error Related Metrics

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -309,13 +309,16 @@ class BrokerServer(
         ))
       }
 
+      // The metrics object for accessing broker related metrics
+      val brokerMetrics = BrokerServerMetrics(metrics)
+
       metadataListener = new BrokerMetadataListener(
         config.nodeId,
         time,
         threadNamePrefix,
         config.metadataSnapshotMaxNewRecordBytes,
         metadataSnapshotter,
-        BrokerServerMetrics(metrics)
+        brokerMetrics
       )
 
       val networkListeners = new ListenerCollection()
@@ -432,7 +435,8 @@ class BrokerServer(
         transactionCoordinator,
         clientQuotaMetadataManager,
         dynamicConfigHandlers.toMap,
-        authorizer)
+        authorizer,
+        brokerMetrics)
 
       // Tell the metadata listener to start publishing its output, and wait for the first
       // publish operation to complete. This first operation will initialize logManager,

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -37,7 +37,7 @@ import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{ClusterResource, Endpoint}
-import org.apache.kafka.controller.{BootstrapMetadata, Controller, QuorumController, QuorumControllerMetrics, QuorumFeatures}
+import org.apache.kafka.controller.{BootstrapMetadata, Controller, ControllerMetrics, QuorumController, QuorumControllerMetrics, QuorumFeatures}
 import org.apache.kafka.metadata.KafkaConfigSchema
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.raft.RaftConfig.AddressSpec
@@ -66,8 +66,9 @@ class ControllerServer(
   val configSchema: KafkaConfigSchema,
   val raftApiVersions: ApiVersions,
   val bootstrapMetadata: BootstrapMetadata,
+  val controllerMetrics: ControllerMetrics,
   val metadataFaultHandler: FaultHandler,
-  val fatalFaultHandler: FaultHandler,
+  val fatalFaultHandler: FaultHandler
 ) extends Logging with KafkaMetricsGroup {
   import kafka.server.Server._
 
@@ -201,7 +202,7 @@ class ControllerServer(
           setSnapshotMaxNewRecordBytes(config.metadataSnapshotMaxNewRecordBytes).
           setLeaderImbalanceCheckIntervalNs(leaderImbalanceCheckIntervalNs).
           setMaxIdleIntervalNs(maxIdleIntervalNs).
-          setMetrics(new QuorumControllerMetrics(KafkaYammerMetrics.defaultRegistry(), time)).
+          setMetrics(controllerMetrics).
           setCreateTopicPolicy(createTopicPolicy.asJava).
           setAlterConfigPolicy(alterConfigPolicy.asJava).
           setConfigurationValidator(new ControllerConfigurationValidator()).

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -116,7 +116,7 @@ class BrokerMetadataListener(
         loadResults
       } catch {
         case e: Throwable =>
-          brokerMetrics.listenerBatchLoadErrorCount.getAndIncrement()
+          brokerMetrics.metadataApplyErrorCount.getAndIncrement()
           throw e
       } finally {
         reader.close()
@@ -175,7 +175,7 @@ class BrokerMetadataListener(
           s"$loadResults")
       } catch {
         case e: Throwable =>
-          brokerMetrics.listenerBatchLoadErrorCount.getAndIncrement()
+          brokerMetrics.metadataApplyErrorCount.getAndIncrement()
           throw e
       } finally {
         reader.close()

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -114,6 +114,11 @@ class BrokerMetadataListener(
           debug(s"Loaded new commits: $loadResults")
         }
         loadResults
+      } catch {
+        case e: Throwable =>
+          brokerMetrics.listenerBatchLoadErrorCount.getAndIncrement()
+          log.error(e.toString)
+          BatchLoadResults(0, 0, 0, 0)
       } finally {
         reader.close()
       }
@@ -169,6 +174,10 @@ class BrokerMetadataListener(
         _delta.finishSnapshot()
         info(s"Loaded snapshot ${reader.snapshotId().offset}-${reader.snapshotId().epoch}: " +
           s"$loadResults")
+      } catch {
+        case e: Throwable =>
+          brokerMetrics.listenerBatchLoadErrorCount.getAndIncrement()
+          log.error(e.toString)
       } finally {
         reader.close()
       }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -117,8 +117,7 @@ class BrokerMetadataListener(
       } catch {
         case e: Throwable =>
           brokerMetrics.listenerBatchLoadErrorCount.getAndIncrement()
-          log.error(e.toString)
-          BatchLoadResults(0, 0, 0, 0)
+          throw e
       } finally {
         reader.close()
       }
@@ -177,7 +176,7 @@ class BrokerMetadataListener(
       } catch {
         case e: Throwable =>
           brokerMetrics.listenerBatchLoadErrorCount.getAndIncrement()
-          log.error(e.toString)
+          throw e
       } finally {
         reader.close()
       }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -116,7 +116,7 @@ class BrokerMetadataListener(
         loadResults
       } catch {
         case e: Throwable =>
-          brokerMetrics.metadataApplyErrorCount.getAndIncrement()
+          brokerMetrics.metadataLoadErrorCount.getAndIncrement()
           throw e
       } finally {
         reader.close()
@@ -175,7 +175,7 @@ class BrokerMetadataListener(
           s"$loadResults")
       } catch {
         case e: Throwable =>
-          brokerMetrics.metadataApplyErrorCount.getAndIncrement()
+          brokerMetrics.metadataLoadErrorCount.getAndIncrement()
           throw e
       } finally {
         reader.close()

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -102,7 +102,8 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
                               txnCoordinator: TransactionCoordinator,
                               clientQuotaMetadataManager: ClientQuotaMetadataManager,
                               dynamicConfigHandlers: Map[String, ConfigHandler],
-                              private val _authorizer: Option[Authorizer]) extends MetadataPublisher with Logging {
+                              private val _authorizer: Option[Authorizer],
+                              brokerMetrics: BrokerServerMetrics) extends MetadataPublisher with Logging {
   logIdent = s"[BrokerMetadataPublisher id=${conf.nodeId}] "
 
   import BrokerMetadataPublisher._
@@ -259,6 +260,7 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
       publishedOffsetAtomic.set(newImage.highestOffsetAndEpoch().offset)
     } catch {
       case t: Throwable => error(s"Error publishing broker metadata at $highestOffsetAndEpoch", t)
+        brokerMetrics.publisherErrorCount.getAndIncrement()
         throw t
     } finally {
       _firstPublish = false

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -260,7 +260,7 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
       publishedOffsetAtomic.set(newImage.highestOffsetAndEpoch().offset)
     } catch {
       case t: Throwable => error(s"Error publishing broker metadata at $highestOffsetAndEpoch", t)
-        brokerMetrics.publisherErrorCount.getAndIncrement()
+        brokerMetrics.metadataLoadErrorCount.getAndIncrement()
         throw t
     } finally {
       _firstPublish = false

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -260,7 +260,7 @@ class BrokerMetadataPublisher(conf: KafkaConfig,
       publishedOffsetAtomic.set(newImage.highestOffsetAndEpoch().offset)
     } catch {
       case t: Throwable => error(s"Error publishing broker metadata at $highestOffsetAndEpoch", t)
-        brokerMetrics.metadataLoadErrorCount.getAndIncrement()
+        brokerMetrics.metadataApplyErrorCount.getAndIncrement()
         throw t
     } finally {
       _firstPublish = false

--- a/core/src/main/scala/kafka/server/metadata/BrokerServerMetrics.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerServerMetrics.scala
@@ -28,8 +28,8 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
 
   val lastAppliedRecordOffset: AtomicLong = new AtomicLong(0)
   val lastAppliedRecordTimestamp: AtomicLong = new AtomicLong(0)
-  val publisherErrorCount: AtomicLong = new AtomicLong(0)
-  val listenerBatchLoadErrorCount: AtomicLong = new AtomicLong(0)
+  val metadataLoadErrorCount: AtomicLong = new AtomicLong(0)
+  val metadataApplyErrorCount: AtomicLong = new AtomicLong(0)
 
   val lastAppliedRecordOffsetName = metrics.metricName(
     "last-applied-record-offset",
@@ -49,16 +49,16 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
     "The difference between now and the timestamp of the last record from the cluster metadata partition that was applied by the broker"
   )
 
-  val publisherErrorCountName = metrics.metricName(
-    "publisher-error-count",
+  val metadataLoadErrorCountName = metrics.metricName(
+    "metadata-load-error-count",
     metricGroupName,
-    "The number of errors encountered by the BrokerMetadataPublisher while publishing a new MetadataImage based on the MetadataDelta"
+    "The number of errors encountered by the BrokerMetadataPublisher while publishing a new MetadataImage by loading the latest MetadataDelta"
   )
 
-  val listenerBatchLoadErrorCountName = metrics.metricName(
-    "listener-batch-load-error-count",
+  val metadataApplyErrorCountName = metrics.metricName(
+    "metadata-apply-error-count",
     metricGroupName,
-    "The number of errors encountered by the BrokerMetadataListener while generating a new MetadataDelta based on the log it has received thus far"
+    "The number of errors encountered by the BrokerMetadataListener while generating a new MetadataDelta by applying the log it has received thus far"
   )
 
   addMetric(metrics, lastAppliedRecordOffsetName) { _ =>
@@ -73,12 +73,12 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
     now - lastAppliedRecordTimestamp.get
   }
 
-  addMetric(metrics, publisherErrorCountName) { _ =>
-    publisherErrorCount.get
+  addMetric(metrics, metadataLoadErrorCountName) { _ =>
+    metadataLoadErrorCount.get
   }
 
-  addMetric(metrics, listenerBatchLoadErrorCountName) { _ =>
-    listenerBatchLoadErrorCount.get
+  addMetric(metrics, metadataApplyErrorCountName) { _ =>
+    metadataApplyErrorCount.get
   }
 
   override def close(): Unit = {
@@ -86,8 +86,8 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
       lastAppliedRecordOffsetName,
       lastAppliedRecordTimestampName,
       lastAppliedRecordLagMsName,
-      publisherErrorCountName,
-      listenerBatchLoadErrorCountName
+      metadataLoadErrorCountName,
+      metadataApplyErrorCountName
     ).foreach(metrics.removeMetric)
   }
 }

--- a/core/src/main/scala/kafka/server/metadata/BrokerServerMetrics.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerServerMetrics.scala
@@ -52,13 +52,13 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
   val metadataLoadErrorCountName = metrics.metricName(
     "metadata-load-error-count",
     metricGroupName,
-    "The number of errors encountered by the BrokerMetadataPublisher while publishing a new MetadataImage by loading the latest MetadataDelta"
+    "The number of errors encountered by the BrokerMetadataListener while loading the metadata log and generating a new MetadataDelta based on it."
   )
 
   val metadataApplyErrorCountName = metrics.metricName(
     "metadata-apply-error-count",
     metricGroupName,
-    "The number of errors encountered by the BrokerMetadataListener while generating a new MetadataDelta by applying the log it has received thus far"
+    "The number of errors encountered by the BrokerMetadataPublisher while applying a new MetadataImage based on the latest MetadataDelta."
   )
 
   addMetric(metrics, lastAppliedRecordOffsetName) { _ =>

--- a/core/src/main/scala/kafka/server/metadata/BrokerServerMetrics.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerServerMetrics.scala
@@ -28,6 +28,8 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
 
   val lastAppliedRecordOffset: AtomicLong = new AtomicLong(0)
   val lastAppliedRecordTimestamp: AtomicLong = new AtomicLong(0)
+  val publisherErrorCount: AtomicLong = new AtomicLong(0)
+  val listenerBatchLoadErrorCount: AtomicLong = new AtomicLong(0)
 
   val lastAppliedRecordOffsetName = metrics.metricName(
     "last-applied-record-offset",
@@ -47,6 +49,18 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
     "The difference between now and the timestamp of the last record from the cluster metadata partition that was applied by the broker"
   )
 
+  val publisherErrorCountName = metrics.metricName(
+    "publisher-error-count",
+    metricGroupName,
+    "The number of errors encountered by the BrokerMetadataPublisher while publishing a new MetadataImage based on the MetadataDelta"
+  )
+
+  val listenerBatchLoadErrorCountName = metrics.metricName(
+    "listener-batch-load-error-count",
+    metricGroupName,
+    "The number of errors encountered by the BrokerMetadataListener while generating a new MetadataDelta based on the log it has received thus far"
+  )
+
   addMetric(metrics, lastAppliedRecordOffsetName) { _ =>
     lastAppliedRecordOffset.get
   }
@@ -59,11 +73,21 @@ final class BrokerServerMetrics private (metrics: Metrics) extends AutoCloseable
     now - lastAppliedRecordTimestamp.get
   }
 
+  addMetric(metrics, publisherErrorCountName) { _ =>
+    publisherErrorCount.get
+  }
+
+  addMetric(metrics, listenerBatchLoadErrorCountName) { _ =>
+    listenerBatchLoadErrorCount.get
+  }
+
   override def close(): Unit = {
     List(
       lastAppliedRecordOffsetName,
       lastAppliedRecordTimestampName,
-      lastAppliedRecordLagMsName
+      lastAppliedRecordLagMsName,
+      publisherErrorCountName,
+      listenerBatchLoadErrorCountName
     ).foreach(metrics.removeMetric)
   }
 }

--- a/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
@@ -37,12 +37,14 @@ final class BrokerServerMetricsTest {
     val expectedMetrics = Set(
       new MetricName("last-applied-record-offset", expectedGroup, "", Collections.emptyMap()),
       new MetricName("last-applied-record-timestamp", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("last-applied-record-lag-ms", expectedGroup, "", Collections.emptyMap())
+      new MetricName("last-applied-record-lag-ms", expectedGroup, "", Collections.emptyMap()),
+      new MetricName("publisher-error-count", expectedGroup, "", Collections.emptyMap()),
+      new MetricName("listener-batch-load-error-count", expectedGroup, "", Collections.emptyMap())
     )
      
     TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
       val metricsMap = metrics.metrics().asScala.filter{ case (name, _) => name.group == expectedGroup }
-      assertEquals(3, metricsMap.size)
+      assertEquals(expectedMetrics.size, metricsMap.size)
       metricsMap.foreach { case (name, metric) =>
         assertTrue(expectedMetrics.contains(name))
       }

--- a/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
@@ -38,8 +38,8 @@ final class BrokerServerMetricsTest {
       new MetricName("last-applied-record-offset", expectedGroup, "", Collections.emptyMap()),
       new MetricName("last-applied-record-timestamp", expectedGroup, "", Collections.emptyMap()),
       new MetricName("last-applied-record-lag-ms", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("publisher-error-count", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("listener-batch-load-error-count", expectedGroup, "", Collections.emptyMap())
+      new MetricName("metadata-load-error-count", expectedGroup, "", Collections.emptyMap()),
+      new MetricName("metadata-apply-error-count", expectedGroup, "", Collections.emptyMap())
     )
      
     TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
@@ -89,34 +89,34 @@ final class BrokerServerMetricsTest {
   }
 
   @Test
-  def testPublisherErrorCount(): Unit = {
+  def testMetadataLoadErrorCount(): Unit = {
     val time = new MockTime()
     val metrics = new Metrics(time)
     TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
-      val publisherErrorCountMetric = metrics.metrics().get(brokerMetrics.publisherErrorCount)
+      val metadataLoadErrorCountMetric = metrics.metrics().get(brokerMetrics.metadataLoadErrorCountName)
 
-      assertEquals(0L, publisherErrorCountMetric.metricValue.asInstanceOf[Long])
+      assertEquals(0L, metadataLoadErrorCountMetric.metricValue.asInstanceOf[Long])
 
       // Update metric value and check
       val errorCount = 100
-      brokerMetrics.publisherErrorCount.set(errorCount)
-      assertEquals(errorCount, publisherErrorCountMetric.metricValue.asInstanceOf[Long])
+      brokerMetrics.metadataLoadErrorCount.set(errorCount)
+      assertEquals(errorCount, metadataLoadErrorCountMetric.metricValue.asInstanceOf[Long])
     }
   }
 
   @Test
-  def testListenerBatchLoadCountError(): Unit = {
+  def testMetadataApplyErrorCount(): Unit = {
     val time = new MockTime()
     val metrics = new Metrics(time)
     TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
-      val listenerBatchLoadCountError = metrics.metrics().get(brokerMetrics.listenerBatchLoadErrorCount)
+      val metadataApplyErrorCountMetric = metrics.metrics().get(brokerMetrics.metadataApplyErrorCountName)
 
-      assertEquals(0L, listenerBatchLoadCountError.metricValue.asInstanceOf[Long])
+      assertEquals(0L, metadataApplyErrorCountMetric.metricValue.asInstanceOf[Long])
 
       // Update metric value and check
       val errorCount = 100
-      brokerMetrics.publisherErrorCount.set(errorCount)
-      assertEquals(errorCount, listenerBatchLoadCountError.metricValue.asInstanceOf[Long])
+      brokerMetrics.metadataApplyErrorCount.set(errorCount)
+      assertEquals(errorCount, metadataApplyErrorCountMetric.metricValue.asInstanceOf[Long])
     }
   }
 }

--- a/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
@@ -87,4 +87,36 @@ final class BrokerServerMetricsTest {
       assertEquals(time.milliseconds - timestamp, lagMetric.metricValue.asInstanceOf[Long])
     }
   }
+
+  @Test
+  def testPublisherErrorCount(): Unit = {
+    val time = new MockTime()
+    val metrics = new Metrics(time)
+    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+      val publisherErrorCountMetric = metrics.metrics().get(brokerMetrics.publisherErrorCount)
+
+      assertEquals(0L, publisherErrorCountMetric.metricValue.asInstanceOf[Long])
+
+      // Update metric value and check
+      val errorCount = 100
+      brokerMetrics.publisherErrorCount.set(errorCount)
+      assertEquals(errorCount, publisherErrorCountMetric.metricValue.asInstanceOf[Long])
+    }
+  }
+
+  @Test
+  def testListenerBatchLoadCountError(): Unit = {
+    val time = new MockTime()
+    val metrics = new Metrics(time)
+    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+      val listenerBatchLoadCountError = metrics.metrics().get(brokerMetrics.listenerBatchLoadErrorCount)
+
+      assertEquals(0L, listenerBatchLoadCountError.metricValue.asInstanceOf[Long])
+
+      // Update metric value and check
+      val errorCount = 100
+      brokerMetrics.publisherErrorCount.set(errorCount)
+      assertEquals(errorCount, listenerBatchLoadCountError.metricValue.asInstanceOf[Long])
+    }
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.{Endpoint, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.metadata.{BrokerRegistration, RecordTestUtils, VersionRange}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
+import org.apache.kafka.server.fault.MockFaultHandler
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
@@ -44,7 +45,8 @@ class BrokerMetadataListenerTest {
       threadNamePrefix = None,
       maxBytesBetweenSnapshots = maxBytesBetweenSnapshots,
       snapshotter = snapshotter,
-      brokerMetrics = metrics
+      brokerMetrics = metrics,
+      new MockFaultHandler("BrokerFaultHandler")
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -77,8 +77,8 @@ class BrokerMetadataListenerTest {
       assertEquals(100L, listener.highestMetadataOffset)
       assertEquals(0L, metrics.lastAppliedRecordOffset.get)
       assertEquals(0L, metrics.lastAppliedRecordTimestamp.get)
-      assertEquals(0L, metrics.publisherErrorCount.get)
-      assertEquals(0L, metrics.listenerBatchLoadErrorCount.get)
+      assertEquals(0L, metrics.metadataLoadErrorCount.get)
+      assertEquals(0L, metrics.metadataApplyErrorCount.get)
 
       val fencedTimestamp = 500L
       val fencedLastOffset = 200L
@@ -112,8 +112,8 @@ class BrokerMetadataListenerTest {
 
       assertEquals(fencedLastOffset, metrics.lastAppliedRecordOffset.get)
       assertEquals(fencedTimestamp, metrics.lastAppliedRecordTimestamp.get)
-      assertEquals(0L, metrics.publisherErrorCount.get)
-      assertEquals(0L, metrics.listenerBatchLoadErrorCount.get)
+      assertEquals(0L, metrics.metadataLoadErrorCount.get)
+      assertEquals(0L, metrics.metadataApplyErrorCount.get)
     } finally {
       listener.close()
     }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -77,6 +77,8 @@ class BrokerMetadataListenerTest {
       assertEquals(100L, listener.highestMetadataOffset)
       assertEquals(0L, metrics.lastAppliedRecordOffset.get)
       assertEquals(0L, metrics.lastAppliedRecordTimestamp.get)
+      assertEquals(0L, metrics.publisherErrorCount.get)
+      assertEquals(0L, metrics.listenerBatchLoadErrorCount.get)
 
       val fencedTimestamp = 500L
       val fencedLastOffset = 200L
@@ -110,6 +112,8 @@ class BrokerMetadataListenerTest {
 
       assertEquals(fencedLastOffset, metrics.lastAppliedRecordOffset.get)
       assertEquals(fencedTimestamp, metrics.lastAppliedRecordTimestamp.get)
+      assertEquals(0L, metrics.publisherErrorCount.get)
+      assertEquals(0L, metrics.listenerBatchLoadErrorCount.get)
     } finally {
       listener.close()
     }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -196,7 +196,8 @@ class BrokerMetadataPublisherTest {
         txnCoordinator = broker.transactionCoordinator,
         clientQuotaMetadataManager = broker.clientQuotaMetadataManager,
         dynamicConfigHandlers = broker.dynamicConfigHandlers.toMap,
-        _authorizer = Option.empty
+        _authorizer = Option.empty,
+        null
       ))
       val numTimesReloadCalled = new AtomicInteger(0)
       Mockito.when(publisher.reloadUpdatedFilesWithoutConfigChange(any[Properties]())).

--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
@@ -51,9 +51,9 @@ public interface ControllerMetrics extends AutoCloseable {
 
     int preferredReplicaImbalanceCount();
 
-    void incrementForceRenounceCount();
+    void incrementMetadataErrorCount();
 
-    int forceRenounceCount();
+    int metadataErrorCount();
 
     void setLastAppliedRecordOffset(long offset);
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetrics.java
@@ -51,6 +51,10 @@ public interface ControllerMetrics extends AutoCloseable {
 
     int preferredReplicaImbalanceCount();
 
+    void incrementForceRenounceCount();
+
+    int forceRenounceCount();
+
     void setLastAppliedRecordOffset(long offset);
 
     long lastAppliedRecordOffset();

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -450,7 +450,7 @@ public final class QuorumController implements Controller {
                     "Renouncing leadership and reverting to the last committed offset {}.",
                     name, exception.getClass().getSimpleName(), curClaimEpoch, deltaUs,
                     lastCommittedOffset, exception);
-            controllerMetrics.incrementForceRenounceCount();
+            controllerMetrics.incrementMetadataErrorCount();
             renounce();
         } else {
             log.warn("{}: failed with unknown server exception {} in {} us.  " +

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -450,6 +450,7 @@ public final class QuorumController implements Controller {
                     "Renouncing leadership and reverting to the last committed offset {}.",
                     name, exception.getClass().getSimpleName(), curClaimEpoch, deltaUs,
                     lastCommittedOffset, exception);
+            controllerMetrics.incrementForceRenounceCount();
             renounce();
         } else {
             log.warn("{}: failed with unknown server exception {} in {} us.  " +

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -450,7 +450,6 @@ public final class QuorumController implements Controller {
                     "Renouncing leadership and reverting to the last committed offset {}.",
                     name, exception.getClass().getSimpleName(), curClaimEpoch, deltaUs,
                     lastCommittedOffset, exception);
-            controllerMetrics.incrementMetadataErrorCount();
             renounce();
         } else {
             log.warn("{}: failed with unknown server exception {} in {} us.  " +

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -26,6 +26,7 @@ import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class QuorumControllerMetrics implements ControllerMetrics {
@@ -47,6 +48,8 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         "KafkaController", "OfflinePartitionsCount");
     private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
         "KafkaController", "PreferredReplicaImbalanceCount");
+    private final static MetricName FORCE_RENOUNCE_COUNT = getMetricName(
+            "KafkaController", "ForceRenounceCount");
     private final static MetricName LAST_APPLIED_RECORD_OFFSET = getMetricName(
         "KafkaController", "LastAppliedRecordOffset");
     private final static MetricName LAST_COMMITTED_RECORD_OFFSET = getMetricName(
@@ -64,6 +67,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private volatile int globalPartitionCount;
     private volatile int offlinePartitionCount;
     private volatile int preferredReplicaImbalanceCount;
+    private volatile AtomicInteger forceRenounceCount;
     private final AtomicLong lastAppliedRecordOffset = new AtomicLong(0);
     private final AtomicLong lastCommittedRecordOffset = new AtomicLong(0);
     private final AtomicLong lastAppliedRecordTimestamp = new AtomicLong(0);
@@ -74,6 +78,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final Gauge<Integer> globalTopicCountGauge;
     private final Gauge<Integer> offlinePartitionCountGauge;
     private final Gauge<Integer> preferredReplicaImbalanceCountGauge;
+    private final Gauge<Integer> forceRenounceBrokerCountGauge;
     private final Gauge<Long> lastAppliedRecordOffsetGauge;
     private final Gauge<Long> lastCommittedRecordOffsetGauge;
     private final Gauge<Long> lastAppliedRecordTimestampGauge;
@@ -93,6 +98,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         this.globalPartitionCount = 0;
         this.offlinePartitionCount = 0;
         this.preferredReplicaImbalanceCount = 0;
+        this.forceRenounceCount = new AtomicInteger(0);
         this.activeControllerCount = registry.newGauge(ACTIVE_CONTROLLER_COUNT, new Gauge<Integer>() {
             @Override
             public Integer value() {
@@ -135,6 +141,12 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
             @Override
             public Integer value() {
                 return preferredReplicaImbalanceCount;
+            }
+        });
+        this.forceRenounceBrokerCountGauge = registry.newGauge(FORCE_RENOUNCE_COUNT, new Gauge<Integer>() {
+            @Override
+            public Integer value() {
+                return forceRenounceCount.get();
             }
         });
         lastAppliedRecordOffsetGauge = registry.newGauge(LAST_APPLIED_RECORD_OFFSET, new Gauge<Long>() {
@@ -243,6 +255,15 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     }
 
     @Override
+    public void incrementForceRenounceCount() {
+        this.forceRenounceCount.getAndIncrement();
+    }
+
+    @Override
+    public int forceRenounceCount() {
+        return this.forceRenounceCount.get();
+    }
+    @Override
     public void setLastAppliedRecordOffset(long offset) {
         lastAppliedRecordOffset.set(offset);
     }
@@ -276,12 +297,15 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     public void close() {
         Arrays.asList(
             ACTIVE_CONTROLLER_COUNT,
+            FENCED_BROKER_COUNT,
+            ACTIVE_BROKER_COUNT,
             EVENT_QUEUE_TIME_MS,
             EVENT_QUEUE_PROCESSING_TIME_MS,
             GLOBAL_TOPIC_COUNT,
             GLOBAL_PARTITION_COUNT,
             OFFLINE_PARTITION_COUNT,
             PREFERRED_REPLICA_IMBALANCE_COUNT,
+            FORCE_RENOUNCE_COUNT,
             LAST_APPLIED_RECORD_OFFSET,
             LAST_COMMITTED_RECORD_OFFSET,
             LAST_APPLIED_RECORD_TIMESTAMP,

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumControllerMetrics.java
@@ -48,8 +48,8 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         "KafkaController", "OfflinePartitionsCount");
     private final static MetricName PREFERRED_REPLICA_IMBALANCE_COUNT = getMetricName(
         "KafkaController", "PreferredReplicaImbalanceCount");
-    private final static MetricName FORCE_RENOUNCE_COUNT = getMetricName(
-            "KafkaController", "ForceRenounceCount");
+    private final static MetricName METADATA_ERROR_COUNT = getMetricName(
+            "KafkaController", "MetadataErrorCount");
     private final static MetricName LAST_APPLIED_RECORD_OFFSET = getMetricName(
         "KafkaController", "LastAppliedRecordOffset");
     private final static MetricName LAST_COMMITTED_RECORD_OFFSET = getMetricName(
@@ -67,7 +67,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private volatile int globalPartitionCount;
     private volatile int offlinePartitionCount;
     private volatile int preferredReplicaImbalanceCount;
-    private volatile AtomicInteger forceRenounceCount;
+    private volatile AtomicInteger metadataErrorCount;
     private final AtomicLong lastAppliedRecordOffset = new AtomicLong(0);
     private final AtomicLong lastCommittedRecordOffset = new AtomicLong(0);
     private final AtomicLong lastAppliedRecordTimestamp = new AtomicLong(0);
@@ -78,7 +78,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     private final Gauge<Integer> globalTopicCountGauge;
     private final Gauge<Integer> offlinePartitionCountGauge;
     private final Gauge<Integer> preferredReplicaImbalanceCountGauge;
-    private final Gauge<Integer> forceRenounceBrokerCountGauge;
+    private final Gauge<Integer> metadataErrorCountGauge;
     private final Gauge<Long> lastAppliedRecordOffsetGauge;
     private final Gauge<Long> lastCommittedRecordOffsetGauge;
     private final Gauge<Long> lastAppliedRecordTimestampGauge;
@@ -98,7 +98,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
         this.globalPartitionCount = 0;
         this.offlinePartitionCount = 0;
         this.preferredReplicaImbalanceCount = 0;
-        this.forceRenounceCount = new AtomicInteger(0);
+        this.metadataErrorCount = new AtomicInteger(0);
         this.activeControllerCount = registry.newGauge(ACTIVE_CONTROLLER_COUNT, new Gauge<Integer>() {
             @Override
             public Integer value() {
@@ -143,10 +143,10 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
                 return preferredReplicaImbalanceCount;
             }
         });
-        this.forceRenounceBrokerCountGauge = registry.newGauge(FORCE_RENOUNCE_COUNT, new Gauge<Integer>() {
+        this.metadataErrorCountGauge = registry.newGauge(METADATA_ERROR_COUNT, new Gauge<Integer>() {
             @Override
             public Integer value() {
-                return forceRenounceCount.get();
+                return metadataErrorCount.get();
             }
         });
         lastAppliedRecordOffsetGauge = registry.newGauge(LAST_APPLIED_RECORD_OFFSET, new Gauge<Long>() {
@@ -255,13 +255,13 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
     }
 
     @Override
-    public void incrementForceRenounceCount() {
-        this.forceRenounceCount.getAndIncrement();
+    public void incrementMetadataErrorCount() {
+        this.metadataErrorCount.getAndIncrement();
     }
 
     @Override
-    public int forceRenounceCount() {
-        return this.forceRenounceCount.get();
+    public int metadataErrorCount() {
+        return this.metadataErrorCount.get();
     }
     @Override
     public void setLastAppliedRecordOffset(long offset) {
@@ -305,7 +305,7 @@ public final class QuorumControllerMetrics implements ControllerMetrics {
             GLOBAL_PARTITION_COUNT,
             OFFLINE_PARTITION_COUNT,
             PREFERRED_REPLICA_IMBALANCE_COUNT,
-            FORCE_RENOUNCE_COUNT,
+            METADATA_ERROR_COUNT,
             LAST_APPLIED_RECORD_OFFSET,
             LAST_COMMITTED_RECORD_OFFSET,
             LAST_APPLIED_RECORD_TIMESTAMP,

--- a/metadata/src/main/java/org/apache/kafka/metadata/fault/MetadataFaultHandler.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/fault/MetadataFaultHandler.java
@@ -27,10 +27,26 @@ import org.slf4j.LoggerFactory;
  */
 public class MetadataFaultHandler implements FaultHandler {
     private static final Logger log = LoggerFactory.getLogger(MetadataFaultHandler.class);
+    private final String prefix;
+    private final Runnable action;
+
+    public MetadataFaultHandler(
+        String prefix,
+        Runnable action
+    ) {
+        this.prefix = prefix;
+        this.action = action;
+    }
 
     @Override
     public void handleFault(String failureMessage, Throwable cause) {
+        failureMessage = prefix + ": " + failureMessage;
         FaultHandler.logFailureMessage(log, failureMessage, cause);
+        try {
+            action.run();
+        } catch (Throwable e) {
+            log.error("Failed to run MetadataFaultHandler action.", e);
+        }
         throw new MetadataFaultException("Encountered metadata fault: " + failureMessage, cause);
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
@@ -27,7 +27,7 @@ public final class MockControllerMetrics implements ControllerMetrics {
     private volatile int partitions = 0;
     private volatile int offlinePartitions = 0;
     private volatile int preferredReplicaImbalances = 0;
-    private volatile AtomicInteger forceRenounces = new AtomicInteger(0);
+    private volatile AtomicInteger metadataErrors = new AtomicInteger(0);
     private volatile long lastAppliedRecordOffset = 0;
     private volatile long lastCommittedRecordOffset = 0;
     private volatile long lastAppliedRecordTimestamp = 0;
@@ -115,13 +115,13 @@ public final class MockControllerMetrics implements ControllerMetrics {
     }
 
     @Override
-    public void incrementForceRenounceCount() {
-        this.forceRenounces.getAndIncrement();
+    public void incrementMetadataErrorCount() {
+        this.metadataErrors.getAndIncrement();
     }
 
     @Override
-    public int forceRenounceCount() {
-        return this.forceRenounces.get();
+    public int metadataErrorCount() {
+        return this.metadataErrors.get();
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockControllerMetrics.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.controller;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public final class MockControllerMetrics implements ControllerMetrics {
     private volatile boolean active = false;
     private volatile int fencedBrokers = 0;
@@ -25,6 +27,7 @@ public final class MockControllerMetrics implements ControllerMetrics {
     private volatile int partitions = 0;
     private volatile int offlinePartitions = 0;
     private volatile int preferredReplicaImbalances = 0;
+    private volatile AtomicInteger forceRenounces = new AtomicInteger(0);
     private volatile long lastAppliedRecordOffset = 0;
     private volatile long lastCommittedRecordOffset = 0;
     private volatile long lastAppliedRecordTimestamp = 0;
@@ -109,6 +112,16 @@ public final class MockControllerMetrics implements ControllerMetrics {
     @Override
     public int preferredReplicaImbalanceCount() {
         return this.preferredReplicaImbalances;
+    }
+
+    @Override
+    public void incrementForceRenounceCount() {
+        this.forceRenounces.getAndIncrement();
+    }
+
+    @Override
+    public int forceRenounceCount() {
+        return this.forceRenounces.get();
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -128,6 +128,25 @@ public class QuorumControllerMetricsTest {
         }
     }
 
+    @Test
+    public void testForceRenounceCount() {
+        MetricsRegistry registry = new MetricsRegistry();
+        MockTime time = new MockTime();
+        try {
+            try (QuorumControllerMetrics quorumControllerMetrics = new QuorumControllerMetrics(registry, time)) {
+                @SuppressWarnings("unchecked")
+                Gauge<Integer> forceRenounceCount = (Gauge<Integer>) registry
+                        .allMetrics()
+                        .get(metricName("KafkaController", "ForceRenounceCount"));
+                assertEquals(0, forceRenounceCount.value());
+                quorumControllerMetrics.incrementForceRenounceCount();
+                assertEquals(1, forceRenounceCount.value());
+            }
+        } finally {
+            registry.shutdown();
+        }
+    }
+
     private static void assertMetricsCreatedAndRemovedUponClose(String expectedType, Set<String> expectedMetricNames) {
         MetricsRegistry registry = new MetricsRegistry();
         MockTime time = new MockTime();

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -42,7 +42,7 @@ public class QuorumControllerMetricsTest {
             "GlobalPartitionCount",
             "OfflinePartitionsCount",
             "PreferredReplicaImbalanceCount",
-            "ForceRenounceCount",
+            "MetadataErrorCount",
             "LastAppliedRecordLagMs",
             "LastAppliedRecordOffset",
             "LastAppliedRecordTimestamp",
@@ -129,18 +129,18 @@ public class QuorumControllerMetricsTest {
     }
 
     @Test
-    public void testForceRenounceCount() {
+    public void testMetadataErrorCount() {
         MetricsRegistry registry = new MetricsRegistry();
         MockTime time = new MockTime();
         try {
             try (QuorumControllerMetrics quorumControllerMetrics = new QuorumControllerMetrics(registry, time)) {
                 @SuppressWarnings("unchecked")
-                Gauge<Integer> forceRenounceCount = (Gauge<Integer>) registry
+                Gauge<Integer> metadataErrorCount = (Gauge<Integer>) registry
                         .allMetrics()
-                        .get(metricName("KafkaController", "ForceRenounceCount"));
-                assertEquals(0, forceRenounceCount.value());
-                quorumControllerMetrics.incrementForceRenounceCount();
-                assertEquals(1, forceRenounceCount.value());
+                        .get(metricName("KafkaController", "MetadataErrorCount"));
+                assertEquals(0, metadataErrorCount.value());
+                quorumControllerMetrics.incrementMetadataErrorCount();
+                assertEquals(1, metadataErrorCount.value());
             }
         } finally {
             registry.shutdown();

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerMetricsTest.java
@@ -36,10 +36,13 @@ public class QuorumControllerMetricsTest {
         String expectedType = "KafkaController";
         Set<String> expectedMetricNames = Utils.mkSet(
             "ActiveControllerCount",
+            "FencedBrokerCount",
+            "ActiveBrokerCount",
             "GlobalTopicCount",
             "GlobalPartitionCount",
             "OfflinePartitionsCount",
             "PreferredReplicaImbalanceCount",
+            "ForceRenounceCount",
             "LastAppliedRecordLagMs",
             "LastAppliedRecordOffset",
             "LastAppliedRecordTimestamp",
@@ -151,9 +154,17 @@ public class QuorumControllerMetricsTest {
     }
 
     private static void assertMetricsCreated(MetricsRegistry registry, Set<String> expectedMetricNames, String expectedType) {
+        assertEquals(registry.allMetrics().keySet().stream()
+                .filter(k -> k.getType() == expectedType).count(),
+                expectedMetricNames.size());
         expectedMetricNames.forEach(expectedName -> {
             MetricName expectMetricName = metricName(expectedType, expectedName);
             assertTrue(registry.allMetrics().containsKey(expectMetricName), "Missing metric: " + expectMetricName);
+        });
+        registry.allMetrics().forEach((actualMetricName, actualMetric) -> {
+            if (actualMetricName.getType() == expectedType) {
+                assertTrue(expectedMetricNames.contains(actualMetricName.getName()), "Unexpected metric: " + actualMetricName);
+            }
         });
     }
 


### PR DESCRIPTION
This PR adds in 3 metrics as described in [KIP-859](https://cwiki.apache.org/confluence/display/KAFKA/KIP-859%3A+Add+Metadata+Log+Processing+Error+Related+Metrics)
* kafka.server:type=broker-metadata-metrics,name=metadata-load-error-count
* kafka.server:type=broker-metadata-metrics,name=metadata-apply-error-count
* kafka.controller:type=KafkaController,name=MetadataErrorCount