### PR TITLE
KAFKA-12878 Support --bootstrap-server in kafka-streams-application-reset tool

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -90,6 +90,7 @@ import java.util.stream.Collectors;
 public class StreamsResetter {
     private static final int EXIT_CODE_SUCCESS = 0;
     private static final int EXIT_CODE_ERROR = 1;
+    private static final String BOOTSTRAP_SERVER_DEFAULT = "localhost:9092";
 
     private static OptionSpec<String> bootstrapServersOption;
     private static OptionSpec<String> bootstrapServerOption;
@@ -157,9 +158,14 @@ public class StreamsResetter {
                 properties.putAll(Utils.loadProps(options.valueOf(commandConfigOption)));
             }
 
-            properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.has(bootstrapServerOption)
-                ? options.valueOf(bootstrapServerOption)
-                : options.valueOf(bootstrapServersOption));
+            String bootstrapServerValue = BOOTSTRAP_SERVER_DEFAULT;
+
+            if (options.has(bootstrapServerOption))
+                bootstrapServerValue = options.valueOf(bootstrapServerOption);
+            else if (options.has(bootstrapServersOption))
+                bootstrapServerValue = options.valueOf(bootstrapServersOption);
+
+            properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServerValue);
 
             adminClient = Admin.create(properties);
             maybeDeleteActiveConsumers(groupId, adminClient);
@@ -220,13 +226,11 @@ public class StreamsResetter {
         bootstrapServersOption = optionParser.accepts("bootstrap-servers", "DEPRECATED: Comma-separated list of broker urls with format: HOST1:PORT1,HOST2:PORT2")
             .withOptionalArg()
             .ofType(String.class)
-            .defaultsTo("localhost:9092")
             .describedAs("urls");
-        bootstrapServerOption = optionParser.accepts("bootstrap-server", "REQUIRED unless --bootstrap-servers(deprecated) is specified. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
-            .requiredUnless("bootstrap-servers")
-            .withRequiredArg()
-            .describedAs("server to connect to")
-            .ofType(String.class);
+        bootstrapServerOption = optionParser.accepts("bootstrap-server", "REQUIRED unless --bootstrap-servers(deprecated) is specified. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2. (default: localhost:9092)")
+            .withOptionalArg()
+            .ofType(String.class)
+            .describedAs("server to connect to");
         inputTopicsOption = optionParser.accepts("input-topics", "Comma-separated list of user input topics. For these topics, the tool by default will reset the offset to the earliest available offset. "
                 + "Reset to other offset position by appending other reset offset option, ex: --input-topics foo --shift-by 5")
             .withRequiredArg()

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -217,15 +217,16 @@ public class StreamsResetter {
             .ofType(String.class)
             .describedAs("id")
             .required();
-        bootstrapServerOption = optionParser.accepts("bootstrap-server", "The server(s) to use for bootstrapping.")
-            .withOptionalArg()
-            .ofType(String.class)
-            .describedAs("Server(s) to use for bootstrapping");
         bootstrapServersOption = optionParser.accepts("bootstrap-servers", "DEPRECATED: Comma-separated list of broker urls with format: HOST1:PORT1,HOST2:PORT2")
             .withOptionalArg()
             .ofType(String.class)
             .defaultsTo("localhost:9092")
             .describedAs("urls");
+        bootstrapServerOption = optionParser.accepts("bootstrap-server", "REQUIRED unless --bootstrap-servers(deprecated) is specified. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+            .requiredUnless("bootstrap-servers")
+            .withRequiredArg()
+            .describedAs("server to connect to")
+            .ofType(String.class);
         inputTopicsOption = optionParser.accepts("input-topics", "Comma-separated list of user input topics. For these topics, the tool by default will reset the offset to the earliest available offset. "
                 + "Reset to other offset position by appending other reset offset option, ex: --input-topics foo --shift-by 5")
             .withRequiredArg()
@@ -281,9 +282,6 @@ public class StreamsResetter {
             }
             if (options.has(versionOption)) {
                 CommandLineUtils.printVersionAndDie();
-            }
-            if (options.has(bootstrapServerOption) && options.has(bootstrapServersOption)) {
-                CommandLineUtils.printUsageAndDie(optionParser, "Please specify only one of bootstrap-server, bootstrap-servers");
             }
         } catch (final OptionException e) {
             CommandLineUtils.printUsageAndDie(optionParser, e.getMessage());

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -224,11 +224,11 @@ public class StreamsResetter {
             .describedAs("id")
             .required();
         bootstrapServersOption = optionParser.accepts("bootstrap-servers", "DEPRECATED: Comma-separated list of broker urls with format: HOST1:PORT1,HOST2:PORT2")
-            .withOptionalArg()
+            .withRequiredArg()
             .ofType(String.class)
             .describedAs("urls");
         bootstrapServerOption = optionParser.accepts("bootstrap-server", "REQUIRED unless --bootstrap-servers(deprecated) is specified. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2. (default: localhost:9092)")
-            .withOptionalArg()
+            .withRequiredArg()
             .ofType(String.class)
             .describedAs("server to connect to");
         inputTopicsOption = optionParser.accepts("input-topics", "Comma-separated list of user input topics. For these topics, the tool by default will reset the offset to the earliest available offset. "

--- a/docs/streams/developer-guide/app-reset-tool.html
+++ b/docs/streams/developer-guide/app-reset-tool.html
@@ -84,9 +84,11 @@
 ---------------------                 -----------
 * --application-id &lt;String: id&gt;       The Kafka Streams application ID
                                         (application.id).
---bootstrap-servers &lt;String: urls&gt;    Comma-separated list of broker urls with
-                                        format: HOST1:PORT1,HOST2:PORT2
-                                        (default: localhost:9092)
+--bootstrap-server [String: Server(s)  The server(s) to use for bootstrapping.
+  to use for bootstrapping]
+--bootstrap-servers [String: urls]     DEPRECATED: Comma-separated list of
+                                         broker urls with format: HOST1:PORT1,
+                                         HOST2:PORT2 (default: localhost:9092)
 --by-duration &lt;String: urls&gt;          Reset offsets to offset by duration from
                                         current timestamp. Format: &#39;PnDTnHnMnS&#39;
 --config-file &lt;String: file name&gt;     Property file containing configs to be

--- a/docs/streams/developer-guide/app-reset-tool.html
+++ b/docs/streams/developer-guide/app-reset-tool.html
@@ -89,7 +89,7 @@
                                          (s) to connect to. The broker list
                                          string in the form HOST1:PORT1,HOST2:
                                          PORT2.
---bootstrap-servers [String: urls]     DEPRECATED: Comma-separated list of
+--bootstrap-servers &lt;String: urls&gt;     DEPRECATED: Comma-separated list of
                                          broker urls with format: HOST1:PORT1,
                                          HOST2:PORT2 (default: localhost:9092)
 --by-duration &lt;String: urls&gt;          Reset offsets to offset by duration from

--- a/docs/streams/developer-guide/app-reset-tool.html
+++ b/docs/streams/developer-guide/app-reset-tool.html
@@ -84,9 +84,9 @@
 ---------------------                 -----------
 * --application-id &lt;String: id&gt;       The Kafka Streams application ID
                                         (application.id).
---bootstrap-server [String: Server(s)  The server(s) to use for bootstrapping.
-  to use for bootstrapping]
---bootstrap-servers [String: urls]     DEPRECATED: Comma-separated list of
+--bootstrap-server &lt;String: Server(s)  REQUIRED unless --bootstrap-servers(deprecated) is specified. The server(s) to use for bootstrapping.
+  to use for bootstrapping&gt;
+--bootstrap-servers &lt;String: urls&gt;     DEPRECATED: Comma-separated list of
                                          broker urls with format: HOST1:PORT1,
                                          HOST2:PORT2 (default: localhost:9092)
 --by-duration &lt;String: urls&gt;          Reset offsets to offset by duration from

--- a/docs/streams/developer-guide/app-reset-tool.html
+++ b/docs/streams/developer-guide/app-reset-tool.html
@@ -84,9 +84,12 @@
 ---------------------                 -----------
 * --application-id &lt;String: id&gt;       The Kafka Streams application ID
                                         (application.id).
---bootstrap-server &lt;String: Server(s)  REQUIRED unless --bootstrap-servers(deprecated) is specified. The server(s) to use for bootstrapping.
-  to use for bootstrapping&gt;
---bootstrap-servers &lt;String: urls&gt;     DEPRECATED: Comma-separated list of
+--bootstrap-server &lt;String: server to  REQUIRED unless --bootstrap-servers
+                            connect to&gt;                            (deprecated) is specified. The server
+                                         (s) to connect to. The broker list
+                                         string in the form HOST1:PORT1,HOST2:
+                                         PORT2.
+--bootstrap-servers [String: urls]     DEPRECATED: Comma-separated list of
                                          broker urls with format: HOST1:PORT1,
                                          HOST2:PORT2 (default: localhost:9092)
 --by-duration &lt;String: urls&gt;          Reset offsets to offset by duration from

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -394,7 +394,7 @@ public abstract class AbstractResetIntegrationTest {
                                    final String appID) throws Exception {
         final List<String> parameterList = new ArrayList<>(
             Arrays.asList("--application-id", appID,
-                    "--bootstrap-servers", cluster.bootstrapServers(),
+                    "--bootstrap-server", cluster.bootstrapServers(),
                     "--input-topics", INPUT_TOPIC
             ));
         if (withIntermediateTopics) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -104,7 +104,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--bootstrap-server", cluster.bootstrapServers(),
             "--input-topics", NON_EXISTING_TOPIC
         };
         final Properties cleanUpConfig = new Properties();
@@ -128,7 +128,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--bootstrap-server", cluster.bootstrapServers(),
             "--input-topics", NON_EXISTING_TOPIC
         };
         final Properties cleanUpConfig = new Properties();
@@ -144,7 +144,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--bootstrap-server", cluster.bootstrapServers(),
             "--intermediate-topics", NON_EXISTING_TOPIC
         };
         final Properties cleanUpConfig = new Properties();
@@ -160,7 +160,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--bootstrap-server", cluster.bootstrapServers(),
             "--internal-topics", NON_EXISTING_TOPIC
         };
         final Properties cleanUpConfig = new Properties();
@@ -176,7 +176,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--bootstrap-server", cluster.bootstrapServers(),
             "--internal-topics", INPUT_TOPIC
         };
         final Properties cleanUpConfig = new Properties();

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -544,7 +544,7 @@ class StreamsResetter(StreamsTestBaseService):
 
         cmd = "(export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%(log4j)s\"; " \
               "%(kafka_run_class)s %(streams_class_name)s " \
-              "--bootstrap-servers %(bootstrap.servers)s " \
+              "--bootstrap-server %(bootstrap.servers)s " \
               "--force " \
               "--application-id %(application.id)s " \
               "--input-topics %(input.topics)s " \


### PR DESCRIPTION
Implementation of [KIP-865](https://cwiki.apache.org/confluence/display/KAFKA/KIP-865%3A+Support+--bootstrap-server+in+kafka-streams-application-reset)

Support of `--bootstrap-server` option for `kafka-streams-application-reset` implemented

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
