### PR TITLE
KAFKA-13908 Rethrow ExecutionException to preserve original cause

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -448,6 +448,7 @@ class BrokerServer(
       try {
         metadataListener.startPublishing(metadataPublisher).get()
       } catch {
+        case ee: ExecutionException => throw ee
         case t: Throwable => throw new RuntimeException("Received a fatal error while " +
           "waiting for the broker to catch up with the current cluster metadata.", t)
       }
@@ -472,6 +473,7 @@ class BrokerServer(
       try {
         lifecycleManager.setReadyToUnfence().get()
       } catch {
+        case ee: ExecutionException => throw ee
         case t: Throwable => throw new RuntimeException("Received a fatal error while " +
           "waiting for the broker to be unfenced.", t)
       }


### PR DESCRIPTION
Rethrow `ExecutionException` instead of wrapping it in `RuntimeException`.
It will preserve original cause in method-wide catch block:

```
    } catch {
      case e: Throwable =>
        maybeChangeStatus(STARTING, STARTED)
        fatal("Fatal error during broker startup. Prepare to shutdown", e)
        shutdown()
        throw if (e.isInstanceOf[ExecutionException]) e.getCause else e
    }

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
