### PR TITLE
KAFKA-10199: Suspend tasks in the state updater on revocation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class PendingUpdateAction {
+
+    enum Action {
+        UPDATE_INPUT_PARTITIONS,
+        RECYCLE,
+        SUSPEND,
+        CLOSE_DIRTY,
+        CLOSE_CLEAN
+    }
+
+    private final Set<TopicPartition> inputPartitions;
+    private final Action action;
+
+    private PendingUpdateAction(final Action action, final Set<TopicPartition> inputPartitions) {
+        this.action = action;
+        this.inputPartitions = inputPartitions;
+    }
+
+    private PendingUpdateAction(final Action action) {
+        this(action, null);
+    }
+
+    public static PendingUpdateAction createUpdateInputPartition(final Set<TopicPartition> inputPartitions) {
+        Objects.requireNonNull(inputPartitions, "Set of input partitions to update is null!");
+        return new PendingUpdateAction(Action.UPDATE_INPUT_PARTITIONS, inputPartitions);
+    }
+
+    public static PendingUpdateAction createRecycleTask(final Set<TopicPartition> inputPartitions) {
+        Objects.requireNonNull(inputPartitions, "Set of input partitions to update is null!");
+        return new PendingUpdateAction(Action.RECYCLE, inputPartitions);
+    }
+
+    public static PendingUpdateAction createSuspend() {
+        return new PendingUpdateAction(Action.SUSPEND);
+    }
+
+    public static PendingUpdateAction createCloseDirty() {
+        return new PendingUpdateAction(Action.CLOSE_DIRTY);
+    }
+
+    public static PendingUpdateAction createCloseClean() {
+        return new PendingUpdateAction(Action.CLOSE_CLEAN);
+    }
+
+    public Set<TopicPartition> getInputPartitions() {
+        if (action != Action.UPDATE_INPUT_PARTITIONS && action != Action.RECYCLE) {
+            throw new IllegalStateException("Action type " + action + " does not have a set of input partitions!");
+        }
+        return inputPartitions;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -457,11 +457,11 @@ public class TaskManager {
         }
         if (task.state() == State.SUSPENDED) {
             task.resume();
-            handleReAssignedRevokedActiveTask(task);
+            moveTaskFromTasksRegistryToStateUpdater(task);
         }
     }
 
-    private void handleReAssignedRevokedActiveTask(final Task task) {
+    private void moveTaskFromTasksRegistryToStateUpdater(final Task task) {
         tasks.removeTask(task);
         stateUpdater.add(task);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -421,29 +421,20 @@ public class TaskManager {
         }
     }
 
-    private void classifyRunningTasks(final Map<TaskId, Set<TopicPartition>> activeTasksToCreate,
-                                      final Map<TaskId, Set<TopicPartition>> standbyTasksToCreate,
-                                      final Map<Task, Set<TopicPartition>> tasksToRecycle,
-                                      final Set<Task> tasksToCloseClean) {
+    private void classifyRunningAndSuspendedTasks(final Map<TaskId, Set<TopicPartition>> activeTasksToCreate,
+                                                  final Map<TaskId, Set<TopicPartition>> standbyTasksToCreate,
+                                                  final Map<Task, Set<TopicPartition>> tasksToRecycle,
+                                                  final Set<Task> tasksToCloseClean) {
         for (final Task task : tasks.allTasks()) {
+            if (!task.isActive()) {
+                throw new IllegalStateException("Standby tasks should only be managed by the state updater");
+            }
             final TaskId taskId = task.id();
             if (activeTasksToCreate.containsKey(taskId)) {
-                if (task.isActive()) {
-                    final Set<TopicPartition> topicPartitions = activeTasksToCreate.get(taskId);
-                    if (tasks.updateActiveTaskInputPartitions(task, topicPartitions)) {
-                        task.updateInputPartitions(topicPartitions, topologyMetadata.nodeToSourceTopics(task.id()));
-                    }
-                    task.resume();
-                } else {
-                    throw new IllegalStateException("Standby tasks should only be managed by the state updater");
-                }
+                handleReAssignedActiveTask(task, activeTasksToCreate.get(taskId));
                 activeTasksToCreate.remove(taskId);
             } else if (standbyTasksToCreate.containsKey(taskId)) {
-                if (!task.isActive()) {
-                    throw new IllegalStateException("Standby tasks should only be managed by the state updater");
-                } else {
-                    tasksToRecycle.put(task, standbyTasksToCreate.get(taskId));
-                }
+                tasksToRecycle.put(task, standbyTasksToCreate.get(taskId));
                 standbyTasksToCreate.remove(taskId);
             } else {
                 tasksToCloseClean.add(task);
@@ -451,41 +442,97 @@ public class TaskManager {
         }
     }
 
+    private void handleReAssignedActiveTask(final Task task,
+                                            final Set<TopicPartition> inputPartitions) {
+        if (tasks.updateActiveTaskInputPartitions(task, inputPartitions)) {
+            task.updateInputPartitions(inputPartitions, topologyMetadata.nodeToSourceTopics(task.id()));
+        }
+        task.resume();
+        if (task.state() == State.RESTORING) {
+            handleReAssignedRevokedActiveTask(task);
+        }
+    }
+
+    private void handleReAssignedRevokedActiveTask(final Task task) {
+        tasks.removeTask(task);
+        stateUpdater.add(task);
+    }
+
     private void classifyTasksWithStateUpdater(final Map<TaskId, Set<TopicPartition>> activeTasksToCreate,
                                                final Map<TaskId, Set<TopicPartition>> standbyTasksToCreate,
                                                final Map<Task, Set<TopicPartition>> tasksToRecycle,
                                                final Set<Task> tasksToCloseClean) {
-        classifyRunningTasks(activeTasksToCreate, standbyTasksToCreate, tasksToRecycle, tasksToCloseClean);
+        classifyRunningAndSuspendedTasks(activeTasksToCreate, standbyTasksToCreate, tasksToRecycle, tasksToCloseClean);
         for (final Task task : stateUpdater.getTasks()) {
             final TaskId taskId = task.id();
-            final Set<TopicPartition> topicPartitions = activeTasksToCreate.get(taskId);
             if (activeTasksToCreate.containsKey(taskId)) {
+                final Set<TopicPartition> inputPartitions = activeTasksToCreate.get(taskId);
                 if (task.isActive()) {
-                    if (!task.inputPartitions().equals(topicPartitions)) {
-                        stateUpdater.remove(taskId);
-                        tasks.addPendingTaskToUpdateInputPartitions(taskId, topicPartitions);
+                    if (tasks.removePendingActiveTaskToSuspend(taskId)) {
+                        prepareRevokedActiveTaskForResuming(task, inputPartitions);
+                    } else {
+                        prepareReAssignedActiveTaskInRestorationForReUse(task, inputPartitions);
                     }
                 } else {
-                    stateUpdater.remove(taskId);
-                    tasks.addPendingTaskToRecycle(taskId, topicPartitions);
+                    prepareRunningStandbyTaskForRecycling(taskId, inputPartitions);
                 }
                 activeTasksToCreate.remove(taskId);
             } else if (standbyTasksToCreate.containsKey(taskId)) {
+                final Set<TopicPartition> topicPartitions = standbyTasksToCreate.get(taskId);
                 if (!task.isActive()) {
-                    if (!task.inputPartitions().equals(topicPartitions)) {
-                        stateUpdater.remove(taskId);
-                        tasks.addPendingTaskToUpdateInputPartitions(taskId, topicPartitions);
-                    }
+                    prepareReAssignedStandbyTaskForRunning(task, topicPartitions);
                 } else {
-                    stateUpdater.remove(taskId);
-                    tasks.addPendingTaskToRecycle(taskId, topicPartitions);
+                    prepareRevokedActiveTaskForRecycling(taskId, topicPartitions);
                 }
                 standbyTasksToCreate.remove(taskId);
             } else {
-                stateUpdater.remove(taskId);
-                tasks.addPendingTaskToCloseClean(taskId);
+                prepareUnusedTaskInStateUpdaterForCleanClose(taskId);
             }
         }
+    }
+
+    private void prepareRevokedActiveTaskForResuming(final Task task,
+                                                     final Set<TopicPartition> inputPartitions) {
+        if (!task.inputPartitions().equals(inputPartitions)) {
+            tasks.addPendingTaskToUpdateInputPartitions(task.id(), inputPartitions);
+        } else {
+            stateUpdater.add(task);
+        }
+    }
+
+    private void prepareReAssignedActiveTaskInRestorationForReUse(final Task task,
+                                                                  final Set<TopicPartition> inputPartitions) {
+        if (!task.inputPartitions().equals(inputPartitions)) {
+            final TaskId taskId = task.id();
+            stateUpdater.remove(taskId);
+            tasks.addPendingTaskToUpdateInputPartitions(taskId, inputPartitions);
+        }
+    }
+
+    private void prepareRunningStandbyTaskForRecycling(final TaskId taskId,
+                                                       final Set<TopicPartition> inputPartitions) {
+        stateUpdater.remove(taskId);
+        tasks.addPendingTaskToRecycle(taskId, inputPartitions);
+    }
+
+    private void prepareRevokedActiveTaskForRecycling(final TaskId taskId,
+                                                      final Set<TopicPartition> inputPartitions) {
+        tasks.removePendingActiveTaskToSuspend(taskId);
+        tasks.addPendingTaskToRecycle(taskId, inputPartitions);
+    }
+
+    private void prepareReAssignedStandbyTaskForRunning(final Task task,
+                                                        final Set<TopicPartition> inputPartitions) {
+        if (!task.inputPartitions().equals(inputPartitions)) {
+            final TaskId taskId = task.id();
+            stateUpdater.remove(taskId);
+            tasks.addPendingTaskToUpdateInputPartitions(taskId, inputPartitions);
+        }
+    }
+
+    private void prepareUnusedTaskInStateUpdaterForCleanClose(final TaskId taskId) {
+        stateUpdater.remove(taskId);
+        tasks.addPendingTaskToCloseClean(taskId);
     }
 
     private Map<TaskId, Set<TopicPartition>> pendingTasksToCreate(final Map<TaskId, Set<TopicPartition>> tasksToCreate) {
@@ -685,10 +732,10 @@ public class TaskManager {
         return !stateUpdater.restoresActiveTasks();
     }
 
-    private void recycleTask(final Task task,
-                             final Set<TopicPartition> inputPartitions,
-                             final Set<Task> tasksToCloseDirty,
-                             final Map<TaskId, RuntimeException> taskExceptions) {
+    private void recycleTaskFromStateUpdater(final Task task,
+                                             final Set<TopicPartition> inputPartitions,
+                                             final Set<Task> tasksToCloseDirty,
+                                             final Map<TaskId, RuntimeException> taskExceptions) {
         Task newTask = null;
         try {
             task.suspend();
@@ -786,7 +833,7 @@ public class TaskManager {
         for (final Task task : stateUpdater.drainRemovedTasks()) {
             Set<TopicPartition> inputPartitions;
             if ((inputPartitions = tasks.removePendingTaskToRecycle(task.id())) != null) {
-                recycleTask(task, inputPartitions, tasksToCloseDirty, taskExceptions);
+                recycleTaskFromStateUpdater(task, inputPartitions, tasksToCloseDirty, taskExceptions);
             } else if (tasks.removePendingTaskToCloseClean(task.id())) {
                 closeTaskClean(task, tasksToCloseDirty, taskExceptions);
             } else if (tasks.removePendingTaskToCloseDirty(task.id())) {
@@ -794,9 +841,12 @@ public class TaskManager {
             } else if ((inputPartitions = tasks.removePendingTaskToUpdateInputPartitions(task.id())) != null) {
                 task.updateInputPartitions(inputPartitions, topologyMetadata.nodeToSourceTopics(task.id()));
                 stateUpdater.add(task);
+            } else if (tasks.removePendingActiveTaskToSuspend(task.id())) {
+                task.suspend();
+                tasks.addTask(task);
             } else {
                 throw new IllegalStateException("Got a removed task " + task.id() + " from the state updater " +
-                    " that is not for recycle, closing, or updating input partitions; this should not happen");
+                    "that is not for recycle, closing, or updating input partitions; this should not happen");
             }
         }
 
@@ -808,7 +858,7 @@ public class TaskManager {
         maybeThrowTaskExceptions(taskExceptions);
     }
 
-    private boolean handleRestoredTasksFromStateUpdater(final long now,
+    private void handleRestoredTasksFromStateUpdater(final long now,
                                                         final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         final Map<TaskId, RuntimeException> taskExceptions = new LinkedHashMap<>();
         final Set<Task> tasksToCloseDirty = new TreeSet<>(Comparator.comparing(Task::id));
@@ -817,7 +867,7 @@ public class TaskManager {
         for (final Task task : stateUpdater.drainRestoredActiveTasks(timeout)) {
             Set<TopicPartition> inputPartitions;
             if ((inputPartitions = tasks.removePendingTaskToRecycle(task.id())) != null) {
-                recycleTask(task, inputPartitions, tasksToCloseDirty, taskExceptions);
+                recycleTaskFromStateUpdater(task, inputPartitions, tasksToCloseDirty, taskExceptions);
             } else if (tasks.removePendingTaskToCloseClean(task.id())) {
                 closeTaskClean(task, tasksToCloseDirty, taskExceptions);
             } else if (tasks.removePendingTaskToCloseDirty(task.id())) {
@@ -825,6 +875,9 @@ public class TaskManager {
             } else if ((inputPartitions = tasks.removePendingTaskToUpdateInputPartitions(task.id())) != null) {
                 task.updateInputPartitions(inputPartitions, topologyMetadata.nodeToSourceTopics(task.id()));
                 transitRestoredTaskToRunning(task, now, offsetResetter);
+            } else if (tasks.removePendingActiveTaskToSuspend(task.id())) {
+                task.suspend();
+                tasks.addTask(task);
             } else {
                 transitRestoredTaskToRunning(task, now, offsetResetter);
             }
@@ -835,8 +888,6 @@ public class TaskManager {
         }
 
         maybeThrowTaskExceptions(taskExceptions);
-
-        return !stateUpdater.restoresActiveTasks();
     }
 
     /**
@@ -960,7 +1011,7 @@ public class TaskManager {
             for (final Task restoringTask : stateUpdater.getTasks()) {
                 if (restoringTask.isActive()) {
                     if (remainingRevokedPartitions.containsAll(restoringTask.inputPartitions())) {
-                        tasks.addPendingTaskToCloseClean(restoringTask.id());
+                        tasks.addPendingActiveTaskToSuspend(restoringTask.id());
                         stateUpdater.remove(restoringTask.id());
                         remainingRevokedPartitions.removeAll(restoringTask.inputPartitions());
                     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.PendingUpdateAction.Action;
 import org.slf4j.Logger;
 
 import java.util.Collection;
@@ -52,12 +53,8 @@ class Tasks implements TasksRegistry {
     // we receive a new assignment and they are revoked from the thread.
     private final Map<TaskId, Set<TopicPartition>> pendingActiveTasksToCreate = new HashMap<>();
     private final Map<TaskId, Set<TopicPartition>> pendingStandbyTasksToCreate = new HashMap<>();
-    private final Map<TaskId, Set<TopicPartition>> pendingTasksToRecycle = new HashMap<>();
-    private final Set<TaskId> pendingActiveTasksToSuspend = new HashSet<>();
-    private final Map<TaskId, Set<TopicPartition>> pendingTasksToUpdateInputPartitions = new HashMap<>();
     private final Set<Task> pendingTasksToInit = new HashSet<>();
-    private final Set<TaskId> pendingTasksToCloseClean = new HashSet<>();
-    private final Set<TaskId> pendingTasksToCloseDirty = new HashSet<>();
+    private final Map<TaskId, PendingUpdateAction> pendingUpdateActions = new HashMap<>();
 
     // TODO: convert to Stream/StandbyTask when we remove TaskManager#StateMachineTask with mocks
     private final Map<TopicPartition, Task> activeTasksPerPartition = new HashMap<>();
@@ -104,42 +101,75 @@ class Tasks implements TasksRegistry {
 
     @Override
     public Set<TopicPartition> removePendingTaskToRecycle(final TaskId taskId) {
-        return pendingTasksToRecycle.remove(taskId);
+        if (containsTaskIdWithAction(taskId, Action.RECYCLE)) {
+            return pendingUpdateActions.remove(taskId).getInputPartitions();
+        }
+        return null;
     }
 
     @Override
     public void addPendingTaskToRecycle(final TaskId taskId, final Set<TopicPartition> inputPartitions) {
-        pendingTasksToRecycle.put(taskId, inputPartitions);
+        pendingUpdateActions.put(taskId, PendingUpdateAction.createRecycleTask(inputPartitions));
     }
 
     @Override
     public Set<TopicPartition> removePendingTaskToUpdateInputPartitions(final TaskId taskId) {
-        return pendingTasksToUpdateInputPartitions.remove(taskId);
+        if (containsTaskIdWithAction(taskId, Action.UPDATE_INPUT_PARTITIONS)) {
+            return pendingUpdateActions.remove(taskId).getInputPartitions();
+        }
+        return null;
     }
 
     @Override
     public void addPendingTaskToUpdateInputPartitions(final TaskId taskId, final Set<TopicPartition> inputPartitions) {
-        pendingTasksToUpdateInputPartitions.put(taskId, inputPartitions);
+        pendingUpdateActions.put(taskId, PendingUpdateAction.createUpdateInputPartition(inputPartitions));
     }
 
     @Override
     public boolean removePendingTaskToCloseDirty(final TaskId taskId) {
-        return pendingTasksToCloseDirty.remove(taskId);
+        if (containsTaskIdWithAction(taskId, Action.CLOSE_DIRTY)) {
+            pendingUpdateActions.remove(taskId);
+            return true;
+        }
+        return false;
     }
 
     @Override
     public void addPendingTaskToCloseDirty(final TaskId taskId) {
-        pendingTasksToCloseDirty.add(taskId);
+        pendingUpdateActions.put(taskId, PendingUpdateAction.createCloseDirty());
     }
 
     @Override
     public boolean removePendingTaskToCloseClean(final TaskId taskId) {
-        return pendingTasksToCloseClean.remove(taskId);
+        if (containsTaskIdWithAction(taskId, Action.CLOSE_CLEAN)) {
+            pendingUpdateActions.remove(taskId);
+            return true;
+        }
+        return false;
     }
 
     @Override
     public void addPendingTaskToCloseClean(final TaskId taskId) {
-        pendingTasksToCloseClean.add(taskId);
+        pendingUpdateActions.put(taskId, PendingUpdateAction.createCloseClean());
+    }
+
+    @Override
+    public boolean removePendingActiveTaskToSuspend(final TaskId taskId) {
+        if (containsTaskIdWithAction(taskId, Action.SUSPEND)) {
+            pendingUpdateActions.remove(taskId);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void addPendingActiveTaskToSuspend(final TaskId taskId) {
+        pendingUpdateActions.put(taskId, PendingUpdateAction.createSuspend());
+    }
+
+    private boolean containsTaskIdWithAction(final TaskId taskId, final Action action) {
+        final PendingUpdateAction pendingUpdateAction = pendingUpdateActions.get(taskId);
+        return !(pendingUpdateAction == null || pendingUpdateAction.getAction() != action);
     }
 
     @Override
@@ -152,16 +182,6 @@ class Tasks implements TasksRegistry {
     @Override
     public void addPendingTaskToInit(final Collection<Task> tasks) {
         pendingTasksToInit.addAll(tasks);
-    }
-
-    @Override
-    public boolean removePendingActiveTaskToSuspend(final TaskId taskId) {
-        return pendingActiveTasksToSuspend.remove(taskId);
-    }
-
-    @Override
-    public void addPendingActiveTaskToSuspend(final TaskId taskId) {
-        pendingActiveTasksToSuspend.add(taskId);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -53,6 +53,7 @@ class Tasks implements TasksRegistry {
     private final Map<TaskId, Set<TopicPartition>> pendingActiveTasksToCreate = new HashMap<>();
     private final Map<TaskId, Set<TopicPartition>> pendingStandbyTasksToCreate = new HashMap<>();
     private final Map<TaskId, Set<TopicPartition>> pendingTasksToRecycle = new HashMap<>();
+    private final Set<TaskId> pendingActiveTasksToSuspend = new HashSet<>();
     private final Map<TaskId, Set<TopicPartition>> pendingTasksToUpdateInputPartitions = new HashMap<>();
     private final Set<Task> pendingTasksToInit = new HashSet<>();
     private final Set<TaskId> pendingTasksToCloseClean = new HashSet<>();
@@ -151,6 +152,16 @@ class Tasks implements TasksRegistry {
     @Override
     public void addPendingTaskToInit(final Collection<Task> tasks) {
         pendingTasksToInit.addAll(tasks);
+    }
+
+    @Override
+    public boolean removePendingActiveTaskToSuspend(final TaskId taskId) {
+        return pendingActiveTasksToSuspend.remove(taskId);
+    }
+
+    @Override
+    public void addPendingActiveTaskToSuspend(final TaskId taskId) {
+        pendingActiveTasksToSuspend.add(taskId);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
@@ -55,6 +55,10 @@ public interface TasksRegistry {
 
     void addPendingTaskToInit(final Collection<Task> tasks);
 
+    boolean removePendingActiveTaskToSuspend(final TaskId taskId);
+
+    void addPendingActiveTaskToSuspend(final TaskId taskId);
+
     void addActiveTasks(final Collection<Task> tasks);
 
     void addStandbyTasks(final Collection<Task> tasks);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -267,7 +267,6 @@ public class TaskManagerTest {
         );
 
         verify(activeTaskCreator, standbyTaskCreator);
-        Mockito.verify(tasks).removePendingActiveTaskToSuspend(activeTaskToRecycle.id());
         Mockito.verify(tasks).addPendingTaskToRecycle(activeTaskToRecycle.id(), activeTaskToRecycle.inputPartitions());
     }
 
@@ -372,29 +371,6 @@ public class TaskManagerTest {
         );
 
         verify(activeTaskCreator, standbyTaskCreator);
-    }
-
-    @Test
-    public void shouldUpdateInputPartitionsOfReAssignedRevokedActiveTaskInStateUpdater() {
-        final StreamTask reAssignedRevokedActiveTask = statefulTask(taskId03, taskId03ChangelogPartitions)
-            .inState(State.RESTORING)
-            .withInputPartitions(taskId03Partitions).build();
-        final Set<TopicPartition> newInputPartitions = taskId02Partitions;
-        final TasksRegistry tasks = Mockito.mock(TasksRegistry.class);
-        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(stateUpdater.getTasks()).thenReturn(mkSet(reAssignedRevokedActiveTask));
-        expect(activeTaskCreator.createTasks(consumer, Collections.emptyMap())).andReturn(emptySet());
-        expect(standbyTaskCreator.createTasks(Collections.emptyMap())).andReturn(emptySet());
-        replay(activeTaskCreator, standbyTaskCreator);
-
-        taskManager.handleAssignment(
-            mkMap(mkEntry(reAssignedRevokedActiveTask.id(), newInputPartitions)),
-            Collections.emptyMap()
-        );
-
-        verify(activeTaskCreator, standbyTaskCreator);
-        Mockito.verify(tasks).addPendingTaskToUpdateInputPartitions(reAssignedRevokedActiveTask.id(), newInputPartitions);
-        Mockito.verify(tasks).removePendingActiveTaskToSuspend(reAssignedRevokedActiveTask.id());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -31,6 +32,9 @@ import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TasksTest {
@@ -43,11 +47,10 @@ public class TasksTest {
     private final static TaskId TASK_0_1 = new TaskId(0, 1);
     private final static TaskId TASK_1_0 = new TaskId(1, 0);
 
-    private final LogContext logContext = new LogContext();
+    private final Tasks tasks = new Tasks(new LogContext());
 
     @Test
     public void shouldKeepAddedTasks() {
-        final Tasks tasks = new Tasks(logContext);
         final StreamTask statefulTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_1)).build();
         final StreamTask statelessTask = statelessTask(TASK_1_0).build();
@@ -77,8 +80,6 @@ public class TasksTest {
 
     @Test
     public void shouldDrainPendingTasksToCreate() {
-        final Tasks tasks = new Tasks(logContext);
-
         tasks.addPendingActiveTasksToCreate(mkMap(
             mkEntry(new TaskId(0, 0, "A"), mkSet(TOPIC_PARTITION_A_0)),
             mkEntry(new TaskId(0, 1, "A"), mkSet(TOPIC_PARTITION_A_1)),
@@ -107,5 +108,142 @@ public class TasksTest {
 
         assertEquals(Collections.emptyMap(), tasks.drainPendingActiveTasksForTopologies(mkSet("B")));
         assertEquals(Collections.emptyMap(), tasks.drainPendingStandbyTasksForTopologies(mkSet("B")));
+    }
+
+    @Test
+    public void shouldAddAndRemovePendingTaskToRecycle() {
+        final Set<TopicPartition> expectedInputPartitions = mkSet(TOPIC_PARTITION_A_0);
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+
+        tasks.addPendingTaskToRecycle(TASK_0_0, expectedInputPartitions);
+        final Set<TopicPartition> actualInputPartitions = tasks.removePendingTaskToRecycle(TASK_0_0);
+
+        assertEquals(expectedInputPartitions, actualInputPartitions);
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+    }
+
+    @Test
+    public void shouldAddAndRemovePendingTaskToUpdateInputPartitions() {
+        final Set<TopicPartition> expectedInputPartitions = mkSet(TOPIC_PARTITION_A_0);
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+
+        tasks.addPendingTaskToUpdateInputPartitions(TASK_0_0, expectedInputPartitions);
+        final Set<TopicPartition> actualInputPartitions = tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0);
+
+        assertEquals(expectedInputPartitions, actualInputPartitions);
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+    }
+
+    @Test
+    public void shouldAddAndRemovePendingTaskToCloseClean() {
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+
+        tasks.addPendingTaskToCloseClean(TASK_0_0);
+
+        assertTrue(tasks.removePendingTaskToCloseClean(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+    }
+
+    @Test
+    public void shouldAddAndRemovePendingTaskToCloseDirty() {
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+
+        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+
+        assertTrue(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+    }
+
+    @Test
+    public void shouldAddAndRemovePendingTaskToSuspend() {
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+
+        tasks.addPendingActiveTaskToSuspend(TASK_0_0);
+
+        assertTrue(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+    }
+
+    @Test
+    public void onlyRemovePendingTaskToRecycleShouldRemoveTaskFromPendingUpdateActions() {
+        tasks.addPendingTaskToRecycle(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
+
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+        assertNotNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+    }
+
+    @Test
+    public void onlyRemovePendingTaskToUpdateInputPartitionsShouldRemoveTaskFromPendingUpdateActions() {
+        tasks.addPendingTaskToUpdateInputPartitions(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
+
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+        assertNotNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+    }
+
+    @Test
+    public void onlyRemovePendingTaskToCloseCleanShouldRemoveTaskFromPendingUpdateActions() {
+        tasks.addPendingTaskToCloseClean(TASK_0_0);
+
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToCloseClean(TASK_0_0));
+    }
+
+    @Test
+    public void onlyRemovePendingTaskToCloseDirtyShouldRemoveTaskFromPendingUpdateActions() {
+        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+    }
+
+    @Test
+    public void onlyRemovePendingTaskToSuspendShouldRemoveTaskFromPendingUpdateActions() {
+        tasks.addPendingActiveTaskToSuspend(TASK_0_0);
+
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+        assertTrue(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+    }
+
+    @Test
+    public void shouldOnlyKeepLastUpdateAction() {
+        tasks.addPendingTaskToRecycle(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
+        tasks.addPendingTaskToUpdateInputPartitions(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
+        assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
+        assertNotNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+
+        tasks.addPendingTaskToUpdateInputPartitions(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
+        tasks.addPendingTaskToCloseClean(TASK_0_0);
+        assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToCloseClean(TASK_0_0));
+
+        tasks.addPendingTaskToCloseClean(TASK_0_0);
+        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+        assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+
+        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+        tasks.addPendingActiveTaskToSuspend(TASK_0_0);
+        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertTrue(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+
+        tasks.addPendingActiveTaskToSuspend(TASK_0_0);
+        tasks.addPendingTaskToRecycle(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
+        assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
+        assertNotNull(tasks.removePendingTaskToRecycle(TASK_0_0));
     }
 }


### PR DESCRIPTION
In the first attempt to handle revoked tasks in the state updater we removed the revoked tasks from the state updater and added it to the set of pending tasks to close cleanly. This is not correct since a revoked task that is immediately reassigned to the same stream thread would neither be re-added to the state updater nor be created again. Also a revoked active task might be added to more than one bookkeeping set in the tasks registry since it might still be returned from stateUpdater.getTasks() after it was removed from the state updater. The reason is that the removal from the state updater is done asynchronously.

This PR solves this issue by introducing a new bookkeeping set in the tasks registry to bookkeep revoked active tasks (actually suspended active tasks).

Additionally this PR closes some testing holes around the modified code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
