### PR TITLE
Docs(Quickstart Guide): Fix invalid link to plugin.path

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -175,7 +175,7 @@ This is my second event</code></pre>
         <p>
             First, make sure to add <code class="language-bash">connect-file-{{fullDotVersion}}.jar</code> to the <code>plugin.path</code> property in the Connect worker's configuration.
             For the purpose of this quickstart we'll use a relative path and consider the connectors' package as an uber jar, which works when the quickstart commands are run from the installation directory.
-            However, it's worth noting that for production deployments using absolute paths is always preferable. See <a href="#connectconfigs_plugin.path">plugin.path</a> for a detailed description of how to set this config.
+            However, it's worth noting that for production deployments using absolute paths is always preferable. See <a href="/documentation/#connectconfigs_plugin.path">plugin.path</a> for a detailed description of how to set this config.
         </p>
 
         <p>


### PR DESCRIPTION
The link to the plugin.path is not pointing to the correct site.

I simply added `/documentation/` to fix it.
