### PR TITLE
KAFKA-14098: Add meaningful client IDs for Connect workers

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -234,22 +234,24 @@ public class MirrorMaker {
         plugins.compareAndSwapWithDelegatingLoader();
         DistributedConfig distributedConfig = new DistributedConfig(workerProps);
         String kafkaClusterId = distributedConfig.kafkaClusterId();
+        String clientIdBase = ConnectUtils.clientIdBase(distributedConfig, advertisedUrl);
         // Create the admin client to be shared by all backing stores for this herder
         Map<String, Object> adminProps = new HashMap<>(distributedConfig.originals());
         ConnectUtils.addMetricsContextProperties(adminProps, distributedConfig, kafkaClusterId);
         SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(adminProps);
-        KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin);
+        KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin, () -> clientIdBase);
         offsetBackingStore.configure(distributedConfig);
         Worker worker = new Worker(workerId, time, plugins, distributedConfig, offsetBackingStore, CLIENT_CONFIG_OVERRIDE_POLICY);
         WorkerConfigTransformer configTransformer = worker.configTransformer();
         Converter internalValueConverter = worker.getInternalValueConverter();
-        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter, sharedAdmin);
+        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter, sharedAdmin, clientIdBase);
         statusBackingStore.configure(distributedConfig);
         ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(
                 internalValueConverter,
                 distributedConfig,
                 configTransformer,
-                sharedAdmin);
+                sharedAdmin,
+                clientIdBase);
         // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
         // herder is stopped. MirrorMaker has multiple herders, and having the herder own the close responsibility is much easier than
         // tracking the various shared admin objects in this class.

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -234,7 +234,7 @@ public class MirrorMaker {
         plugins.compareAndSwapWithDelegatingLoader();
         DistributedConfig distributedConfig = new DistributedConfig(workerProps);
         String kafkaClusterId = distributedConfig.kafkaClusterId();
-        String clientIdBase = ConnectUtils.clientIdBase(distributedConfig, advertisedUrl);
+        String clientIdBase = ConnectUtils.clientIdBase(distributedConfig);
         // Create the admin client to be shared by all backing stores for this herder
         Map<String, Object> adminProps = new HashMap<>(distributedConfig.originals());
         ConnectUtils.addMetricsContextProperties(adminProps, distributedConfig, kafkaClusterId);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -46,6 +46,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
+
 /**
  * <p>
  * Command line utility that runs Kafka Connect in distributed mode. In this mode, the process joints a group of other workers
@@ -103,12 +105,15 @@ public class ConnectDistributed {
         URI advertisedUrl = rest.advertisedUrl();
         String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
 
+        String clientIdBase = ConnectUtils.clientIdBase(config, advertisedUrl.toString());
+
         // Create the admin client to be shared by all backing stores.
         Map<String, Object> adminProps = new HashMap<>(config.originals());
         ConnectUtils.addMetricsContextProperties(adminProps, config, kafkaClusterId);
+        adminProps.put(CLIENT_ID_CONFIG, clientIdBase + "shared-admin");
         SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(adminProps);
 
-        KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin);
+        KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin, () -> clientIdBase);
         offsetBackingStore.configure(config);
 
         ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy = plugins.newPlugin(
@@ -119,14 +124,15 @@ public class ConnectDistributed {
         WorkerConfigTransformer configTransformer = worker.configTransformer();
 
         Converter internalValueConverter = worker.getInternalValueConverter();
-        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter, sharedAdmin);
+        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter, sharedAdmin, clientIdBase);
         statusBackingStore.configure(config);
 
         ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(
                 internalValueConverter,
                 config,
                 configTransformer,
-                sharedAdmin);
+                sharedAdmin,
+                clientIdBase);
 
         // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
         // herder is stopped. This is easier than having to track and own the lifecycle ourselves.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -105,7 +105,7 @@ public class ConnectDistributed {
         URI advertisedUrl = rest.advertisedUrl();
         String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
 
-        String clientIdBase = ConnectUtils.clientIdBase(config, advertisedUrl.toString());
+        String clientIdBase = ConnectUtils.clientIdBase(config);
 
         // Create the admin client to be shared by all backing stores.
         Map<String, Object> adminProps = new HashMap<>(config.originals());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -65,6 +66,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
@@ -261,6 +263,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
     final Map<ConnectorTaskId, Map<String, String>> taskConfigs = new HashMap<>();
     private final Supplier<TopicAdmin> topicAdminSupplier;
     private SharedTopicAdmin ownTopicAdmin;
+    private final String clientId;
 
     // Set of connectors where we saw a task commit with an incomplete set of task config updates, indicating the data
     // is in an inconsistent state and we cannot safely use them until they have been refreshed.
@@ -289,15 +292,16 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
     @Deprecated
     public KafkaConfigBackingStore(Converter converter, DistributedConfig config, WorkerConfigTransformer configTransformer) {
-        this(converter, config, configTransformer, null);
+        this(converter, config, configTransformer, null, "connect-distributed");
     }
 
-    public KafkaConfigBackingStore(Converter converter, DistributedConfig config, WorkerConfigTransformer configTransformer, Supplier<TopicAdmin> adminSupplier) {
+    public KafkaConfigBackingStore(Converter converter, DistributedConfig config, WorkerConfigTransformer configTransformer, Supplier<TopicAdmin> adminSupplier, String clientIdBase) {
         this.lock = new Object();
         this.started = false;
         this.converter = converter;
         this.offset = -1;
         this.topicAdminSupplier = adminSupplier;
+        this.clientId = Objects.requireNonNull(clientIdBase) + "configs";
 
         this.baseProducerProps = baseProducerProps(config);
         // By default, Connect disables idempotent behavior for all producers, even though idempotence became
@@ -390,6 +394,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
     Map<String, Object> fencableProducerProps(DistributedConfig workerConfig) {
         Map<String, Object> result = new HashMap<>(baseProducerProps(workerConfig));
 
+        result.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId + "-leader");
         // Always require producer acks to all to ensure durable writes
         result.put(ProducerConfig.ACKS_CONFIG, "all");
         // We can set this to 5 instead of 1 without risking reordering because we are using an idempotent producer
@@ -663,14 +668,16 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
     // package private for testing
     KafkaBasedLog<String, byte[]> setupAndCreateKafkaBasedLog(String topic, final WorkerConfig config) {
-        Map<String, Object> producerProps = new HashMap<>(baseProducerProps);
-
         String clusterId = config.kafkaClusterId();
         Map<String, Object> originals = config.originals();
+
+        Map<String, Object> producerProps = new HashMap<>(baseProducerProps);
+        producerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
 
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
         if (config.exactlyOnceSourceEnabled()) {
             ConnectUtils.ensureProperty(
@@ -682,6 +689,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
+        adminProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         Supplier<TopicAdmin> adminSupplier;
         if (topicAdminSupplier != null) {
             adminSupplier = topicAdminSupplier;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -292,7 +292,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
     @Deprecated
     public KafkaConfigBackingStore(Converter converter, DistributedConfig config, WorkerConfigTransformer configTransformer) {
-        this(converter, config, configTransformer, null, "connect-distributed");
+        this(converter, config, configTransformer, null, "connect-distributed-");
     }
 
     public KafkaConfigBackingStore(Converter converter, DistributedConfig config, WorkerConfigTransformer configTransformer, Supplier<TopicAdmin> adminSupplier, String clientIdBase) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -155,7 +155,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
     @Deprecated
     public KafkaOffsetBackingStore() {
         this.topicAdminSupplier = null;
-        this.clientIdBase = KafkaOffsetBackingStore::noClientId;
+        this.clientIdBase = () -> "connect-distributed-";
     }
 
     /**
@@ -167,7 +167,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
      *                   may not be null, and may not return null
      * @param clientIdBase a {@link Supplier} that will be used to create a
      * {@link CommonClientConfigs#CLIENT_ID_DOC client ID} for Kafka clients instantiated by this store;
-     *                     may not be null, and may not return null, but may throw {@link UnsupportedVersionException}
+     *                     may not be null, and may not return null, but may throw {@link UnsupportedOperationException}
      *                     if this offset store should not create its own Kafka clients
      */
     public KafkaOffsetBackingStore(Supplier<TopicAdmin> topicAdmin, Supplier<String> clientIdBase) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -86,7 +87,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
             Consumer<byte[], byte[]> consumer,
             TopicAdmin topicAdmin
     ) {
-        return new KafkaOffsetBackingStore(() -> topicAdmin) {
+        return new KafkaOffsetBackingStore(() -> topicAdmin, KafkaOffsetBackingStore::noClientId) {
             @Override
             public void configure(final WorkerConfig config) {
                 this.exactlyOnce = config.exactlyOnceSourceEnabled();
@@ -116,7 +117,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
             Consumer<byte[], byte[]> consumer,
             TopicAdmin topicAdmin
     ) {
-        return new KafkaOffsetBackingStore(() -> topicAdmin) {
+        return new KafkaOffsetBackingStore(() -> topicAdmin, KafkaOffsetBackingStore::noClientId) {
             @Override
             public void configure(final WorkerConfig config) {
                 this.exactlyOnce = config.exactlyOnceSourceEnabled();
@@ -133,9 +134,14 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         };
     }
 
+    private static String noClientId() {
+        throw new UnsupportedOperationException("This offset store should not instantiate any Kafka clients");
+    }
+
     protected KafkaBasedLog<byte[], byte[]> offsetLog;
     private final HashMap<ByteBuffer, ByteBuffer> data = new HashMap<>();
     private final Supplier<TopicAdmin> topicAdminSupplier;
+    private final Supplier<String> clientIdBase;
     private SharedTopicAdmin ownTopicAdmin;
     protected boolean exactlyOnce;
 
@@ -144,11 +150,12 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
      * store to instantiate and close its own {@link TopicAdmin} during {@link #configure(WorkerConfig)}
      * and {@link #stop()}, respectively.
      *
-     * @deprecated use {@link #KafkaOffsetBackingStore(Supplier)} instead
+     * @deprecated use {@link #KafkaOffsetBackingStore(Supplier, Supplier)} instead
      */
     @Deprecated
     public KafkaOffsetBackingStore() {
         this.topicAdminSupplier = null;
+        this.clientIdBase = KafkaOffsetBackingStore::noClientId;
     }
 
     /**
@@ -158,9 +165,14 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
      * {@link TopicAdmin#close(Duration) closing} it when it is no longer needed.
      * @param topicAdmin a {@link Supplier} for the {@link TopicAdmin} to use for this backing store;
      *                   may not be null, and may not return null
+     * @param clientIdBase a {@link Supplier} that will be used to create a
+     * {@link CommonClientConfigs#CLIENT_ID_DOC client ID} for Kafka clients instantiated by this store;
+     *                     may not be null, and may not return null, but may throw {@link UnsupportedVersionException}
+     *                     if this offset store should not create its own Kafka clients
      */
-    public KafkaOffsetBackingStore(Supplier<TopicAdmin> topicAdmin) {
+    public KafkaOffsetBackingStore(Supplier<TopicAdmin> topicAdmin, Supplier<String> clientIdBase) {
         this.topicAdminSupplier = Objects.requireNonNull(topicAdmin);
+        this.clientIdBase = Objects.requireNonNull(clientIdBase);
     }
 
 
@@ -173,6 +185,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         this.exactlyOnce = config.exactlyOnceSourceEnabled();
 
         String clusterId = config.kafkaClusterId();
+        String clientId = Objects.requireNonNull(clientIdBase.get()) + "offsets";
 
         Map<String, Object> originals = config.originals();
         Map<String, Object> producerProps = new HashMap<>(originals);
@@ -185,11 +198,13 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         // These settings might change when https://cwiki.apache.org/confluence/display/KAFKA/KIP-318%3A+Make+Kafka+Connect+Source+idempotent
         // gets approved and scheduled for release.
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "false");
+        producerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(producerProps, config, clusterId);
 
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
         if (config.exactlyOnceSourceEnabled()) {
             ConnectUtils.ensureProperty(
@@ -200,6 +215,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         }
 
         Map<String, Object> adminProps = new HashMap<>(originals);
+        adminProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
         Supplier<TopicAdmin> adminSupplier;
         if (topicAdminSupplier != null) {
@@ -276,8 +292,8 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
      * <p>
      * <b>Note:</b> if the now-deprecated {@link #KafkaOffsetBackingStore()} constructor was used to create
      * this store, the underlying admin client allocated for interacting with the offsets topic will be closed.
-     * On the other hand, if the recommended {@link #KafkaOffsetBackingStore(Supplier)} constructor was used to
-     * create this store, the admin client derived from the given {@link Supplier} will not be closed and it is the
+     * On the other hand, if the recommended {@link #KafkaOffsetBackingStore(Supplier, Supplier)} constructor was
+     * used to create this store, the admin client derived from the given {@link Supplier} will not be closed and it is the
      * caller's responsibility to manage its lifecycle accordingly.
      */
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -131,6 +132,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
     protected final Map<String, CacheEntry<ConnectorStatus>> connectors;
     protected final ConcurrentMap<String, ConcurrentMap<String, TopicStatus>> topics;
     private final Supplier<TopicAdmin> topicAdminSupplier;
+    private final String clientId;
 
     private String statusTopic;
     private KafkaBasedLog<String, byte[]> kafkaLog;
@@ -139,16 +141,17 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
 
     @Deprecated
     public KafkaStatusBackingStore(Time time, Converter converter) {
-        this(time, converter, null);
+        this(time, converter, null, "connect-distributed");
     }
 
-    public KafkaStatusBackingStore(Time time, Converter converter, Supplier<TopicAdmin> topicAdminSupplier) {
+    public KafkaStatusBackingStore(Time time, Converter converter, Supplier<TopicAdmin> topicAdminSupplier, String clientIdBase) {
         this.time = time;
         this.converter = converter;
         this.tasks = new Table<>();
         this.connectors = new HashMap<>();
         this.topics = new ConcurrentHashMap<>();
         this.topicAdminSupplier = topicAdminSupplier;
+        this.clientId = Objects.requireNonNull(clientIdBase) + "statuses";
     }
 
     // visible for testing
@@ -176,14 +179,17 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         // These settings might change when https://cwiki.apache.org/confluence/display/KAFKA/KIP-318%3A+Make+Kafka+Connect+Source+idempotent
         // gets approved and scheduled for release.
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "false"); // disable idempotence since retries is force to 0
+        producerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(producerProps, config, clusterId);
 
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
 
         Map<String, Object> adminProps = new HashMap<>(originals);
+        adminProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
         Supplier<TopicAdmin> adminSupplier;
         if (topicAdminSupplier != null) {
@@ -208,7 +214,8 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         this.kafkaLog = createKafkaBasedLog(statusTopic, producerProps, consumerProps, readCallback, topicDescription, adminSupplier);
     }
 
-    private KafkaBasedLog<String, byte[]> createKafkaBasedLog(String topic, Map<String, Object> producerProps,
+    // Visible for testing
+    protected KafkaBasedLog<String, byte[]> createKafkaBasedLog(String topic, Map<String, Object> producerProps,
                                                               Map<String, Object> consumerProps,
                                                               Callback<ConsumerRecord<String, byte[]>> consumedCallback,
                                                               final NewTopic topicDescription, Supplier<TopicAdmin> adminSupplier) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -141,7 +141,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
 
     @Deprecated
     public KafkaStatusBackingStore(Time time, Converter converter) {
-        this(time, converter, null, "connect-distributed");
+        this(time, converter, null, "connect-distributed-");
     }
 
     public KafkaStatusBackingStore(Time time, Converter converter, Supplier<TopicAdmin> topicAdminSupplier, String clientIdBase) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -28,6 +28,8 @@ import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+
+import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 
 public final class ConnectUtils {
     private static final Logger log = LoggerFactory.getLogger(ConnectUtils.class);
@@ -171,4 +175,28 @@ public final class ConnectUtils {
         return new ConnectException(message, t);
     }
 
+    /**
+     * Create the base of a {@link CommonClientConfigs#CLIENT_ID_DOC client ID} that can be
+     * used for Kafka clients instantiated by this worker. Workers should append an extra identifier
+     * to the end of this base ID to include extra information on what they are using it for; for example,
+     * {@code clientIdBase(config, advertisedUrl) + "configs"} could be used as the client ID for a
+     * consumer, producer, or admin client used to interact with a worker's config topic.
+     * @param config the worker config; may not be null
+     * @param advertisedUrl the advertised URL for the worker; may not be null
+     * @return the base client ID for this worker; never null, never empty, and will always end in a
+     * hyphen ('-')
+     */
+    public static String clientIdBase(WorkerConfig config, String advertisedUrl) {
+        String clusterId = Optional.ofNullable(config.groupId())
+                .orElse("connect");
+        // An identifier for this worker to be used in client IDs
+        // We allow the user to specify this explicitly via the client.id property,
+        // and fall back on the base64-encoded advertised URL if they don't
+        String workerId = Optional.ofNullable(config.getString(CLIENT_ID_CONFIG))
+                .orElseGet(() -> {
+                    byte[] advertisedUrlBytes = advertisedUrl.getBytes(StandardCharsets.UTF_8);
+                    return Base64.getEncoder().withoutPadding().encodeToString(advertisedUrlBytes);
+                });
+        return clusterId + "-" + workerId + "-";
+    }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -141,28 +141,25 @@ public class ConnectUtilsTest {
     public void testClientIdBase() {
         String groupId = "connect-cluster";
         String userSpecifiedClientId = "worker-57";
-        String advertisedUrl = "localhost:8083";
-
-        String encodedAdvertisedUrl = "bG9jYWxob3N0OjgwODM";
 
         String expectedClientIdBase = groupId + "-" + userSpecifiedClientId + "-";
-        assertClientIdBase(groupId, userSpecifiedClientId, advertisedUrl, expectedClientIdBase);
+        assertClientIdBase(groupId, userSpecifiedClientId, expectedClientIdBase);
 
-        expectedClientIdBase = groupId + "-" + encodedAdvertisedUrl + "-";
-        assertClientIdBase(groupId, null, advertisedUrl, expectedClientIdBase);
+        expectedClientIdBase = groupId + "-";
+        assertClientIdBase(groupId, null, expectedClientIdBase);
 
-        expectedClientIdBase = "connect-" + encodedAdvertisedUrl + "-";
-        assertClientIdBase(null, null, advertisedUrl, expectedClientIdBase);
+        expectedClientIdBase = "connect-";
+        assertClientIdBase(null, null, expectedClientIdBase);
 
         expectedClientIdBase = "connect-" + userSpecifiedClientId + "-";
-        assertClientIdBase(null, userSpecifiedClientId, advertisedUrl, expectedClientIdBase);
+        assertClientIdBase(null, userSpecifiedClientId, expectedClientIdBase);
     }
 
-    private void assertClientIdBase(String groupId, String userSpecifiedClientId, String advertisedUrl, String expectedClientIdBase) {
+    private void assertClientIdBase(String groupId, String userSpecifiedClientId, String expectedClientIdBase) {
         WorkerConfig config = mock(WorkerConfig.class);
         when(config.groupId()).thenReturn(groupId);
         when(config.getString(CLIENT_ID_CONFIG)).thenReturn(userSpecifiedClientId);
-        String actualClientIdBase = ConnectUtils.clientIdBase(config, advertisedUrl);
+        String actualClientIdBase = ConnectUtils.clientIdBase(config);
         assertEquals(expectedClientIdBase, actualClientIdBase);
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14098)

Adds the client ID `${groupId}-${clientId}-${topic}` to the producers and consumers used by Connect workers to interact with internal topics, where `${groupId}` is the `group.id` in the worker config file, `${clientId}` is the `client.id` in the worker config file (omitted if none is specified) and `${topic}` is one of `configs`, `statuses`, or `offsets`. Since a single shared admin client is used across all three internal topics, it is given a client ID of `${groupId}-${clientId}-shared-admin`.