### PR TITLE
KAFKA-14197: use raft error RaftBatchTooLargeException instead of exi…

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/errors/RaftBatchTooLargeException.java
+++ b/raft/src/main/java/org/apache/kafka/raft/errors/RaftBatchTooLargeException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.errors;
+
+/**
+ * This record batch is larger than the maximum allowable size
+ */
+public class RaftBatchTooLargeException extends RaftException {
+
+    private final static long serialVersionUID = 1L;
+
+    public RaftBatchTooLargeException(String s) {
+        super(s);
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.raft.internals;
 
-import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.record.CompressionType;
@@ -24,6 +23,7 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.raft.errors.BufferAllocationException;
 import org.apache.kafka.raft.errors.NotLeaderException;
+import org.apache.kafka.raft.errors.RaftBatchTooLargeException;
 import org.apache.kafka.server.common.serialization.RecordSerde;
 
 import org.apache.kafka.common.message.LeaderChangeMessage;
@@ -101,7 +101,7 @@ public class BatchAccumulator<T> implements Closeable {
      *              will be thrown
      * @param records the list of records to include in the batches
      * @return the expected offset of the last record
-     * @throws RecordBatchTooLargeException if the size of one record T is greater than the maximum
+     * @throws RaftBatchTooLargeException if the size of one record T is greater than the maximum
      *         batch size; if this exception is throw some of the elements in records may have
      *         been committed
      * @throws NotLeaderException if the epoch is less than the leader epoch
@@ -121,7 +121,7 @@ public class BatchAccumulator<T> implements Closeable {
      *              will be thrown
      * @param records the list of records to include in a batch
      * @return the expected offset of the last record
-     * @throws RecordBatchTooLargeException if the size of the records is greater than the maximum
+     * @throws RaftBatchTooLargeException if the size of the records is greater than the maximum
      *         batch size; if this exception is throw none of the elements in records were
      *         committed
      * @throws NotLeaderException if the epoch is less than the leader epoch
@@ -190,7 +190,7 @@ public class BatchAccumulator<T> implements Closeable {
         if (currentBatch != null) {
             OptionalInt bytesNeeded = currentBatch.bytesNeeded(records, serializationCache);
             if (bytesNeeded.isPresent() && bytesNeeded.getAsInt() > maxBatchSize) {
-                throw new RecordBatchTooLargeException(
+                throw new RaftBatchTooLargeException(
                     String.format(
                         "The total record(s) size of %d exceeds the maximum allowed batch size of %d",
                         bytesNeeded.getAsInt(),


### PR DESCRIPTION
…sting API error

When writeEvent failed, we'll try to renounce the controller state. But if the error is an `ApiException`, we'll just throw exception. The problem happened when trying to allocate buffer for the batch, we might encounter `RecordBatchTooLargeException`. The RecordBatchTooLargeException thrown from BatchAccumulator#append is one of ApiException, and that will enter [here](https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java#L446) without `renounce`. 

Fix it by creating new `RaftBatchTooLargeException` since this exception thrown by `BatchAccumulator` should be part of RaftException, not ApiException.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
