### PR TITLE
KAFKA-13952 fix RetryWithToleranceOperator to respect infinite retries configuration

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1252,12 +1252,9 @@ public class Worker {
                     connectorConfig.errorMaxDelayInMillis(), connectorConfig.errorToleranceType(), Time.SYSTEM);
             retryWithToleranceOperator.metrics(errorHandlingMetrics);
 
-            WorkerTask workerTask = doBuild(task, id, configState, statusListener, initialState,
+            return doBuild(task, id, configState, statusListener, initialState,
                     connectorConfig, keyConverter, valueConverter, headerConverter, classLoader,
                     errorHandlingMetrics, connectorClass, retryWithToleranceOperator);
-            // the operator should exit retry loops when the task is finally cancelled after exceeding its graceful shutdown timeout
-            retryWithToleranceOperator.exitCondition(workerTask::isCancelled);
-            return workerTask;
         }
 
         abstract WorkerTask doBuild(Task task,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1252,9 +1252,12 @@ public class Worker {
                     connectorConfig.errorMaxDelayInMillis(), connectorConfig.errorToleranceType(), Time.SYSTEM);
             retryWithToleranceOperator.metrics(errorHandlingMetrics);
 
-            return doBuild(task, id, configState, statusListener, initialState,
+            WorkerTask workerTask = doBuild(task, id, configState, statusListener, initialState,
                     connectorConfig, keyConverter, valueConverter, headerConverter, classLoader,
                     errorHandlingMetrics, connectorClass, retryWithToleranceOperator);
+            // the operator should exit retry loops when the task is finally cancelled after exceeding its graceful shutdown timeout
+            retryWithToleranceOperator.exitCondition(workerTask::isCancelled);
+            return workerTask;
         }
 
         abstract WorkerTask doBuild(Task task,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -126,7 +126,7 @@ abstract class WorkerTask implements Runnable {
      */
     public void cancel() {
         cancelled = true;
-        retryWithToleranceOperator.exit();
+        retryWithToleranceOperator.triggerStop();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -126,6 +126,7 @@ abstract class WorkerTask implements Runnable {
      */
     public void cancel() {
         cancelled = true;
+        retryWithToleranceOperator.exit();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -198,13 +198,13 @@ public class RetryWithToleranceOperator implements AutoCloseable {
 
     /**
      * Execute a given operation multiple times (if needed), and tolerate certain exceptions.
+     * Visible for testing.
      *
      * @param operation the operation to be executed.
      * @param tolerated the class of exceptions which can be tolerated.
      * @param <V> The return type of the result of the operation.
      * @return the result of the operation
      */
-    // Visible for testing
     protected <V> V execAndHandleError(Operation<V> operation, Class<? extends Exception> tolerated) {
         try {
             V result = execAndRetry(operation);
@@ -256,10 +256,9 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         return errorToleranceType;
     }
 
-    // Visible for testing
-
     /**
-     * Check whether we can continue retrying or not
+     * Check whether we can continue retrying or not.
+     * Visible for testing.
      * @param startTime the time in milliseconds when the retriable operation was first begun
      * @return true if we can continue retrying; false if the retry timeout has been reached and we can't retry anymore
      */
@@ -270,10 +269,10 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         return (time.milliseconds() - startTime) < errorRetryTimeout;
     }
 
-    // Visible for testing
     /**
      * Do an exponential backoff bounded by {@link #RETRIES_DELAY_MIN_MS} and {@link #errorMaxDelayInMillis}
-     * which can be exited prematurely if {@link #exit()} is called
+     * which can be exited prematurely if {@link #exit()} is called.
+     * Visible for testing.
      * @param attempt the number indicating which backoff attempt it is (beginning with 1)
      * @param deadline the time in milliseconds until when retries can be attempted
      * @return true if it is safe to backoff again, false if the exit condition was triggered via

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -166,7 +166,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
     protected <V> V execAndRetry(Operation<V> operation) throws Exception {
         int attempt = 0;
         long startTime = time.milliseconds();
-        long deadline = startTime + errorRetryTimeout;
+        long deadline = (errorRetryTimeout >= 0) ? startTime + errorRetryTimeout : Long.MAX_VALUE;
         do {
             try {
                 attempt++;
@@ -255,6 +255,9 @@ public class RetryWithToleranceOperator implements AutoCloseable {
 
     // Visible for testing
     boolean checkRetry(long startTime) {
+        if (errorRetryTimeout < 0) {
+            return true;
+        }
         return (time.milliseconds() - startTime) < errorRetryTimeout;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -29,8 +29,10 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Attempt to recover a failed operation with retries and tolerance limits.
@@ -76,22 +78,24 @@ public class RetryWithToleranceOperator implements AutoCloseable {
     private long totalFailures = 0;
     private final Time time;
     private ErrorHandlingMetrics errorHandlingMetrics;
+    private final CountDownLatch exitLatch;
 
     protected final ProcessingContext context;
 
     public RetryWithToleranceOperator(long errorRetryTimeout, long errorMaxDelayInMillis,
                                       ToleranceType toleranceType, Time time) {
-        this(errorRetryTimeout, errorMaxDelayInMillis, toleranceType, time, new ProcessingContext());
+        this(errorRetryTimeout, errorMaxDelayInMillis, toleranceType, time, new ProcessingContext(), new CountDownLatch(1));
     }
 
     RetryWithToleranceOperator(long errorRetryTimeout, long errorMaxDelayInMillis,
                                ToleranceType toleranceType, Time time,
-                               ProcessingContext context) {
+                               ProcessingContext context, CountDownLatch exitLatch) {
         this.errorRetryTimeout = errorRetryTimeout;
         this.errorMaxDelayInMillis = errorMaxDelayInMillis;
         this.errorToleranceType = toleranceType;
         this.time = time;
         this.context = context;
+        this.exitLatch = exitLatch;
     }
 
     public synchronized Future<Void> executeFailed(Stage stage, Class<?> executingClass,
@@ -175,9 +179,8 @@ public class RetryWithToleranceOperator implements AutoCloseable {
                 log.trace("Caught a retriable exception while executing {} operation with {}", context.stage(), context.executingClass());
                 errorHandlingMetrics.recordFailure();
                 if (checkRetry(startTime)) {
-                    backoff(attempt, deadline);
-                    if (Thread.currentThread().isInterrupted()) {
-                        log.trace("Thread was interrupted. Marking operation as failed.");
+                    if (!backoff(attempt, deadline) || Thread.currentThread().isInterrupted()) {
+                        log.trace("Thread was interrupted or exit condition was triggered. Marking operation as failed.");
                         context.error(e);
                         return null;
                     }
@@ -254,6 +257,12 @@ public class RetryWithToleranceOperator implements AutoCloseable {
     }
 
     // Visible for testing
+
+    /**
+     * Check whether we can continue retrying or not
+     * @param startTime the time in milliseconds when the retriable operation was first begun
+     * @return true if we can continue retrying; false if the retry timeout has been reached and we can't retry anymore
+     */
     boolean checkRetry(long startTime) {
         if (errorRetryTimeout < 0) {
             return true;
@@ -262,7 +271,16 @@ public class RetryWithToleranceOperator implements AutoCloseable {
     }
 
     // Visible for testing
-    void backoff(int attempt, long deadline) {
+    /**
+     * Do an exponential backoff bounded by {@link #RETRIES_DELAY_MIN_MS} and {@link #errorMaxDelayInMillis}
+     * which can be exited prematurely if {@link #exit()} is called
+     * @param attempt the number indicating which backoff attempt it is (beginning with 1)
+     * @param deadline the time in milliseconds until when retries can be attempted
+     * @return true if it is safe to backoff again, false if the exit condition was triggered via
+     *         {@link #exit()} and backoff shouldn't be called again
+     * @throws InterruptedException if the thread is interrupted during the call to {@link CountDownLatch#await(long, TimeUnit)}
+     */
+    boolean backoff(int attempt, long deadline) throws InterruptedException {
         int numRetry = attempt - 1;
         long delay = RETRIES_DELAY_MIN_MS << numRetry;
         if (delay > errorMaxDelayInMillis) {
@@ -272,7 +290,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
             delay = deadline - time.milliseconds();
         }
         log.debug("Sleeping for {} millis", delay);
-        time.sleep(delay);
+        return !exitLatch.await(delay, TimeUnit.MILLISECONDS);
     }
 
     public synchronized void metrics(ErrorHandlingMetrics errorHandlingMetrics) {
@@ -332,6 +350,15 @@ public class RetryWithToleranceOperator implements AutoCloseable {
      */
     public synchronized Throwable error() {
         return this.context.error();
+    }
+
+    /**
+     * Exit from any currently ongoing retry loop and mark the operation as failed.
+     * This can be called from a separate thread to break out of an infinite retry loop in
+     * {@link #execAndRetry(Operation)}
+     */
+    public synchronized void exit() {
+        exitLatch.countDown();
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -272,8 +272,9 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         if (delay > errorMaxDelayInMillis) {
             delay = ThreadLocalRandom.current().nextLong(errorMaxDelayInMillis);
         }
-        if (delay + time.milliseconds() > deadline) {
-            delay = deadline - time.milliseconds();
+        long currentTime = time.milliseconds();
+        if (delay + currentTime > deadline) {
+            delay = deadline - currentTime;
         }
         log.debug("Sleeping for up to {} millis", delay);
         try {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime.errors;
 
-import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
@@ -77,7 +76,6 @@ public class RetryWithToleranceOperator implements AutoCloseable {
     private long totalFailures = 0;
     private final Time time;
     private ErrorHandlingMetrics errorHandlingMetrics;
-    private Supplier<Boolean> exitCondition;
 
     protected final ProcessingContext context;
 
@@ -178,8 +176,8 @@ public class RetryWithToleranceOperator implements AutoCloseable {
                 errorHandlingMetrics.recordFailure();
                 if (checkRetry(startTime)) {
                     backoff(attempt, deadline);
-                    if (Thread.currentThread().isInterrupted() || (exitCondition != null && exitCondition.get())) {
-                        log.trace("Thread was interrupted or exit condition was triggered. Marking operation as failed.");
+                    if (Thread.currentThread().isInterrupted()) {
+                        log.trace("Thread was interrupted. Marking operation as failed.");
                         context.error(e);
                         return null;
                     }
@@ -279,10 +277,6 @@ public class RetryWithToleranceOperator implements AutoCloseable {
 
     public synchronized void metrics(ErrorHandlingMetrics errorHandlingMetrics) {
         this.errorHandlingMetrics = errorHandlingMetrics;
-    }
-
-    public synchronized void exitCondition(Supplier<Boolean> exitCondition) {
-        this.exitCondition = exitCondition;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -274,7 +274,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         }
         long currentTime = time.milliseconds();
         if (delay + currentTime > deadline) {
-            delay = deadline - currentTime;
+            delay = Math.max(0, deadline - currentTime);
         }
         log.debug("Sleeping for up to {} millis", delay);
         try {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -356,7 +356,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
      * This can be called from a separate thread to break out of an infinite retry loop in
      * {@link #execAndRetry(Operation)}
      */
-    public synchronized void exit() {
+    public void exit() {
         exitLatch.countDown();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -249,7 +249,7 @@ public class RetryWithToleranceOperatorTest {
             return false;
         });
         EasyMock.expect(exitLatch.await(4800, TimeUnit.MILLISECONDS)).andReturn(true);
-        retryWithToleranceOperator.exit();
+        retryWithToleranceOperator.triggerStop();
         exitLatch.countDown();
         EasyMock.expectLastCall().once();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime.errors;
 
-import java.util.function.Supplier;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
@@ -65,7 +64,6 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_DEFAULT;
 import static org.apache.kafka.connect.runtime.errors.ToleranceType.ALL;
 import static org.apache.kafka.connect.runtime.errors.ToleranceType.NONE;
-import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -297,28 +295,6 @@ public class RetryWithToleranceOperatorTest {
 
         time.setCurrentTimeMs(10000);
         assertTrue(retryWithToleranceOperator.checkRetry(0));
-    }
-
-    @Test
-    public void testExitCondition() throws Exception {
-        MockTime time = new MockTime(0, 0, 0);
-        RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(-1, ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, time);
-        retryWithToleranceOperator.metrics(errorHandlingMetrics);
-        RetriableException e = new RetriableException("test");
-        EasyMock.expect(mockOperation.call()).andThrow(e).anyTimes();
-        Supplier<Boolean> exitCondition = mock(Supplier.class);
-        EasyMock.expect(exitCondition.get()).andReturn(false).times(3);
-        EasyMock.expect(exitCondition.get()).andReturn(true);
-        retryWithToleranceOperator.exitCondition(exitCondition);
-        replay(mockOperation, exitCondition);
-        String result = retryWithToleranceOperator.execAndHandleError(mockOperation, Exception.class);
-        assertNull(result);
-
-        // the operator is configured to retry infinitely (errorRetryTimeout = -1) and the operation's call()
-        // method has been stubbed to always throw a RetriableException. However, the operator is also configured
-        // with an exit condition which returns false the first 3 times it is checked but then returns true.
-        // So, there should 4 retries with 4500 ms in total elapsed time (300 + 600 + 1200 + 2400)
-        assertEquals(4500, time.milliseconds());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -233,7 +233,7 @@ public class RetryWithToleranceOperatorTest {
     @Test
     public void testExitLatch() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
-        CountDownLatch exitLatch = EasyMock.createStrictMock(CountDownLatch.class);
+        CountDownLatch exitLatch = PowerMock.createStrictMock(CountDownLatch.class);
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(-1, ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, time, new ProcessingContext(), exitLatch);
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
         EasyMock.expect(mockOperation.call()).andThrow(new RetriableException("test")).anyTimes();
@@ -269,7 +269,7 @@ public class RetryWithToleranceOperatorTest {
 
     public void execAndHandleRetriableError(long errorRetryTimeout, int numRetriableExceptionsThrown, List<Long> expectedWaits, Exception e, boolean successExpected) throws Exception {
         MockTime time = new MockTime(0, 0, 0);
-        CountDownLatch exitLatch = EasyMock.createStrictMock(CountDownLatch.class);
+        CountDownLatch exitLatch = PowerMock.createStrictMock(CountDownLatch.class);
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(errorRetryTimeout, ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, time, new ProcessingContext(), exitLatch);
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
 
@@ -289,6 +289,7 @@ public class RetryWithToleranceOperatorTest {
         if (successExpected) {
             assertFalse(retryWithToleranceOperator.failed());
             assertEquals("Success", result);
+            EasyMock.verify(mockOperation);
         } else {
             assertTrue(retryWithToleranceOperator.failed());
         }
@@ -296,14 +297,13 @@ public class RetryWithToleranceOperatorTest {
         PowerMock.verifyAll();
     }
 
-    public void execAndHandleNonRetriableError(int numRetriableExceptionsThrown, Exception e) throws Exception {
+    public void execAndHandleNonRetriableError(int numNonRetriableExceptionsThrown, Exception e) throws Exception {
         MockTime time = new MockTime(0, 0, 0);
-        CountDownLatch exitLatch = EasyMock.createStrictMock(CountDownLatch.class);
+        CountDownLatch exitLatch = PowerMock.createStrictMock(CountDownLatch.class);
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(6000, ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, time, new ProcessingContext(), exitLatch);
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
 
-        EasyMock.expect(mockOperation.call()).andThrow(e).times(numRetriableExceptionsThrown);
-        EasyMock.expect(mockOperation.call()).andReturn("Success");
+        EasyMock.expect(mockOperation.call()).andThrow(e).times(numNonRetriableExceptionsThrown);
 
         // expect no call to exitLatch.await() which is only called during the retry backoff
 
@@ -319,7 +319,7 @@ public class RetryWithToleranceOperatorTest {
     @Test
     public void testBackoffLimit() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
-        CountDownLatch exitLatch = EasyMock.createStrictMock(CountDownLatch.class);
+        CountDownLatch exitLatch = PowerMock.createStrictMock(CountDownLatch.class);
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(5, 5000, NONE, time, new ProcessingContext(), exitLatch);
 
         EasyMock.expect(exitLatch.await(300, TimeUnit.MILLISECONDS)).andAnswer(() -> {


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-13952: RetryWithToleranceOperator doesn't respect infinite retries config - i.e. when `errors.retry.timeout` is set to `-1`
- From https://cwiki.apache.org/confluence/display/KAFKA/KIP-298%3A+Error+Handling+in+Connect: 
>errors.retry.timeout: [-1, 0, 1, ... Long.MAX_VALUE], where -1 means infinite duration.
- Also, from the config doc: https://github.com/apache/kafka/blob/0c4da23098f8b8ae9542acd7fbaa1e5c16384a39/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java#L129-L130
- This PR fixes the issue in `RetryWithToleranceOperator` along with a couple of unit tests to ensure the same