### PR TITLE
MINOR: Initialize all error meters when building map in RequestChannel

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -526,8 +526,9 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
     else
       None
 
-  private val errorMeters = mutable.Map[Errors, ErrorMeter]()
-  Errors.values.foreach(error => errorMeters.put(error, new ErrorMeter(name, error)))
+  private val errorMeters = Errors.values.map { error =>
+    error -> new ErrorMeter(name, error)
+  }.toMap
 
   def requestRate(version: Short): Meter = {
     requestRateInternal.getAndMaybePut(version, newMeter(RequestsPerSec, "requests", TimeUnit.SECONDS, tags + ("version" -> version.toString)))
@@ -580,6 +581,5 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
       removeMetric(TemporaryMemoryBytes, tags)
     }
     errorMeters.values.foreach(_.removeMeter())
-    errorMeters.clear()
   }
 }


### PR DESCRIPTION
We have been seeing some errors where the `errorMeters` map seems to be missing some keys. We can fix this by changing the type to be immutable and building it on initialization.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
