### PR TITLE
KAFKA-14196: Pausing partition to prevent duplication when autocommit is enabled

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -756,17 +756,13 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             joinPrepareTimer.update();
         }
 
-        // TODO: See KAFKA-14196 for more detail, we pause the partition from consumption to prevent duplicated
-        //  data returned by the consumer poll loop.  Without pausing the partitions, the consumer will move forward
-        //  returning the data w/o committing them.  And the progress will be lost once the partition is revoked.
-        Set<TopicPartition> partitions = subscriptionState().assignedPartitions();
-        log.debug("Pausing partitions {} before onJoinPrepare", partitions);
-        partitions.stream().forEach(tp -> subscriptionState().pause(tp));
-
         // async commit offsets prior to rebalance if auto-commit enabled
         // and there is no in-flight offset commit request
-        if (autoCommitEnabled && autoCommitOffsetRequestFuture == null) {
-            autoCommitOffsetRequestFuture = maybeAutoCommitOffsetsAsync();
+        if (autoCommitEnabled) {
+            pausePartitions();
+            autoCommitOffsetRequestFuture = autoCommitOffsetRequestFuture == null ?
+                    maybeAutoCommitOffsetsAsync() :
+                    autoCommitOffsetRequestFuture;
         }
 
         // wait for commit offset response before timer expired
@@ -864,6 +860,18 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             throw new KafkaException("User rebalance callback throws an error", exception);
         }
         return true;
+    }
+
+    private void pausePartitions() {
+        // TODO: See KAFKA-14196 for more detail, we pause the partition from consumption to prevent duplicated
+        //  data returned by the consumer poll loop.  Without pausing the partitions, the consumer will move forward
+        //  returning the data w/o committing them.  And the progress will be lost once the partition is revoked.
+        //  This only applies to autocommits, as we expect user to handle the offsets menually during the partition
+        //  revocation.
+
+        Set<TopicPartition> partitions = subscriptionState().assignedPartitions();
+        log.debug("Pausing partitions {} before onJoinPrepare", partitions);
+        partitions.stream().forEach(tp -> subscriptionState().pause(tp));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -761,7 +761,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         // async commit offsets prior to rebalance if auto-commit enabled
         // and there is no in-flight offset commit request
         if (autoCommitEnabled) {
-            pausePartitions(partitionsToRevoke);
+            markPartitionsUnconsumable(subscriptions.assignedPartitions());
             autoCommitOffsetRequestFuture = autoCommitOffsetRequestFuture == null ?
                     maybeAutoCommitOffsetsAsync() :
                     autoCommitOffsetRequestFuture;
@@ -893,6 +893,11 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         }
 
         return exception;
+    }
+
+    private void markPartitionsUnconsumable(final Set<TopicPartition> assignedPartitions) {
+        log.debug("Marking assigned partition unconsumable: {}", assignedPartitions);
+        assignedPartitions.forEach(subscriptions::markUnconsumable);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -273,6 +273,21 @@ public class FetcherTest {
     }
 
     @Test
+    public void testInflightFetchOnPendingPartitions() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, fetcher.sendFetches());
+        subscriptions.markPendingRevocation(singleton(tp0));
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertNull(fetchedRecords().get(tp0));
+    }
+
+    @Test
     public void testFetchingPendingPartitions() {
         buildFetcher();
 
@@ -2308,7 +2323,7 @@ public class FetcherTest {
     }
 
     @Test
-    public void testPendingRevacationPartitionFetching() {
+    public void testFetchingPendingPartitionsBeforeAndAfterSubscriptionReset() {
         buildFetcher();
         assignFromUser(singleton(tp0));
         subscriptions.seek(tp0, 100);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -263,6 +263,7 @@ public class SubscriptionStateTest {
         assertTrue(state.isFetchable(tp0));
         state.markPendingRevocation(singleton(tp0));
         assertFalse(state.isFetchable(tp0));
+        assertFalse(state.isPaused(tp0));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -257,6 +257,15 @@ public class SubscriptionStateTest {
     }
 
     @Test
+    public void testMarkingPartitionUnconsumable() {
+        state.assignFromUser(singleton(tp0));
+        state.seek(tp0, 100);
+        assertTrue(state.isFetchable(tp0));
+        state.markUnconsumable(tp0);
+        assertFalse(state.isFetchable(tp0));
+    }
+
+    @Test
     public void invalidPositionUpdate() {
         state.subscribe(singleton(topic), rebalanceListener);
         assertTrue(state.checkAssignmentMatchedSubscription(singleton(tp0)));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -257,11 +257,11 @@ public class SubscriptionStateTest {
     }
 
     @Test
-    public void testMarkingPartitionUnconsumable() {
+    public void testMarkingPartitionPending() {
         state.assignFromUser(singleton(tp0));
         state.seek(tp0, 100);
         assertTrue(state.isFetchable(tp0));
-        state.markUnconsumable(tp0);
+        state.markPendingRevocation(singleton(tp0));
         assertFalse(state.isFetchable(tp0));
     }
 

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -316,7 +316,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
     @cluster(num_nodes=7)
     @matrix(assignment_strategy=["org.apache.kafka.clients.consumer.RangeAssignor",
-                                 "org.apache.kafka.clients.consumer.StickyAssignor"], clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
+                                 "org.apache.kafka.clients.consumer.CooperativeStickyAssignor"], clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
     def test_consumer_failure(self,  assignment_strategy, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk):
         partition = TopicPartition(self.TOPIC, 0)
 

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -316,8 +316,8 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
     @cluster(num_nodes=7)
     @matrix(assignment_strategy=["org.apache.kafka.clients.consumer.RangeAssignor",
-                                 "org.apache.kafka.clients.consumer.CooperativeStickyAssignor"], clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
-    def test_consumer_failure(self, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk, assignment_strategy):
+                                 "org.apache.kafka.clients.consumer.StickyAssignor"], clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
+    def test_consumer_failure(self,  assignment_strategy, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk):
         partition = TopicPartition(self.TOPIC, 0)
 
         consumer = self.setup_consumer(self.TOPIC, enable_autocommit=enable_autocommit, assignment_strategy=assignment_strategy)

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -315,11 +315,12 @@ class OffsetValidationTest(VerifiableConsumerTest):
                        )
 
     @cluster(num_nodes=7)
-    @matrix(clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
-    def test_consumer_failure(self, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk):
+    @matrix(assignment_strategy=["org.apache.kafka.clients.consumer.RangeAssignor",
+                                 "org.apache.kafka.clients.consumer.CooperativeStickyAssignor"], clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
+    def test_consumer_failure(self, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk, assignment_strategy):
         partition = TopicPartition(self.TOPIC, 0)
 
-        consumer = self.setup_consumer(self.TOPIC, enable_autocommit=enable_autocommit)
+        consumer = self.setup_consumer(self.TOPIC, enable_autocommit=enable_autocommit, assignment_strategy=assignment_strategy)
         producer = self.setup_producer(self.TOPIC)
 
         consumer.start()

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -315,12 +315,11 @@ class OffsetValidationTest(VerifiableConsumerTest):
                        )
 
     @cluster(num_nodes=7)
-    @matrix(assignment_strategy=["org.apache.kafka.clients.consumer.RangeAssignor",
-                                 "org.apache.kafka.clients.consumer.CooperativeStickyAssignor"], clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
-    def test_consumer_failure(self,  assignment_strategy, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk):
+    @matrix(clean_shutdown=[True], enable_autocommit=[True, False], metadata_quorum=quorum.all_non_upgrade)
+    def test_consumer_failure(self, clean_shutdown, enable_autocommit, metadata_quorum=quorum.zk):
         partition = TopicPartition(self.TOPIC, 0)
 
-        consumer = self.setup_consumer(self.TOPIC, enable_autocommit=enable_autocommit, assignment_strategy=assignment_strategy)
+        consumer = self.setup_consumer(self.TOPIC, enable_autocommit=enable_autocommit)
         producer = self.setup_producer(self.TOPIC)
 
         consumer.start()


### PR DESCRIPTION
**Problem**
Several flaky tests under OffsetValidationTest are indicating an underlying consumer duplication issue.  This is caused by [KAFKA-14024](https://issues.apache.org/jira/browse/KAFKA-14024) after switching the autocommit to async, and therefore causes the fetcher to move ahead without committing the previous offsets. The progress will be lost after partition revocation

**Fix**
Add an internal flag to stop the fetcher from sending fetches, for the partition to be revoked.  The reason we didn't use _pause()_ is because we don't want user API to interfere with the behavior, which might potentially introduce more bugs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
