### PR TITLE
KAFKA-12950: Replace EasyMock and PowerMock with Mockito for KafkaStreamsTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,9 +411,7 @@ subprojects {
       "**/SourceTaskOffsetCommitterTest.*",
       "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
       "**/WorkerSourceTaskTest.*", "**/AbstractWorkerSourceTaskTest.*", "**/ExactlyOnceWorkerSourceTaskTest.*",
-      "**/WorkerTaskTest.*",
-      // streams tests
-      "**/KafkaStreamsTest.*"
+      "**/WorkerTaskTest.*"
     ])
   }
 

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1097,7 +1097,7 @@ public class KafkaStreams implements AutoCloseable {
                 // make a copy of threads to avoid holding lock
                 for (final StreamThread streamThread : new ArrayList<>(threads)) {
                     final boolean callingThreadIsNotCurrentStreamThread = !streamThread.getName().equals(Thread.currentThread().getName());
-                    if (streamThread.isAlive() && (callingThreadIsNotCurrentStreamThread || getNumLiveStreamThreads() == 1)) {
+                    if (streamThread.isThreadAlive() && (callingThreadIsNotCurrentStreamThread || getNumLiveStreamThreads() == 1)) {
                         log.info("Removing StreamThread " + streamThread.getName());
                         final Optional<String> groupInstanceID = streamThread.getGroupInstanceID();
                         streamThread.requestLeaveGroupDuringShutdown();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1082,6 +1082,11 @@ public class StreamThread extends Thread {
         partitions.add(partition);
     }
 
+    // This method is added for usage in tests where mocking the underlying native call is not possible.
+    public boolean isThreadAlive() {
+        return isAlive();
+    }
+
     /**
      * Try to commit all active tasks owned by this thread.
      *


### PR DESCRIPTION
This PR build on top of https://github.com/apache/kafka/pull/11017. I have added the previous author's comment in this PR for attribution. I have also addressed the pending comments from @chia7712 in this PR.

Notes to help the reviewer:
1. Mockito has `mockStatic` method which is equivalent to PowerMock's method.
2. When we run the tests using `@RunWith(MockitoJUnitRunner.StrictStubs.class)` Mockito performs a verify() for all stubs that are mentioned, hence, there is no need to explicitly verify the stubs (unless you want to verify the number of times etc.). Note that this does not work for static mocks.

## Testing
Validated that test is run successfully as part of `./gradlew streams:unitTest` 

## Code coverage
### Before
![Screenshot 2022-08-02 at 19 02 42](https://user-images.githubusercontent.com/71267/182432732-86f53330-b982-4fa0-ac20-97ddc96bb66a.png)

### After
![Screenshot 2022-08-02 at 19 02 49](https://user-images.githubusercontent.com/71267/182432748-33b4ab03-b387-44ca-8af6-d24f09afbc9b.png)

