### PR TITLE
KAFKA-14132; Replace EasyMock with Mockito ConnectorsResourceTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,7 @@ subprojects {
     testsToExclude.addAll([
       // connect tests
       "**/ConnectorPluginsResourceTest.*",
-      "**/ConnectorsResourceTest.*", "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
+      "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
       "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
       "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",
       "**/SourceTaskOffsetCommitterTest.*",

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -904,8 +904,6 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testResetConnectorActiveTopics() {
-        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
-        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
         HttpHeaders headers = mock(HttpHeaders.class);
         herder.resetConnectorActiveTopics(CONNECTOR_NAME);
         verify(herder).resetConnectorActiveTopics(CONNECTOR_NAME);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -74,7 +74,6 @@ import java.util.Set;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ALLOW_RESET_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
@@ -718,12 +717,10 @@ public class ConnectorsResourceTest {
     @Test
     public void testFenceZombiesNoInternalRequestSignature() throws Throwable {
         final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
         expectAndCallbackResult(cb, null)
-            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), signatureCapture.capture());
+            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), isNull());
 
         connectorsResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null));
-        assertNull(signatureCapture.getValue());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -84,6 +84,7 @@ import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
@@ -173,6 +174,7 @@ public class ConnectorsResourceTest {
     @After
     public void teardown() {
         restClientStatic.close();
+        verifyNoMoreInteractions(herder);
     }
 
     private static Map<String, String> getConnectorConfig(Map<String, String> mapToClone) {
@@ -903,11 +905,10 @@ public class ConnectorsResourceTest {
     @Test
     public void testResetConnectorActiveTopics() {
         HttpHeaders headers = mock(HttpHeaders.class);
-        herder.resetConnectorActiveTopics(CONNECTOR_NAME);
-        verify(herder).resetConnectorActiveTopics(CONNECTOR_NAME);
         connectorsResource = new ConnectorsResource(herder, workerConfig);
 
         Response response = connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers);
+        verify(herder).resetConnectorActiveTopics(CONNECTOR_NAME);
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -486,13 +486,14 @@ public class ConnectorsResourceTest {
         assertEquals(expectedTasksConnector2, tasksConfig2);
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testGetTasksConfigConnectorNotFound() throws Throwable {
         final ArgumentCaptor<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackException(cb, new NotFoundException("not found"))
             .when(herder).tasksConfig(eq(CONNECTOR_NAME), cb.capture());
 
-        connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        assertThrows(NotFoundException.class, () ->
+            connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -305,24 +305,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testCreateConnectorWithHeaderAuthorization() throws Throwable {
-        CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
-        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
-        HttpHeaders httpHeaders = mock(HttpHeaders.class);
-        expectAndCallbackNotLeaderException(cb)
-            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
-
-        verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> connectorsResource.createConnector(FORWARD, httpHeaders, body)
-        );
-    }
-
-
-
-    @Test
-    public void testCreateConnectorWithoutHeaderAuthorization() throws Throwable {
+    public void testCreateConnectorWithHeaders() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         HttpHeaders httpHeaders = mock(HttpHeaders.class);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.connect.runtime.rest.resources;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 import javax.crypto.Mac;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -43,18 +41,16 @@ import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.IAnswer;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.api.easymock.annotation.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Stubber;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -78,12 +74,20 @@ import java.util.Set;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ALLOW_RESET_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(RestClient.class)
-@PowerMockIgnore({"javax.management.*", "javax.crypto.*"})
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 @SuppressWarnings("unchecked")
 public class ConnectorsResourceTest {
     // Note trailing / and that we do *not* use LEADER_URL to construct our reference values. This checks that we handle
@@ -153,19 +157,23 @@ public class ConnectorsResourceTest {
     @Mock
     private WorkerConfig workerConfig;
 
+    private MockedStatic<RestClient> restClientStatic;
+
     @Before
     public void setUp() throws NoSuchMethodException {
-        PowerMock.mockStatic(RestClient.class,
-                RestClient.class.getMethod("httpRequest", String.class, String.class, HttpHeaders.class, Object.class, TypeReference.class, WorkerConfig.class));
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).andReturn(true);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).andReturn(true);
-        PowerMock.replay(workerConfig);
+        restClientStatic = mockStatic(RestClient.class);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
         connectorsResource = new ConnectorsResource(herder, workerConfig);
-        forward = EasyMock.mock(UriInfo.class);
+        forward = mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.putSingle("forward", "true");
-        EasyMock.expect(forward.getQueryParameters()).andReturn(queryParams).anyTimes();
-        EasyMock.replay(forward);
+        when(forward.getQueryParameters()).thenReturn(queryParams);
+    }
+
+    @After
+    public void teardown() {
+        restClientStatic.close();
     }
 
     private static Map<String, String> getConnectorConfig(Map<String, String> mapToClone) {
@@ -175,85 +183,69 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testListConnectors() {
-        final Capture<Callback<Collection<String>>> cb = Capture.newInstance();
-        EasyMock.expect(herder.connectors()).andReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
-
-        PowerMock.replayAll();
+        when(herder.connectors()).thenReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
 
         Collection<String> connectors = (Collection<String>) connectorsResource.listConnectors(forward, NULL_HEADERS).getEntity();
         // Ordering isn't guaranteed, compare sets
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_NAME, CONNECTOR2_NAME)), new HashSet<>(connectors));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testExpandConnectorsStatus() {
-        EasyMock.expect(herder.connectors()).andReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
-        ConnectorStateInfo connector = EasyMock.mock(ConnectorStateInfo.class);
-        ConnectorStateInfo connector2 = EasyMock.mock(ConnectorStateInfo.class);
-        EasyMock.expect(herder.connectorStatus(CONNECTOR2_NAME)).andReturn(connector2);
-        EasyMock.expect(herder.connectorStatus(CONNECTOR_NAME)).andReturn(connector);
+        when(herder.connectors()).thenReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
+        ConnectorStateInfo connector = mock(ConnectorStateInfo.class);
+        ConnectorStateInfo connector2 = mock(ConnectorStateInfo.class);
+        when(herder.connectorStatus(CONNECTOR2_NAME)).thenReturn(connector2);
+        when(herder.connectorStatus(CONNECTOR_NAME)).thenReturn(connector);
 
-        forward = EasyMock.mock(UriInfo.class);
+        forward = mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.putSingle("expand", "status");
-        EasyMock.expect(forward.getQueryParameters()).andReturn(queryParams).anyTimes();
-        EasyMock.replay(forward);
-
-        PowerMock.replayAll();
+        when(forward.getQueryParameters()).thenReturn(queryParams);
 
         Map<String, Map<String, Object>> expanded = (Map<String, Map<String, Object>>) connectorsResource.listConnectors(forward, NULL_HEADERS).getEntity();
         // Ordering isn't guaranteed, compare sets
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_NAME, CONNECTOR2_NAME)), expanded.keySet());
         assertEquals(connector2, expanded.get(CONNECTOR2_NAME).get("status"));
         assertEquals(connector, expanded.get(CONNECTOR_NAME).get("status"));
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testExpandConnectorsInfo() {
-        EasyMock.expect(herder.connectors()).andReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
-        ConnectorInfo connector = EasyMock.mock(ConnectorInfo.class);
-        ConnectorInfo connector2 = EasyMock.mock(ConnectorInfo.class);
-        EasyMock.expect(herder.connectorInfo(CONNECTOR2_NAME)).andReturn(connector2);
-        EasyMock.expect(herder.connectorInfo(CONNECTOR_NAME)).andReturn(connector);
+        when(herder.connectors()).thenReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
+        ConnectorInfo connector = mock(ConnectorInfo.class);
+        ConnectorInfo connector2 = mock(ConnectorInfo.class);
+        when(herder.connectorInfo(CONNECTOR2_NAME)).thenReturn(connector2);
+        when(herder.connectorInfo(CONNECTOR_NAME)).thenReturn(connector);
 
-        forward = EasyMock.mock(UriInfo.class);
+        forward = mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.putSingle("expand", "info");
-        EasyMock.expect(forward.getQueryParameters()).andReturn(queryParams).anyTimes();
-        EasyMock.replay(forward);
-
-        PowerMock.replayAll();
+        when(forward.getQueryParameters()).thenReturn(queryParams);
 
         Map<String, Map<String, Object>> expanded = (Map<String, Map<String, Object>>) connectorsResource.listConnectors(forward, NULL_HEADERS).getEntity();
         // Ordering isn't guaranteed, compare sets
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_NAME, CONNECTOR2_NAME)), expanded.keySet());
         assertEquals(connector2, expanded.get(CONNECTOR2_NAME).get("info"));
         assertEquals(connector, expanded.get(CONNECTOR_NAME).get("info"));
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testFullExpandConnectors() {
-        EasyMock.expect(herder.connectors()).andReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
-        ConnectorInfo connectorInfo = EasyMock.mock(ConnectorInfo.class);
-        ConnectorInfo connectorInfo2 = EasyMock.mock(ConnectorInfo.class);
-        EasyMock.expect(herder.connectorInfo(CONNECTOR2_NAME)).andReturn(connectorInfo2);
-        EasyMock.expect(herder.connectorInfo(CONNECTOR_NAME)).andReturn(connectorInfo);
-        ConnectorStateInfo connector = EasyMock.mock(ConnectorStateInfo.class);
-        ConnectorStateInfo connector2 = EasyMock.mock(ConnectorStateInfo.class);
-        EasyMock.expect(herder.connectorStatus(CONNECTOR2_NAME)).andReturn(connector2);
-        EasyMock.expect(herder.connectorStatus(CONNECTOR_NAME)).andReturn(connector);
+        when(herder.connectors()).thenReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
+        ConnectorInfo connectorInfo = mock(ConnectorInfo.class);
+        ConnectorInfo connectorInfo2 = mock(ConnectorInfo.class);
+        when(herder.connectorInfo(CONNECTOR2_NAME)).thenReturn(connectorInfo2);
+        when(herder.connectorInfo(CONNECTOR_NAME)).thenReturn(connectorInfo);
+        ConnectorStateInfo connector = mock(ConnectorStateInfo.class);
+        ConnectorStateInfo connector2 = mock(ConnectorStateInfo.class);
+        when(herder.connectorStatus(CONNECTOR2_NAME)).thenReturn(connector2);
+        when(herder.connectorStatus(CONNECTOR_NAME)).thenReturn(connector);
 
-        forward = EasyMock.mock(UriInfo.class);
+        forward = mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("expand", Arrays.asList("info", "status"));
-        EasyMock.expect(forward.getQueryParameters()).andReturn(queryParams).anyTimes();
-        EasyMock.replay(forward);
-
-        PowerMock.replayAll();
+        when(forward.getQueryParameters()).thenReturn(queryParams);
 
         Map<String, Map<String, Object>> expanded = (Map<String, Map<String, Object>>) connectorsResource.listConnectors(forward, NULL_HEADERS).getEntity();
         // Ordering isn't guaranteed, compare sets
@@ -262,30 +254,25 @@ public class ConnectorsResourceTest {
         assertEquals(connectorInfo, expanded.get(CONNECTOR_NAME).get("info"));
         assertEquals(connector2, expanded.get(CONNECTOR2_NAME).get("status"));
         assertEquals(connector, expanded.get(CONNECTOR_NAME).get("status"));
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testExpandConnectorsWithConnectorNotFound() {
-        EasyMock.expect(herder.connectors()).andReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
-        ConnectorStateInfo connector = EasyMock.mock(ConnectorStateInfo.class);
-        ConnectorStateInfo connector2 = EasyMock.mock(ConnectorStateInfo.class);
-        EasyMock.expect(herder.connectorStatus(CONNECTOR2_NAME)).andReturn(connector2);
-        EasyMock.expect(herder.connectorStatus(CONNECTOR_NAME)).andThrow(EasyMock.mock(NotFoundException.class));
+        when(herder.connectors()).thenReturn(Arrays.asList(CONNECTOR2_NAME, CONNECTOR_NAME));
+        ConnectorStateInfo connector = mock(ConnectorStateInfo.class);
+        ConnectorStateInfo connector2 = mock(ConnectorStateInfo.class);
+        when(herder.connectorStatus(CONNECTOR2_NAME)).thenReturn(connector2);
+        doThrow(mock(NotFoundException.class)).when(herder).connectorStatus(CONNECTOR_NAME);
 
-        forward = EasyMock.mock(UriInfo.class);
+        forward = mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.putSingle("expand", "status");
-        EasyMock.expect(forward.getQueryParameters()).andReturn(queryParams).anyTimes();
-        EasyMock.replay(forward);
-
-        PowerMock.replayAll();
+        when(forward.getQueryParameters()).thenReturn(queryParams);
 
         Map<String, Map<String, Object>> expanded = (Map<String, Map<String, Object>>) connectorsResource.listConnectors(forward, NULL_HEADERS).getEntity();
         // Ordering isn't guaranteed, compare sets
         assertEquals(Collections.singleton(CONNECTOR2_NAME), expanded.keySet());
         assertEquals(connector2, expanded.get(CONNECTOR2_NAME).get("status"));
-        PowerMock.verifyAll();
     }
 
 
@@ -293,58 +280,43 @@ public class ConnectorsResourceTest {
     public void testCreateConnector() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG,
-            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
-
-        PowerMock.replayAll();
+            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCreateConnectorNotLeader() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
-        // Should forward request
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq(LEADER_URL + "connectors?forward=false"), EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.eq(body), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES,
-                    ConnectorType.SOURCE)));
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackNotLeaderException(cb).when(herder)
+            .putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
 
-        PowerMock.replayAll();
+        // Should forward request
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
-
-        PowerMock.verifyAll();
-
-
     }
 
     @Test
     public void testCreateConnectorWithHeaderAuthorization() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        HttpHeaders httpHeaders = EasyMock.mock(HttpHeaders.class);
-        EasyMock.expect(httpHeaders.getHeaderString("Authorization")).andReturn("Basic YWxhZGRpbjpvcGVuc2VzYW1l").times(1);
-        EasyMock.replay(httpHeaders);
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        HttpHeaders httpHeaders = mock(HttpHeaders.class);
+        expectAndCallbackNotLeaderException(cb)
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq(LEADER_URL + "connectors?forward=false"),
-            EasyMock.eq("POST"), EasyMock.eq(httpHeaders), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         connectorsResource.createConnector(FORWARD, httpHeaders, body);
-
-        PowerMock.verifyAll();
     }
 
 
@@ -352,37 +324,26 @@ public class ConnectorsResourceTest {
     @Test
     public void testCreateConnectorWithoutHeaderAuthorization() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        HttpHeaders httpHeaders = EasyMock.mock(HttpHeaders.class);
-        EasyMock.expect(httpHeaders.getHeaderString("Authorization")).andReturn(null).times(1);
-        EasyMock.replay(httpHeaders);
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        HttpHeaders httpHeaders = mock(HttpHeaders.class);
+        expectAndCallbackNotLeaderException(cb)
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq(LEADER_URL + "connectors?forward=false"),
-            EasyMock.eq("POST"), EasyMock.eq(httpHeaders), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         connectorsResource.createConnector(FORWARD, httpHeaders, body);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCreateConnectorExists() {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new AlreadyExistsException("already exists"));
-
-        PowerMock.replayAll();
-
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new AlreadyExistsException("already exists"))
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
         assertThrows(AlreadyExistsException.class, () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, body));
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -393,15 +354,12 @@ public class ConnectorsResourceTest {
         final CreateConnectorRequest bodyIn = new CreateConnectorRequest(CONNECTOR_NAME_PADDING_WHITESPACES, inputConfig);
         final CreateConnectorRequest bodyOut = new CreateConnectorRequest(CONNECTOR_NAME, CONNECTOR_CONFIG);
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(bodyOut.name()), EasyMock.eq(bodyOut.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(), CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
+            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -412,15 +370,12 @@ public class ConnectorsResourceTest {
         final CreateConnectorRequest bodyIn = new CreateConnectorRequest(CONNECTOR_NAME_ALL_WHITESPACES, inputConfig);
         final CreateConnectorRequest bodyOut = new CreateConnectorRequest("", CONNECTOR_CONFIG_WITH_EMPTY_NAME);
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(bodyOut.name()), EasyMock.eq(bodyOut.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(), CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
+            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -431,101 +386,72 @@ public class ConnectorsResourceTest {
         final CreateConnectorRequest bodyIn = new CreateConnectorRequest(null, inputConfig);
         final CreateConnectorRequest bodyOut = new CreateConnectorRequest("", CONNECTOR_CONFIG_WITH_EMPTY_NAME);
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(bodyOut.name()), EasyMock.eq(bodyOut.config()), EasyMock.eq(false), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(), CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
+            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testDeleteConnector() throws Throwable {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.deleteConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, null);
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, null).when(herder).deleteConnectorConfig(eq(CONNECTOR_NAME), cb.capture());
 
         connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testDeleteConnectorNotLeader() throws Throwable {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.deleteConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackNotLeaderException(cb).when(herder)
+            .deleteConnectorConfig(eq(CONNECTOR_NAME), cb.capture());
         // Should forward request
-        EasyMock.expect(RestClient.httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null, workerConfig))
-                .andReturn(new RestClient.HttpResponse<>(204, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null, workerConfig)
+        ).thenReturn(new RestClient.HttpResponse<>(204, new HashMap<>(), null));
 
         connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
-
-        PowerMock.verifyAll();
     }
 
     // Not found exceptions should pass through to caller so they can be processed for 404s
     @Test
     public void testDeleteConnectorNotFound() {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.deleteConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).deleteConnectorConfig(eq(CONNECTOR_NAME), cb.capture());
 
         assertThrows(NotFoundException.class, () -> connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testGetConnector() throws Throwable {
-        final Capture<Callback<ConnectorInfo>> cb = Capture.newInstance();
-        herder.connectorInfo(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES,
-            ConnectorType.SOURCE));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<ConnectorInfo>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+            .when(herder).connectorInfo(eq(CONNECTOR_NAME), cb.capture());
 
         ConnectorInfo connInfo = connectorsResource.getConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
         assertEquals(new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE),
             connInfo);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testGetConnectorConfig() throws Throwable {
-        final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
-        herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, CONNECTOR_CONFIG);
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Map<String, String>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, CONNECTOR_CONFIG).when(herder).connectorConfig(eq(CONNECTOR_NAME), cb.capture());
 
         Map<String, String> connConfig = connectorsResource.getConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
         assertEquals(CONNECTOR_CONFIG, connConfig);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testGetConnectorConfigConnectorNotFound() {
-        final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
-        herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Map<String, String>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).connectorConfig(eq(CONNECTOR_NAME), cb.capture());
 
         assertThrows(NotFoundException.class, () -> connectorsResource.getConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -547,118 +473,88 @@ public class ConnectorsResourceTest {
         final Map<ConnectorTaskId, Map<String, String>> expectedTasksConnector2 = new HashMap<>();
         expectedTasksConnector2.put(connector2Task0, connector2Task0Configs);
 
-        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb1 = Capture.newInstance();
-        herder.tasksConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb1));
-        expectAndCallbackResult(cb1, expectedTasksConnector);
-        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb2 = Capture.newInstance();
-        herder.tasksConfig(EasyMock.eq(CONNECTOR2_NAME), EasyMock.capture(cb2));
-        expectAndCallbackResult(cb2, expectedTasksConnector2);
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb1 = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb1, expectedTasksConnector).when(herder).tasksConfig(eq(CONNECTOR_NAME), cb1.capture());
+        final ArgumentCaptor<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb2 = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb2, expectedTasksConnector2).when(herder).tasksConfig(eq(CONNECTOR2_NAME), cb2.capture());
 
         Map<ConnectorTaskId, Map<String, String>> tasksConfig = connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
         assertEquals(expectedTasksConnector, tasksConfig);
         Map<ConnectorTaskId, Map<String, String>> tasksConfig2 = connectorsResource.getTasksConfig(CONNECTOR2_NAME, NULL_HEADERS, FORWARD);
         assertEquals(expectedTasksConnector2, tasksConfig2);
-
-        PowerMock.verifyAll();
     }
 
     @Test(expected = NotFoundException.class)
     public void testGetTasksConfigConnectorNotFound() throws Throwable {
-        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb = Capture.newInstance();
-        herder.tasksConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).tasksConfig(eq(CONNECTOR_NAME), cb.capture());
 
         connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testPutConnectorConfig() throws Throwable {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(CONNECTOR_CONFIG), EasyMock.eq(true), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(false, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES,
-            ConnectorType.SINK)));
-
-        PowerMock.replayAll();
+            ConnectorType.SINK))
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(CONNECTOR_CONFIG), eq(true), cb.capture());
 
         connectorsResource.putConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD, CONNECTOR_CONFIG);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCreateConnectorWithSpecialCharsInName() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME_SPECIAL_CHARS, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME_SPECIAL_CHARS));
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME_SPECIAL_CHARS), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_SPECIAL_CHARS, CONNECTOR_CONFIG,
-                CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
-
-        PowerMock.replayAll();
+            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(body.config()), eq(false), cb.capture());
 
         String rspLocation = connectorsResource.createConnector(FORWARD, NULL_HEADERS, body).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_SPECIAL_CHARS, decoded);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCreateConnectorWithControlSequenceInName() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME_CONTROL_SEQUENCES1, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME_CONTROL_SEQUENCES1));
 
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), EasyMock.eq(body.config()), EasyMock.eq(false), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_CONTROL_SEQUENCES1, CONNECTOR_CONFIG,
-                CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
-
-        PowerMock.replayAll();
+            CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(body.config()), eq(false), cb.capture());
 
         String rspLocation = connectorsResource.createConnector(FORWARD, NULL_HEADERS, body).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_CONTROL_SEQUENCES1, decoded);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testPutConnectorConfigWithSpecialCharsInName() throws Throwable {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
 
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME_SPECIAL_CHARS), EasyMock.eq(CONNECTOR_CONFIG_SPECIAL_CHARS), EasyMock.eq(true), EasyMock.capture(cb));
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_SPECIAL_CHARS, CONNECTOR_CONFIG_SPECIAL_CHARS, CONNECTOR_TASK_NAMES,
-                ConnectorType.SINK)));
-
-        PowerMock.replayAll();
+            ConnectorType.SINK))
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(CONNECTOR_CONFIG_SPECIAL_CHARS), eq(true), cb.capture());
 
         String rspLocation = connectorsResource.putConnectorConfig(CONNECTOR_NAME_SPECIAL_CHARS, NULL_HEADERS, FORWARD, CONNECTOR_CONFIG_SPECIAL_CHARS).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_SPECIAL_CHARS, decoded);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testPutConnectorConfigWithControlSequenceInName() throws Throwable {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
 
-        herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), EasyMock.eq(CONNECTOR_CONFIG_CONTROL_SEQUENCES), EasyMock.eq(true), EasyMock.capture(cb));
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_CONTROL_SEQUENCES1, CONNECTOR_CONFIG_CONTROL_SEQUENCES, CONNECTOR_TASK_NAMES,
-                ConnectorType.SINK)));
-
-        PowerMock.replayAll();
+            ConnectorType.SINK))
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(CONNECTOR_CONFIG_CONTROL_SEQUENCES), eq(true), cb.capture());
 
         String rspLocation = connectorsResource.putConnectorConfig(CONNECTOR_NAME_CONTROL_SEQUENCES1, NULL_HEADERS, FORWARD, CONNECTOR_CONFIG_CONTROL_SEQUENCES).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_CONTROL_SEQUENCES1, decoded);
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -679,47 +575,33 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testGetConnectorTaskConfigs() throws Throwable {
-        final Capture<Callback<List<TaskInfo>>> cb = Capture.newInstance();
-        herder.taskConfigs(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, TASK_INFOS);
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<List<TaskInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, TASK_INFOS).when(herder).taskConfigs(eq(CONNECTOR_NAME), cb.capture());
 
         List<TaskInfo> taskInfos = connectorsResource.getTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
         assertEquals(TASK_INFOS, taskInfos);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testGetConnectorTaskConfigsConnectorNotFound() {
-        final Capture<Callback<List<TaskInfo>>> cb = Capture.newInstance();
-        herder.taskConfigs(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("connector not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<List<TaskInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("connector not found"))
+            .when(herder).taskConfigs(eq(CONNECTOR_NAME), cb.capture());
 
         assertThrows(NotFoundException.class, () -> connectorsResource.getTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testPutConnectorTaskConfigsNoInternalRequestSignature() throws Throwable {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.putTaskConfigs(
-            EasyMock.eq(CONNECTOR_NAME),
-            EasyMock.eq(TASK_CONFIGS),
-            EasyMock.capture(cb),
-            EasyMock.anyObject(InternalRequestSignature.class)
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, null).when(herder).putTaskConfigs(
+            eq(CONNECTOR_NAME),
+            eq(TASK_CONFIGS),
+            cb.capture(),
+            any()
         );
-        expectAndCallbackResult(cb, null);
-
-        PowerMock.replayAll();
 
         connectorsResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(TASK_CONFIGS));
-
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -727,29 +609,23 @@ public class ConnectorsResourceTest {
         final String signatureAlgorithm = "HmacSHA256";
         final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
 
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        final Capture<InternalRequestSignature> signatureCapture = Capture.newInstance();
-        herder.putTaskConfigs(
-            EasyMock.eq(CONNECTOR_NAME),
-            EasyMock.eq(TASK_CONFIGS),
-            EasyMock.capture(cb),
-            EasyMock.capture(signatureCapture)
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
+        expectAndCallbackResult(cb, null).when(herder).putTaskConfigs(
+            eq(CONNECTOR_NAME),
+            eq(TASK_CONFIGS),
+            cb.capture(),
+            signatureCapture.capture()
         );
-        expectAndCallbackResult(cb, null);
 
-        HttpHeaders headers = EasyMock.mock(HttpHeaders.class);
-        EasyMock.expect(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
-            .andReturn(signatureAlgorithm)
-            .once();
-        EasyMock.expect(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
-            .andReturn(encodedSignature)
-            .once();
-
-        PowerMock.replayAll(headers);
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
+            .thenReturn(signatureAlgorithm);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
+            .thenReturn(encodedSignature);
 
         connectorsResource.putTaskConfigs(CONNECTOR_NAME, headers, FORWARD, serializeAsBytes(TASK_CONFIGS));
 
-        PowerMock.verifyAll();
         InternalRequestSignature expectedSignature = new InternalRequestSignature(
             serializeAsBytes(TASK_CONFIGS),
             Mac.getInstance(signatureAlgorithm),
@@ -763,72 +639,57 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testPutConnectorTaskConfigsConnectorNotFound() {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.putTaskConfigs(
-            EasyMock.eq(CONNECTOR_NAME),
-            EasyMock.eq(TASK_CONFIGS),
-            EasyMock.capture(cb),
-            EasyMock.anyObject(InternalRequestSignature.class)
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found")).when(herder).putTaskConfigs(
+            eq(CONNECTOR_NAME),
+            eq(TASK_CONFIGS),
+            cb.capture(),
+            any()
         );
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
 
         assertThrows(NotFoundException.class, () -> connectorsResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS,
             FORWARD, serializeAsBytes(TASK_CONFIGS)));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartConnectorAndTasksConnectorNotFound() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        final Capture<Callback<ConnectorStateInfo>> cb = Capture.newInstance();
-        herder.restartConnectorAndTasks(EasyMock.eq(restartRequest), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<ConnectorStateInfo>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).restartConnectorAndTasks(eq(restartRequest), cb.capture());
 
         assertThrows(NotFoundException.class, () ->
                 connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), FORWARD)
         );
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartConnectorAndTasksLeaderRedirect() throws Throwable {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        final Capture<Callback<ConnectorStateInfo>> cb = Capture.newInstance();
-        herder.restartConnectorAndTasks(EasyMock.eq(restartRequest), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
+        final ArgumentCaptor<Callback<ConnectorStateInfo>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackNotLeaderException(cb).when(herder)
+            .restartConnectorAndTasks(eq(restartRequest), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()),
-                EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()),
+                eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null);
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartConnectorAndTasksRebalanceNeeded() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        final Capture<Callback<ConnectorStateInfo>> cb = Capture.newInstance();
-        herder.restartConnectorAndTasks(EasyMock.eq(restartRequest), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new RebalanceNeededException("Request cannot be completed because a rebalance is expected"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<ConnectorStateInfo>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new RebalanceNeededException("Request cannot be completed because a rebalance is expected"))
+            .when(herder).restartConnectorAndTasks(eq(restartRequest), cb.capture());
 
         ConnectRestException ex = assertThrows(ConnectRestException.class, () ->
                 connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), FORWARD)
         );
         assertEquals(Response.Status.CONFLICT.getStatusCode(), ex.statusCode());
-        PowerMock.verifyAll();
     }
 
     @Test
@@ -841,30 +702,25 @@ public class ConnectorsResourceTest {
         ConnectorStateInfo connectorStateInfo = new ConnectorStateInfo(CONNECTOR_NAME, state, Collections.emptyList(), ConnectorType.SOURCE);
 
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        final Capture<Callback<ConnectorStateInfo>> cb = Capture.newInstance();
-        herder.restartConnectorAndTasks(EasyMock.eq(restartRequest), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, connectorStateInfo);
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<ConnectorStateInfo>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, connectorStateInfo)
+            .when(herder).restartConnectorAndTasks(eq(restartRequest), cb.capture());
 
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), FORWARD);
         assertEquals(CONNECTOR_NAME, ((ConnectorStateInfo) response.getEntity()).name());
         assertEquals(state.state(), ((ConnectorStateInfo) response.getEntity()).connector().state());
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testFenceZombiesNoInternalRequestSignature() throws Throwable {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.fenceZombieSourceTasks(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb), EasyMock.anyObject(InternalRequestSignature.class));
-        expectAndCallbackResult(cb, null);
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
+        expectAndCallbackResult(cb, null)
+            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), signatureCapture.capture());
 
         connectorsResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null));
-
-        PowerMock.verifyAll();
+        assertNull(signatureCapture.getValue());
     }
 
     @Test
@@ -872,24 +728,19 @@ public class ConnectorsResourceTest {
         final String signatureAlgorithm = "HmacSHA256";
         final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
 
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        final Capture<InternalRequestSignature> signatureCapture = Capture.newInstance();
-        herder.fenceZombieSourceTasks(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb), EasyMock.capture(signatureCapture));
-        expectAndCallbackResult(cb, null);
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
+        expectAndCallbackResult(cb, null)
+            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), signatureCapture.capture());
 
-        HttpHeaders headers = EasyMock.mock(HttpHeaders.class);
-        EasyMock.expect(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
-                .andReturn(signatureAlgorithm)
-                .once();
-        EasyMock.expect(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
-                .andReturn(encodedSignature)
-                .once();
-
-        PowerMock.replayAll(headers);
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
+            .thenReturn(signatureAlgorithm);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
+            .thenReturn(encodedSignature);
 
         connectorsResource.fenceZombies(CONNECTOR_NAME, headers, FORWARD, serializeAsBytes(null));
 
-        PowerMock.verifyAll();
         InternalRequestSignature expectedSignature = new InternalRequestSignature(
                 serializeAsBytes(null),
                 Mac.getInstance(signatureAlgorithm),
@@ -899,189 +750,146 @@ public class ConnectorsResourceTest {
                 expectedSignature,
                 signatureCapture.getValue()
         );
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testFenceZombiesConnectorNotFound() throws Throwable {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.fenceZombieSourceTasks(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb), EasyMock.anyObject(InternalRequestSignature.class));
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
 
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), any());
 
         assertThrows(NotFoundException.class,
                 () -> connectorsResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null)));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartConnectorNotFound() {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).restartConnector(eq(CONNECTOR_NAME), cb.capture());
 
         assertThrows(NotFoundException.class, () ->
                 connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, FORWARD)
         );
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartConnectorLeaderRedirect() throws Throwable {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackNotLeaderException(cb).when(herder)
+            .restartConnector(eq(CONNECTOR_NAME), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"),
-                EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"),
+                eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
-        PowerMock.verifyAll();
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartConnectorOwnerRedirect() throws Throwable {
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
         String ownerUrl = "http://owner:8083";
-        expectAndCallbackException(cb, new NotAssignedException("not owner test", ownerUrl));
+        expectAndCallbackException(cb, new NotAssignedException("not owner test", ownerUrl))
+            .when(herder).restartConnector(eq(CONNECTOR_NAME), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"),
-                EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"),
+                eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
-        PowerMock.verifyAll();
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartTaskNotFound() {
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.restartTask(EasyMock.eq(taskId), EasyMock.capture(cb));
-        expectAndCallbackException(cb, new NotFoundException("not found"));
-
-        PowerMock.replayAll();
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+            .when(herder).restartTask(eq(taskId), cb.capture());
 
         assertThrows(NotFoundException.class, () -> connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, FORWARD));
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartTaskLeaderRedirect() throws Throwable {
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
 
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.restartTask(EasyMock.eq(taskId), EasyMock.capture(cb));
-        expectAndCallbackNotLeaderException(cb);
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackNotLeaderException(cb).when(herder)
+            .restartTask(eq(taskId), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"),
-                EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"),
+                eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, null);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testRestartTaskOwnerRedirect() throws Throwable {
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
 
-        final Capture<Callback<Void>> cb = Capture.newInstance();
-        herder.restartTask(EasyMock.eq(taskId), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
         String ownerUrl = "http://owner:8083";
-        expectAndCallbackException(cb, new NotAssignedException("not owner test", ownerUrl));
+        expectAndCallbackException(cb, new NotAssignedException("not owner test", ownerUrl))
+            .when(herder).restartTask(eq(taskId), cb.capture());
 
-        EasyMock.expect(RestClient.httpRequest(EasyMock.eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"),
-                EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.anyObject(), EasyMock.anyObject(WorkerConfig.class)))
-                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
-
-        PowerMock.replayAll();
+        restClientStatic.when(() ->
+            RestClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"),
+                eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class))
+        ).thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
 
         connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, true);
-
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testConnectorActiveTopicsWithTopicTrackingDisabled() {
-        PowerMock.reset(workerConfig);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).andReturn(false);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).andReturn(false);
-        PowerMock.replay(workerConfig);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(false);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(false);
         connectorsResource = new ConnectorsResource(herder, workerConfig);
-        PowerMock.replayAll();
 
         Exception e = assertThrows(ConnectRestException.class,
             () -> connectorsResource.getConnectorActiveTopics(CONNECTOR_NAME));
         assertEquals("Topic tracking is disabled.", e.getMessage());
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testResetConnectorActiveTopicsWithTopicTrackingDisabled() {
-        PowerMock.reset(workerConfig);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).andReturn(false);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).andReturn(true);
-        HttpHeaders headers = EasyMock.mock(HttpHeaders.class);
-        PowerMock.replay(workerConfig);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(false);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
+        HttpHeaders headers = mock(HttpHeaders.class);
         connectorsResource = new ConnectorsResource(herder, workerConfig);
-        PowerMock.replayAll();
 
         Exception e = assertThrows(ConnectRestException.class,
             () -> connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers));
         assertEquals("Topic tracking is disabled.", e.getMessage());
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testResetConnectorActiveTopicsWithTopicTrackingEnabled() {
-        PowerMock.reset(workerConfig);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).andReturn(true);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).andReturn(false);
-        HttpHeaders headers = EasyMock.mock(HttpHeaders.class);
-        PowerMock.replay(workerConfig);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(false);
+        HttpHeaders headers = mock(HttpHeaders.class);
         connectorsResource = new ConnectorsResource(herder, workerConfig);
-        PowerMock.replayAll();
 
         Exception e = assertThrows(ConnectRestException.class,
             () -> connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers));
         assertEquals("Topic tracking reset is disabled.", e.getMessage());
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testConnectorActiveTopics() {
-        PowerMock.reset(workerConfig);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).andReturn(true);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).andReturn(true);
-        EasyMock.expect(herder.connectorActiveTopics(CONNECTOR_NAME))
-                .andReturn(new ActiveTopicsInfo(CONNECTOR_NAME, CONNECTOR_ACTIVE_TOPICS));
-        PowerMock.replay(workerConfig);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
+        when(herder.connectorActiveTopics(CONNECTOR_NAME))
+            .thenReturn(new ActiveTopicsInfo(CONNECTOR_NAME, CONNECTOR_ACTIVE_TOPICS));
         connectorsResource = new ConnectorsResource(herder, workerConfig);
-        PowerMock.replayAll();
 
         Response response = connectorsResource.getConnectorActiveTopics(CONNECTOR_NAME);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -1089,60 +897,52 @@ public class ConnectorsResourceTest {
         assertEquals(CONNECTOR_NAME, ((ActiveTopicsInfo) body.get(CONNECTOR_NAME)).connector());
         assertEquals(new HashSet<>(CONNECTOR_ACTIVE_TOPICS),
                 ((ActiveTopicsInfo) body.get(CONNECTOR_NAME)).topics());
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testResetConnectorActiveTopics() {
-        PowerMock.reset(workerConfig);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).andReturn(true);
-        EasyMock.expect(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).andReturn(true);
-        HttpHeaders headers = EasyMock.mock(HttpHeaders.class);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
+        when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
+        HttpHeaders headers = mock(HttpHeaders.class);
         herder.resetConnectorActiveTopics(CONNECTOR_NAME);
-        EasyMock.expectLastCall();
-        PowerMock.replay(workerConfig);
+        verify(herder).resetConnectorActiveTopics(CONNECTOR_NAME);
         connectorsResource = new ConnectorsResource(herder, workerConfig);
-        PowerMock.replayAll();
 
         Response response = connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers);
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
-        PowerMock.verifyAll();
     }
 
     @Test
     public void testCompleteOrForwardWithErrorAndNoForwardUrl() {
-        final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
-        herder.deleteConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
+        final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         String leaderUrl = null;
-        expectAndCallbackException(cb, new NotLeaderException("not leader", leaderUrl));
-
-        PowerMock.replayAll();
+        expectAndCallbackException(cb, new NotLeaderException("not leader", leaderUrl))
+            .when(herder).deleteConnectorConfig(eq(CONNECTOR_NAME), cb.capture());
 
         ConnectRestException e = assertThrows(ConnectRestException.class, () ->
             connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
         assertTrue(e.getMessage().contains("no known leader URL"));
-        PowerMock.verifyAll();
     }
 
     private <T> byte[] serializeAsBytes(final T value) throws IOException {
         return new ObjectMapper().writeValueAsBytes(value);
     }
 
-    private  <T> void expectAndCallbackResult(final Capture<Callback<T>> cb, final T value) {
-        PowerMock.expectLastCall().andAnswer(() -> {
+    private <T> Stubber expectAndCallbackResult(final ArgumentCaptor<Callback<T>> cb, final T value) {
+        return doAnswer(invocation -> {
             cb.getValue().onCompletion(null, value);
             return null;
         });
     }
 
-    private  <T> void expectAndCallbackException(final Capture<Callback<T>> cb, final Throwable t) {
-        PowerMock.expectLastCall().andAnswer((IAnswer<Void>) () -> {
+    private <T> Stubber expectAndCallbackException(final ArgumentCaptor<Callback<T>> cb, final Throwable t) {
+        return doAnswer(invocation -> {
             cb.getValue().onCompletion(t, null);
             return null;
         });
     }
 
-    private  <T> void expectAndCallbackNotLeaderException(final Capture<Callback<T>> cb) {
-        expectAndCallbackException(cb, new NotLeaderException("not leader test", LEADER_URL));
+    private <T> Stubber expectAndCallbackNotLeaderException(final ArgumentCaptor<Callback<T>> cb) {
+        return expectAndCallbackException(cb, new NotLeaderException("not leader test", LEADER_URL));
     }
 }


### PR DESCRIPTION
The PR migrates EasyMock to Mockito for ConnectorsResourceTest, notable changes:

* The expectCallback functions (such as `expectAndCallbackResult`) have been changed to return a `Stubbing` due to the fact that unlike EasyMock (which applies the mocking to the last statement), Mockito uses a builder pattern on stubbing.
* When using `any(<class>)` from Mockito it doesn't work with `static` classes (or in other words it will fail to pick up the mock if a `class` class is supplied). Due to this `EasyMock.anyObject(InternalRequestSignature.class)` has been changed to `any()` instead of `any(InternalRequestSignature.class)`
* `RestClient` had to be changed to use `mockStatic` 


