### PR TITLE
MINOR: Update of the PAPI testing classes to the latest implementation

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamBranchTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamBranchTest.java
@@ -59,7 +59,7 @@ public class KStreamBranchTest {
 
         assertEquals(3, branches.length);
 
-        final MockProcessorSupplier<Integer, String> supplier = new MockProcessorSupplier<>();
+        final MockProcessorSupplier<Integer, String, Void, Void> supplier = new MockProcessorSupplier<>();
         for (final KStream<Integer, String> branch : branches) {
             branch.process(supplier);
         }
@@ -71,7 +71,7 @@ public class KStreamBranchTest {
             }
         }
 
-        final List<MockProcessor<Integer, String>> processors = supplier.capturedProcessors(3);
+        final List<MockProcessor<Integer, String, Void, Void>> processors = supplier.capturedProcessors(3);
         assertEquals(3, processors.get(0).processed().size());
         assertEquals(1, processors.get(1).processed().size());
         assertEquals(2, processors.get(2).processed().size());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformTest.java
@@ -74,7 +74,7 @@ public class KStreamTransformTest {
 
         final int[] expectedKeys = {1, 10, 100, 1000};
 
-        final MockProcessorSupplier<Integer, Integer> processor = new MockProcessorSupplier<>();
+        final MockProcessorSupplier<Integer, Integer, Void, Void> processor = new MockProcessorSupplier<>();
         final KStream<Integer, Integer> stream = builder.stream(TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()));
         stream.transform(transformerSupplier).process(processor);
 
@@ -136,7 +136,7 @@ public class KStreamTransformTest {
 
         final int[] expectedKeys = {1, 10, 100, 1000};
 
-        final MockProcessorSupplier<Integer, Integer> processor = new MockProcessorSupplier<>();
+        final MockProcessorSupplier<Integer, Integer, Void, Void> processor = new MockProcessorSupplier<>();
         final KStream<Integer, Integer> stream = builder.stream(TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()));
         stream.transform(transformerSupplier).process(processor);
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertArrayEquals;
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KStreamTransformValuesTest {
     private final String topicName = "topic";
-    private final MockProcessorSupplier<Integer, Integer> supplier = new MockProcessorSupplier<>();
+    private final MockProcessorSupplier<Integer, Integer, Void, Void> supplier = new MockProcessorSupplier<>();
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.Integer());
     @Mock
     private InternalProcessorContext context;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -84,7 +84,7 @@ public class KTableTransformValuesTest {
     private static final Consumed<String, String> CONSUMED = Consumed.with(Serdes.String(), Serdes.String());
 
     private TopologyTestDriver driver;
-    private MockProcessorSupplier<String, String> capture;
+    private MockProcessorSupplier<String, String, Void, Void> capture;
     private StreamsBuilder builder;
     @Mock
     private KTableImpl<String, String, String> parent;

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
@@ -32,8 +32,6 @@ import java.util.Map;
 public class MockProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, KOut, VOut> {
     private final MockApiProcessor<KIn, VIn, KOut, VOut> delegate;
 
-    private ProcessorContext<KOut, VOut> context;
-
 
     public MockProcessor(final PunctuationType punctuationType,
                          final long scheduleInterval) {
@@ -46,8 +44,6 @@ public class MockProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, 
 
     @Override
     public void init(ProcessorContext<KOut, VOut> context) {
-        Processor.super.init(context);
-        this.context = context;
         delegate.init(context);
     }
 
@@ -89,14 +85,13 @@ public class MockProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, 
     }
 
     public void addProcessorMetadata(final String key, final long value) {
-        if (context instanceof InternalProcessorContext) {
-            ((InternalProcessorContext<KOut, VOut>) context).addProcessorMetadataKeyValue(key, value);
+        if (delegate.context() instanceof InternalProcessorContext) {
+            ((InternalProcessorContext<KOut, VOut>) delegate.context()).addProcessorMetadataKeyValue(key, value);
         }
     }
 
     @Override
     public void close() {
-        Processor.super.close();
         delegate.close();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
@@ -49,7 +49,7 @@ public class MockProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, 
 
     @Override
     public void process(Record<KIn, VIn> record) {
-        delegate.process(new Record<>(record.key(), record.value(), record.timestamp(), record.headers()));
+        delegate.process(record);
     }
 
     public void checkAndClearProcessResult(final KeyValueTimestamp<?, ?>... expected) {

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorNode.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorNode.java
@@ -16,20 +16,20 @@
  */
 package org.apache.kafka.test;
 
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
-import org.apache.kafka.streams.processor.internals.ProcessorAdapter;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MockProcessorNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, VIn, KOut, VOut> {
 
     private static final String NAME = "MOCK-PROCESS-";
     private static final AtomicInteger INDEX = new AtomicInteger(1);
 
-    public final MockProcessor<KIn, VIn> mockProcessor;
+    public final MockProcessor<KIn, VIn, KOut, VOut> mockProcessor;
 
     public boolean closed;
     public boolean initialized;
@@ -46,9 +46,8 @@ public class MockProcessorNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, 
         this(new MockProcessor<>());
     }
 
-    @SuppressWarnings("unchecked")
-    private MockProcessorNode(final MockProcessor<KIn, VIn> mockProcessor) {
-        super(NAME + INDEX.getAndIncrement(), ProcessorAdapter.adapt(mockProcessor), Collections.<String>emptySet());
+    private MockProcessorNode(final MockProcessor<KIn, VIn, KOut, VOut> mockProcessor) {
+        super(NAME + INDEX.getAndIncrement(), mockProcessor, Collections.<String>emptySet());
 
         this.mockProcessor = mockProcessor;
     }
@@ -61,7 +60,7 @@ public class MockProcessorNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, 
 
     @Override
     public void process(final Record<KIn, VIn> record) {
-        mockProcessor.process(record.key(), record.value());
+        mockProcessor.process(record);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorSupplier.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.Processor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,11 +25,11 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
-public class MockProcessorSupplier<K, V> implements org.apache.kafka.streams.processor.ProcessorSupplier<K, V> {
+public class MockProcessorSupplier<KIn, VIn, KOut, VOut> implements org.apache.kafka.streams.processor.api.ProcessorSupplier<KIn, VIn, KOut, VOut> {
 
     private final long scheduleInterval;
     private final PunctuationType punctuationType;
-    private final List<MockProcessor<K, V>> processors = new ArrayList<>();
+    private final List<MockProcessor<KIn, VIn, KOut, VOut>> processors = new ArrayList<>();
 
     public MockProcessorSupplier() {
         this(-1L);
@@ -44,8 +45,8 @@ public class MockProcessorSupplier<K, V> implements org.apache.kafka.streams.pro
     }
 
     @Override
-    public org.apache.kafka.streams.processor.Processor<K, V> get() {
-        final MockProcessor<K, V> processor = new MockProcessor<>(punctuationType, scheduleInterval);
+    public Processor<KIn, VIn, KOut, VOut> get() {
+        final MockProcessor<KIn, VIn, KOut, VOut> processor = new MockProcessor<>(punctuationType, scheduleInterval);
 
         // to keep tests simple, ignore calls from ApiUtils.checkSupplier
         if (!StreamsTestUtils.isCheckSupplierCall()) {
@@ -56,7 +57,7 @@ public class MockProcessorSupplier<K, V> implements org.apache.kafka.streams.pro
     }
 
     // get the captured processor assuming that only one processor gets returned from this supplier
-    public MockProcessor<K, V> theCapturedProcessor() {
+    public MockProcessor<KIn, VIn, KOut, VOut> theCapturedProcessor() {
         return capturedProcessors(1).get(0);
     }
 
@@ -65,7 +66,7 @@ public class MockProcessorSupplier<K, V> implements org.apache.kafka.streams.pro
     }
 
         // get the captured processors with the expected number
-    public List<MockProcessor<K, V>> capturedProcessors(final int expectedNumberOfProcessors) {
+    public List<MockProcessor<KIn, VIn, KOut, VOut>> capturedProcessors(final int expectedNumberOfProcessors) {
         assertEquals(expectedNumberOfProcessors, processors.size());
 
         return processors;


### PR DESCRIPTION
The papi tests were still using the old PAPI classes. This makes it cumbersome to write tests for new PAPI functionality.

@mjsax This is the split out of the functionality which was proposed by the PR for KIP-813 