### PR TITLE
KAFKA-14309: FK join upgrades not tested with DEV_VERSION

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -143,6 +143,14 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
                 producer.send(record);
 
+                final ProducerRecord<byte[], byte[]> fkRecord =
+                    new ProducerRecord<>(
+                        "fk",
+                        intSerde.serializer().serialize("", value),
+                        stringSerde.serializer().serialize("", key)
+                    );
+                producer.send(fkRecord);
+
                 numRecordsProduced++;
                 if (numRecordsProduced % 100 == 0) {
                     System.out.println(Instant.now() + " " + numRecordsProduced + " records produced");

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -33,7 +33,10 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
@@ -65,6 +68,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
+import static org.apache.kafka.streams.tests.SmokeTestUtil.intSerde;
+import static org.apache.kafka.streams.tests.SmokeTestUtil.stringSerde;
 
 public class StreamsUpgradeTest {
 
@@ -93,9 +98,24 @@ public class StreamsUpgradeTest {
 
     public static KafkaStreams buildStreams(final Properties streamsProperties) {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KStream<Void, Void> dataStream = builder.stream("data");
+        final KTable<String, Integer> dataTable = builder.table(
+            "data", Consumed.with(stringSerde, intSerde));
+        final KStream<String, Integer> dataStream = dataTable.toStream();
         dataStream.process(SmokeTestUtil.printProcessorSupplier("data"));
         dataStream.to("echo");
+
+        final boolean runFkJoin = Boolean.parseBoolean(streamsProperties.getProperty(
+            "test.run_fk_join",
+            "false"));
+        if (runFkJoin) {
+            try {
+                final KTable<Integer, String> fkTable = builder.table(
+                    "fk", Consumed.with(intSerde, stringSerde));
+                buildFKTable(dataStream, fkTable);
+            } catch (final Exception e) {
+                System.err.println("Caught " + e.getMessage());
+            }
+        }
 
         final Properties config = new Properties();
         config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "StreamsUpgradeTest");
@@ -112,6 +132,15 @@ public class StreamsUpgradeTest {
         config.putAll(streamsProperties);
 
         return new KafkaStreams(builder.build(), config, kafkaClientSupplier);
+    }
+
+    private static void buildFKTable(final KStream<String, Integer> primaryTable,
+                                     final KTable<Integer, String> otherTable) {
+        final KStream<String, String> kStream = primaryTable.toTable()
+            .join(otherTable, v -> v, (k0, v0) -> v0)
+            .toStream();
+        kStream.process(SmokeTestUtil.printProcessorSupplier("fk"));
+        kStream.to("fk-result", Produced.with(stringSerde, stringSerde));
     }
 
     private static class FutureKafkaClientSupplier extends DefaultKafkaClientSupplier {

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -616,9 +616,6 @@ class StreamsUpgradeTestJobRunnerService(StreamsTestBaseService):
 
         if self.UPGRADE_FROM is not None:
             properties['upgrade.from'] = self.UPGRADE_FROM
-        if (self.UPGRADE_FROM is not None and KafkaVersion(self.UPGRADE_FROM).supports_fk_joins()) or \
-            (self.KAFKA_STREAMS_VERSION is not None and KafkaVersion(self.KAFKA_STREAMS_VERSION).supports_fk_joins()):
-            properties['test.run_fk_join'] = "true"
         if self.UPGRADE_TO == "future_version":
             properties['test.future.metadata'] = "any_value"
 

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -394,7 +394,6 @@ class StreamsUpgradeTest(Test):
             processor.set_version(version)
 
     def do_stop_start_bounce(self, processor, upgrade_from, new_version, counter, extra_properties = None):
-
         if extra_properties is None:
             extra_properties = {}
 
@@ -472,8 +471,8 @@ class StreamsUpgradeTest(Test):
 
                         if extra_properties.get('test.run_fk_join', False):
                             monitor.wait_until(self.processed_fk_msg,
-                                                     timeout_sec=60,
-                                                     err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node.account))
+                                               timeout_sec=60,
+                                               err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node.account))
 
 
     def do_rolling_bounce(self, processor, counter, current_generation):

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -331,7 +331,7 @@ class StreamsUpgradeTest(Test):
                 monitor.wait_until(self.processed_data_msg,
                                    timeout_sec=60,
                                    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node1.account))
-                if 'test.run_fk_join' in extra_properties:
+                if extra_properties.get('test.run_fk_join', False):
                     monitor.wait_until(self.processed_fk_msg,
                     timeout_sec=60,
                     err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node1.account))
@@ -353,7 +353,7 @@ class StreamsUpgradeTest(Test):
                     second_monitor.wait_until(self.processed_data_msg,
                                               timeout_sec=60,
                                               err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node2.account))
-                    if 'test.run_fk_join' in extra_properties:
+                    if extra_properties.get('test.run_fk_join', False):
                         second_monitor.wait_until(self.processed_fk_msg,
                         timeout_sec=60,
                         err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node2.account))
@@ -378,7 +378,7 @@ class StreamsUpgradeTest(Test):
                         third_monitor.wait_until(self.processed_data_msg,
                                                  timeout_sec=60,
                                                  err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node3.account))
-                        if 'test.run_fk_join' in extra_properties:
+                        if extra_properties.get('test.run_fk_join', False):
                             third_monitor.wait_until(self.processed_fk_msg,
                             timeout_sec=60,
                             err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node2.account))
@@ -470,7 +470,7 @@ class StreamsUpgradeTest(Test):
                                            timeout_sec=60,
                                            err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
 
-                        if "test.run_fk_join" in extra_properties:
+                        if extra_properties.get('test.run_fk_join', False):
                             monitor.wait_until(self.processed_fk_msg,
                                                      timeout_sec=60,
                                                      err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node.account))

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -206,6 +206,11 @@ class StreamsUpgradeTest(Test):
         Starts 3 KafkaStreams instances with version <from_version> and upgrades one-by-one to <to_version>
         """
 
+        if KafkaVersion(from_version).supports_fk_joins() and KafkaVersion(to_version).supports_fk_joins():
+            extra_properties = {'test.run_fk_join': 'true'}
+        else:
+            extra_properties = {}
+
         self.zk = ZookeeperService(self.test_context, num_nodes=1)
         self.zk.start()
 
@@ -219,7 +224,8 @@ class StreamsUpgradeTest(Test):
         self.processor3 = StreamsUpgradeTestJobRunnerService(self.test_context, self.kafka)
 
         self.driver.start()
-        self.start_all_nodes_with(from_version)
+
+        self.start_all_nodes_with(from_version, extra_properties)
 
         self.processors = [self.processor1, self.processor2, self.processor3]
 
@@ -230,13 +236,13 @@ class StreamsUpgradeTest(Test):
         random.shuffle(self.processors)
         for p in self.processors:
             p.CLEAN_NODE_ENABLED = False
-            self.do_stop_start_bounce(p, from_version[:-2], to_version, counter)
+            self.do_stop_start_bounce(p, from_version[:-2], to_version, counter, extra_properties)
             counter = counter + 1
 
         # second rolling bounce
         random.shuffle(self.processors)
         for p in self.processors:
-            self.do_stop_start_bounce(p, None, to_version, counter)
+            self.do_stop_start_bounce(p, None, to_version, counter, extra_properties)
             counter = counter + 1
 
         # shutdown
@@ -308,11 +314,13 @@ class StreamsUpgradeTest(Test):
         else:
             return "Kafka version: " + version
 
-    def start_all_nodes_with(self, version):
+    def start_all_nodes_with(self, version, extra_properties = None):
+        if extra_properties is None:
+            extra_properties = {}
         kafka_version_str = self.get_version_string(version)
 
         # start first with <version>
-        self.prepare_for(self.processor1, version)
+        self.prepare_for(self.processor1, version, extra_properties)
         node1 = self.processor1.node
         with node1.account.monitor_log(self.processor1.STDOUT_FILE) as monitor:
             with node1.account.monitor_log(self.processor1.LOG_FILE) as log_monitor:
@@ -323,14 +331,14 @@ class StreamsUpgradeTest(Test):
                 monitor.wait_until(self.processed_data_msg,
                                    timeout_sec=60,
                                    err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node1.account))
-                if KafkaVersion(version).supports_fk_joins():
+                if 'test.run_fk_join' in extra_properties:
                     monitor.wait_until(self.processed_fk_msg,
                     timeout_sec=60,
                     err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node1.account))
 
 
         # start second with <version>
-        self.prepare_for(self.processor2, version)
+        self.prepare_for(self.processor2, version, extra_properties)
         node2 = self.processor2.node
         with node1.account.monitor_log(self.processor1.STDOUT_FILE) as first_monitor:
             with node2.account.monitor_log(self.processor2.STDOUT_FILE) as second_monitor:
@@ -345,13 +353,13 @@ class StreamsUpgradeTest(Test):
                     second_monitor.wait_until(self.processed_data_msg,
                                               timeout_sec=60,
                                               err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node2.account))
-                    if KafkaVersion(version).supports_fk_joins():
+                    if 'test.run_fk_join' in extra_properties:
                         second_monitor.wait_until(self.processed_fk_msg,
                         timeout_sec=60,
                         err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node2.account))
 
         # start third with <version>
-        self.prepare_for(self.processor3, version)
+        self.prepare_for(self.processor3, version, extra_properties)
         node3 = self.processor3.node
         with node1.account.monitor_log(self.processor1.STDOUT_FILE) as first_monitor:
             with node2.account.monitor_log(self.processor2.STDOUT_FILE) as second_monitor:
@@ -370,20 +378,26 @@ class StreamsUpgradeTest(Test):
                         third_monitor.wait_until(self.processed_data_msg,
                                                  timeout_sec=60,
                                                  err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node3.account))
-                        if KafkaVersion(version).supports_fk_joins():
+                        if 'test.run_fk_join' in extra_properties:
                             third_monitor.wait_until(self.processed_fk_msg,
                             timeout_sec=60,
                             err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node2.account))
 
     @staticmethod
-    def prepare_for(processor, version):
+    def prepare_for(processor, version, extra_properties):
         processor.node.account.ssh("rm -rf " + processor.PERSISTENT_ROOT, allow_fail=False)
+        for k, v in extra_properties.items():
+            processor.set_config(k, v)
         if version == str(DEV_VERSION):
             processor.set_version("")  # set to TRUNK
         else:
             processor.set_version(version)
 
-    def do_stop_start_bounce(self, processor, upgrade_from, new_version, counter):
+    def do_stop_start_bounce(self, processor, upgrade_from, new_version, counter, extra_properties=None):
+
+        if extra_properties is None:
+            extra_properties = {}
+
         kafka_version_str = self.get_version_string(new_version)
 
         first_other_processor = None
@@ -425,6 +439,8 @@ class StreamsUpgradeTest(Test):
         else:
             processor.set_version(new_version)
         processor.set_upgrade_from(upgrade_from)
+        for k, v in extra_properties.items():
+            processor.set_config(k, v)
 
         grep_metadata_error = "grep \"org.apache.kafka.streams.errors.TaskAssignmentException: unable to decode subscription data: version=2\" "
         with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
@@ -453,6 +469,11 @@ class StreamsUpgradeTest(Test):
                         monitor.wait_until(self.processed_data_msg,
                                            timeout_sec=60,
                                            err_msg="Never saw output '%s' on " % self.processed_data_msg + str(node.account))
+
+                        if "test.run_fk_join" in extra_properties:
+                            monitor.wait_until(self.processed_fk_msg,
+                                                     timeout_sec=60,
+                                                     err_msg="Never saw output '%s' on " % self.processed_fk_msg + str(node.account))
 
 
     def do_rolling_bounce(self, processor, counter, current_generation):

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -393,7 +393,7 @@ class StreamsUpgradeTest(Test):
         else:
             processor.set_version(version)
 
-    def do_stop_start_bounce(self, processor, upgrade_from, new_version, counter, extra_properties=None):
+    def do_stop_start_bounce(self, processor, upgrade_from, new_version, counter, extra_properties = None):
 
         if extra_properties is None:
             extra_properties = {}


### PR DESCRIPTION
This change allows foreign key joins to run in the streams upgrade system test. The FK join testing code was originally introduced in #12122 but wasn't executed,

1) In `streams.py`, a version check was performed against `KAFKA_STREAMS_VERSION` which would sometimes fail because `KAFKA_STREAMS_VERSION` is the empty string when testing the current snapshot.

2) FK join code was only added in the `StreamsUpgradeTest` of the `upgrade-system-test-*` grade modules, but not it the main `streams` grade module, which is required for testing the current snapshot. 

The effect was that FK join upgrades were not tested at all.

We introduce `extra_properties` in the system tests, that can be used to pass any property to the upgrade driver, which is supposed to be reused by system tests for switching on and off flags (e.g. for the state restoration code).

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
