### PR TITLE
KAFKA-14284: fix "current-vote" metric in leader state

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1839,7 +1839,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Current Voted</td>
-    <td>The current voted leader's id; -1 indicates not voted for anyone.</td>
+    <td>The current voted leader's id; -1 indicates not under election state or not voted for anyone.</td>
     <td>kafka.server:type=raft-metrics,name=current-vote</td>
   </tr>
   <tr>

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
@@ -84,9 +84,9 @@ public class KafkaRaftMetrics implements AutoCloseable {
         this.currentLeaderIdMetricName = metrics.metricName("current-leader", metricGroupName, "The current quorum leader's id; -1 indicates unknown");
         metrics.addMetric(this.currentLeaderIdMetricName, (mConfig, currentTimeMs) -> state.leaderId().orElse(-1));
 
-        this.currentVotedIdMetricName = metrics.metricName("current-vote", metricGroupName, "The current voted leader's id; -1 indicates not voted for anyone");
+        this.currentVotedIdMetricName = metrics.metricName("current-vote", metricGroupName, "The current voted leader's id; -1 indicates not under election state or not voted for anyone");
         metrics.addMetric(this.currentVotedIdMetricName, (mConfig, currentTimeMs) -> {
-            if (state.isLeader() || state.isCandidate()) {
+            if (state.isCandidate()) {
                 return state.localIdOrThrow();
             } else if (state.isVoted()) {
                 return state.votedStateOrThrow().votedId();


### PR DESCRIPTION
The "current-vote" metric displays the current voted leader's id. It should show a valid value under election state (i.e. candidate or voted state). But it will always show leader's id for leader controller, which is unexpected. 

Compared to the "quorum-state" file, the votedId will show -1 if it's not in "candidate" or "voted" state, which makes more sense.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
