### PR TITLE
KAFKA-14226 (KIP-821): [connect:transform] Introduce support for nested structures

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -573,6 +573,7 @@
       <allow class="org.apache.kafka.connect.source.SourceRecord" />
       <allow class="org.apache.kafka.connect.sink.SinkRecord" />
       <allow pkg="org.apache.kafka.connect.transforms.util" />
+      <allow pkg="org.apache.kafka.connect.transforms.field" />
     </subpackage>
   </subpackage>
 

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -121,6 +122,12 @@ public class ConfigDef {
                 defaultValues.put(key.name, key.defaultValue);
         }
         return defaultValues;
+    }
+
+    public ConfigDef addDefinition(ConfigDef toAdd) {
+        Objects.requireNonNull(toAdd, "Additional ConfigDef may not be null");
+        toAdd.configKeys().values().forEach(this::define);
+        return this;
     }
 
     public ConfigDef define(ConfigKey key) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -23,6 +23,8 @@ import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.field.SingleFieldPath;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import java.util.Map;
@@ -41,11 +43,17 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
     private static final String FIELD_CONFIG = "field";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.MEDIUM, "Field name to extract.");
+        .addDefinition(FieldSyntaxVersion.configDef())
+        .define(
+            FIELD_CONFIG,
+            ConfigDef.Type.STRING,
+            ConfigDef.NO_DEFAULT_VALUE,
+            ConfigDef.Importance.MEDIUM,
+            "Field name to extract.");
 
     private static final String PURPOSE = "field extraction";
 
-    private String fieldName;
+    private SingleFieldPath fieldPath;
 
     @Override
     public String version() {
@@ -55,7 +63,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
     @Override
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-        fieldName = config.getString(FIELD_CONFIG);
+        fieldPath = new SingleFieldPath(config.getString(FIELD_CONFIG), FieldSyntaxVersion.fromConfig(config));
     }
 
     @Override
@@ -63,16 +71,16 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
         final Schema schema = operatingSchema(record);
         if (schema == null) {
             final Map<String, Object> value = requireMapOrNull(operatingValue(record), PURPOSE);
-            return newRecord(record, null, value == null ? null : value.get(fieldName));
+            return newRecord(record, null, value == null ? null : fieldPath.valueFrom(value));
         } else {
             final Struct value = requireStructOrNull(operatingValue(record), PURPOSE);
-            Field field = schema.field(fieldName);
+            Field field = fieldPath.fieldFrom(schema);
 
             if (field == null) {
-                throw new IllegalArgumentException("Unknown field: " + fieldName);
+                throw new IllegalArgumentException("Unknown field: " + fieldPath);
             }
 
-            return newRecord(record, field.schema(), value == null ? null : value.get(fieldName));
+            return newRecord(record, field.schema(), value == null ? null : fieldPath.valueFrom(value));
         }
     }
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/FieldSyntaxVersion.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/FieldSyntaxVersion.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.Locale;
+
+/**
+ * Defines semantics of field paths by versioning.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
+ * @see SingleFieldPath
+ * @see MultiFieldPaths
+ */
+public enum FieldSyntaxVersion {
+    /**
+     * No support for nested fields. Only access attributes on the root data value.
+     * Backward compatibility before KIP-821.
+     */
+    V1,
+    /**
+     * Support for nested fields using dotted notation with backtick pairs to wrap field names that
+     * include dots.
+     * @since 3.x
+     */
+    V2;
+
+    public static final String FIELD_SYNTAX_VERSION_CONFIG = "field.syntax.version";
+    public static final String FIELD_SYNTAX_VERSION_DOC =
+            "Defines the version of the syntax to access fields. "
+                    + "If set to `V1`, then the field paths are limited to access the elements at the root level of the struct or map."
+                    + "If set to `V2`, the syntax will support accessing nested elements. To access nested elements, "
+                    + "dotted notation is used. If dots are already included in the field name, then backtick pairs "
+                    + "can be used to wrap field names containing dots. "
+                    + "E.g. to access the subfield `baz` from a field named \"foo.bar\" in a struct/map  "
+                    + "the following format can be used to access its elements: \"`foo.bar`.baz\".";
+
+    public static final String FIELD_SYNTAX_VERSION_DEFAULT_VALUE = V1.name();
+
+    public static ConfigDef configDef() {
+        return new ConfigDef()
+                .define(
+                        FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG,
+                        ConfigDef.Type.STRING,
+                        FieldSyntaxVersion.FIELD_SYNTAX_VERSION_DEFAULT_VALUE,
+                        ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(FieldSyntaxVersion.class)),
+                        ConfigDef.Importance.HIGH,
+                        FieldSyntaxVersion.FIELD_SYNTAX_VERSION_DOC);
+    }
+
+    public static FieldSyntaxVersion fromConfig(AbstractConfig config) {
+        final String name = config.getString(FIELD_SYNTAX_VERSION_CONFIG);
+        try {
+            return FieldSyntaxVersion.valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException(FIELD_SYNTAX_VERSION_CONFIG, name, "Unrecognized field syntax version");
+        }
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MapValueUpdater.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MapValueUpdater.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import java.util.Map;
+
+@FunctionalInterface
+public interface MapValueUpdater {
+
+    /**
+     * @param originalParent original data object
+     * @param updatedParent data object being updated
+     * @param fieldPath if match happened, null if applies to other fields
+     * @param fieldName field name
+     */
+    void apply(
+            Map<String, Object> originalParent,
+            Map<String, Object> updatedParent,
+            SingleFieldPath fieldPath,
+            String fieldName
+    );
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MultiFieldPaths.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MultiFieldPaths.java
@@ -1,0 +1,499 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Multiple field paths to access data objects ({@code Struct} or {@code Map}) efficiently,
+ * instead of multiple individual {@link SingleFieldPath single-field paths}.
+ *
+ * <p>If the SMT requires accessing a single field on the same data object,
+ * use {@link SingleFieldPath} instead.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
+ * @see SingleFieldPath
+ * @see FieldSyntaxVersion
+ */
+public class MultiFieldPaths {
+    // Invariants:
+    // - Tree values contain either a nested tree or a field path
+    // - A tree can contain paths that are a subset of other paths
+    //   (e.g. foo and foo.bar in V2 would be kept)
+    final Map<String, Object> pathTree;
+
+    MultiFieldPaths(Set<SingleFieldPath> paths) {
+        pathTree = buildPathTree(paths, 0, new HashMap<>());
+    }
+
+    public static MultiFieldPaths of(List<String> fields, FieldSyntaxVersion syntaxVersion) {
+        return new MultiFieldPaths(fields.stream()
+            .map(f -> new SingleFieldPath(f, syntaxVersion))
+            .collect(Collectors.toSet()));
+    }
+
+    /**
+     * Build a nested map of paths to field paths to be used when traversing data structures.
+     *
+     * <p>With the following paths:
+     * <ul>
+     *     <li>foo.bar</li>
+     *     <li>foo.baz</li>
+     *     <li>foo.baz.other</li>
+     * </ul>
+     * a tree with the following structure will be created:
+     * <ul>
+     *     <li>foo:
+     *     <ul>
+     *         <li>bar</li>
+     *         <li>baz:
+     *         <ul>
+     *             <li>"" (empty to represent path at root)</li>
+     *             <li>other</li>
+     *         </ul>
+     *         </li>
+     *     </ul>
+     *     </li>
+     * </ul>
+     *
+     * @param paths    input paths
+     * @param stepIdx  paths step index, starting at zero
+     * @param pathTree building tree, starting empty
+     */
+    static Map<String, Object> buildPathTree(Set<SingleFieldPath> paths, int stepIdx, Map<String, Object> pathTree) {
+        Objects.requireNonNull(pathTree, "Resulting path three may not be null");
+        if (stepIdx < 0) throw new IllegalArgumentException("stepAt index may be higher or equal than zero");
+
+        // group paths by prefix,
+        // if paths overlap (e.g. `foo` and `foo.bar` are added)
+        // only the children are kept (`foo.bar`)
+        final Map<String, Set<SingleFieldPath>> groups = paths.stream()
+            .collect(Collectors.groupingBy(
+                path -> path.stepAt(stepIdx),
+                Collectors.toSet()
+            ));
+
+        // create tree from grouped paths
+        for (Map.Entry<String, Set<SingleFieldPath>> entry : groups.entrySet()) {
+            if (entry.getValue().size() == 1) {
+                final SingleFieldPath path = entry.getValue().iterator().next();
+                if (path.stepAt(stepIdx + 1).isEmpty()) { // if it is the last path step
+                    pathTree.put(entry.getKey(), path);
+                } else {
+                    pathTree.put(entry.getKey(),
+                        buildPathTree(entry.getValue(), stepIdx + 1, new HashMap<>()));
+                }
+            } else {
+                pathTree.put(entry.getKey(),
+                    buildPathTree(entry.getValue(), stepIdx + 1, new HashMap<>()));
+            }
+        }
+        return pathTree;
+    }
+
+    /**
+     * Find values at the field paths on the tree.
+     *
+     * @param struct data value
+     * @return map of field paths and field/values
+     */
+    public Map<SingleFieldPath, Map.Entry<Field, Object>> fieldAndValuesFrom(Struct struct) {
+        return findFieldAndValues(struct, pathTree, new HashMap<>());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<SingleFieldPath, Map.Entry<Field, Object>> findFieldAndValues(
+        Struct originalValue,
+        Map<String, Object> treeAt,
+        Map<SingleFieldPath, Map.Entry<Field, Object>> fieldAndValueMap
+    ) {
+        for (Map.Entry<String, Object> step : treeAt.entrySet()) {
+            Field field = originalValue.schema().field(step.getKey());
+            if (step.getValue() instanceof SingleFieldPath) {
+                Map.Entry<Field, Object> fieldAndValue =
+                    field != null
+                        ? new AbstractMap.SimpleImmutableEntry<>(field, originalValue.get(field))
+                        : null;
+                fieldAndValueMap.put((SingleFieldPath) step.getValue(), fieldAndValue);
+            } else {
+                if (field.schema().type() == Type.STRUCT) {
+                    findFieldAndValues(
+                        originalValue.getStruct(field.name()),
+                        (Map<String, Object>) step.getValue(),
+                        fieldAndValueMap
+                    );
+                }
+            }
+        }
+        return fieldAndValueMap;
+    }
+
+    /**
+     * Find values at the field paths on the tree.
+     *
+     * @param value data value
+     * @return map of field paths and field/values
+     */
+    public Map<SingleFieldPath, Map.Entry<String, Object>> fieldAndValuesFrom(Map<String, Object> value) {
+        return findFieldAndValues(value, pathTree, new HashMap<>());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<SingleFieldPath, Map.Entry<String, Object>> findFieldAndValues(
+        Map<String, Object> value,
+        Map<String, Object> treeAt,
+        Map<SingleFieldPath, Map.Entry<String, Object>> fieldAndValueMap
+    ) {
+        for (Map.Entry<String, Object> step : treeAt.entrySet()) {
+            Object fieldValue = value.get(step.getKey());
+            if (step.getValue() instanceof SingleFieldPath) {
+                fieldAndValueMap.put((
+                        SingleFieldPath) step.getValue(),
+                    new AbstractMap.SimpleImmutableEntry<>(step.getKey(), fieldValue)
+                );
+            } else {
+                if (fieldValue instanceof Map) {
+                    findFieldAndValues(
+                        (Map<String, Object>) fieldValue,
+                        (Map<String, Object>) step.getValue(),
+                        fieldAndValueMap
+                    );
+                }
+            }
+        }
+        return fieldAndValueMap;
+    }
+
+    /**
+     * Access {@code Map} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalValue  schema-based data value
+     * @param whenFound function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Map<String, Object> updateValuesFrom(
+        Map<String, Object> originalValue,
+        MapValueUpdater whenFound
+    ) {
+        return updateValues(originalValue, pathTree, whenFound,
+            (originalParent, updatedParent, fieldPath, fieldName) -> {
+                // filter out
+            },
+            (originalParent, updatedParent, fieldPath, fieldName) ->
+                updatedParent.put(fieldName, originalParent.get(fieldName)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> updateValues(
+        Map<String, Object> originalValue,
+        Map<String, Object> treeAt,
+        MapValueUpdater matching,
+        MapValueUpdater notFound,
+        MapValueUpdater others
+    ) {
+        if (originalValue == null) return null;
+        Map<String, Object> updatedValue = new HashMap<>(originalValue.size());
+        Map<String, Object> notFoundFields = new HashMap<>(treeAt);
+        for (Map.Entry<String, Object> entry : originalValue.entrySet()) {
+            String fieldName = entry.getKey();
+            Object fieldValue = entry.getValue();
+            if (!treeAt.isEmpty()) {
+                if (treeAt.containsKey(fieldName)) {
+                    notFoundFields.remove(fieldName);
+                    Object treeValue = treeAt.get(fieldName);
+                    if (treeValue instanceof SingleFieldPath) {
+                        matching.apply(originalValue, updatedValue, (SingleFieldPath) treeValue, fieldName);
+                    } else {
+                        if (fieldValue instanceof Map) {
+                            Map<String, Object> updatedField = updateValues(
+                                (Map<String, Object>) fieldValue,
+                                (Map<String, Object>) treeValue,
+                                matching, notFound, others);
+                            updatedValue.put(fieldName, updatedField);
+                        } else {
+                            // add back to not found and apply others, as only leaf values are updated
+                            notFoundFields.put(fieldName, treeValue);
+                            others.apply(originalValue, updatedValue, null, fieldName);
+                        }
+                    }
+                } else {
+                    others.apply(originalValue, updatedValue, null, fieldName);
+                }
+            } else {
+                others.apply(originalValue, updatedValue, null, fieldName);
+            }
+        }
+        for (Map.Entry<String, Object> entry : notFoundFields.entrySet()) {
+            String fieldName = entry.getKey();
+            Object treeValue = entry.getValue();
+            if (treeValue instanceof SingleFieldPath) {
+                notFound.apply(originalValue, updatedValue, (SingleFieldPath) treeValue, fieldName);
+            } else {
+                Map<String, Object> updatedField = updateValues(
+                    new HashMap<>(),
+                    (Map<String, Object>) treeValue,
+                    matching, notFound, others);
+                updatedValue.put(fieldName, updatedField);
+            }
+        }
+
+        return updatedValue;
+    }
+
+    /**
+     * Access {@code Struct} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalSchema original struct schema
+     * @param originalValue  schema-based data value
+     * @param updatedSchema updated struct schema
+     * @param whenFound function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Struct updateValuesFrom(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updatedSchema,
+        StructValueUpdater whenFound
+    ) {
+        return updateValues(originalSchema, originalValue, updatedSchema, pathTree, whenFound,
+            (originalParent, originalField, updatedParent, updatedField, fieldPath) -> {
+                // filter out
+            },
+            (originalParent, originalField, updatedParent, nullUpdatedField, nullFieldPath) ->
+                updatedParent.put(originalField.name(), originalParent.get(originalField)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Struct updateValues(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updateSchema,
+        Map<String, Object> treeAt,
+        StructValueUpdater matching,
+        StructValueUpdater notFound,
+        StructValueUpdater others
+    ) {
+        Struct updatedValue = new Struct(updateSchema);
+        Map<String, Object> notFoundFields = new HashMap<>(treeAt);
+        for (Field field : originalSchema.fields()) {
+            if (!treeAt.isEmpty()) {
+                if (treeAt.containsKey(field.name())) {
+                    notFoundFields.remove(field.name());
+                    final Object treeValue = treeAt.get(field.name());
+                    if (treeValue instanceof SingleFieldPath) {
+                        matching.apply(
+                            originalValue,
+                            originalSchema.field(field.name()),
+                            updatedValue,
+                            updateSchema.field(field.name()),
+                            (SingleFieldPath) treeValue
+                        );
+                    } else {
+                        if (field.schema().type() == Type.STRUCT) {
+                            Struct fieldValue = updateValues(
+                                field.schema(),
+                                originalValue.getStruct(field.name()),
+                                updateSchema.field(field.name()).schema(),
+                                (Map<String, Object>) treeValue,
+                                matching, notFound, others
+                            );
+                            updatedValue.put(updateSchema.field(field.name()), fieldValue);
+                        } else {
+                            // add back to not found and apply others, as only leaf values are updated
+                            notFoundFields.put(field.name(), treeValue);
+                            others.apply(originalValue, field, updatedValue, null, null);
+                        }
+                    }
+                } else {
+                    others.apply(originalValue, field, updatedValue, null, null);
+                }
+            } else {
+                others.apply(originalValue, field, updatedValue, null, null);
+            }
+        }
+        for (Map.Entry<String, Object> entry : notFoundFields.entrySet()) {
+            String fieldName = entry.getKey();
+            Object treeValue = entry.getValue();
+            if (treeValue instanceof SingleFieldPath) {
+                notFound.apply(
+                    originalValue,
+                    null,
+                    updatedValue,
+                    updateSchema.field(fieldName),
+                    (SingleFieldPath) treeValue
+                );
+            } else {
+                Struct fieldValue = updateValues(
+                    SchemaBuilder.struct().build(),
+                    null,
+                    updateSchema.field(fieldName).schema(),
+                    (Map<String, Object>) treeValue,
+                    matching, notFound, others
+                );
+                updatedValue.put(updateSchema.field(fieldName), fieldValue);
+            }
+        }
+        return updatedValue;
+    }
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * <p>A copy of the {@code Schema} is used as a base for the updated schema.
+     *
+     * @param originalSchema baseline schema
+     * @param whenFound function to apply when current path(s) is/are found
+     * @return an updated schema. Resulting schemas are usually cached for further access
+     */
+    public Schema updateSchemaFrom(
+        Schema originalSchema,
+        StructSchemaUpdater whenFound
+    ) {
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(originalSchema, SchemaBuilder.struct());
+        return updateSchema(originalSchema, updated, pathTree, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     * @param originalSchema baseline schema
+     * @param baselineSchemaBuilder baseline schema build, if changes to the baseline
+     *                              are required before copying original
+     * @param whenFound function to apply when current path(s) is/are found.
+     * @return an updated schema. Resulting schemas are usually cached for further access.
+     */
+    public Schema updateSchemaFrom(
+        Schema originalSchema,
+        SchemaBuilder baselineSchemaBuilder,
+        StructSchemaUpdater whenFound
+    ) {
+        return updateSchema(originalSchema, baselineSchemaBuilder, pathTree, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Schema updateSchema(
+        Schema originalSchema,
+        SchemaBuilder baseSchemaBuilder,
+        Map<String, Object> treeAt,
+        StructSchemaUpdater whenFound,
+        StructSchemaUpdater whenNotFound,
+        StructSchemaUpdater toOtherFields
+    ) {
+        if (originalSchema.isOptional()) {
+            baseSchemaBuilder.optional();
+        }
+        Map<String, Object> notFoundFields = new HashMap<>(treeAt);
+        for (Field field : originalSchema.fields()) {
+            if (!treeAt.isEmpty()) {
+                if (!treeAt.containsKey(field.name())) {
+                    toOtherFields.apply(baseSchemaBuilder, field, null);
+                } else {
+                    notFoundFields.remove(field.name());
+                    if (treeAt.get(field.name()) instanceof SingleFieldPath) {
+                        whenFound.apply(baseSchemaBuilder, field, (SingleFieldPath) treeAt.get(field.name()));
+                    } else {
+                        if (field.schema().type() == Type.STRUCT) {
+                            Schema fieldSchema = updateSchema(
+                                field.schema(),
+                                SchemaBuilder.struct(),
+                                (Map<String, Object>) treeAt.get(field.name()),
+                                whenFound, whenNotFound, toOtherFields);
+                            baseSchemaBuilder.field(field.name(), fieldSchema);
+                        } else {
+                            toOtherFields.apply(baseSchemaBuilder, field, null);
+                        }
+                    }
+                }
+            } else {
+                toOtherFields.apply(baseSchemaBuilder, field, null);
+            }
+        }
+        for (Map.Entry<String, Object> entry : notFoundFields.entrySet()) {
+            String fieldName = entry.getKey();
+            Object treeValue = entry.getValue();
+            if (treeValue instanceof SingleFieldPath) {
+                whenNotFound.apply(baseSchemaBuilder, null, (SingleFieldPath) treeValue);
+            } else {
+                Schema fieldSchema = updateSchema(
+                    SchemaBuilder.struct().build(),
+                    SchemaBuilder.struct(),
+                    (Map<String, Object>) treeValue,
+                    whenFound, whenNotFound, toOtherFields);
+                baseSchemaBuilder.field(fieldName, fieldSchema);
+            }
+        }
+        return baseSchemaBuilder.build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MultiFieldPaths that = (MultiFieldPaths) o;
+        return Objects.equals(pathTree, that.pathTree);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pathTree);
+    }
+
+    @Override
+    public String toString() {
+        return "FieldPaths(pathTree = " + pathTree + ")";
+    }
+
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MultiFieldPaths.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MultiFieldPaths.java
@@ -24,10 +24,12 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.util.SchemaUtil;
 
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,14 +45,10 @@ import java.util.stream.Collectors;
  * @see FieldSyntaxVersion
  */
 public class MultiFieldPaths {
-    // Invariants:
-    // - Tree values contain either a nested tree or a field path
-    // - A tree can contain paths that are a subset of other paths
-    //   (e.g. foo and foo.bar in V2 would be kept)
-    final Map<String, Object> pathTree;
+    final Trie trie = new Trie();
 
     MultiFieldPaths(Set<SingleFieldPath> paths) {
-        pathTree = buildPathTree(paths, 0, new HashMap<>());
+        paths.forEach(trie::insert);
     }
 
     public static MultiFieldPaths of(List<String> fields, FieldSyntaxVersion syntaxVersion) {
@@ -60,93 +58,34 @@ public class MultiFieldPaths {
     }
 
     /**
-     * Build a nested map of paths to field paths to be used when traversing data structures.
-     *
-     * <p>With the following paths:
-     * <ul>
-     *     <li>foo.bar</li>
-     *     <li>foo.baz</li>
-     *     <li>foo.baz.other</li>
-     * </ul>
-     * a tree with the following structure will be created:
-     * <ul>
-     *     <li>foo:
-     *     <ul>
-     *         <li>bar</li>
-     *         <li>baz:
-     *         <ul>
-     *             <li>"" (empty to represent path at root)</li>
-     *             <li>other</li>
-     *         </ul>
-     *         </li>
-     *     </ul>
-     *     </li>
-     * </ul>
-     *
-     * @param paths    input paths
-     * @param stepIdx  paths step index, starting at zero
-     * @param pathTree building tree, starting empty
-     */
-    static Map<String, Object> buildPathTree(Set<SingleFieldPath> paths, int stepIdx, Map<String, Object> pathTree) {
-        Objects.requireNonNull(pathTree, "Resulting path three may not be null");
-        if (stepIdx < 0) throw new IllegalArgumentException("stepAt index may be higher or equal than zero");
-
-        // group paths by prefix,
-        // if paths overlap (e.g. `foo` and `foo.bar` are added)
-        // only the children are kept (`foo.bar`)
-        final Map<String, Set<SingleFieldPath>> groups = paths.stream()
-            .collect(Collectors.groupingBy(
-                path -> path.stepAt(stepIdx),
-                Collectors.toSet()
-            ));
-
-        // create tree from grouped paths
-        for (Map.Entry<String, Set<SingleFieldPath>> entry : groups.entrySet()) {
-            if (entry.getValue().size() == 1) {
-                final SingleFieldPath path = entry.getValue().iterator().next();
-                if (path.stepAt(stepIdx + 1).isEmpty()) { // if it is the last path step
-                    pathTree.put(entry.getKey(), path);
-                } else {
-                    pathTree.put(entry.getKey(),
-                        buildPathTree(entry.getValue(), stepIdx + 1, new HashMap<>()));
-                }
-            } else {
-                pathTree.put(entry.getKey(),
-                    buildPathTree(entry.getValue(), stepIdx + 1, new HashMap<>()));
-            }
-        }
-        return pathTree;
-    }
-
-    /**
-     * Find values at the field paths on the tree.
+     * Find values at the field paths
      *
      * @param struct data value
      * @return map of field paths and field/values
      */
     public Map<SingleFieldPath, Map.Entry<Field, Object>> fieldAndValuesFrom(Struct struct) {
-        return findFieldAndValues(struct, pathTree, new HashMap<>());
+        if (trie.isEmpty()) return Collections.emptyMap();
+        return findFieldAndValues(struct, trie.root, new HashMap<>());
     }
 
-    @SuppressWarnings("unchecked")
     private Map<SingleFieldPath, Map.Entry<Field, Object>> findFieldAndValues(
         Struct originalValue,
-        Map<String, Object> treeAt,
+        TrieNode trieAt,
         Map<SingleFieldPath, Map.Entry<Field, Object>> fieldAndValueMap
     ) {
-        for (Map.Entry<String, Object> step : treeAt.entrySet()) {
+        for (Map.Entry<String, TrieNode> step : trieAt.steps().entrySet()) {
             Field field = originalValue.schema().field(step.getKey());
-            if (step.getValue() instanceof SingleFieldPath) {
+            if (step.getValue().isLeaf()) {
                 Map.Entry<Field, Object> fieldAndValue =
                     field != null
                         ? new AbstractMap.SimpleImmutableEntry<>(field, originalValue.get(field))
                         : null;
-                fieldAndValueMap.put((SingleFieldPath) step.getValue(), fieldAndValue);
+                fieldAndValueMap.put(step.getValue().path, fieldAndValue);
             } else {
                 if (field.schema().type() == Type.STRUCT) {
                     findFieldAndValues(
                         originalValue.getStruct(field.name()),
-                        (Map<String, Object>) step.getValue(),
+                        step.getValue(),
                         fieldAndValueMap
                     );
                 }
@@ -156,33 +95,34 @@ public class MultiFieldPaths {
     }
 
     /**
-     * Find values at the field paths on the tree.
+     * Find values at the field paths
      *
      * @param value data value
      * @return map of field paths and field/values
      */
     public Map<SingleFieldPath, Map.Entry<String, Object>> fieldAndValuesFrom(Map<String, Object> value) {
-        return findFieldAndValues(value, pathTree, new HashMap<>());
+        if (trie.isEmpty()) return Collections.emptyMap();
+        return findFieldAndValues(value, trie.root, new HashMap<>());
     }
 
     @SuppressWarnings("unchecked")
     private Map<SingleFieldPath, Map.Entry<String, Object>> findFieldAndValues(
         Map<String, Object> value,
-        Map<String, Object> treeAt,
+        TrieNode trieAt,
         Map<SingleFieldPath, Map.Entry<String, Object>> fieldAndValueMap
     ) {
-        for (Map.Entry<String, Object> step : treeAt.entrySet()) {
+        for (Map.Entry<String, TrieNode> step : trieAt.steps().entrySet()) {
             Object fieldValue = value.get(step.getKey());
-            if (step.getValue() instanceof SingleFieldPath) {
-                fieldAndValueMap.put((
-                        SingleFieldPath) step.getValue(),
+            if (step.getValue().isLeaf()) {
+                fieldAndValueMap.put(
+                    step.getValue().path,
                     new AbstractMap.SimpleImmutableEntry<>(step.getKey(), fieldValue)
                 );
             } else {
                 if (fieldValue instanceof Map) {
                     findFieldAndValues(
                         (Map<String, Object>) fieldValue,
-                        (Map<String, Object>) step.getValue(),
+                        step.getValue(),
                         fieldAndValueMap
                     );
                 }
@@ -198,15 +138,16 @@ public class MultiFieldPaths {
      *
      * <p>Other fields keep values from original struct.
      *
-     * @param originalValue  schema-based data value
-     * @param whenFound function to apply when current path(s) is/are found
+     * @param originalValue schema-based data value
+     * @param whenFound     function to apply when current path(s) is/are found
      * @return updated data value
      */
     public Map<String, Object> updateValuesFrom(
         Map<String, Object> originalValue,
         MapValueUpdater whenFound
     ) {
-        return updateValues(originalValue, pathTree, whenFound,
+        if (trie.isEmpty()) return originalValue;
+        return updateValues(originalValue, trie.root, whenFound,
             (originalParent, updatedParent, fieldPath, fieldName) -> {
                 // filter out
             },
@@ -217,33 +158,33 @@ public class MultiFieldPaths {
     @SuppressWarnings("unchecked")
     private Map<String, Object> updateValues(
         Map<String, Object> originalValue,
-        Map<String, Object> treeAt,
+        TrieNode trieAt,
         MapValueUpdater matching,
         MapValueUpdater notFound,
         MapValueUpdater others
     ) {
         if (originalValue == null) return null;
         Map<String, Object> updatedValue = new HashMap<>(originalValue.size());
-        Map<String, Object> notFoundFields = new HashMap<>(treeAt);
+        Map<String, TrieNode> notFoundFields = new HashMap<>(trieAt.steps);
         for (Map.Entry<String, Object> entry : originalValue.entrySet()) {
             String fieldName = entry.getKey();
             Object fieldValue = entry.getValue();
-            if (!treeAt.isEmpty()) {
-                if (treeAt.containsKey(fieldName)) {
+            if (!trieAt.isEmpty()) {
+                if (trieAt.contains(fieldName)) {
                     notFoundFields.remove(fieldName);
-                    Object treeValue = treeAt.get(fieldName);
-                    if (treeValue instanceof SingleFieldPath) {
-                        matching.apply(originalValue, updatedValue, (SingleFieldPath) treeValue, fieldName);
+                    TrieNode trieValue = trieAt.get(fieldName);
+                    if (trieValue.isLeaf()) {
+                        matching.apply(originalValue, updatedValue, trieValue.path, fieldName);
                     } else {
                         if (fieldValue instanceof Map) {
                             Map<String, Object> updatedField = updateValues(
                                 (Map<String, Object>) fieldValue,
-                                (Map<String, Object>) treeValue,
+                                trieValue,
                                 matching, notFound, others);
                             updatedValue.put(fieldName, updatedField);
                         } else {
                             // add back to not found and apply others, as only leaf values are updated
-                            notFoundFields.put(fieldName, treeValue);
+                            notFoundFields.put(fieldName, trieValue);
                             others.apply(originalValue, updatedValue, null, fieldName);
                         }
                     }
@@ -254,15 +195,16 @@ public class MultiFieldPaths {
                 others.apply(originalValue, updatedValue, null, fieldName);
             }
         }
-        for (Map.Entry<String, Object> entry : notFoundFields.entrySet()) {
+
+        for (Map.Entry<String, TrieNode> entry : notFoundFields.entrySet()) {
             String fieldName = entry.getKey();
-            Object treeValue = entry.getValue();
-            if (treeValue instanceof SingleFieldPath) {
-                notFound.apply(originalValue, updatedValue, (SingleFieldPath) treeValue, fieldName);
+            TrieNode trieValue = entry.getValue();
+            if (trieValue.isLeaf()) {
+                notFound.apply(originalValue, updatedValue, trieValue.path, fieldName);
             } else {
                 Map<String, Object> updatedField = updateValues(
                     new HashMap<>(),
-                    (Map<String, Object>) treeValue,
+                    trieValue,
                     matching, notFound, others);
                 updatedValue.put(fieldName, updatedField);
             }
@@ -280,8 +222,8 @@ public class MultiFieldPaths {
      *
      * @param originalSchema original struct schema
      * @param originalValue  schema-based data value
-     * @param updatedSchema updated struct schema
-     * @param whenFound function to apply when current path(s) is/are found
+     * @param updatedSchema  updated struct schema
+     * @param whenFound      function to apply when current path(s) is/are found
      * @return updated data value
      */
     public Struct updateValuesFrom(
@@ -290,7 +232,8 @@ public class MultiFieldPaths {
         Schema updatedSchema,
         StructValueUpdater whenFound
     ) {
-        return updateValues(originalSchema, originalValue, updatedSchema, pathTree, whenFound,
+        if (trie.isEmpty()) return originalValue;
+        return updateValues(originalSchema, originalValue, updatedSchema, trie.root, whenFound,
             (originalParent, originalField, updatedParent, updatedField, fieldPath) -> {
                 // filter out
             },
@@ -298,30 +241,29 @@ public class MultiFieldPaths {
                 updatedParent.put(originalField.name(), originalParent.get(originalField)));
     }
 
-    @SuppressWarnings("unchecked")
     private Struct updateValues(
         Schema originalSchema,
         Struct originalValue,
         Schema updateSchema,
-        Map<String, Object> treeAt,
+        TrieNode trieAt,
         StructValueUpdater matching,
         StructValueUpdater notFound,
         StructValueUpdater others
     ) {
         Struct updatedValue = new Struct(updateSchema);
-        Map<String, Object> notFoundFields = new HashMap<>(treeAt);
+        Map<String, TrieNode> notFoundFields = trieAt.steps();
         for (Field field : originalSchema.fields()) {
-            if (!treeAt.isEmpty()) {
-                if (treeAt.containsKey(field.name())) {
+            if (!trieAt.isEmpty()) {
+                if (trieAt.contains(field.name())) {
                     notFoundFields.remove(field.name());
-                    final Object treeValue = treeAt.get(field.name());
-                    if (treeValue instanceof SingleFieldPath) {
+                    final TrieNode trieValue = trieAt.get(field.name());
+                    if (trieValue.isLeaf()) {
                         matching.apply(
                             originalValue,
                             originalSchema.field(field.name()),
                             updatedValue,
                             updateSchema.field(field.name()),
-                            (SingleFieldPath) treeValue
+                            trieValue.path
                         );
                     } else {
                         if (field.schema().type() == Type.STRUCT) {
@@ -329,13 +271,13 @@ public class MultiFieldPaths {
                                 field.schema(),
                                 originalValue.getStruct(field.name()),
                                 updateSchema.field(field.name()).schema(),
-                                (Map<String, Object>) treeValue,
+                                trieValue,
                                 matching, notFound, others
                             );
                             updatedValue.put(updateSchema.field(field.name()), fieldValue);
                         } else {
                             // add back to not found and apply others, as only leaf values are updated
-                            notFoundFields.put(field.name(), treeValue);
+                            notFoundFields.put(field.name(), trieValue);
                             others.apply(originalValue, field, updatedValue, null, null);
                         }
                     }
@@ -346,23 +288,23 @@ public class MultiFieldPaths {
                 others.apply(originalValue, field, updatedValue, null, null);
             }
         }
-        for (Map.Entry<String, Object> entry : notFoundFields.entrySet()) {
+        for (Map.Entry<String, TrieNode> entry : notFoundFields.entrySet()) {
             String fieldName = entry.getKey();
-            Object treeValue = entry.getValue();
-            if (treeValue instanceof SingleFieldPath) {
+            TrieNode trieValue = entry.getValue();
+            if (trieValue.isLeaf()) {
                 notFound.apply(
                     originalValue,
                     null,
                     updatedValue,
                     updateSchema.field(fieldName),
-                    (SingleFieldPath) treeValue
+                    trieValue.path
                 );
             } else {
                 Struct fieldValue = updateValues(
                     SchemaBuilder.struct().build(),
                     null,
                     updateSchema.field(fieldName).schema(),
-                    (Map<String, Object>) treeValue,
+                    trieValue,
                     matching, notFound, others
                 );
                 updatedValue.put(updateSchema.field(fieldName), fieldValue);
@@ -382,15 +324,16 @@ public class MultiFieldPaths {
      * <p>A copy of the {@code Schema} is used as a base for the updated schema.
      *
      * @param originalSchema baseline schema
-     * @param whenFound function to apply when current path(s) is/are found
+     * @param whenFound      function to apply when current path(s) is/are found
      * @return an updated schema. Resulting schemas are usually cached for further access
      */
     public Schema updateSchemaFrom(
         Schema originalSchema,
         StructSchemaUpdater whenFound
     ) {
+        if (trie.isEmpty()) return originalSchema;
         SchemaBuilder updated = SchemaUtil.copySchemaBasics(originalSchema, SchemaBuilder.struct());
-        return updateSchema(originalSchema, updated, pathTree, whenFound,
+        return updateSchema(originalSchema, updated, trie.root, whenFound,
             (schemaBuilder, field, fieldPath) -> { /* ignore */ },
             (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
     }
@@ -403,10 +346,11 @@ public class MultiFieldPaths {
      * <p>If path is not found, no function is applied, and the path is ignored.
      *
      * <p>Other fields are copied from original schema.
-     * @param originalSchema baseline schema
+     *
+     * @param originalSchema        baseline schema
      * @param baselineSchemaBuilder baseline schema build, if changes to the baseline
      *                              are required before copying original
-     * @param whenFound function to apply when current path(s) is/are found.
+     * @param whenFound             function to apply when current path(s) is/are found.
      * @return an updated schema. Resulting schemas are usually cached for further access.
      */
     public Schema updateSchemaFrom(
@@ -414,16 +358,16 @@ public class MultiFieldPaths {
         SchemaBuilder baselineSchemaBuilder,
         StructSchemaUpdater whenFound
     ) {
-        return updateSchema(originalSchema, baselineSchemaBuilder, pathTree, whenFound,
+        if (trie.isEmpty()) return originalSchema;
+        return updateSchema(originalSchema, baselineSchemaBuilder, trie.root, whenFound,
             (schemaBuilder, field, fieldPath) -> { /* ignore */ },
             (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
     }
 
-    @SuppressWarnings("unchecked")
     private Schema updateSchema(
         Schema originalSchema,
         SchemaBuilder baseSchemaBuilder,
-        Map<String, Object> treeAt,
+        TrieNode trieAt,
         StructSchemaUpdater whenFound,
         StructSchemaUpdater whenNotFound,
         StructSchemaUpdater toOtherFields
@@ -431,21 +375,22 @@ public class MultiFieldPaths {
         if (originalSchema.isOptional()) {
             baseSchemaBuilder.optional();
         }
-        Map<String, Object> notFoundFields = new HashMap<>(treeAt);
+        Map<String, TrieNode> notFoundFields = trieAt.steps();
         for (Field field : originalSchema.fields()) {
-            if (!treeAt.isEmpty()) {
-                if (!treeAt.containsKey(field.name())) {
+            if (!trieAt.isEmpty()) {
+                if (!trieAt.contains(field.name())) {
                     toOtherFields.apply(baseSchemaBuilder, field, null);
                 } else {
                     notFoundFields.remove(field.name());
-                    if (treeAt.get(field.name()) instanceof SingleFieldPath) {
-                        whenFound.apply(baseSchemaBuilder, field, (SingleFieldPath) treeAt.get(field.name()));
+                    TrieNode trieNode = trieAt.get(field.name());
+                    if (trieNode.isLeaf()) {
+                        whenFound.apply(baseSchemaBuilder, field, trieNode.path);
                     } else {
                         if (field.schema().type() == Type.STRUCT) {
                             Schema fieldSchema = updateSchema(
                                 field.schema(),
                                 SchemaBuilder.struct(),
-                                (Map<String, Object>) treeAt.get(field.name()),
+                                trieNode,
                                 whenFound, whenNotFound, toOtherFields);
                             baseSchemaBuilder.field(field.name(), fieldSchema);
                         } else {
@@ -457,16 +402,16 @@ public class MultiFieldPaths {
                 toOtherFields.apply(baseSchemaBuilder, field, null);
             }
         }
-        for (Map.Entry<String, Object> entry : notFoundFields.entrySet()) {
+        for (Map.Entry<String, TrieNode> entry : notFoundFields.entrySet()) {
             String fieldName = entry.getKey();
-            Object treeValue = entry.getValue();
-            if (treeValue instanceof SingleFieldPath) {
-                whenNotFound.apply(baseSchemaBuilder, null, (SingleFieldPath) treeValue);
+            TrieNode trieValue = entry.getValue();
+            if (trieValue.isLeaf()) {
+                whenNotFound.apply(baseSchemaBuilder, null, trieValue.path);
             } else {
                 Schema fieldSchema = updateSchema(
                     SchemaBuilder.struct().build(),
                     SchemaBuilder.struct(),
-                    (Map<String, Object>) treeValue,
+                    trieValue,
                     whenFound, whenNotFound, toOtherFields);
                 baseSchemaBuilder.field(fieldName, fieldSchema);
             }
@@ -483,17 +428,154 @@ public class MultiFieldPaths {
             return false;
         }
         MultiFieldPaths that = (MultiFieldPaths) o;
-        return Objects.equals(pathTree, that.pathTree);
+        return Objects.equals(trie, that.trie);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pathTree);
+        return Objects.hash(trie);
     }
 
     @Override
     public String toString() {
-        return "FieldPaths(pathTree = " + pathTree + ")";
+        return "FieldPaths(trie = " + trie + ")";
     }
 
+    // Invariants:
+    // - Trie values contain either a nested trie or a field path when it is a leaf.
+    // - A trie flattens overlapping paths (e.g. `foo` and `foo.bar` in V2, only `foo.bar` would be kept)
+    static class Trie {
+        TrieNode root;
+
+        Trie() {
+            root = new TrieNode();
+        }
+
+
+        public void insert(SingleFieldPath path) {
+            TrieNode current = root;
+
+            for (String step : path.stepsWithoutLast()) {
+                if (!current.contains(step)) {
+                    current.addStep(step);
+                }
+
+                current = current.get(step);
+            }
+
+            final String step = path.lastStep();
+            if (!current.contains(step)) {
+                current.addLeaf(step, path);
+            }
+        }
+
+        public boolean isEmpty() {
+            return root.isEmpty();
+        }
+
+        public Optional<TrieNode> find(String step) {
+            return root.find(step);
+        }
+
+        public int size() {
+            if (root.isEmpty()) return 0;
+            return root.size();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Trie trie = (Trie) o;
+            return Objects.equals(root, trie.root);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(root);
+        }
+
+        @Override
+        public String toString() {
+            return "Trie(" +
+                "root = " + root +
+                ')';
+        }
+    }
+
+    static class TrieNode {
+        Map<String, TrieNode> steps = new HashMap<>();
+        SingleFieldPath path;
+
+        TrieNode() {
+        }
+
+        private TrieNode(SingleFieldPath path) {
+            this.path = path;
+        }
+
+        public boolean contains(String step) {
+            return steps.containsKey(step);
+        }
+
+        public void addStep(String step) {
+            if (path != null) path = null;
+            steps.put(step, new TrieNode());
+        }
+
+        public void addLeaf(String step, SingleFieldPath path) {
+            if (this.path != null) this.path = null;
+            steps.put(step, new TrieNode(path));
+        }
+
+        public TrieNode get(String step) {
+            return steps.get(step);
+        }
+
+        public Optional<TrieNode> find(String step) {
+            return Optional.ofNullable(steps.get(step));
+        }
+
+        public boolean isEmpty() {
+            return steps.isEmpty() && path == null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TrieNode trieNode = (TrieNode) o;
+            return Objects.equals(steps, trieNode.steps) && Objects.equals(path, trieNode.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(steps, path);
+        }
+
+        @Override
+        public String toString() {
+            return "TrieNode(" +
+                "steps = " + steps +
+                (path != null ? (", path = " + path) : "") +
+                ')';
+        }
+
+        public boolean isLeaf() {
+            return path != null;
+        }
+
+        public Map<String, TrieNode> steps() {
+            return new HashMap<>(steps);
+        }
+
+        public int size() {
+            if (isLeaf()) return 1;
+            int size = 0;
+            for (TrieNode child : steps.values()) {
+                size = size + child.size();
+            }
+            return size;
+        }
+    }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A FieldPath is composed by one or many field names, known as steps,
+ * to access values within a data object (either {@code Struct} or {@code Map<String, Object>}).a
+ *
+ * <p>If the SMT requires accessing multiple fields on the same data object,
+ * use {@link MultiFieldPaths} instead.
+ *
+ * <p>The field path semantics are defined by the {@link FieldSyntaxVersion syntax version}.
+ *
+ * <p>Paths are calculated once and cached for further access.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
+ * @see FieldSyntaxVersion
+ * @see MultiFieldPaths
+ */
+public class SingleFieldPath {
+    // Invariants:
+    // - A field path can contain one or more steps
+    private static final char BACKTICK = '`';
+    private static final char DOT = '.';
+    private static final char BACKSLASH = '\\';
+
+    private final String[] path;
+
+    public SingleFieldPath(String pathText, FieldSyntaxVersion version) {
+        Objects.requireNonNull(pathText, "Field path cannot be null");
+        switch (version) {
+            case V1: // backward compatibility
+                this.path = new String[] {pathText};
+                break;
+            case V2:
+                this.path = buildFieldPathV2(pathText);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown syntax version: " + version);
+        }
+    }
+
+    private String[] buildFieldPathV2(String pathText) {
+        final List<String> steps = new ArrayList<>();
+        int idx = 0;
+        while (idx < pathText.length() && idx >= 0) {
+            if (pathText.charAt(idx) != BACKTICK) {
+                final int start = idx;
+                idx = pathText.indexOf(String.valueOf(DOT), idx);
+                if (idx > 0) { // get path step and move forward
+                    String field = pathText.substring(start, idx);
+                    steps.add(field);
+                    idx++;
+                } else { // add all
+                    String field = pathText.substring(start);
+                    steps.add(field);
+                }
+            } else {
+                StringBuilder field = new StringBuilder();
+                idx++;
+                int start = idx;
+                while (true) {
+                    idx = pathText.indexOf(String.valueOf(BACKTICK), idx);
+                    if (idx == -1) { // if not found, fail
+                        throw new IllegalArgumentException("Incomplete backtick pair in path: " + pathText);
+                    }
+
+                    boolean atEndOfPath = idx >= pathText.length() - 1;
+                    if (atEndOfPath) {
+                        field.append(pathText, start, idx);
+                        // we've reached the end of the path, and the last character is the backtick
+                        steps.add(field.toString());
+                        idx++;
+                        break;
+                    }
+
+                    boolean notFollowedByDot = pathText.charAt(idx + 1) != DOT;
+                    if (notFollowedByDot) {
+                        boolean afterABackslash = pathText.charAt(idx - 1) == BACKSLASH;
+                        if (afterABackslash) {
+                            // this backtick was escaped; include it in the field name, but continue
+                            // looking for an unescaped matching backtick
+                            field.append(pathText, start, idx - 1)
+                                .append(BACKTICK);
+
+                            idx++;
+                            start = idx;
+                        } else {
+                            // this backtick isn't followed by a dot; include it in the field name, but continue
+                            // looking for a matching backtick that is followed by a dot
+                            idx++;
+                        }
+                        continue;
+                    }
+
+                    boolean afterABackslash = pathText.charAt(idx - 1) == BACKSLASH;
+                    if (afterABackslash) {
+                        // this backtick was escaped; include it in the field name, but continue
+                        // looking for an unescaped matching backtick
+                        field.append(pathText, start, idx - 1)
+                            .append(BACKTICK);
+
+                        idx++;
+                        start = idx;
+                        continue;
+                    }
+                    // we've found our matching backtick
+                    field.append(pathText, start, idx);
+                    steps.add(field.toString());
+                    idx += 2; // increment by two to include the backtick and the dot after it
+                    break;
+                }
+
+
+            }
+        }
+        return steps.toArray(new String[0]);
+    }
+
+
+    /**
+     * Access a {@code Field} at the current path within a schema {@code Schema}
+     * If field is not found, then {@code null} is returned.
+     */
+    public Field fieldFrom(Schema schema) {
+        if (path.length == 1) {
+            return schema.field(path[0]);
+        } else {
+            Schema current = schema;
+            for (int i = 0; i < path.length; i++) {
+                if (current == null) {
+                    return null;
+                }
+                if (i == path.length - 1) { // get value
+                    return current.field(path[i]);
+                } else { // iterate
+                    current = current.field(path[i]).schema();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Access a value at the current path within a schema-based {@code Struct}
+     * If object is not found, then {@code null} is returned.
+     */
+    public Object valueFrom(Struct struct) {
+        if (path.length == 1) {
+            return struct.get(path[0]);
+        } else {
+            Struct current = struct;
+            for (int i = 0; i < path.length; i++) {
+                if (current == null) {
+                    return null;
+                }
+                if (i == path.length - 1) { // get value
+                    return current.get(path[i]);
+                } else { // iterate
+                    current = current.getStruct(path[i]);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Access a value at the current path within a schemaless {@code Map<String, Object>}.
+     * If object is not found, then {@code null} is returned.
+     */
+    @SuppressWarnings("unchecked")
+    public Object valueFrom(Map<String, Object> map) {
+        if (path.length == 1) {
+            return map.get(path[0]);
+        } else {
+            Map<String, Object> current = map;
+            for (int i = 0; i < path.length; i++) {
+                if (current == null) {
+                    return null;
+                }
+                if (i == path.length - 1) {
+                    return current.get(path[i]);
+                } else {
+                    current = (Map<String, Object>) current.get(path[i]);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Access {@code Map} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalValue schema-based data value
+     * @param whenFound     function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Map<String, Object> updateValueFrom(
+        Map<String, Object> originalValue,
+        MapValueUpdater whenFound
+    ) {
+        return updateValue(originalValue, 0, whenFound,
+            (originalParent, updatedParent, fieldPath, fieldName) -> {
+                // filter out
+            },
+            (originalParent, updatedParent, fieldPath, fieldName) ->
+                updatedParent.put(fieldName, originalParent.get(fieldName)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> updateValue(
+        Map<String, Object> originalValue,
+        int step,
+        MapValueUpdater update,
+        MapValueUpdater notFound,
+        MapValueUpdater others
+    ) {
+        if (originalValue == null) return null;
+        Map<String, Object> updatedParent = new HashMap<>(originalValue.size());
+        boolean found = false;
+        for (Map.Entry<String, Object> entry : originalValue.entrySet()) {
+            String fieldName = entry.getKey();
+            Object fieldValue = entry.getValue();
+            if (path[step].equals(fieldName)) {
+                found = true;
+                if (step < path.length - 1) {
+                    if (fieldValue instanceof Map) {
+                        Map<String, Object> updatedField = updateValue(
+                            (Map<String, Object>) fieldValue,
+                            step + 1,
+                            update,
+                            notFound,
+                            others);
+                        updatedParent.put(fieldName, updatedField);
+                    } else {
+                        // add back to not found and apply others, as only leaf values are updated
+                        found = false;
+                        others.apply(originalValue, updatedParent, null, fieldName);
+                    }
+                } else {
+                    update.apply(originalValue, updatedParent, this, fieldName);
+                }
+            } else {
+                others.apply(originalValue, updatedParent, null, fieldName);
+            }
+        }
+
+        if (!found) {
+            notFound.apply(originalValue, updatedParent, this, stepAt(step));
+        }
+
+        return updatedParent;
+    }
+
+    /**
+     * Access {@code Struct} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalSchema original struct schema
+     * @param originalValue  schema-based data value
+     * @param updatedSchema  updated struct schema
+     * @param whenFound      function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Struct updateValueFrom(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updatedSchema,
+        StructValueUpdater whenFound
+    ) {
+        return updateValue(originalSchema, originalValue, updatedSchema, 0, whenFound,
+            (originalParent, originalField, updatedParent, updatedField, fieldPath) -> {
+                // filter out
+            },
+            (originalParent, originalField, updatedParent, nullUpdatedField, nullFieldPath) ->
+                updatedParent.put(originalField.name(), originalParent.get(originalField)));
+    }
+
+    private Struct updateValue(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updateSchema,
+        int step,
+        StructValueUpdater update,
+        StructValueUpdater notFound,
+        StructValueUpdater others
+    ) {
+        Struct updated = new Struct(updateSchema);
+        boolean found = false;
+        for (Field field : originalSchema.fields()) {
+            if (step < path.length) {
+                if (path[step].equals(field.name())) {
+                    found = true;
+                    if (step == path.length - 1) {
+                        update.apply(
+                            originalValue,
+                            field,
+                            updated,
+                            updateSchema.field(field.name()),
+                            this
+                        );
+                    } else {
+                        if (field.schema().type() == Type.STRUCT) {
+                            Struct fieldValue = updateValue(
+                                field.schema(),
+                                originalValue.getStruct(field.name()),
+                                updateSchema.field(field.name()).schema(),
+                                step + 1,
+                                update,
+                                notFound,
+                                others
+                            );
+                            updated.put(field.name(), fieldValue);
+                        } else {
+                            // add back to not found and apply others, as only leaf values are updated
+                            found = false;
+                            others.apply(originalValue, field, updated, null, this);
+                        }
+                    }
+                } else {
+                    others.apply(originalValue, field, updated, null, this);
+                }
+            }
+        }
+        if (!found) {
+            notFound.apply(
+                originalValue,
+                null,
+                updated,
+                updateSchema.field(stepAt(step)),
+                this);
+        }
+        return updated;
+    }
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * <p>A copy of the {@code Schema} is used as a base for the updated schema.
+     *
+     * @param originalSchema baseline schema
+     * @param whenFound      function to apply when current path(s) is/are found
+     * @return an updated schema. Resulting schemas are usually cached for further access
+     */
+    public Schema updateSchemaFrom(Schema originalSchema, StructSchemaUpdater whenFound) {
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(originalSchema, SchemaBuilder.struct());
+        return updateSchema(originalSchema, updated, 0, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * @param originalSchema        baseline schema
+     * @param baselineSchemaBuilder baseline schema build, if changes to the baseline
+     *                              are required before copying original
+     * @param whenFound             function to apply when current path(s) is/are found.
+     * @return an updated schema. Resulting schemas are usually cached for further access.
+     */
+    public Schema updateSchemaFrom(
+        Schema originalSchema,
+        SchemaBuilder baselineSchemaBuilder,
+        StructSchemaUpdater whenFound
+    ) {
+        return updateSchema(originalSchema, baselineSchemaBuilder, 0, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+    // Recursive implementation to update schema at different steps.
+    // Consider that resulting schemas are usually cached.
+    private Schema updateSchema(
+        Schema operatingSchema,
+        SchemaBuilder builder,
+        int step,
+        StructSchemaUpdater matching,
+        StructSchemaUpdater notFound,
+        StructSchemaUpdater others
+    ) {
+        if (operatingSchema.isOptional()) {
+            builder.optional();
+        }
+        if (operatingSchema.defaultValue() != null) {
+            builder.defaultValue(operatingSchema.defaultValue());
+        }
+        boolean matched = false;
+        for (Field field : operatingSchema.fields()) {
+            if (step < path.length) {
+                if (path[step].equals(field.name())) {
+                    matched = true;
+                    if (step == path.length - 1) {
+                        matching.apply(builder, field, this);
+                    } else {
+                        Schema fieldSchema = updateSchema(
+                            field.schema(),
+                            SchemaBuilder.struct(),
+                            step + 1,
+                            matching,
+                            notFound,
+                            others);
+                        builder.field(field.name(), fieldSchema);
+                    }
+                } else {
+                    others.apply(builder, field, null);
+                }
+            } else {
+                others.apply(builder, field, null);
+            }
+        }
+        if (!matched) {
+            notFound.apply(builder, null, this);
+        }
+        return builder.build();
+    }
+
+    public String last() {
+        return path[path.length - 1];
+    }
+
+    public boolean isEmpty() {
+        return path.length == 0;
+    }
+
+    public String stepAt(int i) {
+        return i < path.length ? path[i] : "";
+    }
+
+    // For testing
+    String[] path() {
+        return Arrays.copyOf(path, path.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SingleFieldPath fieldPath = (SingleFieldPath) o;
+        return Arrays.equals(path, fieldPath.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(path);
+    }
+
+    @Override
+    public String toString() {
+        return "FieldPath(path = " + Arrays.toString(path) + ")";
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -39,8 +39,6 @@ import java.util.Objects;
  *
  * <p>The field path semantics are defined by the {@link FieldSyntaxVersion syntax version}.
  *
- * <p>Paths are calculated once and cached for further access.
- *
  * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
  * @see FieldSyntaxVersion
  * @see MultiFieldPaths

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -66,7 +66,7 @@ public class SingleFieldPath {
         }
     }
 
-    private List<String> buildFieldPathV2(String pathText) {
+    private static List<String> buildFieldPathV2(String pathText) {
         final List<String> steps = new ArrayList<>();
         int idx = 0;
         while (idx < pathText.length() && idx >= 0) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -91,8 +91,7 @@ public class SingleFieldPath {
                         throw new IllegalArgumentException("Incomplete backtick pair in path: " + pathText);
                     }
 
-                    boolean atEndOfPath = idx >= pathText.length() - 1;
-                    if (atEndOfPath) {
+                    if (idx >= pathText.length() - 1) { // at the end of path
                         field.append(pathText, start, idx);
                         // we've reached the end of the path, and the last character is the backtick
                         steps.add(field.toString());

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -136,8 +136,6 @@ public class SingleFieldPath {
                     idx += 2; // increment by two to include the backtick and the dot after it
                     break;
                 }
-
-
             }
         }
         return steps.toArray(new String[0]);

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -139,7 +139,7 @@ public class SingleFieldPath {
         if (schema == null) return null;
 
         Schema current = schema;
-        for (String pathSegment : path.subList(0, lastStepIndex())) {
+        for (String pathSegment : stepsWithoutLast()) {
             final Field field = current.field(pathSegment);
             if (field != null) {
                 current = field.schema();
@@ -158,7 +158,7 @@ public class SingleFieldPath {
         if (struct == null) return null;
 
         Struct current = struct;
-        for (String pathSegment : path.subList(0, lastStepIndex())) {
+        for (String pathSegment : stepsWithoutLast()) {
             // Check to see if the field actually exists
             if (current.schema().field(pathSegment) == null) {
                 return null;
@@ -171,6 +171,10 @@ public class SingleFieldPath {
         } else {
             return null;
         }
+    }
+
+    List<String> stepsWithoutLast() {
+        return path.subList(0, lastStepIndex());
     }
 
     /**
@@ -459,7 +463,7 @@ public class SingleFieldPath {
         return path.toArray(new String[0]);
     }
 
-    private String lastStep() {
+    String lastStep() {
         return path.get(lastStepIndex());
     }
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -159,7 +159,12 @@ public class SingleFieldPath {
                 if (i == path.length - 1) { // get value
                     return current.field(path[i]);
                 } else { // iterate
-                    current = current.field(path[i]).schema();
+                    final Field field = current.field(path[i]);
+                    if (field != null) {
+                        current = field.schema();
+                    } else {
+                        return null;
+                    }
                 }
             }
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -136,6 +136,8 @@ public class SingleFieldPath {
      * If field is not found, then {@code null} is returned.
      */
     public Field fieldFrom(Schema schema) {
+        if (schema == null) return null;
+
         Schema current = schema;
         for (String pathSegment : path.subList(0, lastStepIndex())) {
             final Field field = current.field(pathSegment);
@@ -153,6 +155,8 @@ public class SingleFieldPath {
      * If object is not found, then {@code null} is returned.
      */
     public Object valueFrom(Struct struct) {
+        if (struct == null) return null;
+
         Struct current = struct;
         for (String pathSegment : path.subList(0, lastStepIndex())) {
             // Check to see if the field actually exists
@@ -175,6 +179,8 @@ public class SingleFieldPath {
      */
     @SuppressWarnings("unchecked")
     public Object valueFrom(Map<String, Object> map) {
+        if (map == null) return null;
+
         if (path.size() == 1) {
             return map.get(path.get(0));
         } else {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -99,22 +99,10 @@ public class SingleFieldPath {
                         break;
                     }
 
-                    boolean notFollowedByDot = pathText.charAt(idx + 1) != DOT;
-                    if (notFollowedByDot) {
-                        boolean afterABackslash = pathText.charAt(idx - 1) == BACKSLASH;
-                        if (afterABackslash) {
-                            // this backtick was escaped; include it in the field name, but continue
-                            // looking for an unescaped matching backtick
-                            field.append(pathText, start, idx - 1)
-                                .append(BACKTICK);
-
-                            idx++;
-                            start = idx;
-                        } else {
-                            // this backtick isn't followed by a dot; include it in the field name, but continue
-                            // looking for a matching backtick that is followed by a dot
-                            idx++;
-                        }
+                    if (pathText.charAt(idx + 1) != DOT) { // not followed by a dot
+                        // this backtick isn't followed by a dot; include it in the field name, but continue
+                        // looking for a matching backtick that is followed by a dot
+                        idx++;
                         continue;
                     }
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -73,7 +73,7 @@ public class SingleFieldPath {
             if (pathText.charAt(idx) != BACKTICK) {
                 final int start = idx;
                 idx = pathText.indexOf(String.valueOf(DOT), idx);
-                if (idx > 0) { // get path step and move forward
+                if (idx >= 0) { // get path step and move forward
                     String field = pathText.substring(start, idx);
                     steps.add(field);
                     idx++;
@@ -137,6 +137,8 @@ public class SingleFieldPath {
                 }
             }
         }
+        if (!pathText.isEmpty() && pathText.charAt(pathText.length() - 1) == DOT)
+            steps.add("");
         return steps.toArray(new String[0]);
     }
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -31,8 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * A FieldPath is composed by one or many field names, known as steps,
- * to access values within a data object (either {@code Struct} or {@code Map<String, Object>}).a
+ * A SingleFieldPath is composed of one or more field names, known as steps,
+ * to access values within a data object (either {@code Struct} or {@code Map<String, Object>}).
  *
  * <p>If the SMT requires accessing multiple fields on the same data object,
  * use {@link MultiFieldPaths} instead.

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -177,17 +177,31 @@ public class SingleFieldPath {
      */
     public Object valueFrom(Struct struct) {
         if (path.length == 1) {
-            return struct.get(path[0]);
+            final Field field = struct.schema().field(path[0]);
+            if (field != null) {
+                return struct.get(path[0]);
+            } else {
+                return null;
+            }
         } else {
             Struct current = struct;
             for (int i = 0; i < path.length; i++) {
                 if (current == null) {
                     return null;
                 }
+                final Field field = current.schema().field(path[i]);
                 if (i == path.length - 1) { // get value
-                    return current.get(path[i]);
+                    if (field != null) {
+                        return current.get(path[i]);
+                    } else {
+                        return null;
+                    }
                 } else { // iterate
-                    current = current.getStruct(path[i]);
+                    if (field != null && field.schema().type() == Type.STRUCT) {
+                        current = current.getStruct(path[i]);
+                    } else {
+                        return null;
+                    }
                 }
             }
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructSchemaUpdater.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructSchemaUpdater.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Function to update Struct schemas based on Field Paths.
+ *
+ * @see FieldPath
+ * @see org.apache.kafka.connect.data.Schema
+ */
+@FunctionalInterface
+public interface StructSchemaUpdater {
+
+    /**
+     * Apply schema update function.
+     *
+     * @param schemaBuilder builder to be updated. Required, not nullable.
+     * @param field nullable when updating fields that do not exist. e.g. paths not found.
+     * @param fieldPath nullable when updating a field that is not related to a path.
+     */
+    void apply(SchemaBuilder schemaBuilder, Field field, SingleFieldPath fieldPath);
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructValueUpdater.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructValueUpdater.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+
+@FunctionalInterface
+public interface StructValueUpdater {
+
+    void apply(Struct originalParent, Field originalField, Struct updatedParent, Field updatedField, SingleFieldPath fieldPath);
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.connect.transforms;
 
+import java.util.HashMap;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +53,22 @@ public class ExtractFieldTest {
     }
 
     @Test
-    public void testNullSchemaless() {
+    public void schemalessAndNestedPath() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        configs.put("field", "magic.foo");
+        xform.configure(configs);
+
+        final Map<String, Object> key = Collections.singletonMap("magic", Collections.singletonMap("foo", 42));
+        final SinkRecord record = new SinkRecord("test", 0, null, key, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        assertEquals(42, transformedRecord.key());
+    }
+
+    @Test
+    public void nullSchemaless() {
         xform.configure(Collections.singletonMap("field", "magic"));
 
         final Map<String, Object> key = null;
@@ -68,6 +85,23 @@ public class ExtractFieldTest {
 
         final Schema keySchema = SchemaBuilder.struct().field("magic", Schema.INT32_SCHEMA).build();
         final Struct key = new Struct(keySchema).put("magic", 42);
+        final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        assertEquals(Schema.INT32_SCHEMA, transformedRecord.keySchema());
+        assertEquals(42, transformedRecord.key());
+    }
+
+    @Test
+    public void withSchemaAndNestedPath() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        configs.put("field", "magic.foo");
+        xform.configure(configs);
+
+        final Schema fooSchema = SchemaBuilder.struct().field("foo", Schema.INT32_SCHEMA).build();
+        final Schema keySchema = SchemaBuilder.struct().field("magic", fooSchema).build();
+        final Struct key = new Struct(keySchema).put("magic", new Struct(fooSchema).put("foo", 42));
         final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
         final SinkRecord transformedRecord = xform.apply(record);
 
@@ -100,6 +134,18 @@ public class ExtractFieldTest {
     }
 
     @Test
+    public void nonExistentNestedFieldSchemalessShouldReturnNull() {
+        xform.configure(Collections.singletonMap("field", "magic.nonexistent"));
+
+        final Map<String, Object> key = Collections.singletonMap("magic", Collections.singletonMap("foo", 42));
+        final SinkRecord record = new SinkRecord("test", 0, null, key, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+    }
+
+    @Test
     public void nonExistentFieldWithSchemaShouldFail() {
         xform.configure(Collections.singletonMap("field", "nonexistent"));
 
@@ -111,7 +157,24 @@ public class ExtractFieldTest {
             xform.apply(record);
             fail("Expected exception wasn't raised");
         } catch (IllegalArgumentException iae) {
-            assertEquals("Unknown field: nonexistent", iae.getMessage());
+            assertEquals("Unknown field: FieldPath(path = [nonexistent])", iae.getMessage());
+        }
+    }
+
+    @Test
+    public void nonExistentNestedFieldWithSchemaShouldFail() {
+        xform.configure(Collections.singletonMap("field", "magic.nonexistent"));
+
+        final Schema fooSchema = SchemaBuilder.struct().field("foo", Schema.INT32_SCHEMA).build();
+        final Schema keySchema = SchemaBuilder.struct().field("magic", fooSchema).build();
+        final Struct key = new Struct(keySchema).put("magic", new Struct(fooSchema).put("foo", 42));
+        final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
+
+        try {
+            xform.apply(record);
+            fail("Expected exception wasn't raised");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("Unknown field: FieldPath(path = [magic.nonexistent])", iae.getMessage());
         }
     }
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.transforms;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -25,12 +26,14 @@ import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,156 +138,587 @@ public class HeaderFromTest {
         }
     }
 
-    public static List<Arguments> data() {
+    public static List<Arguments> schemalessData() {
 
         List<Arguments> result = new ArrayList<>();
 
         for (Boolean testKeyTransform : asList(true, false)) {
             result.add(
-                Arguments.of(
-                    "basic copy",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
-                ));
+                    Arguments.of(
+                            "basic copy",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
             result.add(
-                Arguments.of(
-                    "basic move",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
-                    new RecordBuilder()
-                        // field1 got moved
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
-                ));
+                    Arguments.of(
+                            "basic move",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
             result.add(
-                Arguments.of(
-                    "copy with preexisting header",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
-                ));
+                    Arguments.of(
+                            "copy with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
             result.add(
-                Arguments.of(
-                    "move with preexisting header",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
-                    new RecordBuilder()
-                        // field1 got moved
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
-                ));
-            Schema schema = new SchemaBuilder(Schema.Type.STRUCT).field("foo", STRING_SCHEMA).build();
-            Struct struct = new Struct(schema).put("foo", "foo-value");
+                    Arguments.of(
+                            "move with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
+            Map<String, Object> struct = Collections.singletonMap("foo", "foo-value");
             result.add(
-                Arguments.of(
-                    "copy with struct value",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", schema, struct)
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
-                    new RecordBuilder()
-                        .withField("field1", schema, struct)
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", schema, struct)
-                ));
+                    Arguments.of(
+                            "copy with struct value",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", null, struct)
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", null, struct)
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", null, struct)
+                    ));
             result.add(
-                Arguments.of(
-                    "move with struct value",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", schema, struct)
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
-                    new RecordBuilder()
-                        // field1 got moved
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", schema, struct)
-                ));
+                    Arguments.of(
+                            "move with struct value",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", null, struct)
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", null, struct)
+                    ));
             result.add(
-                Arguments.of(
-                    "two headers from same field",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    // two headers from the same field
-                    asList("field1", "field1"), asList("inserted1", "inserted2"), HeaderFrom.Operation.MOVE,
-                    new RecordBuilder()
-                        // field1 got moved
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
-                        .addHeader("inserted2", STRING_SCHEMA, "field1-value")
-                ));
+                    Arguments.of(
+                            "two headers from same field",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("field1", "field1"), asList("inserted1", "inserted2"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                                    .addHeader("inserted2", STRING_SCHEMA, "field1-value")
+                    ));
             result.add(
-                Arguments.of(
-                    "two fields to same header",
-                    testKeyTransform,
-                    new RecordBuilder()
-                        .withField("field1", STRING_SCHEMA, "field1-value")
-                        .withField("field2", STRING_SCHEMA, "field2-value")
-                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    // two headers from the same field
-                    asList("field1", "field2"), asList("inserted1", "inserted1"), HeaderFrom.Operation.MOVE,
-                    new RecordBuilder()
-                        // field1 and field2 got moved
-                        .addHeader("header1", STRING_SCHEMA, "existing-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
-                        .addHeader("inserted1", STRING_SCHEMA, "field2-value")
-                ));
+                    Arguments.of(
+                            "two fields to same header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("field1", "field2"), asList("inserted1", "inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 and field2 got moved
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field2-value")
+                    ));
         }
         return result;
     }
 
-    private Map<String, Object> config(List<String> headers, List<String> transformFields, HeaderFrom.Operation operation) {
+    public static List<Arguments> structData() {
+
+        List<Arguments> result = new ArrayList<>();
+
+        for (Boolean testKeyTransform : asList(true, false)) {
+            result.add(
+                    Arguments.of(
+                            "basic copy",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "basic move",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "copy with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "move with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                    ));
+            Schema schema = new SchemaBuilder(Schema.Type.STRUCT).field("foo", STRING_SCHEMA).build();
+            Struct struct = new Struct(schema).put("foo", "foo-value");
+            result.add(
+                    Arguments.of(
+                            "copy with struct value",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", schema, struct)
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", schema, struct)
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", schema, struct)
+                    ));
+            result.add(
+                    Arguments.of(
+                            "move with struct value",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", schema, struct)
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("field1"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", schema, struct)
+                    ));
+            result.add(
+                    Arguments.of(
+                            "two headers from same field",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("field1", "field1"), asList("inserted1", "inserted2"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 got moved
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                                    .addHeader("inserted2", STRING_SCHEMA, "field1-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "two fields to same header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("field1", "field2"), asList("inserted1", "inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    // field1 and field2 got moved
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field2-value")
+                    ));
+        }
+        return result;
+    }
+
+    public static List<Arguments> nestedSchemalessData() {
+
+        List<Arguments> result = new ArrayList<>();
+
+        final Map<String, String> foo = new HashMap<>();
+        foo.put("bar", "bar-value");
+        foo.put("baz", "baz-value");
+        final Map<String, String> onlyBaz = singletonMap("baz", "baz-value");
+
+        for (Boolean testKeyTransform : asList(true, false)) {
+
+            result.add(
+                    Arguments.of(
+                            "basic copy",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "basic move",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar got moved
+                                    .withField("foo", null, onlyBaz)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "copy with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "move with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar got moved
+                                    .withField("foo", null, onlyBaz)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "two headers from same field",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("foo.bar", "foo.bar"), asList("inserted1", "inserted2"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar got moved
+                                    .withField("foo", null, onlyBaz)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                                    .addHeader("inserted2", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "two fields to same header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", null, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("foo.bar", "foo.baz"), asList("inserted1", "inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar and foo.baz got moved
+                                    .withField("foo", null, Collections.emptyMap())
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "baz-value")
+                    ));
+
+        }
+        return result;
+    }
+
+    public static List<Arguments> nestedStructData() {
+
+        List<Arguments> result = new ArrayList<>();
+
+        final Schema fooSchema = new SchemaBuilder(Type.STRUCT)
+                .field("bar", STRING_SCHEMA)
+                .field("baz", STRING_SCHEMA)
+                .build();
+        final Struct foo = new Struct(fooSchema)
+                .put("bar", "bar-value")
+                .put("baz", "baz-value");
+        final Schema onlyBazSchema = new SchemaBuilder(Type.STRUCT)
+                .field("baz", STRING_SCHEMA)
+                .build();
+        final Struct onlyBaz = new Struct(onlyBazSchema).put("baz", "baz-value");
+        final Schema emptySchema = new SchemaBuilder(Type.STRUCT).build();
+        final Struct empty = new Struct(emptySchema);
+
+        for (Boolean testKeyTransform : asList(true, false)) {
+            result.add(
+                    Arguments.of(
+                            "basic copy",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "basic move",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar got moved
+                                    .withField("foo", onlyBazSchema, onlyBaz)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "copy with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.COPY,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "move with preexisting header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                            singletonList("foo.bar"), singletonList("inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar got moved
+                                    .withField("foo", onlyBazSchema, onlyBaz)
+                                    .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "two headers from same field",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("foo.bar", "foo.bar"), asList("inserted1", "inserted2"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar got moved
+                                    .withField("foo", onlyBazSchema, onlyBaz)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                                    .addHeader("inserted2", STRING_SCHEMA, "bar-value")
+                    ));
+            result.add(
+                    Arguments.of(
+                            "two fields to same header",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    .withField("foo", fooSchema, foo)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            // two headers from the same field
+                            asList("foo.bar", "foo.baz"), asList("inserted1", "inserted1"),
+                            HeaderFrom.Operation.MOVE,
+                            new RecordBuilder()
+                                    .withField("field1", STRING_SCHEMA, "field1-value")
+                                    .withField("field2", STRING_SCHEMA, "field2-value")
+                                    // foo.bar and foo.baz got moved
+                                    .withField("foo", emptySchema, empty)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "bar-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "baz-value")
+                    ));
+
+        }
+        return result;
+    }
+
+    private Map<String, Object> config(List<String> headers, List<String> transformFields,
+            HeaderFrom.Operation operation) {
+        return config(headers, transformFields, operation, FieldSyntaxVersion.V1);
+    }
+
+    private Map<String, Object> config(List<String> headers, List<String> transformFields,
+            HeaderFrom.Operation operation, FieldSyntaxVersion version) {
         Map<String, Object> result = new HashMap<>();
         result.put(HeaderFrom.HEADERS_FIELD, headers);
         result.put(HeaderFrom.FIELDS_FIELD, transformFields);
         result.put(HeaderFrom.OPERATION_FIELD, operation.toString());
+        result.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, version.name());
         return result;
     }
 
     @ParameterizedTest
-    @MethodSource("data")
-    public void schemaless(String description,
-                           boolean keyTransform,
-                           RecordBuilder originalBuilder,
-                           List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
-                           RecordBuilder expectedBuilder) {
-        HeaderFrom<SourceRecord> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
+    @MethodSource("schemalessData")
+    public void schemaless(
+            String description,
+            boolean keyTransform,
+            RecordBuilder originalBuilder,
+            List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
+            RecordBuilder expectedBuilder
+    ) {
+        HeaderFrom<SourceRecord> xform =
+                keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
 
         xform.configure(config(headers1, transformFields, operation));
         ConnectHeaders headers = new ConnectHeaders();
@@ -296,15 +730,64 @@ public class HeaderFromTest {
         assertSameRecord(expectedRecord, xformed);
     }
 
+
     @ParameterizedTest
-    @MethodSource("data")
-    public void withSchema(String description,
-                           boolean keyTransform,
-                           RecordBuilder originalBuilder,
-                           List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
-                           RecordBuilder expectedBuilder) {
+    @MethodSource("nestedSchemalessData")
+    public void schemalessWithNestedData(
+            String description,
+            boolean keyTransform,
+            RecordBuilder originalBuilder,
+            List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
+            RecordBuilder expectedBuilder
+    ) {
+        HeaderFrom<SourceRecord> xform =
+                keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
+
+        xform.configure(config(headers1, transformFields, operation, FieldSyntaxVersion.V2));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+
+        SourceRecord originalRecord = originalBuilder.schemaless(keyTransform);
+        SourceRecord expectedRecord = expectedBuilder.schemaless(keyTransform);
+        SourceRecord xformed = xform.apply(originalRecord);
+        assertSameRecord(expectedRecord, xformed);
+    }
+
+    @ParameterizedTest
+    @MethodSource("structData")
+    public void withSchema(
+            String description,
+            boolean keyTransform,
+            RecordBuilder originalBuilder,
+            List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
+            RecordBuilder expectedBuilder
+    ) {
         HeaderFrom<SourceRecord> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
         xform.configure(config(headers1, transformFields, operation));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+        Headers expect = headers.duplicate();
+        for (int i = 0; i < headers1.size(); i++) {
+            expect.add(headers1.get(i), originalBuilder.fieldValues.get(i), originalBuilder.fieldSchemas.get(i));
+        }
+
+        SourceRecord originalRecord = originalBuilder.withSchema(keyTransform);
+        SourceRecord expectedRecord = expectedBuilder.withSchema(keyTransform);
+        SourceRecord xformed = xform.apply(originalRecord);
+        assertSameRecord(expectedRecord, xformed);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nestedStructData")
+    public void withNestedSchema(
+            String description,
+            boolean keyTransform,
+            RecordBuilder originalBuilder,
+            List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
+            RecordBuilder expectedBuilder
+    ) {
+        HeaderFrom<SourceRecord> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
+        xform.configure(config(headers1, transformFields, operation, FieldSyntaxVersion.V2));
         ConnectHeaders headers = new ConnectHeaders();
         headers.addString("existing", "existing-value");
         Headers expect = headers.duplicate();

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -26,9 +26,11 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -397,6 +399,15 @@ public class TimestampConverterTest {
     }
 
     @Test
+    public void testWithSchemaNullFieldToTimestampV2() {
+        testWithSchemaNullFieldConversionV2("Timestamp", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Timestamp", TimestampConverter.OPTIONAL_TIME_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Timestamp", TimestampConverter.OPTIONAL_DATE_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Timestamp", Schema.OPTIONAL_STRING_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Timestamp", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA);
+    }
+
+    @Test
     public void testWithSchemaNullValueToUnix() {
         testWithSchemaNullValueConversion("unix", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
         testWithSchemaNullValueConversion("unix", TimestampConverter.OPTIONAL_TIME_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
@@ -412,6 +423,15 @@ public class TimestampConverterTest {
         testWithSchemaNullFieldConversion("unix", TimestampConverter.OPTIONAL_DATE_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
         testWithSchemaNullFieldConversion("unix", Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
         testWithSchemaNullFieldConversion("unix", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
+    }
+
+    @Test
+    public void testWithSchemaNullFieldToUnixV2() {
+        testWithSchemaNullFieldConversionV2("unix", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
+        testWithSchemaNullFieldConversionV2("unix", TimestampConverter.OPTIONAL_TIME_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
+        testWithSchemaNullFieldConversionV2("unix", TimestampConverter.OPTIONAL_DATE_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
+        testWithSchemaNullFieldConversionV2("unix", Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
+        testWithSchemaNullFieldConversionV2("unix", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA);
     }
 
     @Test
@@ -433,6 +453,15 @@ public class TimestampConverterTest {
     }
 
     @Test
+    public void testWithSchemaNullFieldToTimeV2() {
+        testWithSchemaNullFieldConversionV2("Time", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Time", TimestampConverter.OPTIONAL_TIME_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Time", TimestampConverter.OPTIONAL_DATE_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Time", Schema.OPTIONAL_STRING_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Time", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, TimestampConverter.OPTIONAL_TIME_SCHEMA);
+    }
+
+    @Test
     public void testWithSchemaNullValueToDate() {
         testWithSchemaNullValueConversion("Date", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
         testWithSchemaNullValueConversion("Date", TimestampConverter.OPTIONAL_TIME_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
@@ -451,6 +480,15 @@ public class TimestampConverterTest {
     }
 
     @Test
+    public void testWithSchemaNullFieldToDateV2() {
+        testWithSchemaNullFieldConversionV2("Date", Schema.OPTIONAL_INT64_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Date", TimestampConverter.OPTIONAL_TIME_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Date", TimestampConverter.OPTIONAL_DATE_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Date", Schema.OPTIONAL_STRING_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
+        testWithSchemaNullFieldConversionV2("Date", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, TimestampConverter.OPTIONAL_DATE_SCHEMA);
+    }
+
+    @Test
     public void testWithSchemaNullValueToString() {
         testWithSchemaNullValueConversion("string", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
         testWithSchemaNullValueConversion("string", TimestampConverter.OPTIONAL_TIME_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
@@ -466,6 +504,15 @@ public class TimestampConverterTest {
         testWithSchemaNullFieldConversion("string", TimestampConverter.OPTIONAL_DATE_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
         testWithSchemaNullFieldConversion("string", Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
         testWithSchemaNullFieldConversion("string", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+    }
+
+    @Test
+    public void testWithSchemaNullFieldToStringV2() {
+        testWithSchemaNullFieldConversionV2("string", Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+        testWithSchemaNullFieldConversionV2("string", TimestampConverter.OPTIONAL_TIME_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+        testWithSchemaNullFieldConversionV2("string", TimestampConverter.OPTIONAL_DATE_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+        testWithSchemaNullFieldConversionV2("string", Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+        testWithSchemaNullFieldConversionV2("string", TimestampConverter.OPTIONAL_TIMESTAMP_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
     }
 
     private void testWithSchemaNullValueConversion(String targetType, Schema originalSchema, Schema expectedSchema) {
@@ -510,6 +557,42 @@ public class TimestampConverterTest {
         assertNull(transformed.value());
     }
 
+    private void testWithSchemaNullFieldConversionV2(String targetType, Schema originalSchema, Schema expectedSchema) {
+        Map<String, String> config = new HashMap<>();
+        config.put(TimestampConverter.TARGET_TYPE_CONFIG, targetType);
+        config.put(TimestampConverter.FORMAT_CONFIG, STRING_DATE_FMT);
+        config.put(TimestampConverter.FIELD_CONFIG, "foo.ts");
+        config.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        xformValue.configure(config);
+        SchemaBuilder structSchema = SchemaBuilder.struct()
+                .field("ts", originalSchema)
+                .field("other", Schema.STRING_SCHEMA);
+        SchemaBuilder fooSchema = SchemaBuilder.struct().field("foo", structSchema);
+
+        SchemaBuilder expectedStructSchema = SchemaBuilder.struct()
+                .field("ts", expectedSchema)
+                .field("other", Schema.STRING_SCHEMA);
+        SchemaBuilder expectedFooSchema = SchemaBuilder.struct().field("foo", expectedStructSchema.build());
+
+        Struct original = new Struct(structSchema);
+        original.put("ts", null);
+        original.put("other", "test");
+        Struct foo = new Struct(fooSchema);
+        foo.put("foo", original);
+
+        // Struct field is null
+        SourceRecord transformed = xformValue.apply(createRecordWithSchema(fooSchema.build(), foo));
+
+        assertEquals(expectedFooSchema.build(), transformed.valueSchema());
+        assertNull(requireStruct(transformed.value(), "").getStruct("foo").get("ts"));
+
+        // entire Struct is null
+        transformed = xformValue.apply(createRecordWithSchema(fooSchema.optional().build(), null));
+
+        assertEquals(expectedFooSchema.optional().build(), transformed.valueSchema());
+        assertNull(transformed.value());
+    }
+
     // Convert field instead of entire key/value
 
     @Test
@@ -524,6 +607,23 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(Collections.singletonMap("ts", DATE.getTime()), transformed.value());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSchemalessFieldConversionV2() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Date");
+        config.put(TimestampConverter.FIELD_CONFIG, "foo.ts");
+        config.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        xformValue.configure(config);
+
+        Object value = Collections.singletonMap("ts", DATE_PLUS_TIME.getTime());
+        Object foo = Collections.singletonMap("foo", value);
+        SourceRecord transformed = xformValue.apply(createRecordSchemaless(foo));
+
+        assertNull(transformed.valueSchema());
+        assertEquals(Collections.singletonMap("ts", DATE.getTime()), ((Map<String, Object>) transformed.value()).get("foo"));
     }
 
     @Test
@@ -551,6 +651,38 @@ public class TimestampConverterTest {
         assertEquals(expectedSchema, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), ((Struct) transformed.value()).get("ts"));
         assertEquals("test", ((Struct) transformed.value()).get("other"));
+    }
+
+    @Test
+    public void testWithSchemaFieldConversionV2() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
+        config.put(TimestampConverter.FIELD_CONFIG, "foo.ts");
+        config.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        xformValue.configure(config);
+
+        // ts field is a unix timestamp
+        Schema structWithTimestampFieldSchema = SchemaBuilder.struct()
+                .field("ts", Schema.INT64_SCHEMA)
+                .field("other", Schema.STRING_SCHEMA)
+                .build();
+        SchemaBuilder fooSchema = SchemaBuilder.struct().field("foo", structWithTimestampFieldSchema);
+
+        Struct original = new Struct(structWithTimestampFieldSchema);
+        original.put("ts", DATE_PLUS_TIME_UNIX);
+        original.put("other", "test");
+        Struct foo = new Struct(fooSchema).put("foo", original);
+
+        SourceRecord transformed = xformValue.apply(createRecordWithSchema(fooSchema, foo));
+
+        Schema expectedSchema = SchemaBuilder.struct()
+                .field("ts", Timestamp.SCHEMA)
+                .field("other", Schema.STRING_SCHEMA)
+                .build();
+        Schema expectedFooSchema = SchemaBuilder.struct().field("foo", expectedSchema).build();
+        assertEquals(expectedFooSchema, transformed.valueSchema());
+        assertEquals(DATE_PLUS_TIME.getTime(), ((Struct) transformed.value()).getStruct("foo").get("ts"));
+        assertEquals("test", ((Struct) transformed.value()).getStruct("foo").get("other"));
     }
 
     @Test
@@ -669,6 +801,40 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME_UNIX_SECONDS, transformed.value());
+    }
+
+
+    @Test
+    public void testWithSchemaFieldConversionWithDefaultValueV2() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
+        config.put(TimestampConverter.FIELD_CONFIG, "foo.ts");
+        config.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        xformValue.configure(config);
+
+        Instant now = Instant.now();
+        // ts field is a unix timestamp
+        Schema structWithTimestampFieldSchema = SchemaBuilder.struct()
+                .field("ts", SchemaBuilder.int64().defaultValue(now.toEpochMilli()).build())
+                .field("other", Schema.STRING_SCHEMA)
+                .build();
+        SchemaBuilder fooSchema = SchemaBuilder.struct().field("foo", structWithTimestampFieldSchema);
+
+        Struct original = new Struct(structWithTimestampFieldSchema);
+        original.put("ts", DATE_PLUS_TIME_UNIX);
+        original.put("other", "test");
+        Struct foo = new Struct(fooSchema).put("foo", original);
+
+        SourceRecord transformed = xformValue.apply(createRecordWithSchema(fooSchema, foo));
+
+        Schema expectedSchema = SchemaBuilder.struct()
+                .field("ts", Timestamp.builder().defaultValue(java.util.Date.from(now)).build())
+                .field("other", Schema.STRING_SCHEMA)
+                .build();
+        Schema expectedFooSchema = SchemaBuilder.struct().field("foo", expectedSchema).build();
+        assertEquals(expectedFooSchema, transformed.valueSchema());
+        assertEquals(DATE_PLUS_TIME.getTime(), ((Struct) transformed.value()).getStruct("foo").get("ts"));
+        assertEquals("test", ((Struct) transformed.value()).getStruct("foo").get("other"));
     }
 
     // Validate Key implementation in addition to Value

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/MultiFieldPathsTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/MultiFieldPathsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MultiFieldPathsTest {
+    @Test void shouldBuildPathWithSinglePathV1() {
+        SingleFieldPath path = new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V1);
+        MultiFieldPaths paths = createMultiFieldPaths(path);
+        assertEquals(1, paths.pathTree.size());
+        assertEquals(path, paths.pathTree.get("foo.bar.baz"));
+    }
+
+    @Test void shouldBuildPathWithSamePathV1() {
+        SingleFieldPath path = new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V1);
+        MultiFieldPaths paths = createMultiFieldPaths(path, path);
+        assertEquals(1, paths.pathTree.size());
+        assertEquals(path, paths.pathTree.get("foo.bar.baz"));
+    }
+
+    @Test void shouldBuildPathWithSinglePathV2() {
+        SingleFieldPath path = new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V2);
+        MultiFieldPaths paths = createMultiFieldPaths(path);
+        assertEquals(1, paths.pathTree.size());
+        assertEquals(path, ((Map<?, ?>) ((Map<?, ?>) paths.pathTree.get("foo")).get("bar")).get("baz"));
+    }
+
+    @Test void shouldKeepOverlappingPaths() {
+        SingleFieldPath foo = new SingleFieldPath("foo", FieldSyntaxVersion.V2);
+        SingleFieldPath foobar = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        MultiFieldPaths path = createMultiFieldPaths(
+            foo,
+            foobar
+        );
+        assertEquals(1, path.pathTree.size());
+        assertEquals(2, ((Map<?, ?>) path.pathTree.get("foo")).size());
+        assertEquals(foo, ((Map<?, ?>) path.pathTree.get("foo")).get(""));
+        assertEquals(foobar, ((Map<?, ?>) path.pathTree.get("foo")).get("bar"));
+    }
+
+    @Test void shouldRenameSchemaV1Fields() {
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", Schema.STRING_SCHEMA)
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA)
+                .build();
+
+        MultiFieldPaths fieldPath = MultiFieldPaths.of(Arrays.asList("foo", "bar"), FieldSyntaxVersion.V1);
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                updated,
+                (builder, field, path) -> builder.field(field.name() + "_other", field.schema())
+        );
+
+        assertEquals(3, result.fields().size());
+        assertEquals("foo_other", result.fields().get(0).name());
+        assertEquals("bar_other", result.fields().get(1).name());
+        assertEquals("baz", result.fields().get(2).name());
+    }
+
+    @Test void shouldRenameSchemaV2Fields() {
+        SchemaBuilder nested = SchemaBuilder.struct()
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", nested)
+                .build();
+
+        MultiFieldPaths fieldPath = MultiFieldPaths.of(Arrays.asList("foo.baz", "foo.bar"), FieldSyntaxVersion.V2);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                (builder, field, path) -> builder.field(field.name() + "_other", field.schema())
+        );
+
+        assertEquals(1, result.fields().size());
+        assertEquals(2, result.field("foo").schema().fields().size());
+        assertEquals("bar_other", result.field("foo").schema().fields().get(0).name());
+        assertEquals("baz_other", result.field("foo").schema().fields().get(1).name());
+    }
+
+    @Test void shouldUpdateValuesV1FromSchemaless() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("foo", 42);
+        value.put("bar", 21);
+
+        SingleFieldPath fooPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        SingleFieldPath barPath = new SingleFieldPath("bar", FieldSyntaxVersion.V1);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(fooPath, barPath);
+        Map<String, Object> updated = fieldPaths.updateValuesFrom(
+                value,
+                (orig, map, f, k) -> map.put(k, ((Integer) orig.get(k)) * 2)
+        );
+
+        Map<SingleFieldPath, Map.Entry<String, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(fooPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    @Test void shouldUpdateNestedValuesV2FromSchemaless() {
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("bar", 21);
+        nested.put("baz", 42);
+        Map<String, Object> value = Collections.singletonMap("foo", nested);
+
+        SingleFieldPath barPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        SingleFieldPath bazPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(bazPath, barPath);
+        Map<String, Object> updated = fieldPaths.updateValuesFrom(
+                value,
+                (orig, map, f, k) -> map.put(k, ((Integer) orig.get(k)) * 2)
+        );
+
+        Map<SingleFieldPath, Map.Entry<String, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(bazPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    @Test void shouldUpdateValueV1WithSchema() {
+        Schema schema = SchemaBuilder.struct()
+                .field("foo.bar", Schema.INT32_SCHEMA)
+                .field("foo.baz", Schema.INT32_SCHEMA)
+                .build();
+        Struct value = new Struct(schema)
+                .put("foo.bar", 21)
+                .put("foo.baz", 42);
+
+        SingleFieldPath bazPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V1);
+        SingleFieldPath barPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V1);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(bazPath, barPath);
+        Struct updated = fieldPaths.updateValuesFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        Map<SingleFieldPath, Map.Entry<Field, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(bazPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    @Test void shouldUpdateNestedValueV2WithSchema() {
+        SchemaBuilder nestedSchema = SchemaBuilder.struct()
+                .field("bar", Schema.INT32_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", nestedSchema)
+                .build();
+        Struct nested = new Struct(nestedSchema)
+                .put("bar", 21)
+                .put("baz", 42);
+        Struct value = new Struct(schema).put("foo", nested);
+
+        SingleFieldPath bazPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        SingleFieldPath barPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(bazPath, barPath);
+        Struct updated = fieldPaths.updateValuesFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        Map<SingleFieldPath, Map.Entry<Field, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(bazPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    static MultiFieldPaths createMultiFieldPaths(SingleFieldPath... fields) {
+        return new MultiFieldPaths(new HashSet<>(Arrays.asList(fields)));
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -196,4 +196,24 @@ class SingleFieldPathTest {
 
         assertEquals(84, fieldPath.valueFrom(updated));
     }
+
+    @Test
+    void shouldIncludeEmptyFieldNames() {
+        assertArrayEquals(
+            new String[] {"", "", ""},
+            new SingleFieldPath("..", FieldSyntaxVersion.V2).path()
+        );
+        assertArrayEquals(
+            new String[] {"foo", "", ""},
+            new SingleFieldPath("foo..", FieldSyntaxVersion.V2).path()
+        );
+        assertArrayEquals(
+            new String[] {"", "bar", ""},
+            new SingleFieldPath(".bar.", FieldSyntaxVersion.V2).path()
+        );
+        assertArrayEquals(
+            new String[] {"", "", "baz"},
+            new SingleFieldPath("..baz", FieldSyntaxVersion.V2).path()
+        );
+    }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -18,9 +18,11 @@ package org.apache.kafka.connect.transforms.field;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
 import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -215,5 +217,14 @@ class SingleFieldPathTest {
             new String[] {"", "", "baz"},
             new SingleFieldPath("..baz", FieldSyntaxVersion.V2).path()
         );
+    }
+
+    @Test void shouldReturnNullFieldWhenFieldNotFound() {
+        SchemaBuilder barSchema = SchemaBuilder.struct().field("bar", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct().field("foo", barSchema).build();
+
+        assertNull(new SingleFieldPath("un.known", FieldSyntaxVersion.V2).fieldFrom(schema));
+        assertNull(new SingleFieldPath("foo.unknown", FieldSyntaxVersion.V2).fieldFrom(schema));
+        assertNull(new SingleFieldPath("unknown", FieldSyntaxVersion.V2).fieldFrom(schema));
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -227,4 +227,14 @@ class SingleFieldPathTest {
         assertNull(new SingleFieldPath("foo.unknown", FieldSyntaxVersion.V2).fieldFrom(schema));
         assertNull(new SingleFieldPath("unknown", FieldSyntaxVersion.V2).fieldFrom(schema));
     }
+
+    @Test void shouldReturnNullValueWhenFieldNotFound() {
+        SchemaBuilder barSchema = SchemaBuilder.struct().field("bar", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct().field("foo", barSchema).build();
+        Struct struct = new Struct(schema).put("foo", new Struct(barSchema).put("bar", 42));
+
+        assertNull(new SingleFieldPath("un.known", FieldSyntaxVersion.V2).valueFrom(struct));
+        assertNull(new SingleFieldPath("foo.unknown", FieldSyntaxVersion.V2).valueFrom(struct));
+        assertNull(new SingleFieldPath("unknown", FieldSyntaxVersion.V2).valueFrom(struct));
+    }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -60,11 +60,15 @@ class SingleFieldPathTest {
     }
 
     @Test void shouldBuildV2AndIgnoreBackticksThatAreNotWrapping() {
+        assertArrayEquals(new String[] {"foo", "`bar.baz"}, new SingleFieldPath("foo.``bar.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar.baz`"}, new SingleFieldPath("foo.`bar.baz``", FieldSyntaxVersion.V2).path());
         assertArrayEquals(new String[] {"foo", "ba`r.baz"}, new SingleFieldPath("foo.`ba`r.baz`", FieldSyntaxVersion.V2).path());
         assertArrayEquals(new String[] {"foo", "ba`r", "baz"}, new SingleFieldPath("foo.ba`r.baz", FieldSyntaxVersion.V2).path());
     }
 
     @Test void shouldBuildV2AndEscapeBackticks() {
+        assertArrayEquals(new String[] {"foo", "bar`.baz"}, new SingleFieldPath("foo.`bar\\`.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar.`baz"}, new SingleFieldPath("foo.`bar.\\`baz`", FieldSyntaxVersion.V2).path());
         assertArrayEquals(new String[] {"foo", "bar`.`baz"}, new SingleFieldPath("foo.`bar\\`.\\`baz`", FieldSyntaxVersion.V2).path());
         assertArrayEquals(new String[] {"foo", "bar\\`.`baz"}, new SingleFieldPath("foo.`bar\\\\`.\\`baz`", FieldSyntaxVersion.V2).path());
     }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.junit.jupiter.api.Test;
+
+class SingleFieldPathTest {
+    final static String[] EMPTY_PATH = new String[]{};
+
+    @Test void shouldBuildV1WithDotsAndBacktickPair() {
+        assertArrayEquals(
+                new String[] {"foo.bar.baz"},
+                new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V1).path());
+        assertArrayEquals(
+                new String[] {"foo.`bar.baz`"},
+                new SingleFieldPath("foo.`bar.baz`", FieldSyntaxVersion.V1).path());
+    }
+
+    @Test void shouldBuildV2WithEmptyPath() {
+        assertArrayEquals(EMPTY_PATH, new SingleFieldPath("", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldBuildV2WithoutDots() {
+        assertArrayEquals(new String[] {"foobarbaz"}, new SingleFieldPath("foobarbaz", FieldSyntaxVersion.V2).path());
+    }
+    @Test void shouldBuildV2WithoutWrappingBackticks() {
+        assertArrayEquals(new String[] {"foo`bar`baz"}, new SingleFieldPath("foo`bar`baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldBuildV2WhenIncludesDots() {
+        assertArrayEquals(new String[] {"foo", "bar", "baz"}, new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldBuildV2WhenIncludesDotsAndBacktickPair() {
+        assertArrayEquals(new String[] {"foo", "bar.baz"}, new SingleFieldPath("foo.`bar.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar", "baz"}, new SingleFieldPath("foo.`bar`.baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldBuildV2AndIgnoreBackticksThatAreNotWrapping() {
+        assertArrayEquals(new String[] {"foo", "ba`r.baz"}, new SingleFieldPath("foo.`ba`r.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "ba`r", "baz"}, new SingleFieldPath("foo.ba`r.baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldBuildV2AndEscapeBackticks() {
+        assertArrayEquals(new String[] {"foo", "bar`.`baz"}, new SingleFieldPath("foo.`bar\\`.\\`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar\\`.`baz"}, new SingleFieldPath("foo.`bar\\\\`.\\`baz`", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldBuildV2WithBackticksWrappingBackticks() {
+        assertArrayEquals(new String[] {"foo", "`bar`", "baz"}, new SingleFieldPath("foo.`\\`bar\\``.baz", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"`foo.bar.baz`"}, new SingleFieldPath("`\\`foo.bar.baz\\``", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test void shouldFilterSchemaV1Fields() {
+        Schema schema = SchemaBuilder.struct().field("foo", Schema.STRING_SCHEMA)
+            .field("bar", Schema.STRING_SCHEMA)
+            .field("baz", Schema.INT32_SCHEMA)
+            .build();
+
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        Schema result = new SingleFieldPath("foo", FieldSyntaxVersion.V1)
+            .updateSchemaFrom(schema, updated, (builder, field, path) -> {
+                // ignore field
+            });
+
+        assertEquals(2, result.fields().size());
+        assertEquals("bar", result.fields().get(0).name());
+        assertEquals("baz", result.fields().get(1).name());
+    }
+    @Test void shouldFilterSchemaV2Fields() {
+        Schema schema = SchemaBuilder.struct().field("foo",
+            SchemaBuilder.struct().field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA))
+            .build();
+
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                updated, (builder, field, path) -> {
+                        // ignore field
+                });
+
+        assertEquals(1, result.fields().size());
+        assertEquals(1, result.field("foo").schema().fields().size());
+        assertEquals("bar", result.field("foo").schema().fields().get(0).name());
+    }
+
+    @Test void shouldRenameSchemaV1Fields() {
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", Schema.STRING_SCHEMA)
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA)
+                .build();
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                (builder, field, path) -> builder.field("other", field.schema())
+        );
+
+        assertEquals(3, result.fields().size());
+        assertEquals("other", result.fields().get(0).name());
+        assertEquals("bar", result.fields().get(1).name());
+        assertEquals("baz", result.fields().get(2).name());
+    }
+
+    @Test void shouldRenameSchemaV2Fields() {
+        SchemaBuilder nested = SchemaBuilder.struct()
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", nested)
+                .build();
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                (builder, field, path) -> builder.field("other", field.schema())
+        );
+
+        assertEquals(1, result.fields().size());
+        assertEquals(2, result.field("foo").schema().fields().size());
+        assertEquals("bar", result.field("foo").schema().fields().get(0).name());
+        assertEquals("other", result.field("foo").schema().fields().get(1).name());
+    }
+
+    @Test void shouldUpdateValueV1FromSchemaless() {
+        Map<String, Object> value = Collections.singletonMap("foo", 42);
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        Map<String, Object> updated = fieldPath
+            .updateValueFrom(value, (orig, map, f, k) -> map.put(k, ((Integer) orig.get(k)) * 2));
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test void shouldUpdateNestedValueV2FromSchemaless() {
+        Map<String, Object> value = Collections.singletonMap("foo", Collections.singletonMap("bar", 42));
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        Map<String, Object> updated = fieldPath.updateValueFrom(
+                value,
+                (original, map, f, k) -> map.put(k, ((Integer) original.get(k)) * 2)
+        );
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test void shouldUpdateValueV1WithSchema() {
+        Schema schema = SchemaBuilder.struct().field("foo", Schema.INT32_SCHEMA).build();
+        Struct value = new Struct(schema).put("foo", 42);
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        Struct updated = fieldPath.updateValueFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test void shouldUpdateNestedValueV2WithSchema() {
+        SchemaBuilder barSchema = SchemaBuilder.struct().field("bar", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct().field("foo", barSchema).build();
+        Struct value = new Struct(schema).put("foo", new Struct(barSchema).put("bar", 42));
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        Struct updated = fieldPath.updateValueFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -70,14 +70,15 @@ class SingleFieldPathTest {
 
     @Test void shouldBuildV2AndEscapeBackticks() {
         assertArrayEquals(new String[] {"foo", "bar`.baz"}, new SingleFieldPath("foo.`bar\\`.baz`", FieldSyntaxVersion.V2).path());
-        assertArrayEquals(new String[] {"foo", "bar.`baz"}, new SingleFieldPath("foo.`bar.\\`baz`", FieldSyntaxVersion.V2).path());
-        assertArrayEquals(new String[] {"foo", "bar`.`baz"}, new SingleFieldPath("foo.`bar\\`.\\`baz`", FieldSyntaxVersion.V2).path());
-        assertArrayEquals(new String[] {"foo", "bar\\`.`baz"}, new SingleFieldPath("foo.`bar\\\\`.\\`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar.`baz"}, new SingleFieldPath("foo.`bar.`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar`.`baz"}, new SingleFieldPath("foo.`bar\\`.`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar\\`.`baz"}, new SingleFieldPath("foo.`bar\\\\`.`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar`.\\`baz"}, new SingleFieldPath("foo.`bar\\`.\\`baz`", FieldSyntaxVersion.V2).path());
     }
 
     @Test void shouldBuildV2WithBackticksWrappingBackticks() {
-        assertArrayEquals(new String[] {"foo", "`bar`", "baz"}, new SingleFieldPath("foo.`\\`bar\\``.baz", FieldSyntaxVersion.V2).path());
-        assertArrayEquals(new String[] {"`foo.bar.baz`"}, new SingleFieldPath("`\\`foo.bar.baz\\``", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "`bar`", "baz"}, new SingleFieldPath("foo.``bar``.baz", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"`foo.bar.baz`"}, new SingleFieldPath("``foo.bar.baz``", FieldSyntaxVersion.V2).path());
     }
 
     @Test void shouldFilterSchemaV1Fields() {


### PR DESCRIPTION
[KIP-821](https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures) implementation.

Includes the following changes:

- Introduces a new modules inside `o.a.k.connect.transforms`: `fields`
- FieldPath interface and 2 implementations: `SingleFieldPath` and `MultiFieldPaths`
- Utils to hold and update Map, Struct and Schema values.
- Add support for nested fields to the following SMTs:
  - ExtractField
  - HeaderFrom
  - MaskField
  - TimestampConverter

> Added some SMTs to the same PR to show how the FieldPath is used, instead of separate PRs that will make this harder to appreciate.

Upcoming SMTs will be updated in following PRs to complete the scope of KIP-821.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
