### PR TITLE
MINOR: Improve unit test coverage of LeaderAndIsr class

### DIFF
--- a/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
+++ b/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
@@ -31,4 +31,56 @@ final class LeaderAndIsrTest {
     assertEquals(List(3), recoveringLeaderAndIsr.isr)
     assertEquals(LeaderRecoveryState.RECOVERING, recoveringLeaderAndIsr.leaderRecoveryState)
   }
+
+  @Test
+  def testNewLeaderAndIsr(): Unit = {
+    val leaderAndIsr = LeaderAndIsr(1, List(1, 2))
+    val newLeaderAndIsr = leaderAndIsr.newLeaderAndIsr(2, List(1, 2))
+
+    assertEquals(2, newLeaderAndIsr.leader)
+    assertEquals(List(1, 2), newLeaderAndIsr.isr)
+    assertEquals(LeaderRecoveryState.RECOVERED, newLeaderAndIsr.leaderRecoveryState)
+  }
+
+  @Test
+  def testNewLeader(): Unit = {
+    val leaderAndIsr = LeaderAndIsr(2, List(1, 2, 3))
+
+    assertEquals(2, leaderAndIsr.leader)
+    assertEquals(List(1, 2, 3), leaderAndIsr.isr)
+
+    val newLeaderAndIsr = leaderAndIsr.newLeader(3)
+
+    assertEquals(3, newLeaderAndIsr.leader)
+    assertEquals(List(1, 2, 3), newLeaderAndIsr.isr)
+  }
+
+  @Test
+  def testNewEpoch() : Unit = {
+    val leaderAndIsr = LeaderAndIsr(3, List(1, 2, 3))
+
+    assertEquals(0, leaderAndIsr.leaderEpoch)
+
+    val leaderWithNewEpoch = leaderAndIsr.newEpoch
+
+    assertEquals(1, leaderWithNewEpoch.leaderEpoch)
+  }
+
+  @Test
+  def testLeaderOpt() : Unit = {
+    val leaderAndIsr = LeaderAndIsr(2, List(1, 2, 3))
+
+    assertEquals(2, leaderAndIsr.leaderOpt.get)
+  }
+
+  @Test
+  def testWithZkVersion() : Unit = {
+    val leaderAndIsr = LeaderAndIsr(3, List(1, 2, 3))
+
+    assertEquals(0, leaderAndIsr.zkVersion)
+
+    val leaderWithNewZkVersion = leaderAndIsr.withZkVersion(2)
+
+    assertEquals(2, leaderWithNewZkVersion.zkVersion)
+  }
 }

--- a/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
+++ b/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
@@ -72,15 +72,4 @@ final class LeaderAndIsrTest {
 
     assertEquals(2, leaderAndIsr.leaderOpt.get)
   }
-
-  @Test
-  def testWithZkVersion() : Unit = {
-    val leaderAndIsr = LeaderAndIsr(3, List(1, 2, 3))
-
-    assertEquals(0, leaderAndIsr.zkVersion)
-
-    val leaderWithNewZkVersion = leaderAndIsr.withZkVersion(2)
-
-    assertEquals(2, leaderWithNewZkVersion.zkVersion)
-  }
 }


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

This PR adds a few test cases for `LeaderAndIsr` class. Currently, on the UNIT level, we check `newRecoveringLeaderAndIsr` method. Therefore I have created mostly all unit tests for such class to improve coverage. 
