### PR TITLE
KAFKA-10149: Allow auto preferred leader election when there are ongoing partition reassignments

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1260,10 +1260,7 @@ class KafkaController(val config: KafkaConfig,
       // check ratio and if greater than desired ratio, trigger a rebalance for the topic partitions
       // that need to be on this broker
       if (imbalanceRatio > (config.leaderImbalancePerBrokerPercentage.toDouble / 100)) {
-        // do this check only if the broker is live and there are no partitions being reassigned currently
-        // and preferred replica election is not in progress
         val candidatePartitions = topicsNotInPreferredReplica.keys.filter(tp =>
-          controllerContext.partitionsBeingReassigned.isEmpty &&
           !topicDeletionManager.isTopicQueuedUpForDeletion(tp.topic) &&
           controllerContext.allTopics.contains(tp.topic) &&
           canPreferredReplicaBeLeader(tp)


### PR DESCRIPTION
Auto preferred leader election should be allowed even if there are ongoing reassignments. Otherwise, it might result in unbalanced leaders if there are any long-running reassignments. For partitions being reassigned, a leader election will only be triggered when the TRS = ISR as part of the partition reassignment procedure automatically if the current leader is not in TRS or isn't alive (step [B3](https://github.com/apache/kafka/blob/f83d95d9a28267f7ef7a7b1e584dcdb4aa842210/core/src/main/scala/kafka/controller/KafkaController.scala#L699)).

For example, let's say there are broker `(1,2,3,4)`, and a partition is current on `(1,2)` , 1 is the current leader:
- if we reassign that partition to `(3, 4)`, a leader election would be triggered during the reassignment step B3, and 3 will be the new leader.
- if we reassign that partition to `(3, 1)`, leader election **won't** be triggered during the reassignment as the current leader is still in the TRS, 1 will continue to be the leader. The auto preferred leader election will help in such situation.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
