### PR TITLE
KAFKA-14214: Convert StandardAuthorizer to copy-on-write

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AuthorizerBenchmark.java
@@ -20,7 +20,9 @@ package org.apache.kafka.jmh.acl;
 import kafka.security.authorizer.AclAuthorizer;
 import kafka.security.authorizer.AclAuthorizer.VersionedAcls;
 import kafka.security.authorizer.AclEntry;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
@@ -34,7 +36,10 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.metadata.authorizer.StandardAcl;
+import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.Authorizer;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -50,6 +55,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.collection.JavaConverters;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +67,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -68,7 +75,50 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 15)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-public class AclAuthorizerBenchmark {
+public class AuthorizerBenchmark {
+    public enum AuthorizerType {
+        ZK(AclAuthorizer::new),
+        KRAFT(StandardAuthorizer::new);
+
+        private Supplier<Authorizer> supplier;
+
+        AuthorizerType(Supplier<Authorizer> supplier) {
+            this.supplier = supplier;
+        }
+
+        Authorizer newAuthorizer() {
+            return supplier.get();
+        }
+
+        void setupAcls(
+            Authorizer authorizer,
+            Map<ResourcePattern, Set<AclEntry>> aclEntries
+        ) {
+            switch (this) {
+                case ZK:
+                    for (Map.Entry<ResourcePattern, Set<AclEntry>> entryMap : aclEntries.entrySet()) {
+                        ((AclAuthorizer) authorizer).updateCache(entryMap.getKey(),
+                                new VersionedAcls(JavaConverters.asScalaSetConverter(entryMap.getValue()).asScala().toSet(), 1));
+                    }
+                    break;
+                case KRAFT:
+                    Map<Uuid, StandardAcl> acls = new HashMap<>();
+                    for (Map.Entry<ResourcePattern, Set<AclEntry>> entryMap : aclEntries.entrySet()) {
+                        for (AclEntry aclEntry : entryMap.getValue()) {
+                            StandardAcl acl = StandardAcl.fromAclBinding(new AclBinding(entryMap.getKey(), aclEntry.ace()));
+                            acls.put(Uuid.randomUuid(), acl);
+                        }
+                    }
+                    ((StandardAuthorizer) authorizer).loadSnapshot(acls);
+                    ((StandardAuthorizer) authorizer).completeInitialLoad();
+                    break;
+            }
+        }
+    }
+
+    @Param({"ZK", "KRAFT"})
+    private AuthorizerType authorizerType;
+
     @Param({"10000", "50000", "200000"})
     private int resourceCount;
     //no. of. rules per resource
@@ -80,20 +130,21 @@ public class AclAuthorizerBenchmark {
 
     private final int hostPreCount = 1000;
     private final String resourceNamePrefix = "foo-bar35_resource-";
-    private final AclAuthorizer aclAuthorizer = new AclAuthorizer();
     private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    private Authorizer authorizer;
     private List<Action> actions = new ArrayList<>();
     private RequestContext authorizeContext;
     private RequestContext authorizeByResourceTypeContext;
     private String authorizeByResourceTypeHostName = "127.0.0.2";
 
-    private HashMap<ResourcePattern, AclAuthorizer.VersionedAcls> aclToUpdate = new HashMap<>();
+    private HashMap<ResourcePattern, Set<AclEntry>> aclToUpdate = new HashMap<>();
 
     Random rand = new Random(System.currentTimeMillis());
     double eps = 1e-9;
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
+        authorizer = authorizerType.newAuthorizer();
         prepareAclCache();
         prepareAclToUpdate();
         // By adding `-95` to the resource name prefix, we cause the `TreeMap.from/to` call to return
@@ -177,24 +228,18 @@ public class AclAuthorizerBenchmark {
             }
         }
 
-        for (Map.Entry<ResourcePattern, Set<AclEntry>> entryMap : aclEntries.entrySet()) {
-            aclAuthorizer.updateCache(entryMap.getKey(),
-                new VersionedAcls(JavaConverters.asScalaSetConverter(entryMap.getValue()).asScala().toSet(), 1));
-        }
+        authorizerType.setupAcls(authorizer, aclEntries);
     }
 
     private void prepareAclToUpdate() {
-        scala.collection.mutable.Set<AclEntry> entries = new scala.collection.mutable.HashSet<>();
         for (int i = 0; i < resourceCount; i++) {
-            scala.collection.immutable.Set<AclEntry> immutable = new scala.collection.immutable.HashSet<>();
+            Set<AclEntry> aclEntries = new HashSet<>();
             for (int j = 0; j < aclCount; j++) {
-                entries.add(new AclEntry(new AccessControlEntry(
-                    principal.toString(), "127.0.0" + j, AclOperation.WRITE, AclPermissionType.ALLOW)));
-                immutable = entries.toSet();
+                aclEntries.add(new AclEntry(new AccessControlEntry(
+                        principal.toString(), "127.0.0" + j, AclOperation.WRITE, AclPermissionType.ALLOW)));
             }
-            aclToUpdate.put(
-                new ResourcePattern(ResourceType.TOPIC, randomResourceName(resourceNamePrefix), PatternType.LITERAL),
-                new AclAuthorizer.VersionedAcls(immutable, i));
+            aclToUpdate.put(new ResourcePattern(ResourceType.TOPIC,
+                            randomResourceName(resourceNamePrefix), PatternType.LITERAL), aclEntries);
         }
     }
 
@@ -207,30 +252,27 @@ public class AclAuthorizerBenchmark {
     }
 
     @TearDown(Level.Trial)
-    public void tearDown() {
-        aclAuthorizer.close();
+    public void tearDown() throws IOException {
+        authorizer.close();
     }
 
     @Benchmark
     public void testAclsIterator() {
-        aclAuthorizer.acls(AclBindingFilter.ANY);
+        authorizer.acls(AclBindingFilter.ANY);
     }
 
     @Benchmark
     public void testAuthorizer() {
-        aclAuthorizer.authorize(authorizeContext, actions);
+        authorizer.authorize(authorizeContext, actions);
     }
 
     @Benchmark
     public void testAuthorizeByResourceType() {
-        aclAuthorizer.authorizeByResourceType(authorizeByResourceTypeContext, AclOperation.READ, ResourceType.TOPIC);
+        authorizer.authorizeByResourceType(authorizeByResourceTypeContext, AclOperation.READ, ResourceType.TOPIC);
     }
 
     @Benchmark
     public void testUpdateCache() {
-        AclAuthorizer aclAuthorizer = new AclAuthorizer();
-        for (Map.Entry<ResourcePattern, VersionedAcls> e : aclToUpdate.entrySet()) {
-            aclAuthorizer.updateCache(e.getKey(), e.getValue());
-        }
+        authorizerType.setupAcls(authorizer, aclToUpdate);
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -190,7 +190,8 @@ public class AclControlManager {
         existingAcls.add(aclWithId.acl());
         if (!snapshotId.isPresent()) {
             authorizer.ifPresent(a -> {
-                a.addAcl(aclWithId.id(), aclWithId.acl());
+                a.applyAclChanges(Collections.singletonMap(
+                    aclWithId.id(), aclWithId.acl()), Collections.emptySet());
             });
         }
     }
@@ -208,7 +209,7 @@ public class AclControlManager {
         }
         if (!snapshotId.isPresent()) {
             authorizer.ifPresent(a -> {
-                a.removeAcl(record.id());
+                a.applyAclChanges(Collections.emptyMap(), Collections.singleton(record.id()));
             });
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizer.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -76,14 +77,15 @@ public interface ClusterMetadataAuthorizer extends Authorizer {
     void loadSnapshot(Map<Uuid, StandardAcl> acls);
 
     /**
-     * Add a new ACL. Any ACL with the same ID will be replaced.
+     * Add or remove ACLs.
+     *
+     * @param newAcls           The ACLs to add.
+     * @param removedAclIds     The ACL IDs to remove.
      */
-    void addAcl(Uuid id, StandardAcl acl);
-
-    /**
-     * Remove the ACL with the given ID.
-     */
-    void removeAcl(Uuid id);
+    void applyAclChanges(
+        Map<Uuid, StandardAcl> newAcls,
+        Set<Uuid> removedAclIds
+    );
 
     /**
      * Create ACLs. This function must be called on the active controller, or else

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAclWithId.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAclWithId.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.metadata.AccessControlEntryRecord;
 
+import java.util.Comparator;
 import java.util.Objects;
 
 
@@ -28,6 +29,13 @@ import java.util.Objects;
  * A tuple of (id, acl)
  */
 final public class StandardAclWithId {
+    public final static Comparator<StandardAclWithId> ACL_COMPARATOR = new Comparator<StandardAclWithId>() {
+        @Override
+        public int compare(StandardAclWithId a, StandardAclWithId  b) {
+            return a.acl().compareTo(b.acl());
+        }
+    };
+
     public static StandardAclWithId fromRecord(AccessControlEntryRecord record) {
         return new StandardAclWithId(record.id(), StandardAcl.fromRecord(record));
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizer.java
@@ -96,18 +96,16 @@ public class StandardAuthorizer implements ClusterMetadataAuthorizer {
     }
 
     @Override
-    public void addAcl(Uuid id, StandardAcl acl) {
-        data.addAcl(id, acl);
-    }
-
-    @Override
-    public void removeAcl(Uuid id) {
-        data.removeAcl(id);
-    }
-
-    @Override
     public synchronized void loadSnapshot(Map<Uuid, StandardAcl> acls) {
-        data = data.copyWithNewAcls(acls.entrySet());
+        data = data.copyWithAllNewAcls(acls);
+    }
+
+    @Override
+    public synchronized void applyAclChanges(
+        Map<Uuid, StandardAcl> newAcls,
+        Set<Uuid> removedAclIds
+    ) {
+        data = data.copyWithAclChanges(newAcls, removedAclIds);
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -164,12 +164,10 @@ public class AclControlManagerTest {
         }
 
         @Override
-        public void addAcl(Uuid id, StandardAcl acl) {
-            // do nothing
-        }
-
-        @Override
-        public void removeAcl(Uuid id) {
+        public void applyAclChanges(
+            Map<Uuid, StandardAcl> newAcls,
+            Set<Uuid> removedAclIds
+        ) {
             // do nothing
         }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizerTest.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -122,12 +123,10 @@ public class ClusterMetadataAuthorizerTest {
         }
 
         @Override
-        public void addAcl(Uuid id, StandardAcl acl) {
-            // do nothing
-        }
-
-        @Override
-        public void removeAcl(Uuid id) {
+        public void applyAclChanges(
+            Map<Uuid, StandardAcl> newAcls,
+            Set<Uuid> removedAclIds
+        ) {
             // do nothing
         }
 


### PR DESCRIPTION
Convert StandardAuthorizer to use a copy-on-write sorted array rather than a ConcurrentSkipList. The issue with the skiplist was that because it was modified while in use by StandardAuthorizer#authorize, we could sometimes expose an inconsistent state. For example, if we added a "deny principal foo", followed by "allow all", a request for principal foo might happen to see the second one, without seeing the first one, even though the first one was added first.

The sorted array data structure is more compact than the tree, although it has the disadvantage of needing to be copied every time it's modified. On the broker side, we can apply a batch of updates atomically now. On the controller side, we still apply updates one-by-one, for now.

This PR renames AclAuthorizerBenchmark to AuthorizerBenchmark and extends it to report information about StandardAuthorizer as well as AclAuthorizer.

Co-authored-by: Akhilesh Chaganti <achaganti@confluent.io>