### PR TITLE
KAFKA-14314: Add check for null upstreamTopic

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -495,7 +495,7 @@ public class MirrorSourceConnector extends SourceConnector {
             return true;
         } else {
             String upstreamTopic = replicationPolicy.upstreamTopic(topic);
-            if (upstreamTopic.equals(topic)) {
+            if (upstreamTopic == null || upstreamTopic.equals(topic)) {
                 // Extra check for IdentityReplicationPolicy and similar impls that don't prevent cycles.
                 return false;
             }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -322,7 +322,7 @@ public class MirrorSourceConnectorTest {
     }
 
     @Test
-    public void testIsCycleWithNullUpstreamTopic() throws Exception {
+    public void testIsCycleWithNullUpstreamTopic() {
         class BadReplicationPolicy extends DefaultReplicationPolicy {
             @Override
             public String upstreamTopic(String topic) {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -59,7 +60,7 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testReplicatesHeartbeatsByDefault() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"), 
+        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
             new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
         assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
         assertTrue(connector.shouldReplicateTopic("us-west.heartbeats"), "should replicate upstream heartbeats");
@@ -139,7 +140,7 @@ public class MirrorSourceConnectorTest {
         assertEquals(processedDenyAllAclBinding.entry().operation(), AclOperation.ALL, "should not change ALL");
         assertEquals(processedDenyAllAclBinding.entry().permissionType(), AclPermissionType.DENY, "should not change DENY");
     }
-    
+
     @Test
     public void testConfigPropertyFiltering() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
@@ -318,5 +319,18 @@ public class MirrorSourceConnectorTest {
         // when partitions are added to the source cluster, reconfiguration is triggered
         connector.refreshTopicPartitions();
         verify(connector, times(1)).computeAndCreateTopicPartitions();
+    }
+
+    @Test
+    public void testIsCycleWithNullUpstreamTopic() throws Exception {
+        class BadReplicationPolicy extends DefaultReplicationPolicy {
+            @Override
+            public String upstreamTopic(String topic) {
+                return null;
+            }
+        }
+        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+                new BadReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+        assertDoesNotThrow(() -> connector.isCycle(".b"));
     }
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -323,14 +323,14 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testIsCycleWithNullUpstreamTopic() {
-        class BadReplicationPolicy extends DefaultReplicationPolicy {
+        class CustomReplicationPolicy extends DefaultReplicationPolicy {
             @Override
             public String upstreamTopic(String topic) {
                 return null;
             }
         }
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new BadReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+                new CustomReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
         assertDoesNotThrow(() -> connector.isCycle(".b"));
     }
 }


### PR DESCRIPTION
This PR addresses [KAFKA-14314](https://issues.apache.org/jira/browse/KAFKA-14314), fixing the case where `MirrorSourceConnector.isCycle()` could throw a NullPointerException if the upstreamTopic evaluates as null. The test for this condition creates a dummy `ReplicationPolicy` to simulate this occurrence.