### PR TITLE
KAFKA-14208: Should not wake-up with non-blocking coordinator discovery

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -249,7 +249,14 @@ public abstract class AbstractCoordinator implements Closeable {
                 throw fatalException;
             }
             final RequestFuture<Void> future = lookupCoordinator();
-            client.poll(future, timer);
+
+            // if we do not want to block on discovering coordinator at all,
+            // then we should not try to poll in a loop, and should not throw wake-up exception either
+            if (timer.timeoutMs() == 0L) {
+                client.poll(timer, future, true);
+            } else {
+                client.poll(future, timer);
+            }
 
             if (!future.isDone()) {
                 // ran out of time

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -273,6 +273,39 @@ public class AbstractCoordinatorTest {
     }
 
     @Test
+    public void testNoWakeupWhenNonBlockingDiscoverCoordinator() {
+        setupCoordinator();
+
+        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+
+        consumerClient.wakeup();
+
+        coordinator.ensureCoordinatorReady(mockTime.timer(0));
+
+        // a follow-up poll should still throw
+        try {
+            coordinator.joinGroupIfNeeded(mockTime.timer(0));
+            fail("Should have woken up from joinGroupIfNeeded()");
+        } catch (WakeupException ignored) {
+        }
+    }
+
+    @Test
+    public void testWakeupWhenBlockingDiscoverCoordinator() throws Exception {
+        setupCoordinator();
+
+        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+
+        consumerClient.wakeup();
+
+        try {
+            coordinator.ensureCoordinatorReady(mockTime.timer(1));
+            fail("Should have woken up from ensureCoordinatorReady()");
+        } catch (WakeupException ignored) {
+        }
+    }
+
+    @Test
     public void testTimeoutAndRetryJoinGroupIfNeeded() throws Exception {
         setupCoordinator();
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));


### PR DESCRIPTION
Today we may try to discover coordinator in both blocking (e.g. in `poll`) and non-blocking (e.g. in `commitAsync`) way. For the latter we would poll the underlying network client with timeout 0, and in this case we should not trigger wakeup since these are non-blocking calls and hence should not throw wake-ups.

In this PR I'm trying to fix it in a least intrusive way (a more general fix should be, potentially, to have two versions of `ensureCoordinatorReady`), since in our threading refactoring, the `ensureCoordinatorReady` function would not be called by the calling thread any more and only triggered by the background thread, and hence we would have a much simpler manner to ensure that non-blocking functions never throw wake-ups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
