### PR TITLE
KAFKA-14255: Fetching from follower should be disallowed if fetch from follower is disabled

### DIFF
--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -44,6 +44,9 @@
   //
   // Version 10 indicates that we can use the ZStd compression algorithm, as
   // described in KIP-110.
+  //
+  // Version 11 adds RackId, as described in KIP-392.
+  //
   // Version 12 adds flexible versions support as well as epoch validation through
   // the `LastFetchedEpoch` field
   //
@@ -97,7 +100,7 @@
       { "name": "Partitions", "type": "[]int32", "versions": "7+",
         "about": "The partitions indexes to forget." }
     ]},
-    { "name": "RackId", "type":  "string", "versions": "11+", "default": "", "ignorable": true,
+    { "name": "RackId", "type": "string", "versions": "11+", "default": "", "ignorable": true,
       "about": "Rack ID of the consumer making this request"}
   ]
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -949,7 +949,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
       val clientMetadata = if (versionId >= 11 && replicaManager.hasReplicaSelector) {
         // Fetching from follower is only supported from Fetch API version 11. Moreover, we
-        // only allow it if the broker has a replica selector configured. If it does not, there
+        // only allow it if the broker has a replica selector configured. If it does not, there is
         // no point in letting the client read from a follower replica because it is not expected.
         Some(new DefaultClientMetadata(
           fetchRequest.rackId,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -253,6 +253,8 @@ class ReplicaManager(val config: KafkaConfig,
   // Visible for testing
   private[server] val replicaSelectorOpt: Option[ReplicaSelector] = createReplicaSelector()
 
+  def hasReplicaSelector: Boolean = replicaSelectorOpt.isDefined
+
   newGauge("LeaderCount", () => leaderPartitionsIterator.size)
   // Visible for testing
   private[kafka] val partitionCount = newGauge("PartitionCount", () => allPartitions.size)
@@ -1103,8 +1105,9 @@ class ReplicaManager(val config: KafkaConfig,
           throw new InconsistentTopicIdException("Topic ID in the fetch session did not match the topic ID in the log.")
 
         // If we are the leader, determine the preferred read-replica
-        val preferredReadReplica = params.clientMetadata.flatMap(
-          metadata => findPreferredReadReplica(partition, metadata, params.replicaId, fetchInfo.fetchOffset, fetchTimeMs))
+        val preferredReadReplica = params.clientMetadata.flatMap { metadata =>
+          findPreferredReadReplica(partition, metadata, params.replicaId, fetchInfo.fetchOffset, fetchTimeMs)
+        }
 
         if (preferredReadReplica.isDefined) {
           replicaSelectorOpt.foreach { selector =>

--- a/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
@@ -35,7 +35,7 @@ class BaseFetchRequestTest extends BaseRequestTest {
 
   protected var producer: KafkaProducer[String, String] = _
 
-  override def brokerPropertyOverrides(properties: Properties): Unit = {
+  protected override def brokerPropertyOverrides(properties: Properties): Unit = {
     properties.put(KafkaConfig.FetchMaxBytes, Int.MaxValue.toString)
   }
 


### PR DESCRIPTION
There are clients out there that have implemented KIP-392 (Fetch From Follower) and thus use FetchRequest >= 11. However, they have not implemented KIP-320 which add the leader epoch to the FetchRequest in version 9. Without KIP-320, it is not safe to fetch from the follower. If a client does it by mistake – e.g. based on stale metadata – that could lead to offset out of range.

This patch proposes to disable fetching from a follower when the cluster does not have a replica selector. If it does not, consumers are not expected to fetch from followers.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
