### PR TITLE
[WIP] MINOR: Use named class for ExpiringCredential to improve `principalLogText()` output

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerRefreshingLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerRefreshingLogin.java
@@ -76,6 +76,35 @@ import org.slf4j.LoggerFactory;
  * @see SaslConfigs#SASL_LOGIN_REFRESH_BUFFER_SECONDS_DOC
  */
 public class OAuthBearerRefreshingLogin implements Login {
+
+    private static class OAuthBearerExpiringCredential implements ExpiringCredential {
+        private final OAuthBearerToken token;
+
+        public OAuthBearerExpiringCredential(OAuthBearerToken token) {
+            this.token = token;
+        }
+
+        @Override
+        public String principalName() {
+            return token.principalName();
+        }
+
+        @Override
+        public Long startTimeMs() {
+            return token.startTimeMs();
+        }
+
+        @Override
+        public long expireTimeMs() {
+            return token.lifetimeMs();
+        }
+
+        @Override
+        public Long absoluteLastRefreshTimeMs() {
+            return null;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(OAuthBearerRefreshingLogin.class);
     private ExpiringCredentialRefreshingLogin expiringCredentialRefreshingLogin = null;
 
@@ -103,27 +132,7 @@ public class OAuthBearerRefreshingLogin implements Login {
                 final OAuthBearerToken token = privateCredentialTokens.iterator().next();
                 if (log.isDebugEnabled())
                     log.debug("Found expiring credential with principal '{}'.", token.principalName());
-                return new ExpiringCredential() {
-                    @Override
-                    public String principalName() {
-                        return token.principalName();
-                    }
-
-                    @Override
-                    public Long startTimeMs() {
-                        return token.startTimeMs();
-                    }
-
-                    @Override
-                    public long expireTimeMs() {
-                        return token.lifetimeMs();
-                    }
-
-                    @Override
-                    public Long absoluteLastRefreshTimeMs() {
-                        return null;
-                    }
-                };
+                return new OAuthBearerExpiringCredential(token);
             }
         };
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
@@ -275,9 +275,7 @@ public abstract class ExpiringCredentialRefreshingLogin implements AutoCloseable
              * (it seems likely to be a bug, but it doesn't hurt to keep trying to refresh).
              */
             long retvalNextRefreshMs = relativeToMs + DELAY_SECONDS_BEFORE_NEXT_RETRY_WHEN_RELOGIN_FAILS * 1000L;
-            // The principal here is always null?
-            log.warn("[Principal={}]: No Expiring credential found: will try again at {}", principalLogText(),
-                    new Date(retvalNextRefreshMs));
+            log.warn("No Expiring credential found: will try again at {}", new Date(retvalNextRefreshMs));
             return retvalNextRefreshMs;
         }
         long expireTimeMs = expiringCredential.expireTimeMs();
@@ -378,14 +376,13 @@ public abstract class ExpiringCredentialRefreshingLogin implements AutoCloseable
              * Perform a login, making note of any credential that might need a logout()
              * afterwards
              */
-            String principalName = expiringCredential.principalName();
             ExpiringCredential optionalCredentialToLogout = expiringCredential;
             LoginContext optionalLoginContextToLogout = loginContext;
             boolean cleanLogin = false; // remember to restore the original if necessary
             try {
                 loginContext = loginContextFactory.createLoginContext(ExpiringCredentialRefreshingLogin.this);
                 log.info("Initiating re-login for {}, logout() still needs to be called on a previous login = {}",
-                        principalName, optionalCredentialToLogout != null);
+                    expiringCredential.principalName(), optionalCredentialToLogout != null);
                 loginContext.login();
                 cleanLogin = true; // no need to restore the original
                 // Perform a logout() on any original credential if necessary
@@ -409,7 +406,6 @@ public abstract class ExpiringCredentialRefreshingLogin implements AutoCloseable
                  * seems likely to be a bug, but it doesn't hurt to keep trying to refresh).
                  */
                 log.error("No Expiring Credential after a supposedly-successful re-login");
-                principalName = null;
             } else {
                 if (expiringCredential == optionalCredentialToLogout)
                     /*
@@ -428,8 +424,7 @@ public abstract class ExpiringCredentialRefreshingLogin implements AutoCloseable
 
     // Visible for testing
     String principalLogText() {
-        return expiringCredential == null ? ""
-                : expiringCredential.getClass().getSimpleName() + ":" + principalName();
+        return expiringCredential.getClass().getSimpleName() + ":" + principalName();
     }
 
     private long currentMs() {


### PR DESCRIPTION
`ExpiringCredentialRefreshingLogin.principalLogText()` outputs the expiring credential
simple class name, which is empty for anonymous classes.

I also took the change to remove effectively dead code given that some of
the checks would always have the same result.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
