### PR TITLE
MINOR; Remove end html tag from upgrade

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -2062,4 +2062,3 @@ Release 0.7 is incompatible with newer releases. Major changes were made to the 
 </script>
 
 <div class="p-upgrade"></div>
-</html>


### PR DESCRIPTION
The `</html>` doesn't have a matching `<html>` tag. Those tags are added by the server side include and are not needed in docs/upgrade.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
