### PR TITLE
MINOR: Add setting input partitions for task mocks

### DIFF
--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -325,6 +325,11 @@ public final class StreamsTestUtils {
             return this;
         }
 
+        public TaskBuilder<T> withInputPartitions(final Set<TopicPartition> inputPartitions) {
+            when(task.inputPartitions()).thenReturn(inputPartitions);
+            return this;
+        }
+
         public T build() {
             return task;
         }


### PR DESCRIPTION
We recently added a builder to create task mocks for unit
tests. This PR adds the functionality to add input partitions
to task mocks when the builder is used.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
