### PR TITLE
KAFKA-14273: Kafka doesn't start with KRaft on Windows

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/FileBasedStateStore.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FileBasedStateStore.java
@@ -149,6 +149,7 @@ public class FileBasedStateStore implements QuorumStateStore {
             writer.write(jsonState.toString());
             writer.flush();
             fileOutputStream.getFD().sync();
+            fileOutputStream.close();
             Utils.atomicMoveWithFallback(temp.toPath(), stateFile.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException(


### PR DESCRIPTION
Windows does not allow moving a file if a file descriptor is still opened.
Closing the FileOutputStream prior to moving the file fix the issue.