### PR TITLE
KAFKA-14214: Introduce read-write lock to StandardAuthorizer for consistent ACL reads.

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
@@ -219,6 +219,7 @@ public class AclAuthorizerBenchmark {
                         StandardAcl acl = StandardAcl.fromAclBinding(new AclBinding(entryMap.getKey(), aclEntry.ace()));
                         ((StandardAuthorizer) authorizer).addAcl(Uuid.randomUuid(), acl);
                     }
+                    ((StandardAuthorizer) authorizer).completeInitialLoad();
                     break;
             }
         }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
@@ -20,7 +20,9 @@ package org.apache.kafka.jmh.acl;
 import kafka.security.authorizer.AclAuthorizer;
 import kafka.security.authorizer.AclAuthorizer.VersionedAcls;
 import kafka.security.authorizer.AclEntry;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
@@ -34,7 +36,10 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.metadata.authorizer.StandardAcl;
+import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.Authorizer;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -50,6 +55,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.collection.JavaConverters;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +67,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -69,6 +76,22 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class AclAuthorizerBenchmark {
+
+    public enum AuthorizerType {
+        ACL(AclAuthorizer::new),
+        KRAFT(StandardAuthorizer::new);
+
+        private Supplier<Authorizer> supplier;
+
+        AuthorizerType(Supplier<Authorizer> supplier) {
+            this.supplier = supplier;
+        }
+
+        Authorizer newAuthorizer() {
+            return supplier.get();
+        }
+    }
+
     @Param({"10000", "50000", "200000"})
     private int resourceCount;
     //no. of. rules per resource
@@ -78,10 +101,13 @@ public class AclAuthorizerBenchmark {
     @Param({"0", "20", "50", "90", "99", "99.9", "99.99", "100"})
     private double denyPercentage;
 
+    @Param({"ACL", "KRAFT"})
+    private AuthorizerType authorizerType;
+
     private final int hostPreCount = 1000;
     private final String resourceNamePrefix = "foo-bar35_resource-";
-    private final AclAuthorizer aclAuthorizer = new AclAuthorizer();
     private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    private Authorizer authorizer;
     private List<Action> actions = new ArrayList<>();
     private RequestContext authorizeContext;
     private RequestContext authorizeByResourceTypeContext;
@@ -94,6 +120,7 @@ public class AclAuthorizerBenchmark {
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
+        authorizer = authorizerType.newAuthorizer();
         prepareAclCache();
         prepareAclToUpdate();
         // By adding `-95` to the resource name prefix, we cause the `TreeMap.from/to` call to return
@@ -177,9 +204,23 @@ public class AclAuthorizerBenchmark {
             }
         }
 
+        setupAcls(aclEntries);
+    }
+
+    private void setupAcls(Map<ResourcePattern, Set<AclEntry>> aclEntries) {
         for (Map.Entry<ResourcePattern, Set<AclEntry>> entryMap : aclEntries.entrySet()) {
-            aclAuthorizer.updateCache(entryMap.getKey(),
-                new VersionedAcls(JavaConverters.asScalaSetConverter(entryMap.getValue()).asScala().toSet(), 1));
+            switch (authorizerType) {
+                case ACL:
+                    ((AclAuthorizer) authorizer).updateCache(entryMap.getKey(),
+                        new VersionedAcls(JavaConverters.asScalaSetConverter(entryMap.getValue()).asScala().toSet(), 1));
+                    break;
+                case KRAFT:
+                    for (AclEntry aclEntry : entryMap.getValue()) {
+                        StandardAcl acl = StandardAcl.fromAclBinding(new AclBinding(entryMap.getKey(), aclEntry.ace()));
+                        ((StandardAuthorizer) authorizer).addAcl(Uuid.randomUuid(), acl);
+                    }
+                    break;
+            }
         }
     }
 
@@ -207,30 +248,31 @@ public class AclAuthorizerBenchmark {
     }
 
     @TearDown(Level.Trial)
-    public void tearDown() {
-        aclAuthorizer.close();
+    public void tearDown() throws IOException {
+        authorizer.close();
     }
 
     @Benchmark
     public void testAclsIterator() {
-        aclAuthorizer.acls(AclBindingFilter.ANY);
+        authorizer.acls(AclBindingFilter.ANY);
     }
 
     @Benchmark
     public void testAuthorizer() {
-        aclAuthorizer.authorize(authorizeContext, actions);
+        authorizer.authorize(authorizeContext, actions);
     }
 
     @Benchmark
     public void testAuthorizeByResourceType() {
-        aclAuthorizer.authorizeByResourceType(authorizeByResourceTypeContext, AclOperation.READ, ResourceType.TOPIC);
+        authorizer.authorizeByResourceType(authorizeByResourceTypeContext, AclOperation.READ, ResourceType.TOPIC);
     }
 
     @Benchmark
     public void testUpdateCache() {
-        AclAuthorizer aclAuthorizer = new AclAuthorizer();
-        for (Map.Entry<ResourcePattern, VersionedAcls> e : aclToUpdate.entrySet()) {
-            aclAuthorizer.updateCache(e.getKey(), e.getValue());
+        if (authorizerType == AuthorizerType.ACL) {
+            for (Map.Entry<ResourcePattern, VersionedAcls> e : aclToUpdate.entrySet()) {
+                ((AclAuthorizer) authorizer).updateCache(e.getKey(), e.getValue());
+            }
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
@@ -136,9 +136,13 @@ public class StandardAuthorizer implements ClusterMetadataAuthorizer {
 
     @Override
     public void loadSnapshot(Map<Uuid, StandardAcl> acls) {
+        StandardAuthorizerData newData = StandardAuthorizerData.createEmpty();
+        for (Map.Entry<Uuid, StandardAcl> entry : acls.entrySet()) {
+            newData.addAcl(entry.getKey(), entry.getValue());
+        }
         lock.writeLock().lock();
         try {
-            data = data.copyWithNewAcls(acls.entrySet());
+            data = data.copyWithNewAcls(newData.getAclsByResource(), newData.getAclsById());
         } finally {
             lock.writeLock().unlock();
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Supplier;
 
 import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
 import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -531,25 +531,14 @@ public class StandardAuthorizerData {
     }
 
     Iterable<AclBinding> acls(AclBindingFilter filter) {
-        return new AclIterable(filter);
-    }
-
-    class AclIterable implements Iterable<AclBinding> {
-        private final List<AclBinding> aclBindingList = new ArrayList<>();
-
-        AclIterable(AclBindingFilter filter) {
-            aclsByResource.forEach(acl -> {
-                AclBinding aclBinding = acl.toBinding();
-                if (filter.matches(aclBinding)) {
-                    aclBindingList.add(aclBinding);
-                }
-            });
-        }
-
-        @Override
-        public Iterator<AclBinding> iterator() {
-            return aclBindingList.iterator();
-        }
+        List<AclBinding> aclBindingList = new ArrayList<>();
+        aclsByResource.forEach(acl -> {
+            AclBinding aclBinding = acl.toBinding();
+            if (filter.matches(aclBinding)) {
+                aclBindingList.add(aclBinding);
+            }
+        });
+        return aclBindingList;
     }
 
     private interface MatchingRule {

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -203,6 +203,20 @@ public class StandardAuthorizerData {
         return newData;
     }
 
+    StandardAuthorizerData copyWithNewAcls(TreeSet<StandardAcl> aclsByResource, HashMap<Uuid,
+        StandardAcl> aclsById) {
+        StandardAuthorizerData newData =  new StandardAuthorizerData(
+            log,
+            aclMutator,
+            loadingComplete,
+            superUsers,
+            defaultRule.result,
+            aclsByResource,
+            aclsById);
+        log.info("Initialized with {} acl(s).", aclsById.size());
+        return newData;
+    }
+
     void addAcl(Uuid id, StandardAcl acl) {
         try {
             StandardAcl prevAcl = aclsById.putIfAbsent(id, acl);
@@ -614,5 +628,13 @@ public class StandardAuthorizerData {
                 return null;
             }
         }
+    }
+
+    TreeSet<StandardAcl> getAclsByResource() {
+        return aclsByResource;
+    }
+
+    HashMap<Uuid, StandardAcl> getAclsById() {
+        return aclsById;
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -44,7 +44,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.NavigableSet;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -37,13 +37,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
@@ -185,22 +183,6 @@ public class StandardAuthorizerData {
             newDefaultResult,
             aclsByResource,
             aclsById);
-    }
-
-    StandardAuthorizerData copyWithNewAcls(Collection<Entry<Uuid, StandardAcl>> aclEntries) {
-        StandardAuthorizerData newData = new StandardAuthorizerData(
-            log,
-            aclMutator,
-            loadingComplete,
-            superUsers,
-            defaultRule.result,
-            new TreeSet<>(),
-            new HashMap<>());
-        for (Entry<Uuid, StandardAcl> entry : aclEntries) {
-            newData.addAcl(entry.getKey(), entry.getValue());
-        }
-        log.info("Applied {} acl(s) from image.", aclEntries.size());
-        return newData;
     }
 
     StandardAuthorizerData copyWithNewAcls(TreeSet<StandardAcl> aclsByResource, HashMap<Uuid,
@@ -544,6 +526,12 @@ public class StandardAuthorizerData {
         return acl.permissionType().equals(ALLOW) ? ALLOWED : DENIED;
     }
 
+    /**
+     * Creates a consistent Iterable on read-only copy of AclBindings data for the given filter.
+     *
+     * @param filter The filter constraining the AclBindings to be present in the Iterable.
+     * @return Iterable over AclBindings matching the filter.
+     */
     Iterable<AclBinding> acls(AclBindingFilter filter) {
         List<AclBinding> aclBindingList = new ArrayList<>();
         aclsByResource.forEach(acl -> {

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -36,6 +36,7 @@ import org.apache.kafka.server.authorizer.AuthorizationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -535,14 +536,15 @@ public class StandardAuthorizerData {
     }
 
     class AclIterable implements Iterable<AclBinding> {
-        private final List<AclBinding> aclBindingList;
+        private final List<AclBinding> aclBindingList = new ArrayList<>();
 
         AclIterable(AclBindingFilter filter) {
-            this.aclBindingList = aclsByResource
-                .stream()
-                .map(StandardAcl::toBinding)
-                .filter(filter::matches)
-                .collect(Collectors.toList());
+            aclsByResource.forEach(acl -> {
+                AclBinding aclBinding = acl.toBinding();
+                if (filter.matches(aclBinding)) {
+                    aclBindingList.add(aclBinding);
+                }
+            });
         }
 
         @Override

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -47,7 +47,6 @@ import java.util.Map.Entry;
 import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.acl.AclOperation.ALL;
 import static org.apache.kafka.common.acl.AclOperation.ALTER;


### PR DESCRIPTION
KAFKA-14214: Introduce read-write lock to StandardAuthorizer for consistent ACL reads.

The issue with StandardAuthorizer#authorize is, that it looks up
aclsByResources (which is of type ConcurrentSkipListMap)twice for every
authorize call and uses Iterator with weak consistency guarantees on top of
aclsByResources. This can cause the authorize function call to process the
concurrent writes out of order.

Implemented ReadWrite lock at StandardAuthorizer level to make sure the reads
are strongly consistent with write order.