### PR TITLE
KAFKA-14206: upgrade zookeeper version to 3.7.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -120,7 +120,7 @@ versions += [
   swaggerAnnotations: "2.2.0",
   swaggerJaxrs2: "2.2.0",
   zinc: "1.6.1",
-  zookeeper: "3.6.3",
+  zookeeper: "3.7.1",
   zstd: "1.5.2-1"
 ]
 libs += [


### PR DESCRIPTION
Upgrade zookeeper version to the latest stable release 3.7.1 due to some CVEs.

> Apache ZooKeeper 3.8.0 is our current release, and 3.7.1 our latest stable release.

https://zookeeper.apache.org/releases.html


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
