### PR TITLE
KAFKA-14270: Fix generated Kafka Streams version file name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1926,7 +1926,7 @@ project(':streams') {
   }
 
   task createStreamsVersionFile() {
-    def receiptFile = file("$buildDir/kafka/$buildVersionFileName")
+    def receiptFile = file("$buildDir/kafka/$buildStreamsVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
     outputs.file receiptFile


### PR DESCRIPTION
Kafka Streams expects a version resource at /kafka/kafka-streams-version.properties. It is read by `ClientMetrics`, initialised by

https://github.com/apache/kafka/blob/3.3.0/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java#L894

When the resource is not found,

https://github.com/apache/kafka/blob/3.3.0/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java#L55

logs a warning at startup:

```
org.apache.kafka.streams.internals.metrics.ClientMetrics <clinit> WARN: Error while loading kafka-streams-version.properties
java.lang.NullPointerException: inStream parameter is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.Properties.load(Properties.java:407)
	at org.apache.kafka.streams.internals.metrics.ClientMetrics.<clinit>(ClientMetrics.java:53)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:894)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:856)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:826)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:738)
```

https://issues.apache.org/jira/browse/KAFKA-14270

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
