### PR TITLE
KAFKA-10199: Register and unregister changelog topics in state updater

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -133,6 +133,11 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
+    public ProcessorStateManager stateManager() {
+        return stateMgr;
+    }
+
+    @Override
     public void revive() {
         if (state == CLOSED) {
             clearTaskTimeout();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -65,6 +65,7 @@ class ActiveTaskCreator {
     private final StreamsProducer threadProducer;
     private final Map<TaskId, StreamsProducer> taskProducers;
     private final ProcessingMode processingMode;
+    private final boolean stateUpdaterEnabled;
 
     ActiveTaskCreator(final TopologyMetadata topologyMetadata,
                       final StreamsConfig applicationConfig,
@@ -76,7 +77,8 @@ class ActiveTaskCreator {
                       final KafkaClientSupplier clientSupplier,
                       final String threadId,
                       final UUID processId,
-                      final Logger log) {
+                      final Logger log,
+                      final boolean stateUpdaterEnabled) {
         this.topologyMetadata = topologyMetadata;
         this.applicationConfig = applicationConfig;
         this.streamsMetrics = streamsMetrics;
@@ -87,6 +89,7 @@ class ActiveTaskCreator {
         this.clientSupplier = clientSupplier;
         this.threadId = threadId;
         this.log = log;
+        this.stateUpdaterEnabled = stateUpdaterEnabled;
 
         createTaskSensor = ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
         processingMode = processingMode(applicationConfig);
@@ -154,8 +157,8 @@ class ActiveTaskCreator {
                 stateDirectory,
                 storeChangelogReader,
                 topology.storeToChangelogTopic(),
-                partitions
-            );
+                partitions,
+                stateUpdaterEnabled);
 
             final InternalProcessorContext<Object, Object> context = new ProcessorContextImpl(
                 taskId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogRegister.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogRegister.java
@@ -33,7 +33,7 @@ public interface ChangelogRegister {
      */
     void register(final TopicPartition partition, final ProcessorStateManager stateManager);
 
-    void register(final Set<TopicPartition> partition, final ProcessorStateManager stateManager);
+    void register(final Set<TopicPartition> partitions, final ProcessorStateManager stateManager);
 
     /**
      * Unregisters and removes the passed in partitions from the set of changelogs

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogRegister.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogRegister.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.Collection;
+import java.util.Set;
+
 import org.apache.kafka.common.TopicPartition;
 
 /**
@@ -30,6 +32,8 @@ public interface ChangelogRegister {
      * @param stateManager the state manager used for restoring (one per task)
      */
     void register(final TopicPartition partition, final ProcessorStateManager stateManager);
+
+    void register(final Set<TopicPartition> partition, final ProcessorStateManager stateManager);
 
     /**
      * Unregisters and removes the passed in partitions from the set of changelogs

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
@@ -217,4 +217,9 @@ public class ReadOnlyTask implements Task {
     public Optional<Long> timeCurrentIdlingStarted() {
         throw new UnsupportedOperationException("This task is read-only");
     }
+
+    @Override
+    public ProcessorStateManager stateManager() {
+        throw new UnsupportedOperationException("This task is read-only");
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -43,6 +43,7 @@ class StandbyTaskCreator {
     private final ThreadCache dummyCache;
     private final Logger log;
     private final Sensor createTaskSensor;
+    private final boolean stateUpdaterEnabled;
 
     StandbyTaskCreator(final TopologyMetadata topologyMetadata,
                        final StreamsConfig applicationConfig,
@@ -50,13 +51,15 @@ class StandbyTaskCreator {
                        final StateDirectory stateDirectory,
                        final ChangelogReader storeChangelogReader,
                        final String threadId,
-                       final Logger log) {
+                       final Logger log,
+                       final boolean stateUpdaterEnabled) {
         this.topologyMetadata = topologyMetadata;
         this.applicationConfig = applicationConfig;
         this.streamsMetrics = streamsMetrics;
         this.stateDirectory = stateDirectory;
         this.storeChangelogReader = storeChangelogReader;
         this.log = log;
+        this.stateUpdaterEnabled = stateUpdaterEnabled;
 
         createTaskSensor = ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
 
@@ -85,8 +88,8 @@ class StandbyTaskCreator {
                     stateDirectory,
                     storeChangelogReader,
                     topology.storeToChangelogTopic(),
-                    partitions
-                );
+                    partitions,
+                    stateUpdaterEnabled);
 
                 final InternalProcessorContext<Object, Object> context = new ProcessorContextImpl(
                     taskId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -347,6 +348,12 @@ public class StoreChangelogReader implements ChangelogReader {
         }
     }
 
+    public void register(final Set<TopicPartition> changelogPartitions, final ProcessorStateManager stateManager) {
+        for (final TopicPartition changelogPartition : changelogPartitions) {
+            register(changelogPartition, stateManager);
+        }
+    }
+
     private ChangelogMetadata restoringChangelogByPartition(final TopicPartition partition) {
         final ChangelogMetadata changelogMetadata = changelogs.get(partition);
         if (changelogMetadata == null) {
@@ -444,6 +451,8 @@ public class StoreChangelogReader implements ChangelogReader {
                 final Set<TaskId> corruptedTasks = new HashSet<>();
                 e.partitions().forEach(partition -> corruptedTasks.add(changelogs.get(partition).stateManager.taskId()));
                 throw new TaskCorruptedException(corruptedTasks, e);
+            } catch (final InterruptException interruptException) {
+                throw interruptException;
             } catch (final KafkaException e) {
                 throw new StreamsException("Restore consumer get unexpected error polling records.", e);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -348,6 +348,7 @@ public class StoreChangelogReader implements ChangelogReader {
         }
     }
 
+    @Override
     public void register(final Set<TopicPartition> changelogPartitions, final ProcessorStateManager stateManager) {
         for (final TopicPartition changelogPartition : changelogPartitions) {
             register(changelogPartition, stateManager);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -215,6 +215,8 @@ public interface Task {
 
     State state();
 
+    ProcessorStateManager stateManager();
+
     default boolean needsInitializationOrRestoration() {
         return state() == State.CREATED || state() == State.RESTORING;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -169,7 +169,7 @@ class Tasks implements TasksRegistry {
 
     private boolean containsTaskIdWithAction(final TaskId taskId, final Action action) {
         final PendingUpdateAction pendingUpdateAction = pendingUpdateActions.get(taskId);
-        return !(pendingUpdateAction == null || pendingUpdateAction.getAction() != action);
+        return pendingUpdateAction != null && pendingUpdateAction.getAction() == action;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -504,8 +504,8 @@ public class ActiveTaskCreatorTest {
             mockClientSupplier,
             "clientId-StreamThread-0",
             uuid,
-            new LogContext().logger(ActiveTaskCreator.class)
-        );
+            new LogContext().logger(ActiveTaskCreator.class),
+            false);
 
         assertThat(
             activeTaskCreator.createTasks(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
@@ -39,6 +39,13 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
+    public void register(final Set<TopicPartition> changelogPartitions, final ProcessorStateManager stateManager) {
+        for (final TopicPartition changelogPartition : changelogPartitions) {
+            register(changelogPartition, stateManager);
+        }
+    }
+
+    @Override
     public void restore(final Map<TaskId, Task> tasks) {
         // do nothing
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -210,7 +210,8 @@ public class ProcessorStateManagerTest {
                 mkEntry(persistentStoreTwoName, persistentStoreTwoTopicName),
                 mkEntry(nonPersistentStoreName, nonPersistentStoreTopicName)
             ),
-            mkSet(persistentStorePartition, nonPersistentStorePartition));
+            mkSet(persistentStorePartition, nonPersistentStorePartition),
+            false);
 
         assertTrue(stateMgr.changelogAsSource(persistentStorePartition));
         assertTrue(stateMgr.changelogAsSource(nonPersistentStorePartition));
@@ -229,7 +230,8 @@ public class ProcessorStateManagerTest {
                 mkEntry(persistentStoreName, persistentStoreTopicName),
                 mkEntry(persistentStoreTwoName, persistentStoreTopicName)
             ),
-            Collections.emptySet());
+            Collections.emptySet(),
+            false);
 
         stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
         stateMgr.registerStore(persistentStoreTwo, persistentStore.stateRestoreCallback, null);
@@ -403,7 +405,8 @@ public class ProcessorStateManagerTest {
             stateDirectory,
             changelogReader,
             emptyMap(),
-            emptySet());
+            emptySet(),
+            false);
 
         try {
             stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
@@ -675,7 +678,8 @@ public class ProcessorStateManagerTest {
             stateDirectory,
             changelogReader,
             emptyMap(),
-            emptySet());
+            emptySet(),
+            false);
 
         try {
             stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
@@ -1179,7 +1183,8 @@ public class ProcessorStateManagerTest {
                 mkEntry(persistentStoreTwoName, persistentStoreTwoTopicName),
                 mkEntry(nonPersistentStoreName, nonPersistentStoreTopicName)
             ),
-            emptySet());
+            emptySet(),
+            false);
     }
 
     private ProcessorStateManager getStateManager(final Task.TaskType taskType) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -3020,7 +3020,8 @@ public class StreamThreadTest {
             stateDirectory,
             new MockChangelogReader(),
             CLIENT_ID,
-            log);
+            log,
+            false);
         return standbyTaskCreator.createTasks(singletonMap(new TaskId(1, 2), emptySet()));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -416,7 +416,9 @@ public class StreamThreadStateStoreProviderTest {
                 clientSupplier.adminClient,
                 clientSupplier.restoreConsumer,
                 new MockStateRestoreListener()),
-            topology.storeToChangelogTopic(), partitions);
+            topology.storeToChangelogTopic(),
+            partitions,
+            false);
         final RecordCollector recordCollector = new RecordCollectorImpl(
             logContext,
             taskId,

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.StandbyTask;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -318,6 +319,7 @@ public final class StreamsTestUtils {
                                               final Set<TopicPartition> changelogPartitions) {
             when(task.changelogPartitions()).thenReturn(changelogPartitions);
             when(task.id()).thenReturn(taskId);
+            when(task.stateManager()).thenReturn(mock(ProcessorStateManager.class));
         }
 
         public TaskBuilder<T> inState(final Task.State state) {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -65,7 +65,6 @@ import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
-import org.apache.kafka.streams.processor.internals.StateManager;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamsProducer;
 import org.apache.kafka.streams.processor.internals.Task;

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -65,6 +65,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
+import org.apache.kafka.streams.processor.internals.StateManager;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamsProducer;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -489,8 +490,8 @@ public class TopologyTestDriver implements Closeable {
                 stateDirectory,
                 new MockChangelogRegister(),
                 processorTopology.storeToChangelogTopic(),
-                new HashSet<>(partitionsByInputTopic.values())
-            );
+                new HashSet<>(partitionsByInputTopic.values()),
+                false);
             final RecordCollector recordCollector = new RecordCollectorImpl(
                 logContext,
                 TASK_ID,
@@ -1126,6 +1127,13 @@ public class TopologyTestDriver implements Closeable {
         @Override
         public void register(final TopicPartition partition, final ProcessorStateManager stateManager) {
             restoringPartitions.add(partition);
+        }
+
+        @Override
+        public void register(final Set<TopicPartition> changelogPartitions, final ProcessorStateManager stateManager) {
+            for (final TopicPartition changelogPartition : changelogPartitions) {
+                register(changelogPartition, stateManager);
+            }
         }
 
         @Override


### PR DESCRIPTION
Registering and unregistering the changelog topics in the changelog reader outside of the state updater leads to race conditions between the stream thread and the state updater thread. Thus, this PR moves registering and unregistering of changelog topics in the changelog reader into the state updater if the state updater is enabled.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
