### PR TITLE
HOTFIX: Fix compilation in TaskManager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -849,7 +849,7 @@ public class TaskManager {
             for (final Task restoringTask : stateUpdater.getTasks()) {
                 if (restoringTask.isActive()) {
                     if (remainingRevokedPartitions.containsAll(restoringTask.inputPartitions())) {
-                        tasks.addPendingTaskToClose(restoringTask.id());
+                        tasks.addPendingTaskToCloseClean(restoringTask.id());
                         stateUpdater.remove(restoringTask.id());
                         remainingRevokedPartitions.removeAll(restoringTask.inputPartitions());
                     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -819,19 +819,6 @@ public class TaskManagerTest {
         Mockito.verify(task, never()).closeClean();
     }
 
-    private TaskManager setupForRevocation(final Set<Task> tasksInStateUpdater,
-                                           final Set<Task> removedTasks) {
-        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, true);
-        when(stateUpdater.getTasks()).thenReturn(tasksInStateUpdater);
-        when(stateUpdater.drainRemovedTasks()).thenReturn(removedTasks);
-        expect(consumer.assignment()).andReturn(emptySet()).anyTimes();
-        consumer.resume(anyObject());
-        expectLastCall().anyTimes();
-        replay(consumer);
-
-        return taskManager;
-    }
-
     @Test
     public void shouldCloseActiveUnassignedSuspendedTasksWhenClosingRevokedTasks() {
         final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true);


### PR DESCRIPTION
Compilation is failing at the moment following merge of https://github.com/apache/kafka/commit/9f20f8995399d9e03f518f7b9c8be2bffb2fdcfc:
```
> Task :streams:compileJava
/Users/jgustafson/Projects/kafka/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java:852: error: cannot find symbol
                        tasks.addPendingTaskToClose(restoringTask.id());
                             ^
  symbol:   method addPendingTaskToClose(org.apache.kafka.streams.processor.TaskId)
  location: variable tasks of type org.apache.kafka.streams.processor.internals.Tasks
1 error
```
The patch changes the call to use `addPendingTaskToCloseClean`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
