### PR TITLE
KAFKA-14198: Define separate swagger configuration in Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2535,6 +2535,10 @@ project(':connect:json') {
 }
 
 project(':connect:runtime') {
+  configurations {
+    swagger
+  }
+
   archivesBaseName = "connect-runtime"
 
   dependencies {
@@ -2564,7 +2568,9 @@ project(':connect:runtime') {
     implementation libs.mavenArtifact
     implementation libs.swaggerAnnotations
 
-    compileOnly libs.swaggerJaxrs2
+    // We use this library to generate OpenAPI docs for the REST API, but we don't want or need it at compile
+    // or run time. So, we add it to a separate configuration, which we use later on during docs generation
+    swagger libs.swaggerJaxrs2
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':core')
@@ -2653,9 +2659,9 @@ project(':connect:runtime') {
   }
 
   task genConnectOpenAPIDocs(type: io.swagger.v3.plugins.gradle.tasks.ResolveTask, dependsOn: setVersionInOpenAPISpec) {
-    classpath = sourceSets.main.compileClasspath + sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath
 
-    buildClasspath = classpath
+    buildClasspath = classpath + configurations.swagger.asCollection()
     outputFileName = 'connect_rest'
     outputFormat = 'YAML'
     prettyPrint = 'TRUE'


### PR DESCRIPTION
Follow-up from https://github.com/apache/kafka/pull/12609. Non-urgent, just tidies up the build file a bit.

Tested and verified locally by:

1. Running `./gradlew releaseTarGz` and then examining the resulting release artifact with `tar tf tar tf core/build/distributions/kafka_2.13-3.4.0-SNAPSHOT.tgz` to ensure that it did not contain the `swaggerJaxrs2` jar or its dependencies
2. Running `./gradlew siteDocsTar` and then examining the resulting docs with `cat docs/generated/connect_rest.yaml` to ensure that all Connect REST endpoints were included.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
