### PR TITLE
MINOR: reduce Metadata log volume when last seen epoch is not updated

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -399,9 +399,11 @@ public class Metadata implements Closeable {
                 // Between the time that a topic is deleted and re-created, the client may lose track of the
                 // corresponding topicId (i.e. `oldTopicId` will be null). In this case, when we discover the new
                 // topicId, we allow the corresponding leader epoch to override the last seen value.
-                log.info("Resetting the last seen epoch of partition {} to {} since the associated topicId changed from {} to {}",
-                         tp, newEpoch, oldTopicId, topicId);
-                lastSeenLeaderEpochs.put(tp, newEpoch);
+                if (!Objects.equals(currentEpoch, newEpoch)) {
+                    log.info("Resetting the last seen epoch of partition {} to {} since the associated topicId changed from {} to {}",
+                            tp, newEpoch, oldTopicId, topicId);
+                    lastSeenLeaderEpochs.put(tp, newEpoch);
+                }
                 return Optional.of(partitionMetadata);
             } else if (currentEpoch == null || newEpoch >= currentEpoch) {
                 // If the received leader epoch is at least the same as the previous one, update the metadata


### PR DESCRIPTION
Context
-------

Since updating to kafka client 3.0.1, we noticed quite a lot of new info-level logs generated by `org.apache.kafka.clients.Metadata`.

The logs look like this:
```
[Producer clientId=producer-1] Resetting the last seen epoch of partition user-3 to 2044 since the associated topicId changed from null to O5w7zNcCTpKdylvkOUMesQ
```

They appear at seemingly random times, while keeping the same last seen epoch value.

Proposed fix
------------

As suggested in https://github.com/apache/kafka/pull/12378, I am updating the code condition to avoid generating a log when the last seen epoch reset operation is a no-op.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
