### PR TITLE
KAFKA-14154; Ensure AlterPartition not sent to stale controller

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -398,7 +398,12 @@ final class ClusterConnectionStates {
      * @return the state of our connection
      */
     public ConnectionState connectionState(String id) {
-        return nodeState(id).state;
+        NodeConnectionState connectionState = this.nodeState.get(id);
+        if (connectionState == null) {
+            return null;
+        } else {
+            return connectionState.state;
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -316,7 +316,11 @@ public class NetworkClient implements KafkaClient {
      */
     @Override
     public void disconnect(String nodeId) {
-        if (connectionStates.isDisconnected(nodeId)) {
+        ConnectionState connectionState = connectionStates.connectionState(nodeId);
+        if (connectionState == null) {
+            log.debug("Client requested disconnect from node {}, which has no current connection state", nodeId);
+            return;
+        } else if (connectionState.isDisconnected()) {
             log.debug("Client requested disconnect from node {}, which is already disconnected", nodeId);
             return;
         }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1590,7 +1590,7 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   private def submitAlterPartition(proposedIsrState: PendingPartitionChange): CompletableFuture[LeaderAndIsr] = {
-    debug(s"Submitting ISR state change $proposedIsrState")
+    debug(s"Submitting ISR state change $proposedIsrState with controller epoch $controllerEpoch")
     val future = alterIsrManager.submit(
       new TopicIdPartition(topicId.getOrElse(Uuid.ZERO_UUID), topicPartition),
       proposedIsrState.sentLeaderAndIsr,

--- a/core/src/main/scala/kafka/server/AlterPartitionManager.scala
+++ b/core/src/main/scala/kafka/server/AlterPartitionManager.scala
@@ -262,7 +262,7 @@ class DefaultAlterPartitionManager(
     // We can use topic ids only if all the pending changed have one defined and
     // we use IBP 2.8 or above.
     var canUseTopicIds = metadataVersion.isTopicIdsSupported
-    var maxRequiredControllerEpoch = 0
+    var minRequiredControllerEpoch = 0
 
     val message = new AlterPartitionRequestData()
       .setBrokerId(brokerId)
@@ -291,8 +291,8 @@ class DefaultAlterPartitionManager(
           partitionData.setLeaderRecoveryState(item.leaderAndIsr.leaderRecoveryState.value)
         }
 
-        if (item.controllerEpoch > maxRequiredControllerEpoch) {
-          maxRequiredControllerEpoch = item.controllerEpoch
+        if (item.controllerEpoch > minRequiredControllerEpoch) {
+          minRequiredControllerEpoch = item.controllerEpoch
         }
 
         topicData.partitions.add(partitionData)
@@ -300,7 +300,7 @@ class DefaultAlterPartitionManager(
     }
 
     // If we cannot use topic ids, the builder will ensure that no version higher than 1 is used.
-    (new AlterPartitionRequest.Builder(message, canUseTopicIds), maxRequiredControllerEpoch, topicNamesByIds)
+    (new AlterPartitionRequest.Builder(message, canUseTopicIds), minRequiredControllerEpoch, topicNamesByIds)
   }
 
   def handleAlterPartitionResponse(

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -212,7 +212,7 @@ class BrokerServer(
       credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
 
       val controllerNodes = RaftConfig.voterConnectionsToNodes(controllerQuorumVotersFuture.get()).asScala
-      val controllerNodeProvider = RaftControllerNodeProvider(raftManager, config, controllerNodes)
+      val controllerNodeProvider = KRaftControllerNodeProvider(raftManager, config, controllerNodes)
 
       clientToControllerChannelManager = BrokerToControllerChannelManager(
         controllerNodeProvider,

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -263,7 +263,7 @@ class KafkaServer(
         logManager.startup(zkClient.getAllTopicsInCluster())
 
         metadataCache = MetadataCache.zkMetadataCache(config.brokerId, config.interBrokerProtocolVersion, brokerFeatures)
-        val controllerNodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
+        val controllerNodeProvider = ZkMetadataCacheControllerNodeProvider(config, metadataCache)
 
         /* initialize feature change listener */
         _featureChangeListener = new FinalizedFeatureChangeListener(metadataCache, _zkClient)

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -55,9 +55,9 @@ class BrokerLifecycleManagerTest {
   }
 
   class SimpleControllerNodeProvider extends ControllerNodeProvider {
-    val node = new AtomicReference[Node](null)
+    val node = new AtomicReference[ControllerNodeAndEpoch](null)
 
-    override def get(): Option[Node] = Option(node.get())
+    override def get(): Option[ControllerNodeAndEpoch] = Option(node.get())
 
     override def listenerName: ListenerName = new ListenerName("PLAINTEXT")
 
@@ -121,7 +121,8 @@ class BrokerLifecycleManagerTest {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
     val manager = new BrokerLifecycleManager(context.config, context.time, None)
     val controllerNode = new Node(3000, "localhost", 8021)
-    context.controllerNodeProvider.node.set(controllerNode)
+    val controllerEpoch = 15
+    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch(controllerNode, controllerEpoch))
     context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
       new BrokerRegistrationResponseData().setBrokerEpoch(1000)), controllerNode)
     manager.start(() => context.highestMetadataOffset.get(),
@@ -139,8 +140,9 @@ class BrokerLifecycleManagerTest {
   def testRegistrationTimeout(): Unit = {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
     val controllerNode = new Node(3000, "localhost", 8021)
+    val controllerEpoch = 15
     val manager = new BrokerLifecycleManager(context.config, context.time, None)
-    context.controllerNodeProvider.node.set(controllerNode)
+    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch(controllerNode, controllerEpoch))
     def newDuplicateRegistrationResponse(): Unit = {
       context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
         new BrokerRegistrationResponseData().
@@ -182,7 +184,8 @@ class BrokerLifecycleManagerTest {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
     val manager = new BrokerLifecycleManager(context.config, context.time, None)
     val controllerNode = new Node(3000, "localhost", 8021)
-    context.controllerNodeProvider.node.set(controllerNode)
+    val controllerEpoch = 15
+    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch(controllerNode, controllerEpoch))
     context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
       new BrokerRegistrationResponseData().setBrokerEpoch(1000)), controllerNode)
     context.mockClient.prepareResponseFrom(new BrokerHeartbeatResponse(

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -57,7 +57,7 @@ class BrokerLifecycleManagerTest {
   class SimpleControllerNodeProvider extends ControllerNodeProvider {
     val node = new AtomicReference[ControllerNodeAndEpoch](null)
 
-    override def get(): Option[ControllerNodeAndEpoch] = Option(node.get())
+    override def get(): ControllerNodeAndEpoch = node.get()
 
     override def listenerName: ListenerName = new ListenerName("PLAINTEXT")
 
@@ -122,7 +122,10 @@ class BrokerLifecycleManagerTest {
     val manager = new BrokerLifecycleManager(context.config, context.time, None)
     val controllerNode = new Node(3000, "localhost", 8021)
     val controllerEpoch = 15
-    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch(controllerNode, controllerEpoch))
+    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch.Known(
+      epoch = controllerEpoch,
+      node = controllerNode
+    ))
     context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
       new BrokerRegistrationResponseData().setBrokerEpoch(1000)), controllerNode)
     manager.start(() => context.highestMetadataOffset.get(),
@@ -142,7 +145,10 @@ class BrokerLifecycleManagerTest {
     val controllerNode = new Node(3000, "localhost", 8021)
     val controllerEpoch = 15
     val manager = new BrokerLifecycleManager(context.config, context.time, None)
-    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch(controllerNode, controllerEpoch))
+    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch.Known(
+      epoch = controllerEpoch,
+      node = controllerNode
+    ))
     def newDuplicateRegistrationResponse(): Unit = {
       context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
         new BrokerRegistrationResponseData().
@@ -185,7 +191,10 @@ class BrokerLifecycleManagerTest {
     val manager = new BrokerLifecycleManager(context.config, context.time, None)
     val controllerNode = new Node(3000, "localhost", 8021)
     val controllerEpoch = 15
-    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch(controllerNode, controllerEpoch))
+    context.controllerNodeProvider.node.set(ControllerNodeAndEpoch.Known(
+      epoch = controllerEpoch,
+      node = controllerNode
+    ))
     context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
       new BrokerRegistrationResponseData().setBrokerEpoch(1000)), controllerNode)
     context.mockClient.prepareResponseFrom(new BrokerHeartbeatResponse(

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -71,7 +71,12 @@ class ForwardingManagerTest {
     val responseBuffer = RequestTestUtils.serializeResponseWithHeader(responseBody, requestHeader.apiVersion,
       requestCorrelationId + 1)
 
-    Mockito.when(controllerNodeProvider.get()).thenReturn(Some(new Node(0, "host", 1234)))
+    val controller = new Node(0, "host", 1234)
+    val controllerEpoch = 156
+    Mockito.when(controllerNodeProvider.get()).thenReturn(
+      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+    )
+
     val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
     client.prepareResponse(isEnvelopeRequest, new EnvelopeResponse(responseBuffer, Errors.NONE));
 
@@ -95,7 +100,12 @@ class ForwardingManagerTest {
     val responseBuffer = RequestTestUtils.serializeResponseWithHeader(responseBody,
       requestHeader.apiVersion, requestCorrelationId)
 
-    Mockito.when(controllerNodeProvider.get()).thenReturn(Some(new Node(0, "host", 1234)))
+    val controller = new Node(0, "host", 1234)
+    val controllerEpoch = 156
+    Mockito.when(controllerNodeProvider.get()).thenReturn(
+      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+    )
+
     val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
     client.prepareResponse(isEnvelopeRequest, new EnvelopeResponse(responseBuffer, Errors.UNSUPPORTED_VERSION));
 
@@ -136,7 +146,11 @@ class ForwardingManagerTest {
     val (requestHeader, requestBuffer) = buildRequest(testAlterConfigRequest, requestCorrelationId)
     val request = buildRequest(requestHeader, requestBuffer, clientPrincipal)
 
-    Mockito.when(controllerNodeProvider.get()).thenReturn(Some(new Node(0, "host", 1234)))
+    val controller = new Node(0, "host", 1234)
+    val controllerEpoch = 156
+    Mockito.when(controllerNodeProvider.get()).thenReturn(
+      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+    )
 
     val response = new AtomicReference[AbstractResponse]()
     forwardingManager.forwardRequest(request, res => res.foreach(response.set))
@@ -162,8 +176,11 @@ class ForwardingManagerTest {
     val (requestHeader, requestBuffer) = buildRequest(testAlterConfigRequest, requestCorrelationId)
     val request = buildRequest(requestHeader, requestBuffer, clientPrincipal)
 
-    val controllerNode = new Node(0, "host", 1234)
-    Mockito.when(controllerNodeProvider.get()).thenReturn(Some(controllerNode))
+    val controller = new Node(0, "host", 1234)
+    val controllerEpoch = 156
+    Mockito.when(controllerNodeProvider.get()).thenReturn(
+      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+    )
 
     client.prepareUnsupportedVersionResponse(req => req.apiKey == requestHeader.apiKey)
 
@@ -183,10 +200,12 @@ class ForwardingManagerTest {
     val (requestHeader, requestBuffer) = buildRequest(testAlterConfigRequest, requestCorrelationId)
     val request = buildRequest(requestHeader, requestBuffer, clientPrincipal)
 
-    val controllerNode = new Node(0, "host", 1234)
-    Mockito.when(controllerNodeProvider.get()).thenReturn(Some(controllerNode))
-
-    client.createPendingAuthenticationError(controllerNode, 50)
+    val controller = new Node(0, "host", 1234)
+    val controllerEpoch = 156
+    Mockito.when(controllerNodeProvider.get()).thenReturn(
+      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+    )
+    client.createPendingAuthenticationError(controller, 50)
 
     val response = new AtomicReference[AbstractResponse]()
     forwardingManager.forwardRequest(request, res => res.foreach(response.set))

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -74,7 +74,10 @@ class ForwardingManagerTest {
     val controller = new Node(0, "host", 1234)
     val controllerEpoch = 156
     Mockito.when(controllerNodeProvider.get()).thenReturn(
-      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+      ControllerNodeAndEpoch.Known(
+        epoch = controllerEpoch,
+        node = controller
+      )
     )
 
     val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
@@ -103,7 +106,10 @@ class ForwardingManagerTest {
     val controller = new Node(0, "host", 1234)
     val controllerEpoch = 156
     Mockito.when(controllerNodeProvider.get()).thenReturn(
-      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+      ControllerNodeAndEpoch.Known(
+        epoch = controllerEpoch,
+        node = controller
+      )
     )
 
     val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
@@ -122,7 +128,7 @@ class ForwardingManagerTest {
     val (requestHeader, requestBuffer) = buildRequest(testAlterConfigRequest, requestCorrelationId)
     val request = buildRequest(requestHeader, requestBuffer, clientPrincipal)
 
-    Mockito.when(controllerNodeProvider.get()).thenReturn(None)
+    Mockito.when(controllerNodeProvider.get()).thenReturn(ControllerNodeAndEpoch.DefaultUnknown)
 
     val response = new AtomicReference[AbstractResponse]()
     forwardingManager.forwardRequest(request, res => res.foreach(response.set))
@@ -149,7 +155,10 @@ class ForwardingManagerTest {
     val controller = new Node(0, "host", 1234)
     val controllerEpoch = 156
     Mockito.when(controllerNodeProvider.get()).thenReturn(
-      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+      ControllerNodeAndEpoch.Known(
+        epoch = controllerEpoch,
+        node = controller
+      )
     )
 
     val response = new AtomicReference[AbstractResponse]()
@@ -179,7 +188,10 @@ class ForwardingManagerTest {
     val controller = new Node(0, "host", 1234)
     val controllerEpoch = 156
     Mockito.when(controllerNodeProvider.get()).thenReturn(
-      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+      ControllerNodeAndEpoch.Known(
+        epoch = controllerEpoch,
+        node = controller
+      )
     )
 
     client.prepareUnsupportedVersionResponse(req => req.apiKey == requestHeader.apiKey)
@@ -203,7 +215,10 @@ class ForwardingManagerTest {
     val controller = new Node(0, "host", 1234)
     val controllerEpoch = 156
     Mockito.when(controllerNodeProvider.get()).thenReturn(
-      Some(ControllerNodeAndEpoch(node = controller, epoch = controllerEpoch))
+      ControllerNodeAndEpoch.Known(
+        epoch = controllerEpoch,
+        node = controller
+      )
     )
     client.createPendingAuthenticationError(controller, 50)
 

--- a/core/src/test/scala/unit/kafka/server/MockBrokerToControllerChannelManager.scala
+++ b/core/src/test/scala/unit/kafka/server/MockBrokerToControllerChannelManager.scala
@@ -76,9 +76,9 @@ class MockBrokerToControllerChannelManager(
         unsentIterator.remove()
       } else {
         controllerNodeProvider.get() match {
-          case Some(controllerNodeAndEpoch) if client.ready(controllerNodeAndEpoch.node, time.milliseconds()) =>
+          case ControllerNodeAndEpoch.Known(_, node) if client.ready(node, time.milliseconds()) =>
             val clientRequest = client.newClientRequest(
-              controllerNodeAndEpoch.node.idString,
+              node.idString,
               queueItem.request,
               queueItem.createdTimeMs,
               true, // we expect response,


### PR DESCRIPTION
It is possible currently for a leader to send an `AlterPartition` request to a stale controller which does not have the latest leader epoch discovered through a `LeaderAndIsr` request. In this case, the stale controller returns `FENCED_LEADER_EPOCH`, which causes the partition leader to get stuck. This is a change in behavior following https://github.com/apache/kafka/pull/12032. Prior to that patch, the request would either be accepted (potentially incorrectly) if the `LeaderAndIsr` state matched that on the controller, or it would have returned `NOT_CONTROLLER` after the stale controller failed to apply the update to Zookeeper. 

This patch fixes the problem by ensuring that `AlterPartition` is sent to a controller with an epoch which is at least as large as that of the controller which sent the `LeaderAndIsr` request. The way this is achieved is by tracking the controller epoch in `BrokerToControllerChannelManager` and ensuring that it is only updated monotonically regardless of the source. If we find a controller epoch through `LeaderAndIsr` which is larger than what we have in the `MetadataCache`, then the controller node is reset and we wait until we have discovered the controller node with a higher epoch. This ensures that the `FENCED_LEADER_EPOCH` error from the controller can be trusted. 

A more elegant solution to this problem would probably be to include the controller epoch in the `AlterPartition` request, but this would require a version bump. Alternatively, we considered letting the controller return `UNKNOWN_LEADER_EPOCH` instead of `FENCED_LEADER_EPOCH` when the epoch is larger than what it has in its context. This too likely would require a version bump. Finally, we considered reverting https://github.com/apache/kafka/pull/12032, which would restore the looser validation logic which allows the controller to accept `AlterPartition` requests with larger leader epochs. We rejected this option because we feel it can lead to correctness violations.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
