### PR TITLE
KAFKA-14247: add handler impl to the prototype

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -64,27 +64,6 @@ public class DefaultBackgroundThread extends KafkaThread {
     private final AtomicReference<Optional<RuntimeException>> exception =
         new AtomicReference<>(Optional.empty());
 
-    public DefaultBackgroundThread(final ConsumerConfig config,
-                                   final LogContext logContext,
-                                   final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                   final SubscriptionState subscriptions,
-                                   final ConsumerMetadata metadata,
-                                   final ConsumerNetworkClient networkClient,
-                                   final Metrics metrics) {
-        this(
-            Time.SYSTEM,
-            config,
-            logContext,
-            applicationEventQueue,
-            backgroundEventQueue,
-            subscriptions,
-            metadata,
-            networkClient,
-            metrics
-        );
-    }
-
     public DefaultBackgroundThread(final Time time,
                                    final ConsumerConfig config,
                                    final LogContext logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -114,14 +114,13 @@ public class DefaultEventHandler implements EventHandler {
             logContext
         );
         final ConsumerNetworkClient networkClient = new ConsumerNetworkClient(
-            logContext,
-            netClient,
-            metadata,
-            time,
-            config.getInt(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
-            config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-            config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)
-        );
+                logContext,
+                netClient,
+                metadata,
+                time,
+                config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
+                config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG));
         this.backgroundThread = new DefaultBackgroundThread(
             time,
             config,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -35,6 +35,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * An {@code EventHandler} that uses a single background thread to consume {@code ApplicationEvent} and produce
@@ -46,6 +47,24 @@ public class DefaultEventHandler implements EventHandler {
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
     private final DefaultBackgroundThread backgroundThread;
 
+    public DefaultEventHandler(final ConsumerConfig config,
+                               final LogContext logContext,
+                               final SubscriptionState subscriptionState,
+                               final ApiVersions apiVersions,
+                               final Metrics metrics,
+                               final ClusterResourceListeners clusterResourceListeners,
+                               final Sensor fetcherThrottleTimeSensor) {
+        this(Time.SYSTEM,
+                config,
+                logContext,
+                new LinkedBlockingQueue<>(),
+                new LinkedBlockingQueue<>(),
+                subscriptionState,
+                apiVersions,
+                metrics,
+                clusterResourceListeners,
+                fetcherThrottleTimeSensor);
+    }
 
     public DefaultEventHandler(final Time time,
                                final ConsumerConfig config,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -215,7 +215,7 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         }
     }
 
-    private ClusterResourceListeners configureClusterResourceListeners(
+    private static <K, V> ClusterResourceListeners configureClusterResourceListeners(
             final Deserializer<K> keyDeserializer,
             final Deserializer<V> valueDeserializer,
             final List<?>... candidateLists) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -195,6 +195,7 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
      * been made.
      * @return The set of topics currently subscribed to
      */
+    @Override
     public Set<String> subscription() {
         return Collections.unmodifiableSet(this.subscriptions.subscription());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -122,6 +122,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         );
     }
 
+    // Visible for testing
     PrototypeAsyncConsumer(
             Time time,
             LogContext logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -196,7 +196,7 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
      * @return The set of topics currently subscribed to
      */
     public Set<String> subscription() {
-        return Collections.unmodifiableSet(new HashSet<>(this.subscriptions.subscription()));
+        return Collections.unmodifiableSet(this.subscriptions.subscription());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -16,32 +16,99 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * This prototype consumer uses the EventHandler to process application events so that the network IO can be processed in a background thread. Visit
+ * This prototype consumer uses the EventHandler to process application
+ * events so that the network IO can be processed in a background thread. Visit
  * <a href="https://cwiki.apache.org/confluence/display/KAFKA/Proposal%3A+Consumer+Threading+Model+Refactor" >this document</a>
  * for detail implementation.
  */
 public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
+    private static final String CLIENT_ID_METRIC_TAG = "client-id";
+    private static final String JMX_PREFIX = "kafka.consumer";
+
+    private final LogContext logContext;
     private final EventHandler eventHandler;
     private final Time time;
+    private final Optional<String> groupId;
+    private final String clientId;
+    private final Logger log;
+    private final SubscriptionState subscriptions;
+    private final Metrics metrics;
 
-    public PrototypeAsyncConsumer(final Time time, final EventHandler eventHandler) {
+    @SuppressWarnings("unchecked")
+    public PrototypeAsyncConsumer(final Time time,
+                                  final ConsumerConfig config,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
         this.time = time;
-        this.eventHandler = eventHandler;
+        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
+                GroupRebalanceConfig.ProtocolType.CONSUMER);
+        this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+        this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+
+        // If group.instance.id is set, we will append it to the log context.
+        if (groupRebalanceConfig.groupInstanceId.isPresent()) {
+            logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
+                    ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+        } else {
+            logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+        }
+        this.log = logContext.logger(getClass());
+        OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
+        this.subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
+        this.metrics = buildMetrics(config, time, clientId);
+        List<ConsumerInterceptor<K, V>> interceptorList = (List) config.getConfiguredInstances(
+                ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                ConsumerInterceptor.class,
+                Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId));
+        ClusterResourceListeners clusterResourceListeners = configureClusterResourceListeners(keyDeserializer,
+                valueDeserializer, metrics.reporters(), interceptorList);
+        this.eventHandler = new DefaultEventHandler(
+                config,
+                logContext,
+                subscriptions,
+                new ApiVersions(),
+                this.metrics,
+                clusterResourceListeners,
+                null // this is coming from the fetcher, but we don't have one
+        );
     }
+
 
     /**
      * poll implementation using {@link EventHandler}.
@@ -84,9 +151,10 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return ConsumerRecords.empty();
     }
 
-    abstract void processEvent(BackgroundEvent backgroundEvent, Duration timeout);
+    abstract void processEvent(final BackgroundEvent backgroundEvent,
+                               final Duration timeout);
 
-    abstract ConsumerRecords<K, V> processFetchResults(Fetch<K, V> fetch);
+    abstract ConsumerRecords<K, V> processFetchResults(final Fetch<K, V> fetch);
 
     abstract Fetch<K, V> collectFetches();
 
@@ -100,7 +168,8 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     /**
-     * This method sends a commit event to the EventHandler and waits for the event to finish.
+     * This method sends a commit event to the EventHandler and waits for
+     * the event to finish.
      *
      * @param timeout max wait time for the blocking operation.
      */
@@ -113,11 +182,21 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         try {
             commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (final TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException("timeout");
+            throw new org.apache.kafka.common.errors.TimeoutException(
+                     "timeout");
         } catch (final Exception e) {
             // handle exception here
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Get the current subscription.  or an empty set if no such call has
+     * been made.
+     * @return The set of topics currently subscribed to
+     */
+    public Set<String> subscription() {
+        return Collections.unmodifiableSet(new HashSet<>(this.subscriptions.subscription()));
     }
 
     /**
@@ -134,5 +213,35 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         public boolean process() {
             return true;
         }
+    }
+
+    private ClusterResourceListeners configureClusterResourceListeners(
+            final Deserializer<K> keyDeserializer,
+            final Deserializer<V> valueDeserializer,
+            final List<?>... candidateLists) {
+        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
+        for (List<?> candidateList: candidateLists)
+            clusterResourceListeners.maybeAddAll(candidateList);
+
+        clusterResourceListeners.maybeAdd(keyDeserializer);
+        clusterResourceListeners.maybeAdd(valueDeserializer);
+        return clusterResourceListeners;
+    }
+
+    private static Metrics buildMetrics(
+            final ConsumerConfig config,
+            final Time time,
+            final String clientId) {
+        Map<String, String> metricsTags = Collections.singletonMap(CLIENT_ID_METRIC_TAG, clientId);
+        MetricConfig metricConfig = new MetricConfig()
+                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
+                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
+                .tags(metricsTags);
+        List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
+        MetricsContext metricsContext = new KafkaMetricsContext(
+                JMX_PREFIX,
+                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+        return new Metrics(metricConfig, reporters, time, metricsContext);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -40,7 +39,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PrototypeAsyncConsumerTest {
     private Map<String, Object> properties;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Properties;
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PrototypeAsyncConsumerTest {
+    private final Properties properties = new Properties();
+
+    @BeforeEach
+    public void setup() {
+        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(CLIENT_ID_CONFIG, "test-client");
+    }
+    @Test
+    public void testSubscription() {
+        SubscriptionState subscriptionState = new SubscriptionState(new LogContext(), OffsetResetStrategy.EARLIEST);
+        PrototypeAsyncConsumer consumer =
+                Mockito.mock(PrototypeAsyncConsumer.class);
+        subscriptionState.subscribe(singleton("t1"), new NoOpConsumerRebalanceListener());
+        Set<String> subscriptionRes = subscriptionState.subscription();
+        Mockito.doCallRealMethod()
+                .when(consumer)
+                .subscription();
+        Mockito.doReturn(subscriptionRes).when(consumer).subscription();
+        assertEquals(1, consumer.subscription().size());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -16,42 +16,99 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.Properties;
-import java.util.Set;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.singleton;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PrototypeAsyncConsumerTest {
-    private final Properties properties = new Properties();
+    private Map<String, Object> properties;
+    private SubscriptionState subscriptionState;
+    private MockTime time;
+    private LogContext logContext;
+    private Metrics metrics;
+    private ClusterResourceListeners clusterResourceListeners;
+    private Optional<String> groupId;
+    private String clientId;
+    private EventHandler eventHandler;
 
     @BeforeEach
     public void setup() {
-        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(CLIENT_ID_CONFIG, "test-client");
+        this.subscriptionState = Mockito.mock(SubscriptionState.class);
+        this.eventHandler = Mockito.mock(EventHandler.class);
+        this.logContext = new LogContext();
+        this.time = new MockTime();
+        this.metrics = new Metrics(time);
+        this.groupId = Optional.empty();
+        this.clientId = "client-1";
+        this.clusterResourceListeners = new ClusterResourceListeners();
+        this.properties = new HashMap<>();
+        this.properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                "localhost" +
+                ":9999");
+        this.properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.properties.put(CLIENT_ID_CONFIG, "test-client");
     }
     @Test
     public void testSubscription() {
-        SubscriptionState subscriptionState = new SubscriptionState(new LogContext(), OffsetResetStrategy.EARLIEST);
-        PrototypeAsyncConsumer consumer =
-                Mockito.mock(PrototypeAsyncConsumer.class);
-        subscriptionState.subscribe(singleton("t1"), new NoOpConsumerRebalanceListener());
-        Set<String> subscriptionRes = subscriptionState.subscription();
-        Mockito.doCallRealMethod()
-                .when(consumer)
-                .subscription();
-        Mockito.doReturn(subscriptionRes).when(consumer).subscription();
+        this.subscriptionState =
+                new SubscriptionState(new LogContext(), OffsetResetStrategy.EARLIEST);
+        PrototypeAsyncConsumer<String, String> consumer =
+                setupConsumerWithDefault();
+        subscriptionState.subscribe(singleton("t1"),
+                new NoOpConsumerRebalanceListener());
         assertEquals(1, consumer.subscription().size());
+    }
+
+    @Test
+    public void testPoll() {
+        PrototypeAsyncConsumer<String, String> consumer =
+                setupConsumerWithDefault();
+        assertTrue(consumer.poll(Duration.ofMillis(100)).isEmpty());
+    }
+
+    @Test
+    public void testUnimplementedException() {
+        PrototypeAsyncConsumer<String, String> consumer =
+                setupConsumerWithDefault();
+        assertThrows(KafkaException.class, consumer::assignment, "not implemented exception");
+    }
+
+    public PrototypeAsyncConsumer<String, String> setupConsumerWithDefault() {
+        ConsumerConfig config = new ConsumerConfig(properties);
+        return new PrototypeAsyncConsumer<>(
+                this.time,
+                this.logContext,
+                config,
+                this.subscriptionState,
+                this.eventHandler,
+                this.metrics,
+                this.clusterResourceListeners,
+                this.groupId,
+                this.clientId,
+                0);
+
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -56,7 +56,7 @@ public class PrototypeAsyncConsumerTest {
     @BeforeEach
     public void setup() {
         this.subscriptionState = Mockito.mock(SubscriptionState.class);
-        this.eventHandler = Mockito.mock(EventHandler.class);
+        this.eventHandler = Mockito.mock(DefaultEventHandler.class);
         this.logContext = new LogContext();
         this.time = new MockTime();
         this.metrics = new Metrics(time);
@@ -80,13 +80,6 @@ public class PrototypeAsyncConsumerTest {
         subscriptionState.subscribe(singleton("t1"),
                 new NoOpConsumerRebalanceListener());
         assertEquals(1, consumer.subscription().size());
-    }
-
-    @Test
-    public void testPoll() {
-        PrototypeAsyncConsumer<String, String> consumer =
-                setupConsumerWithDefault();
-        assertTrue(consumer.poll(Duration.ofMillis(100)).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
*This is a minor revision for KAFKA-14247. We added how the handler is called and constructed to the prototype code path.

I also added the SubscriptionState instance to elucidate the idea that it is created on the client thread. The `subscription()` demonstrates that it maintains the same access pattern as the current impl.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
