### PR TITLE
(WIP) KAFKA-14196: Mark partition unfetchable

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -759,6 +759,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         // async commit offsets prior to rebalance if auto-commit enabled
         // and there is no in-flight offset commit request
         if (autoCommitEnabled && autoCommitOffsetRequestFuture == null) {
+            markPartitionsUnconsumable(subscriptions.assignedPartitions());
             autoCommitOffsetRequestFuture = maybeAutoCommitOffsetsAsync();
         }
 
@@ -857,6 +858,11 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             throw new KafkaException("User rebalance callback throws an error", exception);
         }
         return true;
+    }
+
+    private void markPartitionsUnconsumable(final Set<TopicPartition> assignedPartitions) {
+        log.debug("Marking assigned partition unconsumable: {}", assignedPartitions);
+        assignedPartitions.forEach(subscriptions::markUnconsumable);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -257,6 +257,15 @@ public class SubscriptionStateTest {
     }
 
     @Test
+    public void testMarkingPartitionUnconsumable() {
+        state.assignFromUser(singleton(tp0));
+        state.seek(tp0, 100);
+        assertTrue(state.isFetchable(tp0));
+        state.markUnconsumable(tp0);
+        assertFalse(state.isFetchable(tp0));
+    }
+
+    @Test
     public void invalidPositionUpdate() {
         state.subscribe(singleton(topic), rebalanceListener);
         assertTrue(state.checkAssignmentMatchedSubscription(singleton(tp0)));


### PR DESCRIPTION
In KAFKA-14196 we discovered that rebalance can possibly causes some of the fetched offset being lost when autocommit was enabled, and thus causing duplication.  The reason being the fetcher continues to make progress while the async commit is trying to complete.

Our solution is to mark consumer partitions unconsumable, to stop the fetcher.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
