### PR TITLE
KAFKA-14203 Don't make snapshots on broker after metadata errors

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -325,7 +325,7 @@ class BrokerMetadataListener(
     try {
       _image = _delta.apply()
     } catch {
-      case t: Throwable => metadataLoadingFaultHandler.handleFault(s"Error applying metadata delta $delta", t)
+      case t: Throwable => throw metadataLoadingFaultHandler.handleFault(s"Error applying metadata delta $delta", t)
     }
 
     _delta = new MetadataDelta(_image)

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -313,7 +313,7 @@ class BrokerMetadataListenerTest {
   }
 
   @Test
-  def testNoShapshotAfterError(): Unit = {
+  def testNoSnapshotAfterError(): Unit = {
     val snapshotter = new MockMetadataSnapshotter()
     val faultHandler = new MockFaultHandler("metadata loading")
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -53,7 +53,7 @@ class BrokerMetadataListenerTest {
       maxBytesBetweenSnapshots = maxBytesBetweenSnapshots,
       snapshotter = snapshotter,
       brokerMetrics = metrics,
-      metadataLoadingFaultHandler = metadataLoadingFaultHandler
+      _metadataLoadingFaultHandler = metadataLoadingFaultHandler
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.{Endpoint, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.metadata.{BrokerRegistration, RecordTestUtils, VersionRange}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
-import org.apache.kafka.server.fault.MockFaultHandler
+import org.apache.kafka.server.fault.{FaultHandler, MockFaultHandler}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, Test}
 
@@ -45,6 +45,7 @@ class BrokerMetadataListenerTest {
     metrics: BrokerServerMetrics = BrokerServerMetrics(new Metrics()),
     snapshotter: Option[MetadataSnapshotter] = None,
     maxBytesBetweenSnapshots: Long = 1000000L,
+    faultHandler: FaultHandler = metadataLoadingFaultHandler
   ): BrokerMetadataListener = {
     new BrokerMetadataListener(
       brokerId = 0,
@@ -53,7 +54,7 @@ class BrokerMetadataListenerTest {
       maxBytesBetweenSnapshots = maxBytesBetweenSnapshots,
       snapshotter = snapshotter,
       brokerMetrics = metrics,
-      _metadataLoadingFaultHandler = metadataLoadingFaultHandler
+      _metadataLoadingFaultHandler = faultHandler
     )
   }
 
@@ -168,6 +169,7 @@ class BrokerMetadataListenerTest {
   }
 
   private val FOO_ID = Uuid.fromString("jj1G9utnTuCegi_gpnRgYw")
+  private val BAR_ID = Uuid.fromString("SzN5j0LvSEaRIJHrxfMAlg")
 
   private def generateManyRecords(listener: BrokerMetadataListener,
                                   endOffset: Long): Unit = {
@@ -189,6 +191,27 @@ class BrokerMetadataListenerTest {
         )
       )
     }
+    listener.getImageRecords().get()
+  }
+
+  private def generateBadRecords(listener: BrokerMetadataListener,
+                                endOffset: Long): Unit = {
+    listener.handleCommit(
+      RecordTestUtils.mockBatchReader(
+        endOffset,
+        0,
+        util.Arrays.asList(
+          new ApiMessageAndVersion(new PartitionChangeRecord().
+            setPartitionId(0).
+            setTopicId(BAR_ID).
+            setRemovingReplicas(Collections.singletonList(1)), 0.toShort),
+          new ApiMessageAndVersion(new PartitionChangeRecord().
+            setPartitionId(0).
+            setTopicId(BAR_ID).
+            setRemovingReplicas(Collections.emptyList()), 0.toShort)
+        )
+      )
+    )
     listener.getImageRecords().get()
   }
 
@@ -287,6 +310,39 @@ class BrokerMetadataListenerTest {
     // Waiting for the metadata version update to get processed
     listener.getImageRecords().get()
     assertEquals(endOffset, snapshotter.activeSnapshotOffset, "We should generate snapshot on feature update")
+  }
+
+  @Test
+  def testNoShapshotAfterError(): Unit = {
+    val snapshotter = new MockMetadataSnapshotter()
+    val faultHandler = new MockFaultHandler("metadata loading")
+
+    val listener = newBrokerMetadataListener(
+      snapshotter = Some(snapshotter),
+      maxBytesBetweenSnapshots = 1000L,
+      faultHandler = faultHandler)
+    try {
+      val brokerIds = 0 to 3
+
+      registerBrokers(listener, brokerIds, endOffset = 100L)
+      createTopicWithOnePartition(listener, replicas = brokerIds, endOffset = 200L)
+      listener.getImageRecords().get()
+      assertEquals(200L, listener.highestMetadataOffset)
+      assertEquals(-1L, snapshotter.prevCommittedOffset)
+      assertEquals(-1L, snapshotter.activeSnapshotOffset)
+
+      // Append invalid records that will normally trigger a snapshot
+      generateBadRecords(listener, 1000L)
+      assertEquals(-1L, snapshotter.prevCommittedOffset)
+      assertEquals(-1L, snapshotter.activeSnapshotOffset)
+
+      // Generate some records that will not throw an error, verify still no snapshots
+      generateManyRecords(listener, 2000L)
+      assertEquals(-1L, snapshotter.prevCommittedOffset)
+      assertEquals(-1L, snapshotter.activeSnapshotOffset)
+    } finally {
+      listener.close()
+    }
   }
 
   private def registerBrokers(


### PR DESCRIPTION
When we encounter an error while processing metadata on the broker, we have a "best effort" strategy (log the error and continue). One problem with this is that the broker's metadata state (in MetadataImage) is no longer consistent with the quorum. If we take snapshots of this inconsistent MetadataImage, we would eventually truncate the bad parts of the log and lose the data forever. By preventing snapshots, we preserve the log to allow for some (future) remediation.

This patch adds a simple boolean that gets set when we encounter a metadata error. The boolean can only be cleared by restarting the broker.