### PR TITLE
Enable KStream to be merged with itself

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPassThrough.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPassThrough.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+
+public class KStreamPassThrough<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, VIn> {
+
+    @Override
+    public Processor<KIn, VIn, KIn, VIn> get() {
+        return new KStreamPassThroughProcessor();
+    }
+
+    private class KStreamPassThroughProcessor implements Processor<KIn, VIn, KIn, VIn> {
+
+        private ProcessorContext<KIn, VIn> context;
+
+        @Override
+        public void init(final ProcessorContext<KIn, VIn> context) {
+            this.context = context;
+        }
+
+        @Override
+        public void process(final Record<KIn, VIn> record) {
+            context.forward(record);
+        }
+    }
+}


### PR DESCRIPTION
Why:
It is an interesting question what should be the result when merging a KStream with itself. Should the merge duplicate the messages or should it be a noop.
I think the only reasonable solution is to duplicate the messages because there are many different ways to disguise a KStream (e.g. adding peek operation on it).
It is therefore impossible to implement the solution where it is a noop.

How does it help with resolving the issue:
This change makes the behavior of the merge operation consistent.
