### PR TITLE
KAFKA-14162: HoistField SMT should not return an immutable map for schemaless key/value

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HoistField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HoistField.java
@@ -26,7 +26,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class HoistField<R extends ConnectRecord<R>> implements Transformation<R> {
@@ -59,7 +59,9 @@ public abstract class HoistField<R extends ConnectRecord<R>> implements Transfor
         final Object value = operatingValue(record);
 
         if (schema == null) {
-            return newRecord(record, null, Collections.singletonMap(fieldName, value));
+            Map<String, Object> updatedValue = new HashMap<>();
+            updatedValue.put(fieldName, value);
+            return newRecord(record, null, updatedValue);
         } else {
             Schema updatedSchema = schemaUpdateCache.get(schema);
             if (updatedSchema == null) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.transforms;
 
+import java.util.ArrayList;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Field;
@@ -28,7 +29,6 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -148,9 +148,9 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         Object maskedValue = PRIMITIVE_VALUE_MAPPING.get(value.getClass());
         if (maskedValue == null) {
             if (value instanceof List)
-                maskedValue = Collections.emptyList();
+                maskedValue = new ArrayList<>();
             else if (value instanceof Map)
-                maskedValue = Collections.emptyMap();
+                maskedValue = new HashMap<>();
             else
                 throw new DataException("Cannot mask value of type: " + value.getClass());
         }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -69,7 +70,7 @@ public class HoistFieldTest {
         assertNull(transformedRecord.keySchema());
         @SuppressWarnings("unchecked")
         Map<String, Object> key = (Map<String, Object>) transformedRecord.key();
-        key.put("k", "v");
+        assertDoesNotThrow(() -> key.put("k", "v"));
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -69,8 +69,12 @@ public class HoistFieldTest {
 
         assertNull(transformedRecord.keySchema());
         @SuppressWarnings("unchecked")
-        Map<String, Object> key = (Map<String, Object>) transformedRecord.key();
-        assertDoesNotThrow(() -> key.put("k", "v"));
+        Map<String, Object> actualKey = (Map<String, Object>) transformedRecord.key();
+        actualKey.put("k", "v");
+        Map<String, Object> expectedKey = new HashMap<>();
+        expectedKey.put("k", "v");
+        expectedKey.put("magic", 420);
+        assertEquals(expectedKey, actualKey);
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -56,6 +57,19 @@ public class HoistFieldTest {
         assertEquals(Schema.Type.STRUCT, transformedRecord.keySchema().type());
         assertEquals(record.keySchema(),  transformedRecord.keySchema().field("magic").schema());
         assertEquals(42, ((Struct) transformedRecord.key()).get("magic"));
+    }
+
+    @Test
+    public void testSchemalessMapIsMutable() {
+        xform.configure(Collections.singletonMap("field", "magic"));
+
+        final SinkRecord record = new SinkRecord("test", 0, null, 420, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> key = (Map<String, Object>) transformedRecord.key();
+        key.put("k", "v");
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -249,5 +250,19 @@ public class MaskFieldTest {
     @Test
     public void testEmptyStringReplacementValue() {
         assertThrows(ConfigException.class, () -> checkReplacementSchemaless("short", ""), "String must be non-empty");
+    }
+
+    @Test
+    public void testNullListAndMapReplacementsAreMutable() {
+        final List<String> maskFields = new ArrayList<>(SCHEMA.fields().size());
+        SCHEMA.fields().forEach(f -> maskFields.add(f.name()));
+        final Struct updatedValue = (Struct) transform(maskFields, null).apply(record(SCHEMA, VALUES_WITH_SCHEMA)).value();
+        @SuppressWarnings("unchecked") List<Integer> list = (List<Integer>) updatedValue.get("array");
+        assertEquals(0, list.size());
+        assertDoesNotThrow(() -> list.add(0));
+
+        @SuppressWarnings("unchecked") Map<String, String> map = (Map<String, String>) updatedValue.get("map");
+        assertEquals(0, map.size());
+        assertDoesNotThrow(() -> map.put("k", "v"));
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -257,12 +256,16 @@ public class MaskFieldTest {
         final List<String> maskFields = new ArrayList<>(SCHEMA.fields().size());
         SCHEMA.fields().forEach(f -> maskFields.add(f.name()));
         final Struct updatedValue = (Struct) transform(maskFields, null).apply(record(SCHEMA, VALUES_WITH_SCHEMA)).value();
-        @SuppressWarnings("unchecked") List<Integer> list = (List<Integer>) updatedValue.get("array");
-        assertEquals(0, list.size());
-        assertDoesNotThrow(() -> list.add(0));
+        @SuppressWarnings("unchecked") List<Integer> actualList = (List<Integer>) updatedValue.get("array");
+        assertEquals(0, actualList.size());
+        actualList.add(0);
+        List<Integer> expectedList = Collections.singletonList(0);
+        assertEquals(expectedList, actualList);
 
-        @SuppressWarnings("unchecked") Map<String, String> map = (Map<String, String>) updatedValue.get("map");
-        assertEquals(0, map.size());
-        assertDoesNotThrow(() -> map.put("k", "v"));
+        @SuppressWarnings("unchecked") Map<String, String> actualMap = (Map<String, String>) updatedValue.get("map");
+        assertEquals(0, actualMap.size());
+        actualMap.put("k", "v");
+        Map<String, String> expectedMap = Collections.singletonMap("k", "v");
+        assertEquals(expectedMap, actualMap);
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
@@ -253,19 +253,16 @@ public class MaskFieldTest {
 
     @Test
     public void testNullListAndMapReplacementsAreMutable() {
-        final List<String> maskFields = new ArrayList<>(SCHEMA.fields().size());
-        SCHEMA.fields().forEach(f -> maskFields.add(f.name()));
+        final List<String> maskFields = Arrays.asList("array", "map");
         final Struct updatedValue = (Struct) transform(maskFields, null).apply(record(SCHEMA, VALUES_WITH_SCHEMA)).value();
         @SuppressWarnings("unchecked") List<Integer> actualList = (List<Integer>) updatedValue.get("array");
-        assertEquals(0, actualList.size());
+        assertEquals(Collections.emptyList(), actualList);
         actualList.add(0);
-        List<Integer> expectedList = Collections.singletonList(0);
-        assertEquals(expectedList, actualList);
+        assertEquals(Collections.singletonList(0), actualList);
 
         @SuppressWarnings("unchecked") Map<String, String> actualMap = (Map<String, String>) updatedValue.get("map");
-        assertEquals(0, actualMap.size());
+        assertEquals(Collections.emptyMap(), actualMap);
         actualMap.put("k", "v");
-        Map<String, String> expectedMap = Collections.singletonMap("k", "v");
-        assertEquals(expectedMap, actualMap);
+        assertEquals(Collections.singletonMap("k", "v"), actualMap);
     }
 }


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-14162
- The HoistField SMT currently returns an immutable map for schemaless keys and values - https://github.com/apache/kafka/blob/22007fba7c7346c5416f4db4e104434fdab265ee/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HoistField.java#L62
- This can cause failures in connectors if they attempt to modify the SourceRecord's key or value since Kafka Connect doesn't document that these keys/values are immutable. Furthermore, no other SMT does this.
- An example of a connector that would fail when schemaless values are used with this SMT is Microsoft's Cosmos DB Sink Connector - https://github.com/microsoft/kafka-connect-cosmosdb/blob/368566367a1dcbf9a91213067f1b9219a530bb16/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java#L123-L130