### PR TITLE
KAFKA-10199: Shutdown state updater on task manager shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -236,6 +236,7 @@ public class DefaultStateUpdater implements StateUpdater {
                 task.maybeCheckpoint(true);
                 removedTasks.add(task);
             });
+            updatingTasks.clear();
             pausedTasks.forEach((id, task) -> {
                 removedTasks.add(task);
             });

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -154,16 +154,16 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void addNewActiveTasks(final Collection<Task> newTasks) {
+    public void addActiveTasks(final Collection<Task> newTasks) {
         if (!newTasks.isEmpty()) {
             for (final Task activeTask : newTasks) {
-                addNewActiveTask(activeTask);
+                addActiveTask(activeTask);
             }
         }
     }
 
     @Override
-    public void addNewActiveTask(final Task task) {
+    public void addActiveTask(final Task task) {
         final TaskId taskId = task.id();
 
         if (activeTasksPerId.containsKey(taskId)) {
@@ -182,7 +182,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void addNewStandbyTasks(final Collection<Task> newTasks) {
+    public void addStandbyTasks(final Collection<Task> newTasks) {
         if (!newTasks.isEmpty()) {
             for (final Task standbyTask : newTasks) {
                 final TaskId taskId = standbyTask.id();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
@@ -55,11 +55,11 @@ public interface TasksRegistry {
 
     void addPendingTaskToInit(final Collection<Task> tasks);
 
-    void addNewActiveTasks(final Collection<Task> newTasks);
+    void addActiveTasks(final Collection<Task> tasks);
 
-    void addNewActiveTask(final Task task);
+    void addActiveTask(final Task task);
 
-    void addNewStandbyTasks(final Collection<Task> newTasks);
+    void addStandbyTasks(final Collection<Task> tasks);
 
     void removeTask(final Task taskToRemove);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -128,7 +128,6 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldRemoveTasksFromAndClearInputQueueOnShutdown() throws Exception {
-        stateUpdater.shutdown(Duration.ofMillis(Long.MAX_VALUE));
         final StreamTask statelessTask = statelessTask(TASK_0_0).inState(State.RESTORING).build();
         final StreamTask statefulTask = statefulTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -52,8 +52,8 @@ public class TasksTest {
         final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_1)).build();
         final StreamTask statelessTask = statelessTask(TASK_1_0).build();
 
-        tasks.addNewActiveTasks(mkSet(statefulTask, statelessTask));
-        tasks.addNewStandbyTasks(Collections.singletonList(standbyTask));
+        tasks.addActiveTasks(mkSet(statefulTask, statelessTask));
+        tasks.addStandbyTasks(Collections.singletonList(standbyTask));
 
         assertEquals(statefulTask, tasks.task(statefulTask.id()));
         assertEquals(statelessTask, tasks.task(statelessTask.id()));


### PR DESCRIPTION
When the task manager is shutdown, the state updater should also
shutdown. After the shutdown of the state updater, the tasks
in its output queues should be closed.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
