### PR TITLE
KAFKA-14277: Add event queue size method

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
@@ -255,6 +255,11 @@ public interface EventQueue extends AutoCloseable {
     default void wakeup() { }
 
     /**
+     * Return the number of events scheduled in the queue.
+     */
+    int size();
+
+    /**
      * Synchronously close the event queue and wait for any threads to be joined.
      */
     void close() throws InterruptedException;


### PR DESCRIPTION
From [KAFKA-14277](https://issues.apache.org/jira/browse/KAFKA-14277), a `size` method for the event queue interface in the `server-common` package could come in handy. 

For example, It could be useful in certain scenarios like using it to expose metrics to track the number of tasks in the queue. 
