### PR TITLE
KAFKA-14280: return random backoff for 1st retries

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -647,12 +647,13 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         }
     }
 
-    private int binaryExponentialElectionBackoffMs(int retries) {
+    // visible for testing
+    int binaryExponentialElectionBackoffMs(int retries) {
         if (retries <= 0) {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
         // upper limit exponential co-efficients at 20 to avoid overflow
-        return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries - 1)),
+        return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries)),
                 raftConfig.electionBackoffMaxMs());
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -653,7 +653,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
         // upper limit exponential co-efficients at 20 to avoid overflow
-        return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries)),
+        return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, Math.max(1, retries - 1))),
                 raftConfig.electionBackoffMaxMs());
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -653,7 +653,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
         // upper limit exponential co-efficients at 20 to avoid overflow
-        return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, Math.max(1, retries - 1))),
+        return Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries)),
                 raftConfig.electionBackoffMaxMs());
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1225,7 +1225,7 @@ public class KafkaRaftClientTest {
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters).build();
 
         TestUtils.waitForCondition(() -> context.client.binaryExponentialElectionBackoffMs(1) > 0, 1000,
-            "exponential election backoff should return a value in range [0, 4] for retries = 1");
+            "exponential election backoff should return a value in range [0, 400] for retries = 1");
 
         int remainingRetries = 10;
         while (remainingRetries-- >= 0) {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1217,6 +1217,25 @@ public class KafkaRaftClientTest {
     }
 
     @Test
+    public void testBinaryExponentialElectionBackoffMs() throws InterruptedException, IOException {
+        int localId = 0;
+        int otherNodeId = 1;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters).build();
+
+        TestUtils.waitForCondition(() -> context.client.binaryExponentialElectionBackoffMs(1) > 0, 1000,
+            "exponential election backoff should return a value in range [0, 4] for retries = 1");
+
+        int remainingRetries = 10;
+        while (remainingRetries-- >= 0) {
+            int backOffMs = context.client.binaryExponentialElectionBackoffMs(Integer.MAX_VALUE);
+            assertTrue(backOffMs >= 0 && backOffMs <= context.electionBackoffMaxMs,
+                "exponential election backoff should return a value in range [0, electionBackoffMaxMs] for large retries");
+        }
+    }
+
+    @Test
     public void testRetryElection() throws Exception {
         int localId = 0;
         int otherNodeId = 1;


### PR DESCRIPTION
When doing quorum election, we added a random election backoff if vote got rejected or timeout, and hope next round, there will be no conflict between different voters. But currently, we calculate the random backoff by:

```
Math.min(RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries - 1)),
        raftConfig.electionBackoffMaxMs());
```

That means, when multiple candidates tried to backoff for the 1st retries, they will all get 0ms backoff, and then keep conflicting again.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
