### PR TITLE
MINOR: Replace usage of File.createTempFile() with TestUtils.tempFile()

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.test.TestSslUtils.SslConfigsBuilder;
+import org.apache.kafka.test.TestUtils;
 
 public class CertStores {
 
@@ -66,7 +67,7 @@ public class CertStores {
     private CertStores(boolean server, String commonName, String keyAlgorithm, TestSslUtils.CertificateBuilder certBuilder, boolean usePem) throws Exception {
         String name = server ? "server" : "client";
         Mode mode = server ? Mode.SERVER : Mode.CLIENT;
-        File truststoreFile = usePem ? null : File.createTempFile(name + "TS", ".jks");
+        File truststoreFile = usePem ? null : TestUtils.tempFile(name + "TS", ".jks");
         sslConfig = new SslConfigsBuilder(mode)
                 .useClientCert(!server)
                 .certAlias(name)

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -66,7 +66,7 @@ public abstract class SslSelectorTest extends SelectorTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
 
         Map<String, Object> sslServerConfigs = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         this.server = new EchoServer(SecurityProtocol.SSL, sslServerConfigs);
@@ -249,7 +249,7 @@ public abstract class SslSelectorTest extends SelectorTest {
         MemoryPool pool = new SimpleMemoryPool(900, 900, false, null);
         //the initial channel builder is for clients, we need a server one
         String tlsProtocol = "TLSv1.2";
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
         Map<String, Object> sslServerConfigs = new TestSslUtils.SslConfigsBuilder(Mode.SERVER)
                 .tlsProtocol(tlsProtocol)
                 .createNewTrustStore(trustStoreFile)

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,8 +53,7 @@ public class JaasContextTest {
 
     @BeforeEach
     public void setUp() throws IOException {
-        jaasConfigFile = File.createTempFile("jaas", ".conf");
-        jaasConfigFile.deleteOnExit();
+        jaasConfigFile = TestUtils.tempFile("jaas", ".conf");
         System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, jaasConfigFile.toString());
         Configuration.setConfiguration(null);
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -384,7 +384,7 @@ public abstract class SslFactoryTest {
     }
 
     private void verifyKeystoreVerifiableUsingTruststore(boolean usePem, String tlsProtocol) throws Exception {
-        File trustStoreFile1 = usePem ? null : File.createTempFile("truststore1", ".jks");
+        File trustStoreFile1 = usePem ? null : TestUtils.tempFile("truststore1", ".jks");
         Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile1)
                 .usePem(usePem)
@@ -392,7 +392,7 @@ public abstract class SslFactoryTest {
         SslFactory sslFactory = new SslFactory(Mode.SERVER, null, true);
         sslFactory.configure(sslConfig1);
 
-        File trustStoreFile2 = usePem ? null : File.createTempFile("truststore2", ".jks");
+        File trustStoreFile2 = usePem ? null : TestUtils.tempFile("truststore2", ".jks");
         Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile2)
                 .usePem(usePem)

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -244,7 +244,7 @@ public class TestSslUtils {
 
         if (certChain != null) {
             if (ksPath == null) {
-                ksPath = File.createTempFile("keystore", ".pem").getPath();
+                ksPath = TestUtils.tempFile("keystore", ".pem").getPath();
                 sslProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ksPath);
             }
             sslProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.kafka.common.security.authenticator.TestJaasConfig;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -223,8 +224,7 @@ public class JaasBasicAuthFilterTest {
     }
 
     private File setupPropertyLoginFile(boolean includeUsers) throws IOException {
-        File credentialFile = File.createTempFile("credential", ".properties");
-        credentialFile.deleteOnExit();
+        File credentialFile = TestUtils.tempFile("credential", ".properties");
         if (includeUsers) {
             List<String> lines = new ArrayList<>();
             lines.add("user=password");

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -65,8 +65,8 @@ public class FileStreamSourceTaskTest {
     }
 
     @AfterEach
-    public void teardown() {
-        tempFile.delete();
+    public void teardown() throws IOException {
+        Files.deleteIfExists(tempFile.toPath());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,8 +69,8 @@ public class FileOffsetBackingStoreTest {
     }
 
     @After
-    public void teardown() {
-        tempFile.delete();
+    public void teardown() throws IOException {
+        Files.deleteIfExists(tempFile.toPath());
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -14,7 +14,6 @@
 
 package kafka.api
 
-import java.io.File
 import java.{lang, util}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -46,7 +46,7 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
   override protected def listenerName = new ListenerName("CLIENT")
   override protected def interBrokerListenerName: ListenerName = new ListenerName("BROKER")
 
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   override val brokerCount: Int = 2
 
   private val kafkaServerSaslMechanisms = Seq("SCRAM-SHA-256")

--- a/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
@@ -12,7 +12,6 @@
   */
 package kafka.api
 
-import java.io.File
 import java.util
 import java.util.Properties
 
@@ -83,7 +82,7 @@ class DescribeAuthorizedOperationsTest extends IntegrationTestHarness with SaslS
 
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
 
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 
   override def configureSecurityBeforeServersStart(): Unit = {
     val authorizer = CoreUtils.createObject[Authorizer](classOf[AclAuthorizer].getName)

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -18,7 +18,6 @@
 package kafka.api
 
 import com.yammer.metrics.core.Gauge
-import java.io.File
 import java.util.{Collections, Properties}
 import java.util.concurrent.ExecutionException
 
@@ -83,7 +82,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   val part = 0
   val tp = new TopicPartition(topic, part)
 
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   protected def authorizerClass: Class[_] = classOf[AclAuthorizer]
 
   val topicResource = new ResourcePattern(TOPIC, topic, LITERAL)

--- a/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
@@ -12,11 +12,9 @@
   */
 package kafka.api
 
-import java.io.File
-
 import kafka.server.KafkaConfig
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
-import kafka.utils.JaasTestUtils
+import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
 import scala.jdk.CollectionConverters._
@@ -26,7 +24,7 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
   private val kafkaServerSaslMechanisms = List("GSSAPI", "PLAIN")
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   override protected val serverSaslProperties = Some(kafkaServerSaslProperties(kafkaServerSaslMechanisms, kafkaClientSaslMechanism))
   override protected val clientSaslProperties = Some(kafkaClientSaslProperties(kafkaClientSaslMechanism))
 

--- a/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
@@ -12,7 +12,6 @@
   */
 package kafka.api
 
-import java.io.File
 import java.util.Locale
 
 import kafka.server.KafkaConfig
@@ -31,7 +30,7 @@ class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
   // disable secure acls of zkClient in QuorumTestHarness
   override protected def zkAclsEnabled = Some(false)
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   override protected val serverSaslProperties = Some(kafkaServerSaslProperties(kafkaServerSaslMechanisms, kafkaClientSaslMechanism))
   override protected val clientSaslProperties = Some(kafkaClientSaslProperties(kafkaClientSaslMechanism))
 

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -12,7 +12,6 @@
   */
 package kafka.api
 
-import java.io.File
 import java.util
 
 import kafka.log.LogConfig
@@ -51,7 +50,7 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
 
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 
   override def generateConfigs: Seq[KafkaConfig] = {
     this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, authorizationAdmin.authorizerClassName)

--- a/core/src/test/scala/integration/kafka/api/SaslSslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslConsumerTest.scala
@@ -12,17 +12,15 @@
   */
 package kafka.api
 
-import java.io.File
-
 import kafka.server.KafkaConfig
-import kafka.utils.JaasTestUtils
+import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 
 class SaslSslConsumerTest extends BaseConsumerTest with SaslSetup {
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {

--- a/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
@@ -12,7 +12,6 @@
   */
 package kafka.api
 
-import java.io.File
 import java.util
 import java.util.concurrent._
 
@@ -84,7 +83,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
 
   override protected def securityProtocol = SecurityProtocol.SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   private val adminClients = mutable.Buffer.empty[Admin]
 
   override def setUpSasl(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/SslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslConsumerTest.scala
@@ -12,11 +12,11 @@
   */
 package kafka.api
 
-import java.io.File
+import kafka.utils.TestUtils
 
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
 class SslConsumerTest extends BaseConsumerTest {
   override protected def securityProtocol = SecurityProtocol.SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 }

--- a/core/src/test/scala/integration/kafka/api/SslProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslProducerSendTest.scala
@@ -17,11 +17,11 @@
 
 package kafka.api
 
-import java.io.File
+import kafka.utils.TestUtils
 
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
 class SslProducerSendTest extends BaseProducerSendTest {
   override protected def securityProtocol = SecurityProtocol.SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 }

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -14,9 +14,8 @@
 
 package kafka.api
 
-import java.io.File
-
 import kafka.server._
+import kafka.utils.TestUtils
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.Sanitizer
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
@@ -24,7 +23,7 @@ import org.junit.jupiter.api.{BeforeEach, TestInfo}
 class UserClientIdQuotaTest extends BaseQuotaTest {
 
   override protected def securityProtocol = SecurityProtocol.SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 
   override def producerClientId = "QuotasTestProducer-!@#$%^&*()"
   override def consumerClientId = "QuotasTestConsumer-!@#$%^&*()"

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -15,16 +15,14 @@
 package kafka.api
 
 import kafka.server.KafkaBroker
-import kafka.utils.JaasTestUtils
+import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
-
-import java.io.File
 
 class UserQuotaTest extends BaseQuotaTest with SaslSetup {
 
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
-  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   private val kafkaServerSaslMechanisms = Seq("GSSAPI")
   private val kafkaClientSaslMechanism = "GSSAPI"
   override protected val serverSaslProperties = Some(kafkaServerSaslProperties(kafkaServerSaslMechanisms, kafkaClientSaslMechanism))

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -96,8 +96,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   private val kafkaClientSaslMechanism = "PLAIN"
   private val kafkaServerSaslMechanisms = List("PLAIN")
 
-  private val trustStoreFile1 = File.createTempFile("truststore", ".jks")
-  private val trustStoreFile2 = File.createTempFile("truststore", ".jks")
+  private val trustStoreFile1 = TestUtils.tempFile("truststore", ".jks")
+  private val trustStoreFile2 = TestUtils.tempFile("truststore", ".jks")
   private val sslProperties1 = TestUtils.sslConfigs(Mode.SERVER, clientCert = false, Some(trustStoreFile1), "kafka")
   private val sslProperties2 = TestUtils.sslConfigs(Mode.SERVER, clientCert = false, Some(trustStoreFile2), "kafka")
   private val invalidSslProperties = invalidSslConfigs
@@ -385,7 +385,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Broker keystore update for internal listener with compatible keystore should succeed
     val sslPropertiesCopy = sslProperties1.clone().asInstanceOf[Properties]
     val oldFile = new File(sslProperties1.getProperty(SSL_KEYSTORE_LOCATION_CONFIG))
-    val newFile = File.createTempFile("keystore", ".jks")
+    val newFile = TestUtils.tempFile("keystore", ".jks")
     Files.copy(oldFile.toPath, newFile.toPath, StandardCopyOption.REPLACE_EXISTING)
     sslPropertiesCopy.setProperty(SSL_KEYSTORE_LOCATION_CONFIG, newFile.getPath)
     alterSslKeystore(sslPropertiesCopy, SecureInternal)
@@ -393,7 +393,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Verify that keystores can be updated using same file name.
     val reusableProps = sslProperties2.clone().asInstanceOf[Properties]
-    val reusableFile = File.createTempFile("keystore", ".jks")
+    val reusableFile = TestUtils.tempFile("keystore", ".jks")
     reusableProps.setProperty(SSL_KEYSTORE_LOCATION_CONFIG, reusableFile.getPath)
     Files.copy(new File(sslProperties1.getProperty(SSL_KEYSTORE_LOCATION_CONFIG)).toPath,
       reusableFile.toPath, StandardCopyOption.REPLACE_EXISTING)
@@ -1407,7 +1407,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val cert2 = load(trustStore2Props).getCertificate("kafka")
     val certs = Map("kafka1" -> cert1, "kafka2" -> cert2)
 
-    val combinedStorePath = File.createTempFile("truststore", ".jks").getAbsolutePath
+    val combinedStorePath = TestUtils.tempFile("truststore", ".jks").getAbsolutePath
     val password = trustStore1Props.get(SSL_TRUSTSTORE_PASSWORD_CONFIG).asInstanceOf[Password]
     TestSslUtils.createTrustStore(combinedStorePath, password, certs.asJava)
     val newStoreProps = new Properties

--- a/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
@@ -18,7 +18,6 @@
 
 package kafka.server
 
-import java.io.File
 import java.util.{Collections, Objects, Properties}
 import java.util.concurrent.TimeUnit
 
@@ -52,7 +51,7 @@ abstract class MultipleListenersWithSameSecurityProtocolBaseTest extends QuorumT
 
   import MultipleListenersWithSameSecurityProtocolBaseTest._
 
-  private val trustStoreFile = File.createTempFile("truststore", ".jks")
+  private val trustStoreFile = TestUtils.tempFile("truststore", ".jks")
   private val servers = new ArrayBuffer[KafkaServer]
   private val producers = mutable.Map[ClientMetadata, KafkaProducer[Array[Byte], Array[Byte]]]()
   private val consumers = mutable.Map[ClientMetadata, KafkaConsumer[Array[Byte], Array[Byte]]]()

--- a/core/src/test/scala/other/kafka/TestTruncate.scala
+++ b/core/src/test/scala/other/kafka/TestTruncate.scala
@@ -17,7 +17,8 @@
 
 package kafka
 
-import java.io._
+import kafka.utils.TestUtils
+
 import java.nio._
 import java.nio.channels.FileChannel
 import java.nio.file.StandardOpenOption
@@ -26,7 +27,7 @@ import java.nio.file.StandardOpenOption
 object TestTruncate {
 
   def main(args: Array[String]): Unit = {
-    val name = File.createTempFile("kafka", ".test")
+    val name = TestUtils.tempFile("kafka", ".test")
     name.deleteOnExit()
     val file = FileChannel.open(name.toPath, StandardOpenOption.READ, StandardOpenOption.WRITE)
     val buffer = ByteBuffer.allocate(12)

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -16,12 +16,11 @@
  */
 package kafka
 
-import java.io.File
 import java.nio.file.Files
 import java.util
 import java.util.Properties
 import kafka.server.KafkaConfig
-import kafka.utils.Exit
+import kafka.utils.{Exit, TestUtils}
 import kafka.utils.TestUtils.assertBadConfigContainingMessage
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.config.types.Password
@@ -390,8 +389,7 @@ class KafkaTest {
   }
 
   def prepareConfig(lines : Array[String]): String = {
-    val file = File.createTempFile("kafkatest", ".properties")
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("kafkatest", ".properties")
 
     val writer = Files.newOutputStream(file.toPath)
     try {

--- a/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
@@ -16,7 +16,6 @@
  */
 package kafka.admin
 
-import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
@@ -261,8 +260,7 @@ object LeaderElectionCommandTest {
   }
 
   def tempTopicPartitionFile(partitions: Set[TopicPartition]): Path = {
-    val file = File.createTempFile("leader-election-command", ".json")
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("leader-election-command", ".json")
 
     val jsonString = TestUtils.stringifyTopicPartitions(partitions)
 

--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -12,7 +12,7 @@
   */
 package kafka.admin
 
-import java.io.{BufferedWriter, File, FileWriter}
+import java.io.{BufferedWriter, FileWriter}
 import java.text.{SimpleDateFormat}
 import java.util.{Calendar, Date, Properties}
 
@@ -356,8 +356,7 @@ class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
 
     produceConsumeAndShutdown(topic = topic, group = group, totalMessages = 100, numConsumers = 2)
 
-    val file = File.createTempFile("reset", ".csv")
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("reset", ".csv")
 
     val exportedOffsets = consumerGroupCommand.resetOffsets()
     val bw = new BufferedWriter(new FileWriter(file))
@@ -397,8 +396,7 @@ class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
     awaitConsumerGroupInactive(consumerGroupCommand, group1)
     awaitConsumerGroupInactive(consumerGroupCommand, group2)
 
-    val file = File.createTempFile("reset", ".csv")
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("reset", ".csv")
 
     val exportedOffsets = consumerGroupCommand.resetOffsets()
     val bw = new BufferedWriter(new FileWriter(file))

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1917,7 +1917,7 @@ class SocketServerTest {
   }
 
   private def sslServerProps: Properties = {
-    val trustStoreFile = File.createTempFile("truststore", ".jks")
+    val trustStoreFile = TestUtils.tempFile("truststore", ".jks")
     val sslProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, interBrokerSecurityProtocol = Some(SecurityProtocol.SSL),
       trustStoreFile = Some(trustStoreFile))
     sslProps.put(KafkaConfig.ListenersProp, "SSL://localhost:0")

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
@@ -41,7 +41,6 @@ import org.apache.zookeeper.client.ZKClientConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
-import java.io.File
 import java.net.InetAddress
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
@@ -1074,8 +1073,7 @@ class AclAuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     prepareConfig(Array("broker.id=1", "zookeeper.connect=somewhere"))
 
   private def prepareConfig(lines : Array[String]): String = {
-    val file = File.createTempFile("kafkatest", ".properties")
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("kafkatest", ".properties")
 
     val writer = Files.newOutputStream(file.toPath)
     try {

--- a/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileWithFailureHandlerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileWithFailureHandlerTest.scala
@@ -16,10 +16,8 @@
   */
 package kafka.server.checkpoints
 
-import java.io.File
-
 import kafka.server.epoch.EpochEntry
-import kafka.utils.Logging
+import kafka.utils.{Logging, TestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -27,8 +25,7 @@ class LeaderEpochCheckpointFileWithFailureHandlerTest extends Logging {
 
   @Test
   def shouldPersistAndOverwriteAndReloadFile(): Unit ={
-    val file = File.createTempFile("temp-checkpoint-file", System.nanoTime().toString)
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("temp-checkpoint-file", System.nanoTime().toString)
 
     val checkpoint = new LeaderEpochCheckpointFile(file)
 
@@ -53,8 +50,7 @@ class LeaderEpochCheckpointFileWithFailureHandlerTest extends Logging {
 
   @Test
   def shouldRetainValuesEvenIfCheckpointIsRecreated(): Unit ={
-    val file = File.createTempFile("temp-checkpoint-file", System.nanoTime().toString)
-    file.deleteOnExit()
+    val file = TestUtils.tempFile("temp-checkpoint-file", System.nanoTime().toString)
 
     //Given a file with data in
     val checkpoint = new LeaderEpochCheckpointFile(file)

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -19,7 +19,7 @@ package kafka.tools
 
 import java.io.{ByteArrayOutputStream, File, PrintWriter}
 import java.text.SimpleDateFormat
-import kafka.utils.Exit
+import kafka.utils.{Exit, TestUtils}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.Test
@@ -113,8 +113,7 @@ class ConsumerPerformanceTest {
 
   @Test
   def testClientIdOverride(): Unit = {
-    val consumerConfigFile = File.createTempFile("test_consumer_config",".conf")
-    consumerConfigFile.deleteOnExit()
+    val consumerConfigFile = TestUtils.tempFile("test_consumer_config",".conf")
     new PrintWriter(consumerConfigFile.getPath) { write("client.id=consumer-1"); close() }
 
     //Given

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -17,7 +17,7 @@
 
 package kafka.tools
 
-import java.io.{ByteArrayOutputStream, File, PrintWriter}
+import java.io.{ByteArrayOutputStream, PrintWriter}
 import java.text.SimpleDateFormat
 import kafka.utils.{Exit, TestUtils}
 import org.apache.kafka.clients.consumer.ConsumerConfig

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -150,6 +150,11 @@ object TestUtils extends Logging {
   def tempFile(): File = JTestUtils.tempFile()
 
   /**
+   * Create a temporary file with particular suffix and prefix
+   */
+  def tempFile(prefix: String, suffix: String): File = JTestUtils.tempFile(prefix, suffix)
+
+  /**
    * Create a temporary file and return an open file channel for this file
    */
   def tempChannel(): FileChannel =

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.test.IntegrationTest;
 
+import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -236,7 +237,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
 
         // RESET
-        final File resetFile = File.createTempFile("reset", ".csv");
+        final File resetFile = TestUtils.tempFile("reset", ".csv");
         try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
             writer.write(INPUT_TOPIC + ",0,1");
         }
@@ -277,7 +278,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
 
         // RESET
-        final File resetFile = File.createTempFile("reset", ".csv");
+        final File resetFile = TestUtils.tempFile("reset", ".csv");
         try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
             writer.write(INPUT_TOPIC + ",0,1");
         }
@@ -322,7 +323,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
 
         // RESET
-        final File resetFile = File.createTempFile("reset", ".csv");
+        final File resetFile = TestUtils.tempFile("reset", ".csv");
         try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
             writer.write(INPUT_TOPIC + ",0,1");
         }

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -56,7 +55,8 @@ public class ProducerPerformanceTest {
     ProducerPerformance producerPerformanceSpy;
 
     private File createTempFile(String contents) throws IOException {
-        File file = TestUtils.tempFile("ProducerPerformanceTest", ".tmp");
+        File file = File.createTempFile("ProducerPerformanceTest", ".tmp");
+        file.deleteOnExit();
         Files.write(file.toPath(), contents.getBytes());
         return file;
     }

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -55,8 +56,7 @@ public class ProducerPerformanceTest {
     ProducerPerformance producerPerformanceSpy;
 
     private File createTempFile(String contents) throws IOException {
-        File file = File.createTempFile("ProducerPerformanceTest", ".tmp");
-        file.deleteOnExit();
+        File file = TestUtils.tempFile("ProducerPerformanceTest", ".tmp");
         Files.write(file.toPath(), contents.getBytes());
         return file;
     }


### PR DESCRIPTION
**Why**
Current set of integration tests leak files in the `/tmp` directory which makes it cumbersome if you don't restart the machine often.

**Fix**
Replace the usage of `File.createTempFile` with existing `TestUtils.tempFile` method across the test files. `TestUtils.tempFile` automatically performs a clean up of the temp files generated in `/tmp/` folder.

**Testing**
`./gradlew integrationTest` and `./gradlew unitTest` is successful locally.