### PR TITLE
[KAFKA-9965] Fix accumulator tryAppend, so that fresh new producerBatch is created

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -89,7 +89,7 @@
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(ConsumerCoordinator|BufferPool|Fetcher|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler).java"/>
+              files="(ConsumerCoordinator|BufferPool|Fetcher|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler|RecordAccumulator).java"/>
 
     <suppress checks="(JavaNCSS|CyclomaticComplexity|MethodLength)"
               files="CoordinatorClient.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -375,10 +375,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
             this.metrics = new Metrics(metricConfig, reporters, time, metricsContext);
             this.producerMetrics = new KafkaProducerMetrics(metrics);
-            this.partitioner = config.getConfiguredInstance(
-                    ProducerConfig.PARTITIONER_CLASS_CONFIG,
-                    Partitioner.class,
-                    Collections.singletonMap(ProducerConfig.CLIENT_ID_CONFIG, clientId));
+            this.partitioner = newPartitioner(config);
             warnIfPartitionerDeprecated();
             this.partitionerIgnoreKeys = config.getBoolean(ProducerConfig.PARTITIONER_IGNORE_KEYS_CONFIG);
             long retryBackoffMs = config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG);
@@ -505,6 +502,14 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         this.metadata = metadata;
         this.sender = sender;
         this.ioThread = ioThread;
+    }
+
+    // visible for testing
+    Partitioner newPartitioner(ProducerConfig config) {
+        return config.getConfiguredInstance(
+            ProducerConfig.PARTITIONER_CLASS_CONFIG,
+            Partitioner.class,
+            Collections.singletonMap(ProducerConfig.CLIENT_ID_CONFIG, clientId));
     }
 
     // visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -271,9 +272,11 @@ public class RecordAccumulator {
                 // Now that we know the effective partition, let the caller know.
                 setPartition(callbacks, effectivePartition);
 
+                // boolean to check if a new Deque<ProducerBatch> will get created for this partition.
+                boolean noDqForPartition = !topicInfo.batches.containsKey(effectivePartition);
+
                 // check if we have an in-progress batch
                 Deque<ProducerBatch> dq = topicInfo.batches.computeIfAbsent(effectivePartition, k -> new ArrayDeque<>());
-                RecordAppendResult appendResult;
                 synchronized (dq) {
                     // After taking the lock, validate that the partition hasn't changed and retry.
                     if (topicInfo.builtInPartitioner.isPartitionChanged(partitionInfo)) {
@@ -281,17 +284,19 @@ public class RecordAccumulator {
                                 partitionInfo.partition(), topic);
                         continue;
                     }
-                    appendResult = tryAppend(timestamp, key, value, headers, callbacks, dq, nowMs);
-                    if (appendResult != null && !appendResult.newBatchCreated) {
+                    RecordAppendResult appendResult = tryAppend(timestamp, key, value, headers, callbacks, dq, nowMs);
+                    if (appendResult != null) {
                         topicInfo.builtInPartitioner.updatePartitionInfo(partitionInfo, appendResult.appendedBytes, cluster);
                         return appendResult;
                     }
                 }
 
-                // either 1. current topicPartition producerBatch is full - return and prepare for another batch/partition.
-                // 2. no producerBatch existed for this topicPartition, create a new producerBatch.
-                if (appendResult == null && abortOnNewBatch) {
-                    // existing batch is full, return a result that will cause another call to append.
+                // noDqForPartition is true either when 1. partition was encountered for first time so no Deque existed previously.
+                // 2. DQ was removed due to - all batches were cleared due to expiration or sender cleared batches after draining.
+                // if so, abort and look to call partitioner -> onNewBatch and select other partition.
+                // This prevents a single partition getting re-selected after recent drain.
+                if (abortOnNewBatch && noDqForPartition) {
+                    // existing batch is full or no batch exists, return a result that will cause another call to append.
                     return new RecordAppendResult(null, false, false, true, 0);
                 }
 
@@ -315,7 +320,7 @@ public class RecordAccumulator {
                                 partitionInfo.partition(), topic);
                         continue;
                     }
-                    appendResult = appendNewBatch(topic, effectivePartition, dq, timestamp, key, value, headers, callbacks, buffer, nowMs);
+                    RecordAppendResult appendResult = appendNewBatch(topic, effectivePartition, dq, timestamp, key, value, headers, callbacks, buffer, nowMs);
                     // Set buffer to null, so that deallocate doesn't return it back to free pool, since it's used in the batch.
                     if (appendResult.newBatchCreated)
                         buffer = null;
@@ -356,7 +361,7 @@ public class RecordAccumulator {
         assert partition != RecordMetadata.UNKNOWN_PARTITION;
 
         RecordAppendResult appendResult = tryAppend(timestamp, key, value, headers, callbacks, dq, nowMs);
-        if (appendResult != null && !appendResult.newBatchCreated) {
+        if (appendResult != null) {
             // Somebody else found us a batch, return the one we waited for! Hopefully this doesn't happen often...
             return appendResult;
         }
@@ -397,15 +402,13 @@ public class RecordAccumulator {
             int initialBytes = last.estimatedSizeInBytes();
             FutureRecordMetadata future = last.tryAppend(timestamp, key, value, headers, callback, nowMs);
             if (future == null) {
-                // producerBatch doesn't have anymore room, return then try to create a new batch.
                 last.closeForRecordAppends();
-                return null;
             } else {
                 int appendedBytes = last.estimatedSizeInBytes() - initialBytes;
                 return new RecordAppendResult(future, deque.size() > 1 || last.isFull(), false, false, appendedBytes);
             }
         }
-        return new RecordAppendResult(null, false, true, false, 0);
+        return null;
     }
 
     private boolean isMuted(TopicPartition tp) {
@@ -432,19 +435,26 @@ public class RecordAccumulator {
      */
     public List<ProducerBatch> expiredBatches(long now) {
         List<ProducerBatch> expiredBatches = new ArrayList<>();
-        for (TopicInfo topicInfo : topicInfoMap.values()) {
-            for (Deque<ProducerBatch> deque : topicInfo.batches.values()) {
+        for (Entry<String, TopicInfo> entryTopicInfo : topicInfoMap.entrySet()) {
+            TopicInfo topicInfo = entryTopicInfo.getValue();
+            for (Entry<Integer, Deque<ProducerBatch>> entry : topicInfo.batches.entrySet()) {
                 // expire the batches in the order of sending
+                Deque<ProducerBatch> deque = entry.getValue();
                 synchronized (deque) {
-                    while (!deque.isEmpty()) {
-                        ProducerBatch batch = deque.getFirst();
-                        if (batch.hasReachedDeliveryTimeout(deliveryTimeoutMs, now)) {
-                            deque.poll();
-                            batch.abortRecordAppends();
-                            expiredBatches.add(batch);
-                        } else {
-                            maybeUpdateNextBatchExpiryTime(batch);
-                            break;
+                    if (!deque.isEmpty()) {
+                        while (!deque.isEmpty()) {
+                            ProducerBatch batch = deque.getFirst();
+                            if (batch.hasReachedDeliveryTimeout(deliveryTimeoutMs, now)) {
+                                deque.poll();
+                                batch.abortRecordAppends();
+                                expiredBatches.add(batch);
+                            } else {
+                                maybeUpdateNextBatchExpiryTime(batch);
+                                break;
+                            }
+                        }
+                        if (deque.isEmpty()) {
+                            clearDeque(new TopicPartition(entryTopicInfo.getKey(), entry.getKey()));
                         }
                     }
                 }
@@ -809,8 +819,10 @@ public class RecordAccumulator {
             synchronized (deque) {
                 // invariant: !isMuted(tp,now) && deque != null
                 ProducerBatch first = deque.peekFirst();
-                if (first == null)
+                if (first == null) {
+                    clearDeque(tp);
                     continue;
+                }
 
                 // first != null
                 boolean backoff = first.attempts() > 0 && first.waitedTimeMs(now) < retryBackoffMs;
@@ -942,6 +954,13 @@ public class RecordAccumulator {
         if (topicInfo == null)
             return null;
         return topicInfo.batches.get(tp.partition());
+    }
+
+    /* Visible for testing */
+    public void clearDeque(TopicPartition tp) {
+        TopicInfo topicInfo = topicInfoMap.get(tp.topic());
+        if (topicInfo != null)
+            topicInfo.batches.remove(tp.partition());
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -1248,6 +1248,16 @@ public class RecordAccumulatorTest {
         }
     }
 
+    @Test
+    public void testFirstRecordCreatesProducerBatchIfNoneExists() throws InterruptedException {
+        RecordAccumulator accum = createTestRecordAccumulator(DefaultRecordBatch.RECORD_BATCH_OVERHEAD,
+            10L * DefaultRecordBatch.RECORD_BATCH_OVERHEAD, CompressionType.NONE, 10);
+        // accum.append should create a new ProducerBatch if none exists even when abortOnNewBatch is true
+        accum.append(topic, partition1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, true, time.milliseconds(), cluster);
+        Deque<ProducerBatch> partitionBatches = accum.getDeque(tp1);
+        assertEquals(1, partitionBatches.size());
+    }
+
     private int prepareSplitBatches(RecordAccumulator accum, long seed, int recordSize, int numRecords)
         throws InterruptedException {
         Random random = new Random();


### PR DESCRIPTION
Issue - partitioner.partition is called [once](https://github.com/apache/kafka/blob/1cc1e776f703b180f4bd979e8a551805b3bdc94e/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L1012). For this partition -> `accumulator` would try to find existing batch present to fill record in. 
If not, it would abortAppend on record in this partition buffer, and flag `abortForNewBatch`. 
With `abortForNewBatch`, partitioner.partition is called again! RoundRobin partition would increment the counter twice for the same record (when key, and record.partition is null). For even number of partitions, only half of them are filled up. 

Since every second partition gets records filled in batch, `accumulator` will always find empty batch for current partition, and hence it will always get skipped. 


Solution 
here is what i had in mind with the approach on this PR
```
Partitions -> p0,p1,p2,p3
records -> r0,r1,r2 ... ,r11

Happy case 
first iteration -> 
p0 {}, p1 {r0}, p2 {}, p3 {r1}
second iteration -> 
p0 {r2}, p1 {r0, r3}, p2 {r4}, p3 {r1, r5}
third iteration -> 
p0 {r2, r6}, p1 {r0, r3, r7}, p2 {r4, r8}, p3 {r1, r5, r9}
fourth iteration -> 
p0 {r2, r6, r10}, p1 {r0, r3, r7, r11}, p2 {r4, r8}, p3 {r1, r5, r9}

What happens with "drain"(s) ? 

first iteration -> 
p0 {}, p1 {r0}, p2 {}, p3 {r1}
second iteration -> 
p0 {r2}, p1 {r0, r3}, p2 {r4}, p3 {r1, r5}

--- drain on partition p0
p0 {}, p1 {r0, r3}, p2 {r4}, p3 {r1, r5}

third iteration -> 
p0 {}, p1 {r0, r3, r6}, p2 {r4, r7}, p3 {r1, r5, r8}
fourth iteration -> 
p0 {r9}, p1 {r0, r3, r6, r10}, p2 {r4, r7, r11}, p3 {r1, r5, r8}

[Slow producer] What happens if drain happens AFTER partition is checked for DQ's presence?
first iteration -> 
p0 {}, p1 {r0}, p2 {}, p3 {r1}
second iteration -> 
p0 {r2}, p1 {r0, r3}, p2 {r4}, p3 {r1, r5}

--- drain on partition p0  -> but after "p0" was checked to have a DQ. Hence it is selected again unfortunately
p0 {}, p1 {r0, r3}, p2 {r4}, p3 {r1, r5}

third iteration ->  (p0 is filled up, even if it was just drained, which is fine imo)
p0 {r6}, p1 {r0, r3, r7}, p2 {r4, r8}, p3 {r1, r5, r9}
fourth iteration -> 
p0 {r6, r10}, p1 {r0, r3, r7, r11}, p2 {r4, r8}, p3 {r1, r5, r9}

```




### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
