### PR TITLE
KAFKA-14133: Replace EasyMock with Mockito in streams test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -310,10 +310,9 @@ public class ProcessorStateManagerTest {
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
-        verify(store).close();
 
         stateMgr.close();
-
+        verify(store).close();
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -81,6 +81,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -332,9 +333,9 @@ public class ProcessorStateManagerTest {
         stateMgr.recycle();
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
-        verify(context).uninitialize();
 
         stateMgr.registerStateStores(singletonList(store), context);
+        verify(context, times(2)).uninitialize();
 
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -310,6 +310,7 @@ public class ProcessorStateManagerTest {
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
+        verify(store).close();
 
         stateMgr.close();
 
@@ -332,6 +333,7 @@ public class ProcessorStateManagerTest {
         stateMgr.recycle();
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
+        verify(context).uninitialize();
 
         stateMgr.registerStateStores(singletonList(store), context);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -40,16 +40,14 @@ import org.apache.kafka.streams.state.internals.StoreQueryUtils;
 import org.apache.kafka.test.MockKeyValueStore;
 import org.apache.kafka.test.MockRestoreCallback;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -70,12 +68,6 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -87,8 +79,12 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ProcessorStateManagerTest {
 
     private final String applicationId = "test-application";
@@ -124,11 +120,11 @@ public class ProcessorStateManagerTest {
     private OffsetCheckpoint checkpoint;
     private StateDirectory stateDirectory;
 
-    @Mock(type = MockType.NICE)
+    @Mock
     private StateStore store;
-    @Mock(type = MockType.NICE)
+    @Mock
     private StateStoreMetadata storeMetadata;
-    @Mock(type = MockType.NICE)
+    @Mock
     private InternalProcessorContext context;
 
     @Before
@@ -144,11 +140,6 @@ public class ProcessorStateManagerTest {
         }), new MockTime(), true, true);
         checkpointFile = new File(stateDirectory.getOrCreateDirectoryForTask(taskId), CHECKPOINT_FILE_NAME);
         checkpoint = new OffsetCheckpoint(checkpointFile);
-
-        expect(storeMetadata.changelogPartition()).andReturn(persistentStorePartition).anyTimes();
-        expect(storeMetadata.store()).andReturn(store).anyTimes();
-        expect(store.name()).andReturn(persistentStoreName).anyTimes();
-        replay(storeMetadata, store);
     }
 
     @After
@@ -310,29 +301,17 @@ public class ProcessorStateManagerTest {
     @Test
     public void shouldUnregisterChangelogsDuringClose() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
-        reset(storeMetadata);
-        final StateStore store = EasyMock.createMock(StateStore.class);
-        expect(storeMetadata.changelogPartition()).andStubReturn(persistentStorePartition);
-        expect(storeMetadata.store()).andStubReturn(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-
-        context.uninitialize();
-        store.init((StateStoreContext) context, store);
-        replay(storeMetadata, context, store);
+        final StateStore store = mock(StateStore.class);
+        when(store.name()).thenReturn(persistentStoreName);
 
         stateMgr.registerStateStores(singletonList(store), context);
-        verify(context, store);
+        verify(context).uninitialize();
+        verify(store).init((StateStoreContext) context, store);
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
 
-        reset(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-        store.close();
-        replay(store);
-
         stateMgr.close();
-        verify(store);
 
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
     }
@@ -340,18 +319,12 @@ public class ProcessorStateManagerTest {
     @Test
     public void shouldRecycleStoreAndReregisterChangelog() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
-        reset(storeMetadata);
-        final StateStore store = EasyMock.createMock(StateStore.class);
-        expect(storeMetadata.changelogPartition()).andStubReturn(persistentStorePartition);
-        expect(storeMetadata.store()).andStubReturn(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-
-        context.uninitialize();
-        store.init((StateStoreContext) context, store);
-        replay(storeMetadata, context, store);
-
+        final StateStore store = mock(StateStore.class);
+        when(store.name()).thenReturn(persistentStoreName);
         stateMgr.registerStateStores(singletonList(store), context);
-        verify(context, store);
+
+        verify(context).uninitialize();
+        verify(store).init((StateStoreContext) context, store);
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
@@ -360,14 +333,8 @@ public class ProcessorStateManagerTest {
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
 
-        reset(context, store);
-        context.uninitialize();
-        expect(store.name()).andStubReturn(persistentStoreName);
-        replay(context, store);
-
         stateMgr.registerStateStores(singletonList(store), context);
 
-        verify(context, store);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
     }
 
@@ -1092,10 +1059,8 @@ public class ProcessorStateManagerTest {
     public void shouldThrowOnFailureToWritePositionCheckpointFile() throws IOException {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
         final CommitCallback persistentCheckpoint = mock(CommitCallback.class);
-        persistentCheckpoint.onCommit();
         final IOException ioException = new IOException("asdf");
-        expectLastCall().andThrow(ioException);
-        replay(persistentCheckpoint);
+        doThrow(ioException).when(persistentCheckpoint).onCommit();
         stateMgr.registerStore(
             persistentStore,
             persistentStore.stateRestoreCallback,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -216,6 +216,7 @@ public class StandbyTaskTest {
         task.maybeCheckpoint(true);
 
         verify(stateManager).checkpoint();
+        verify(stateManager).flush();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -301,6 +301,8 @@ public class StandbyTaskTest {
 
     @Test
     public void shouldSuspendAndCommitBeforeCloseClean() {
+        when(stateManager.changelogOffsets())
+            .thenReturn(Collections.singletonMap(partition, 60L));
         stateManager.close();
         stateManager.checkpoint();
         verify(stateManager, times(1)).checkpoint();
@@ -319,6 +321,8 @@ public class StandbyTaskTest {
 
         final double expectedCloseTaskMetric = 1.0;
         verifyCloseTaskMetric(expectedCloseTaskMetric, streamsMetrics, metricName);
+
+        verify(stateManager).changelogOffsets();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -297,8 +297,6 @@ public class StandbyTaskTest {
 
         task.suspend();
         task.closeDirty();
-
-        verify(stateManager, atLeastOnce()).close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -300,7 +300,6 @@ public class StandbyTaskTest {
 
         task.suspend();
         task.closeDirty();
-        verify(stateManager).close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -235,6 +235,7 @@ public class StandbyTaskTest {
         assertEquals(Collections.singletonMap(partition, 11000L), task.offsetSnapshotSinceLastFlush);
         task.maybeCheckpoint(false);  // this should not checkpoint
         assertEquals(Collections.singletonMap(partition, 11000L), task.offsetSnapshotSinceLastFlush);
+        verify(stateManager).flush();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -323,6 +323,7 @@ public class StandbyTaskTest {
         verifyCloseTaskMetric(expectedCloseTaskMetric, streamsMetrics, metricName);
 
         verify(stateManager).changelogOffsets();
+        verify(stateManager, atLeastOnce()).close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -47,6 +47,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -76,6 +77,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -305,9 +307,10 @@ public class StandbyTaskTest {
     public void shouldSuspendAndCommitBeforeCloseClean() {
         when(stateManager.changelogOffsets())
             .thenReturn(Collections.singletonMap(partition, 60L));
+        final InOrder stateManagerOrdered = inOrder(stateManager);
         stateManager.close();
         stateManager.checkpoint();
-        verify(stateManager, times(1)).checkpoint();
+        stateManagerOrdered.verify(stateManager, times(1)).checkpoint();
         when(stateManager.changelogOffsets())
                 .thenReturn(Collections.singletonMap(partition, 60L));
         final MetricName metricName = setupCloseTaskMetric();
@@ -325,7 +328,7 @@ public class StandbyTaskTest {
         verifyCloseTaskMetric(expectedCloseTaskMetric, streamsMetrics, metricName);
 
         verify(stateManager).changelogOffsets();
-        verify(stateManager, atLeastOnce()).close();
+        stateManagerOrdered.verify(stateManager, atLeastOnce()).close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -73,6 +73,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -179,6 +180,7 @@ public class StandbyTaskTest {
 
     @Test
     public void shouldTransitToRunningAfterInitialization() {
+        stateManager.registerStateStores(any(), any());
         task = createStandbyTask();
 
         assertEquals(CREATED, task.state());
@@ -191,6 +193,7 @@ public class StandbyTaskTest {
         task.initializeIfNeeded();
 
         assertEquals(RUNNING, task.state());
+        verify(stateManager, atLeastOnce()).registerStateStores(any(), any());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -298,6 +298,7 @@ public class StandbyTaskTest {
 
         task.suspend();
         task.closeDirty();
+        verify(stateManager).close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -304,7 +304,6 @@ public class StandbyTaskTest {
     @Test
     public void shouldSuspendAndCommitBeforeCloseClean() {
         stateManager.close();
-        verify(stateManager, atLeastOnce()).close();
         stateManager.checkpoint();
         verify(stateManager, times(1)).checkpoint();
         when(stateManager.changelogOffsets())


### PR DESCRIPTION
Batch 3 of the tests detailed in https://issues.apache.org/jira/browse/KAFKA-14133 which use EasyMock and need to be moved to Mockito.

EDIT: This issue has been solved
Unfortunately some tests are failing and I am not exactly sure how and why this is happening, specifically

* `shouldNotUpdateLimitForNonSourceStandbyChangelog`
* `shouldOnlyRestoreStandbyChangelogInUpdateStandbyState`
* `shouldRestoreToLimitInStandbyState`

As you can see from the diff in this PR, the changes from `EasyMock` to `Mockito` in these functions was quite trivial/mechanical but the tests are failing with errors that are confusing to me, i.e.

```
[2022-08-17 12:13:33,803] DEBUG test-reader Transiting to update standby tasks: {} (org.apache.kafka.streams.processor.internals.StoreChangelogReader:317)
[2022-08-17 12:13:33,803] DEBUG test-reader Resumed partitions [] from the restore consumer (org.apache.kafka.streams.processor.internals.StoreChangelogReader:899)
[2022-08-17 12:13:33,804] DEBUG test-reader Added partitions [topic-0] to the restore consumer, current assignment is [topic-0] (org.apache.kafka.streams.processor.internals.StoreChangelogReader:861)
[2022-08-17 12:13:33,804] DEBUG test-reader Start restoring changelog partition topic-0 from current offset 0 to end offset 7. (org.apache.kafka.streams.processor.internals.StoreChangelogReader:918)
[2022-08-17 12:13:33,805] WARN test-reader Encountered org.apache.kafka.clients.consumer.OffsetOutOfRangeException fetching records from restore consumer for partitions [topic-0], it is likely that the consumer's position has fallen out of the topic partition offset range because the topic was truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing it later. (org.apache.kafka.streams.processor.internals.StoreChangelogReader:438)
org.apache.kafka.clients.consumer.OffsetOutOfRangeException: Offsets out of range with no configured reset policy for partitions: {topic-0=1}
	at org.apache.kafka.clients.consumer.MockConsumer.poll(MockConsumer.java:208)
	at org.apache.kafka.streams.processor.internals.StoreChangelogReader.restore(StoreChangelogReader.java:433)
	at org.apache.kafka.streams.processor.internals.StoreChangelogReaderTest.shouldRestoreToLimitInStandbyState(StoreChangelogReaderTest.java:836)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.mockito.internal.junit.JUnitSessionStore$1.evaluateSafely(JUnitSessionStore.java:55)
	at org.mockito.internal.junit.JUnitSessionStore$1.evaluate(JUnitSessionStore.java:43)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)

Tasks [null] are corrupted and hence needs to be re-initialized
org.apache.kafka.streams.errors.TaskCorruptedException: Tasks [null] are corrupted and hence needs to be re-initialized
	at app//org.apache.kafka.streams.processor.internals.StoreChangelogReader.restore(StoreChangelogReader.java:446)
	at app//org.apache.kafka.streams.processor.internals.StoreChangelogReaderTest.shouldRestoreToLimitInStandbyState(StoreChangelogReaderTest.java:836)
```

@cadonna @clolov @C0urante @ijuma Maybe you have an idea what is going on here? Also note that due to Mockito not working with inline `thenReturn` mock statements (see https://github.com/mockito/mockito/wiki/FAQ#can-i-thenreturn-an-inlined-mock-) I did some refactorings in `StoreChangelogReaderTest`, i.e. `mockTasks` and `mockTask` have been moved from inner local methods to the class. This was also done as an attempt to solve the aforementioned problems but it ended up having zero effect (also note in general apart from these problems it had zero effect on the tests).

Also note that `@SuppressWarnings("unchecked")` is necessary because unlike EasyMock, Mockito doesn't have any support for generics in the `mock` method (see https://github.com/mockito/mockito/issues/1531)

Finally with `ProcesserStateManagerTest` some verifications, stubbed calls have been removed for the same reasons behind https://github.com/apache/kafka/pull/12505#discussion_r947652273, i.e. `MockitoJUnitRunner.StrictStubs` was complaining that there was extra erroneous stubs/verifications and I needed to remove them to make `StrictStubs` happy. This stubbing was also unnecessary in `EasyMock`.