### PR TITLE
KAFKA-14299: Return emptied ChangelogReader to ACTIVE_RESTORING

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -90,6 +90,7 @@ public class StoreChangelogReader implements ChangelogReader {
     //   1) restoring active task or
     //   2) updating standby task at a given time,
     // but never doing both
+    // A changelog reader with no tasks at all is in state ACTIVE_RESTORING
     enum ChangelogReaderState {
         ACTIVE_RESTORING("ACTIVE_RESTORING"),
 
@@ -990,6 +991,10 @@ public class StoreChangelogReader implements ChangelogReader {
         }
 
         removeChangelogsFromRestoreConsumer(revokedInitializedChangelogs);
+
+        if (changelogs.isEmpty()) {
+            state = ChangelogReaderState.ACTIVE_RESTORING;
+        }
     }
 
     @Override
@@ -998,6 +1003,8 @@ public class StoreChangelogReader implements ChangelogReader {
             changelogMetadata.clear();
         }
         changelogs.clear();
+
+        state = ChangelogReaderState.ACTIVE_RESTORING;
 
         try {
             restoreConsumer.unsubscribe();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -1071,9 +1071,19 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         assertEquals(ACTIVE_RESTORING, changelogReader.state());
         assertEquals(mkSet(tp, tp1, tp2), consumer.assignment());
         assertEquals(mkSet(tp1, tp2), consumer.paused());
+    }
 
+    @Test
+    public void shouldTransitStateBackToActiveRestoringAfterRemovingLastTask() {
+        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback);
+        EasyMock.expect(standbyStateManager.storeMetadata(tp1)).andReturn(storeMetadataOne).anyTimes();
+        EasyMock.expect(storeMetadataOne.changelogPartition()).andReturn(tp1).anyTimes();
+        EasyMock.expect(storeMetadataOne.store()).andReturn(store).anyTimes();
+        EasyMock.replay(standbyStateManager, store, storeMetadataOne);
+        changelogReader.register(tp1, standbyStateManager);
         changelogReader.transitToUpdateStandby();
-        changelogReader.unregister(mkSet(tp, tp1, tp2));
+
+        changelogReader.unregister(mkSet(tp1));
         assertTrue(changelogReader.isEmpty());
         assertEquals(ACTIVE_RESTORING, changelogReader.state());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -992,6 +992,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         assertTrue(changelogReader.isEmpty());
         assertNull(changelogReader.changelogMetadata(tp1));
         assertNull(changelogReader.changelogMetadata(tp2));
+        assertEquals(changelogReader.state(), ACTIVE_RESTORING);
     }
 
     @Test
@@ -1070,6 +1071,11 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         assertEquals(ACTIVE_RESTORING, changelogReader.state());
         assertEquals(mkSet(tp, tp1, tp2), consumer.assignment());
         assertEquals(mkSet(tp1, tp2), consumer.paused());
+
+        changelogReader.transitToUpdateStandby();
+        changelogReader.unregister(mkSet(tp, tp1, tp2));
+        assertTrue(changelogReader.isEmpty());
+        assertEquals(ACTIVE_RESTORING, changelogReader.state());
     }
 
     @Test


### PR DESCRIPTION
The ChangelogReader starts of in `ACTIVE_RESTORING` state, and then goes to
`STANDBY_RESTORING` when changelogs from standby tasks are added. When 
the last standby changelogs are removed, it remained in `STANDBY_RESTORING`, 
which means that an empty ChangelogReader could be in either 
`ACTIVE_RESTORING` or `STANDBY_RESTORING` depending on the exact
 sequence of add/remove operations. This could lead the state updater into an illegal
state. Instead of changing the state updater, I propose to stengthen the state invariant 
of the `ChangelogReader` slightly: it should always be in `ACTIVE_RESTORING`
state when empty.

This is tested by extending existing unit tests.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
