### PR TITLE
MINOR: Fix allDepInsight build task with gradle 7.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ subprojects {
   task allDeps(type: DependencyReportTask) {}
   // enable running :dependencyInsight task recursively on all subprojects
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
-  task allDepInsight(type: DependencyInsightReportTask) doLast {}
+  task allDepInsight(type: DependencyInsightReportTask) {showingAllVariants = false} doLast {}
 
   apply plugin: 'java-library'
   apply plugin: 'checkstyle'


### PR DESCRIPTION
gradle allDepInsight task is failing with gradle 7.5. Fixed the issue by setting the newly added option `showingAllVariants = false` for DependencyInsightReportTask

```
➜  ./gradlew allDepInsight --configuration spotbugs --dependency org.apache.commons:commons-text

> Configure project :
Starting build with version 3.4.0-SNAPSHOT (commit id 215d4f93) using Gradle 7.5.1, Java 1.8 and Scala 2.13.8
Build properties: maxParallelForks=16, maxScalacThreads=8, maxTestRetries=0

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':clients:allDepInsight'.
> Cannot query the value of task ':clients:allDepInsight' property 'showingAllVariants' because it has no value available.
```
