### PR TITLE
MINOR: Retry on test failure for branch builds and increase max test retry to 10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,15 +29,10 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def retryFlagsString(env) {
-    if (isChangeRequest(env)) " -PmaxTestRetries=1 -PmaxTestRetryFailures=5"
-    else ""
-}
-
 def doTest(env, target = "unitTest integrationTest") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed \
-      -PignoreFailures=true -PmaxParallelForks=2""" + retryFlagsString(env)
+      -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
   junit '**/build/test-results/**/TEST-*.xml'
 }
 


### PR DESCRIPTION
Originally, we only enabled retries for PR builds to avoid hiding timing related issues. In practice, however, the results are too noisy without any retry due to various environmental issues.

Enable 1 retry for all builds and increase the max test retry to 10.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
