### PR TITLE
MINOR: More verbose display granularity in gradle test logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -428,6 +428,7 @@ subprojects {
       events = userTestLoggingEvents ?: testLoggingEvents
       showStandardStreams = userShowStandardStreams ?: testShowStandardStreams
       exceptionFormat = testExceptionFormat
+      displayGranularity = 0
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
@@ -460,6 +461,7 @@ subprojects {
       events = userTestLoggingEvents ?: testLoggingEvents
       showStandardStreams = userShowStandardStreams ?: testShowStandardStreams
       exceptionFormat = testExceptionFormat
+      displayGranularity = 0
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
@@ -507,6 +509,7 @@ subprojects {
       events = userTestLoggingEvents ?: testLoggingEvents
       showStandardStreams = userShowStandardStreams ?: testShowStandardStreams
       exceptionFormat = testExceptionFormat
+      displayGranularity = 0
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 


### PR DESCRIPTION
We have recently been seeing a lot of build failures:
```
[2022-09-18T10:01:25.947Z] * What went wrong:
[2022-09-18T10:01:25.947Z] Execution failed for task ':core:unitTest'.
[2022-09-18T10:01:25.947Z] > Process 'Gradle Test Executor 116' finished with non-zero exit value 1
```
It is difficult to track this back from the build output because we don't know which test was executing on 'Gradle Test Executor 116.' There is a test logging property `displayGranularity`, which lets us see the executor for each test run: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.logging.TestLogging.html#org.gradle.api.tasks.testing.logging.TestLogging:displayGranularity. 

When `displayGranularity` is set to 2 (the default), we get the following:
```
AdminZkClientTest > testGetBrokerMetadatas() PASSED
```
When set to 0, it looks like this instead:
```
Gradle Test Run :core:test > Gradle Test Executor 76 > AdminZkClientTest > testGetBrokerMetadatas() PASSED
```
Hopefully having this extra information makes it easier to debug failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
