### PR TITLE
MINOR: Update comment on verifyTaskGenerationAndOwnership method in DistributedHerder

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1732,9 +1732,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                                     throw ConnectUtils.maybeWrap(cause, "Failed to perform round of zombie fencing");
                                 }
                             },
-                            () -> {
-                                verifyTaskGenerationAndOwnership(taskId, taskGeneration);
-                            }
+                            () -> verifyTaskGenerationAndOwnership(taskId, taskGeneration)
                     );
                 } else {
                     return worker.startSourceTask(
@@ -1941,8 +1939,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
     }
 
-    // Currently unused, but will be invoked by exactly-once source tasks after they have successfully
-    // initialized their transactional producer
+    // Invoked by exactly-once worker source tasks after they have successfully initialized their transactional
+    // producer to ensure that it is still safe to bring up the task
     private void verifyTaskGenerationAndOwnership(ConnectorTaskId id, int initialTaskGen) {
         log.debug("Reading to end of config topic to ensure it is still safe to bring up source task {} with exactly-once support", id);
         if (!refreshConfigSnapshot(Long.MAX_VALUE)) {


### PR DESCRIPTION
`verifyTaskGenerationAndOwnership` was added in https://github.com/apache/kafka/pull/11779 and was used by exactly once source tasks in https://github.com/apache/kafka/pull/11780. The current description for the method is outdated and this PR updates it. 