### PR TITLE
KAFKA-14193: Update expected task configs for FileStream source and sink connectors in ConnectRestApiTest

### DIFF
--- a/tests/kafkatest/tests/connect/connect_rest_test.py
+++ b/tests/kafkatest/tests/connect/connect_rest_test.py
@@ -157,10 +157,15 @@ class ConnectRestApiTest(KafkaTest):
         expected_source_task_info = [{
             'id': {'connector': 'local-file-source', 'task': 0},
             'config': {
+                'connector.class': 'org.apache.kafka.connect.file.FileStreamSourceConnector',
                 'task.class': 'org.apache.kafka.connect.file.FileStreamSourceTask',
                 'file': self.INPUT_FILE,
                 'topic': self.TOPIC,
-                'batch.size': self.DEFAULT_BATCH_SIZE
+                'tasks.max': '1',
+                'name': 'local-file-source',
+                'errors.log.include.messages': 'true',
+                'errors.tolerance': 'none',
+                'errors.log.enable': 'true'
             }
         }]
         source_task_info = self.cc.get_connector_tasks("local-file-source")
@@ -168,9 +173,17 @@ class ConnectRestApiTest(KafkaTest):
         expected_sink_task_info = [{
             'id': {'connector': 'local-file-sink', 'task': 0},
             'config': {
+                'connector.class': 'org.apache.kafka.connect.file.FileStreamSinkConnector',
                 'task.class': 'org.apache.kafka.connect.file.FileStreamSinkTask',
                 'file': self.OUTPUT_FILE,
-                'topics': self.TOPIC
+                'topics': self.TOPIC,
+                'key.converter.schemas.enable': 'True',
+                'tasks.max': '1',
+                'name': 'local-file-sink',
+                'value.converter.schemas.enable':'True',
+                'errors.tolerance': 'none',
+                'errors.log.enable': 'true',
+                'errors.log.include.messages': 'true',
             }
         }]
         sink_task_info = self.cc.get_connector_tasks("local-file-sink")


### PR DESCRIPTION
- [ConnectRestApiTest](https://github.com/apache/kafka/blob/trunk/tests/kafkatest/tests/connect/connect_rest_test.py) is currently failing on `trunk` and `3.3` with the following assertion error:

```
AssertionError()
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 183, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 243, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.9/dist-packages/ducktape/mark/_mark.py", line 433, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/connect/connect_rest_test.py", line 106, in test_rest_api
    self.verify_config(self.FILE_SOURCE_CONNECTOR, self.FILE_SOURCE_CONFIGS, configs)
  File "/opt/kafka-dev/tests/kafkatest/tests/connect/connect_rest_test.py", line 219, in verify_config
    assert config_def == set(config_names)
```

- On closer inspection, this is because of the new source connector EOS related configs added in https://github.com/apache/kafka/pull/11775. 

- Adding the following new configs - `offsets.storage.topic, transaction.boundary, exactly.once.support, transaction.boundary.interval.ms` in the expected config defs [here](https://github.com/apache/kafka/blob/6f4778301b1fcac1e2750cc697043d674eaa230d/tests/kafkatest/tests/connect/connect_rest_test.py#L35) fixes the tests on the 3.3 branch. However, the tests still fail on trunk due to the changes from https://github.com/apache/kafka/pull/12450.

- The plan to fix this is to raise two PRs against trunk patching `connect_rest_test.py` - the first one fixing the EOS configs related issue which can be backported to 3.3 and the second one fixing the issue related to propagation of full connector configs to tasks which shouldn't be backported to 3.3 (because the commit from https://github.com/apache/kafka/pull/12450 is only on trunk and not on 3.3)

- This is the second of the two PRs and should not be backported to `3.3`