### PR TITLE
MINOR: Enable "abort previous builds" for PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
   agent none
   
   options {
-    disableConcurrentBuilds(abortPrevious: changeRequest())
+    disableConcurrentBuilds(abortPrevious: isChangeRequest(env)
   }
   
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
   agent none
   
   options {
-    disableConcurrentBuilds(abortPrevious: isChangeRequest(env)
+    disableConcurrentBuilds(abortPrevious: isChangeRequest(env))
   }
   
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
   agent none
   
   options {
-    disableConcurrentBuilds()
+    disableConcurrentBuilds(abortPrevious: changeRequest())
   }
   
   stages {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fffApache Kafka
+Apache Kafka
 =================
 See our [web site](https://kafka.apache.org) for details on the project.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Apache Kafka
+fffApache Kafka
 =================
 See our [web site](https://kafka.apache.org) for details on the project.
 


### PR DESCRIPTION
When a new commit is pushed to a PR, we should abort the build
and start a new one instead of queuing one build per commit.
This reduces wasted resources and provides the desired feedback
faster (since we only care about the build results for the last
commit in the PR).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
