### PR TITLE
KAFKA-14256: Upgrade from Scala 2.13.8 to 2.13.10

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -252,9 +252,9 @@ plexus-utils-3.3.0
 reload4j-1.2.19
 rocksdbjni-6.29.4.1
 scala-collection-compat_2.13-2.6.0
-scala-library-2.13.8
+scala-library-2.13.10
 scala-logging_2.13-3.9.4
-scala-reflect-2.13.8
+scala-reflect-2.13.10
 scala-java8-compat_2.13-1.0.2
 snakeyaml-1.30
 snappy-java-1.1.8.4

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.13.8
+  SCALA_VERSION=2.13.10
   if [[ -f "$base_dir/gradle.properties" ]]; then
     SCALA_VERSION=`grep "^scalaVersion=" "$base_dir/gradle.properties" | cut -d= -f 2`
   fi

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.13.8
+  set SCALA_VERSION=2.13.10
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/build.gradle
+++ b/build.gradle
@@ -653,6 +653,9 @@ subprojects {
       "-Xlint:unused"
     ]
 
+    if (versions.baseScala == '2.13')
+      scalaCompileOptions.additionalParameters += ["-Wconf:msg=@nowarn annotation does not suppress any warnings:s"] // See https://github.com/scala/scala/pull/9960
+
     // See README.md for details on this option and the meaning of each value
     if (userScalaOptimizerMode.equals("method"))
       scalaCompileOptions.additionalParameters += ["-opt:l:method"]

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -202,9 +202,9 @@ class TopicCommandTest {
       () => topicService.deleteTopic(new TopicCommandOptions(Array("--topic", topicName))))
     assertTrue(exception.getCause.isInstanceOf[ThrottlingQuotaExceededException])
 
-    verify(adminClient, times(1)).deleteTopics(
-      eqThat(Seq(topicName).asJavaCollection),
-      argThat((_.shouldRetryOnQuotaViolation() == false): ArgumentMatcher[DeleteTopicsOptions])
+    verify(adminClient).deleteTopics(
+      argThat((topics: java.util.Collection[String]) => topics.asScala.toBuffer.equals(Seq(topicName))),
+      argThat((options: DeleteTopicsOptions) => !options.shouldRetryOnQuotaViolation)
     )
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=3.4.0-SNAPSHOT
-scalaVersion=2.13.8
+scalaVersion=2.13.10
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
 
 // Add Scala version
 def defaultScala212Version = '2.12.15'
-def defaultScala213Version = '2.13.8'
+def defaultScala213Version = '2.13.10'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -123,7 +123,7 @@ versions += [
   spotbugs: "4.7.3",
   swaggerAnnotations: "2.2.0",
   swaggerJaxrs2: "2.2.0",
-  zinc: "1.6.1",
+  zinc: "1.7.2",
   zookeeper: "3.6.3",
   zstd: "1.5.2-1"
 ]


### PR DESCRIPTION
In addition to the version bump, we also had to:
* Update the zinc version
* Workaround compiler warnings via suppression (proper fix in a follow up)
* Adjust `testDeleteTopicDoesNotRetryThrottlingQuotaExceededException` to fix a test failure

Release notes:
* https://github.com/scala/scala/releases/tag/v2.13.9
* https://github.com/scala/scala/releases/tag/v2.13.10