### PR TITLE
KAFKA-14194: Fix NPE in Cluster.nodeIfOnline

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -252,7 +252,8 @@ public final class Cluster {
      */
     public Optional<Node> nodeIfOnline(TopicPartition partition, int id) {
         Node node = nodeById(id);
-        if (node != null && !Arrays.asList(partition(partition).offlineReplicas()).contains(node)) {
+        PartitionInfo partitionInfo = partition(partition);
+        if (node != null && partitionInfo != null && !Arrays.asList(partitionInfo.offlineReplicas()).contains(node)) {
             return Optional.of(node);
         } else {
             return Optional.empty();

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -793,18 +793,13 @@ public class MetadataTest {
 
     @Test
     public void testNodeIfOnlineNonExistentTopicPartition() {
-        Node node0 = new Node(0, "localhost", 9092);
-
-        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 2, Collections.emptyMap(), Collections.emptyMap(), _tp -> 99,
-            (error, partition, leader, leaderEpoch, replicas, isr, offlineReplicas) ->
-                new MetadataResponse.PartitionMetadata(error, partition, Optional.of(node0.id()), leaderEpoch,
-                    Collections.singletonList(node0.id()), Collections.emptyList(),
-                        Collections.emptyList()), ApiKeys.METADATA.latestVersion(), Collections.emptyMap());
-        metadata.updateWithCurrentRequestVersion(emptyMetadataResponse(), false, 0L);
-        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 10L);
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(2, Collections.emptyMap());
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
 
         TopicPartition tp = new TopicPartition("topic-1", 0);
 
+        assertEquals(metadata.fetch().nodeById(0).id(), 0);
+        assertNull(metadata.fetch().partition(tp));
         assertEquals(metadata.fetch().nodeIfOnline(tp, 0), Optional.empty());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -792,6 +792,23 @@ public class MetadataTest {
     }
 
     @Test
+    public void testNodeIfOnlineNonExistentTopicPartition() {
+        Node node0 = new Node(0, "localhost", 9092);
+
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 2, Collections.emptyMap(), Collections.emptyMap(), _tp -> 99,
+            (error, partition, leader, leaderEpoch, replicas, isr, offlineReplicas) ->
+                new MetadataResponse.PartitionMetadata(error, partition, Optional.of(node0.id()), leaderEpoch,
+                    Collections.singletonList(node0.id()), Collections.emptyList(),
+                        Collections.emptyList()), ApiKeys.METADATA.latestVersion(), Collections.emptyMap());
+        metadata.updateWithCurrentRequestVersion(emptyMetadataResponse(), false, 0L);
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 10L);
+
+        TopicPartition tp = new TopicPartition("topic-1", 0);
+
+        assertEquals(metadata.fetch().nodeIfOnline(tp, 0), Optional.empty());
+    }
+
+    @Test
     public void testLeaderMetadataInconsistentWithBrokerMetadata() {
         // Tests a reordering scenario which can lead to inconsistent leader state.
         // A partition initially has one broker offline. That broker comes online and


### PR DESCRIPTION
When utilizing the rack-aware consumer configuration and rolling updates are being applied to the Kafka brokers the metadata updates can be in a transient state and a given topic-partition can be missing from the metadata. This seems to resolve itself after a bit of time but before it can resolve the `Cluster.nodeIfOnline` method throws an NPE. This PR checks to make sure that a given topic-partition has partition info available before using that partition info.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
