### PR TITLE
KAFKA-13133 Replace EasyMock and PowerMock with Mockito for AbstractHerderTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,7 +404,7 @@ subprojects {
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
     testsToExclude.addAll([
       // connect tests
-      "**/AbstractHerderTest.*", "**/ConnectorPluginsResourceTest.*",
+      "**/ConnectorPluginsResourceTest.*",
       "**/ConnectorsResourceTest.*", "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
       "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
       "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",


### PR DESCRIPTION
- Builds on top off https://github.com/apache/kafka/pull/11137 by @wycccccc which seems to have gone stale (so they should be credited as a co-author if this PR is merged)
- Rebased onto latest `trunk`, fixed conflicts and replaced usage of `EasyMock` with `Mockito` in newly added tests
- Addressed review comments by @mimaison on https://github.com/apache/kafka/pull/11137