### PR TITLE
KAFKA-14170: Fix NPE in the deleteTopics() code path of KRaft Controller

### DIFF
--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -151,11 +151,11 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     adminClientConfig: Properties = new Properties
   ): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(aliveBrokers, listenerName, adminClientConfig)) { admin =>
-        TestUtils.createOffsetsTopicWithAdmin(admin, aliveBrokers)
+      resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
+        TestUtils.createOffsetsTopicWithAdmin(admin, brokers)
       }
     } else {
-      TestUtils.createOffsetsTopic(zkClient, aliveBrokers)
+      TestUtils.createOffsetsTopic(zkClient, brokers)
     }
   }
 
@@ -173,11 +173,11 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     adminClientConfig: Properties = new Properties
   ): scala.collection.immutable.Map[Int, Int] = {
     if (isKRaftTest()) {
-      resource(createAdminClient(aliveBrokers, listenerName, adminClientConfig)) { admin =>
+      resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
         TestUtils.createTopicWithAdmin(
           admin = admin,
           topic = topic,
-          brokers = aliveBrokers,
+          brokers = brokers,
           numPartitions = numPartitions,
           replicationFactor = replicationFactor,
           topicConfig = topicConfig
@@ -189,7 +189,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         topic = topic,
         numPartitions = numPartitions,
         replicationFactor = replicationFactor,
-        servers = aliveBrokers,
+        servers = brokers,
         topicConfig = topicConfig
       )
     }
@@ -206,12 +206,12 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     listenerName: ListenerName = listenerName
   ): scala.collection.immutable.Map[Int, Int] =
     if (isKRaftTest()) {
-      resource(createAdminClient(aliveBrokers, listenerName)) { admin =>
+      resource(createAdminClient(brokers, listenerName)) { admin =>
         TestUtils.createTopicWithAdmin(
           admin = admin,
           topic = topic,
           replicaAssignment = partitionReplicaAssignment,
-          brokers = aliveBrokers
+          brokers = brokers
         )
       }
     } else {
@@ -219,7 +219,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         zkClient,
         topic,
         partitionReplicaAssignment,
-        aliveBrokers
+        brokers
       )
     }
 
@@ -228,7 +228,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     listenerName: ListenerName = listenerName
   ): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(aliveBrokers, listenerName)) { admin =>
+      resource(createAdminClient(brokers, listenerName)) { admin =>
         TestUtils.deleteTopicWithAdmin(
           admin = admin,
           topic = topic,

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -151,11 +151,11 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     adminClientConfig: Properties = new Properties
   ): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
-        TestUtils.createOffsetsTopicWithAdmin(admin, brokers)
+      resource(createAdminClient(aliveBrokers, listenerName, adminClientConfig)) { admin =>
+        TestUtils.createOffsetsTopicWithAdmin(admin, aliveBrokers)
       }
     } else {
-      TestUtils.createOffsetsTopic(zkClient, servers)
+      TestUtils.createOffsetsTopic(zkClient, aliveBrokers)
     }
   }
 
@@ -173,11 +173,11 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     adminClientConfig: Properties = new Properties
   ): scala.collection.immutable.Map[Int, Int] = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
+      resource(createAdminClient(aliveBrokers, listenerName, adminClientConfig)) { admin =>
         TestUtils.createTopicWithAdmin(
           admin = admin,
           topic = topic,
-          brokers = brokers,
+          brokers = aliveBrokers,
           numPartitions = numPartitions,
           replicationFactor = replicationFactor,
           topicConfig = topicConfig
@@ -189,7 +189,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         topic = topic,
         numPartitions = numPartitions,
         replicationFactor = replicationFactor,
-        servers = servers,
+        servers = aliveBrokers,
         topicConfig = topicConfig
       )
     }
@@ -206,12 +206,12 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     listenerName: ListenerName = listenerName
   ): scala.collection.immutable.Map[Int, Int] =
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName)) { admin =>
+      resource(createAdminClient(aliveBrokers, listenerName)) { admin =>
         TestUtils.createTopicWithAdmin(
           admin = admin,
           topic = topic,
           replicaAssignment = partitionReplicaAssignment,
-          brokers = brokers
+          brokers = aliveBrokers
         )
       }
     } else {
@@ -219,7 +219,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         zkClient,
         topic,
         partitionReplicaAssignment,
-        servers
+        aliveBrokers
       )
     }
 
@@ -228,11 +228,11 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     listenerName: ListenerName = listenerName
   ): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName)) { admin =>
+      resource(createAdminClient(aliveBrokers, listenerName)) { admin =>
         TestUtils.deleteTopicWithAdmin(
           admin = admin,
           topic = topic,
-          brokers = brokers)
+          brokers = aliveBrokers)
       }
     } else {
       adminZkClient.deleteTopic(topic)

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -155,7 +155,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         TestUtils.createOffsetsTopicWithAdmin(admin, brokers)
       }
     } else {
-      TestUtils.createOffsetsTopic(zkClient, brokers)
+      TestUtils.createOffsetsTopic(zkClient, servers)
     }
   }
 
@@ -189,7 +189,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         topic = topic,
         numPartitions = numPartitions,
         replicationFactor = replicationFactor,
-        servers = brokers,
+        servers = servers,
         topicConfig = topicConfig
       )
     }
@@ -219,7 +219,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         zkClient,
         topic,
         partitionReplicaAssignment,
-        brokers
+        servers
       )
     }
 

--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
@@ -32,9 +32,44 @@ import org.apache.kafka.common.requests.MetadataResponse
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+
+import scala.collection.Seq
 import scala.jdk.CollectionConverters._
 
 class DeleteTopicsRequestTest extends BaseRequestTest with Logging {
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testTopicDeletionClusterHasOfflinePartitions(quorum: String): Unit = {
+    // Create a two topics with one partition/replica. Make one of them offline.
+    val offlineTopic = "topic-1"
+    val onlineTopic = "topic-2"
+    createTopicWithAssignment(offlineTopic, Map[Int, Seq[Int]](0 -> Seq(0)))
+    createTopicWithAssignment(onlineTopic, Map[Int, Seq[Int]](0 -> Seq(1)))
+    killBroker(0)
+    ensureConsistentKRaftMetadata()
+
+    // Ensure one topic partition is offline.
+    TestUtils.waitUntilTrue(() => {
+      aliveBrokers.head.metadataCache.getPartitionInfo(onlineTopic, 0).exists(_.leader() == 1)
+      aliveBrokers.head.metadataCache.getPartitionInfo(offlineTopic, 0).exists(_.leader() == -1)
+    }, "Topic partition is not offline")
+
+    // Delete the newly created topic and topic with offline partition. See the deletion is
+    // successful.
+    deleteTopic(onlineTopic)
+    deleteTopic(offlineTopic)
+    ensureConsistentKRaftMetadata()
+
+    // Restart the dead broker.
+    restartDeadBrokers()
+
+    // Make sure the brokers no longer see any deleted topics.
+    TestUtils.waitUntilTrue(() =>
+      !aliveBrokers.forall(_.metadataCache.contains(onlineTopic)) &&
+        !aliveBrokers.forall(_.metadataCache.contains(offlineTopic)),
+      "The topics are found in the Broker's cache")
+  }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))

--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
@@ -51,8 +51,9 @@ class DeleteTopicsRequestTest extends BaseRequestTest with Logging {
 
     // Ensure one topic partition is offline.
     TestUtils.waitUntilTrue(() => {
-      aliveBrokers.head.metadataCache.getPartitionInfo(onlineTopic, 0).exists(_.leader() == 1)
-      aliveBrokers.head.metadataCache.getPartitionInfo(offlineTopic, 0).exists(_.leader() == -1)
+      aliveBrokers.head.metadataCache.getPartitionInfo(onlineTopic, 0).exists(_.leader() == 1) &&
+        aliveBrokers.head.metadataCache.getPartitionInfo(offlineTopic, 0).exists(_.leader() ==
+          MetadataResponse.NO_LEADER_ID)
     }, "Topic partition is not offline")
 
     // Delete the newly created topic and topic with offline partition. See the deletion is

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
@@ -191,7 +191,7 @@ public class BrokersToIsrs {
     void removeTopicEntryForBroker(Uuid topicId, int brokerId) {
         Map<Uuid, int[]> topicMap = isrMembers.get(brokerId);
         if (topicMap != null) {
-            if (brokerId == NO_LEADER) {
+            if (brokerId == NO_LEADER && topicMap.containsKey(topicId)) {
                 offlinePartitionCount.set(offlinePartitionCount.get() - topicMap.get(topicId).length);
             }
             topicMap.remove(topicId);

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
@@ -257,8 +257,7 @@ public final class MetadataDelta {
     }
 
     public void replay(RemoveTopicRecord record) {
-        getOrCreateTopicsDelta().replay(record);
-        String topicName = topicsDelta.replay(record);
+        String topicName = getOrCreateTopicsDelta().replay(record);
         getOrCreateConfigsDelta().replay(record, topicName);
     }
 


### PR DESCRIPTION
KAFKA-14170: Fix NPE in the deleteTopics() code path of KRaft Controller

While replaying the `RemoveTopicRecord` in the Controller, we remove all the
in-memory states for the topic. While removing any offline partition data, if
there are any offline partitions in the system, we wrongly look up the offline
partition count for the topic we're removing. Fixed this lookup and added an
integration test.

While adding an integration test, found a bug in MetadataDelta#replay code
while processing `RemoveTopicRecord`. Fixed that as well.