### PR TITLE
KAFKA-2526 : fix deserializer/serializer from properties for console …

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -63,7 +63,7 @@ object ConsoleConsumer extends Logging {
 
   def run(conf: ConsumerConfig): Unit = {
     val timeoutMs = if (conf.timeoutMs >= 0) conf.timeoutMs.toLong else Long.MaxValue
-    val consumer = new KafkaConsumer(consumerProps(conf), new ByteArrayDeserializer, new ByteArrayDeserializer)
+    val consumer = new KafkaConsumer[Array[Byte],Array[Byte]](consumerProps(conf))
 
     val consumerWrapper =
       if (conf.partitionArg.isDefined)
@@ -299,10 +299,11 @@ object ConsoleConsumer extends Logging {
     var includedTopicsArg: String = _
     var filterSpec: TopicFilter = _
     val extraConsumerProps = CommandLineUtils.parseKeyValueArgs(options.valuesOf(consumerPropertyOpt).asScala)
-    val consumerProps = if (options.has(consumerConfigOpt))
-      Utils.loadProps(options.valueOf(consumerConfigOpt))
-    else
-      new Properties()
+    val consumerProps = new Properties
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    if (options.has(consumerConfigOpt))
+      consumerProps.putAll(Utils.loadProps(options.valueOf(consumerConfigOpt)))
     val fromBeginning = options.has(resetBeginningOpt)
     val partitionArg = if (options.has(partitionIdOpt)) Some(options.valueOf(partitionIdOpt).intValue) else None
     val skipMessageOnError = options.has(skipMessageOnErrorOpt)

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -29,6 +29,7 @@ import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, ToolsUtils}
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.serialization.{ByteArraySerializer}
 import org.apache.kafka.common.utils.Utils
 import scala.jdk.CollectionConverters._
 
@@ -93,9 +94,10 @@ object ConsoleProducer {
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec)
     if (props.getProperty(ProducerConfig.CLIENT_ID_CONFIG) == null)
       props.put(ProducerConfig.CLIENT_ID_CONFIG, "console-producer")
-    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
-
+    if (props.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG) == null)
+      props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+    if (props.getProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG) == null)
+      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
     CommandLineUtils.maybeMergeOptions(
       props, ProducerConfig.LINGER_MS_CONFIG, config.options, config.sendTimeoutOpt)
     CommandLineUtils.maybeMergeOptions(


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>
Fixes [KAFKA-2526](https://issues.apache.org/jira/browse/KAFKA-2526)

Configuration of the `ConsoleProducer` and `ConsoleConsumer` has been broken since 2017. Despite there being CLI options, these are ignored. The `client.properties` file is also ignored for both.

I have a custom deserilazer and serializer that I want to use (it does encryption and decryption). 

<!--*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*-->

This is behavior correction rather than change. There are no tests, or test infrastructure for these two tools.

Testing will be manual.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
