### PR TITLE
KAFKA-14250: MirrorSourceTask exception causes the task to fail

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageReaderImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageReaderImpl.java
@@ -91,7 +91,7 @@ public class OffsetStorageReaderImpl implements CloseableOffsetStorageReader {
                     throw new ConnectException(
                         "Offset reader is closed. This is likely because the task has already been "
                             + "scheduled to stop but has taken longer than the graceful shutdown "
-                            + "period to do so.");
+                            + "period to do so.", new CancellationException());
                 }
                 offsetReadFuture = backingStore.get(serializedToOriginal.keySet());
                 offsetReadFutures.add(offsetReadFuture);
@@ -103,7 +103,7 @@ public class OffsetStorageReaderImpl implements CloseableOffsetStorageReader {
                 throw new ConnectException(
                     "Offset reader closed while attempting to read offsets. This is likely because "
                         + "the task was been scheduled to stop but has taken longer than the "
-                        + "graceful shutdown period to do so.");
+                        + "graceful shutdown period to do so.", e);
             } finally {
                 synchronized (offsetReadFutures) {
                     offsetReadFutures.remove(offsetReadFuture);


### PR DESCRIPTION
Exception during normal operation in MirrorSourceTask causes the task to fail instead of shutting down gracefully.

In MirrorSourceTask we are loading offsets for the topic partitions. At this point, while we are fetching the partitions, it is possible for the offset reader to be stopped by a parallel thread. Stopping the reader causes a CancellationException to be thrown, due to KAFKA-9051.

Currently this exception is not caught in MirrorSourceTask and so the exception propagates up and causes the task to go into FAILED state. We only need it to go to STOPPED state so that it would be restarted later.

This can be achieved by catching the exception and stopping the task directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
