### PR TITLE
KAFKA-14136 Generate ConfigRecord even if the value is unchanged

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -230,7 +230,7 @@ public class ConfigurationControlManager {
                     break;
             }
             if (!Objects.equals(currentValue, newValue) || configResource.type().equals(Type.BROKER)) {
-                // We need to generate records even if the value is unchanged to trigger reloads on the brokers
+                // KAFKA-14136 We need to generate records even if the value is unchanged to trigger reloads on the brokers
                 newRecords.add(new ApiMessageAndVersion(new ConfigRecord().
                     setResourceType(configResource.type().id()).
                     setResourceName(configResource.name()).
@@ -320,7 +320,7 @@ public class ConfigurationControlManager {
             String newValue = entry.getValue();
             String currentValue = currentConfigs.get(key);
             if (!Objects.equals(currentValue, newValue) || configResource.type().equals(Type.BROKER)) {
-                // We need to generate records even if the value is unchanged to trigger reloads on the brokers
+                // KAFKA-14136 We need to generate records even if the value is unchanged to trigger reloads on the brokers
                 newRecords.add(new ApiMessageAndVersion(new ConfigRecord().
                     setResourceType(configResource.type().id()).
                     setResourceName(configResource.name()).


### PR DESCRIPTION
This patch changes the AlterConfigs behavior in KRaft mode to match that of ZK. When we receive a LegacyAlterConfig or IncrementalAlterConfig that does _not_ change a value for a key, we will still generate a ConfigRecord.

This is to allow certain refresh behavior on the broker side (e.g., reloading trust stores and key stores).

The DynamicBrokerReconfigurationTests which reload key stores and trust stores are enabled in this PR to validate the new behavior.

Also, a small fix for KAFKA-14115 is included.
