### PR TITLE
KAFKA-14299: Fix incorrect pauses in separate state restoration

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -183,13 +183,9 @@ public class TaskManager {
                 .stream()
                 .flatMap(task -> task.inputPartitions().stream())
                 .collect(Collectors.toSet());
-
-            mainConsumer.pause(
-                mainConsumer.assignment()
-                    .stream()
-                    .filter(partition -> !partitionsNotToPause.contains(partition))
-                    .collect(Collectors.toSet())
-            );
+            final Set<TopicPartition> partitionsToPause = new HashSet<>(mainConsumer.assignment());
+            partitionsToPause.removeAll(partitionsNotToPause);
+            mainConsumer.pause(partitionsToPause);
         }
 
         releaseLockedUnassignedTaskDirectories();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -177,6 +177,14 @@ public class TaskManager {
         // before then the assignment has not been updated yet.
         mainConsumer.pause(mainConsumer.assignment());
 
+        if (stateUpdater != null) {
+            // All tasks that need restoration are now owned by the state updater.
+            // All tasks that are owned by the task manager are ready and can be resumed immediately.
+            for (final Task t : tasks.allTasks()) {
+                mainConsumer.resume(t.inputPartitions());
+            }
+        }
+
         releaseLockedUnassignedTaskDirectories();
 
         rebalanceInProgress = false;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.kafka.streams.integration;
 
-import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.tests.SmokeTestClient;
 import org.apache.kafka.streams.tests.SmokeTestDriver;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -43,18 +42,18 @@ import java.util.Set;
 import static org.apache.kafka.streams.tests.SmokeTestDriver.generate;
 import static org.apache.kafka.streams.tests.SmokeTestDriver.verify;
 
-@Timeout(600)
-@Tag("integration")
+@Category(IntegrationTest.class)
 public class SmokeTestDriverIntegrationTest {
-
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(600);
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
 
-    @BeforeAll
+    @BeforeClass
     public static void startCluster() throws IOException {
         CLUSTER.start();
     }
 
-    @AfterAll
+    @AfterClass
     public static void closeCluster() {
         CLUSTER.stop();
     }
@@ -95,20 +94,12 @@ public class SmokeTestDriverIntegrationTest {
 
     }
 
-    private static Stream<Boolean> parameters() {
-        return Stream.of(
-            Boolean.TRUE,
-            Boolean.FALSE
-          );
-    }
-
     // In this test, we try to keep creating new stream, and closing the old one, to maintain only 3 streams alive.
     // During the new stream added and old stream left, the stream process should still complete without issue.
     // We set 2 timeout condition to fail the test before passing the verification:
     // (1) 6 min timeout, (2) 30 tries of polling without getting any data
-    @ParameterizedTest
-    @MethodSource("parameters")
-    public void shouldWorkWithRebalance(final boolean stateUpdaterEnabled) throws InterruptedException {
+    @Test
+    public void shouldWorkWithRebalance() throws InterruptedException {
         Exit.setExitProcedure((statusCode, message) -> {
             throw new AssertionError("Test called exit(). code:" + statusCode + " message:" + message);
         });
@@ -128,7 +119,6 @@ public class SmokeTestDriverIntegrationTest {
 
         final Properties props = new Properties();
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
         // decrease the session timeout so that we can trigger the rebalance soon after old client left closed
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -1486,28 +1486,28 @@ public class TaskManagerTest {
         final Set<TopicPartition> assigned = mkSet(t1p0, t1p1);
         expect(consumer.assignment()).andReturn(assigned);
         consumer.pause(assigned);
-        expectLastCall();
         replay(consumer);
+
         taskManager.handleRebalanceComplete();
+
         verify(consumer);
     }
 
     @Test
     public void shouldNotPauseReadyTasksWithStateUpdaterOnRebalanceComplete() {
-        taskManager = setUpTaskManager(StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE, true);
         final StreamTask statefulTask0 = statefulTask(taskId00, taskId00ChangelogPartitions)
-            .inState(State.RESTORING)
+            .inState(State.RUNNING)
             .withInputPartitions(taskId00Partitions).build();
-        taskManager.addTask(statefulTask0);
+        final TasksRegistry tasks = Mockito.mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
+        when(tasks.allTasks()).thenReturn(mkSet(statefulTask0));
         final Set<TopicPartition> assigned = mkSet(t1p0, t1p1);
-
         expect(consumer.assignment()).andReturn(assigned);
-        consumer.pause(assigned);
-        expectLastCall();
-        consumer.resume(mkSet(t1p0));
-        expectLastCall();
+        consumer.pause(mkSet(t1p1));
         replay(consumer);
+
         taskManager.handleRebalanceComplete();
+
         verify(consumer);
     }
 


### PR DESCRIPTION
The original code path paused the main consumer for all tasks before entering the restoration section
of the code, and then resumed all after restoration has finished.

In the new state updater part of the code, tasks that do not require restoration skip the restoration completely. They remain with the TaskManger and are never transferred to the StateUpdater, and thus are never resumed.

This change makes sure that tasks that remain with the TaskManager are not paused.

Testing through unit tests and running benchmarks. Furthermore, use the SmokeTestDriverIntegrationTest to
exercise the new code path under rebalances.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
