### PR TITLE
MINOR: re-enable WorkerTest for java 16+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -409,7 +409,7 @@ subprojects {
       "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
       "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",
       "**/SourceTaskOffsetCommitterTest.*",
-      "**/WorkerTest.*", "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
+      "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
       "**/WorkerSourceTaskTest.*", "**/AbstractWorkerSourceTaskTest.*", "**/ExactlyOnceWorkerSourceTaskTest.*",
       "**/WorkerTaskTest.*",
       // streams tests


### PR DESCRIPTION
…As it no longer uses Powermock, it can be run on Java 16+

Signed-off-by: Liam Clarke-Hutchinson <liam@steelsky.co.nz>

Verified by running unit test with following JVM: 

```
liam.clarke-hutchinson@ELH-5AMD6R ~/d/kafka (WorkerTestJava16)> java -version
openjdk version "18.0.2" 2022-07-19
OpenJDK Runtime Environment Temurin-18.0.2+9 (build 18.0.2+9)
OpenJDK 64-Bit Server VM Temurin-18.0.2+9 (build 18.0.2+9, mixed mode, sharing)
```

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
