### PR TITLE
HOTFIX: Revert "KAFKA-12960: Enforcing strict retention time for WindowStore and Sess…"

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -52,7 +52,6 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
     protected final AbstractSegments<S> segments;
     protected final KeySchema baseKeySchema;
     protected final Optional<KeySchema> indexKeySchema;
-    private final long retentionPeriod;
 
 
     protected ProcessorContext context;
@@ -67,27 +66,22 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
     AbstractDualSchemaRocksDBSegmentedBytesStore(final String name,
                                                  final KeySchema baseKeySchema,
                                                  final Optional<KeySchema> indexKeySchema,
-                                                 final AbstractSegments<S> segments,
-                                                 final long retentionPeriod) {
+                                                 final AbstractSegments<S> segments) {
         this.name = name;
         this.baseKeySchema = baseKeySchema;
         this.indexKeySchema = indexKeySchema;
         this.segments = segments;
-        this.retentionPeriod = retentionPeriod;
     }
 
     @Override
     public KeyValueIterator<Bytes, byte[]> all() {
-
-        final long actualFrom = getActualFrom(0, baseKeySchema instanceof PrefixedWindowKeySchemas.TimeFirstWindowKeySchema);
-
         final List<S> searchSpace = segments.allSegments(true);
-        final Bytes from = baseKeySchema.lowerRange(null, actualFrom);
+        final Bytes from = baseKeySchema.lowerRange(null, 0);
         final Bytes to = baseKeySchema.upperRange(null, Long.MAX_VALUE);
 
         return new SegmentIterator<>(
                 searchSpace.iterator(),
-                baseKeySchema.hasNextCondition(null, null, actualFrom, Long.MAX_VALUE, true),
+                baseKeySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE, true),
                 from,
                 to,
                 true);
@@ -95,16 +89,13 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
     @Override
     public KeyValueIterator<Bytes, byte[]> backwardAll() {
-
-        final long actualFrom = getActualFrom(0, baseKeySchema instanceof PrefixedWindowKeySchemas.TimeFirstWindowKeySchema);
-
         final List<S> searchSpace = segments.allSegments(false);
-        final Bytes from = baseKeySchema.lowerRange(null, actualFrom);
+        final Bytes from = baseKeySchema.lowerRange(null, 0);
         final Bytes to = baseKeySchema.upperRange(null, Long.MAX_VALUE);
 
         return new SegmentIterator<>(
                 searchSpace.iterator(),
-                baseKeySchema.hasNextCondition(null, null, actualFrom, Long.MAX_VALUE, false),
+                baseKeySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE, false),
                 from,
                 to,
                 false);
@@ -127,15 +118,6 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
     }
 
     abstract protected KeyValue<Bytes, byte[]> getIndexKeyValue(final Bytes baseKey, final byte[] baseValue);
-
-    // isTimeFirstWindowSchema true implies ON_WINDOW_CLOSE semantics. There's an edge case
-    // when retentionPeriod = grace Period. If we add 1, then actualFrom > to which would
-    // lead to no records being returned.
-    protected long getActualFrom(final long from, final boolean isTimeFirstWindowSchema) {
-        return isTimeFirstWindowSchema ? Math.max(from, observedStreamTime - retentionPeriod) :
-                Math.max(from, observedStreamTime - retentionPeriod + 1);
-
-    }
 
     // For testing
     void putIndex(final Bytes indexKey, final byte[] value) {
@@ -209,24 +191,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
     @Override
     public byte[] get(final Bytes rawKey) {
-        final long timestampFromRawKey = baseKeySchema.segmentTimestamp(rawKey);
-        // check if timestamp is expired
-
-        if (baseKeySchema instanceof PrefixedWindowKeySchemas.TimeFirstWindowKeySchema) {
-            if (timestampFromRawKey < observedStreamTime - retentionPeriod) {
-                LOG.debug("Record with key {} is expired as timestamp from key ({}) < actual stream time ({})",
-                        rawKey.toString(), timestampFromRawKey, observedStreamTime - retentionPeriod);
-                return null;
-            }
-        } else {
-            if (timestampFromRawKey < observedStreamTime - retentionPeriod + 1) {
-                LOG.debug("Record with key {} is expired as timestamp from key ({}) < actual stream time ({})",
-                        rawKey.toString(), timestampFromRawKey, observedStreamTime - retentionPeriod + 1);
-                return null;
-            }
-        }
-
-        final S segment = segments.getSegmentForTimestamp(timestampFromRawKey);
+        final S segment = segments.getSegmentForTimestamp(baseKeySchema.segmentTimestamp(rawKey));
         if (segment == null) {
             return null;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -23,6 +23,6 @@ public class RocksDBSegmentedBytesStore extends AbstractRocksDBSegmentedBytesSto
                                final long retention,
                                final long segmentInterval,
                                final KeySchema keySchema) {
-        super(name, metricsScope, retention, keySchema, new KeyValueSegments(name, metricsScope, retention, segmentInterval));
+        super(name, metricsScope, keySchema, new KeyValueSegments(name, metricsScope, retention, segmentInterval));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStore.java
@@ -23,6 +23,6 @@ public class RocksDBTimestampedSegmentedBytesStore extends AbstractRocksDBSegmen
                                           final long retention,
                                           final long segmentInterval,
                                           final KeySchema keySchema) {
-        super(name, metricsScope, retention, keySchema, new TimestampedSegments(name, metricsScope, retention, segmentInterval));
+        super(name, metricsScope, keySchema, new TimestampedSegments(name, metricsScope, retention, segmentInterval));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
@@ -1650,7 +1650,22 @@ public class KStreamSlidingWindowAggregateTest {
         final Map<Long, ValueAndTimestamp<String>> expected = new HashMap<>();
 
         if (emitFinal) {
-            // only non-expired records
+            expected.put(0L, ValueAndTimestamp.make("ARSTU", 10L));
+            expected.put(3L, ValueAndTimestamp.make("ASTU", 10L));
+            expected.put(4L, ValueAndTimestamp.make("ATU", 10L));
+            expected.put(5L, ValueAndTimestamp.make("ABTU", 15L));
+            expected.put(6L, ValueAndTimestamp.make("ABCU", 16L));
+            expected.put(8L, ValueAndTimestamp.make("ABCDU", 18L));
+            expected.put(9L, ValueAndTimestamp.make("ABCD", 18L));
+            expected.put(11L, ValueAndTimestamp.make("BCD", 18L));
+            expected.put(16L, ValueAndTimestamp.make("CD", 18L));
+            expected.put(17L, ValueAndTimestamp.make("D", 18L));
+            expected.put(20L, ValueAndTimestamp.make("E", 30L));
+            expected.put(30L, ValueAndTimestamp.make("EF", 40L));
+            expected.put(31L, ValueAndTimestamp.make("F", 40L));
+            expected.put(45L, ValueAndTimestamp.make("G", 55L));
+            expected.put(46L, ValueAndTimestamp.make("GH", 56L));
+            expected.put(48L, ValueAndTimestamp.make("GHIJ", 58L));
             expected.put(52L, ValueAndTimestamp.make("GHIJK", 62L));
             expected.put(53L, ValueAndTimestamp.make("GHIJKLMN", 63L));
             expected.put(56L, ValueAndTimestamp.make("HIJKLMN", 63L));
@@ -1660,7 +1675,6 @@ public class KStreamSlidingWindowAggregateTest {
             expected.put(66L, ValueAndTimestamp.make("O", 76L));
             expected.put(67L, ValueAndTimestamp.make("OP", 77L));
             expected.put(70L, ValueAndTimestamp.make("OPQ", 80L));
-
         } else {
             expected.put(0L, ValueAndTimestamp.make("ARSTU", 10L));
             expected.put(3L, ValueAndTimestamp.make("ASTU", 10L));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -286,12 +286,11 @@ public class KStreamWindowAggregateTest {
         inputTopic1.pipeInput("A", "1", 20L);
 
         processors.get(0).checkAndClearProcessResult(
-                new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)), "0+1+1", 10),
-                new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(5, 15)), "0+2+2", 13),
-                new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(5, 15)), "0+3", 14),
-                new KeyValueTimestamp<>(new Windowed<>("D", new TimeWindow(5, 15)), "0+4", 12)
+            new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)), "0+1+1", 10),
+            new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(5, 15)), "0+2+2", 13),
+            new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(5, 15)), "0+3", 14),
+            new KeyValueTimestamp<>(new Windowed<>("D", new TimeWindow(5, 15)), "0+4", 12)
         );
-
         processors.get(1).checkAndClearProcessResult();
         processors.get(2).checkAndClearProcessResult();
 
@@ -302,24 +301,18 @@ public class KStreamWindowAggregateTest {
         inputTopic2.pipeInput("A", "a", 15L);
 
         processors.get(0).checkAndClearProcessResult();
-
-        if (withCache) {
-            processors.get(1).checkAndClearProcessResult(
-                    new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)), "0+a", 0),
-                    new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(0, 10)), "0+b", 1),
-                    new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(0, 10)), "0+c", 2)
-            );
-            processors.get(2).checkAndClearProcessResult(
-                    new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)),
-                            "0+1+1%0+a", 9),
-                    new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(0, 10)),
-                            "0+2%0+b", 1),
-                    new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(0, 10)), "0+3%0+c",
-                            2));
-        } else {
-            processors.get(0).checkAndClearProcessResult();
-            processors.get(2).checkAndClearProcessResult();
-        }
+        processors.get(1).checkAndClearProcessResult(
+            new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)), "0+a", 0),
+            new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(0, 10)), "0+b", 1),
+            new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(0, 10)), "0+c", 2)
+        );
+        processors.get(2).checkAndClearProcessResult(
+            new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)),
+                "0+1+1%0+a", 9),
+            new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(0, 10)),
+                "0+2%0+b", 1),
+            new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(0, 10)), "0+3%0+c",
+                2));
 
         inputTopic2.pipeInput("A", "a", 5L);
         inputTopic2.pipeInput("B", "b", 6L);
@@ -328,23 +321,11 @@ public class KStreamWindowAggregateTest {
         inputTopic2.pipeInput("A", "a", 21L);
 
         processors.get(0).checkAndClearProcessResult();
-        if (withCache) {
-            processors.get(1).checkAndClearProcessResult(
-                    new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)), "0+a", 5),
-                    new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(5, 15)), "0+b", 6),
-                    new KeyValueTimestamp<>(new Windowed<>("D", new TimeWindow(5, 15)), "0+d+d", 10)
-            );
-        } else {
-            processors.get(1).checkAndClearProcessResult(
-                    new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)), "0+a", 0),
-                    new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(0, 10)), "0+b", 1),
-                    new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(0, 10)), "0+c", 2),
-                    new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)), "0+a", 5),
-                    new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(5, 15)), "0+b", 6),
-                    new KeyValueTimestamp<>(new Windowed<>("D", new TimeWindow(5, 15)), "0+d+d", 10)
-            );
-
-        }
+        processors.get(1).checkAndClearProcessResult(
+            new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)), "0+a", 5),
+            new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(5, 15)), "0+b", 6),
+            new KeyValueTimestamp<>(new Windowed<>("D", new TimeWindow(5, 15)), "0+d+d", 10)
+        );
         processors.get(2).checkAndClearProcessResult(
             new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)), "0+1+1%0+a",
                 10),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
@@ -233,21 +233,12 @@ public class SessionWindowedKStreamImplTest {
             processData(driver);
             final SessionStore<String, Long> store = driver.getSessionStore("count-store");
             final List<KeyValue<Windowed<String>, Long>> data = StreamsTestUtils.toList(store.fetch("1", "2"));
-            if (!emitFinal) {
-                assertThat(
-                        data,
-                        equalTo(Arrays.asList(
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(10, 15)), 2L),
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), 1L),
-                                KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), 2L))));
-            } else {
-                assertThat(
-                        data,
-                        equalTo(Arrays.asList(
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), 1L),
-                                KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), 2L))));
-
-            }
+            assertThat(
+                data,
+                equalTo(Arrays.asList(
+                    KeyValue.pair(new Windowed<>("1", new SessionWindow(10, 15)), 2L),
+                    KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), 1L),
+                    KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), 2L))));
         }
     }
 
@@ -260,21 +251,12 @@ public class SessionWindowedKStreamImplTest {
             final SessionStore<String, String> sessionStore = driver.getSessionStore("reduced");
             final List<KeyValue<Windowed<String>, String>> data = StreamsTestUtils.toList(sessionStore.fetch("1", "2"));
 
-            if (!emitFinal) {
-                assertThat(
-                        data,
-                        equalTo(Arrays.asList(
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(10, 15)), "1+2"),
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), "3"),
-                                KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), "1+2"))));
-            } else {
-                assertThat(
-                        data,
-                        equalTo(Arrays.asList(
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), "3"),
-                                KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), "1+2"))));
-
-            }
+            assertThat(
+                data,
+                equalTo(Arrays.asList(
+                    KeyValue.pair(new Windowed<>("1", new SessionWindow(10, 15)), "1+2"),
+                    KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), "3"),
+                    KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), "1+2"))));
         }
     }
 
@@ -290,21 +272,12 @@ public class SessionWindowedKStreamImplTest {
             processData(driver);
             final SessionStore<String, String> sessionStore = driver.getSessionStore("aggregated");
             final List<KeyValue<Windowed<String>, String>> data = StreamsTestUtils.toList(sessionStore.fetch("1", "2"));
-            if (!emitFinal) {
-                assertThat(
-                        data,
-                        equalTo(Arrays.asList(
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(10, 15)), "0+0+1+2"),
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), "0+3"),
-                                KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), "0+0+1+2"))));
-            } else {
-                assertThat(
-                        data,
-                        equalTo(Arrays.asList(
-                                KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), "0+3"),
-                                KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), "0+0+1+2"))));
-
-            }
+            assertThat(
+                data,
+                equalTo(Arrays.asList(
+                    KeyValue.pair(new Windowed<>("1", new SessionWindow(10, 15)), "0+0+1+2"),
+                    KeyValue.pair(new Windowed<>("1", new SessionWindow(600, 600)), "0+3"),
+                    KeyValue.pair(new Windowed<>("2", new SessionWindow(599, 600)), "0+0+1+2"))));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -179,10 +179,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyA.getBytes()), 0, windows[2].start())) {
-            // For all tests, actualFrom is computed using observedStreamTime - retention + 1.
-            // so actualFrom = 60000(observedStreamTime) - 1000(retention) + 1 = 59001
-            // all records expired as actual from is 59001 and to is 1000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.emptyList();
+
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L)
+            );
 
             assertEquals(expected, toList(values));
         }
@@ -190,8 +191,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
 
-            // all records expired as actual from is 59001 and to is 1000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.emptyList();
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L)
+            );
 
             assertEquals(expected, toList(values));
         }
@@ -199,16 +203,20 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             null, Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
 
-            // all records expired as actual from is 59001 and to is 1000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.emptyList();
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L)
+            );
+
             assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyB.getBytes()), null, 0, windows[3].start())) {
 
-            // key B is expired as actual from is 59001
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
                 KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
             );
 
@@ -218,8 +226,10 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             null, null, 0, windows[3].start())) {
 
-            // keys A and B expired as actual from is 59001
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
                 KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
             );
 
@@ -241,10 +251,10 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             Bytes.wrap(keyA.getBytes()), 0, windows[2].start())) {
 
-            // For all tests, actualFrom is computed using observedStreamTime - retention + 1.
-            // so actualFrom = 60000(observedStreamTime) - 1000(retention) + 1 = 59001
-            // all records expired as actual from is 59001 and to = 1000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.emptyList();
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
+            );
 
             assertEquals(expected, toList(values));
         }
@@ -252,8 +262,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
 
-            // all records expired as actual from is 59001 and to = 1000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.emptyList();
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
+            );
 
             assertEquals(expected, toList(values));
         }
@@ -261,17 +274,21 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             null, Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
 
-            // all records expired as actual from is 59001 and to = 1000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.emptyList();
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
+            );
+
             assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             Bytes.wrap(keyB.getBytes()), null, 0, windows[3].start())) {
 
-            // only 1 record left as actual from is 59001 and to = 60,000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
-                    KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L)
             );
 
             assertEquals(expected, toList(values));
@@ -280,9 +297,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             null, null, 0, windows[3].start())) {
 
-            // only 1 record left as actual from is 59001 and to = 60,000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
-                    KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
             );
 
             assertEquals(expected, toList(values));
@@ -835,24 +854,18 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         bytesStore.put(serializeKey(new Windowed<>(keyB, windows[2])), expectedValue3);
         bytesStore.put(serializeKey(new Windowed<>(keyC, windows[3])), expectedValue4);
 
-        // Record expired as timestampFromRawKey = 1000 while observedStreamTime = 60,000 and retention = 1000.
         final byte[] value1 = ((RocksDBTimeOrderedSessionSegmentedBytesStore) bytesStore).fetchSession(
             key1, windows[0].start(), windows[0].end());
-        assertNull(value1);
+        assertEquals(Bytes.wrap(value1), Bytes.wrap(expectedValue1));
 
-        // Record expired as timestampFromRawKey = 1000 while observedStreamTime = 60,000 and retention = 1000.
         final byte[] value2 = ((RocksDBTimeOrderedSessionSegmentedBytesStore) bytesStore).fetchSession(
             key1, windows[1].start(), windows[1].end());
-        assertNull(value2);
+        assertEquals(Bytes.wrap(value2), Bytes.wrap(expectedValue2));
 
-        // expired record
-        // timestampFromRawKey = 1500 while observedStreamTime = 60,000 and retention = 1000.
         final byte[] value3 = ((RocksDBTimeOrderedSessionSegmentedBytesStore) bytesStore).fetchSession(
             key2, windows[2].start(), windows[2].end());
-        assertNull(value3);
+        assertEquals(Bytes.wrap(value3), Bytes.wrap(expectedValue3));
 
-        // only non-expired record
-        // timestampFromRawKey = 60,000 while observedStreamTime = 60,000 and retention = 1000.
         final byte[] value4 = ((RocksDBTimeOrderedSessionSegmentedBytesStore) bytesStore).fetchSession(
             key3, windows[3].start(), windows[3].end());
         assertEquals(Bytes.wrap(value4), Bytes.wrap(expectedValue4));
@@ -978,26 +991,10 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
             try (final KeyValueIterator<Bytes, byte[]> results = bytesStore.fetch(
                 Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 1, 2000)) {
 
-                final List<KeyValue<Windowed<String>, Long>> expected;
-
-                // actual from: observedStreamTime - retention + 1
-                if (getBaseSchema() instanceof TimeFirstWindowKeySchema) {
-                    // For windowkeyschema, actual from is 1
-                    // observed stream time = 1000. Retention Period = 1000.
-                    // actual from = (1000 - 1000 + 1)
-                    // and search happens in the range 1-2000
-                    expected = asList(
-                            KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
-                            KeyValue.pair(new Windowed<>(keyB, windows[2]), 20L)
-                    );
-                } else {
-                    // For session key schema, actual from is 501
-                    // observed stream time = 1500. Retention Period = 1000.
-                    // actual from = (1500 - 1000 + 1)
-                    // and search happens in the range 501-2000
-                    expected = Collections.singletonList(KeyValue.pair(new Windowed<>(keyB, windows[2]), 20L));
-                }
-
+                final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                    KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                    KeyValue.pair(new Windowed<>(keyB, windows[2]), 20L)
+                );
                 assertEquals(expected, toList(results));
             }
 
@@ -1013,27 +1010,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         bytesStore.put(serializeKey(new Windowed<>(key, windows[0])), serializeValue(10));
         bytesStore.put(serializeKey(new Windowed<>(key, windows[1])), serializeValue(50));
         bytesStore.put(serializeKey(new Windowed<>(key, windows[2])), serializeValue(100));
-        // actual from: observedStreamTime - retention + 1
-        // retention = 1000
         try (final KeyValueIterator<Bytes, byte[]> results = bytesStore.fetch(Bytes.wrap(key.getBytes()), 1, 999)) {
-
-            final List<KeyValue<Windowed<String>, Long>> expected;
-
-            // actual from: observedStreamTime - retention + 1
-            if (getBaseSchema() instanceof TimeFirstWindowKeySchema) {
-                // For windowkeyschema, actual from is 1
-                // observed stream time = 1000. actual from = (1000 - 1000 + 1)
-                // and search happens in the range 1-2000
-                expected = asList(
-                        KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
-                        KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
-                );
-            } else {
-                // For session key schema, actual from is 501
-                // observed stream time = 1500. actual from = (1500 - 1000 + 1)
-                // and search happens in the range 501-2000 deeming first record as expired.
-                expected = Collections.singletonList(KeyValue.pair(new Windowed<>(key, windows[1]), 50L));
-            }
+            final List<KeyValue<Windowed<String>, Long>> expected = asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
+            );
 
             assertEquals(expected, toList(results));
         }
@@ -1073,22 +1054,13 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.fetch(Bytes.wrap(key.getBytes()), 0, 1500));
 
-        // For all tests, actualFrom is computed using observedStreamTime - retention + 1.
-        // so actualFrom = 60000(observedStreamTime) - 1000(retention) + 1 = 59001
-        // don't return expired records.
         assertEquals(
-            Collections.emptyList(),
-            results
-        );
-
-        final List<KeyValue<Windowed<String>, Long>> results1 = toList(bytesStore.fetch(Bytes.wrap(key.getBytes()), 59000, 60000));
-
-        // only non expired record as actual from is 59001
-        assertEquals(
-            Collections.singletonList(
-                KeyValue.pair(new Windowed<>(key, windows[3]), 1000L)
+            asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
+                KeyValue.pair(new Windowed<>(key, windows[1]), 100L),
+                KeyValue.pair(new Windowed<>(key, windows[2]), 500L)
             ),
-                results1
+            results
         );
 
         segments.close();
@@ -1114,11 +1086,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         );
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
-        // actualFrom is computed using observedStreamTime - retention + 1.
-        // so actualFrom = 60000(observedStreamTime) - 1000(retention) + 1 = 59001
-        // only one record returned as actual from is 59001
         assertEquals(
-            Collections.singletonList(
+            asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 50L),
                 KeyValue.pair(new Windowed<>(keyB, windows[3]), 100L)
             ),
             results
@@ -1145,13 +1115,12 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
             ),
             segmentDirs()
         );
-        // For all tests, actualFrom is computed using observedStreamTime - retention + 1.
-        // so actualFrom = 60000(observedStreamTime) - 1000(retention) + 1 = 59001
-        // key A expired as actual from is 59,001
+
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.backwardAll());
         assertEquals(
-            Collections.singletonList(
-                KeyValue.pair(new Windowed<>(keyB, windows[3]), 100L)
+            asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[3]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 50L)
             ),
             results
         );
@@ -1178,11 +1147,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         );
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.fetchAll(0L, 60_000L));
-        // For all tests, actualFrom is computed using observedStreamTime - retention + 1.
-        // so actualFrom = 60000(observedStreamTime) - 1000(retention) + 1 = 59001
-        // only 1 record fetched as actual from is 59001
         assertEquals(
-            Collections.singletonList(
+            asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
                 KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
             ),
             results
@@ -1310,9 +1277,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         assertEquals(2, bytesStore.getSegments().size());
 
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
         expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 100L));
 
-        // after restoration, only 1 record should be returned as actual from is 59001 and the prior record is expired.
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(expected, results);
     }
@@ -1365,9 +1332,10 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
 
         final String key = "a";
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[2]), 100L));
         expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 200L));
 
-        // after restoration, only non expired segments should be returned which is one as actual from is 59001
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(expected, results);
         assertThat(bytesStore.getPosition(), Matchers.notNullValue());
@@ -1400,9 +1368,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         assertEquals(2, bytesStore.getSegments().size());
 
         final String key = "a";
-
-        // only non expired record as actual from is 59001
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[2]), 100L));
         expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 200L));
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
@@ -1439,15 +1407,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         assertEquals(1, bytesStore.getSegments().size());
         final String key = "a";
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
-
-        // actual from = observedStreamTime - retention + 1.
-        // retention = 1000
-        if (getBaseSchema() instanceof TimeFirstWindowKeySchema) {
-            // For window stores, observedSteam = 1000 => actualFrom = 1
-            // For session stores, observedSteam = 1500 => actualFrom = 501 which deems
-            // the below record as expired.
-            expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
-        }
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(expected, results);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -171,30 +171,44 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyA.getBytes()), 0, windows[2].start())) {
-            // All Records expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            assertEquals(Collections.emptyList(), toList(values));
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L)
+            );
+
+            assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
-            // All Records expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            assertEquals(Collections.emptyList(), toList(values));
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L)
+            );
+
+            assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             null, Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
-            // All Records expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            assertEquals(Collections.emptyList(), toList(values));
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L)
+            );
+
+            assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             Bytes.wrap(keyB.getBytes()), null, 0, windows[3].start())) {
-            // Only 1 record not expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
                 KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
             );
 
@@ -203,9 +217,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.fetch(
             null, null, 0, windows[3].start())) {
-            // Only 1 record not expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
                 KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
             );
 
@@ -226,33 +242,44 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             Bytes.wrap(keyA.getBytes()), 0, windows[2].start())) {
 
-            // All Records expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            assertEquals(Collections.emptyList(), toList(values));
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
+            );
+
+            assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             Bytes.wrap(keyA.getBytes()), Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
 
-            // All Records expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            assertEquals(Collections.emptyList(), toList(values));
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
+            );
+
+            assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             null, Bytes.wrap(keyB.getBytes()), 0, windows[2].start())) {
 
-            // All Records expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            assertEquals(Collections.emptyList(), toList(values));
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
+            );
+
+            assertEquals(expected, toList(values));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             Bytes.wrap(keyB.getBytes()), null, 0, windows[3].start())) {
-            // Only 1 record not expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
-                KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L)
             );
 
             assertEquals(expected, toList(values));
@@ -260,10 +287,12 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         try (final KeyValueIterator<Bytes, byte[]> values = bytesStore.backwardFetch(
             null, null, 0, windows[3].start())) {
-            // Only 1 record not expired as observed stream time = 60000 implying actual-from = 59001 (60000 - 1000 + 1)
-            // for WindowKeySchema, to = 60000 while for SessionKeySchema, to = 30000
-            final List<KeyValue<Windowed<String>, Long>> expected = Collections.singletonList(
-                KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L)
+
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(keyC, windows[3]), 200L),
+                KeyValue.pair(new Windowed<>(keyB, windows[2]), 100L),
+                KeyValue.pair(new Windowed<>(keyA, windows[1]), 50L),
+                KeyValue.pair(new Windowed<>(keyA, windows[0]), 10L)
             );
 
             assertEquals(expected, toList(values));
@@ -277,18 +306,10 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         bytesStore.put(serializeKey(new Windowed<>(key, windows[1])), serializeValue(50));
         bytesStore.put(serializeKey(new Windowed<>(key, windows[2])), serializeValue(100));
         try (final KeyValueIterator<Bytes, byte[]> results = bytesStore.fetch(Bytes.wrap(key.getBytes()), 1, 999)) {
-            final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
-            /*
-            * For WindowKeySchema, the observedStreamTime is 1000 which means 1 extra record gets returned while for
-            * SessionKeySchema, it's 1500. Which changes the actual-from while fetching. In case of SessionKeySchema, the
-            * fetch happens from 501-999 while for WindowKeySchema it's from 1-999.
-            */
-            if (schema instanceof SessionKeySchema) {
-                expected.add(KeyValue.pair(new Windowed<>(key, windows[1]), 50L));
-            } else {
-                expected.add(KeyValue.pair(new Windowed<>(key, windows[0]), 10L));
-                expected.add(KeyValue.pair(new Windowed<>(key, windows[1]), 50L));
-            }
+            final List<KeyValue<Windowed<String>, Long>> expected = Arrays.asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 10L),
+                KeyValue.pair(new Windowed<>(key, windows[1]), 50L)
+            );
 
             assertEquals(expected, toList(results));
         }
@@ -320,13 +341,16 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         assertEquals(Utils.mkSet(segments.segmentName(0), segments.segmentName(1)), segmentDirs());
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.fetch(Bytes.wrap(key.getBytes()), 0, 1500));
-        /*
-        * All records expired as observed stream time = 60,000 which sets actual-from to 59001(60,000 - 1000 + 1). to = 1500.
-         */
+
         assertEquals(
-            Collections.emptyList(),
+            Arrays.asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
+                KeyValue.pair(new Windowed<>(key, windows[1]), 100L),
+                KeyValue.pair(new Windowed<>(key, windows[2]), 500L)
+            ),
             results
         );
+
         segments.close();
     }
 
@@ -347,12 +371,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             ),
             segmentDirs()
         );
-        /*
-        * Only 1 record returned. observed stream time = 60000, actual from = 59001 (60000 - 1000 + 1) and to = Long.MAX.
-         */
+
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
         assertEquals(
-            Collections.singletonList(
+            Arrays.asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
                 KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
             ),
             results
@@ -378,12 +401,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             ),
             segmentDirs()
         );
-        /*
-         * Only 1 record returned. observed stream time = 60000, actual from = 59001 (60000 - 1000 + 1) and to = 60,000.
-         */
+
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.fetchAll(0L, 60_000L));
         assertEquals(
-            Collections.singletonList(
+            Arrays.asList(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
                 KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
             ),
             results
@@ -507,10 +529,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         // 2 segments are created during restoration.
         assertEquals(2, bytesStore.getSegments().size());
 
-        /*
-         * Only 1 record returned. observed stream time = 60000, actual from = 59001 (60000 - 1000 + 1) and to = Long.MAX.
-         */
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
         expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 100L));
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
@@ -564,10 +584,9 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         assertEquals(2, bytesStore.getSegments().size());
 
         final String key = "a";
-        /*
-         * Only 1 record returned. observed stream time = 60000, actual from = 59001 (60000 - 1000 + 1) and to = Long.MAX.
-         */
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[2]), 100L));
         expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 200L));
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
@@ -602,10 +621,9 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         assertEquals(2, bytesStore.getSegments().size());
 
         final String key = "a";
-        /*
-         * Only 1 record returned. observed stream time = 60000, actual from = 59001 (60000 - 1000 + 1) and to = Long.MAX.
-         */
         final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[2]), 100L));
         expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 200L));
 
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
@@ -641,20 +659,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         // 1 segments are created during restoration.
         assertEquals(1, bytesStore.getSegments().size());
         final String key = "a";
+        final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
 
-        /*
-         * For WindowKeySchema, the observedStreamTime is 1000 which means 1 extra record gets returned while for
-         * SessionKeySchema, it's 1500. Which changes the actual-from while fetching. In case of SessionKeySchema, the
-         * fetch happens from 501 to end while for WindowKeySchema it's from 1 to end.
-         */
         final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
-        if (schema instanceof SessionKeySchema) {
-            assertEquals(Collections.emptyList(), results);
-        } else {
-            final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
-            expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
-            assertEquals(expected, results);
-        }
+        assertEquals(expected, results);
         assertThat(bytesStore.getPosition(), Matchers.notNullValue());
         assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 2L));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -342,7 +342,7 @@ public abstract class AbstractWindowBytesStoreTest {
         );
         assertEquals(
             asList(zero, one, two, three),
-            toList(windowStore.fetchAll(ofEpochMilli(defaultStartTime), ofEpochMilli(defaultStartTime + 3)))
+            toList(windowStore.fetchAll(ofEpochMilli(defaultStartTime + 0), ofEpochMilli(defaultStartTime + 3)))
         );
         assertEquals(
             asList(one, two, three, four, five),
@@ -360,7 +360,7 @@ public abstract class AbstractWindowBytesStoreTest {
         );
         assertEquals(
             asList(three, two, one, zero),
-            toList(windowStore.backwardFetchAll(ofEpochMilli(defaultStartTime), ofEpochMilli(defaultStartTime + 3)))
+            toList(windowStore.backwardFetchAll(ofEpochMilli(defaultStartTime + 0), ofEpochMilli(defaultStartTime + 3)))
         );
         assertEquals(
             asList(five, four, three, two, one),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -101,8 +101,7 @@ public class CachingPersistentWindowStoreTest {
     @Before
     public void setUp() {
         keySchema = new WindowKeySchema();
-        ///KAFKA-12960: Adding a retention of 100 ms to make all test cases work as is.
-        bytesStore = new RocksDBSegmentedBytesStore("test", "metrics-scope", 100, SEGMENT_INTERVAL, keySchema);
+        bytesStore = new RocksDBSegmentedBytesStore("test", "metrics-scope", 0, SEGMENT_INTERVAL, keySchema);
         underlyingStore = new RocksDBWindowStore(bytesStore, false, WINDOW_SIZE);
         final TimeWindowedDeserializer<String> keyDeserializer = new TimeWindowedDeserializer<>(new StringDeserializer(), WINDOW_SIZE);
         keyDeserializer.setIsChangelogTopic(true);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -95,7 +95,6 @@ public class MeteredSessionStoreTest {
     private static final byte[] VALUE_BYTES = VALUE.getBytes();
     private static final long START_TIMESTAMP = 24L;
     private static final long END_TIMESTAMP = 42L;
-    private static final int RETENTION_PERIOD = 100;
 
     private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 0, "My-Topology");
@@ -428,54 +427,6 @@ public class MeteredSessionStoreTest {
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
-    }
-
-    @Test
-    public void shouldReturnNoSessionsWhenFetchedKeyHasExpired() {
-        final long systemTime = Time.SYSTEM.milliseconds();
-        expect(innerStore.findSessions(KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
-                .andReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
-        init();
-
-        final KeyValueIterator<Windowed<String>, String> iterator = store.findSessions(KEY, systemTime - RETENTION_PERIOD, systemTime);
-        assertFalse(iterator.hasNext());
-        iterator.close();
-    }
-
-    @Test
-    public void shouldReturnNoSessionsInBackwardOrderWhenFetchedKeyHasExpired() {
-        final long systemTime = Time.SYSTEM.milliseconds();
-        expect(innerStore.backwardFindSessions(KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
-                .andReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
-        init();
-
-        final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFindSessions(KEY, systemTime - RETENTION_PERIOD, systemTime);
-        assertFalse(iterator.hasNext());
-        iterator.close();
-    }
-
-    @Test
-    public void shouldNotFindExpiredSessionRangeFromStore() {
-        final long systemTime = Time.SYSTEM.milliseconds();
-        expect(innerStore.findSessions(KEY_BYTES, KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
-                .andReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
-        init();
-
-        final KeyValueIterator<Windowed<String>, String> iterator = store.findSessions(KEY, KEY, systemTime - RETENTION_PERIOD, systemTime);
-        assertFalse(iterator.hasNext());
-        iterator.close();
-    }
-
-    @Test
-    public void shouldNotFindExpiredSessionRangeInBackwardOrderFromStore() {
-        final long systemTime = Time.SYSTEM.milliseconds();
-        expect(innerStore.backwardFindSessions(KEY_BYTES, KEY_BYTES, systemTime - RETENTION_PERIOD, systemTime))
-                .andReturn(new KeyValueIteratorStub<>(KeyValueIterators.emptyIterator()));
-        init();
-
-        final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFindSessions(KEY, KEY, systemTime - RETENTION_PERIOD, systemTime);
-        assertFalse(iterator.hasNext());
-        iterator.close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -66,7 +66,6 @@ public class MeteredTimestampedWindowStoreTest {
         ValueAndTimestamp.make("value", TIMESTAMP);
     private static final byte[] VALUE_AND_TIMESTAMP_BYTES = "\0\0\0\0\0\0\0avalue".getBytes();
     private static final int WINDOW_SIZE_MS = 10;
-    private static final int RETENTION_PERIOD = 100;
 
     private InternalMockProcessorContext context;
     private final TaskId taskId = new TaskId(0, 0, "My-Topology");

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -45,7 +45,6 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -83,7 +82,6 @@ public class MeteredWindowStoreTest {
     private static final String VALUE = "value";
     private static final byte[] VALUE_BYTES = VALUE.getBytes();
     private static final int WINDOW_SIZE_MS = 10;
-    private static final int RETENTION_PERIOD = 100;
     private static final long TIMESTAMP = 42L;
 
     private final String threadId = Thread.currentThread().getName();
@@ -269,18 +267,6 @@ public class MeteredWindowStoreTest {
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertThat((Double) metric.metricValue(), greaterThan(0.0));
-        verify(innerStoreMock);
-    }
-
-    @Test
-    public void shouldReturnNoRecordWhenFetchedKeyHasExpired() {
-        expect(innerStoreMock.fetch(Bytes.wrap("a".getBytes()), 1, 1 + RETENTION_PERIOD))
-                .andReturn(KeyValueIterators.emptyWindowStoreIterator());
-        replay(innerStoreMock);
-
-        store.init((StateStoreContext) context, store);
-        store.fetch("a", ofEpochMilli(1), ofEpochMilli(1).plus(RETENTION_PERIOD, ChronoUnit.MILLIS)).close(); // recorded on close;
-
         verify(innerStoreMock);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -17,34 +17,16 @@
 package org.apache.kafka.streams.state.internals;
 
 import java.util.Collection;
-
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.internals.SessionWindow;
-import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
-import org.apache.kafka.streams.query.Position;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.Stores;
 
-import java.util.Collections;
-import java.util.HashSet;
-
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.common.utils.Utils.mkSet;
-import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @RunWith(Parameterized.class)
 public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
@@ -108,79 +90,4 @@ public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
         }
     }
 
-
-    @Test
-    public void shouldNotFetchExpiredSessions() {
-        final long systemTime = Time.SYSTEM.milliseconds();
-        sessionStore.put(new Windowed<>("p", new SessionWindow(systemTime - 3 * RETENTION_PERIOD, systemTime - 2 * RETENTION_PERIOD)), 1L);
-        sessionStore.put(new Windowed<>("q", new SessionWindow(systemTime - 2 * RETENTION_PERIOD, systemTime - RETENTION_PERIOD)), 4L);
-        sessionStore.put(new Windowed<>("r", new SessionWindow(systemTime - RETENTION_PERIOD, systemTime - RETENTION_PERIOD / 2)), 3L);
-        sessionStore.put(new Windowed<>("p", new SessionWindow(systemTime - RETENTION_PERIOD, systemTime - RETENTION_PERIOD / 2)), 2L);
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-                     sessionStore.findSessions("p", systemTime - 2 * RETENTION_PERIOD, systemTime - RETENTION_PERIOD)
-        ) {
-            assertEquals(mkSet(2L), valuesToSet(iterator));
-        }
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-                     sessionStore.backwardFindSessions("p", systemTime - 5 * RETENTION_PERIOD, systemTime - 4 * RETENTION_PERIOD)
-        ) {
-            assertFalse(iterator.hasNext());
-        }
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-                     sessionStore.findSessions("p", "r", systemTime - 5 * RETENTION_PERIOD, systemTime - 4 * RETENTION_PERIOD)
-        ) {
-            assertFalse(iterator.hasNext());
-        }
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-                     sessionStore.findSessions("p", "r", systemTime - RETENTION_PERIOD, systemTime - RETENTION_PERIOD / 2)
-        ) {
-            assertEquals(valuesToSet(iterator), mkSet(2L, 3L, 4L));
-        }
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-                     sessionStore.findSessions("p", "r", systemTime - 2 * RETENTION_PERIOD, systemTime - RETENTION_PERIOD)
-        ) {
-            assertEquals(valuesToSet(iterator), mkSet(2L, 3L, 4L));
-        }
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-                     sessionStore.backwardFindSessions("p", "r", systemTime - 2 * RETENTION_PERIOD, systemTime - RETENTION_PERIOD)
-        ) {
-            assertEquals(valuesToSet(iterator), mkSet(2L, 3L, 4L));
-        }
-    }
-
-    @Test
-    public void shouldRemoveExpired() {
-        sessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 1L);
-        sessionStore.put(new Windowed<>("aa", new SessionWindow(0, SEGMENT_INTERVAL)), 2L);
-        sessionStore.put(new Windowed<>("a", new SessionWindow(10, SEGMENT_INTERVAL)), 3L);
-
-        // Advance stream time to expire the first record
-        sessionStore.put(new Windowed<>("aa", new SessionWindow(10, 2 * SEGMENT_INTERVAL)), 4L);
-
-        try (final KeyValueIterator<Windowed<String>, Long> iterator =
-            sessionStore.findSessions("a", "b", 0L, Long.MAX_VALUE)
-        ) {
-            // The 2 records with values 2L and 3L are considered expired as
-            // their end times < observed stream time - retentionPeriod + 1.
-            assertEquals(valuesToSet(iterator), new HashSet<>(Collections.singletonList(4L)));
-        }
-    }
-
-    @Test
-    public void shouldMatchPositionAfterPut() {
-        final MeteredSessionStore<String, Long> meteredSessionStore = (MeteredSessionStore<String, Long>) sessionStore;
-        final ChangeLoggingSessionBytesStore changeLoggingSessionBytesStore = (ChangeLoggingSessionBytesStore) meteredSessionStore.wrapped();
-        final WrappedStateStore rocksDBSessionStore = (WrappedStateStore) changeLoggingSessionBytesStore.wrapped();
-
-        context.setRecordContext(new ProcessorRecordContext(0, 1, 0, "", new RecordHeaders()));
-        sessionStore.put(new Windowed<String>("a", new SessionWindow(0, 0)), 1L);
-        context.setRecordContext(new ProcessorRecordContext(0, 2, 0, "", new RecordHeaders()));
-        sessionStore.put(new Windowed<String>("aa", new SessionWindow(0, SEGMENT_INTERVAL)), 2L);
-        context.setRecordContext(new ProcessorRecordContext(0, 3, 0, "", new RecordHeaders()));
-        sessionStore.put(new Windowed<String>("a", new SessionWindow(10, SEGMENT_INTERVAL)), 3L);
-
-        final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 3L)))));
-        final Position actual = rocksDBSessionStore.getPosition();
-        assertEquals(expected, actual);
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -187,40 +187,19 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
             ),
             segmentDirs(baseDir)
         );
-        // For all tests, for WindowStore actualFrom is computed using observedStreamTime - retention + 1.
-        // while for TimeOrderedWindowStores, actualFrom = observedStreamTime - retention
-        // expired record
+
         assertEquals(
-            new HashSet<>(Collections.emptyList()),
+            new HashSet<>(Collections.singletonList("zero")),
             valuesToSet(windowStore.fetch(
                 0,
                 ofEpochMilli(startTime - WINDOW_SIZE),
                 ofEpochMilli(startTime + WINDOW_SIZE))));
-        // RocksDbWindwStore =>
-        //  from = 149997
-        //  to = 150003
-        //  actualFrom = 150001
-        // record one timestamp is 150,000 So, it's ignored.
-        // RocksDBTimeOrderedWindowStore*Index =>
-        //  from = 149997
-        //  to = 150003
-        //  actualFrom = 150000, hence not ignored
-        if (storeType == StoreType.RocksDBWindowStore) {
-            assertEquals(
-                new HashSet<>(Collections.emptyList()),
-                valuesToSet(windowStore.fetch(
-                    1,
-                        ofEpochMilli(startTime + increment - WINDOW_SIZE),
-                        ofEpochMilli(startTime + increment + WINDOW_SIZE))));
-
-        } else {
-            assertEquals(
-                new HashSet<>(Collections.singletonList("one")),
-                valuesToSet(windowStore.fetch(
-                        1,
-                        ofEpochMilli(startTime + increment - WINDOW_SIZE),
-                        ofEpochMilli(startTime + increment + WINDOW_SIZE))));
-        }
+        assertEquals(
+            new HashSet<>(Collections.singletonList("one")),
+            valuesToSet(windowStore.fetch(
+                1,
+                ofEpochMilli(startTime + increment - WINDOW_SIZE),
+                ofEpochMilli(startTime + increment + WINDOW_SIZE))));
         assertEquals(
             new HashSet<>(Collections.singletonList("two")),
             valuesToSet(windowStore.fetch(
@@ -268,32 +247,12 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
                 1,
                 ofEpochMilli(startTime + increment - WINDOW_SIZE),
                 ofEpochMilli(startTime + increment + WINDOW_SIZE))));
-        // RocksDbWindwStore =>
-        //  from = 179997
-        //  to = 180003
-        //  actualFrom = 170001
-        // record one timestamp is 180,000 So, it's ignored.
-        // RocksDBTimeOrderedWindowStore*Index =>
-        //  from = 179997
-        //  to = 180003
-        //  actualFrom = 180000, hence not ignored
-        if (storeType == StoreType.RocksDBWindowStore) {
-            assertEquals(
-                    // expired record
-                    new HashSet<>(Collections.emptyList()),
-                    valuesToSet(windowStore.fetch(
-                            2,
-                            ofEpochMilli(startTime + increment * 2 - WINDOW_SIZE),
-                            ofEpochMilli(startTime + increment * 2 + WINDOW_SIZE))));
-        } else {
-            assertEquals(
-                    // expired record
-                    new HashSet<>(Collections.singletonList("two")),
-                    valuesToSet(windowStore.fetch(
-                            2,
-                            ofEpochMilli(startTime + increment * 2 - WINDOW_SIZE),
-                            ofEpochMilli(startTime + increment * 2 + WINDOW_SIZE))));
-        }
+        assertEquals(
+            new HashSet<>(Collections.singletonList("two")),
+            valuesToSet(windowStore.fetch(
+                2,
+                ofEpochMilli(startTime + increment * 2 - WINDOW_SIZE),
+                ofEpochMilli(startTime + increment * 2 + WINDOW_SIZE))));
         assertEquals(
             new HashSet<>(Collections.emptyList()),
             valuesToSet(windowStore.fetch(
@@ -342,8 +301,7 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
                 ofEpochMilli(startTime + increment - WINDOW_SIZE),
                 ofEpochMilli(startTime + increment + WINDOW_SIZE))));
         assertEquals(
-            // expired record
-            new HashSet<>(Collections.emptyList()),
+            new HashSet<>(Collections.singletonList("two")),
             valuesToSet(windowStore.fetch(
                 2,
                 ofEpochMilli(startTime + increment * 2 - WINDOW_SIZE),
@@ -413,24 +371,12 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
                 3,
                 ofEpochMilli(startTime + increment * 3 - WINDOW_SIZE),
                 ofEpochMilli(startTime + increment * 3 + WINDOW_SIZE))));
-        if (storeType == StoreType.RocksDBWindowStore) {
-            assertEquals(
-                    // expired record
-                    new HashSet<>(Collections.emptyList()),
-                    valuesToSet(windowStore.fetch(
-                            4,
-                            ofEpochMilli(startTime + increment * 4 - WINDOW_SIZE),
-                            ofEpochMilli(startTime + increment * 4 + WINDOW_SIZE))));
-        } else {
-            assertEquals(
-                    // expired record
-                    new HashSet<>(Collections.singletonList("four")),
-                    valuesToSet(windowStore.fetch(
-                            4,
-                            ofEpochMilli(startTime + increment * 4 - WINDOW_SIZE),
-                            ofEpochMilli(startTime + increment * 4 + WINDOW_SIZE))));
-
-        }
+        assertEquals(
+            new HashSet<>(Collections.singletonList("four")),
+            valuesToSet(windowStore.fetch(
+                4,
+                ofEpochMilli(startTime + increment * 4 - WINDOW_SIZE),
+                ofEpochMilli(startTime + increment * 4 + WINDOW_SIZE))));
         assertEquals(
             new HashSet<>(Collections.singletonList("five")),
             valuesToSet(windowStore.fetch(
@@ -519,14 +465,7 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
             iter.next();
             fetchedCount++;
         }
-        // 1 extra record is expired in the case of RocksDBWindowStore as
-        // actualFrom = observedStreamTime - retentionPeriod + 1. The +1
-        // isn't present for RocksDbTimeOrderedStoreWith*Index
-        if (storeType == StoreType.RocksDBWindowStore) {
-            assertEquals(1, fetchedCount);
-        } else {
-            assertEquals(2, fetchedCount);
-        }
+        assertEquals(2, fetchedCount);
 
         assertEquals(
             Utils.mkSet(segments.segmentName(1L), segments.segmentName(3L)),
@@ -541,10 +480,8 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
             iter.next();
             fetchedCount++;
         }
-
-        // the latest record has a timestamp > 60k. So, the +1 in actualFrom calculation in
-        // RocksDbWindowStore shouldn't have an implciation and all stores should return the same fetched counts.
         assertEquals(1, fetchedCount);
+
         assertEquals(
             Utils.mkSet(segments.segmentName(3L), segments.segmentName(5L)),
             segmentDirs(baseDir)
@@ -626,9 +563,6 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
                                        Serdes.Integer(),
                                        Serdes.String());
         windowStore.init((StateStoreContext) context, windowStore);
-
-        // For all tests, for WindowStore actualFrom is computed using observedStreamTime - retention + 1.
-        // while for TimeOrderedWindowStores, actualFrom = observedStreamTime - retention
 
         assertEquals(
             new HashSet<>(Collections.emptyList()),
@@ -716,31 +650,12 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
                 3,
                 ofEpochMilli(startTime + increment * 3 - WINDOW_SIZE),
                 ofEpochMilli(startTime + increment * 3 + WINDOW_SIZE))));
-        // RocksDbWindwStore =>
-        //  from = 239,997
-        //  to = 240,003
-        //  actualFrom = 240,001
-        // record four timestamp is 240,000 So, it's ignored.
-        // RocksDBTimeOrderedWindowStore*Index =>
-        //  from = 239,997
-        //  to = 240,003
-        //  actualFrom = 240,000, hence not ignored
-        if (storeType == StoreType.RocksDBWindowStore) {
-            assertEquals(
-                    new HashSet<>(Collections.emptyList()),
-                    valuesToSet(windowStore.fetch(
-                            4,
-                            ofEpochMilli(startTime + increment * 4 - WINDOW_SIZE),
-                            ofEpochMilli(startTime + increment * 4 + WINDOW_SIZE))));
-        } else {
-            assertEquals(
-                    new HashSet<>(Collections.singletonList("four")),
-                    valuesToSet(windowStore.fetch(
-                            4,
-                            ofEpochMilli(startTime + increment * 4 - WINDOW_SIZE),
-                            ofEpochMilli(startTime + increment * 4 + WINDOW_SIZE))));
-
-        }
+        assertEquals(
+            new HashSet<>(Collections.singletonList("four")),
+            valuesToSet(windowStore.fetch(
+                4,
+                ofEpochMilli(startTime + increment * 4 - WINDOW_SIZE),
+                ofEpochMilli(startTime + increment * 4 + WINDOW_SIZE))));
         assertEquals(
             new HashSet<>(Collections.singletonList("five")),
             valuesToSet(windowStore.fetch(


### PR DESCRIPTION
This reverts commit 07c10024890c0761ba47ccd4d6301e8101d8c8de which broke trunk.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
