### PR TITLE
HOTFIX: Only update input partitions of standby tasks if they really changed

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -408,8 +408,7 @@ public class TaskManager {
                 activeTasksToCreate.remove(taskId);
             } else if (standbyTasksToCreate.containsKey(taskId)) {
                 if (!task.isActive()) {
-                    final Set<TopicPartition> topicPartitions = standbyTasksToCreate.get(taskId);
-                    task.updateInputPartitions(topicPartitions, topologyMetadata.nodeToSourceTopics(task.id()));
+                    updateInputPartitionsOfStandbyTaskIfTheyChanged(task, standbyTasksToCreate.get(taskId));
                     task.resume();
                 } else {
                     tasksToRecycle.put(task, standbyTasksToCreate.get(taskId));
@@ -418,6 +417,27 @@ public class TaskManager {
             } else {
                 tasksToCloseClean.add(task);
             }
+        }
+    }
+
+    private void updateInputPartitionsOfStandbyTaskIfTheyChanged(final Task task,
+                                                                 final Set<TopicPartition> inputPartitions) {
+        /*
+        We should only update input partitions of a standby task if the input partitions really changed. Updating the
+        input partitions of tasks also updates the mapping from source nodes to input topics in the processor topology
+        within the task. The mapping is updated with the topics from the topology metadata. The topology metadata does
+        not prefix intermediate internal topics with the application ID. Thus, if a standby task has input partitions
+        from an intermediate internal topic the update of the mapping in the processor topology leads to an invalid
+        topology exception during recycling of a standby task to an active task when the input queues are created. This
+        is because the input topics in the processor topology and the input partitions of the task do not match because
+        the former miss the application ID prefix.
+        For standby task that have only input partitions from intermediate internal topics this check avoids the invalid
+        topology exception. Unfortunately, a subtopology might have input partitions subscribed to with a regex
+        additionally intermediate internal topics which might still lead to an invalid topology exception during recycling
+        irrespectively of this check here. Thus, there is still a bug to fix here.
+         */
+        if (!task.inputPartitions().equals(inputPartitions)) {
+            task.updateInputPartitions(inputPartitions, topologyMetadata.nodeToSourceTopics(task.id()));
         }
     }
 


### PR DESCRIPTION
Updating the input partitions of tasks also updates the mapping from source nodes to input topics in the processor topology within the task. The mapping is updated with the topics from the topology metadata. The topology metadata does not prefix intermediate internal topics with the application ID. Thus, if a standby task has input partitions from an intermediate internal topic the update of the mapping in the processor topology leads to an invalid topology exception during recycling of a standby task to an active task when the input queues are created. This is because the input topics in the processor topology and the input partitions of the task do not match because the former miss the application ID prefix.

The added verification to only update input partitions of standby tasks if they really changed avoids the invalid topology exception if the standby task only has input partitions from intermediate internal topics since they should never change. If the standby task has input partitions from intermediate internal topics and external topics subscribed to via a regex pattern, the invalid topology exception might still be triggered.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
