### PR TITLE
KAFKA-14299: Never transition to UpdateStandby twice

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -214,7 +214,9 @@ public class DefaultStateUpdater implements StateUpdater {
         private void addToExceptionsAndFailedTasksThenRemoveFromUpdatingTasks(final ExceptionAndTasks exceptionAndTasks) {
             exceptionsAndFailedTasks.add(exceptionAndTasks);
             exceptionAndTasks.getTasks().stream().map(Task::id).forEach(updatingTasks::remove);
-            transitToUpdateStandbysIfOnlyStandbysLeft();
+            if (exceptionAndTasks.getTasks().stream().anyMatch(Task::isActive)) {
+                transitToUpdateStandbysIfOnlyStandbysLeft();
+            }
         }
 
         private void addToExceptionsAndFailedTasksThenClearUpdatingTasks(final ExceptionAndTasks exceptionAndTasks) {
@@ -310,7 +312,9 @@ public class DefaultStateUpdater implements StateUpdater {
             task.maybeCheckpoint(true);
             pausedTasks.put(taskId, task);
             updatingTasks.remove(taskId);
-            transitToUpdateStandbysIfOnlyStandbysLeft();
+            if (task.isActive()) {
+                transitToUpdateStandbysIfOnlyStandbysLeft();
+            }
             log.debug((task.isActive() ? "Active" : "Standby")
                 + " task " + task.id() + " was paused from the updating tasks and added to the paused tasks.");
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -658,6 +658,7 @@ class DefaultStateUpdaterTest {
         orderVerifier.verify(changelogReader, atLeast(1)).enforceRestoreActive();
         orderVerifier.verify(changelogReader).transitToUpdateStandby();
     }
+    
     @Test
     public void shouldNotTransitToStandbyAgainAfterStandbyTaskFailed() throws Exception {
         final StandbyTask task1 = standbyTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -667,10 +667,8 @@ class DefaultStateUpdaterTest {
                 mkEntry(task1.id(), task1),
                 mkEntry(task2.id(), task2)
         );
-        final TaskCorruptedException taskCorruptedException =
-                new TaskCorruptedException(mkSet(task1.id()));
-        final ExceptionAndTasks expectedExceptionAndTasks =
-                new ExceptionAndTasks(mkSet(task1), taskCorruptedException);
+        final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(mkSet(task1.id()));
+        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task1), taskCorruptedException);
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         doThrow(taskCorruptedException).doNothing().when(changelogReader).restore(updatingTasks);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -658,6 +658,28 @@ class DefaultStateUpdaterTest {
         orderVerifier.verify(changelogReader, atLeast(1)).enforceRestoreActive();
         orderVerifier.verify(changelogReader).transitToUpdateStandby();
     }
+    @Test
+    public void shouldNotTransitToStandbyAgainAfterStandbyTaskFailed() throws Exception {
+        final StandbyTask task1 = standbyTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        final StandbyTask task2 = standbyTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
+        final Map<TaskId, Task> updatingTasks = mkMap(
+                mkEntry(task1.id(), task1),
+                mkEntry(task2.id(), task2)
+        );
+        final TaskCorruptedException taskCorruptedException =
+                new TaskCorruptedException(mkSet(task1.id()));
+        final ExceptionAndTasks expectedExceptionAndTasks =
+                new ExceptionAndTasks(mkSet(task1), taskCorruptedException);
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        doThrow(taskCorruptedException).doNothing().when(changelogReader).restore(updatingTasks);
+
+        stateUpdater.start();
+        stateUpdater.add(task1);
+        stateUpdater.add(task2);
+
+        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
+        verify(changelogReader, times(1)).transitToUpdateStandby();
+    }
 
     @Test
     public void shouldUpdateStandbyTaskAfterAllActiveStatefulTasksRemoved() throws Exception {
@@ -859,6 +881,22 @@ class DefaultStateUpdaterTest {
         verifyUpdatingTasks(task2);
         verifyExceptionsAndFailedTasks();
         verify(changelogReader, times(1)).enforceRestoreActive();
+        verify(changelogReader, times(1)).transitToUpdateStandby();
+    }
+
+    @Test
+    public void shouldPauseStandbyTaskAndNotTransitToUpdateStandbyAgain() throws Exception {
+        final StandbyTask task1 = standbyTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        final StandbyTask task2 = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
+
+        stateUpdater.start();
+        stateUpdater.add(task1);
+        stateUpdater.add(task2);
+        verifyUpdatingTasks(task1, task2);
+
+        when(topologyMetadata.isPaused("A")).thenReturn(true);
+
+        verifyPausedTasks(task1);
         verify(changelogReader, times(1)).transitToUpdateStandby();
     }
 


### PR DESCRIPTION
In two situations, the current code could transition the `ChangelogReader`
 to `UpdateStandby` when already in that state, causing and 
`InvalidStateException`. Namely these two cases are:

1) When only standby tasks are restoring and one of them crashes.
2) When only standby tasks are restoring and one of them is paused.

This change fixes both issues by only transitioning if the paused or
failed task is an active task.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
