### PR TITLE
MINOR: Dump log tool should support bootstrap checkpoint file

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.metadata.{MetadataJsonConverters, MetadataRecordT
 import org.apache.kafka.common.protocol.ByteBufferAccessor
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.controller.BootstrapMetadata
 import org.apache.kafka.metadata.MetadataRecordSerde
 import org.apache.kafka.snapshot.Snapshots
 
@@ -253,8 +254,12 @@ object DumpLogSegments {
       val startOffset = file.getName.split("\\.")(0).toLong
       println(s"Log starting offset: $startOffset")
     } else if (file.getName.endsWith(Snapshots.SUFFIX)) {
-      val path = Snapshots.parse(file.toPath).get()
-      println(s"Snapshot end offset: ${path.snapshotId.offset}, epoch: ${path.snapshotId.epoch}")
+      if (file.getName == BootstrapMetadata.BOOTSTRAP_FILE) {
+        println("KRaft bootstrap snapshot")
+      } else {
+        val path = Snapshots.parse(file.toPath).get()
+        println(s"Snapshot end offset: ${path.snapshotId.offset}, epoch: ${path.snapshotId.epoch}")
+      }
     }
     val fileRecords = FileRecords.open(file, false).slice(0, maxBytes)
     try {


### PR DESCRIPTION
It should be possible to use `kafka-dump-log.sh` to print the `bootstrap.checkpoint` file. This patch makes it so.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
