### PR TITLE
KIP-873: Add PipeDeserializer/PipeSerialize

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/PipeDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/PipeDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import org.apache.kafka.common.header.Headers;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+public class PipeDeserializer<T> implements Deserializer<T> {
+    private Deserializer<byte[]> from;
+    private Deserializer<T> to;
+
+    public PipeDeserializer() {
+    }
+
+    public PipeDeserializer(Deserializer<byte[]> from, Deserializer<T> to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        try {
+            from = (Deserializer<byte[]>) Class.forName(String.valueOf(configs.get("pipe.deserializer.from"))).getDeclaredConstructor().newInstance();
+            to = (Deserializer<T>) Class.forName(String.valueOf(configs.get("pipe.deserializer.to"))).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException |
+                 InvocationTargetException e) {
+            throw new IllegalStateException(e);
+        }
+        from.configure(configs, isKey);
+        to.configure(configs, isKey);
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        return to.deserialize(topic, from.deserialize(topic, data));
+    }
+
+    @Override
+    public T deserialize(String topic, Headers headers, byte[] data) {
+        return to.deserialize(topic, headers, from.deserialize(topic, headers, data));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/PipeSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/PipeSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Map;
+
+/**
+ * {@link PipeSerializer} solves the problem of needing to do a two step serialization. For example, you want to serialize CloudEvent and then encrypt them.
+ * <p>
+ * To configure:
+ * <code>
+ * pipe.serializer.from=com.example.CloudEventSerializer
+ * pipe.serializer.to=com.example.EncryptionSerializer
+ * </code>
+ *
+ * @param <T>
+ */
+public class PipeSerializer<T> implements Serializer<T> {
+    private Serializer<T> from;
+    private Serializer<byte[]> to;
+
+    public PipeSerializer() {
+    }
+
+    public PipeSerializer(Serializer<T> from, Serializer<byte[]> to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        try {
+            from = (Serializer<T>) Class.forName(String.valueOf(configs.get("pipe.serializer.from"))).getDeclaredConstructor().newInstance();
+            to = (Serializer<byte[]>) Class.forName(String.valueOf(configs.get("pipe.serializer.to"))).getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        from.configure(configs, isKey);
+        to.configure(configs, isKey);
+    }
+
+    @Override
+    public byte[] serialize(String topic, T data) {
+        return to.serialize(topic, from.serialize(topic, data));
+    }
+
+    @Override
+    public byte[] serialize(String topic, Headers headers, T data) {
+        return to.serialize(topic, headers, from.serialize(topic, headers, data));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/serialization/PipeDeserializerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/PipeDeserializerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PipeDeserializerTest {
+
+    @Test
+    void deserialize() {
+        try (PipeDeserializer<String> sut = new PipeDeserializer<>()) {
+            Map<String, String> configs = new HashMap<>();
+            configs.put("pipe.deserializer.from", ByteArrayDeserializer.class.getName());
+            configs.put("pipe.deserializer.to", StringDeserializer.class.getName());
+            sut.configure(configs, false);
+            assertEquals("foo", sut.deserialize(null, "foo".getBytes(StandardCharsets.UTF_8)));
+            assertEquals("foo", sut.deserialize(null, null, "foo".getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/serialization/PipeSerializerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/PipeSerializerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class PipeSerializerTest {
+
+    @Test
+    void serialize() {
+        try (PipeSerializer<String> sut = new PipeSerializer<>()) {
+            Map<String, String> configs = new HashMap<>();
+            configs.put("pipe.serializer.from", StringSerializer.class.getName());
+            configs.put("pipe.serializer.to", ByteArraySerializer.class.getName());
+            sut.configure(configs, false);
+
+            assertArrayEquals("foo".getBytes(StandardCharsets.UTF_8), sut.serialize(null, "foo"));
+            assertArrayEquals("foo".getBytes(StandardCharsets.UTF_8), sut.serialize(null, null, "foo"));
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>
[KIP-873](https://cwiki.apache.org/confluence/x/PYvGDQ)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

`PipeSerializer` solves the problem of needing to do a two step serialization. For example, you want to serialize CloudEvent and then encrypt them.

To configure:

```properties
pipe.serializer.from=com.example.CloudEventSerializer
pipe.serializer.to=com.example.EncryptionSerializer
```

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

Unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
