### PR TITLE
minor: Trying to fix some flakiness in KRaftClusterTest::testDescribeQuorumRequestToBrokers()

### DIFF
--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -828,12 +828,14 @@ class KRaftClusterTest {
           TestUtils.computeUntilTrue(
             admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions)
               .quorumInfo().get().observers()
-          ) { observers => observers.stream.allMatch(observer => (observer.logEndOffset > 0
-            && observer.lastFetchTimestamp() != OptionalLong.empty()
-            && observer.lastCaughtUpTimestamp() != OptionalLong.empty()))
+          ) { observers =>
+            (
+              cluster.brokers.asScala.keySet == observers.asScala.map(_.replicaId).toSet
+                && observers.stream.allMatch(observer => (observer.logEndOffset > 0
+                && observer.lastFetchTimestamp() != OptionalLong.empty()
+                && observer.lastCaughtUpTimestamp() != OptionalLong.empty())))
           }
 
-        assertEquals(cluster.brokers.asScala.keySet, observers.asScala.map(_.replicaId).toSet)
         assertTrue(observerResponseValid, s"At least one observer did not return the expected state within timeout." +
             s"The responses gathered for all the observers: ${observers.toString}")
       } finally {

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -804,7 +804,6 @@ class KRaftClusterTest {
       }
       val admin = createAdminClient(cluster)
       try {
-
         val quorumState = admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions)
         val quorumInfo = quorumState.quorumInfo.get()
 

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -811,29 +811,31 @@ class KRaftClusterTest {
         assertTrue(cluster.controllers.asScala.keySet.contains(quorumInfo.leaderId),
           s"Leader ID ${quorumInfo.leaderId} was not a controller ID.")
 
-        val(voters, voterResponseValid) = TestUtils.computeUntilTrue(
-          admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions)
-            .quorumInfo().get().voters()){
-          voters => voters.stream
+        val (voters, voterResponseValid) =
+          TestUtils.computeUntilTrue(
+            admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions)
+              .quorumInfo().get().voters()
+          ) { voters => voters.stream
             .allMatch(voter => (voter.logEndOffset > 0
               && voter.lastFetchTimestamp() != OptionalLong.empty()
               && voter.lastCaughtUpTimestamp() != OptionalLong.empty()))
-        }
+          }
 
-        assertTrue(voterResponseValid, s"Atleast one voter did not return the expected state within timeout." +
+        assertTrue(voterResponseValid, s"At least one voter did not return the expected state within timeout." +
           s"The responses gathered for all the voters: ${voters.toString}")
 
-        val(observers, observerResponseValid) = TestUtils.computeUntilTrue(
-          admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions)
-            .quorumInfo().get().observers()){
-          observers => observers.stream.allMatch(observer => (observer.logEndOffset > 0
+        val (observers, observerResponseValid) =
+          TestUtils.computeUntilTrue(
+            admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions)
+              .quorumInfo().get().observers()
+          ) { observers => observers.stream.allMatch(observer => (observer.logEndOffset > 0
             && observer.lastFetchTimestamp() != OptionalLong.empty()
             && observer.lastCaughtUpTimestamp() != OptionalLong.empty()))
-        }
+          }
 
         assertEquals(cluster.brokers.asScala.keySet, observers.asScala.map(_.replicaId).toSet)
-        assertTrue(observerResponseValid, s"Atleast one voter did not return the expected state within timeout." +
-            s"The responses gathered for all the voters: ${observers.toString}")
+        assertTrue(observerResponseValid, s"At least one observer did not return the expected state within timeout." +
+            s"The responses gathered for all the observers: ${observers.toString}")
       } finally {
         admin.close()
       }


### PR DESCRIPTION
Trying to address failures where the response for a voter/observer is still empty as the leader might not know about them yet. 

e.g. a failure like:
```
org.opentest4j.AssertionFailedError: expected: not equal but was: <OptionalLong.empty>
Stacktrace
org.opentest4j.AssertionFailedError: expected: not equal but was: <OptionalLong.empty>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
	at org.junit.jupiter.api.AssertNotEquals.failEqual(AssertNotEquals.java:276)
	at org.junit.jupiter.api.AssertNotEquals.assertNotEquals(AssertNotEquals.java:265)
	at org.junit.jupiter.api.AssertNotEquals.assertNotEquals(AssertNotEquals.java:260)
	at org.junit.jupiter.api.Assertions.assertNotEquals(Assertions.java:2815)
	at kafka.server.KRaftClusterTest.$anonfun$testDescribeQuorumRequestToBrokers$5(KRaftClusterTest.scala:818)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at kafka.server.KRaftClusterTest.testDescribeQuorumRequestToBrokers(KRaftClusterTest.scala:814)
```