### PR TITLE
KAFKA-14285: Delete quota node in zookeeper when configs are empty

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -133,8 +133,10 @@ object ConfigCommand extends Logging {
     val entityType = entity.root.entityType
     val entityName = entity.fullSanitizedName
     val errorMessage = s"--bootstrap-server option must be specified to update $entityType configs: {add: $configsToBeAdded, delete: $configsToBeDeleted}"
+    var isUserClientId = false
 
     if (entityType == ConfigType.User) {
+      isUserClientId = entity.child.exists(e => ConfigType.Client.equals(e.entityType))
       if (!configsToBeAdded.isEmpty || configsToBeDeleted.nonEmpty) {
         val info = "User configuration updates using ZooKeeper are only supported for SCRAM credential updates."
         val scramMechanismNames = ScramMechanism.values.map(_.mechanismName)
@@ -165,7 +167,7 @@ object ConfigCommand extends Logging {
     configs ++= configsToBeAdded
     configsToBeDeleted.foreach(configs.remove(_))
 
-    adminZkClient.changeConfigs(entityType, entityName, configs)
+    adminZkClient.changeConfigs(entityType, entityName, configs, isUserClientId)
 
     println(s"Completed updating config for entity: $entity.")
   }

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -28,7 +28,7 @@ import kafka.server.DynamicConfig.QuotaConfigs
 import kafka.server.metadata.ZkConfigRepository
 import kafka.utils._
 import kafka.utils.Implicits._
-import kafka.zk.{AdminZkClient, KafkaZkClient}
+import kafka.zk.{AdminZkClient, KafkaZkClient, ConfigEntityZNode}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ScramMechanism}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource}
@@ -740,14 +740,15 @@ class ZkAdminManager(val config: KafkaConfig,
 
   def alterClientQuotas(entries: Seq[ClientQuotaAlteration], validateOnly: Boolean): Map[ClientQuotaEntity, ApiError] = {
     def alterEntityQuotas(entity: ClientQuotaEntity, ops: Iterable[ClientQuotaAlteration.Op]): Unit = {
-      val (path, configType, configKeys) = parseAndSanitizeQuotaEntity(entity) match {
-        case (Some(user), Some(clientId), None) => (user + "/clients/" + clientId, ConfigType.User, DynamicConfig.User.configKeys)
-        case (Some(user), None, None) => (user, ConfigType.User, DynamicConfig.User.configKeys)
-        case (None, Some(clientId), None) => (clientId, ConfigType.Client, DynamicConfig.Client.configKeys)
+      val (userOpt, clientIdOpt, ipOpt) = parseAndSanitizeQuotaEntity(entity)
+      val (path, configType, configKeys, userClientQuota) = (userOpt, clientIdOpt, ipOpt) match {
+        case (Some(user), Some(clientId), None) => (user + "/clients/" + clientId, ConfigType.User, DynamicConfig.User.configKeys, true)
+        case (Some(user), None, None) => (user, ConfigType.User, DynamicConfig.User.configKeys, false)
+        case (None, Some(clientId), None) => (clientId, ConfigType.Client, DynamicConfig.Client.configKeys, false)
         case (None, None, Some(ip)) =>
           if (!DynamicConfig.Ip.isValidIpEntity(ip))
             throw new InvalidRequestException(s"$ip is not a valid IP or resolvable host.")
-          (ip, ConfigType.Ip, DynamicConfig.Ip.configKeys)
+          (ip, ConfigType.Ip, DynamicConfig.Ip.configKeys, false)
         case (_, _, Some(_)) => throw new InvalidRequestException(s"Invalid quota entity combination, " +
           s"IP entity should not be used with user/client ID entity.")
         case _ => throw new InvalidRequestException("Invalid client quota entity")
@@ -779,8 +780,30 @@ class ZkAdminManager(val config: KafkaConfig,
           }
         }
       }
-      if (!validateOnly)
+      if (!validateOnly) {
         adminZkClient.changeConfigs(configType, path, props)
+        if (props.isEmpty) {
+          // try to clean empty quota nodes
+          val currPath = ConfigEntityZNode.path(configType, path)
+          if (zkClient.getChildren(currPath).isEmpty) {
+            var pathToDelete = currPath
+            if (userClientQuota) {
+              val clientsPath = ConfigEntityZNode.path(ConfigType.User, userOpt.get + "/" + ConfigType.Client)
+              val clientsChildren = zkClient.getChildren(clientsPath)
+              if (clientsChildren.size == 1 && clientsChildren.head.equals(clientIdOpt.get)) {
+                pathToDelete = clientsPath
+                val userData = adminZkClient.fetchEntityConfig(ConfigType.User, userOpt.get)
+                val userPath = ConfigEntityZNode.path(ConfigType.User, userOpt.get)
+                val userChildren = zkClient.getChildren(userPath)
+                if (userData.isEmpty && userChildren.size == 1 && userChildren.head.equals(ConfigType.Client)) {
+                  pathToDelete = userPath
+                }
+              }
+            }
+            zkClient.deletePath(pathToDelete)
+          }
+        }
+      }
     }
     entries.map { entry =>
       val apiError = try {

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -376,7 +376,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
    * @param isUserClientId If true, this entity is user and clientId entity
    * @return True, if the node is deleted
    */
-  private def tryCleanQuotaNodes(entityType: String, entityName: String, isUserClientId: Boolean = false): Boolean = {
+  private def tryCleanQuotaNodes(entityType: String, entityName: String, isUserClientId: Boolean): Boolean = {
     val currPath = ConfigEntityZNode.path(entityType, entityName)
     if (zkClient.getChildren(currPath).isEmpty) {
       var pathToDelete = currPath

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -354,6 +354,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
    * @param entityType The entityType of the configs that will be changed
    * @param entityName The entityName of the entityType
    * @param configs The config of the entityName
+   * @param isUserClientId If true, this entity is user and clientId entity
    */
   def changeConfigs(entityType: String, entityName: String, configs: Properties, isUserClientId: Boolean = false): Unit = {
 
@@ -367,25 +368,39 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
     }
   }
 
+  /**
+   * Try to clean quota nodes in zk, if the configs of the node are empty and there are no children left,
+   * to avoid infinite growth of quota nodes
+   * @param entityType The entityType of the node we are trying to clean
+   * @param entityName The entityName of the entityType
+   * @param isUserClientId If true, this entity is user and clientId entity
+   * @return True, if the node is deleted
+   */
   private def tryCleanQuotaNodes(entityType: String, entityName: String, isUserClientId: Boolean = false): Boolean = {
     val currPath = ConfigEntityZNode.path(entityType, entityName)
     if (zkClient.getChildren(currPath).isEmpty) {
       var pathToDelete = currPath
+      // If the entity is user and clientId, we need to do some further check if the parent user node is also empty
+      // after current userClientId node deleted. If so, we also need to try cleaning the corresponding user node.
       if (isUserClientId) {
         val user = entityName.substring(0, entityName.indexOf("/"))
         val clientId = entityName.substring(entityName.lastIndexOf("/") + 1)
         val clientsPath = ConfigEntityZNode.path(ConfigType.User, user + "/" + ConfigType.Client)
         val clientsChildren = zkClient.getChildren(clientsPath)
+        // If current client is the only child of clients, the node of clients can also be deleted.
         if (clientsChildren == Seq(clientId)) {
           pathToDelete = clientsPath
           val userData = fetchEntityConfig(ConfigType.User, user)
           val userPath = ConfigEntityZNode.path(ConfigType.User, user)
           val userChildren = zkClient.getChildren(userPath)
+          // If the configs of the user are empty and the clients node is the only child of the user,
+          // the node of user can also be deleted.
           if (userData.isEmpty && userChildren == Seq(ConfigType.Client)) {
             pathToDelete = userPath
           }
         }
       }
+      info(s"Deleting zk node $pathToDelete since node of entityType $entityType and entityName $entityName is empty.")
       zkClient.deletePath(pathToDelete)
       true
     } else
@@ -415,6 +430,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
    * @param sanitizedEntityName: <sanitizedUserPrincipal> or <sanitizedUserPrincipal>/clients/<clientId>
    * @param configs: The final set of configs that will be applied to the topic. If any new configs need to be added or
    *                 existing configs need to be deleted, it should be done prior to invoking this API
+   * @param isUserClientId If true, this entity is user and clientId entity
    *
    */
   def changeUserOrUserClientIdConfig(sanitizedEntityName: String, configs: Properties, isUserClientId: Boolean = false): Unit = {
@@ -511,7 +527,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
   private def changeEntityConfig(rootEntityType: String, fullSanitizedEntityName: String, configs: Properties, isUserClientId: Boolean = false): Unit = {
     val sanitizedEntityPath = rootEntityType + '/' + fullSanitizedEntityName
     var needUpdateConfigs = true
-    // If the entityType is quota and node is empty, which means the configs are empty and no children left,
+    // If the entityType is quota and node is empty, which means if the configs are empty and no children left,
     // we should try to clean up to avoid continuous increment of zk nodes.
     if ((ConfigType.Client.equals(rootEntityType) || ConfigType.User.equals(rootEntityType) || ConfigType.Ip.equals(rootEntityType)) && configs.isEmpty) {
       if (tryCleanQuotaNodes(rootEntityType, fullSanitizedEntityName, isUserClientId)) {

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -1354,7 +1354,7 @@ class ConfigCommandTest extends Logging {
       override def fetchEntityConfig(entityType: String, entityName: String): Properties = {
         credentials.getOrElse(entityName, new Properties())
       }
-      override def changeUserOrUserClientIdConfig(sanitizedEntityName: String, configChange: Properties): Unit = {
+      override def changeUserOrUserClientIdConfig(sanitizedEntityName: String, configChange: Properties, isUserClientId: Boolean = false): Unit = {
         assertEquals(user, sanitizedEntityName)
         assertEquals(mechanisms, configChange.keySet().asScala)
         for (mechanism <- mechanisms) {
@@ -1581,7 +1581,7 @@ class ConfigCommandTest extends Logging {
     override def changeBrokerConfig(brokerIds: Seq[Int], configs: Properties): Unit = {}
     override def fetchEntityConfig(entityType: String, entityName: String): Properties = {new Properties}
     override def changeClientIdConfig(clientId: String, configs: Properties): Unit = {}
-    override def changeUserOrUserClientIdConfig(sanitizedEntityName: String, configs: Properties): Unit = {}
+    override def changeUserOrUserClientIdConfig(sanitizedEntityName: String, configs: Properties, isUserClientId: Boolean = false): Unit = {}
     override def changeTopicConfig(topic: String, configs: Properties): Unit = {}
   }
 

--- a/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import java.util.Properties
+
 import kafka.server.metadata.ZkConfigRepository
 import kafka.utils.TestUtils
 import kafka.zk.{AdminZkClient, KafkaZkClient}

--- a/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
@@ -17,18 +17,16 @@
 
 package kafka.server
 
-import java.util.{Collections, Properties, HashMap}
+import java.util.Properties
 import kafka.server.metadata.ZkConfigRepository
 import kafka.utils.TestUtils
-import kafka.zk.{AdminZkClient, ConfigEntityTypeZNode, KafkaZkClient}
+import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.config.ConfigResource
-import org.apache.kafka.common.config.internals.QuotaConfigs
 import org.apache.kafka.common.message.DescribeConfigsRequestData
 import org.apache.kafka.common.message.DescribeConfigsResponseData
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -37,27 +35,17 @@ import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 
-class ZkAdminManagerTest extends QuorumTestHarness {
+class ZkAdminManagerTest {
 
-  private val kafkaZkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
+  private val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
   private val metrics = new Metrics()
   private val brokerId = 1
   private val topic = "topic-1"
   private val metadataCache: MetadataCache = mock(classOf[MetadataCache])
-  private val producerByteRate = 1024
-  private val ipConnectionRate = 10
-  private var adminManager: ZkAdminManager = _
-
-  @BeforeEach
-  override def setUp(testInfo: TestInfo): Unit = {
-    super.setUp(testInfo)
-    adminManager = new ZkAdminManager(createKafkaConfig(), metrics, metadataCache, super.zkClient)
-  }
 
   @AfterEach
-  override def tearDown(): Unit = {
+  def tearDown(): Unit = {
     metrics.close()
-    super.tearDown()
   }
 
   def createConfigHelper(metadataCache: MetadataCache, zkClient: KafkaZkClient): ConfigHelper = {
@@ -65,21 +53,16 @@ class ZkAdminManagerTest extends QuorumTestHarness {
     new ConfigHelper(metadataCache, KafkaConfig.fromProps(props), new ZkConfigRepository(new AdminZkClient(zkClient)))
   }
 
-  def createKafkaConfig(): KafkaConfig = {
-    val props = TestUtils.createBrokerConfig(brokerId, "zk")
-    KafkaConfig(props, doLog = false)
-  }
-
   @Test
   def testDescribeConfigsWithNullConfigurationKeys(): Unit = {
-    when(kafkaZkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
     when(metadataCache.contains(topic)).thenReturn(true)
 
     val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
       .setResourceName(topic)
       .setResourceType(ConfigResource.Type.TOPIC.id)
       .setConfigurationKeys(null))
-    val configHelper = createConfigHelper(metadataCache, kafkaZkClient)
+    val configHelper = createConfigHelper(metadataCache, zkClient)
     val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = configHelper.describeConfigs(resources, true, true)
     assertEquals(Errors.NONE.code, results.head.errorCode())
     assertFalse(results.head.configs().isEmpty, "Should return configs")
@@ -87,13 +70,13 @@ class ZkAdminManagerTest extends QuorumTestHarness {
 
   @Test
   def testDescribeConfigsWithEmptyConfigurationKeys(): Unit = {
-    when(kafkaZkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
     when(metadataCache.contains(topic)).thenReturn(true)
 
     val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
       .setResourceName(topic)
       .setResourceType(ConfigResource.Type.TOPIC.id))
-    val configHelper = createConfigHelper(metadataCache, kafkaZkClient)
+    val configHelper = createConfigHelper(metadataCache, zkClient)
     val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = configHelper.describeConfigs(resources, true, true)
     assertEquals(Errors.NONE.code, results.head.errorCode())
     assertFalse(results.head.configs().isEmpty, "Should return configs")
@@ -101,7 +84,7 @@ class ZkAdminManagerTest extends QuorumTestHarness {
 
   @Test
   def testDescribeConfigsWithConfigurationKeys(): Unit = {
-    when(kafkaZkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
     when(metadataCache.contains(topic)).thenReturn(true)
 
     val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
@@ -109,7 +92,7 @@ class ZkAdminManagerTest extends QuorumTestHarness {
       .setResourceType(ConfigResource.Type.TOPIC.id)
       .setConfigurationKeys(List("retention.ms", "retention.bytes", "segment.bytes").asJava)
     )
-    val configHelper = createConfigHelper(metadataCache, kafkaZkClient)
+    val configHelper = createConfigHelper(metadataCache, zkClient)
     val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = configHelper.describeConfigs(resources, true, true)
     assertEquals(Errors.NONE.code, results.head.errorCode())
     val resultConfigKeys = results.head.configs().asScala.map(r => r.name()).toSet
@@ -118,11 +101,11 @@ class ZkAdminManagerTest extends QuorumTestHarness {
 
   @Test
   def testDescribeConfigsWithDocumentation(): Unit = {
-    when(kafkaZkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(new Properties)
-    when(kafkaZkClient.getEntityConfigs(ConfigType.Broker, brokerId.toString)).thenReturn(new Properties)
+    when(zkClient.getEntityConfigs(ConfigType.Topic, topic)).thenReturn(new Properties)
+    when(zkClient.getEntityConfigs(ConfigType.Broker, brokerId.toString)).thenReturn(new Properties)
     when(metadataCache.contains(topic)).thenReturn(true)
 
-    val configHelper = createConfigHelper(metadataCache, kafkaZkClient)
+    val configHelper = createConfigHelper(metadataCache, zkClient)
 
     val resources = List(
       new DescribeConfigsRequestData.DescribeConfigsResource()
@@ -142,70 +125,5 @@ class ZkAdminManagerTest extends QuorumTestHarness {
         assertNotEquals(s"Config ${c.name} should have non blank documentation", "", c.documentation.trim)
       })
     })
-  }
-
-  @Test
-  def testAlterClientQuotasWithUserAndClientId(): Unit = {
-    val alterEntityMap = new HashMap[String, String]()
-    alterEntityMap.put(ClientQuotaEntity.USER, "user01")
-    alterEntityMap.put(ClientQuotaEntity.CLIENT_ID, "client01")
-    val quotaEntity = new ClientQuotaEntity(alterEntityMap)
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, producerByteRate)))), validateOnly = false)
-    val props = zkClient.getEntityConfigs(ConfigType.User, "user01/clients/client01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG).toInt, producerByteRate)
-
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, null)))), validateOnly = false)
-    val users = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.User))
-    assert(users.isEmpty)
-  }
-
-  @Test
-  def testAlterClientQuotasWithUser(): Unit = {
-    val alterEntityMap = new HashMap[String, String]()
-    alterEntityMap.put(ClientQuotaEntity.USER, "user01")
-    val quotaEntity = new ClientQuotaEntity(alterEntityMap)
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, producerByteRate)))), validateOnly = false)
-    val props = zkClient.getEntityConfigs(ConfigType.User, "user01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG).toInt, producerByteRate)
-
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, null)))), validateOnly = false)
-    val users = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.User))
-    assert(users.isEmpty)
-  }
-
-  @Test
-  def testAlterClientQuotasWithClientId(): Unit = {
-    val alterEntityMap = new HashMap[String, String]()
-    alterEntityMap.put(ClientQuotaEntity.CLIENT_ID, "client01")
-    val quotaEntity = new ClientQuotaEntity(alterEntityMap)
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, producerByteRate)))), validateOnly = false)
-    val props = zkClient.getEntityConfigs(ConfigType.Client, "client01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG).toInt, producerByteRate)
-
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, null)))), validateOnly = false)
-    val clients = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.Client))
-    assert(clients.isEmpty)
-  }
-
-  @Test
-  def testAlterClientQuotasWithIp(): Unit = {
-    val alterEntityMap = new HashMap[String, String]()
-    alterEntityMap.put(ClientQuotaEntity.IP, "127.0.0.1")
-    val quotaEntity = new ClientQuotaEntity(alterEntityMap)
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG, ipConnectionRate)))), validateOnly = false)
-    val props = zkClient.getEntityConfigs(ConfigType.Ip, "127.0.0.1")
-    assertEquals(props.getProperty(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG).toInt, ipConnectionRate)
-
-    adminManager.alterClientQuotas(Seq(new ClientQuotaAlteration(quotaEntity, Collections.singleton(
-      new ClientQuotaAlteration.Op(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG, null)))), validateOnly = false)
-    val ips = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.Ip))
-    assert(ips.isEmpty)
   }
 }

--- a/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
@@ -365,7 +365,7 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
     config.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, producerByteRate)
     adminZkClient.changeUserOrUserClientIdConfig("user01/clients/client01", config, isUserClientId = true)
     var props = zkClient.getEntityConfigs(ConfigType.User, "user01/clients/client01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG), producerByteRate)
+    assertEquals(producerByteRate, props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG))
 
     // Children of clients and user01 should all be empty, so user01 should be deleted
     adminZkClient.changeUserOrUserClientIdConfig("user01/clients/client01", new Properties(), isUserClientId = true)
@@ -374,10 +374,10 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
 
     adminZkClient.changeUserOrUserClientIdConfig("user01", config)
     props = zkClient.getEntityConfigs(ConfigType.User, "user01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG), producerByteRate)
+    assertEquals(producerByteRate, props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG))
     adminZkClient.changeUserOrUserClientIdConfig("user01/clients/client01", config, isUserClientId = true)
     props = zkClient.getEntityConfigs(ConfigType.User, "user01/clients/client01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG), producerByteRate)
+    assertEquals(producerByteRate, props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG))
 
     // Children of clients are empty but configs of user01 are not empty, so clients should be deleted, but user01 should not
     adminZkClient.changeUserOrUserClientIdConfig("user01/clients/client01", new Properties(), isUserClientId = true)
@@ -391,7 +391,7 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
     config.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, producerByteRate)
     adminZkClient.changeUserOrUserClientIdConfig("user01", config)
     val props = zkClient.getEntityConfigs(ConfigType.User, "user01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG), producerByteRate)
+    assertEquals(producerByteRate, props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG))
 
     adminZkClient.changeUserOrUserClientIdConfig("user01", new Properties())
     val users = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.User))
@@ -404,7 +404,7 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
     config.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, producerByteRate)
     adminZkClient.changeClientIdConfig("client01", config)
     val props = zkClient.getEntityConfigs(ConfigType.Client, "client01")
-    assertEquals(props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG), producerByteRate)
+    assertEquals(producerByteRate, props.getProperty(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG))
 
     adminZkClient.changeClientIdConfig("client01", new Properties())
     val users = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.Client))
@@ -417,7 +417,7 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
     config.put(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG, ipConnectionRate)
     adminZkClient.changeIpConfig("127.0.0.1", config)
     val props = zkClient.getEntityConfigs(ConfigType.Ip, "127.0.0.1")
-    assertEquals(props.getProperty(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG), ipConnectionRate)
+    assertEquals(ipConnectionRate, props.getProperty(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG))
 
     adminZkClient.changeIpConfig("127.0.0.1", new Properties())
     val users = zkClient.getChildren(ConfigEntityTypeZNode.path(ConfigType.Ip))


### PR DESCRIPTION
The PR resolve issue KAFKA-14285. After doing changeConfigs, check and clean quota nodes if configs are empty, to avoid infinite increasement of quota nodes in zookeeper
related PR: https://github.com/apache/kafka/pull/12727
@showuon 