### PR TITLE
MINOR: Fix ConsumerPerformanceTest to work with non-default locales

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.Test
 
 class ConsumerPerformanceTest {
-
-  private val outContent = new ByteArrayOutputStream()
   private val dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS")
 
   @Test
@@ -149,16 +147,21 @@ class ConsumerPerformanceTest {
   }
 
   private def testHeaderMatchContent(detailed: Boolean, expectedOutputLineCount: Int, fun: () => Unit): Unit = {
-    Console.withOut(outContent) {
-      ConsumerPerformance.printHeader(detailed)
-      fun()
+    val outContent = new ByteArrayOutputStream
+    try {
+      Console.withOut(outContent) {
+        ConsumerPerformance.printHeader(detailed)
+        fun()
 
-      val contents = outContent.toString.split("\n")
-      assertEquals(expectedOutputLineCount, contents.length)
-      val header = contents(0)
-      val body = contents(1)
+        val contents = outContent.toString.split("\n")
+        assertEquals(expectedOutputLineCount, contents.length)
+        val header = contents(0)
+        val body = contents(1)
 
-      assertEquals(header.split(",").length, body.split(",").length)
+        assertEquals(header.split(",\\s").length, body.split(",\\s").length)
+      }
+    } finally {
+      outContent.close()
     }
   }
 }


### PR DESCRIPTION
**Problem**
`ConsumerPerformanceTest` fails when running on a machine with a Locale where decimal is represented by a comma. E.g. in locale of Germany, one point two is written as `1,2` and not `1.2` as with the default locale.

The test fails because it validates that each header has a corresponding value by assuming that comma is a separator between values & headers. This assumption fails for Germany Locale because comma could be part of a float number.

**Fix**
This change introduces a minor fix to change the validation. Instead of separating the attributes using a comma, now we use comma<space> as a separator.

**Bonus fix**
Close the stream after it is not required.