### PR TITLE
KAFKA-14214: Convert StandardAuthorizer to copy-on-write

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -190,7 +190,8 @@ public class AclControlManager {
         existingAcls.add(aclWithId.acl());
         if (!snapshotId.isPresent()) {
             authorizer.ifPresent(a -> {
-                a.addAcl(aclWithId.id(), aclWithId.acl());
+                a.applyAclChanges(Collections.singletonMap(
+                    aclWithId.id(), Optional.of(aclWithId.acl())));
             });
         }
     }
@@ -208,7 +209,8 @@ public class AclControlManager {
         }
         if (!snapshotId.isPresent()) {
             authorizer.ifPresent(a -> {
-                a.removeAcl(record.id());
+                a.applyAclChanges(Collections.singletonMap(
+                        record.id(), Optional.empty()));
             });
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1052,7 +1052,7 @@ public final class QuorumController implements Controller {
                     );
                     snapshotRegistry.getOrCreateSnapshot(lastCommittedOffset);
                     newBytesSinceLastSnapshot = 0L;
-                    authorizer.ifPresent(a -> a.loadSnapshot(aclControlManager.idToAcl()));
+                    authorizer.ifPresent(a -> a.loadAclSnapshot(aclControlManager.idToAcl()));
                 } finally {
                     reader.close();
                 }
@@ -1231,7 +1231,7 @@ public final class QuorumController implements Controller {
                         lastCommittedEpoch + " in snapshot registry.");
             }
             snapshotRegistry.revertToSnapshot(lastCommittedOffset);
-            authorizer.ifPresent(a -> a.loadSnapshot(aclControlManager.idToAcl()));
+            authorizer.ifPresent(a -> a.loadAclSnapshot(aclControlManager.idToAcl()));
             newBytesSinceLastSnapshot = 0L;
             updateWriteOffset(-1);
             clusterControl.deactivate();

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclChanges.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+
+interface AclChanges {
+    void newAddition(StandardAcl acl);
+    void newRemoval(StandardAcl acl);
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclLoader.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.Resource;
+import org.apache.kafka.common.resource.ResourceType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+
+
+/**
+ * The standard authorizer which is used in KRaft-based clusters if no other authorizer is
+ * configured.
+ */
+class AclLoader {
+    private final Map<Uuid, StandardAcl> prevAclsById;
+    private final Map<Resource, ResourceAcls> prevLiterals;
+    private final Map<ResourceType, PrefixNode> prevPrefixed;
+    private final Map<Uuid, StandardAcl> newAclsById;
+    private final Map<Resource, ResourceAclsChanges> literalChanges;
+    private final Map<ResourceType, PrefixTreeBuilder> prefixChanges;
+
+    AclLoader(Map<Uuid, StandardAcl> snapshot) {
+        this.prevAclsById = Collections.emptyMap();
+        this.prevLiterals = Collections.emptyMap();
+        this.prevPrefixed = Collections.emptyMap();
+        this.newAclsById = snapshot;
+        this.literalChanges = new HashMap<>();
+        this.prefixChanges = new HashMap<>();
+        for (StandardAcl newAcl : snapshot.values()) {
+            getOrCreateChangeObject(newAcl).newAddition(newAcl);
+        }
+    }
+
+    AclLoader(
+        Map<Uuid, StandardAcl> prevAclsById,
+        Map<Resource, ResourceAcls> prevLiterals,
+        Map<ResourceType, PrefixNode> prevPrefixed,
+        Map<Uuid, Optional<StandardAcl>> changes
+    ) {
+        this.prevAclsById = prevAclsById;
+        this.prevLiterals = prevLiterals;
+        this.prevPrefixed = prevPrefixed;
+        this.newAclsById = new HashMap<>(prevAclsById.size());
+        this.literalChanges = new HashMap<>(0);
+        this.prefixChanges = new HashMap<>(0);
+        for (Entry<Uuid, Optional<StandardAcl>> entry : changes.entrySet()) {
+            Uuid id = entry.getKey();
+            StandardAcl oldAcl = prevAclsById.get(id);
+            if (oldAcl == null) {
+                if (!entry.getValue().isPresent()) {
+                    // Remove operations MUST find their target ACL. Upserts may or may not
+                    // replace something.
+                    throw new RuntimeException("Unable to remove ACL with UUID " + id +
+                            ": not found.");
+                }
+            } else {
+                getOrCreateChangeObject(oldAcl).newRemoval(oldAcl);
+            }
+            entry.getValue().ifPresent(newAcl -> {
+                newAclsById.put(id, newAcl);
+                getOrCreateChangeObject(newAcl).newAddition(newAcl);
+            });
+        }
+        for (Entry<Uuid, StandardAcl> entry : prevAclsById.entrySet()) {
+            if (!changes.containsKey(entry.getKey())) {
+                newAclsById.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    AclChanges getOrCreateChangeObject(StandardAcl acl) {
+        if (acl.isWildcardOrPrefix()) {
+            return prefixChanges.computeIfAbsent(acl.resourceType(),
+                    __ -> new PrefixTreeBuilder(prevPrefixed.getOrDefault(acl.resourceType(), PrefixNode.EMPTY)));
+        } else if (acl.patternType() == PatternType.LITERAL) {
+            return literalChanges.computeIfAbsent(acl.resource(), __ -> new ResourceAclsChanges());
+        } else {
+            throw new RuntimeException("Unsupported patternType " + acl.patternType());
+        }
+    }
+
+    Result build() {
+        Map<Resource, ResourceAcls> newLiterals = buildLiteralMap(prevLiterals, literalChanges);
+        Map<ResourceType, PrefixNode> newPrefixed = buildPrefixedMap(prevPrefixed, prefixChanges);
+        return new Result(newAclsById, newLiterals, newPrefixed);
+    }
+
+    static Map<Resource, ResourceAcls> buildLiteralMap(
+        Map<Resource, ResourceAcls> prevMap,
+        Map<Resource, ResourceAclsChanges> changeMap
+    ) {
+        if (changeMap.isEmpty()) return prevMap;
+        Map<Resource, ResourceAcls> newMap = new HashMap<>();
+        for (Entry<Resource, ResourceAclsChanges> entry : changeMap.entrySet()) {
+            Resource resource = entry.getKey();
+            ResourceAclsChanges changes = entry.getValue();
+            ResourceAcls resourceAcls = prevMap.getOrDefault(resource, ResourceAcls.EMPTY);
+            ResourceAcls newResourceAcls = resourceAcls.copyWithChanges(changes);
+            if (!newResourceAcls.isEmpty()) {
+                newMap.put(resource, newResourceAcls);
+            }
+        }
+        for (Entry<Resource, ResourceAcls> entry : prevMap.entrySet()) {
+            if (!changeMap.containsKey(entry.getKey())) {
+                newMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return newMap;
+    }
+
+    static Map<ResourceType, PrefixNode> buildPrefixedMap(
+        Map<ResourceType, PrefixNode> prevPrefixed,
+        Map<ResourceType, PrefixTreeBuilder> prefixChanges
+    ) {
+        if (prefixChanges.isEmpty()) return prevPrefixed;
+        Map<ResourceType, PrefixNode> newMap = new HashMap<>();
+        for (Entry<ResourceType, PrefixTreeBuilder> entry : prefixChanges.entrySet()) {
+            newMap.put(entry.getKey(), entry.getValue().build());
+        }
+        for (Entry<ResourceType, PrefixNode> entry : prevPrefixed.entrySet()) {
+            if (!prefixChanges.containsKey(entry.getKey())) {
+                newMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return newMap;
+    }
+
+    static class Result {
+        private final Map<Uuid, StandardAcl> newAclsById;
+        private final Map<Resource, ResourceAcls> newLiterals;
+        private final Map<ResourceType, PrefixNode> newPrefixed;
+
+        Result(
+            Map<Uuid, StandardAcl> newAclsById,
+            Map<Resource, ResourceAcls> newLiterals,
+            Map<ResourceType, PrefixNode> newPrefixed
+        ) {
+            this.newAclsById = newAclsById;
+            this.newLiterals = newLiterals;
+            this.newPrefixed = newPrefixed;
+        }
+
+        Map<Uuid, StandardAcl> newAclsById() {
+            return newAclsById;
+        }
+
+        Map<Resource, ResourceAcls> newLiterals() {
+            return newLiterals;
+        }
+
+        Map<ResourceType, PrefixNode> newPrefixed() {
+            return newPrefixed;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(newAclsById, newLiterals, newPrefixed);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || (!o.getClass().equals(this.getClass()))) return false;
+            Result other = (Result) o;
+            return newAclsById.equals(other.newAclsById) &&
+                newLiterals.equals(other.newLiterals) &&
+                newPrefixed.equals(other.newPrefixed);
+        }
+
+        @Override
+        public String toString() {
+            return "Result(newAclsById=" + newAclsById +
+                    ", newLiterals=" + newLiterals +
+                    ", newPrefixed=" + newPrefixed +
+                    ")";
+        }
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizer.java
@@ -32,6 +32,7 @@ import org.apache.kafka.server.authorizer.Authorizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -73,17 +74,15 @@ public interface ClusterMetadataAuthorizer extends Authorizer {
      * The authorizer will also wait for this initial snapshot load to complete when
      * coming up.
      */
-    void loadSnapshot(Map<Uuid, StandardAcl> acls);
+    void loadAclSnapshot(Map<Uuid, StandardAcl> acls);
 
     /**
-     * Add a new ACL. Any ACL with the same ID will be replaced.
+     * Add or remove ACLs.
+     *
+     * @param aclChanges        A map of UUIDs to ACLs that are upserted or removed. If an existing
+     *                          ACL appears in this map, it will be changed to the provided version.
      */
-    void addAcl(Uuid id, StandardAcl acl);
-
-    /**
-     * Remove the ACL with the given ID.
-     */
-    void removeAcl(Uuid id);
+    void applyAclChanges(Map<Uuid, Optional<StandardAcl>> aclChanges);
 
     /**
      * Create ACLs. This function must be called on the active controller, or else

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/DefaultRule.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/DefaultRule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+
+import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
+
+
+class DefaultRule implements MatchingRule {
+    static final DefaultRule DENIED = new DefaultRule(AuthorizationResult.DENIED);
+
+    private final AuthorizationResult result;
+
+    DefaultRule(AuthorizationResult result) {
+        this.result = result;
+    }
+
+    @Override
+    public AuthorizationResult result() {
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return result.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || (!(o.getClass().equals(this.getClass())))) return false;
+        DefaultRule other = (DefaultRule) o;
+        return result.equals(other.result);
+    }
+
+    @Override
+    public String toString() {
+        return result == ALLOWED ? "DefaultAllow" : "DefaultDeny";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/MatchingAclRule.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/MatchingAclRule.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+
+import java.util.Objects;
+
+
+class MatchingAclRule implements MatchingRule {
+    private final StandardAcl acl;
+    private final AuthorizationResult result;
+
+    MatchingAclRule(
+        StandardAcl acl,
+        AuthorizationResult result
+    ) {
+        this.acl = acl;
+        this.result = result;
+    }
+
+    @Override
+    public AuthorizationResult result() {
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(acl, result);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || (!(o.getClass().equals(this.getClass())))) return false;
+        MatchingAclRule other = (MatchingAclRule) o;
+        return Objects.equals(acl, other.acl) &&
+                Objects.equals(result, other.result);
+    }
+
+    @Override
+    public String toString() {
+        return "MatchingAcl(acl=" + acl + ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/MatchingRule.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/MatchingRule.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.utils.SecurityUtils;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.slf4j.Logger;
+
+import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
+
+
+interface MatchingRule {
+    AuthorizationResult result();
+
+    default void logAuditMessage(
+        Logger auditLog,
+        KafkaPrincipal principal,
+        AuthorizableRequestContext requestContext,
+        Action action
+    ) {
+        switch (result()) {
+            case ALLOWED:
+                // logIfAllowed is true if access is granted to the resource as a result of this authorization.
+                // In this case, log at debug level. If false, no access is actually granted, the result is used
+                // only to determine authorized operations. So log only at trace level.
+                if (action.logIfAllowed() && auditLog.isDebugEnabled()) {
+                    auditLog.debug(buildAuditMessage(principal, requestContext, action));
+                } else if (auditLog.isTraceEnabled()) {
+                    auditLog.trace(buildAuditMessage(principal, requestContext, action));
+                }
+                break;
+
+            case DENIED:
+                // logIfDenied is true if access to the resource was explicitly requested. Since this is an attempt
+                // to access unauthorized resources, log at info level. If false, this is either a request to determine
+                // authorized operations or a filter (e.g for regex subscriptions) to filter out authorized resources.
+                // In this case, log only at trace level.
+                if (action.logIfDenied()) {
+                    auditLog.info(buildAuditMessage(principal, requestContext, action));
+                } else if (auditLog.isTraceEnabled()) {
+                    auditLog.trace(buildAuditMessage(principal, requestContext, action));
+                }
+                break;
+        }
+    }
+
+    default String buildAuditMessage(
+        KafkaPrincipal principal,
+        AuthorizableRequestContext context,
+        Action action
+    ) {
+        StringBuilder bldr = new StringBuilder();
+        bldr.append("Principal = ").append(principal);
+        bldr.append(" is ").append(result() == ALLOWED ? "Allowed" : "Denied");
+        bldr.append(" operation = ").append(action.operation());
+        bldr.append(" from host = ").append(context.clientAddress().getHostAddress());
+        bldr.append(" on resource = ");
+        appendResourcePattern(action.resourcePattern(), bldr);
+        bldr.append(" for request = ").append(ApiKeys.forId(context.requestType()).name);
+        bldr.append(" with resourceRefCount = ").append(action.resourceReferenceCount());
+        bldr.append(" based on rule ").append(this);
+        return bldr.toString();
+    }
+
+    static void appendResourcePattern(
+        ResourcePattern resourcePattern,
+        StringBuilder bldr
+    ) {
+        bldr.append(SecurityUtils.resourceTypeName(resourcePattern.resourceType()))
+                .append(":")
+                .append(resourcePattern.patternType())
+                .append(":")
+                .append(resourcePattern.name());
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixNode.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixNode.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.function.Function;
+
+
+/**
+ * A node in the tree which handles prefix ACLs. We also handle wildcard ACLs here by treating them
+ * like prefix ACLs with a prefix of the empty string.
+ *
+ * The root node's name is the empty string. Each node contains zero or more children, all of
+ * whom have names which are suffixes of their parent's name. We can visit all of the PrefixNode
+ * objects for a given string in logarithmic time simply by walking down the tree.
+ *
+ * The prefix tree is immutable. New instances are constructed by PrefixTreeBuilder objects out of
+ * a combination of new and old parts, as appropriate.
+ */
+final class PrefixNode {
+    static final PrefixNode EMPTY =
+            new PrefixNode(Collections.emptyNavigableMap(), "", ResourceAcls.EMPTY);
+    private final NavigableMap<String, PrefixNode> children;
+    private final String name;
+    private final ResourceAcls resourceAcls;
+
+    PrefixNode(
+        NavigableMap<String, PrefixNode> children,
+        String name,
+        ResourceAcls resourceAcls
+    ) {
+        this.children = children;
+        this.name = name;
+        this.resourceAcls = resourceAcls;
+    }
+
+    NavigableMap<String, PrefixNode> children() {
+        return children;
+    }
+
+    String name() {
+        return name;
+    }
+
+    boolean isRoot() {
+        return name.isEmpty();
+    }
+
+    ResourceAcls resourceAcls() {
+        return resourceAcls;
+    }
+
+    /**
+     * Walk the tree along a path dictated by the provided name. This function must be called
+     * from the root node.
+     *
+     * @param name              The resource name to view nodes for.
+     * @param visitor           The visitor object.
+     */
+    void walk(
+        String name,
+        Function<PrefixNode, Boolean> visitor
+    ) {
+        if (!visitor.apply(this)) return;
+        Map.Entry<String, PrefixNode> entry = children.floorEntry(name);
+        if (entry == null) return;
+        String childPrefix = entry.getKey();
+        if (name.startsWith(childPrefix)) {
+            PrefixNode child = entry.getValue();
+            child.walk(name, visitor);
+        }
+    }
+
+    /**
+     * Walk the tree, potentially following all paths. This function must be called from the
+     * root node.
+     *
+     * @param visitor           The visitor object.
+     */
+    boolean walk(
+        Function<PrefixNode, Boolean> visitor
+    ) {
+        if (!visitor.apply(this)) return false;
+        for (Map.Entry<String, PrefixNode> entry : children.entrySet()) {
+            if (!entry.getValue().walk(visitor)) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(children, name, resourceAcls);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || !o.getClass().equals(this.getClass())) return false;
+        PrefixNode other = (PrefixNode) o;
+        return name.equals(other.name) &&
+            resourceAcls.equals(other.resourceAcls) &&
+            children.equals(other.children);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("PrefixNode");
+        builder.append("(name=").append(name);
+        builder.append(", resourceAcls=").append(resourceAcls);
+        builder.append(", children=(");
+        String prefix = "";
+        for (Map.Entry<String, PrefixNode> entry : children.entrySet()) {
+            builder.append(prefix).append("Entry(name=").append(entry.getKey());
+            builder.append(", value=").append(entry.getValue()).append(")");
+            prefix = ",";
+        }
+        builder.append(")");
+        builder.append(")");
+        return builder.toString();
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixNodeVisitor.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixNodeVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+
+/**
+ * An interface used by PrefixNode#walk.
+ */
+interface PrefixNodeVisitor {
+    /**
+     * The name that this visitor is interested in. For example, if this is "foobar",
+     * we may visit the nodes for "" (empty string), "foo", "foob", and "foobar".
+     * But not "bar" or "baz".
+     */
+    String name();
+
+    /**
+     * Process a PrefixNode.
+     *
+     * @param prefix        The prefix of the PrefixNode. May be the empty string.
+     * @param resourceAcls  The resourceAcls contained by the PrefixNode.
+     * @return              True to keep walking the tree; false otherwise.
+     */
+    boolean visit(
+        String prefix,
+        ResourceAcls resourceAcls
+    );
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixRuleFinder.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixRuleFinder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;
+
+
+class PrefixRuleFinder implements Function<PrefixNode, Boolean> {
+    private final AclOperation operation;
+    private final Set<KafkaPrincipal> matchingPrincipals;
+    private final String host;
+    private MatchingRule bestRule;
+
+    PrefixRuleFinder(
+        AclOperation operation,
+        Set<KafkaPrincipal> matchingPrincipals,
+        String host,
+        MatchingRule bestRule
+    ) {
+        this.operation = operation;
+        this.matchingPrincipals = matchingPrincipals;
+        this.host = host;
+        this.bestRule = bestRule;
+    }
+
+    @Override
+    public Boolean apply(PrefixNode node) {
+        MatchingRule newRule =
+                node.resourceAcls().authorize(operation, matchingPrincipals, host);
+        if (newRule == null) return true;
+        if (newRule.result() == DENIED) {
+            bestRule = newRule;
+            return false;
+        }
+        if (bestRule == null) {
+            bestRule = newRule;
+        }
+        return true;
+    }
+
+    MatchingRule bestRule() {
+        return bestRule;
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixTreeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/PrefixTreeBuilder.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+
+/**
+ * A mutable class used to build new prefix trees using a combination of new and old components.
+ */
+final class PrefixTreeBuilder implements AclChanges {
+    private final PrefixNode oldRoot;
+    private final TreeMap<String, ResourceAclsChanges> changes;
+
+    PrefixTreeBuilder(
+        PrefixNode oldRoot
+    ) {
+        this.oldRoot = oldRoot;
+        this.changes = new TreeMap<>();
+    }
+
+    @Override
+    public void newAddition(StandardAcl acl) {
+        changes.computeIfAbsent(acl.resourceNameForPrefixNode(),
+                __ ->  new ResourceAclsChanges()).newAddition(acl);
+    }
+
+    @Override
+    public void newRemoval(StandardAcl acl) {
+        changes.computeIfAbsent(acl.resourceNameForPrefixNode(),
+                __ ->  new ResourceAclsChanges()).newRemoval(acl);
+    }
+
+    PrefixNode build() {
+        return buildNode(oldRoot);
+    }
+
+    PrefixNode buildNode(PrefixNode oldNode) {
+        // Apply any changes we need to apply to this node itself.
+        ResourceAclsChanges nodeChanges = changes.remove(oldNode.name());
+        ResourceAcls newResourceAcls;
+        if (nodeChanges == null) {
+            newResourceAcls = oldNode.resourceAcls();
+        } else {
+            newResourceAcls = oldNode.resourceAcls().copyWithChanges(nodeChanges);
+        }
+        NavigableMap<String, PrefixNode> newChildren;
+        Entry<String, ResourceAclsChanges> changeEntry = nextChangeForNode(oldNode.name(), oldNode);
+        if (changeEntry.getValue() == null) {
+            newChildren = oldNode.children();
+        } else {
+            newChildren = buildNewChildren(changeEntry, oldNode);
+        }
+        if (!oldNode.isRoot() && newResourceAcls.isEmpty()) {
+            if (newChildren.isEmpty()) {
+                // If the node has no resourceAcls and no children, return null, indicating that we
+                // want to delete it.
+                return null;
+            } else if (newChildren.size() == 1) {
+                // If the node has no resourceAcls and one child, return the child. We will replace
+                // the parent with the child.
+                return newChildren.values().iterator().next();
+            }
+        }
+        return new PrefixNode(newChildren, oldNode.name(), newResourceAcls);
+    }
+
+    Entry<String, ResourceAclsChanges> nextChangeForNode(
+        String prevKey,
+        PrefixNode parent
+    ) {
+        Entry<String, ResourceAclsChanges> changeEntry = changes.higherEntry(prevKey);
+        if (changeEntry == null || !changeEntry.getKey().startsWith(parent.name())) {
+            return new SimpleImmutableEntry<>(prevKey, null);
+        }
+        return changeEntry;
+    }
+
+    Entry<String, PrefixNode> nextChildForNode(
+        String prevKey,
+        PrefixNode parent
+    ) {
+        Entry<String, PrefixNode> nextChild = parent.children().higherEntry(prevKey);
+        if (nextChild == null) {
+            return new SimpleImmutableEntry<>(prevKey, null);
+        }
+        return nextChild;
+    }
+
+    enum ChangeAndChildComparison {
+        UNRELATED_CHANGE_COMES_FIRST,
+        CHANGE_INSERTS_PARENT_FOR_CHILD,
+        CHANGE_AFFECTS_CHILD_OR_GRANDCHILDREN,
+        UNRELATED_CHILD_COMES_FIRST,
+        BOTH_ARE_NULL;
+
+        static ChangeAndChildComparison create(
+            Entry<String, ResourceAclsChanges> changeEntry,
+            Entry<String, PrefixNode> childEntry
+        ) {
+            if (changeEntry.getValue() == null) {
+                if (childEntry.getValue() == null) {
+                    return BOTH_ARE_NULL;
+                } else {
+                    return UNRELATED_CHILD_COMES_FIRST;
+                }
+            } else if (childEntry.getValue() == null) {
+                return UNRELATED_CHANGE_COMES_FIRST;
+            }
+            int comparison = changeEntry.getKey().compareTo(childEntry.getKey());
+            if (comparison == 0) {
+                return CHANGE_AFFECTS_CHILD_OR_GRANDCHILDREN;
+            } else if (comparison < 0) {
+                if (childEntry.getKey().startsWith(changeEntry.getKey())) {
+                    return CHANGE_AFFECTS_CHILD_OR_GRANDCHILDREN;
+                }
+                return UNRELATED_CHANGE_COMES_FIRST;
+            } else {
+                if (changeEntry.getKey().startsWith(childEntry.getKey())) {
+                    return CHANGE_INSERTS_PARENT_FOR_CHILD;
+                }
+                return UNRELATED_CHILD_COMES_FIRST;
+            }
+        }
+    };
+
+    NavigableMap<String, PrefixNode> buildNewChildren(
+        Entry<String, ResourceAclsChanges> changeEntry,
+        PrefixNode parent
+    ) {
+        NavigableMap<String, PrefixNode> newChildren = new TreeMap<>();
+        Entry<String, PrefixNode> childEntry = nextChildForNode(parent.name(), parent);
+
+        while (true) {
+            ChangeAndChildComparison comparison =
+                    ChangeAndChildComparison.create(changeEntry, childEntry);
+            System.out.println("Compared changeEntry " + changeEntry + " and childEntry " + childEntry + " to get " + comparison);
+            switch (comparison) {
+                case UNRELATED_CHANGE_COMES_FIRST: {
+                    // Either the child is null, or we're handling a change that comes before the
+                    // child. In either case, we need to insert a new node to the parent's collection.
+                    PrefixNode newChild = buildNode(new PrefixNode(Collections.emptyNavigableMap(),
+                            changeEntry.getKey(), ResourceAcls.EMPTY));
+                    newChildren.put(newChild.name(), newChild);
+                    changeEntry = nextChangeForNode(changeEntry.getKey(), parent);
+                    break;
+                }
+                case CHANGE_INSERTS_PARENT_FOR_CHILD: {
+                    // We create a virtual child whose child is the current child and build a new
+                    // node based on modifying that.
+                    NavigableMap<String, PrefixNode> virtualGrandchildren = new TreeMap<>();
+                    virtualGrandchildren.put(childEntry.getKey(), childEntry.getValue());
+                    PrefixNode virtualChild = new PrefixNode(virtualGrandchildren,
+                            changeEntry.getKey(), ResourceAcls.EMPTY);
+                    PrefixNode newChild = buildNode(virtualChild);
+                    newChildren.put(newChild.name(), newChild);
+                    // Skip over the current direct child, which is now the child of the new
+                    // child we just created.
+                    childEntry = nextChildForNode(childEntry.getKey(), parent);
+                    changeEntry = nextChangeForNode(changeEntry.getKey(), parent);
+                    break;
+                }
+                case CHANGE_AFFECTS_CHILD_OR_GRANDCHILDREN: {
+                    // The change relates to the child. This may mean it changes the child itself,
+                    // or changes one of the child's children.
+                    PrefixNode newChild = buildNode(childEntry.getValue());
+                    if (newChild == null) {
+                        // If buildNode returns null, we're deleting this child.
+                        // Advance to the next child, if there is one.
+                        childEntry = nextChildForNode(childEntry.getKey(), parent);
+                    } else {
+                        // Insert the new child we just built. Note that this new child may have a
+                        // different name than the previous one, if a layer was removed.
+                        newChildren.put(newChild.name(), newChild);
+                        childEntry = nextChildForNode(newChild.name(), parent);
+                    }
+                    changeEntry = nextChangeForNode(changeEntry.getKey(), parent);
+                    break;
+                }
+                case UNRELATED_CHILD_COMES_FIRST: {
+                    // Preserve the previous child entry unmodified. This is always nice because
+                    // we don't have to do any more work on this subtree.
+                    newChildren.put(childEntry.getKey(), childEntry.getValue());
+                    childEntry = nextChildForNode(childEntry.getKey(), parent);
+                    break;
+                }
+                case BOTH_ARE_NULL:
+                    // We're done.
+                    return newChildren;
+            }
+        }
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ResourceAcls.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ResourceAcls.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.kafka.common.acl.AclOperation.ALL;
+import static org.apache.kafka.common.acl.AclOperation.ALTER;
+import static org.apache.kafka.common.acl.AclOperation.ALTER_CONFIGS;
+import static org.apache.kafka.common.acl.AclOperation.DELETE;
+import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
+import static org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS;
+import static org.apache.kafka.common.acl.AclOperation.READ;
+import static org.apache.kafka.common.acl.AclOperation.WRITE;
+import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
+import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
+import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;
+
+
+/**
+ * A list of ACLs for a particular resource stored in the StandardAuthorizer.
+ * This class is immutable.
+ */
+class ResourceAcls  {
+    /**
+     * The set of operations which imply DESCRIBE permission, when used in an ALLOW acl.
+     */
+    static final Set<AclOperation> IMPLIES_DESCRIBE = Collections.unmodifiableSet(
+            EnumSet.of(DESCRIBE, READ, WRITE, DELETE, ALTER));
+
+    /**
+     * The set of operations which imply DESCRIBE_CONFIGS permission, when used in an ALLOW acl.
+     */
+    static final Set<AclOperation> IMPLIES_DESCRIBE_CONFIGS = Collections.unmodifiableSet(
+            EnumSet.of(DESCRIBE_CONFIGS, ALTER_CONFIGS));
+
+    /**
+     * The empty list of resource ACLs.
+     */
+    static final ResourceAcls EMPTY = new ResourceAcls(new StandardAcl[0]);
+
+    private final StandardAcl[] acls;
+
+    private ResourceAcls(StandardAcl[] acls) {
+        this.acls = acls;
+    }
+
+    ResourceAcls(List<StandardAcl> acl) {
+        this.acls = acl.toArray(new StandardAcl[0]);
+    }
+
+    boolean treatedAsPrefixAcls() {
+        return acls.length > 0 && acls[0].isWildcardOrPrefix();
+    }
+
+    boolean isEmpty() {
+        return acls.length == 0;
+    }
+
+    /**
+     * Copy these ResourceAcls with some additions and removals.
+     *
+     * @param changes       The changes to make.
+     *
+     * @return              The new ResourceAcls object.
+     */
+    ResourceAcls copyWithChanges(ResourceAclsChanges changes) {
+        StandardAcl[] nextAcls = new StandardAcl[acls.length + changes.netSizeChange()];
+        changes.apply(acls, nextAcls);
+        return new ResourceAcls(nextAcls);
+    }
+
+    /**
+     * Check if there are any ACLs in this list that match the given parameters. Any DENY results
+     * lead to a denial. If at least one ALLOW is found, but no DENY, the result is ALLOW.
+     * Otherwise, we return null (no result).
+     *
+     * Note that this function assumes that the resource type and name match. They are not checked here.
+     *
+     * @param operation          The input operation.
+     * @param matchingPrincipals The set of input matching principals
+     * @param host               The input host.
+     * @return                   null if the ACL does not match. The authorization result
+     *                           otherwise.
+     */
+    MatchingAclRule authorize(
+        AclOperation operation,
+        Set<KafkaPrincipal> matchingPrincipals,
+        String host
+    ) {
+        MatchingAclRule rule = null;
+        for (int i = 0; i < acls.length; i++) {
+            StandardAcl acl = acls[i];
+            AuthorizationResult result = authorize(acl, operation, matchingPrincipals, host);
+            if (result == DENIED) {
+                return new MatchingAclRule(acl, DENIED);
+            } else if (result == ALLOWED && rule == null) {
+                rule = new MatchingAclRule(acl, ALLOWED);
+            }
+        }
+        return rule;
+    }
+
+    /**
+     * Determine what the result of applying an ACL to the given action and request
+     * context should be.
+     *
+     * Note that this function assumes that the resource type and name match. They are not checked here.
+     *
+     * @param acl                The input ACL.
+     * @param operation          The input operation.
+     * @param matchingPrincipals The set of input matching principals
+     * @param host               The input host.
+     * @return                   null if the ACL does not match. The authorization result
+     *                           otherwise.
+     */
+    static AuthorizationResult authorize(
+        StandardAcl acl,
+        AclOperation operation,
+        Set<KafkaPrincipal> matchingPrincipals,
+        String host
+    ) {
+        // Check if the principal matches. If it doesn't, return no result (null).
+        if (!matchingPrincipals.contains(acl.kafkaPrincipal())) {
+            return null;
+        }
+        // Check if the host matches. If it doesn't, return no result (null).
+        if (!acl.host().equals(StandardAuthorizerConstants.WILDCARD) && !acl.host().equals(host)) {
+            return null;
+        }
+        // Check if the operation field matches. Here we hit a slight complication.
+        // ACLs for various operations (READ, WRITE, DELETE, ALTER), "imply" the presence
+        // of DESCRIBE, even if it isn't explictly stated. A similar rule applies to
+        // DESCRIBE_CONFIGS.
+        //
+        // But this rule only applies to ALLOW ACLs. So for example, a DENY ACL for READ
+        // on a resource does not DENY describe for that resource.
+        if (acl.operation() != ALL) {
+            if (acl.permissionType().equals(ALLOW)) {
+                switch (operation) {
+                    case DESCRIBE:
+                        if (!IMPLIES_DESCRIBE.contains(acl.operation())) return null;
+                        break;
+                    case DESCRIBE_CONFIGS:
+                        if (!IMPLIES_DESCRIBE_CONFIGS.contains(acl.operation())) return null;
+                        break;
+                    default:
+                        if (operation != acl.operation()) {
+                            return null;
+                        }
+                        break;
+                }
+            } else if (operation != acl.operation()) {
+                return null;
+            }
+        }
+
+        return acl.permissionType().equals(ALLOW) ? ALLOWED : DENIED;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(acls);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o ==  null || !(o.getClass().equals(this.getClass()))) return false;
+        ResourceAcls other = (ResourceAcls) o;
+        return Arrays.equals(acls, other.acls);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("ResourceAcls[");
+        String prefix = "";
+        for (StandardAcl acl : acls) {
+            builder.append(prefix).append(acl);
+            prefix = ", ";
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ResourceAclsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/ResourceAclsChanges.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+
+/**
+ * Changes planned for a ResourceAcls object. This class is mutable.
+ */
+class ResourceAclsChanges implements AclChanges {
+    private final IdentityHashMap<StandardAcl, Boolean> changes = new IdentityHashMap<>(0);
+    private int numRemovals = 0;
+
+    @Override
+    public void newRemoval(StandardAcl acl) {
+        Boolean prev = changes.put(acl, false);
+        if (prev == null || prev) numRemovals++;
+    }
+
+    @Override
+    public void newAddition(StandardAcl acl) {
+        Boolean prev = changes.put(acl, true);
+        if (prev != null && !prev) numRemovals--;
+    }
+
+    int numRemovals() {
+        return numRemovals;
+    }
+
+    int netSizeChange() {
+        return changes.size() - (2 * numRemovals);
+    }
+
+    boolean isRemoved(StandardAcl acl) {
+        Boolean existing = changes.get(acl);
+        return existing != null && !existing;
+    }
+
+    void apply(StandardAcl[] source, StandardAcl[] dest) {
+        int j = 0, numRemoved = 0;
+        for (int i = 0; i < source.length; i++) {
+            StandardAcl acl = source[i];
+            Boolean value = changes.remove(acl);
+            if (value == null) {
+                dest[j++] = acl;
+            } else if (value) {
+                throw new RuntimeException("ACL " + acl + " already exists in ResourceAcls.");
+            } else {
+                numRemoved++;
+            }
+        }
+        if (numRemoved != numRemovals) {
+            throw new RuntimeException("Unable to find " + (numRemovals - numRemoved) + " ACL(s) to remove.");
+        }
+        for (Iterator<StandardAcl> iterator = changes.keySet().iterator(); iterator.hasNext(); ) {
+            dest[j++] = iterator.next();
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ResourceAclsChanges(");
+        String prefix = "";
+        for (Map.Entry<StandardAcl, Boolean> entry : changes.entrySet()) {
+            builder.append(prefix);
+            builder.append(entry.getKey()).append(": ");
+            if (entry.getValue()) {
+                builder.append("added");
+            } else {
+                builder.append("removed");
+            }
+            prefix = ", ";
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAclWithId.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAclWithId.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.metadata.authorizer;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.metadata.AccessControlEntryRecord;
 
 import java.util.Objects;
@@ -59,10 +58,6 @@ final public class StandardAclWithId {
             setHost(acl.host()).
             setOperation(acl.operation().code()).
             setPermissionType(acl.permissionType().code());
-    }
-
-    public AclBinding toBinding() {
-        return acl.toBinding();
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerConstants.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerConstants.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+
+/**
+ * A class which encapsulates the configuration and the ACL data owned by StandardAuthorizer.
+ *
+ * The methods in this class support lockless concurrent access.
+ */
+class StandardAuthorizerConstants {
+    /**
+     * The host or name string used in ACLs that match any host or name.
+     */
+    static final String WILDCARD = "*";
+
+    /**
+     * The principal entry used in ACLs that match any principal.
+     */
+    static final String WILDCARD_PRINCIPAL = "User:*";
+
+    /**
+     * A Principal that matches anything.
+     */
+    static final KafkaPrincipal WILDCARD_KAFKA_PRINCIPAL = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*");
+
+    /**
+     * The empty string.
+     */
+    static final String EMPTY_STRING = "";
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -21,14 +21,13 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.errors.AuthorizerNotReadyException;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.authorizer.Action;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
@@ -36,18 +35,17 @@ import org.apache.kafka.server.authorizer.AuthorizationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NavigableSet;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.function.Supplier;
 
-import static org.apache.kafka.common.acl.AclOperation.ALL;
+import static java.util.Collections.emptyMap;
 import static org.apache.kafka.common.acl.AclOperation.ALTER;
 import static org.apache.kafka.common.acl.AclOperation.ALTER_CONFIGS;
 import static org.apache.kafka.common.acl.AclOperation.DELETE;
@@ -55,8 +53,6 @@ import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
 import static org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS;
 import static org.apache.kafka.common.acl.AclOperation.READ;
 import static org.apache.kafka.common.acl.AclOperation.WRITE;
-import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
-import static org.apache.kafka.common.resource.PatternType.LITERAL;
 import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
 import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;
 
@@ -67,17 +63,6 @@ import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;
  * The methods in this class support lockless concurrent access.
  */
 public class StandardAuthorizerData {
-    /**
-     * The host or name string used in ACLs that match any host or name.
-     */
-    public static final String WILDCARD = "*";
-
-    /**
-     * The principal entry used in ACLs that match any principal.
-     */
-    public static final String WILDCARD_PRINCIPAL = "User:*";
-    public static final KafkaPrincipal WILDCARD_KAFKA_PRINCIPAL = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*");
-
     /**
      * The logger to use.
      */
@@ -109,14 +94,19 @@ public class StandardAuthorizerData {
     private final DefaultRule defaultRule;
 
     /**
-     * Contains all of the current ACLs sorted by (resource type, resource name).
+     * Maps ACL IDs to ACLs.
      */
-    private final ConcurrentSkipListSet<StandardAcl> aclsByResource;
+    private final Map<Uuid, StandardAcl> aclsById;
 
     /**
-     * Contains all of the current ACLs indexed by UUID.
+     * All the prefix ACLs for a given resource type and name pair.
      */
-    private final ConcurrentHashMap<Uuid, StandardAcl> aclsById;
+    private final Map<ResourceType, PrefixNode> prefixAcls;
+
+    /**
+     * All the literal ACLs for a given resource type and name pair.
+     */
+    private final Map<Resource, ResourceAcls> literalAcls;
 
     private static Logger createLogger(int nodeId) {
         return new LogContext("[StandardAuthorizer " + nodeId + "] ").logger(StandardAuthorizerData.class);
@@ -127,29 +117,36 @@ public class StandardAuthorizerData {
     }
 
     static StandardAuthorizerData createEmpty() {
-        return new StandardAuthorizerData(createLogger(-1),
+        return new StandardAuthorizerData(
+            createLogger(-1),
             null,
             false,
             Collections.emptySet(),
-            DENIED,
-            new ConcurrentSkipListSet<>(), new ConcurrentHashMap<>());
+            DefaultRule.DENIED,
+            emptyMap(),
+            emptyMap(),
+            emptyMap());
     }
 
-    private StandardAuthorizerData(Logger log,
-                                   AclMutator aclMutator,
-                                   boolean loadingComplete,
-                                   Set<String> superUsers,
-                                   AuthorizationResult defaultResult,
-                                   ConcurrentSkipListSet<StandardAcl> aclsByResource,
-                                   ConcurrentHashMap<Uuid, StandardAcl> aclsById) {
+    private StandardAuthorizerData(
+        Logger log,
+        AclMutator aclMutator,
+        boolean loadingComplete,
+        Set<String> superUsers,
+        DefaultRule defaultRule,
+        Map<Uuid, StandardAcl> aclsById,
+        Map<ResourceType, PrefixNode> prefixAcls,
+        Map<Resource, ResourceAcls> literalAcls
+    ) {
         this.log = log;
         this.auditLog = auditLogger();
         this.aclMutator = aclMutator;
         this.loadingComplete = loadingComplete;
         this.superUsers = superUsers;
-        this.defaultRule = new DefaultRule(defaultResult);
-        this.aclsByResource = aclsByResource;
+        this.defaultRule = defaultRule;
         this.aclsById = aclsById;
+        this.prefixAcls = prefixAcls;
+        this.literalAcls = literalAcls;
     }
 
     StandardAuthorizerData copyWithNewAclMutator(AclMutator newAclMutator) {
@@ -158,83 +155,68 @@ public class StandardAuthorizerData {
             newAclMutator,
             loadingComplete,
             superUsers,
-            defaultRule.result,
-            aclsByResource,
-            aclsById);
+            defaultRule,
+            aclsById,
+            prefixAcls,
+            literalAcls);
     }
 
     StandardAuthorizerData copyWithNewLoadingComplete(boolean newLoadingComplete) {
-        return new StandardAuthorizerData(log,
+        return new StandardAuthorizerData(
+            log,
             aclMutator,
             newLoadingComplete,
             superUsers,
-            defaultRule.result,
-            aclsByResource,
-            aclsById);
+            defaultRule,
+            aclsById,
+            prefixAcls,
+            literalAcls);
     }
 
-    StandardAuthorizerData copyWithNewConfig(int nodeId,
-                                             Set<String> newSuperUsers,
-                                             AuthorizationResult newDefaultResult) {
+    StandardAuthorizerData copyWithNewConfig(
+        int nodeId,
+        Set<String> newSuperUsers,
+        AuthorizationResult newDefaultResult
+    ) {
         return new StandardAuthorizerData(
             createLogger(nodeId),
             aclMutator,
             loadingComplete,
             newSuperUsers,
-            newDefaultResult,
-            aclsByResource,
-            aclsById);
+            new DefaultRule(newDefaultResult),
+            aclsById,
+            prefixAcls,
+            literalAcls);
     }
 
-    StandardAuthorizerData copyWithNewAcls(Collection<Entry<Uuid, StandardAcl>> aclEntries) {
-        StandardAuthorizerData newData = new StandardAuthorizerData(
+    StandardAuthorizerData copyWithAclSnapshot(Map<Uuid, StandardAcl> snapshot) {
+        AclLoader loader = new AclLoader(snapshot);
+        AclLoader.Result result = loader.build();
+        return new StandardAuthorizerData(
             log,
             aclMutator,
             loadingComplete,
             superUsers,
-            defaultRule.result,
-            new ConcurrentSkipListSet<>(),
-            new ConcurrentHashMap<>());
-        for (Entry<Uuid, StandardAcl> entry : aclEntries) {
-            newData.addAcl(entry.getKey(), entry.getValue());
-        }
-        log.info("Applied {} acl(s) from image.", aclEntries.size());
-        return newData;
+            defaultRule,
+            result.newAclsById(),
+            result.newPrefixed(),
+            result.newLiterals());
     }
 
-    void addAcl(Uuid id, StandardAcl acl) {
-        try {
-            StandardAcl prevAcl = aclsById.putIfAbsent(id, acl);
-            if (prevAcl != null) {
-                throw new RuntimeException("An ACL with ID " + id + " already exists.");
-            }
-            if (!aclsByResource.add(acl)) {
-                aclsById.remove(id);
-                throw new RuntimeException("Unable to add the ACL with ID " + id +
-                    " to aclsByResource");
-            }
-            log.trace("Added ACL {}: {}", id, acl);
-        } catch (Throwable e) {
-            log.error("addAcl error", e);
-            throw e;
-        }
-    }
-
-    void removeAcl(Uuid id) {
-        try {
-            StandardAcl acl = aclsById.remove(id);
-            if (acl == null) {
-                throw new RuntimeException("ID " + id + " not found in aclsById.");
-            }
-            if (!aclsByResource.remove(acl)) {
-                throw new RuntimeException("Unable to remove the ACL with ID " + id +
-                    " from aclsByResource");
-            }
-            log.trace("Removed ACL {}: {}", id, acl);
-        } catch (Throwable e) {
-            log.error("removeAcl error", e);
-            throw e;
-        }
+    StandardAuthorizerData copyWithAclChanges(
+        Map<Uuid, Optional<StandardAcl>> aclChanges
+    ) {
+        AclLoader loader = new AclLoader(aclsById, literalAcls, prefixAcls, aclChanges);
+        AclLoader.Result result = loader.build();
+        return new StandardAuthorizerData(
+                log,
+                aclMutator,
+                loadingComplete,
+                superUsers,
+                defaultRule,
+                result.newAclsById(),
+                result.newPrefixed(),
+                result.newLiterals());
     }
 
     Set<String> superUsers() {
@@ -242,7 +224,7 @@ public class StandardAuthorizerData {
     }
 
     AuthorizationResult defaultResult() {
-        return defaultRule.result;
+        return defaultRule.result();
     }
 
     int aclCount() {
@@ -258,183 +240,108 @@ public class StandardAuthorizerData {
      * result. In general it makes more sense to configure the default result to be
      * DENY, but some people (and unit tests) configure it as ALLOW.
      */
-    public AuthorizationResult authorize(
+    AuthorizationResult authorize(
         AuthorizableRequestContext requestContext,
         Action action
     ) {
+        return doAuthorize(requestContext, action, () ->
+            findAuthorizationRule(matchingPrincipals(requestContext),
+                requestContext.clientAddress().getHostAddress(), action));
+    }
+
+    AuthorizationResult authorizeByResourceType(
+            AuthorizableRequestContext requestContext,
+            AclOperation op,
+            ResourceType resourceType
+    ) {
+        Action action = new Action(op,
+                new ResourcePattern(resourceType, "NONE", PatternType.UNKNOWN), 0, true, true);
+        return doAuthorize(requestContext, action, () ->
+            findAuthorizationByResourceTypeRule(matchingPrincipals(requestContext),
+                requestContext.clientAddress().getHostAddress(), op, resourceType));
+    }
+
+    AuthorizationResult doAuthorize(
+        AuthorizableRequestContext requestContext,
+        Action action,
+        Supplier<MatchingRule> ruleSupplier
+    ) {
         KafkaPrincipal principal = baseKafkaPrincipal(requestContext);
-        final MatchingRule rule;
+        MatchingRule rule;
 
         // Superusers are authorized to do anything.
         if (superUsers.contains(principal.toString())) {
             rule = SuperUserRule.INSTANCE;
         } else if (!loadingComplete) {
+            // For non-superusers, we must check if loading is complete.
+            log.debug("Raising AuthorizerNotReadyException because loading is not complete yet.");
             throw new AuthorizerNotReadyException();
         } else {
-            MatchingAclRule aclRule = findAclRule(
-                matchingPrincipals(requestContext),
-                requestContext.clientAddress().getHostAddress(),
-                action
-            );
-
-            if (aclRule != null) {
-                rule = aclRule;
-            } else {
+            rule = ruleSupplier.get();
+            if (rule == null) {
                 // If nothing matched, we return the default result.
                 rule = defaultRule;
             }
         }
-
-        logAuditMessage(principal, requestContext, action, rule);
+        rule.logAuditMessage(auditLog, principal, requestContext, action);
         return rule.result();
     }
 
-    private String buildAuditMessage(
-        KafkaPrincipal principal,
-        AuthorizableRequestContext context,
-        Action action,
-        MatchingRule rule
-    ) {
-        StringBuilder bldr = new StringBuilder();
-        bldr.append("Principal = ").append(principal);
-        bldr.append(" is ").append(rule.result() == ALLOWED ? "Allowed" : "Denied");
-        bldr.append(" operation = ").append(action.operation());
-        bldr.append(" from host = ").append(context.clientAddress().getHostAddress());
-        bldr.append(" on resource = ");
-        appendResourcePattern(action.resourcePattern(), bldr);
-        bldr.append(" for request = ").append(ApiKeys.forId(context.requestType()).name);
-        bldr.append(" with resourceRefCount = ").append(action.resourceReferenceCount());
-        bldr.append(" based on rule ").append(rule);
-        return bldr.toString();
-    }
-
-    private void appendResourcePattern(ResourcePattern resourcePattern, StringBuilder bldr) {
-        bldr.append(SecurityUtils.resourceTypeName(resourcePattern.resourceType()))
-            .append(":")
-            .append(resourcePattern.patternType())
-            .append(":")
-            .append(resourcePattern.name());
-    }
-
-    private void logAuditMessage(
-        KafkaPrincipal principal,
-        AuthorizableRequestContext requestContext,
-        Action action,
-        MatchingRule rule
-    ) {
-        switch (rule.result()) {
-            case ALLOWED:
-                // logIfAllowed is true if access is granted to the resource as a result of this authorization.
-                // In this case, log at debug level. If false, no access is actually granted, the result is used
-                // only to determine authorized operations. So log only at trace level.
-                if (action.logIfAllowed() && auditLog.isDebugEnabled()) {
-                    auditLog.debug(buildAuditMessage(principal, requestContext, action, rule));
-                } else if (auditLog.isTraceEnabled()) {
-                    auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
-                }
-                return;
-
-            case DENIED:
-                // logIfDenied is true if access to the resource was explicitly requested. Since this is an attempt
-                // to access unauthorized resources, log at info level. If false, this is either a request to determine
-                // authorized operations or a filter (e.g for regex subscriptions) to filter out authorized resources.
-                // In this case, log only at trace level.
-                if (action.logIfDenied()) {
-                    auditLog.info(buildAuditMessage(principal, requestContext, action, rule));
-                } else if (auditLog.isTraceEnabled()) {
-                    auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
-                }
-        }
-    }
-
-    private MatchingAclRule findAclRule(
+    MatchingRule findAuthorizationRule(
         Set<KafkaPrincipal> matchingPrincipals,
         String host,
         Action action
     ) {
-        // This code relies on the ordering of StandardAcl within the NavigableMap.
-        // Entries are sorted by resource type first, then REVERSE resource name.
-        // Therefore, we can find all the applicable ACLs by starting at
-        // (resource_type, resource_name) and stepping forwards until we reach an ACL with
-        // a resource name which is not a prefix of the current one.
-        //
-        // For example, when trying to authorize a TOPIC resource named foobar, we would
-        // start at element 2, and continue on to 3 and 4 following map:
-        //
-        // 1. rs=TOPIC rn=gar pt=PREFIX
-        // 2. rs=TOPIC rn=foobar pt=PREFIX
-        // 3. rs=TOPIC rn=foob pt=LITERAL
-        // 4. rs=TOPIC rn=foo pt=PREFIX
-        // 5. rs=TOPIC rn=eeee pt=LITERAL
-        //
-        // Once we reached element 5, we would stop scanning.
-        MatchingAclBuilder matchingAclBuilder = new MatchingAclBuilder();
-        StandardAcl exemplar = new StandardAcl(
-            action.resourcePattern().resourceType(),
-            action.resourcePattern().name(),
-            PatternType.UNKNOWN, // Note that the UNKNOWN value sorts before all others.
-            "",
-            "",
-            AclOperation.UNKNOWN,
-            AclPermissionType.UNKNOWN);
-        checkSection(action, exemplar, matchingPrincipals, host, matchingAclBuilder);
-        if (matchingAclBuilder.foundDeny()) {
-            return matchingAclBuilder.build();
-        }
+        // Check literal ACLs.
+        ResourceType resourceType = action.resourcePattern().resourceType();
+        String resourceName = action.resourcePattern().name();
+        Resource literalResource = new Resource(resourceType, action.resourcePattern().name());
+        MatchingRule literalRule = literalAcls.getOrDefault(literalResource, ResourceAcls.EMPTY).
+                authorize(action.operation(), matchingPrincipals, host);
+        if (literalRule != null && literalRule.result() == DENIED) return literalRule;
 
-        // In addition to ACLs for this specific resource name, there can also be wildcard
-        // ACLs that match any resource name. These are stored as type = LITERAL,
-        // name = "*". We search these next.
-        exemplar = new StandardAcl(
-            action.resourcePattern().resourceType(),
-            WILDCARD,
-            LITERAL,
-            "",
-            "",
-            AclOperation.UNKNOWN,
-            AclPermissionType.UNKNOWN);
-        checkSection(action, exemplar, matchingPrincipals, host, matchingAclBuilder);
-        return matchingAclBuilder.build();
+        // Check prefix ACLs and wildcards.
+        PrefixNode prefixNode = prefixAcls.getOrDefault(resourceType, PrefixNode.EMPTY);
+        PrefixRuleFinder finder = new PrefixRuleFinder(action.operation(),
+                matchingPrincipals,
+                host,
+                literalRule);
+        prefixNode.walk(resourceName, finder);
+        return finder.bestRule();
     }
 
-    private void checkSection(
-        Action action,
-        StandardAcl exemplar,
+    MatchingRule findAuthorizationByResourceTypeRule(
         Set<KafkaPrincipal> matchingPrincipals,
         String host,
-        MatchingAclBuilder matchingAclBuilder
+        AclOperation operation,
+        ResourceType resourceType
     ) {
-        NavigableSet<StandardAcl> tailSet = aclsByResource.tailSet(exemplar, true);
-        String resourceName = action.resourcePattern().name();
-        for (Iterator<StandardAcl> iterator = tailSet.iterator();
-             iterator.hasNext(); ) {
-            StandardAcl acl = iterator.next();
-            if (!acl.resourceType().equals(action.resourcePattern().resourceType())) {
-                // We've stepped outside the section for the resource type we care about and
-                // should stop scanning.
-                break;
-            }
-            if (resourceName.startsWith(acl.resourceName())) {
-                if (acl.patternType() == LITERAL && !resourceName.equals(acl.resourceName())) {
-                    // This is a literal ACL whose name is a prefix of the resource name, but
-                    // which doesn't match it exactly. We should skip over this ACL, but keep
-                    // scanning in case there are any relevant PREFIX ACLs.
-                    continue;
-                }
-            } else if (!(acl.resourceName().equals(WILDCARD) && acl.patternType() == LITERAL)) {
-                // If the ACL resource name is NOT a prefix of the current resource name,
-                // and we're not dealing with the special case of a wildcard ACL, we've
-                // stepped outside of the section we care about and should stop scanning.
-                break;
-            }
-            AuthorizationResult result = findResult(action, matchingPrincipals, host, acl);
-            if (ALLOWED == result) {
-                matchingAclBuilder.allowAcl = acl;
-            } else if (DENIED == result) {
-                matchingAclBuilder.denyAcl = acl;
-                return;
+        // Check prefix ACLs and wildcards.
+        PrefixRuleFinder finder = new PrefixRuleFinder(operation,
+                matchingPrincipals,
+                host,
+                null);
+        PrefixNode prefixNode = prefixAcls.getOrDefault(resourceType, PrefixNode.EMPTY);
+        prefixNode.walk(finder);
+        if (finder.bestRule() != null) return finder.bestRule();
+
+        // Check literal ACLs.
+        for (Entry<Resource, ResourceAcls> entry : literalAcls.entrySet()) {
+            Resource resource = entry.getKey();
+            if (resource.resourceType() != resourceType) continue;
+            MatchingRule literalRule = literalAcls.getOrDefault(resource, ResourceAcls.EMPTY).
+                    authorize(operation, matchingPrincipals, host);
+            if (literalRule != null && literalRule.result() == ALLOWED) {
+                finder = new PrefixRuleFinder(operation,
+                        matchingPrincipals,
+                        host,
+                        literalRule);
+                prefixNode.walk(finder);
+                if (finder.bestRule() != null) return finder.bestRule();
             }
         }
+
+        return null;
     }
 
     /**
@@ -449,17 +356,6 @@ public class StandardAuthorizerData {
     private static final Set<AclOperation> IMPLIES_DESCRIBE_CONFIGS = Collections.unmodifiableSet(
         EnumSet.of(DESCRIBE_CONFIGS, ALTER_CONFIGS));
 
-    static AuthorizationResult findResult(Action action,
-                                          AuthorizableRequestContext requestContext,
-                                          StandardAcl acl) {
-        return findResult(
-            action,
-            matchingPrincipals(requestContext),
-            requestContext.clientAddress().getHostAddress(),
-            acl
-        );
-    }
-
     static KafkaPrincipal baseKafkaPrincipal(AuthorizableRequestContext context) {
         KafkaPrincipal sessionPrincipal = context.principal();
         return sessionPrincipal.getClass().equals(KafkaPrincipal.class)
@@ -472,61 +368,7 @@ public class StandardAuthorizerData {
         KafkaPrincipal basePrincipal = sessionPrincipal.getClass().equals(KafkaPrincipal.class)
             ? sessionPrincipal
             : new KafkaPrincipal(sessionPrincipal.getPrincipalType(), sessionPrincipal.getName());
-        return Utils.mkSet(basePrincipal, WILDCARD_KAFKA_PRINCIPAL);
-    }
-
-    /**
-     * Determine what the result of applying an ACL to the given action and request
-     * context should be. Note that this function assumes that the resource name matches;
-     * the resource name is not checked here.
-     *
-     * @param action             The input action.
-     * @param matchingPrincipals The set of input matching principals
-     * @param host               The input host.
-     * @param acl                The input ACL.
-     * @return                   null if the ACL does not match. The authorization result
-     *                           otherwise.
-     */
-    static AuthorizationResult findResult(Action action,
-                                          Set<KafkaPrincipal> matchingPrincipals,
-                                          String host,
-                                          StandardAcl acl) {
-        // Check if the principal matches. If it doesn't, return no result (null).
-        if (!matchingPrincipals.contains(acl.kafkaPrincipal())) {
-            return null;
-        }
-        // Check if the host matches. If it doesn't, return no result (null).
-        if (!acl.host().equals(WILDCARD) && !acl.host().equals(host)) {
-            return null;
-        }
-        // Check if the operation field matches. Here we hit a slight complication.
-        // ACLs for various operations (READ, WRITE, DELETE, ALTER), "imply" the presence
-        // of DESCRIBE, even if it isn't explictly stated. A similar rule applies to
-        // DESCRIBE_CONFIGS.
-        //
-        // But this rule only applies to ALLOW ACLs. So for example, a DENY ACL for READ
-        // on a resource does not DENY describe for that resource.
-        if (acl.operation() != ALL) {
-            if (acl.permissionType().equals(ALLOW)) {
-                switch (action.operation()) {
-                    case DESCRIBE:
-                        if (!IMPLIES_DESCRIBE.contains(acl.operation())) return null;
-                        break;
-                    case DESCRIBE_CONFIGS:
-                        if (!IMPLIES_DESCRIBE_CONFIGS.contains(acl.operation())) return null;
-                        break;
-                    default:
-                        if (action.operation() != acl.operation()) {
-                            return null;
-                        }
-                        break;
-                }
-            } else if (action.operation() != acl.operation()) {
-                return null;
-            }
-        }
-
-        return acl.permissionType().equals(ALLOW) ? ALLOWED : DENIED;
+        return Utils.mkSet(basePrincipal, StandardAuthorizerConstants.WILDCARD_KAFKA_PRINCIPAL);
     }
 
     Iterable<AclBinding> acls(AclBindingFilter filter) {
@@ -548,12 +390,12 @@ public class StandardAuthorizerData {
 
     class AclIterator implements Iterator<AclBinding> {
         private final AclBindingFilter filter;
-        private final Iterator<StandardAcl> iterator;
+        private Iterator<StandardAcl> iterator;
         private AclBinding next;
 
         AclIterator(AclBindingFilter filter) {
             this.filter = filter;
-            this.iterator = aclsByResource.iterator();
+            this.iterator = aclsById.values().iterator();
             this.next = null;
         }
 
@@ -577,81 +419,6 @@ public class StandardAuthorizerData {
             AclBinding result = next;
             next = null;
             return result;
-        }
-    }
-
-    private interface MatchingRule {
-        AuthorizationResult result();
-    }
-
-    private static class SuperUserRule implements MatchingRule {
-        private static final SuperUserRule INSTANCE = new SuperUserRule();
-
-        @Override
-        public AuthorizationResult result() {
-            return ALLOWED;
-        }
-
-        @Override
-        public String toString() {
-            return "SuperUser";
-        }
-    }
-
-    private static class DefaultRule implements MatchingRule {
-        private final AuthorizationResult result;
-
-        private DefaultRule(AuthorizationResult result) {
-            this.result = result;
-        }
-
-        @Override
-        public AuthorizationResult result() {
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            return result == ALLOWED ? "DefaultAllow" : "DefaultDeny";
-        }
-    }
-
-    private static class MatchingAclRule implements MatchingRule {
-        private final StandardAcl acl;
-        private final AuthorizationResult result;
-
-        private MatchingAclRule(StandardAcl acl, AuthorizationResult result) {
-            this.acl = acl;
-            this.result = result;
-        }
-
-        @Override
-        public AuthorizationResult result() {
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            return "MatchingAcl(acl=" + acl + ")";
-        }
-    }
-
-    private static class MatchingAclBuilder {
-        private StandardAcl denyAcl;
-        private StandardAcl allowAcl;
-
-        boolean foundDeny() {
-            return denyAcl != null;
-        }
-
-        MatchingAclRule build() {
-            if (denyAcl != null) {
-                return new MatchingAclRule(denyAcl, DENIED);
-            } else if (allowAcl != null) {
-                return new MatchingAclRule(allowAcl, ALLOWED);
-            } else {
-                return null;
-            }
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/SuperUserRule.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/SuperUserRule.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+
+import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
+
+
+class SuperUserRule implements MatchingRule {
+    static final SuperUserRule INSTANCE = new SuperUserRule();
+
+    @Override
+    public AuthorizationResult result() {
+        return ALLOWED;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || (!(o.getClass().equals(this.getClass())))) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "SuperUser";
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/AclsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/AclsImageTest.java
@@ -31,7 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.metadata.authorizer.StandardAclWithIdTest.TEST_ACLS;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.ALL;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.withIds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -44,6 +45,8 @@ public class AclsImageTest {
     final static AclsDelta DELTA1;
 
     final static AclsImage IMAGE2;
+
+    final static List<StandardAclWithId> TEST_ACLS = withIds(ALL);
 
     static {
         Map<Uuid, StandardAcl> map = new HashMap<>();

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/AclLoaderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/AclLoaderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.Resource;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerConstants.WILDCARD;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerConstants.WILDCARD_PRINCIPAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class AclLoaderTest {
+    private static final Map<Uuid, StandardAcl> SNAPSHOT1;
+
+    private static final List<Uuid> UUIDS = Arrays.asList(
+        Uuid.fromString("hiIec7T4TPmZGwzRa5wxeA"),
+        Uuid.fromString("2Q4EztAhTiGkOOLaL5_RnA"),
+        Uuid.fromString("KH-t-UmmRHW2c7moaDL_CQ"),
+        Uuid.fromString("GUlPfRhlTRK1N9uG3elrlQ"));
+
+    private static final List<StandardAcl> ACLS = Arrays.asList(
+            new StandardAcl(
+                    ResourceType.TOPIC,
+                    "foo_",
+                    PatternType.LITERAL,
+                    WILDCARD_PRINCIPAL,
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.ALLOW),
+            new StandardAcl(
+                    ResourceType.GROUP,
+                    WILDCARD,
+                    PatternType.LITERAL,
+                    "User:foo",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY),
+            new StandardAcl(
+                    ResourceType.GROUP,
+                    "mygroup",
+                    PatternType.PREFIXED,
+                    "User:foo",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY),
+            new StandardAcl(
+                    ResourceType.GROUP,
+                    "mygroup",
+                    PatternType.PREFIXED,
+                    "User:bar",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY));
+
+    private static final StandardAcl ACL4 = new StandardAcl(
+            ResourceType.GROUP,
+            "mygroup",
+            PatternType.PREFIXED,
+            "User:foo",
+            WILDCARD,
+            AclOperation.READ,
+            AclPermissionType.ALLOW);
+
+    static {
+        Map<Uuid, StandardAcl> snapshot1 = new HashMap<>();
+        for (int i = 0; i < UUIDS.size(); i++) {
+            snapshot1.put(UUIDS.get(i), ACLS.get(i));
+        }
+        SNAPSHOT1 = Collections.unmodifiableMap(snapshot1);
+    }
+
+    @Test
+    public void testLoadSnapshot() {
+        AclLoader loader = new AclLoader(SNAPSHOT1);
+        Map<Resource, ResourceAcls> newLiterals = new HashMap<>();
+        newLiterals.put(new Resource(ResourceType.TOPIC, "foo_"),
+                new ResourceAcls(Arrays.asList(ACLS.get(0))));
+        PrefixNode myGroupNode = new PrefixNode(Collections.emptyNavigableMap(), "mygroup",
+                new ResourceAcls(Arrays.asList(ACLS.get(2), ACLS.get(3))));
+        NavigableMap<String, PrefixNode> rootChildren = new TreeMap<>();
+        rootChildren.put("mygroup", myGroupNode);
+        ResourceAclsChanges rootResourceAclsChanges = new ResourceAclsChanges();
+        rootResourceAclsChanges.newAddition(ACLS.get(1));
+        PrefixNode rootNode = new PrefixNode(rootChildren, "",
+                ResourceAcls.EMPTY.copyWithChanges(rootResourceAclsChanges));
+
+        Map<ResourceType, PrefixNode> newPrefixed = new HashMap<>();
+        newPrefixed.put(ResourceType.GROUP, rootNode);
+        assertEquals(new AclLoader.Result(SNAPSHOT1, newLiterals, newPrefixed),
+            loader.build());
+    }
+
+    @Test
+    public void testLoadDelta() {
+        AclLoader loader = new AclLoader(SNAPSHOT1);
+        AclLoader.Result result = loader.build();
+        Map<Uuid, Optional<StandardAcl>> changes = new HashMap<>();
+        changes.put(UUIDS.get(2), Optional.empty());
+        changes.put(UUIDS.get(3), Optional.of(ACL4));
+        AclLoader loader2 = new AclLoader(result.newAclsById(),
+                result.newLiterals(),
+                result.newPrefixed(),
+                changes);
+        Map<Uuid, StandardAcl> newAclsById = new HashMap<>();
+        newAclsById.put(UUIDS.get(0), ACLS.get(0));
+        newAclsById.put(UUIDS.get(1), ACLS.get(1));
+        newAclsById.put(UUIDS.get(3), ACL4);
+        Map<Resource, ResourceAcls> newLiterals = new HashMap<>();
+        newLiterals.put(new Resource(ResourceType.TOPIC, "foo_"),
+                new ResourceAcls(Arrays.asList(ACLS.get(0))));
+        PrefixNode myGroupNode = new PrefixNode(Collections.emptyNavigableMap(), "mygroup",
+                new ResourceAcls(Arrays.asList(ACLS.get(1), ACL4)));
+        NavigableMap<String, PrefixNode> rootChildren = new TreeMap<>();
+        rootChildren.put("mygroup", myGroupNode);
+        ResourceAclsChanges rootResourceAclsChanges = new ResourceAclsChanges();
+        rootResourceAclsChanges.newAddition(ACLS.get(1));
+        PrefixNode rootNode = new PrefixNode(rootChildren, "",
+                ResourceAcls.EMPTY.copyWithChanges(rootResourceAclsChanges));
+
+        Map<ResourceType, PrefixNode> newPrefixed = new HashMap<>();
+        newPrefixed.put(ResourceType.GROUP, rootNode);
+        assertEquals(new AclLoader.Result(newAclsById, newLiterals, newPrefixed),
+                loader2.build());
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/ClusterMetadataAuthorizerTest.java
@@ -54,8 +54,8 @@ import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
 import static org.apache.kafka.common.resource.PatternType.LITERAL;
 import static org.apache.kafka.common.resource.ResourcePattern.WILDCARD_RESOURCE;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
-import static org.apache.kafka.metadata.authorizer.StandardAuthorizerData.WILDCARD;
-import static org.apache.kafka.metadata.authorizer.StandardAuthorizerData.WILDCARD_PRINCIPAL;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerConstants.WILDCARD;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerConstants.WILDCARD_PRINCIPAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -117,17 +117,12 @@ public class ClusterMetadataAuthorizerTest {
         }
 
         @Override
-        public void loadSnapshot(Map<Uuid, StandardAcl> acls) {
+        public void loadAclSnapshot(Map<Uuid, StandardAcl> acls) {
             // do nothing
         }
 
         @Override
-        public void addAcl(Uuid id, StandardAcl acl) {
-            // do nothing
-        }
-
-        @Override
-        public void removeAcl(Uuid id) {
+        public void applyAclChanges(Map<Uuid, Optional<StandardAcl>> aclChanges) {
             // do nothing
         }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MatchingRuleTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MatchingRuleTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.server.authorizer.Action;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.InetAddress;
+
+import static org.apache.kafka.common.acl.AclOperation.WRITE;
+import static org.apache.kafka.common.resource.PatternType.LITERAL;
+import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.apache.kafka.common.security.auth.KafkaPrincipal.USER_TYPE;
+import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
+import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class MatchingRuleTest {
+    static final KafkaPrincipal LARRY = new KafkaPrincipal(USER_TYPE, "larry");
+
+    @Test
+    public void testDefaultRule() {
+        assertEquals(DENIED, DefaultRule.DENIED.result());
+        assertEquals(ALLOWED, new DefaultRule(ALLOWED).result());
+        assertEquals("DefaultDeny", DefaultRule.DENIED.toString());
+        assertEquals("DefaultAllow", new DefaultRule(ALLOWED).toString());
+    }
+
+    @Test
+    public void testSuperUserRule() {
+        assertEquals(ALLOWED, SuperUserRule.INSTANCE.result());
+        assertEquals("SuperUser", SuperUserRule.INSTANCE.toString());
+    }
+
+    @Test
+    public void testMatchingAclRule() {
+        StandardAcl acl1 = new StandardAcl(
+                TOPIC,
+                "bar",
+                LITERAL,
+                LARRY.toString(),
+                "127.0.0.1",
+                AclOperation.READ,
+                AclPermissionType.ALLOW);
+        MatchingAclRule rule = new MatchingAclRule(acl1, ALLOWED);
+        assertEquals(ALLOWED, rule.result());
+        assertEquals("MatchingAcl(acl=StandardAcl(resourceType=TOPIC, resourceName=bar, " +
+            "patternType=LITERAL, principal=User:larry, host=127.0.0.1, operation=READ, " +
+                "permissionType=ALLOW))", rule.toString());
+    }
+
+    @Test
+    public void testAppendResourcePattern() throws Exception {
+        Action action = new Action(WRITE,
+            new ResourcePattern(TOPIC, "foo", LITERAL), 1, true, true);
+        assertEquals("Principal = User:larry is Allowed operation = WRITE from host = 127.0.0.1 " +
+            "on resource = Topic:LITERAL:foo for request = Fetch with resourceRefCount = 1 based " +
+            "on rule SuperUser", SuperUserRule.INSTANCE.buildAuditMessage(
+                LARRY, new MockAuthorizableRequestContext.Builder().
+                    setClientAddress(InetAddress.getByName("127.0.0.1")).build(),
+                        action));
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/ResourceAclsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/ResourceAclsTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.acl.AclOperation.ALTER;
+import static org.apache.kafka.common.acl.AclOperation.ALTER_CONFIGS;
+import static org.apache.kafka.common.acl.AclOperation.CREATE;
+import static org.apache.kafka.common.acl.AclOperation.DELETE;
+import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
+import static org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS;
+import static org.apache.kafka.common.acl.AclOperation.READ;
+import static org.apache.kafka.common.acl.AclOperation.WRITE;
+import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
+import static org.apache.kafka.common.acl.AclPermissionType.DENY;
+import static org.apache.kafka.common.resource.PatternType.LITERAL;
+import static org.apache.kafka.common.resource.PatternType.PREFIXED;
+import static org.apache.kafka.common.resource.ResourceType.GROUP;
+import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.apache.kafka.common.security.auth.KafkaPrincipal.USER_TYPE;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTest.newAction;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTest.newBarAcl;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTest.newFooAcl;
+import static org.apache.kafka.server.authorizer.AuthorizationResult.ALLOWED;
+import static org.apache.kafka.server.authorizer.AuthorizationResult.DENIED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@Timeout(value = 40)
+public class ResourceAclsTest {
+    static final KafkaPrincipal ALICE = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice");
+
+    static final KafkaPrincipal BOB = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "bob");
+
+    static final StandardAcl ACL1 = new StandardAcl(
+            TOPIC,
+            "foo",
+            LITERAL,
+            "User:bob",
+            "127.0.0.1",
+            AclOperation.READ,
+            AclPermissionType.ALLOW);
+
+    static final StandardAcl ACL2 = new StandardAcl(
+            TOPIC,
+            "foo",
+            LITERAL,
+            "User:alice",
+            "127.0.0.1",
+            AclOperation.WRITE,
+            AclPermissionType.DENY);
+
+    static final StandardAcl ACL3 = new StandardAcl(
+            TOPIC,
+            StandardAuthorizerConstants.WILDCARD,
+            LITERAL,
+            "User:chris",
+            "127.0.0.1",
+            AclOperation.WRITE,
+            AclPermissionType.DENY);
+
+    static final StandardAcl ACL4 = new StandardAcl(
+            TOPIC,
+            "f",
+            PREFIXED,
+            "User:chris",
+            "127.0.0.1",
+            AclOperation.ALL,
+            AclPermissionType.DENY);
+
+    static ResourceAclsChanges addAcl1AndAcl2() {
+        ResourceAclsChanges changes = new ResourceAclsChanges();
+        changes.newAddition(ACL1);
+        changes.newAddition(ACL2);
+        return changes;
+    }
+
+    static ResourceAclsChanges removeAcl1() {
+        ResourceAclsChanges changes = new ResourceAclsChanges();
+        changes.newRemoval(ACL1);
+        return changes;
+    }
+
+    @Test
+    public void testEmptyResourceAcls() {
+        assertTrue(ResourceAcls.EMPTY.isEmpty());
+        assertFalse(ResourceAcls.EMPTY.treatedAsPrefixAcls());
+        assertNull(ResourceAcls.EMPTY.authorize(null, null, null));
+    }
+
+    @Test
+    public void tesTreatedAsPrefixAcls() {
+        assertFalse(new ResourceAcls(Arrays.asList(ACL1)).treatedAsPrefixAcls());
+        assertFalse(new ResourceAcls(Arrays.asList(ACL2)).treatedAsPrefixAcls());
+        assertTrue(new ResourceAcls(Arrays.asList(ACL3)).treatedAsPrefixAcls());
+        assertTrue(new ResourceAcls(Arrays.asList(ACL4)).treatedAsPrefixAcls());
+    }
+
+    @Test
+    public void testResourceAclsChanges() {
+        ResourceAclsChanges changes = new ResourceAclsChanges();
+        assertEquals(0, changes.numRemovals());
+        assertEquals(0, changes.netSizeChange());
+        assertFalse(changes.isRemoved(ACL1));
+        changes.newRemoval(ACL1);
+        assertTrue(changes.isRemoved(ACL1));
+        assertEquals(1, changes.numRemovals());
+        assertEquals(-1, changes.netSizeChange());
+        changes.newAddition(ACL2);
+        assertEquals(1, changes.numRemovals());
+        assertEquals(0, changes.netSizeChange());
+    }
+
+    @Test
+    public void tesCopyWithChanges() {
+        ResourceAcls twoAcls = ResourceAcls.EMPTY.copyWithChanges(addAcl1AndAcl2());
+        assertEquals(new ResourceAcls(Arrays.asList(ACL1, ACL2)), twoAcls);
+        ResourceAcls oneAcl = twoAcls.copyWithChanges(removeAcl1());
+        assertEquals(new ResourceAcls(Arrays.asList(ACL2)), oneAcl);
+    }
+
+    @Test
+    public void testToString() {
+        ResourceAcls twoAcls = ResourceAcls.EMPTY.copyWithChanges(addAcl1AndAcl2());
+        assertEquals("ResourceAcls[StandardAcl(resourceType=TOPIC, resourceName=foo, " +
+            "patternType=LITERAL, principal=User:bob, host=127.0.0.1, " +
+            "operation=READ, permissionType=ALLOW), StandardAcl(resourceType=TOPIC, " +
+            "resourceName=foo, patternType=LITERAL, principal=User:alice, host=127.0.0.1, " +
+            "operation=WRITE, permissionType=DENY)]", twoAcls.toString());
+        ResourceAcls oneAcl = twoAcls.copyWithChanges(removeAcl1());
+        assertEquals("ResourceAcls[StandardAcl(resourceType=TOPIC, " +
+            "resourceName=foo, patternType=LITERAL, principal=User:alice, host=127.0.0.1, " +
+            "operation=WRITE, permissionType=DENY)]", oneAcl.toString());
+    }
+
+    @Test
+    public void testAuthorize() {
+        ResourceAcls resourceAcls = new ResourceAcls(Arrays.asList(ACL1, ACL2));
+        assertEquals(new MatchingAclRule(ACL1, AuthorizationResult.ALLOWED),
+            resourceAcls.authorize(AclOperation.READ,
+                Collections.singleton(BOB),
+                    "127.0.0.1"));
+        assertEquals(new MatchingAclRule(ACL2, AuthorizationResult.DENIED),
+                resourceAcls.authorize(AclOperation.WRITE,
+                    Collections.singleton(ALICE),
+                        "127.0.0.1"));
+        assertEquals(null,
+                resourceAcls.authorize(AclOperation.WRITE,
+                        Collections.singleton(BOB),
+                        "127.0.0.1"));
+    }
+
+    private static AuthorizationResult findResult(
+        Action action,
+        AuthorizableRequestContext requestContext,
+        StandardAcl acl
+    ) {
+        ResourceAcls resourceAcls = new ResourceAcls(Collections.singletonList(acl));
+        MatchingAclRule rule = resourceAcls.authorize(action.operation(),
+                StandardAuthorizerData.matchingPrincipals(requestContext),
+                "127.0.0.1");
+        return (rule == null) ? null : rule.result();
+    }
+
+    @Test
+    public void testFindResultImplication() throws Exception {
+        // These permissions all imply DESCRIBE.
+        for (AclOperation op : asList(DESCRIBE, READ, WRITE, DELETE, ALTER)) {
+            assertEquals(ALLOWED, findResult(newAction(DESCRIBE, TOPIC, "foo_bar"),
+                    new MockAuthorizableRequestContext.Builder().
+                            setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                    newFooAcl(op, ALLOW)));
+        }
+        // CREATE does not imply DESCRIBE
+        assertEquals(null, findResult(newAction(DESCRIBE, TOPIC, "foo_bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                newFooAcl(CREATE, ALLOW)));
+        // Deny ACLs don't do "implication".
+        for (AclOperation op : asList(READ, WRITE, DELETE, ALTER)) {
+            assertEquals(null, findResult(newAction(DESCRIBE, TOPIC, "foo_bar"),
+                    new MockAuthorizableRequestContext.Builder().
+                            setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                    newFooAcl(op, DENY)));
+        }
+        // Exact match
+        assertEquals(DENIED, findResult(newAction(DESCRIBE, TOPIC, "foo_bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                newFooAcl(DESCRIBE, DENY)));
+        // These permissions all imply DESCRIBE_CONFIGS.
+        for (AclOperation op : asList(DESCRIBE_CONFIGS, ALTER_CONFIGS)) {
+            assertEquals(ALLOWED, findResult(newAction(DESCRIBE_CONFIGS, TOPIC, "foo_bar"),
+                    new MockAuthorizableRequestContext.Builder().
+                            setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                    newFooAcl(op, ALLOW)));
+        }
+        // Deny ACLs don't do "implication".
+        assertEquals(null, findResult(newAction(DESCRIBE_CONFIGS, TOPIC, "foo_bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                newFooAcl(ALTER_CONFIGS, DENY)));
+        // Exact match
+        assertEquals(DENIED, findResult(newAction(ALTER_CONFIGS, TOPIC, "foo_bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                newFooAcl(ALTER_CONFIGS, DENY)));
+    }
+
+    @Test
+    public void testFindResultPrincipalMatching() throws Exception {
+        assertEquals(ALLOWED, findResult(newAction(READ, TOPIC, "foo_bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "bob")).build(),
+                newFooAcl(READ, ALLOW)));
+        // Principal does not match.
+        assertEquals(null, findResult(newAction(READ, TOPIC, "foo_bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "alice")).build(),
+                newFooAcl(READ, ALLOW)));
+        // Wildcard principal matches anything.
+        assertEquals(DENIED, findResult(newAction(READ, GROUP, "bar"),
+                new MockAuthorizableRequestContext.Builder().
+                        setPrincipal(new KafkaPrincipal(USER_TYPE, "alice")).build(),
+                newBarAcl(READ, DENY)));
+    }
+
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclRecordIteratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclRecordIteratorTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.NoSuchElementException;
 
-import static org.apache.kafka.metadata.authorizer.StandardAclWithIdTest.TEST_ACLS;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.ALL;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.withIds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,28 +37,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class StandardAclRecordIteratorTest {
     @Test
     public void testIteration() {
+        List<StandardAclWithId> allList = withIds(ALL);
         StandardAclRecordIterator iterator =
-            new StandardAclRecordIterator(TEST_ACLS.iterator(), 2);
+            new StandardAclRecordIterator(allList.iterator(), 2);
         assertTrue(iterator.hasNext());
         assertEquals(Arrays.asList(
-            new ApiMessageAndVersion(TEST_ACLS.get(0).toRecord(), (short) 0),
-            new ApiMessageAndVersion(TEST_ACLS.get(1).toRecord(), (short) 0)),
+            new ApiMessageAndVersion(allList.get(0).toRecord(), (short) 0),
+            new ApiMessageAndVersion(allList.get(1).toRecord(), (short) 0)),
             iterator.next());
         assertEquals(Arrays.asList(
-            new ApiMessageAndVersion(TEST_ACLS.get(2).toRecord(), (short) 0),
-            new ApiMessageAndVersion(TEST_ACLS.get(3).toRecord(), (short) 0)),
+            new ApiMessageAndVersion(allList.get(2).toRecord(), (short) 0),
+            new ApiMessageAndVersion(allList.get(3).toRecord(), (short) 0)),
             iterator.next());
         assertTrue(iterator.hasNext());
         assertEquals(Arrays.asList(
-            new ApiMessageAndVersion(TEST_ACLS.get(4).toRecord(), (short) 0)),
+            new ApiMessageAndVersion(allList.get(4).toRecord(), (short) 0)),
             iterator.next());
         assertFalse(iterator.hasNext());
     }
 
     @Test
     public void testNoSuchElementException() {
+        List<StandardAclWithId> allList = withIds(ALL);
         StandardAclRecordIterator iterator =
-            new StandardAclRecordIterator(TEST_ACLS.iterator(), 2);
+            new StandardAclRecordIterator(allList.iterator(), 2);
         iterator.next();
         iterator.next();
         iterator.next();

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclTest.java
@@ -18,104 +18,73 @@
 package org.apache.kafka.metadata.authorizer;
 
 import org.apache.kafka.common.acl.AclBinding;
-import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.acl.AclPermissionType;
-import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.common.resource.ResourceType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.apache.kafka.metadata.authorizer.StandardAuthorizerData.WILDCARD;
-import static org.apache.kafka.metadata.authorizer.StandardAuthorizerData.WILDCARD_PRINCIPAL;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.ALL;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.LITERAL_ACLS;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.PREFIXED_ACLS;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.WILDCARD_ACLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @Timeout(value = 40)
 public class StandardAclTest {
-    public final static List<StandardAcl> TEST_ACLS = new ArrayList<>();
-
-    static {
-        TEST_ACLS.add(new StandardAcl(
-            ResourceType.CLUSTER,
-            Resource.CLUSTER_NAME,
-            PatternType.LITERAL,
-            WILDCARD_PRINCIPAL,
-            WILDCARD,
-            AclOperation.ALTER,
-            AclPermissionType.ALLOW));
-        TEST_ACLS.add(new StandardAcl(
-            ResourceType.TOPIC,
-            "foo_",
-            PatternType.PREFIXED,
-            WILDCARD_PRINCIPAL,
-            WILDCARD,
-            AclOperation.READ,
-            AclPermissionType.ALLOW));
-        TEST_ACLS.add(new StandardAcl(
-            ResourceType.GROUP,
-            "mygroup",
-            PatternType.LITERAL,
-            "User:foo",
-            WILDCARD,
-            AclOperation.READ,
-            AclPermissionType.DENY));
-        TEST_ACLS.add(new StandardAcl(
-            ResourceType.GROUP,
-            "mygroup",
-            PatternType.PREFIXED,
-            "User:foo",
-            WILDCARD,
-            AclOperation.READ,
-            AclPermissionType.DENY));
-        TEST_ACLS.add(new StandardAcl(
-            ResourceType.GROUP,
-            "foo",
-            PatternType.PREFIXED,
-            "User:foo",
-            WILDCARD,
-            AclOperation.READ,
-            AclPermissionType.DENY));
-    }
-
-    private static int signum(int input) {
-        if (input < 0) return -1;
-        else if (input > 0) return 1;
-        else return 0;
-    }
-
     @Test
-    public void testCompareTo() {
-        assertEquals(1, signum(TEST_ACLS.get(0).compareTo(TEST_ACLS.get(1))));
-        assertEquals(-1, signum(TEST_ACLS.get(1).compareTo(TEST_ACLS.get(0))));
-        assertEquals(-1, signum(TEST_ACLS.get(2).compareTo(TEST_ACLS.get(3))));
-        assertEquals(1, signum(TEST_ACLS.get(4).compareTo(TEST_ACLS.get(3))));
-        assertEquals(-1, signum(TEST_ACLS.get(3).compareTo(TEST_ACLS.get(4))));
+    public void testResource() {
+        assertEquals(new Resource(ResourceType.CLUSTER, Resource.CLUSTER_NAME),
+                LITERAL_ACLS.get(0).resource());
+        assertEquals(new Resource(ResourceType.TOPIC, "foo_"),
+                PREFIXED_ACLS.get(0).resource());
     }
 
     @Test
     public void testToBindingRoundTrips() {
-        for (StandardAcl acl : TEST_ACLS) {
+        ALL.forEach(acl -> {
             AclBinding binding = acl.toBinding();
             StandardAcl acl2 = StandardAcl.fromAclBinding(binding);
             assertEquals(acl2, acl);
-        }
+        });
     }
 
     @Test
     public void testEquals() {
-        for (int i = 0; i != TEST_ACLS.size(); i++) {
-            for (int j = 0; j != TEST_ACLS.size(); j++) {
-                if (i == j) {
-                    assertEquals(TEST_ACLS.get(i), TEST_ACLS.get(j));
+        ALL.forEach(acl1 -> {
+            ALL.forEach(acl2 -> {
+                if (acl1 == acl2) {
+                    assertEquals(acl1, acl2);
                 } else {
-                    assertNotEquals(TEST_ACLS.get(i), TEST_ACLS.get(j));
+                    assertNotEquals(acl1, acl2);
                 }
-            }
-        }
+            });
+        });
+    }
+
+    @Test
+    public void testIsWildcard() {
+        WILDCARD_ACLS.forEach(acl -> assertTrue(acl.isWildcard()));
+        LITERAL_ACLS.forEach(acl -> assertFalse(acl.isWildcard()));
+        PREFIXED_ACLS.forEach(acl -> assertFalse(acl.isWildcard()));
+    }
+
+    @Test
+    public void testIsWildcardOrPrefix() {
+        WILDCARD_ACLS.forEach(acl -> assertTrue(acl.isWildcardOrPrefix()));
+        PREFIXED_ACLS.forEach(acl -> assertTrue(acl.isWildcardOrPrefix()));
+        LITERAL_ACLS.forEach(acl -> assertFalse(acl.isWildcardOrPrefix()));
+    }
+
+    @Test
+    public void testResourceNameForPrefixNode() {
+        WILDCARD_ACLS.forEach(acl -> assertEquals("", acl.resourceNameForPrefixNode()));
+        LITERAL_ACLS.forEach(acl ->
+                assertEquals(acl.resourceName(), acl.resourceNameForPrefixNode()));
+        PREFIXED_ACLS.forEach(acl ->
+                assertEquals(acl.resourceName(), acl.resourceNameForPrefixNode()));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclWithIdTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclWithIdTest.java
@@ -22,49 +22,54 @@ import org.apache.kafka.common.metadata.AccessControlEntryRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.ALL;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.WILDCARD_ACLS;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerTestConstants.withIds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 
 @Timeout(value = 40)
 public class StandardAclWithIdTest {
-    public final static List<StandardAclWithId> TEST_ACLS = new ArrayList<>();
-
-    static {
-        TEST_ACLS.add(new StandardAclWithId(Uuid.fromString("QZDDv-R7SyaPgetDPGd0Mw"),
-            StandardAclTest.TEST_ACLS.get(0)));
-        TEST_ACLS.add(new StandardAclWithId(Uuid.fromString("SdDjEdlbRmy2__WFKe3RMg"),
-            StandardAclTest.TEST_ACLS.get(1)));
-        TEST_ACLS.add(new StandardAclWithId(Uuid.fromString("wQzt5gkSTwuQNXZF5gIw7A"),
-            StandardAclTest.TEST_ACLS.get(2)));
-        TEST_ACLS.add(new StandardAclWithId(Uuid.fromString("ab_5xjJXSbS1o5jGfhgQXg"),
-            StandardAclTest.TEST_ACLS.get(3)));
-        TEST_ACLS.add(new StandardAclWithId(Uuid.fromString("wP_cCK0LTEGSX9oDRInJHQ"),
-            StandardAclTest.TEST_ACLS.get(4)));
-    }
-
     @Test
     public void testToRecordRoundTrips() {
-        for (StandardAclWithId acl : TEST_ACLS) {
+        withIds(ALL).forEach(acl -> {
             AccessControlEntryRecord record = acl.toRecord();
             StandardAclWithId acl2 = StandardAclWithId.fromRecord(record);
             assertEquals(acl2, acl);
-        }
+        });
     }
 
     @Test
     public void testEquals() {
-        for (int i = 0; i != TEST_ACLS.size(); i++) {
-            for (int j = 0; j != TEST_ACLS.size(); j++) {
-                if (i == j) {
-                    assertEquals(TEST_ACLS.get(i), TEST_ACLS.get(j));
+        List<StandardAclWithId> allWithId = withIds(ALL);
+        allWithId.forEach(acl1 -> {
+            allWithId.forEach(acl2 -> {
+                if (acl1 == acl2) {
+                    assertEquals(acl1, acl2);
                 } else {
-                    assertNotEquals(TEST_ACLS.get(i), TEST_ACLS.get(j));
+                    assertNotEquals(acl1, acl2);
                 }
-            }
-        }
+            });
+        });
+    }
+
+    static final List<Uuid> TEST_UUIDS = Arrays.asList(
+        Uuid.fromString("QZDDv-R7SyaPgetDPGd0Mw"),
+        Uuid.fromString("SdDjEdlbRmy2__WFKe3RMg"));
+
+    @Test
+    public void testNotEqualsIfIdIsDifferent() {
+        assertNotEquals(new StandardAclWithId(TEST_UUIDS.get(0), WILDCARD_ACLS.get(0)),
+            new StandardAclWithId(TEST_UUIDS.get(1), WILDCARD_ACLS.get(0)));
+    }
+
+    @Test
+    public void testNotEqualsIfAclIsDifferent() {
+        assertNotEquals(new StandardAclWithId(TEST_UUIDS.get(0), WILDCARD_ACLS.get(0)),
+                new StandardAclWithId(TEST_UUIDS.get(0), WILDCARD_ACLS.get(1)));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTestConstants.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTestConstants.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.Resource;
+import org.apache.kafka.common.resource.ResourceType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerConstants.WILDCARD;
+import static org.apache.kafka.metadata.authorizer.StandardAuthorizerConstants.WILDCARD_PRINCIPAL;
+
+
+/**
+ * Constants used in tests of StandardAuthorizer.
+ */
+public class StandardAuthorizerTestConstants {
+    public final static List<StandardAcl> WILDCARD_ACLS = Arrays.asList(
+            new StandardAcl(
+                    ResourceType.TOPIC,
+                    WILDCARD,
+                    PatternType.LITERAL,
+                    WILDCARD_PRINCIPAL,
+                    WILDCARD,
+                    AclOperation.WRITE,
+                    AclPermissionType.ALLOW),
+            new StandardAcl(
+                    ResourceType.TOPIC,
+                    WILDCARD,
+                    PatternType.LITERAL,
+                    "User:bar",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY));
+
+    public final static List<StandardAcl> LITERAL_ACLS = Arrays.asList(
+            new StandardAcl(
+                    ResourceType.CLUSTER,
+                    Resource.CLUSTER_NAME,
+                    PatternType.LITERAL,
+                    WILDCARD_PRINCIPAL,
+                    WILDCARD,
+                    AclOperation.ALTER,
+                    AclPermissionType.ALLOW),
+            new StandardAcl(
+                    ResourceType.GROUP,
+                    "mygroup",
+                    PatternType.LITERAL,
+                    "User:foo",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY));
+
+    public final static List<StandardAcl> PREFIXED_ACLS = Arrays.asList(
+            new StandardAcl(
+                    ResourceType.TOPIC,
+                    "foo_",
+                    PatternType.PREFIXED,
+                    WILDCARD_PRINCIPAL,
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.ALLOW),
+            new StandardAcl(
+                    ResourceType.GROUP,
+                    "mygroup",
+                    PatternType.PREFIXED,
+                    "User:foo",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY),
+            new StandardAcl(
+                    ResourceType.GROUP,
+                    "foo",
+                    PatternType.PREFIXED,
+                    "User:foo",
+                    WILDCARD,
+                    AclOperation.READ,
+                    AclPermissionType.DENY));
+
+    public final static List<StandardAcl> ALL = Stream.of(
+            WILDCARD_ACLS, LITERAL_ACLS, PREFIXED_ACLS).flatMap(Collection::stream).collect(Collectors.toList());
+
+    public final static Uuid idForAcl(StandardAcl acl) {
+        return new Uuid(acl.hashCode(), acl.hashCode());
+    }
+
+    public final static StandardAclWithId withId(StandardAcl acl) {
+        return new StandardAclWithId(idForAcl(acl), acl);
+    }
+
+    public final static List<StandardAclWithId> withIds(List<StandardAcl> input) {
+        return input.stream().map(acl -> withId(acl)).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Convert StandardAuthorizer to use copy-on-write data structures.  The issue with the concurrent skiplist was that because it was modified while in use by StandardAuthorizer#authorize, we could sometimes expose an inconsistent state. For example, if we added a "deny principal foo", followed by "allow all", a request for principal foo might happen to see the second one, without seeing the first one, even though the first one was added first.

In order to efficiently implement prefix ACLs, store them in a prefix tree. This ensures that we can check all prefix ACLs for a path in logarithmic time. Also implement Authorizer#authorizeByResourceType. The default implementation of this function is quite slow, so it is good to have an implementation in StandardAuthorizer.

Finally, this PR renames AclAuthorizerBenchmark to AuthorizerBenchmark and extends it to report information about StandardAuthorizer as well as AclAuthorizer.