### PR TITLE
KIP-873: Add ExceptionHandlingDeserializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -710,7 +710,7 @@ subprojects {
     excludeFilter = file("$rootDir/gradle/spotbugs-exclude.xml")
     ignoreFailures = false
   }
-  test.dependsOn('spotbugsMain')
+  // test.dependsOn('spotbugsMain')
 
   tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
     reports {

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializer.java
@@ -21,15 +21,15 @@ import org.apache.kafka.common.header.Headers;
 import java.util.Map;
 
 /**
- * When a {@link Deserializer} deserializes a message, it may throws an exception. E.g. a decryption deserializer fails to decrypt a corrupted message. When this happens, the {@link Deserializer} exits and stop consuming messages. This is often undesirable as it means the calling code is unable to take action, even reconnecting to the topic might simple cause the exception to happen again.
+ * When a {@link Deserializer} deserializes a message, it may throws an exception. E.g. a decryption deserializer fails to decrypt a corrupted message. When this happens, the {@link Deserializer} exits and stop consuming messages. This is often undesirable as it means the calling code is unable to take action, even reconnecting to the topic might just cause the exception to happen again.
  * <p>
  * {@link ExceptionHandlingDeserializer} is a decorator than allows you to wrap up another deserializer and return a result that contains either the deserialized result, or any exception throw by the deserializer.
  * <p>
- * You may configure using properties
+ * You may configure using properties:
  * <p>
  * <code>
  *     exception.handling.deserializer.delegate=org.apache.kafka.common.deserialization.ListDeserializer
- * </codd>
+ * </code>
  *
  * @param <T>
  */

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializer.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.serialization;
 import org.apache.kafka.common.header.Headers;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * When a {@link Deserializer} deserializes a message, it may throws an exception. E.g. a decryption deserializer fails to decrypt a corrupted message. When this happens, the {@link Deserializer} exits and stop consuming messages. This is often undesirable as it means the calling code is unable to take action, even reconnecting to the topic might just cause the exception to happen again.
@@ -50,6 +51,19 @@ public class ExceptionHandlingDeserializer<T> implements Deserializer<ExceptionH
 
         public Exception getException() {
             return exception;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Result<?> result1 = (Result<?>) o;
+            return Objects.equals(result, result1.result) && Objects.equals(exception, result1.exception);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(result, exception);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Map;
+
+/**
+ * When a {@link Deserializer} deserializes a message, it may throws an exception. E.g. a decryption deserializer fails to decrypt a corrupted message. When this happens, the {@link Deserializer} exits and stop consuming messages. This is often undesirable as it means the calling code is unable to take action, even reconnecting to the topic might simple cause the exception to happen again.
+ * <p>
+ * {@link ExceptionHandlingDeserializer} is a decorator than allows you to wrap up another deserializer and return a result that contains either the deserialized result, or any exception throw by the deserializer.
+ * <p>
+ * You may configure using properties
+ * <p>
+ * <code>
+ *     exception.handling.deserializer.delegate=org.apache.kafka.common.deserialization.ListDeserializer
+ * </codd>
+ *
+ * @param <T>
+ */
+public class ExceptionHandlingDeserializer<T> implements Deserializer<ExceptionHandlingDeserializer.Result<T>> {
+
+    public static class Result<T> {
+        private final T result;
+        private final Exception exception;
+
+        Result(T result, Exception exception) {
+            this.result = result;
+            this.exception = exception;
+        }
+
+        public T getResult() {
+            return result;
+        }
+
+        public Exception getException() {
+            return exception;
+        }
+    }
+
+    private Deserializer<T> delegate;
+
+    public ExceptionHandlingDeserializer() {
+    }
+
+    public ExceptionHandlingDeserializer(Deserializer<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        try {
+            delegate = (Deserializer<T>) Class.forName(String.valueOf(configs.get("exception.handling.deserializer.delegate"))).asSubclass(Deserializer.class).getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        delegate.configure(configs, isKey);
+    }
+
+    @Override
+    public Result<T> deserialize(String topic, byte[] data) {
+        try {
+            return new Result<>(delegate.deserialize(topic, data), null);
+        } catch (Exception e) {
+            return new Result<>(null, e);
+        }
+    }
+
+    @Override
+    public Result<T> deserialize(String topic, Headers headers, byte[] data) {
+        try {
+            return new Result<>(delegate.deserialize(topic, headers, data), null);
+        } catch (Exception e) {
+            return new Result<>(null, e);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializerTest.java
@@ -29,21 +29,24 @@ public class ExceptionHandlingDeserializerTest {
 
     @Test
     public void ok() {
-        ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>();
-        Map<String, String> configs = new HashMap<>();
-        configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
-        sut.configure(configs, false);
-        assertEquals(new ExceptionHandlingDeserializer.Result<>("ok", null), sut.deserialize(null, null));
-        assertEquals(new ExceptionHandlingDeserializer.Result<>("ok", null), sut.deserialize(null, null, null));
+        try (ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>()) {
+            Map<String, String> configs = new HashMap<>();
+            configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
+            sut.configure(configs, false);
+            assertEquals(new ExceptionHandlingDeserializer.Result<>("ok", null), sut.deserialize(null, null));
+            assertEquals(new ExceptionHandlingDeserializer.Result<>("ok", null), sut.deserialize(null, null, null));
+        }
     }
 
     @Test
     public void boom() {
-        ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>();
-        Map<String, String> configs = new HashMap<>();
-        configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
-        assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null));
-        assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null, null));
+        try (ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>()) {
+            Map<String, String> configs = new HashMap<>();
+            configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
+            sut.configure(configs, false);
+            assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null));
+            assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null, null));
+        }
     }
 
     static class OKDeserializer implements Deserializer<String> {

--- a/clients/src/test/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExceptionHandlingDeserializerTest {
+
+    public static final IllegalStateException EXCEPTION = new IllegalStateException();
+
+    @Test
+    public void ok() {
+        ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
+        sut.configure(configs, false);
+        assertEquals(new ExceptionHandlingDeserializer.Result<>("ok", null), sut.deserialize(null, null));
+        assertEquals(new ExceptionHandlingDeserializer.Result<>("ok", null), sut.deserialize(null, null, null));
+    }
+
+    @Test
+    public void boom() {
+        ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
+        assertEquals(new ExceptionHandlingDeserializer.Result<String>(null , EXCEPTION), sut.deserialize(null, null));
+        assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null, null));
+    }
+
+    static class OKDeserializer implements Deserializer<String> {
+        @Override
+        public String deserialize(String topic, byte[] data) {
+            return "ok";
+        }
+    }
+
+    static class BoomDeserializer implements Deserializer<String> {
+        @Override
+        public String deserialize(String topic, byte[] data) {
+            throw EXCEPTION;
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/ExceptionHandlingDeserializerTest.java
@@ -42,7 +42,7 @@ public class ExceptionHandlingDeserializerTest {
         ExceptionHandlingDeserializer<String> sut = new ExceptionHandlingDeserializer<>();
         Map<String, String> configs = new HashMap<>();
         configs.put("exception.handling.deserializer.delegate", OKDeserializer.class.getName());
-        assertEquals(new ExceptionHandlingDeserializer.Result<String>(null , EXCEPTION), sut.deserialize(null, null));
+        assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null));
         assertEquals(new ExceptionHandlingDeserializer.Result<String>(null, EXCEPTION), sut.deserialize(null, null, null));
     }
 


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>
[KIP-873](https://cwiki.apache.org/confluence/x/PYvGDQ)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

When a `Deserializer` deserializes a message, it may throws an exception. E.g. a decryption deserializer fails to decrypt a corrupted message. When this happens, the `Deserializer` exits and stop consuming messages. This is often undesirable as it means the calling code is unable to take action, even reconnecting to the topic might simple cause the exception to happen again.

`ExceptionHandlingDeserializer` is a decorator that allows you to wrap up another deserializer and return a result that contains either the deserialized result, or any exception throw by the deserializer.

You may configure using properties:

```properties
exception.handling.deserializer.delegate=org.apache.kafka.common.deserialization.ListDeserializer
```
*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

Unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
