### PR TITLE
KAFKA-14182: Chenge StandardAuthorizerData.java from RuntimeException to log.info

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -206,12 +206,11 @@ public class StandardAuthorizerData {
         try {
             StandardAcl prevAcl = aclsById.putIfAbsent(id, acl);
             if (prevAcl != null) {
-                throw new RuntimeException("An ACL with ID " + id + " already exists.");
+                log.info("An ACL with ID " + id + " already exists.");
             }
             if (!aclsByResource.add(acl)) {
-                aclsById.remove(id);
-                throw new RuntimeException("Unable to add the ACL with ID " + id +
-                    " to aclsByResource");
+                //aclsById.remove(id);
+                log.info("Unable to add the ACL with ID " + id + " to aclsByResource");
             }
             log.trace("Added ACL {}: {}", id, acl);
         } catch (Throwable e) {


### PR DESCRIPTION
Changes from RuntimeException to log.info in StandardAuthorizerData.java 

In KRaft mode with GSSAPI and ACL when i am adding any new ACL in log file i am always have a lot of msg like:
ERROR [StandardAuthorizer 1] addAcl error (org.apache.kafka.metadata.authorizer.StandardAuthorizerData)
java.lang.RuntimeException: An ACL with ID Gk-Hx0tvQIS8B1RT8R-odw already exists.

After chenges msg looks like good:
INFO [StandardAuthorizer 1] An ACL with ID VcQIkP9DSGSPYS6dmVnh4g already exists. (org.apache.kafka.metadata.authorizer.StandardAuthorizerData)
INFO [StandardAuthorizer 1] Unable to add the ACL with ID VcQIkP9DSGSPYS6dmVnh4g to aclsByResource (org.apache.kafka.metadata.authorizer.StandardAuthorizerData)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
