### PR TITLE
MINOR: Update offset.storage.topic description

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -108,7 +108,7 @@ public class WorkerConfig extends AbstractConfig {
 
     public static final String OFFSET_COMMIT_INTERVAL_MS_CONFIG = "offset.flush.interval.ms";
     private static final String OFFSET_COMMIT_INTERVAL_MS_DOC
-            = "Interval at which to try committing offsets for tasks.";
+            = "Interval at which to try committing offsets for source tasks.";
     public static final long OFFSET_COMMIT_INTERVAL_MS_DEFAULT = 60000L;
 
     public static final String OFFSET_COMMIT_TIMEOUT_MS_CONFIG = "offset.flush.timeout.ms";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -108,7 +108,7 @@ public class WorkerConfig extends AbstractConfig {
 
     public static final String OFFSET_COMMIT_INTERVAL_MS_CONFIG = "offset.flush.interval.ms";
     private static final String OFFSET_COMMIT_INTERVAL_MS_DOC
-            = "Interval at which to try committing offsets for source tasks.";
+            = "Interval at which to try committing offsets for tasks.";
     public static final long OFFSET_COMMIT_INTERVAL_MS_DEFAULT = 60000L;
 
     public static final String OFFSET_COMMIT_TIMEOUT_MS_CONFIG = "offset.flush.timeout.ms";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -119,7 +119,7 @@ public class DistributedConfig extends WorkerConfig {
      * <code>offset.storage.topic</code>
      */
     public static final String OFFSET_STORAGE_TOPIC_CONFIG = OFFSET_STORAGE_PREFIX + TOPIC_SUFFIX;
-    private static final String OFFSET_STORAGE_TOPIC_CONFIG_DOC = "The name of the Kafka topic where connector offsets are stored";
+    private static final String OFFSET_STORAGE_TOPIC_CONFIG_DOC = "The name of the Kafka topic where source connector offsets are stored";
 
     /**
      * <code>offset.storage.partitions</code>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfig.java
@@ -28,7 +28,7 @@ public class StandaloneConfig extends WorkerConfig {
      * <code>offset.storage.file.filename</code>
      */
     public static final String OFFSET_STORAGE_FILE_FILENAME_CONFIG = "offset.storage.file.filename";
-    private static final String OFFSET_STORAGE_FILE_FILENAME_DOC = "File to store source task offsets";
+    private static final String OFFSET_STORAGE_FILE_FILENAME_DOC = "File to store source connector offsets";
 
     static {
         CONFIG = baseConfigDef()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfig.java
@@ -28,7 +28,7 @@ public class StandaloneConfig extends WorkerConfig {
      * <code>offset.storage.file.filename</code>
      */
     public static final String OFFSET_STORAGE_FILE_FILENAME_CONFIG = "offset.storage.file.filename";
-    private static final String OFFSET_STORAGE_FILE_FILENAME_DOC = "File to store offset data in";
+    private static final String OFFSET_STORAGE_FILE_FILENAME_DOC = "File to store source task offsets";
 
     static {
         CONFIG = baseConfigDef()

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -53,7 +53,7 @@
 
     <p>The important configuration options specific to standalone mode are:</p>
     <ul>
-        <li><code>offset.storage.file.filename</code> - File to store offset data in</li>
+        <li><code>offset.storage.file.filename</code> - File to store source task offsets</li>
     </ul>
 
     <p>The parameters that are configured here are intended for producers and consumers used by Kafka Connect to access the configuration, offset and status topics. For configuration of the producers used by Kafka source tasks and the consumers used by Kafka sink tasks, the same parameters can be used but need to be prefixed with <code>producer.</code> and <code>consumer.</code> respectively. The only Kafka client parameter that is inherited without a prefix from the worker configuration is <code>bootstrap.servers</code>, which in most cases will be sufficient, since the same cluster is often used for all purposes. A notable exception is a secured cluster, which requires extra parameters to allow connections. These parameters will need to be set up to three times in the worker configuration, once for management access, once for Kafka sources and once for Kafka sinks.</p> 

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -53,7 +53,7 @@
 
     <p>The important configuration options specific to standalone mode are:</p>
     <ul>
-        <li><code>offset.storage.file.filename</code> - File to store source task offsets</li>
+        <li><code>offset.storage.file.filename</code> - File to store source connector offsets</li>
     </ul>
 
     <p>The parameters that are configured here are intended for producers and consumers used by Kafka Connect to access the configuration, offset and status topics. For configuration of the producers used by Kafka source tasks and the consumers used by Kafka sink tasks, the same parameters can be used but need to be prefixed with <code>producer.</code> and <code>consumer.</code> respectively. The only Kafka client parameter that is inherited without a prefix from the worker configuration is <code>bootstrap.servers</code>, which in most cases will be sufficient, since the same cluster is often used for all purposes. A notable exception is a secured cluster, which requires extra parameters to allow connections. These parameters will need to be set up to three times in the worker configuration, once for management access, once for Kafka sources and once for Kafka sinks.</p> 


### PR DESCRIPTION
This is a minor change just to clarify that this topic only stores offsets of source connector tasks. Instead, offsets for sink connector tasks are stored in __consumer_offsets, as for consumer groups.