### PR TITLE
KAFKA-14133: Replace EasyMock with Mockito in streams tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorTest.java
@@ -37,11 +37,12 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueBuffer;
 import org.apache.kafka.test.MockInternalNewProcessorContext;
-import org.easymock.EasyMock;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -61,7 +62,9 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KTableSuppressProcessorTest {
     private static final long ARBITRARY_LONG = 5L;
 
@@ -82,7 +85,8 @@ public class KTableSuppressProcessorTest {
                 .withLoggingDisabled()
                 .build();
 
-            final KTableImpl<K, ?, V> parent = EasyMock.mock(KTableImpl.class);
+            @SuppressWarnings("unchecked")
+            final KTableImpl<K, ?, V> parent = mock(KTableImpl.class);
             final Processor<K, Change<V>, K, Change<V>> processor =
                 new KTableSuppressProcessorSupplier<>((SuppressedInternal<K>) suppressed, storeName, parent).get();
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
@@ -16,41 +16,33 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
-import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.SessionStore;
-import org.apache.kafka.test.MockRecordCollector;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Optional;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ChangeLoggingSessionBytesStoreTest {
 
-    private final TaskId taskId = new TaskId(0, 0);
-    private final MockRecordCollector collector = new MockRecordCollector();
-
-    @Mock(type = MockType.NICE)
+    @Mock
     private SessionStore<Bytes, byte[]> inner;
-    @Mock(type = MockType.NICE)
+    @Mock
     private ProcessorContextImpl context;
 
     private ChangeLoggingSessionBytesStore store;
@@ -63,199 +55,128 @@ public class ChangeLoggingSessionBytesStoreTest {
     @Before
     public void setUp() {
         store = new ChangeLoggingSessionBytesStore(inner);
+        store.init((StateStoreContext) context, store);
     }
 
-    private void init() {
-        EasyMock.expect(context.taskId()).andReturn(taskId).anyTimes();
-        EasyMock.expect(context.recordCollector()).andReturn(collector).anyTimes();
-        EasyMock.expect(context.recordMetadata()).andReturn(Optional.empty()).anyTimes();
-        inner.init((StateStoreContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner, context);
-        store.init((StateStoreContext) context, store);
+    @After
+    public void tearDown() {
+        verify(inner).init((StateStoreContext) context, store);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        inner.init((ProcessorContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
         store.init((ProcessorContext) context, store);
-        EasyMock.verify(inner);
+
+        verify(inner).init((ProcessorContext) context, store);
     }
 
     @Test
     public void shouldDelegateInit() {
-        inner.init((StateStoreContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
-        store.init((StateStoreContext) context, store);
-        EasyMock.verify(inner);
+        // testing the combination of setUp and tearDown
     }
 
     @Test
     public void shouldLogPuts() {
-        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
-        inner.put(key1, value1);
-        EasyMock.expectLastCall();
-
-        init();
-
         final Bytes binaryKey = SessionKeySchema.toBinary(key1);
+        when(inner.getPosition()).thenReturn(Position.emptyPosition());
 
-        EasyMock.reset(context);
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.empty());
-        context.logChange(store.name(), binaryKey, value1, 0L, Position.emptyPosition());
-
-        EasyMock.replay(context);
         store.put(key1, value1);
 
-        EasyMock.verify(inner, context);
+        verify(inner).put(key1, value1);
+        verify(context).logChange(store.name(), binaryKey, value1, 0L, Position.emptyPosition());
     }
 
     @Test
     public void shouldLogPutsWithPosition() {
-        EasyMock.expect(inner.getPosition()).andReturn(POSITION).anyTimes();
-        inner.put(key1, value1);
-        EasyMock.expectLastCall();
-
-        init();
-
         final Bytes binaryKey = SessionKeySchema.toBinary(key1);
+        when(inner.getPosition()).thenReturn(POSITION);
 
-        EasyMock.reset(context);
-        final RecordMetadata recordContext = new ProcessorRecordContext(0L, 1L, 0, "", new RecordHeaders());
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.of(recordContext));
-        EasyMock.expect(context.timestamp()).andStubReturn(0L);
-        context.logChange(store.name(), binaryKey, value1, 0L, POSITION);
-
-        EasyMock.replay(context);
         store.put(key1, value1);
 
-        EasyMock.verify(inner, context);
+        verify(inner).put(key1, value1);
+        verify(context).logChange(store.name(), binaryKey, value1, 0L, POSITION);
     }
 
     @Test
     public void shouldLogRemoves() {
-        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
-        inner.remove(key1);
-        EasyMock.expectLastCall();
-
-        init();
-        store.remove(key1);
-
         final Bytes binaryKey = SessionKeySchema.toBinary(key1);
+        when(inner.getPosition()).thenReturn(Position.emptyPosition());
 
-        EasyMock.reset(context);
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.empty());
-        context.logChange(store.name(), binaryKey, null, 0L, Position.emptyPosition());
-
-        EasyMock.replay(context);
+        store.remove(key1);
         store.remove(key1);
 
-        EasyMock.verify(inner, context);
+        verify(inner, times(2)).remove(key1);
+        verify(context, times(2)).logChange(store.name(), binaryKey, null, 0L, Position.emptyPosition());
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFetching() {
-        EasyMock.expect(inner.fetch(bytesKey)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.fetch(bytesKey);
-        EasyMock.verify(inner);
+
+        verify(inner).fetch(bytesKey);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenBackwardFetching() {
-        EasyMock.expect(inner.backwardFetch(bytesKey)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.backwardFetch(bytesKey);
-        EasyMock.verify(inner);
+
+        verify(inner).backwardFetch(bytesKey);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFetchingRange() {
-        EasyMock.expect(inner.fetch(bytesKey, bytesKey)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.fetch(bytesKey, bytesKey);
-        EasyMock.verify(inner);
+
+        verify(inner).fetch(bytesKey, bytesKey);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenBackwardFetchingRange() {
-        EasyMock.expect(inner.backwardFetch(bytesKey, bytesKey)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.backwardFetch(bytesKey, bytesKey);
-        EasyMock.verify(inner);
+
+        verify(inner).backwardFetch(bytesKey, bytesKey);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFindingSessions() {
-        EasyMock.expect(inner.findSessions(bytesKey, 0, 1)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.findSessions(bytesKey, 0, 1);
-        EasyMock.verify(inner);
+
+        verify(inner).findSessions(bytesKey, 0, 1);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenBackwardFindingSessions() {
-        EasyMock.expect(inner.backwardFindSessions(bytesKey, 0, 1)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.backwardFindSessions(bytesKey, 0, 1);
-        EasyMock.verify(inner);
+
+        verify(inner).backwardFindSessions(bytesKey, 0, 1);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFindingSessionRange() {
-        EasyMock.expect(inner.findSessions(bytesKey, bytesKey, 0, 1)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.findSessions(bytesKey, bytesKey, 0, 1);
-        EasyMock.verify(inner);
+
+        verify(inner).findSessions(bytesKey, bytesKey, 0, 1);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenBackwardFindingSessionRange() {
-        EasyMock.expect(inner.backwardFindSessions(bytesKey, bytesKey, 0, 1)).andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.backwardFindSessions(bytesKey, bytesKey, 0, 1);
-        EasyMock.verify(inner);
+
+        verify(inner).backwardFindSessions(bytesKey, bytesKey, 0, 1);
     }
 
     @Test
     public void shouldFlushUnderlyingStore() {
-        inner.flush();
-        EasyMock.expectLastCall();
-
-        init();
-
         store.flush();
-        EasyMock.verify(inner);
+
+        verify(inner).flush();
     }
 
     @Test
     public void shouldCloseUnderlyingStore() {
-        inner.close();
-        EasyMock.expectLastCall();
-
-        init();
-
         store.close();
-        EasyMock.verify(inner);
+
+        verify(inner).close();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedWindowBytesStoreTest.java
@@ -17,44 +17,36 @@
 
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
-import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.test.MockRecordCollector;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Optional;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ChangeLoggingTimestampedWindowBytesStoreTest {
-
-    private final TaskId taskId = new TaskId(0, 0);
-    private final MockRecordCollector collector = new MockRecordCollector();
 
     private final byte[] value = {0};
     private final byte[] valueAndTimestamp = {0, 0, 0, 0, 0, 0, 0, 42, 0};
     private final Bytes bytesKey = Bytes.wrap(value);
 
-    @Mock(type = MockType.NICE)
+    @Mock
     private WindowStore<Bytes, byte[]> inner;
-    @Mock(type = MockType.NICE)
+    @Mock
     private ProcessorContextImpl context;
     private ChangeLoggingTimestampedWindowBytesStore store;
 
@@ -63,129 +55,79 @@ public class ChangeLoggingTimestampedWindowBytesStoreTest {
     @Before
     public void setUp() {
         store = new ChangeLoggingTimestampedWindowBytesStore(inner, false);
+        store.init((StateStoreContext) context, store);
     }
 
-    private void init() {
-        EasyMock.expect(context.taskId()).andReturn(taskId).anyTimes();
-        EasyMock.expect(context.recordCollector()).andReturn(collector).anyTimes();
-        EasyMock.expect(context.recordMetadata()).andReturn(Optional.empty()).anyTimes();
-        inner.init((StateStoreContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner, context);
-
-        store.init((StateStoreContext) context, store);
+    @After
+    public void tearDown() {
+        verify(inner).init((StateStoreContext) context, store);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        inner.init((ProcessorContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
         store.init((ProcessorContext) context, store);
-        EasyMock.verify(inner);
+
+        verify(inner).init((ProcessorContext) context, store);
     }
 
     @Test
     public void shouldDelegateInit() {
-        inner.init((StateStoreContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
-        store.init((StateStoreContext) context, store);
-        EasyMock.verify(inner);
+        // testing the combination of setUp and tearDown
     }
 
     @Test
     @SuppressWarnings("deprecation")
     public void shouldLogPuts() {
-        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
-        inner.put(bytesKey, valueAndTimestamp, 0);
-        EasyMock.expectLastCall();
-
-        init();
-
         final Bytes key = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 0);
+        when(inner.getPosition()).thenReturn(Position.emptyPosition());
 
-        EasyMock.reset(context);
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.empty());
-        context.logChange(store.name(), key, value, 42, Position.emptyPosition());
-
-        EasyMock.replay(context);
         store.put(bytesKey, valueAndTimestamp, context.timestamp());
 
-        EasyMock.verify(inner, context);
+        verify(inner).put(bytesKey, valueAndTimestamp, 0);
+        verify(context).logChange(store.name(), key, value, 42, Position.emptyPosition());
     }
 
     @Test
     public void shouldLogPutsWithPosition() {
-        EasyMock.expect(inner.getPosition()).andReturn(POSITION).anyTimes();
-        inner.put(bytesKey, valueAndTimestamp, 0);
-        EasyMock.expectLastCall();
-
-        init();
-
         final Bytes key = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 0);
+        when(inner.getPosition()).thenReturn(POSITION);
 
-        EasyMock.reset(context);
-        final RecordMetadata recordContext = new ProcessorRecordContext(0L, 1L, 0, "", new RecordHeaders());
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.of(recordContext));
-        final Position position = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
-        context.logChange(store.name(), key, value, 42, position);
-
-        EasyMock.replay(context);
         store.put(bytesKey, valueAndTimestamp, context.timestamp());
 
-        EasyMock.verify(inner, context);
+        verify(inner).put(bytesKey, valueAndTimestamp, 0);
+        verify(context).logChange(store.name(), key, value, 42, POSITION);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFetching() {
-        EasyMock
-            .expect(inner.fetch(bytesKey, 0, 10))
-            .andReturn(KeyValueIterators.emptyWindowStoreIterator());
-
-        init();
-
         store.fetch(bytesKey, ofEpochMilli(0), ofEpochMilli(10));
-        EasyMock.verify(inner);
+
+        verify(inner).fetch(bytesKey, 0, 10);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFetchingRange() {
-        EasyMock
-            .expect(inner.fetch(bytesKey, bytesKey, 0, 1))
-            .andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.fetch(bytesKey, bytesKey, ofEpochMilli(0), ofEpochMilli(1));
-        EasyMock.verify(inner);
+
+        verify(inner).fetch(bytesKey, bytesKey, 0, 1);
     }
 
     @Test
     @SuppressWarnings("deprecation")
     public void shouldRetainDuplicatesWhenSet() {
         store = new ChangeLoggingTimestampedWindowBytesStore(inner, true);
-        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
-        inner.put(bytesKey, valueAndTimestamp, 0);
-        EasyMock.expectLastCall().times(2);
-
-        init();
-
+        store.init((StateStoreContext) context, store);
         final Bytes key1 = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 1);
         final Bytes key2 = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 2);
-
-        EasyMock.reset(context);
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.empty());
-        context.logChange(store.name(), key1, value, 42L, Position.emptyPosition());
-        context.logChange(store.name(), key2, value, 42L, Position.emptyPosition());
-
-        EasyMock.replay(context);
+        when(inner.getPosition()).thenReturn(Position.emptyPosition());
 
         store.put(bytesKey, valueAndTimestamp, context.timestamp());
         store.put(bytesKey, valueAndTimestamp, context.timestamp());
 
-        EasyMock.verify(inner, context);
+        verify(inner, times(2)).put(bytesKey, valueAndTimestamp, 0);
+        verify(context).logChange(store.name(), key1, value, 42L, Position.emptyPosition());
+        verify(context).logChange(store.name(), key2, value, 42L, Position.emptyPosition());
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
@@ -17,43 +17,35 @@
 
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
-import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.test.MockRecordCollector;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Optional;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ChangeLoggingWindowBytesStoreTest {
-
-    private final TaskId taskId = new TaskId(0, 0);
-    private final MockRecordCollector collector = new MockRecordCollector();
 
     private final byte[] value = {0};
     private final Bytes bytesKey = Bytes.wrap(value);
 
-    @Mock(type = MockType.NICE)
+    @Mock
     private WindowStore<Bytes, byte[]> inner;
-    @Mock(type = MockType.NICE)
+    @Mock
     private ProcessorContextImpl context;
     private ChangeLoggingWindowBytesStore store;
 
@@ -62,154 +54,92 @@ public class ChangeLoggingWindowBytesStoreTest {
     @Before
     public void setUp() {
         store = new ChangeLoggingWindowBytesStore(inner, false, WindowKeySchema::toStoreKeyBinary);
+        store.init((StateStoreContext) context, store);
     }
 
-    private void init() {
-        EasyMock.expect(context.taskId()).andReturn(taskId).anyTimes();
-        EasyMock.expect(context.recordCollector()).andReturn(collector).anyTimes();
-        EasyMock.expect(context.recordMetadata()).andReturn(Optional.empty()).anyTimes();
-        inner.init((StateStoreContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner, context);
-
-        store.init((StateStoreContext) context, store);
+    @After
+    public void tearDown() {
+        verify(inner).init((StateStoreContext) context, store);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        inner.init((ProcessorContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
         store.init((ProcessorContext) context, store);
-        EasyMock.verify(inner);
+
+        verify(inner).init((ProcessorContext) context, store);
     }
 
     @Test
     public void shouldDelegateInit() {
-        inner.init((StateStoreContext) context, store);
-        EasyMock.expectLastCall();
-        EasyMock.replay(inner);
-        store.init((StateStoreContext) context, store);
-        EasyMock.verify(inner);
+        // testing the combination of setUp and tearDown
     }
 
     @Test
     public void shouldLogPuts() {
-        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
-        inner.put(bytesKey, value, 0);
-        EasyMock.expectLastCall();
-
-        init();
-
         final Bytes key = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 0);
+        when(inner.getPosition()).thenReturn(Position.emptyPosition());
 
-        EasyMock.reset(context);
-        EasyMock.expect(context.timestamp()).andStubReturn(0L);
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.empty());
-        context.logChange(store.name(), key, value, 0L, Position.emptyPosition());
-
-        EasyMock.replay(context);
         store.put(bytesKey, value, context.timestamp());
 
-        EasyMock.verify(inner, context);
+        verify(inner).put(bytesKey, value, 0);
+        verify(context).logChange(store.name(), key, value, 0L, Position.emptyPosition());
     }
 
     @Test
     public void shouldLogPutsWithPosition() {
-        EasyMock.expect(inner.getPosition()).andReturn(POSITION).anyTimes();
-        inner.put(bytesKey, value, 0);
-        EasyMock.expectLastCall();
-
-        init();
-
         final Bytes key = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 0);
+        when(inner.getPosition()).thenReturn(POSITION);
 
-        EasyMock.reset(context);
-        final RecordMetadata recordContext = new ProcessorRecordContext(0L, 1L, 0, "", new RecordHeaders());
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.of(recordContext));
-        EasyMock.expect(context.timestamp()).andStubReturn(0L);
-        final Position position = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
-        context.logChange(store.name(), key, value, 0L, position);
-
-        EasyMock.replay(context);
         store.put(bytesKey, value, context.timestamp());
 
-        EasyMock.verify(inner, context);
+        verify(inner).put(bytesKey, value, 0);
+        verify(context).logChange(store.name(), key, value, 0L, POSITION);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFetching() {
-        EasyMock
-            .expect(inner.fetch(bytesKey, 0, 10))
-            .andReturn(KeyValueIterators.emptyWindowStoreIterator());
-
-        init();
-
         store.fetch(bytesKey, ofEpochMilli(0), ofEpochMilli(10));
-        EasyMock.verify(inner);
+
+        verify(inner).fetch(bytesKey, 0, 10);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenBackwardFetching() {
-        EasyMock
-            .expect(inner.backwardFetch(bytesKey, 0, 10))
-            .andReturn(KeyValueIterators.emptyWindowStoreIterator());
-
-        init();
-
         store.backwardFetch(bytesKey, ofEpochMilli(0), ofEpochMilli(10));
-        EasyMock.verify(inner);
+
+        verify(inner).backwardFetch(bytesKey, 0, 10);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenFetchingRange() {
-        EasyMock
-            .expect(inner.fetch(bytesKey, bytesKey, 0, 1))
-            .andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.fetch(bytesKey, bytesKey, ofEpochMilli(0), ofEpochMilli(1));
-        EasyMock.verify(inner);
+
+        verify(inner).fetch(bytesKey, bytesKey, 0, 1);
     }
 
     @Test
     public void shouldDelegateToUnderlyingStoreWhenBackwardFetchingRange() {
-        EasyMock
-            .expect(inner.backwardFetch(bytesKey, bytesKey, 0, 1))
-            .andReturn(KeyValueIterators.emptyIterator());
-
-        init();
-
         store.backwardFetch(bytesKey, bytesKey, ofEpochMilli(0), ofEpochMilli(1));
-        EasyMock.verify(inner);
+
+        verify(inner).backwardFetch(bytesKey, bytesKey, 0, 1);
     }
 
     @Test
     public void shouldRetainDuplicatesWhenSet() {
         store = new ChangeLoggingWindowBytesStore(inner, true, WindowKeySchema::toStoreKeyBinary);
-        EasyMock.expect(inner.getPosition()).andReturn(Position.emptyPosition()).anyTimes();
-        inner.put(bytesKey, value, 0);
-        EasyMock.expectLastCall().times(2);
-
-        init();
+        store.init((StateStoreContext) context, store);
+        when(inner.getPosition()).thenReturn(Position.emptyPosition());
 
         final Bytes key1 = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 1);
         final Bytes key2 = WindowKeySchema.toStoreKeyBinary(bytesKey, 0, 2);
 
-        EasyMock.reset(context);
-        EasyMock.expect(context.timestamp()).andStubReturn(0L);
-        EasyMock.expect(context.recordMetadata()).andStubReturn(Optional.empty());
-        context.logChange(store.name(), key1, value, 0L, Position.emptyPosition());
-        context.logChange(store.name(), key2, value, 0L, Position.emptyPosition());
-
-        EasyMock.replay(context);
-
         store.put(bytesKey, value, context.timestamp());
         store.put(bytesKey, value, context.timestamp());
 
-        EasyMock.verify(inner, context);
+        verify(inner, times(2)).put(bytesKey, value, 0);
+        verify(context).logChange(store.name(), key1, value, 0L, Position.emptyPosition());
+        verify(context).logChange(store.name(), key2, value, 0L, Position.emptyPosition());
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -48,8 +48,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -188,8 +186,8 @@ public class MeteredTimestampedWindowStoreTest {
         store.fetch(KEY, TIMESTAMP);
         store.put(KEY, VALUE_AND_TIMESTAMP, TIMESTAMP);
 
-        verify(innerStoreMock).fetch(any(Bytes.class), eq(TIMESTAMP));
-        verify(innerStoreMock).put(any(Bytes.class), any(byte[].class), eq(TIMESTAMP));
+        verify(innerStoreMock).fetch(KEY_BYTES, TIMESTAMP);
+        verify(innerStoreMock).put(KEY_BYTES, VALUE_AND_TIMESTAMP_BYTES, TIMESTAMP);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -40,19 +40,21 @@ import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.niceMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class MeteredTimestampedWindowStoreTest {
 
     private static final String STORE_NAME = "mocked-store";
@@ -69,20 +71,10 @@ public class MeteredTimestampedWindowStoreTest {
 
     private InternalMockProcessorContext context;
     private final TaskId taskId = new TaskId(0, 0, "My-Topology");
-    private final WindowStore<Bytes, byte[]> innerStoreMock = EasyMock.createNiceMock(WindowStore.class);
+    @Mock
+    private WindowStore<Bytes, byte[]> innerStoreMock;
     private final Metrics metrics = new Metrics(new MetricConfig().recordLevel(Sensor.RecordingLevel.DEBUG));
-    private MeteredTimestampedWindowStore<String, String> store = new MeteredTimestampedWindowStore<>(
-        innerStoreMock,
-        WINDOW_SIZE_MS, // any size
-        STORE_TYPE,
-        new MockTime(),
-        Serdes.String(),
-        new ValueAndTimestampSerde<>(new SerdeThatDoesntHandleNull())
-    );
-
-    {
-        EasyMock.expect(innerStoreMock.name()).andStubReturn(STORE_NAME);
-    }
+    private MeteredTimestampedWindowStore<String, String> store;
 
     @Before
     public void setUp() {
@@ -100,11 +92,23 @@ public class MeteredTimestampedWindowStoreTest {
             Time.SYSTEM,
             taskId
         );
+
+        when(innerStoreMock.name()).thenReturn(STORE_NAME);
+
+        store = new MeteredTimestampedWindowStore<>(
+            innerStoreMock,
+            WINDOW_SIZE_MS, // any size
+            STORE_TYPE,
+            new MockTime(),
+            Serdes.String(),
+            new ValueAndTimestampSerde<>(new SerdeThatDoesntHandleNull())
+        );
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
+        @SuppressWarnings("unchecked")
         final WindowStore<Bytes, byte[]> inner = mock(WindowStore.class);
         final MeteredTimestampedWindowStore<String, String> outer = new MeteredTimestampedWindowStore<>(
             inner,
@@ -114,16 +118,16 @@ public class MeteredTimestampedWindowStoreTest {
             Serdes.String(),
             new ValueAndTimestampSerde<>(new SerdeThatDoesntHandleNull())
         );
-        expect(inner.name()).andStubReturn("store");
-        inner.init((ProcessorContext) context, outer);
-        expectLastCall();
-        replay(inner);
+        when(inner.name()).thenReturn("store");
+
         outer.init((ProcessorContext) context, outer);
-        verify(inner);
+
+        verify(inner).init((ProcessorContext) context, outer);
     }
 
     @Test
     public void shouldDelegateInit() {
+        @SuppressWarnings("unchecked")
         final WindowStore<Bytes, byte[]> inner = mock(WindowStore.class);
         final MeteredTimestampedWindowStore<String, String> outer = new MeteredTimestampedWindowStore<>(
             inner,
@@ -133,12 +137,11 @@ public class MeteredTimestampedWindowStoreTest {
             Serdes.String(),
             new ValueAndTimestampSerde<>(new SerdeThatDoesntHandleNull())
         );
-        expect(inner.name()).andStubReturn("store");
-        inner.init((StateStoreContext) context, outer);
-        expectLastCall();
-        replay(inner);
+        when(inner.name()).thenReturn("store");
+
         outer.init((StateStoreContext) context, outer);
-        verify(inner);
+
+        verify(inner).init((StateStoreContext) context, outer);
     }
 
     @Test
@@ -155,19 +158,23 @@ public class MeteredTimestampedWindowStoreTest {
     }
 
     private void doShouldPassChangelogTopicNameToStateStoreSerde(final String topic) {
-        final Serde<String> keySerde = niceMock(Serde.class);
+        @SuppressWarnings("unchecked")
+        final Serde<String> keySerde = mock(Serde.class);
+        @SuppressWarnings("unchecked")
         final Serializer<String> keySerializer = mock(Serializer.class);
-        final Serde<ValueAndTimestamp<String>> valueSerde = niceMock(Serde.class);
+        @SuppressWarnings("unchecked")
+        final Serde<ValueAndTimestamp<String>> valueSerde = mock(Serde.class);
+        @SuppressWarnings("unchecked")
         final Deserializer<ValueAndTimestamp<String>> valueDeserializer = mock(Deserializer.class);
+        @SuppressWarnings("unchecked")
         final Serializer<ValueAndTimestamp<String>> valueSerializer = mock(Serializer.class);
-        expect(keySerde.serializer()).andStubReturn(keySerializer);
-        expect(keySerializer.serialize(topic, KEY)).andStubReturn(KEY.getBytes());
-        expect(valueSerde.deserializer()).andStubReturn(valueDeserializer);
-        expect(valueDeserializer.deserialize(topic, VALUE_AND_TIMESTAMP_BYTES)).andStubReturn(VALUE_AND_TIMESTAMP);
-        expect(valueSerde.serializer()).andStubReturn(valueSerializer);
-        expect(valueSerializer.serialize(topic, VALUE_AND_TIMESTAMP)).andStubReturn(VALUE_AND_TIMESTAMP_BYTES);
-        expect(innerStoreMock.fetch(KEY_BYTES, TIMESTAMP)).andStubReturn(VALUE_AND_TIMESTAMP_BYTES);
-        replay(innerStoreMock, keySerializer, keySerde, valueDeserializer, valueSerializer, valueSerde);
+        when(keySerde.serializer()).thenReturn(keySerializer);
+        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(valueSerde.deserializer()).thenReturn(valueDeserializer);
+        when(valueDeserializer.deserialize(topic, VALUE_AND_TIMESTAMP_BYTES)).thenReturn(VALUE_AND_TIMESTAMP);
+        when(valueSerde.serializer()).thenReturn(valueSerializer);
+        when(valueSerializer.serialize(topic, VALUE_AND_TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(innerStoreMock.fetch(KEY_BYTES, TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         store = new MeteredTimestampedWindowStore<>(
             innerStoreMock,
             WINDOW_SIZE_MS,
@@ -176,29 +183,26 @@ public class MeteredTimestampedWindowStoreTest {
             keySerde,
             valueSerde
         );
-        store.init((StateStoreContext) context, store);
 
+        store.init((StateStoreContext) context, store);
         store.fetch(KEY, TIMESTAMP);
         store.put(KEY, VALUE_AND_TIMESTAMP, TIMESTAMP);
 
-        verify(keySerializer, valueDeserializer, valueSerializer);
+        verify(innerStoreMock).fetch(any(Bytes.class), eq(TIMESTAMP));
+        verify(innerStoreMock).put(any(Bytes.class), any(byte[].class), eq(TIMESTAMP));
     }
 
     @Test
     public void shouldCloseUnderlyingStore() {
-        innerStoreMock.close();
-        EasyMock.expectLastCall();
-        EasyMock.replay(innerStoreMock);
-
         store.init((StateStoreContext) context, store);
         store.close();
-        EasyMock.verify(innerStoreMock);
+
+        verify(innerStoreMock).close();
     }
 
     @Test
     public void shouldNotExceptionIfFetchReturnsNull() {
-        EasyMock.expect(innerStoreMock.fetch(Bytes.wrap("a".getBytes()), 0)).andReturn(null);
-        EasyMock.replay(innerStoreMock);
+        when(innerStoreMock.fetch(Bytes.wrap("a".getBytes()), 0)).thenReturn(null);
 
         store.init((StateStoreContext) context, store);
         assertNull(store.fetch("a", 0));
@@ -206,8 +210,7 @@ public class MeteredTimestampedWindowStoreTest {
 
     @Test
     public void shouldNotThrowExceptionIfSerdesCorrectlySetFromProcessorContext() {
-        EasyMock.expect(innerStoreMock.name()).andStubReturn("mocked-store");
-        EasyMock.replay(innerStoreMock);
+        when(innerStoreMock.name()).thenReturn("mocked-store");
         final MeteredTimestampedWindowStore<String, Long> store = new MeteredTimestampedWindowStore<>(
             innerStoreMock,
             10L, // any size
@@ -230,8 +233,7 @@ public class MeteredTimestampedWindowStoreTest {
 
     @Test
     public void shouldNotThrowExceptionIfSerdesCorrectlySetFromConstructorParameters() {
-        EasyMock.expect(innerStoreMock.name()).andStubReturn("mocked-store");
-        EasyMock.replay(innerStoreMock);
+        when(innerStoreMock.name()).thenReturn("mocked-store");
         final MeteredTimestampedWindowStore<String, Long> store = new MeteredTimestampedWindowStore<>(
             innerStoreMock,
             10L, // any size


### PR DESCRIPTION
Batch 4 of the tests detailed in https://issues.apache.org/jira/browse/KAFKA-14133 which use EasyMock and need to be moved to Mockito.