### PR TITLE
KAFKA-14167; Completion exceptions should not be translated directly to error codes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -132,6 +132,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 /**
@@ -469,7 +471,15 @@ public enum Errors {
      * If there are multiple matches in the class hierarchy, the first match starting from the bottom is used.
      */
     public static Errors forException(Throwable t) {
-        Class<?> clazz = t.getClass();
+        // Get the underlying cause for common exception types from the concurrent library.
+        // This is useful to handle cases where exceptions may be raised from a future or a
+        // completion stage (as might be the case for requests sent to the controller in `ControllerApis`)
+        Throwable throwableToBeEncoded = t;
+        if (t instanceof CompletionException || t instanceof ExecutionException) {
+            throwableToBeEncoded = t.getCause();
+        }
+
+        Class<?> clazz = throwableToBeEncoded.getClass();
         while (clazz != null) {
             Errors error = classToError.get(clazz);
             if (error != null)

--- a/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
@@ -56,6 +56,10 @@ public class AllocateProducerIdsResponse extends AbstractResponse {
         return data.throttleTimeMs();
     }
 
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
     public static AllocateProducerIdsResponse parse(ByteBuffer buffer, short version) {
         return new AllocateProducerIdsResponse(new AllocateProducerIdsResponseData(
                 new ByteBufferAccessor(buffer), version));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
@@ -38,9 +38,10 @@ public class ApiError {
     public static ApiError fromThrowable(Throwable t) {
         // Avoid populating the error message if it's a generic one. Also don't populate error
         // message for UNKNOWN_SERVER_ERROR to ensure we don't leak sensitive information.
-        Errors error = Errors.forException(t);
+        Throwable throwableToBeEncoded = Errors.getCause(t);
+        Errors error = Errors.forException(throwableToBeEncoded);
         String message = error == Errors.UNKNOWN_SERVER_ERROR ||
-            error.message().equals(t.getMessage()) ? null : t.getMessage();
+            error.message().equals(throwableToBeEncoded.getMessage()) ? null : throwableToBeEncoded.getMessage();
         return new ApiError(error, message);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
@@ -21,8 +21,6 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.util.Objects;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Encapsulates an error code (via the Errors enum) and an optional message. Generally, the optional message is only
@@ -38,18 +36,11 @@ public class ApiError {
     private final String message;
 
     public static ApiError fromThrowable(Throwable t) {
-        Throwable throwableToBeEncoded = t;
-        // Get the underlying cause for common exception types from the concurrent library.
-        // This is useful to handle cases where exceptions may be raised from a future or a
-        // completion stage (as might be the case for requests sent to the controller in `ControllerApis`)
-        if (t instanceof CompletionException || t instanceof ExecutionException) {
-            throwableToBeEncoded = t.getCause();
-        }
         // Avoid populating the error message if it's a generic one. Also don't populate error
         // message for UNKNOWN_SERVER_ERROR to ensure we don't leak sensitive information.
-        Errors error = Errors.forException(throwableToBeEncoded);
+        Errors error = Errors.forException(t);
         String message = error == Errors.UNKNOWN_SERVER_ERROR ||
-            error.message().equals(throwableToBeEncoded.getMessage()) ? null : throwableToBeEncoded.getMessage();
+            error.message().equals(t.getMessage()) ? null : t.getMessage();
         return new ApiError(error, message);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiError.java
@@ -38,7 +38,7 @@ public class ApiError {
     public static ApiError fromThrowable(Throwable t) {
         // Avoid populating the error message if it's a generic one. Also don't populate error
         // message for UNKNOWN_SERVER_ERROR to ensure we don't leak sensitive information.
-        Throwable throwableToBeEncoded = Errors.getCause(t);
+        Throwable throwableToBeEncoded = Errors.maybeUnwrapException(t);
         Errors error = Errors.forException(throwableToBeEncoded);
         String message = error == Errors.UNKNOWN_SERVER_ERROR ||
             error.message().equals(throwableToBeEncoded.getMessage()) ? null : throwableToBeEncoded.getMessage();

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiErrorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiErrorTest.java
@@ -41,10 +41,10 @@ public class ApiErrorTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void fromThrowableShouldReturnCorrectError(Throwable t, Errors expectedErrors, String expectedMsg) {
+    public void fromThrowableShouldReturnCorrectError(Throwable t, Errors expectedError, String expectedMsg) {
         ApiError apiError = ApiError.fromThrowable(t);
-        assertEquals(apiError.error(), expectedErrors);
-        assertEquals(apiError.message(), expectedMsg);
+        assertEquals(expectedError, apiError.error());
+        assertEquals(expectedMsg, apiError.message());
     }
 
     private static Collection<Arguments> parameters() {

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -20,7 +20,7 @@ package kafka.server
 import java.util
 import java.util.{Collections, OptionalLong}
 import java.util.Map.Entry
-import java.util.concurrent.{CompletableFuture, CompletionException}
+import java.util.concurrent.CompletableFuture
 import kafka.network.RequestChannel
 import kafka.raft.RaftManager
 import kafka.server.QuotaFactory.QuotaManagers
@@ -117,10 +117,7 @@ class ControllerApis(val requestChannel: RequestChannel,
           // log the original exception here
           error(s"Unexpected error handling request ${request.requestDesc(true)} " +
             s"with context ${request.context}", exception)
-
-          // For building the correct error request, we do need send the "cause" exception
-          val actualException = if (exception.isInstanceOf[CompletionException]) exception.getCause else exception
-          requestHelper.handleError(request, actualException)
+          requestHelper.handleError(request, exception)
         }
       }
     } catch {

--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -267,11 +267,11 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
                 .orElseThrow(() -> new IllegalArgumentException("Unknown brokerId " + brokerId));
         }
 
-        private Stream<BrokerServer> brokers() {
+        public Stream<BrokerServer> brokers() {
             return clusterReference.get().brokers().values().stream();
         }
 
-        private Stream<ControllerServer> controllers() {
+        public Stream<ControllerServer> controllers() {
             return clusterReference.get().controllers().values().stream();
         }
 

--- a/core/src/test/scala/unit/kafka/server/AllocateProducerIdsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AllocateProducerIdsRequestTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package unit.kafka.server
+
+import kafka.network.SocketServer
+import kafka.server.{BrokerServer, ControllerServer, IntegrationTestUtils}
+import kafka.test.ClusterInstance
+import kafka.test.annotation.{ClusterTest, ClusterTestDefaults, Type}
+import kafka.test.junit.ClusterTestExtensions
+import kafka.test.junit.RaftClusterInvocationContext.RaftClusterInstance
+import org.apache.kafka.common.message.AllocateProducerIdsRequestData
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests._
+import org.apache.kafka.server.common.ProducerIdsBlock
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.{Tag, Timeout}
+
+@Timeout(120)
+@ExtendWith(value = Array(classOf[ClusterTestExtensions]))
+@ClusterTestDefaults(clusterType = Type.KRAFT)
+@Tag("integration")
+class AllocateProducerIdsRequestTest(cluster: ClusterInstance) {
+
+  @ClusterTest
+  def testAllocateProducersIdSentToController(): Unit = {
+    val raftCluster = cluster.asInstanceOf[RaftClusterInstance]
+    val sourceBroker = raftCluster.brokers.findFirst().get()
+
+    val controllerId = sourceBroker.raftManager.leaderAndEpoch.leaderId().getAsInt
+    val controllerServer = raftCluster.controllers()
+      .filter(_.config.nodeId == controllerId)
+      .findFirst()
+      .get()
+
+    val allocateResponse = sendAndReceiveAllocateProducerIds(sourceBroker, controllerServer)
+    assertEquals(Errors.NONE, allocateResponse.error)
+    assertEquals(ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE, allocateResponse.data.producerIdLen)
+    assertTrue(allocateResponse.data.producerIdStart >= 0)
+  }
+
+  @ClusterTest(controllers = 3)
+  def testAllocateProducersIdSentToNonController(): Unit = {
+    val raftCluster = cluster.asInstanceOf[RaftClusterInstance]
+    val sourceBroker = raftCluster.brokers.findFirst().get()
+
+    val controllerId = sourceBroker.raftManager.leaderAndEpoch.leaderId().getAsInt
+    val controllerServer = raftCluster.controllers()
+      .filter(_.config.nodeId != controllerId)
+      .findFirst()
+      .get()
+
+    val allocateResponse = sendAndReceiveAllocateProducerIds(sourceBroker, controllerServer)
+    assertEquals(Errors.NOT_CONTROLLER, Errors.forCode(allocateResponse.data.errorCode))
+  }
+
+  private def sendAndReceiveAllocateProducerIds(
+    sourceBroker: BrokerServer,
+    controllerServer: ControllerServer
+  ): AllocateProducerIdsResponse = {
+    val allocateRequest = new AllocateProducerIdsRequest.Builder(
+      new AllocateProducerIdsRequestData()
+        .setBrokerId(sourceBroker.config.brokerId)
+        .setBrokerEpoch(sourceBroker.lifecycleManager.brokerEpoch)
+    ).build()
+
+    connectAndReceive(
+      controllerServer.socketServer,
+      allocateRequest
+    )
+  }
+
+  private def connectAndReceive(
+    controllerSocketServer: SocketServer,
+    request: AllocateProducerIdsRequest
+  ): AllocateProducerIdsResponse = {
+    IntegrationTestUtils.connectAndReceive[AllocateProducerIdsResponse](
+      request,
+      controllerSocketServer,
+      cluster.controllerListenerName.get
+    )
+  }
+
+}


### PR DESCRIPTION
There are a few cases in `ControllerApis` where we may see an `ApiException` wrapped as a `CompletionException`. This can happen in `QuorumController.allocateProducerIds` where the returned future is the result of calling `thenApply` on the future passed to the controller. The danger when this happens is that the `CompletionException` gets passed to `Errors.forException`, which translates it to an `UNKNOWN_SERVER_ERROR`. At a minimum, I found that the `AllocateProducerIds` and `UpdateFeatures` APIs were affected by this bug, but it is difficult to root out all cases. 

Interestingly, `DeleteTopics` is not affected by this bug as I originally suspected. This is because we have logic in `ApiError.fromThrowable` to check for both `CompletionException` and `ExecutionException` and to pull out the underlying cause. This patch duplicates this logic from `ApiError.fromThrowable` into `Errors.forException` to be sure that we handle all cases where exceptions are converted to error codes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
