### PR TITLE
MINOR: Demystify rebalance schedule log

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -54,6 +54,7 @@ import org.apache.kafka.streams.state.HostInfo;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1355,7 +1356,10 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             log.info("Requested to schedule immediate rebalance for new tasks to be safely revoked from current owner.");
             nextScheduledRebalanceMs.set(0L);
         } else if (encodedNextScheduledRebalanceMs < Long.MAX_VALUE) {
-            log.info("Requested to schedule probing rebalance for {} ms.", encodedNextScheduledRebalanceMs);
+            log.info(
+                "Requested to schedule next probing rebalance at {} to try for a more balanced assignment.",
+                Instant.ofEpochMilli(encodedNextScheduledRebalanceMs) // The Instant#toString format is more readable.
+            );
             nextScheduledRebalanceMs.set(encodedNextScheduledRebalanceMs);
         } else {
             log.info("No followup rebalance was requested, resetting the rebalance schedule.");


### PR DESCRIPTION
People have a hard time understanding what's going on with probing rebalances, partly due to cryptic messages like this:

```
2022-08-31T12:03:29.197+09:00 ..... Requested to schedule probing rebalance for 1661915609131 ms.
2022-08-31T12:04:29.578+09:00 ..... Requested to schedule probing rebalance for 1661915669542 ms.
```

We should provide a little more context and also encode the timestamp as a readable date/time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
