### PR TITLE
KAFKA-14133: Replace EasyMock with Mockito in streams tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
@@ -22,50 +22,50 @@ import org.apache.kafka.streams.errors.MissingSourceTopicException;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.internals.StreamThread.State;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class StreamsRebalanceListenerTest {
 
-    private final TaskManager taskManager = mock(TaskManager.class);
-    private final StreamThread streamThread = mock(StreamThread.class);
+    @Mock
+    private TaskManager taskManager;
+    @Mock
+    private StreamThread streamThread;
     private final AtomicInteger assignmentErrorCode = new AtomicInteger();
     private final MockTime time = new MockTime();
-    private final StreamsRebalanceListener streamsRebalanceListener = new StreamsRebalanceListener(
-        time,
-        taskManager,
-        streamThread,
-        LoggerFactory.getLogger(StreamsRebalanceListenerTest.class),
-        assignmentErrorCode
-    );
+    private StreamsRebalanceListener streamsRebalanceListener;
 
     @Before
-    public void before() {
-        expect(streamThread.state()).andStubReturn(null);
-        expect(taskManager.activeTaskIds()).andStubReturn(null);
-        expect(taskManager.standbyTaskIds()).andStubReturn(null);
+    public void setup() {
+         streamsRebalanceListener = new StreamsRebalanceListener(
+                time,
+                taskManager,
+                streamThread,
+                LoggerFactory.getLogger(StreamsRebalanceListenerTest.class),
+                assignmentErrorCode
+        );
     }
 
     @Test
     public void shouldThrowMissingSourceTopicException() {
-        taskManager.handleRebalanceComplete();
-        expectLastCall();
-        replay(taskManager, streamThread);
         assignmentErrorCode.set(AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code());
 
         final MissingSourceTopicException exception = assertThrows(
@@ -73,37 +73,28 @@ public class StreamsRebalanceListenerTest {
             () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
         );
         assertThat(exception.getMessage(), is("One or more source topics were missing during rebalance"));
-        verify(taskManager, streamThread);
+        verify(taskManager).handleRebalanceComplete();
     }
 
     @Test
     public void shouldSwallowVersionProbingError() {
-        expect(streamThread.setState(State.PARTITIONS_ASSIGNED)).andStubReturn(State.PARTITIONS_REVOKED);
-        streamThread.setPartitionAssignedTime(time.milliseconds());
-        taskManager.handleRebalanceComplete();
-        replay(taskManager, streamThread);
         assignmentErrorCode.set(AssignorError.VERSION_PROBING.code());
         streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList());
-        verify(taskManager, streamThread);
+        verify(streamThread).setState(eq(State.PARTITIONS_ASSIGNED));
+        verify(streamThread).setPartitionAssignedTime(eq(time.milliseconds()));
+        verify(taskManager).handleRebalanceComplete();
     }
 
     @Test
     public void shouldSendShutdown() {
-        streamThread.shutdownToError();
-        EasyMock.expectLastCall();
-        taskManager.handleRebalanceComplete();
-        EasyMock.expectLastCall();
-        replay(taskManager, streamThread);
         assignmentErrorCode.set(AssignorError.SHUTDOWN_REQUESTED.code());
         streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList());
-        verify(taskManager, streamThread);
+        verify(taskManager).handleRebalanceComplete();
+        verify(streamThread).shutdownToError();
     }
 
     @Test
     public void shouldThrowTaskAssignmentException() {
-        taskManager.handleRebalanceComplete();
-        expectLastCall();
-        replay(taskManager, streamThread);
         assignmentErrorCode.set(AssignorError.ASSIGNMENT_ERROR.code());
 
         final TaskAssignmentException exception = assertThrows(
@@ -111,12 +102,12 @@ public class StreamsRebalanceListenerTest {
             () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
         );
         assertThat(exception.getMessage(), is("Hit an unexpected exception during task assignment phase of rebalance"));
-        verify(taskManager, streamThread);
+
+        verify(taskManager).handleRebalanceComplete();
     }
 
     @Test
     public void shouldThrowTaskAssignmentExceptionOnUnrecognizedErrorCode() {
-        replay(taskManager, streamThread);
         assignmentErrorCode.set(Integer.MAX_VALUE);
 
         final TaskAssignmentException exception = assertThrows(
@@ -124,62 +115,51 @@ public class StreamsRebalanceListenerTest {
             () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
         );
         assertThat(exception.getMessage(), is("Hit an unrecognized exception during rebalance"));
-        verify(taskManager, streamThread);
     }
 
     @Test
     public void shouldHandleAssignedPartitions() {
-        taskManager.handleRebalanceComplete();
-        expect(streamThread.setState(State.PARTITIONS_ASSIGNED)).andReturn(State.RUNNING);
-        streamThread.setPartitionAssignedTime(time.milliseconds());
-
-        replay(taskManager, streamThread);
         assignmentErrorCode.set(AssignorError.NONE.code());
 
         streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList());
 
-        verify(taskManager, streamThread);
+        verify(streamThread).setState(eq(State.PARTITIONS_ASSIGNED));
+        verify(streamThread).setPartitionAssignedTime(eq(time.milliseconds()));
+        verify(taskManager).handleRebalanceComplete();
     }
 
     @Test
     public void shouldHandleRevokedPartitions() {
         final Collection<TopicPartition> partitions = Collections.singletonList(new TopicPartition("topic", 0));
-        expect(streamThread.setState(State.PARTITIONS_REVOKED)).andReturn(State.RUNNING);
-        taskManager.handleRevocation(partitions);
-        replay(streamThread, taskManager);
+        when(streamThread.setState(State.PARTITIONS_REVOKED)).thenReturn(State.RUNNING);
 
         streamsRebalanceListener.onPartitionsRevoked(partitions);
 
-        verify(taskManager, streamThread);
+        verify(taskManager).handleRevocation(eq(partitions));
     }
 
     @Test
     public void shouldNotHandleRevokedPartitionsIfStateCannotTransitToPartitionRevoked() {
-        expect(streamThread.setState(State.PARTITIONS_REVOKED)).andReturn(null);
-        replay(streamThread, taskManager);
+        when(streamThread.setState(State.PARTITIONS_REVOKED)).thenReturn(null);
 
         streamsRebalanceListener.onPartitionsRevoked(Collections.singletonList(new TopicPartition("topic", 0)));
 
-        verify(taskManager, streamThread);
+        verify(taskManager, never()).handleRevocation(any());
     }
 
     @Test
     public void shouldNotHandleEmptySetOfRevokedPartitions() {
-        expect(streamThread.setState(State.PARTITIONS_REVOKED)).andReturn(State.RUNNING);
-        replay(streamThread, taskManager);
+        when(streamThread.setState(State.PARTITIONS_REVOKED)).thenReturn(State.RUNNING);
 
         streamsRebalanceListener.onPartitionsRevoked(Collections.emptyList());
 
-        verify(taskManager, streamThread);
+        verify(taskManager, never()).handleRevocation(any());
     }
 
     @Test
     public void shouldHandleLostPartitions() {
-        taskManager.handleLostAll();
-        replay(streamThread, taskManager);
-
         streamsRebalanceListener.onPartitionsLost(Collections.singletonList(new TopicPartition("topic", 0)));
 
-        verify(taskManager, streamThread);
+        verify(taskManager).handleLostAll();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
@@ -37,7 +37,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -79,8 +78,8 @@ public class StreamsRebalanceListenerTest {
     public void shouldSwallowVersionProbingError() {
         assignmentErrorCode.set(AssignorError.VERSION_PROBING.code());
         streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList());
-        verify(streamThread).setState(eq(State.PARTITIONS_ASSIGNED));
-        verify(streamThread).setPartitionAssignedTime(eq(time.milliseconds()));
+        verify(streamThread).setState(State.PARTITIONS_ASSIGNED);
+        verify(streamThread).setPartitionAssignedTime(time.milliseconds());
         verify(taskManager).handleRebalanceComplete();
     }
 
@@ -122,8 +121,8 @@ public class StreamsRebalanceListenerTest {
 
         streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList());
 
-        verify(streamThread).setState(eq(State.PARTITIONS_ASSIGNED));
-        verify(streamThread).setPartitionAssignedTime(eq(time.milliseconds()));
+        verify(streamThread).setState(State.PARTITIONS_ASSIGNED);
+        verify(streamThread).setPartitionAssignedTime(time.milliseconds());
         verify(taskManager).handleRebalanceComplete();
     }
 
@@ -134,7 +133,7 @@ public class StreamsRebalanceListenerTest {
 
         streamsRebalanceListener.onPartitionsRevoked(partitions);
 
-        verify(taskManager).handleRevocation(eq(partitions));
+        verify(taskManager).handleRevocation(partitions);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
@@ -55,8 +55,7 @@ public class StreamsRebalanceListenerTest {
 
     @Before
     public void setup() {
-         streamsRebalanceListener = new StreamsRebalanceListener(
-                time,
+        streamsRebalanceListener = new StreamsRebalanceListener(time,
                 taskManager,
                 streamThread,
                 LoggerFactory.getLogger(StreamsRebalanceListenerTest.class),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TimestampedKeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TimestampedKeyValueStoreMaterializerTest.java
@@ -33,23 +33,23 @@ import org.apache.kafka.streams.state.internals.ChangeLoggingTimestampedKeyValue
 import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
 import org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStore;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class TimestampedKeyValueStoreMaterializerTest {
 
     private final String storePrefix = "prefix";
-    @Mock(type = MockType.NICE)
+    @Mock
     private InternalNameProvider nameProvider;
 
     @Test
@@ -107,12 +107,11 @@ public class TimestampedKeyValueStoreMaterializerTest {
 
     @Test
     public void shouldCreateKeyValueStoreWithTheProvidedInnerStore() {
-        final KeyValueBytesStoreSupplier supplier = EasyMock.createNiceMock(KeyValueBytesStoreSupplier.class);
+        final KeyValueBytesStoreSupplier supplier = mock(KeyValueBytesStoreSupplier.class);
         final InMemoryKeyValueStore store = new InMemoryKeyValueStore("name");
-        EasyMock.expect(supplier.name()).andReturn("name").anyTimes();
-        EasyMock.expect(supplier.get()).andReturn(store);
-        EasyMock.expect(supplier.metricsScope()).andReturn("metricScope");
-        EasyMock.replay(supplier);
+        when(supplier.name()).thenReturn("name");
+        when(supplier.get()).thenReturn(store);
+        when(supplier.metricsScope()).thenReturn("metricScope");
 
         final MaterializedInternal<String, Integer, KeyValueStore<Bytes, byte[]>> materialized =
             new MaterializedInternal<>(Materialized.as(supplier), nameProvider, storePrefix);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -51,7 +51,6 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -59,7 +58,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -116,7 +114,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         final CachingKeyValueStore outer = new CachingKeyValueStore(inner, false);
         when(inner.name()).thenReturn("store");
         outer.init((ProcessorContext) context, outer);
-        verify(inner).init(eq((ProcessorContext) context), eq(outer));
+        verify(inner).init((ProcessorContext) context, outer);
     }
 
     @Test
@@ -125,7 +123,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         final CachingKeyValueStore outer = new CachingKeyValueStore(inner, false);
         when(inner.name()).thenReturn("store");
         outer.init((StateStoreContext) context, outer);
-        verify(inner).init(eq((StateStoreContext) context), eq(outer));
+        verify(inner).init((StateStoreContext) context, outer);
     }
 
     @Test
@@ -159,8 +157,8 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).flush(eq(CACHE_NAMESPACE));
-        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -172,8 +170,8 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).flush(eq(CACHE_NAMESPACE));
-        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -185,8 +183,8 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).flush(eq(CACHE_NAMESPACE));
-        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -437,9 +435,9 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
             }
         }
 
-        assertThat(numberOfKeysReturned, is(2));
-        assertThat(keys, is(Arrays.asList("p1", "p11")));
-        assertThat(values, is(Arrays.asList("2", "2")));
+        assertEquals(2, numberOfKeysReturned);
+        assertEquals(Arrays.asList("p1", "p11"), keys);
+        assertEquals(Arrays.asList("2", "2"), values);
 
     }
 
@@ -466,9 +464,9 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
             }
         }
 
-        assertThat(numberOfKeysReturned, is(2));
-        assertThat(keys, is(Arrays.asList("abcd", "abcdd")));
-        assertThat(values, is(Arrays.asList("2", "1")));
+        assertEquals(2, numberOfKeysReturned);
+        assertEquals(Arrays.asList("abcd", "abcdd"), keys);
+        assertEquals(Arrays.asList("2", "1"), values);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -157,7 +157,6 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
@@ -171,7 +170,6 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         assertThrows(RuntimeException.class, store::close);
 
         verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -185,7 +183,6 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
 
         verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -40,6 +40,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
@@ -59,6 +60,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -152,37 +154,37 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringStateStoreClose() {
         setUpCloseTests();
-
+        InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, store::close);
 
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -154,7 +154,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, store::close);
@@ -166,7 +166,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, store::close);
@@ -178,7 +178,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldCloseCacheAfterErrorDuringStateStoreClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache);
+        final InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, store::close);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -36,10 +36,11 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +59,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     private final static String TOPIC = "topic";
@@ -105,26 +112,20 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        final KeyValueStore<Bytes, byte[]> inner = EasyMock.mock(InMemoryKeyValueStore.class);
+        final KeyValueStore<Bytes, byte[]> inner = mock(InMemoryKeyValueStore.class);
         final CachingKeyValueStore outer = new CachingKeyValueStore(inner, false);
-        EasyMock.expect(inner.name()).andStubReturn("store");
-        inner.init((ProcessorContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
+        when(inner.name()).thenReturn("store");
         outer.init((ProcessorContext) context, outer);
-        EasyMock.verify(inner);
+        verify(inner).init(eq((ProcessorContext) context), eq(outer));
     }
 
     @Test
     public void shouldDelegateInit() {
-        final KeyValueStore<Bytes, byte[]> inner = EasyMock.mock(InMemoryKeyValueStore.class);
+        final KeyValueStore<Bytes, byte[]> inner = mock(InMemoryKeyValueStore.class);
         final CachingKeyValueStore outer = new CachingKeyValueStore(inner, false);
-        EasyMock.expect(inner.name()).andStubReturn("store");
-        inner.init((StateStoreContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
+        when(inner.name()).thenReturn("store");
         outer.init((StateStoreContext) context, outer);
-        EasyMock.verify(inner);
+        verify(inner).init(eq((StateStoreContext) context), eq(outer));
     }
 
     @Test
@@ -153,57 +154,48 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on flush"));
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.replay(underlyingStore);
+
+        doThrow(new RuntimeException("Simulating an error on flush")).when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, store::close);
-        EasyMock.verify(cache, underlyingStore);
+
+        verify(cache).flush(eq(CACHE_NAMESPACE));
+        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        cache.close(CACHE_NAMESPACE);
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on close"));
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.replay(underlyingStore);
+
+        doThrow(new RuntimeException("Simulating an error on close")).when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, store::close);
-        EasyMock.verify(cache, underlyingStore);
+
+        verify(cache).flush(eq(CACHE_NAMESPACE));
+        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringStateStoreClose() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        cache.close(CACHE_NAMESPACE);
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on close"));
-        EasyMock.replay(underlyingStore);
+
+        doThrow(new RuntimeException("Simulating an error on close")).when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, store::close);
-        EasyMock.verify(cache, underlyingStore);
+
+        verify(cache).flush(eq(CACHE_NAMESPACE));
+        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(underlyingStore).close();
     }
 
+    @SuppressWarnings("unchecked")
     private void setUpCloseTests() {
-        underlyingStore = EasyMock.createNiceMock(KeyValueStore.class);
-        EasyMock.expect(underlyingStore.name()).andStubReturn("store-name");
-        EasyMock.expect(underlyingStore.isOpen()).andStubReturn(true);
-        EasyMock.replay(underlyingStore);
+        underlyingStore = mock(KeyValueStore.class);
+        when(underlyingStore.name()).thenReturn("store-name");
         store = new CachingKeyValueStore(underlyingStore, false);
-        cache = EasyMock.niceMock(ThreadCache.class);
+        cache = mock(ThreadCache.class);
         context = new InternalMockProcessorContext<>(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, new RecordHeaders()));
         store.init((StateStoreContext) context, store);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -45,6 +45,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
@@ -70,6 +71,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -268,31 +270,34 @@ public class CachingInMemorySessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringWrappedStoreClose() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -41,10 +41,11 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -68,8 +69,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PointlessArithmeticExpression")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class CachingInMemorySessionStoreTest {
 
     private static final int MAX_CACHE_SIZE_BYTES = 600;
@@ -105,26 +112,20 @@ public class CachingInMemorySessionStoreTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        final SessionStore<Bytes, byte[]> inner = EasyMock.mock(InMemorySessionStore.class);
+        final SessionStore<Bytes, byte[]> inner = mock(InMemorySessionStore.class);
         final CachingSessionStore outer = new CachingSessionStore(inner, SEGMENT_INTERVAL);
-        EasyMock.expect(inner.name()).andStubReturn("store");
-        inner.init((ProcessorContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
+        when(inner.name()).thenReturn("store");
         outer.init((ProcessorContext) context, outer);
-        EasyMock.verify(inner);
+        verify(inner).init(eq((ProcessorContext) context), eq(outer));
     }
 
     @Test
     public void shouldDelegateInit() {
-        final SessionStore<Bytes, byte[]> inner = EasyMock.mock(InMemorySessionStore.class);
+        final SessionStore<Bytes, byte[]> inner = mock(InMemorySessionStore.class);
         final CachingSessionStore outer = new CachingSessionStore(inner, SEGMENT_INTERVAL);
-        EasyMock.expect(inner.name()).andStubReturn("store");
-        inner.init((StateStoreContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
+        when(inner.name()).thenReturn("store");
         outer.init((StateStoreContext) context, outer);
-        EasyMock.verify(inner);
+        verify(inner).init(eq((StateStoreContext) context), eq(outer));
     }
 
     @Test
@@ -268,57 +269,42 @@ public class CachingInMemorySessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on flush"));
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.replay(underlyingStore);
+        doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        EasyMock.verify(cache, underlyingStore);
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
+        verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        cache.close(CACHE_NAMESPACE);
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on close"));
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.replay(underlyingStore);
+        doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        EasyMock.verify(cache, underlyingStore);
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
+        verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringWrappedStoreClose() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        cache.close(CACHE_NAMESPACE);
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on close"));
-        EasyMock.replay(underlyingStore);
+        doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        EasyMock.verify(cache, underlyingStore);
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
+        verify(underlyingStore).close();
     }
 
+    @SuppressWarnings("unchecked")
     private void setUpCloseTests() {
-        underlyingStore = EasyMock.createNiceMock(SessionStore.class);
-        EasyMock.expect(underlyingStore.name()).andStubReturn("store-name");
-        EasyMock.expect(underlyingStore.isOpen()).andStubReturn(true);
-        EasyMock.replay(underlyingStore);
+        underlyingStore = mock(SessionStore.class);
+        when(underlyingStore.name()).thenReturn("store-name");
         cachingStore = new CachingSessionStore(underlyingStore, SEGMENT_INTERVAL);
-        cache = EasyMock.niceMock(ThreadCache.class);
+        cache = mock(ThreadCache.class);
         final InternalMockProcessorContext context = new InternalMockProcessorContext<>(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, new RecordHeaders()));
         cachingStore.init((StateStoreContext) context, cachingStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -270,7 +270,7 @@ public class CachingInMemorySessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
@@ -281,7 +281,7 @@ public class CachingInMemorySessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
@@ -292,7 +292,7 @@ public class CachingInMemorySessionStoreTest {
     @Test
     public void shouldCloseCacheAfterErrorDuringWrappedStoreClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache);
+        final InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -271,7 +271,6 @@ public class CachingInMemorySessionStoreTest {
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
@@ -283,7 +282,6 @@ public class CachingInMemorySessionStoreTest {
 
         assertThrows(RuntimeException.class, cachingStore::close);
         verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -295,7 +293,6 @@ public class CachingInMemorySessionStoreTest {
         assertThrows(RuntimeException.class, cachingStore::close);
         verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -69,7 +69,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -116,7 +115,7 @@ public class CachingInMemorySessionStoreTest {
         final CachingSessionStore outer = new CachingSessionStore(inner, SEGMENT_INTERVAL);
         when(inner.name()).thenReturn("store");
         outer.init((ProcessorContext) context, outer);
-        verify(inner).init(eq((ProcessorContext) context), eq(outer));
+        verify(inner).init((ProcessorContext) context, outer);
     }
 
     @Test
@@ -125,7 +124,7 @@ public class CachingInMemorySessionStoreTest {
         final CachingSessionStore outer = new CachingSessionStore(inner, SEGMENT_INTERVAL);
         when(inner.name()).thenReturn("store");
         outer.init((StateStoreContext) context, outer);
-        verify(inner).init(eq((StateStoreContext) context), eq(outer));
+        verify(inner).init((StateStoreContext) context, outer);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -40,10 +40,11 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -67,7 +68,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class CachingPersistentSessionStoreTest {
 
     private static final int MAX_CACHE_SIZE_BYTES = 600;
@@ -258,58 +266,45 @@ public class CachingPersistentSessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on flush"));
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.replay(underlyingStore);
+        doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(anyString());
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        EasyMock.verify(cache, underlyingStore);
+        verify(cache).flush(eq(CACHE_NAMESPACE));
+        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        cache.close(CACHE_NAMESPACE);
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on close"));
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.replay(underlyingStore);
+
+        doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        EasyMock.verify(cache, underlyingStore);
+        verify(cache).flush(eq(CACHE_NAMESPACE));
+        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringWrappedStoreClose() {
         setUpCloseTests();
-        EasyMock.reset(cache);
-        cache.flush(CACHE_NAMESPACE);
-        cache.close(CACHE_NAMESPACE);
-        EasyMock.replay(cache);
-        EasyMock.reset(underlyingStore);
-        underlyingStore.close();
-        EasyMock.expectLastCall().andThrow(new RuntimeException("Simulating an error on close"));
-        EasyMock.replay(underlyingStore);
+
+        doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        EasyMock.verify(cache, underlyingStore);
+        verify(cache).flush(eq(CACHE_NAMESPACE));
+        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(underlyingStore).close();
     }
 
+    @SuppressWarnings("unchecked")
     private void setUpCloseTests() {
         underlyingStore.close();
-        underlyingStore = EasyMock.createNiceMock(SessionStore.class);
-        EasyMock.expect(underlyingStore.name()).andStubReturn("store-name");
-        EasyMock.expect(underlyingStore.isOpen()).andStubReturn(true);
-        EasyMock.replay(underlyingStore);
+        underlyingStore = mock(SessionStore.class);
+        when(underlyingStore.name()).thenReturn("store-name");
         cachingStore = new CachingSessionStore(underlyingStore, SEGMENT_INTERVAL);
-        cache = EasyMock.niceMock(ThreadCache.class);
+        cache = mock(ThreadCache.class);
         final InternalMockProcessorContext context =
             new InternalMockProcessorContext<>(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, new RecordHeaders()));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -69,7 +69,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -269,8 +268,8 @@ public class CachingPersistentSessionStoreTest {
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(anyString());
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(eq(CACHE_NAMESPACE));
-        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -281,8 +280,8 @@ public class CachingPersistentSessionStoreTest {
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(eq(CACHE_NAMESPACE));
-        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -293,8 +292,8 @@ public class CachingPersistentSessionStoreTest {
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(eq(CACHE_NAMESPACE));
-        verify(cache).close(eq(CACHE_NAMESPACE));
+        verify(cache).flush(CACHE_NAMESPACE);
+        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -265,7 +265,7 @@ public class CachingPersistentSessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
@@ -276,7 +276,7 @@ public class CachingPersistentSessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
@@ -287,7 +287,7 @@ public class CachingPersistentSessionStoreTest {
     @Test
     public void shouldCloseCacheAfterErrorDuringWrappedStoreClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache);
+        final InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -265,10 +265,9 @@ public class CachingPersistentSessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(anyString());
+        doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
@@ -281,7 +280,6 @@ public class CachingPersistentSessionStoreTest {
 
         assertThrows(RuntimeException.class, cachingStore::close);
         verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -294,7 +292,6 @@ public class CachingPersistentSessionStoreTest {
         assertThrows(RuntimeException.class, cachingStore::close);
         verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -44,6 +44,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
@@ -68,10 +69,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
@@ -265,33 +265,34 @@ public class CachingPersistentSessionStoreTest {
     @Test
     public void shouldCloseWrappedStoreAndCacheAfterErrorDuringCacheFlush() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringWrappedStoreClose() {
         setUpCloseTests();
-
+        InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -1042,7 +1042,7 @@ public class CachingPersistentWindowStoreTest {
     @Test
     public void shouldCloseCacheAndWrappedStoreAfterErrorDuringCacheFlush() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
@@ -1053,7 +1053,7 @@ public class CachingPersistentWindowStoreTest {
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache, underlyingStore);
+        final InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
@@ -1064,7 +1064,7 @@ public class CachingPersistentWindowStoreTest {
     @Test
     public void shouldCloseCacheAfterErrorDuringStateStoreClose() {
         setUpCloseTests();
-        InOrder inOrder = inOrder(cache);
+        final InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -51,6 +51,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
@@ -82,6 +83,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1040,31 +1042,34 @@ public class CachingPersistentWindowStoreTest {
     @Test
     public void shouldCloseCacheAndWrappedStoreAfterErrorDuringCacheFlush() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache, underlyingStore);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(cache).close(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(underlyingStore).close();
     }
 
     @Test
     public void shouldCloseCacheAfterErrorDuringStateStoreClose() {
         setUpCloseTests();
+        InOrder inOrder = inOrder(cache);
         doThrow(new RuntimeException("Simulating an error on close")).doNothing().when(underlyingStore).close();
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
+        inOrder.verify(cache).flush(CACHE_NAMESPACE);
+        inOrder.verify(cache).close(CACHE_NAMESPACE);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -81,7 +81,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -133,7 +132,7 @@ public class CachingPersistentWindowStoreTest {
         final CachingWindowStore outer = new CachingWindowStore(inner, WINDOW_SIZE, SEGMENT_INTERVAL);
         when(inner.name()).thenReturn("store");
         outer.init((ProcessorContext) context, outer);
-        verify(inner).init(eq((ProcessorContext) context), eq(outer));
+        verify(inner).init((ProcessorContext) context, outer);
     }
 
     @SuppressWarnings("unchecked")
@@ -143,7 +142,7 @@ public class CachingPersistentWindowStoreTest {
         final CachingWindowStore outer = new CachingWindowStore(inner, WINDOW_SIZE, SEGMENT_INTERVAL);
         when(inner.name()).thenReturn("store");
         outer.init((StateStoreContext) context, outer);
-        verify(inner).init(eq((StateStoreContext) context), eq(outer));
+        verify(inner).init((StateStoreContext) context, outer);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -1043,7 +1043,6 @@ public class CachingPersistentWindowStoreTest {
         doThrow(new RuntimeException("Simulating an error on flush")).doNothing().when(cache).flush(CACHE_NAMESPACE);
 
         assertThrows(RuntimeException.class, cachingStore::close);
-        verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
@@ -1055,7 +1054,6 @@ public class CachingPersistentWindowStoreTest {
 
         assertThrows(RuntimeException.class, cachingStore::close);
         verify(cache).flush(CACHE_NAMESPACE);
-        verify(cache).close(CACHE_NAMESPACE);
         verify(underlyingStore).close();
     }
 
@@ -1067,7 +1065,6 @@ public class CachingPersistentWindowStoreTest {
         assertThrows(RuntimeException.class, cachingStore::close);
         verify(cache).flush(CACHE_NAMESPACE);
         verify(cache).close(CACHE_NAMESPACE);
-        verify(underlyingStore).close();
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -41,10 +41,11 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -54,17 +55,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("rawtypes")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ChangeLoggingKeyValueBytesStoreTest {
 
     private final MockRecordCollector collector = new MockRecordCollector();
@@ -110,25 +112,19 @@ public class ChangeLoggingKeyValueBytesStoreTest {
     @Test
     public void shouldDelegateDeprecatedInit() {
         final InternalMockProcessorContext context = mockContext();
-        final KeyValueStore<Bytes, byte[]> innerMock = EasyMock.mock(InMemoryKeyValueStore.class);
+        final KeyValueStore<Bytes, byte[]> innerMock = mock(InMemoryKeyValueStore.class);
         final StateStore outer = new ChangeLoggingKeyValueBytesStore(innerMock);
-        innerMock.init((ProcessorContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(innerMock);
         outer.init((ProcessorContext) context, outer);
-        EasyMock.verify(innerMock);
+        verify(innerMock).init((ProcessorContext) context, outer);
     }
 
     @Test
     public void shouldDelegateInit() {
         final InternalMockProcessorContext context = mockContext();
-        final KeyValueStore<Bytes, byte[]> innerMock = EasyMock.mock(InMemoryKeyValueStore.class);
+        final KeyValueStore<Bytes, byte[]> innerMock = mock(InMemoryKeyValueStore.class);
         final StateStore outer = new ChangeLoggingKeyValueBytesStore(innerMock);
-        innerMock.init((StateStoreContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(innerMock);
         outer.init((StateStoreContext) context, outer);
-        EasyMock.verify(innerMock);
+        verify(innerMock).init((StateStoreContext) context, outer);
     }
 
     @Test
@@ -280,12 +276,9 @@ public class ChangeLoggingKeyValueBytesStoreTest {
 
         final Map<String, Object> myValues = new HashMap<>();
         myValues.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
-        expect(streamsConfig.originals()).andStubReturn(myValues);
-        expect(streamsConfig.values()).andStubReturn(Collections.emptyMap());
-        expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andStubReturn("add-id");
-        expect(streamsConfig.defaultValueSerde()).andStubReturn(Serdes.ByteArray());
-        expect(streamsConfig.defaultKeySerde()).andStubReturn(Serdes.ByteArray());
-        replay(streamsConfig);
+        when(streamsConfig.originals()).thenReturn(myValues);
+        when(streamsConfig.values()).thenReturn(Collections.emptyMap());
+        when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");
         return streamsConfig;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreTest.java
@@ -30,10 +30,11 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 
@@ -41,8 +42,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("rawtypes")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
 
     private final MockRecordCollector collector = new MockRecordCollector();
@@ -83,25 +87,20 @@ public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
     @Test
     public void shouldDelegateDeprecatedInit() {
         final InternalMockProcessorContext context = mockContext();
-        final KeyValueStore<Bytes, byte[]> inner = EasyMock.mock(InMemoryKeyValueStore.class);
+        final KeyValueStore<Bytes, byte[]> inner = mock(InMemoryKeyValueStore.class);
         final StateStore outer = new ChangeLoggingTimestampedKeyValueBytesStore(inner);
-        inner.init((ProcessorContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
         outer.init((ProcessorContext) context, outer);
-        EasyMock.verify(inner);
+        verify(inner).init((ProcessorContext) context, outer);
     }
 
     @Test
     public void shouldDelegateInit() {
         final InternalMockProcessorContext context = mockContext();
-        final KeyValueStore<Bytes, byte[]> inner = EasyMock.mock(InMemoryKeyValueStore.class);
+        final KeyValueStore<Bytes, byte[]> inner = mock(InMemoryKeyValueStore.class);
         final StateStore outer = new ChangeLoggingTimestampedKeyValueBytesStore(inner);
-        inner.init((StateStoreContext) context, outer);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
+
         outer.init((StateStoreContext) context, outer);
-        EasyMock.verify(inner);
+        verify(inner).init((StateStoreContext) context, outer);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -25,10 +25,11 @@ import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.StateStoreProviderStub;
 import org.apache.kafka.test.StreamsTestUtils;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,14 +40,17 @@ import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class CompositeReadOnlyWindowStoreTest {
 
     private static final long WINDOW_SIZE = 30_000;
@@ -172,10 +176,9 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void shouldThrowInvalidStateStoreExceptionOnRebalance() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject()))
-            .andThrow(new InvalidStateStoreException("store is unavailable"));
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any()))
+            .thenThrow(new InvalidStateStoreException("store is unavailable"));
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -188,10 +191,9 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void shouldThrowInvalidStateStoreExceptionOnRebalanceWhenBackwards() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject()))
-            .andThrow(new InvalidStateStoreException("store is unavailable"));
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any()))
+            .thenThrow(new InvalidStateStoreException("store is unavailable"));
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -239,9 +241,8 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void emptyBackwardIteratorAlwaysReturnsFalse() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject())).andReturn(emptyList());
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any())).thenReturn(emptyList());
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -257,9 +258,8 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void emptyIteratorAlwaysReturnsFalse() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject())).andReturn(emptyList());
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any())).thenReturn(emptyList());
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -275,9 +275,8 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void emptyBackwardIteratorPeekNextKeyShouldThrowNoSuchElementException() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject())).andReturn(emptyList());
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any())).thenReturn(emptyList());
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -292,9 +291,8 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void emptyIteratorPeekNextKeyShouldThrowNoSuchElementException() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject())).andReturn(emptyList());
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any())).thenReturn(emptyList());
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -309,9 +307,8 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void emptyIteratorNextShouldThrowNoSuchElementException() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject())).andReturn(emptyList());
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any())).thenReturn(emptyList());
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,
@@ -326,9 +323,8 @@ public class CompositeReadOnlyWindowStoreTest {
 
     @Test
     public void emptyBackwardIteratorNextShouldThrowNoSuchElementException() {
-        final StateStoreProvider storeProvider = EasyMock.createNiceMock(StateStoreProvider.class);
-        EasyMock.expect(storeProvider.stores(anyString(), anyObject())).andReturn(emptyList());
-        EasyMock.replay(storeProvider);
+        final StateStoreProvider storeProvider = mock(StateStoreProvider.class);
+        when(storeProvider.stores(anyString(), any())).thenReturn(emptyList());
 
         final CompositeReadOnlyWindowStore<Object, Object> store = new CompositeReadOnlyWindowStore<>(
             storeProvider,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -23,40 +23,35 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KeyValueStoreBuilderTest {
 
-    @Mock(type = MockType.NICE)
+    @Mock
     private KeyValueBytesStoreSupplier supplier;
-    @Mock(type = MockType.NICE)
+    @Mock
     private KeyValueStore<Bytes, byte[]> inner;
     private KeyValueStoreBuilder<String, String> builder;
 
     @Before
     public void setUp() {
-        EasyMock.expect(supplier.get()).andReturn(inner);
-        EasyMock.expect(supplier.name()).andReturn("name");
-        expect(supplier.metricsScope()).andReturn("metricScope");
-        EasyMock.replay(supplier);
+        when(supplier.get()).thenReturn(inner);
+        when(supplier.name()).thenReturn("name");
+        when(supplier.metricsScope()).thenReturn("metricScope");
         builder = new KeyValueStoreBuilder<>(
             supplier,
             Serdes.String(),
@@ -127,26 +122,14 @@ public class KeyValueStoreBuilderTest {
     }
 
     @Test
-    public void shouldThrowNullPointerIfKeySerdeIsNull() {
-        assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(supplier, null, Serdes.String(), new MockTime()));
-    }
-
-    @Test
-    public void shouldThrowNullPointerIfValueSerdeIsNull() {
-        assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), null, new MockTime()));
-    }
-
-    @Test
     public void shouldThrowNullPointerIfTimeIsNull() {
         assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
     }
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        reset(supplier);
-        expect(supplier.get()).andReturn(new RocksDBStore("name", null));
-        expect(supplier.name()).andReturn("name");
-        replay(supplier);
+        when(supplier.name()).thenReturn("name");
+        when(supplier.metricsScope()).thenReturn(null);
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -59,10 +59,12 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -83,7 +85,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class StreamThreadStateStoreProviderTest {
 
     private StreamTask taskOne;
@@ -91,6 +96,7 @@ public class StreamThreadStateStoreProviderTest {
     private StateDirectory stateDirectory;
     private File stateDir;
     private final String topicName = "topic";
+    @Mock
     private StreamThread threadMock;
     private Map<TaskId, Task> tasks;
 
@@ -174,7 +180,6 @@ public class StreamThreadStateStoreProviderTest {
         taskTwo.initializeIfNeeded();
         tasks.put(new TaskId(0, 1), taskTwo);
 
-        threadMock = EasyMock.createNiceMock(StreamThread.class);
         provider = new StreamThreadStateStoreProvider(threadMock);
 
     }
@@ -451,7 +456,7 @@ public class StreamThreadStateStoreProviderTest {
             new TopologyConfig(null, streamsConfig, new Properties()).getTaskConfig(),
             streamsMetrics,
             stateDirectory,
-            EasyMock.createNiceMock(ThreadCache.class),
+            mock(ThreadCache.class),
             new MockTime(),
             stateManager,
             recordCollector,
@@ -459,14 +464,10 @@ public class StreamThreadStateStoreProviderTest {
     }
 
     private void mockThread(final boolean initialized) {
-        EasyMock.expect(threadMock.isRunning()).andReturn(initialized);
-        EasyMock.expect(threadMock.allTasks()).andStubReturn(tasks);
-        EasyMock.expect(threadMock.activeTaskMap()).andStubReturn(tasks);
-        EasyMock.expect(threadMock.activeTasks()).andStubReturn(new ArrayList<>(tasks.values()));
-        EasyMock.expect(threadMock.state()).andReturn(
+        when(threadMock.activeTasks()).thenReturn(new ArrayList<>(tasks.values()));
+        when(threadMock.state()).thenReturn(
             initialized ? StreamThread.State.RUNNING : StreamThread.State.PARTITIONS_ASSIGNED
-        ).anyTimes();
-        EasyMock.replay(threadMock);
+        );
     }
 
     private void configureClients(final MockClientSupplier clientSupplier, final String topic) {


### PR DESCRIPTION
Batch 2 of the tests detailed in https://issues.apache.org/jira/browse/KAFKA-14133 which use EasyMock and need to be moved to Mockito.