### PR TITLE
KAFKA-10199: Remove tasks from state updater on shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -60,6 +60,7 @@ public class DefaultStateUpdater implements StateUpdater {
         private final ChangelogReader changelogReader;
         private final AtomicBoolean isRunning = new AtomicBoolean(true);
         private final Map<TaskId, Task> updatingTasks = new ConcurrentHashMap<>();
+        private final Map<TaskId, Task> pausedTasks = new ConcurrentHashMap<>();
         private final Logger log;
 
         public StateUpdaterThread(final String name, final ChangelogReader changelogReader) {
@@ -86,6 +87,10 @@ public class DefaultStateUpdater implements StateUpdater {
             return !updatingTasks.isEmpty() && updatingTasks.values().stream().noneMatch(Task::isActive);
         }
 
+        public Collection<Task> getPausedTasks() {
+            return pausedTasks.values();
+        }
+
         @Override
         public void run() {
             log.info("State updater thread started");
@@ -100,7 +105,8 @@ public class DefaultStateUpdater implements StateUpdater {
             } catch (final RuntimeException anyOtherException) {
                 handleRuntimeException(anyOtherException);
             } finally {
-                clear();
+                clearInputQueue();
+                removeUpdatingAndPausedTasks();
                 shutdownGate.countDown();
                 log.info("State updater thread shutdown");
             }
@@ -224,18 +230,21 @@ public class DefaultStateUpdater implements StateUpdater {
             }
         }
 
-        private void clear() {
+        private void clearInputQueue() {
             tasksAndActionsLock.lock();
-            restoredActiveTasksLock.lock();
             try {
                 tasksAndActions.clear();
-                restoredActiveTasks.clear();
             } finally {
-                restoredActiveTasksLock.unlock();
                 tasksAndActionsLock.unlock();
             }
+        }
+
+        private void removeUpdatingAndPausedTasks() {
             changelogReader.clear();
+            updatingTasks.forEach((id, task) -> removedTasks.add(task));
             updatingTasks.clear();
+            pausedTasks.forEach((id, task) -> removedTasks.add(task));
+            pausedTasks.clear();
         }
 
         private List<TaskAndAction> getTasksAndActions() {
@@ -388,7 +397,6 @@ public class DefaultStateUpdater implements StateUpdater {
     private final Condition restoredActiveTasksCondition = restoredActiveTasksLock.newCondition();
     private final BlockingQueue<ExceptionAndTasks> exceptionsAndFailedTasks = new LinkedBlockingQueue<>();
     private final BlockingQueue<Task> removedTasks = new LinkedBlockingQueue<>();
-    private final Map<TaskId, Task> pausedTasks = new ConcurrentHashMap<>();
 
     private final long commitIntervalMs;
     private long lastCommitMs;
@@ -417,6 +425,7 @@ public class DefaultStateUpdater implements StateUpdater {
 
     @Override
     public void shutdown(final Duration timeout) {
+        removeAddedTasksFromInputQueue();
         if (stateUpdaterThread != null) {
             stateUpdaterThread.isRunning.set(false);
             stateUpdaterThread.interrupt();
@@ -427,6 +436,21 @@ public class DefaultStateUpdater implements StateUpdater {
                 stateUpdaterThread = null;
             } catch (final InterruptedException ignored) {
             }
+        }
+    }
+
+    private void removeAddedTasksFromInputQueue() {
+        tasksAndActionsLock.lock();
+        try {
+            TaskAndAction taskAndAction;
+            while ((taskAndAction = tasksAndActions.peek()) != null) {
+                if (taskAndAction.getAction() == Action.ADD) {
+                    removedTasks.add(taskAndAction.getTask());
+                }
+                tasksAndActions.poll();
+            }
+        } finally {
+            tasksAndActionsLock.unlock();
         }
     }
 
@@ -557,7 +581,9 @@ public class DefaultStateUpdater implements StateUpdater {
     }
 
     public Set<Task> getPausedTasks() {
-        return Collections.unmodifiableSet(new HashSet<>(pausedTasks.values()));
+        return stateUpdaterThread != null
+            ? Collections.unmodifiableSet(new HashSet<>(stateUpdaterThread.getPausedTasks()))
+            : Collections.emptySet();
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -127,7 +127,7 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldRemoveTasksFromAndClearInputQueueOnShutdown() throws Exception {
-        stateUpdater.shutdown(Duration.ofMinutes(1));
+        stateUpdater.shutdown(Duration.ofMillis(Long.MAX_VALUE));
         final StreamTask statelessTask = statelessTask(TASK_0_0).inState(State.RESTORING).build();
         final StreamTask statefulTask = statefulTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();
@@ -146,7 +146,7 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldRemoveUpdatingTasksOnShutdown() throws Exception {
-        stateUpdater.shutdown(Duration.ofMinutes(1));
+        stateUpdater.shutdown(Duration.ofMillis(Long.MAX_VALUE));
         stateUpdater = new DefaultStateUpdater(new StreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, time);
         final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();
@@ -168,7 +168,7 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldRemovePausedTasksOnShutdown() throws Exception {
         final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
-        final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_1)).inState(State.RUNNING).build();
         stateUpdater.start();
         stateUpdater.add(activeTask);
         stateUpdater.add(standbyTask);
@@ -190,8 +190,8 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(activeTask);
         stateUpdater.add(standbyTask);
         stateUpdater.pause(standbyTask.id());
-        verifyUpdatingTasks(activeTask);
         verifyPausedTasks(standbyTask);
+        verifyUpdatingTasks(activeTask);
         verifyRemovedTasks();
 
         stateUpdater.shutdown(Duration.ofMinutes(1));


### PR DESCRIPTION
The state updater removes its updating and paused task on shutdown.
The removed tasks are added to the output queue for removed tasks.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
