### PR TITLE
MINOR; Fix LICENSE-binary based on the 3.3 dependencies

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -207,29 +207,31 @@ License Version 2.0:
 
 audience-annotations-0.5.0
 commons-cli-1.4
-commons-lang3-3.8.1
-jackson-annotations-2.12.6
-jackson-core-2.12.6
-jackson-databind-2.12.6.1
-jackson-dataformat-csv-2.12.6
-jackson-datatype-jdk8-2.12.6
-jackson-jaxrs-base-2.12.6
-jackson-jaxrs-json-provider-2.12.6
-jackson-module-jaxb-annotations-2.12.6
-jackson-module-paranamer-2.10.5
-jackson-module-scala_2.13-2.12.6
+commons-lang3-3.12.0
+jackson-annotations-2.13.3
+jackson-core-2.13.3
+jackson-databind-2.13.3
+jackson-dataformat-csv-2.13.3
+jackson-dataformat-yaml-2.13.3
+jackson-datatype-jdk8-2.13.3
+jackson-datatype-jsr310-2.13.3
+jackson-jaxrs-base-2.13.3
+jackson-jaxrs-json-provider-2.13.3
+jackson-module-jaxb-annotations-2.13.3
+jackson-module-scala_2.13-2.13.3
+jackson-module-scala_2.12-2.13.3
 jakarta.validation-api-2.0.2
 javassist-3.27.0-GA
-jetty-client-9.4.44.v20210927
-jetty-continuation-9.4.44.v20210927
-jetty-http-9.4.44.v20210927
-jetty-io-9.4.44.v20210927
-jetty-security-9.4.44.v20210927
-jetty-server-9.4.44.v20210927
-jetty-servlet-9.4.44.v20210927
-jetty-servlets-9.4.44.v20210927
-jetty-util-9.4.44.v20210927
-jetty-util-ajax-9.4.44.v20210927
+jetty-client-9.4.48.v20220622
+jetty-continuation-9.4.48.v20220622
+jetty-http-9.4.48.v20220622
+jetty-io-9.4.48.v20220622
+jetty-security-9.4.48.v20220622
+jetty-server-9.4.48.v20220622
+jetty-servlet-9.4.48.v20220622
+jetty-servlets-9.4.48.v20220622
+jetty-util-9.4.48.v20220622
+jetty-util-ajax-9.4.48.v20220622
 jersey-common-2.34
 jersey-server-2.34
 jose4j-0.7.9
@@ -237,16 +239,15 @@ lz4-java-1.8.0
 maven-artifact-3.8.4
 metrics-core-4.1.12.1
 metrics-core-2.2.0
-netty-buffer-4.1.73.Final
-netty-codec-4.1.73.Final
-netty-common-4.1.73.Final
-netty-handler-4.1.73.Final
-netty-resolver-4.1.73.Final
-netty-tcnative-classes-2.0.46.Final
-netty-transport-4.1.73.Final
-netty-transport-classes-epoll-4.1.73.Final
-netty-transport-native-epoll-4.1.73.Final
-netty-transport-native-unix-common-4.1.73.Final
+netty-buffer-4.1.78.Final
+netty-codec-4.1.78.Final
+netty-common-4.1.78.Final
+netty-handler-4.1.78.Final
+netty-resolver-4.1.78.Final
+netty-transport-4.1.78.Final
+netty-transport-classes-epoll-4.1.78.Final
+netty-transport-native-epoll-4.1.78.Final
+netty-transport-native-unix-common-4.1.78.Final
 plexus-utils-3.3.0
 reload4j-1.2.19
 rocksdbjni-6.29.4.1
@@ -255,7 +256,13 @@ scala-library-2.13.8
 scala-logging_2.13-3.9.4
 scala-reflect-2.13.8
 scala-java8-compat_2.13-1.0.2
+snakeyaml-1.30
 snappy-java-1.1.8.4
+swagger-annotations-2.2.0
+swagger-core-2.2.0
+swagger-integration-2.2.0
+swagger-jaxrs2-2.2.0
+swagger-models-2.2.0
 zookeeper-3.6.3
 zookeeper-jute-3.6.3
 
@@ -268,8 +275,8 @@ See licenses/ for text of these licenses.
 Eclipse Distribution License - v 1.0
 see: licenses/eclipse-distribution-license-1.0
 
-jakarta.activation-api-1.2.1
-jakarta.xml.bind-api-2.3.2
+jakarta.activation-api-1.2.2
+jakarta.xml.bind-api-2.3.3
 
 ---------------------------------------
 Eclipse Public License - v 2.0
@@ -305,6 +312,7 @@ argparse4j-0.7.0, see: licenses/argparse-MIT
 jopt-simple-5.0.4, see: licenses/jopt-simple-MIT
 slf4j-api-1.7.36, see: licenses/slf4j-MIT
 slf4j-reload4j-1.7.36, see: licenses/slf4j-MIT
+classgraph-4.8.138, see: license/classgraph-MIT
 
 ---------------------------------------
 BSD 2-Clause

--- a/licenses/classgraph-MIT
+++ b/licenses/classgraph-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Luke Hutchison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The following commands don't show any missings licenses
```
$ ./gradlewAll clean releaseTarGz
$ tar xzf core/build/distributions/kafka_2.13-3.3.0-SNAPSHOT.tgz
$ cd kafka_2.13-3.3.0-SNAPSHOT/
$ for f in $(ls libs | grep -v "^kafka\|connect\|trogdor"); do if ! grep -q ${f%.*} LICENSE; then echo "${f%.*} is missing in license file"; fi; done
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
