### PR TITLE
KAFKA-14198: swagger-jaxrs2 dependency should be compileOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2653,7 +2653,8 @@ project(':connect:runtime') {
   }
 
   task genConnectOpenAPIDocs(type: io.swagger.v3.plugins.gradle.tasks.ResolveTask, dependsOn: setVersionInOpenAPISpec) {
-    classpath = sourceSets.main.compileClasspath
+    classpath = sourceSets.main.compileClasspath + sourceSets.main.runtimeClasspath
+
     buildClasspath = classpath
     outputFileName = 'connect_rest'
     outputFormat = 'YAML'

--- a/build.gradle
+++ b/build.gradle
@@ -2562,8 +2562,9 @@ project(':connect:runtime') {
     implementation libs.jettyClient
     implementation libs.reflections
     implementation libs.mavenArtifact
-    implementation libs.swaggerJaxrs2
     implementation libs.swaggerAnnotations
+
+    compileOnly libs.swaggerJaxrs2
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':core')
@@ -2652,7 +2653,7 @@ project(':connect:runtime') {
   }
 
   task genConnectOpenAPIDocs(type: io.swagger.v3.plugins.gradle.tasks.ResolveTask, dependsOn: setVersionInOpenAPISpec) {
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.compileClasspath
     buildClasspath = classpath
     outputFileName = 'connect_rest'
     outputFormat = 'YAML'


### PR DESCRIPTION
Verified that the artifact generated by `releaseTarGz` no longer includes
swagger-jaxrs2 or its dependencies (like snakeyaml).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
