### PR TITLE
KAFKA-14122: Fix flaky test DynamicBrokerReconfigurationTest#testKeyStoreAlter

### DIFF
--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -355,7 +355,9 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Produce/consume should work with new truststore with new producer/consumer
     val producer = ProducerBuilder().trustStoreProps(sslProperties2).maxRetries(0).build()
-    val consumer = ConsumerBuilder("group1").trustStoreProps(sslProperties2).topic(topic2).build()
+    // Start the new consumer in a separate group than the continous consumer started at the beginning of the test so
+    // that it is not disrupted by rebalance.
+    val consumer = ConsumerBuilder("group2").trustStoreProps(sslProperties2).topic(topic2).build()
     verifyProduceConsume(producer, consumer, 10, topic2)
 
     // Broker keystore update for internal listener with incompatible keystore should fail without update


### PR DESCRIPTION
# Background
At the beginning of the test, we create a producer (say P1) & consumer (say C1) (with enable_auto_commit=true, auto.commit.interval.ms = 5000 and groupId="group1"). P1 and C1 continuously write and read messages throughout the test and at the end we assert that all messages were received and **no duplicates were received**.

During the execution of the test, we create more producers and consumers as we dynamically change configuration and assert sanity of produce/consumer operation. When creating a new consumer (say C2), **we create it in the same consumer group as C1, i.e. groupId="group1"**.

# Problem
When C2 is created, it triggers a rebalance within the consumer group "group1" which already has C1. Thus, consumption of C1 is disrupted. Since C1 uses `enable_auto_commit=true`, there is a possibility that it reads duplicate messages after rebalance. When it reads duplicate messages after rebalance, it causes the test to fail.

# Solution
Do not disturb the operation of C1 when introducing C2 by creating C2 with a separate group "group2". This fixes the flakiness of the test.
