### PR TITLE
Kafka 14115

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -381,7 +381,7 @@ public class ConfigurationControlManager {
         if (configs.isEmpty()) {
             configData.remove(configResource);
         }
-        log.info("{}: set configuration {} to {}", configResource, record.name(), configSchema.getLoggableValue(record));
+        log.info("{}: set configuration {} to {}", configResource, record.name(), record.value());
     }
 
     // VisibleForTesting

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -381,7 +381,7 @@ public class ConfigurationControlManager {
         if (configs.isEmpty()) {
             configData.remove(configResource);
         }
-        log.info("{}: set configuration {} to {}", configResource, record.name(), record.value());
+        log.info("{}: set configuration {} to {}", configResource, record.name(), configSchema.getLoggableValue(record));
     }
 
     // VisibleForTesting

--- a/metadata/src/main/java/org/apache/kafka/metadata/KafkaConfigSchema.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/KafkaConfigSchema.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.Locale;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -141,7 +142,19 @@ public class KafkaConfigSchema {
         if (configDef == null) return true;
         ConfigDef.ConfigKey configKey = configDef.configKeys().get(key);
         if (configKey == null) return true;
+        if (key.toUpperCase(Locale.ROOT).contains(ConfigDef.Type.PASSWORD.toString())) return true;
         return configKey.type.isSensitive();
+    }
+
+    /**
+     * Sensitive configs such as Password must be hidden from logging.
+     * */
+    public String getLoggableValue(ConfigRecord record) {
+        if (record == null) return null;
+        if (isSensitive(record)) {
+            return Password.HIDDEN;
+        }
+        return record.value();
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/KafkaConfigSchema.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/KafkaConfigSchema.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.Locale;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -142,19 +141,7 @@ public class KafkaConfigSchema {
         if (configDef == null) return true;
         ConfigDef.ConfigKey configKey = configDef.configKeys().get(key);
         if (configKey == null) return true;
-        if (key.toUpperCase(Locale.ROOT).contains(ConfigDef.Type.PASSWORD.toString())) return true;
         return configKey.type.isSensitive();
-    }
-
-    /**
-     * Sensitive configs such as Password must be hidden from logging.
-     * */
-    public String getLoggableValue(ConfigRecord record) {
-        if (record == null) return null;
-        if (isSensitive(record)) {
-            return Password.HIDDEN;
-        }
-        return record.value();
     }
 
     /**

--- a/metadata/src/test/java/org/apache/kafka/metadata/KafkaConfigSchemaTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/KafkaConfigSchemaTest.java
@@ -20,8 +20,6 @@ package org.apache.kafka.metadata;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -38,7 +36,6 @@ import static org.apache.kafka.metadata.ConfigSynonym.HOURS_TO_MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 @Timeout(value = 40)
@@ -51,8 +48,7 @@ public class KafkaConfigSchemaTest {
             define("baz", ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "baz doc").
             define("quux", ConfigDef.Type.INT, ConfigDef.Importance.HIGH, "quux doc").
             define("quuux", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "quuux doc").
-            define("quuux2", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "quuux2 doc").
-            define("ssl.password", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "password doc"));
+            define("quuux2", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "quuux2 doc"));
         CONFIGS.put(TOPIC, new ConfigDef().
             define("abc", ConfigDef.Type.LIST, ConfigDef.Importance.HIGH, "abc doc").
             define("def", ConfigDef.Type.LONG, ConfigDef.Importance.HIGH, "def doc").
@@ -165,19 +161,5 @@ public class KafkaConfigSchemaTest {
             dynamicClusterConfigs,
             dynamicNodeConfigs,
             dynamicTopicConfigs));
-    }
-
-    @Test
-    public void testGetLoggableValue() {
-        ConfigRecord record1 = new ConfigRecord().
-                setResourceType(BROKER.id()).setResourceName("0").
-                setName("foo.bar").setValue("bar");
-        assertEquals(SCHEMA.getLoggableValue(record1), record1.value());
-        ConfigRecord record2 = null;
-        assertNull(SCHEMA.getLoggableValue(record2));
-        ConfigRecord record3 = new ConfigRecord().
-                setResourceType(BROKER.id()).setResourceName("0").
-                setName("ssl.password").setValue("bar");
-        assertEquals(SCHEMA.getLoggableValue(record3), Password.HIDDEN);
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/KafkaConfigSchemaTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/KafkaConfigSchemaTest.java
@@ -20,6 +20,8 @@ package org.apache.kafka.metadata;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -36,6 +38,7 @@ import static org.apache.kafka.metadata.ConfigSynonym.HOURS_TO_MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 @Timeout(value = 40)
@@ -48,7 +51,8 @@ public class KafkaConfigSchemaTest {
             define("baz", ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "baz doc").
             define("quux", ConfigDef.Type.INT, ConfigDef.Importance.HIGH, "quux doc").
             define("quuux", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "quuux doc").
-            define("quuux2", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "quuux2 doc"));
+            define("quuux2", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "quuux2 doc").
+            define("ssl.password", ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, "password doc"));
         CONFIGS.put(TOPIC, new ConfigDef().
             define("abc", ConfigDef.Type.LIST, ConfigDef.Importance.HIGH, "abc doc").
             define("def", ConfigDef.Type.LONG, ConfigDef.Importance.HIGH, "def doc").
@@ -161,5 +165,19 @@ public class KafkaConfigSchemaTest {
             dynamicClusterConfigs,
             dynamicNodeConfigs,
             dynamicTopicConfigs));
+    }
+
+    @Test
+    public void testGetLoggableValue() {
+        ConfigRecord record1 = new ConfigRecord().
+                setResourceType(BROKER.id()).setResourceName("0").
+                setName("foo.bar").setValue("bar");
+        assertEquals(SCHEMA.getLoggableValue(record1), record1.value());
+        ConfigRecord record2 = null;
+        assertNull(SCHEMA.getLoggableValue(record2));
+        ConfigRecord record3 = new ConfigRecord().
+                setResourceType(BROKER.id()).setResourceName("0").
+                setName("ssl.password").setValue("bar");
+        assertEquals(SCHEMA.getLoggableValue(record3), Password.HIDDEN);
     }
 }


### PR DESCRIPTION
[KAFKA-14115] Password configs are logged in plaintext in KRaft
 
While updating the config for a broker ConfigurationControlManager is logging sensitive config values (listener.name.external.ssl.key.password). 
ConfigResource(type=BROKER, name='1'): set configuration listener.name.external.ssl.key.password to bar 

We need to redact these values the same as BrokerMetadataPublisher 
 Updating broker 1 with new configuration : listener.name.external.ssl.key.password -> [hidden]

Changes: updated isSensitive method to check if the config name contains the string password and used the same while logging config values.

@mumrah Can you please review this PR ?