### PR TITLE
 MINOR: Upgrade spotbugs dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -120,7 +120,7 @@ versions += [
   scoverage: "1.4.11",
   slf4j: "1.7.36",
   snappy: "1.1.8.4",
-  spotbugs: "4.2.2",
+  spotbugs: "4.7.3",
   swaggerAnnotations: "2.2.0",
   swaggerJaxrs2: "2.2.0",
   zinc: "1.6.1",

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -28,8 +28,10 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <!-- Disable warnings about mutable objects and the use of public fields.
             EI_EXPOSE_REP: May expose internal representation by returning reference to mutable object
             EI_EXPOSE_REP2: May expose internal representation by incorporating reference to mutable object
-            MS_PKGPROTECT: Field should be package protected -->
-        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2,MS_PKGPROTECT"/>
+            MS_PKGPROTECT: Field should be package protected
+            MS_EXPOSE_REP: Public static method may expose internal representation by returning array
+            EI_EXPOSE_STATIC_REP2: May expose internal static state by storing a mutable object into a static field -->
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2,MS_PKGPROTECT,EI_EXPOSE_STATIC_REP2,MS_EXPOSE_REP"/>
     </Match>
 
     <Match>
@@ -90,6 +92,8 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Bug pattern="MS_CANNOT_BE_FINAL"/>
             <Bug pattern="IC_INIT_CIRCULARITY"/>
             <Bug pattern="SE_NO_SUITABLE_CONSTRUCTOR"/>
+            <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
+            <Bug pattern="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA"/>
         </Or>
     </Match>
 


### PR DESCRIPTION
Upgrade spotbugs 4.7.3 to handle [CVE-2022-42889](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
