### PR TITLE
KAFKA-14332; Make Kafka tests use their own separate import-control.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -700,6 +700,8 @@ subprojects {
 
   configure(checkstyleTest) {
     group = 'Verification'
+    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = checkstyleConfigProperties("import-control-test.xml")
     description = 'Run checkstyle on all test Java sources'
   }
 

--- a/checkstyle/import-control-test.xml
+++ b/checkstyle/import-control-test.xml
@@ -1,0 +1,661 @@
+<!DOCTYPE import-control PUBLIC
+        "-//Puppy Crawl//DTD Import Control 1.1//EN"
+        "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<import-control pkg="org.apache.kafka">
+
+    <!-- THINK HARD ABOUT THE LAYERING OF THE PROJECT BEFORE CHANGING THIS FILE -->
+
+    <!-- common library dependencies -->
+    <allow pkg="java" />
+    <allow pkg="javax.management" />
+    <allow pkg="org.slf4j" />
+    <allow pkg="org.junit" />
+    <allow pkg="org.opentest4j" />
+    <allow pkg="org.hamcrest" />
+    <allow pkg="org.mockito" />
+    <allow pkg="org.easymock" />
+    <allow pkg="org.powermock" />
+    <allow pkg="java.security" />
+    <allow pkg="javax.net.ssl" />
+    <allow pkg="javax.security" />
+    <allow pkg="org.ietf.jgss" />
+    <allow pkg="net.jqwik.api" />
+
+    <!-- anyone can use public classes -->
+    <allow pkg="org.apache.kafka.common" exact-match="true" />
+    <allow pkg="org.apache.kafka.common.security" />
+    <allow pkg="org.apache.kafka.common.serialization" />
+    <allow pkg="org.apache.kafka.common.utils" />
+    <allow pkg="org.apache.kafka.common.errors" exact-match="true" />
+    <allow pkg="org.apache.kafka.common.memory" />
+
+    <subpackage name="common">
+        <allow class="org.apache.kafka.clients.consumer.ConsumerRecord" exact-match="true" />
+        <allow class="org.apache.kafka.common.message.ApiMessageType" exact-match="true" />
+        <disallow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.common" exact-match="true" />
+        <allow pkg="org.apache.kafka.common.annotation" />
+        <allow pkg="org.apache.kafka.common.config" exact-match="true" />
+        <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
+        <allow pkg="org.apache.kafka.test" />
+
+        <subpackage name="acl">
+            <allow pkg="org.apache.kafka.common.annotation" />
+            <allow pkg="org.apache.kafka.common.acl" />
+            <allow pkg="org.apache.kafka.common.resource" />
+        </subpackage>
+
+        <subpackage name="config">
+            <allow pkg="org.apache.kafka.common.config" />
+            <!-- for testing -->
+            <allow pkg="org.apache.kafka.common.metrics" />
+        </subpackage>
+
+        <!-- Third-party compression libraries should only be references from this package -->
+        <subpackage name="compress">
+            <allow pkg="com.github.luben.zstd" />
+            <allow pkg="net.jpountz.lz4" />
+            <allow pkg="net.jpountz.xxhash" />
+            <allow pkg="org.apache.kafka.common.compress" />
+            <allow pkg="org.xerial.snappy" />
+        </subpackage>
+
+        <subpackage name="message">
+            <allow pkg="com.fasterxml.jackson" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.protocol.types" />
+            <allow pkg="org.apache.kafka.common.message" />
+            <allow pkg="org.apache.kafka.common.record" />
+        </subpackage>
+
+        <subpackage name="metadata">
+            <allow pkg="com.fasterxml.jackson" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.protocol.types" />
+            <allow pkg="org.apache.kafka.common.message" />
+            <allow pkg="org.apache.kafka.common.metadata" />
+        </subpackage>
+
+        <subpackage name="metrics">
+            <allow pkg="org.apache.kafka.common.metrics" />
+        </subpackage>
+
+        <subpackage name="memory">
+            <allow pkg="org.apache.kafka.common.metrics" />
+        </subpackage>
+
+        <subpackage name="network">
+            <allow pkg="org.apache.kafka.common.security.auth" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.config" />
+            <allow pkg="org.apache.kafka.common.metrics" />
+            <allow pkg="org.apache.kafka.common.security" />
+            <allow class="org.apache.kafka.common.requests.ApiVersionsResponse" />
+        </subpackage>
+
+        <subpackage name="resource">
+            <allow pkg="org.apache.kafka.common.annotation" />
+            <allow pkg="org.apache.kafka.common.resource" />
+        </subpackage>
+
+        <subpackage name="security">
+            <allow pkg="org.apache.kafka.common.annotation" />
+            <allow pkg="org.apache.kafka.common.network" />
+            <allow pkg="org.apache.kafka.common.config" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.errors" />
+            <!-- To access DefaultPrincipalData -->
+            <allow pkg="org.apache.kafka.common.message" />
+            <subpackage name="authenticator">
+                <allow pkg="org.apache.kafka.common.message" />
+                <allow pkg="org.apache.kafka.common.protocol.types" />
+                <allow pkg="org.apache.kafka.common.requests" />
+                <allow pkg="org.apache.kafka.clients" />
+            </subpackage>
+            <subpackage name="ssl">
+                <allow pkg="javax.crypto" />
+            </subpackage>
+            <subpackage name="scram">
+                <allow pkg="javax.crypto" />
+            </subpackage>
+            <subpackage name="oauthbearer">
+                <allow pkg="com.fasterxml.jackson.databind" />
+                <allow pkg="org.jose4j" />
+            </subpackage>
+        </subpackage>
+
+        <subpackage name="protocol">
+            <allow pkg="org.apache.kafka.common.errors" />
+            <allow pkg="org.apache.kafka.common.message" />
+            <allow pkg="org.apache.kafka.common.network" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.protocol.types" />
+            <allow pkg="org.apache.kafka.common.record" />
+            <allow pkg="org.apache.kafka.common.requests" />
+            <allow pkg="org.apache.kafka.common.resource" />
+            <allow pkg="com.fasterxml.jackson" />
+        </subpackage>
+
+        <subpackage name="record">
+            <allow pkg="org.apache.kafka.common.compress" />
+            <allow pkg="org.apache.kafka.common.header" />
+            <allow pkg="org.apache.kafka.common.record" />
+            <allow pkg="org.apache.kafka.common.message" />
+            <allow pkg="org.apache.kafka.common.network" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.protocol.types" />
+            <allow pkg="org.apache.kafka.common.errors" />
+        </subpackage>
+
+        <subpackage name="header">
+            <allow pkg="org.apache.kafka.common.header" />
+            <allow pkg="org.apache.kafka.common.record" />
+        </subpackage>
+
+        <subpackage name="requests">
+            <allow pkg="org.apache.kafka.common.acl" />
+            <allow pkg="org.apache.kafka.common.feature" />
+            <allow pkg="org.apache.kafka.common.protocol" />
+            <allow pkg="org.apache.kafka.common.message" />
+            <allow pkg="org.apache.kafka.common.network" />
+            <allow pkg="org.apache.kafka.common.quota" />
+            <allow pkg="org.apache.kafka.common.requests" />
+            <allow pkg="org.apache.kafka.common.resource" />
+            <allow pkg="org.apache.kafka.common.record" />
+            <!-- for AuthorizableRequestContext interface -->
+            <allow pkg="org.apache.kafka.server.authorizer" />
+            <!-- for IncrementalAlterConfigsRequest Builder -->
+            <allow pkg="org.apache.kafka.clients.admin" />
+            <!-- for testing -->
+            <allow pkg="org.apache.kafka.common.errors" />
+        </subpackage>
+
+        <subpackage name="serialization">
+            <allow pkg="org.apache.kafka.clients" />
+            <allow class="org.apache.kafka.common.errors.SerializationException" />
+            <allow class="org.apache.kafka.common.header.Headers" />
+        </subpackage>
+
+        <subpackage name="utils">
+            <allow pkg="org.apache.kafka.common" />
+            <allow pkg="org.apache.log4j" />
+        </subpackage>
+
+        <subpackage name="quotas">
+            <allow pkg="org.apache.kafka.common" />
+        </subpackage>
+    </subpackage>
+
+    <subpackage name="controller">
+        <allow pkg="com.yammer.metrics"/>
+        <allow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.clients.admin" />
+        <allow pkg="org.apache.kafka.common.acl" />
+        <allow pkg="org.apache.kafka.common.annotation" />
+        <allow pkg="org.apache.kafka.common.config" />
+        <allow pkg="org.apache.kafka.common.feature" />
+        <allow pkg="org.apache.kafka.common.internals" />
+        <allow pkg="org.apache.kafka.common.message" />
+        <allow pkg="org.apache.kafka.common.metadata" />
+        <allow pkg="org.apache.kafka.common.metrics" />
+        <allow pkg="org.apache.kafka.common.network" />
+        <allow pkg="org.apache.kafka.common.protocol" />
+        <allow pkg="org.apache.kafka.common.quota" />
+        <allow pkg="org.apache.kafka.common.record" />
+        <allow pkg="org.apache.kafka.common.requests" />
+        <allow pkg="org.apache.kafka.common.resource" />
+        <allow pkg="org.apache.kafka.controller" />
+        <allow pkg="org.apache.kafka.metadata" />
+        <allow pkg="org.apache.kafka.metadata.authorizer" />
+        <allow pkg="org.apache.kafka.metalog" />
+        <allow pkg="org.apache.kafka.queue" />
+        <allow pkg="org.apache.kafka.raft" />
+        <allow pkg="org.apache.kafka.server.authorizer" />
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.server.fault" />
+        <allow pkg="org.apache.kafka.server.metrics" />
+        <allow pkg="org.apache.kafka.server.policy"/>
+        <allow pkg="org.apache.kafka.server.util"/>
+        <allow pkg="org.apache.kafka.snapshot" />
+        <allow pkg="org.apache.kafka.test" />
+        <allow pkg="org.apache.kafka.timeline" />
+    </subpackage>
+
+    <subpackage name="image">
+        <allow pkg="org.apache.kafka.common.config" />
+        <allow pkg="org.apache.kafka.common.message" />
+        <allow pkg="org.apache.kafka.common.metadata" />
+        <allow pkg="org.apache.kafka.common.protocol" />
+        <allow pkg="org.apache.kafka.common.quota" />
+        <allow pkg="org.apache.kafka.common.resource" />
+        <allow pkg="org.apache.kafka.common.requests" />
+        <allow pkg="org.apache.kafka.image" />
+        <allow pkg="org.apache.kafka.image.writer" />
+        <allow pkg="org.apache.kafka.metadata" />
+        <allow pkg="org.apache.kafka.raft" />
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.server.util" />
+        <allow pkg="org.apache.kafka.snapshot" />
+    </subpackage>
+
+    <subpackage name="metadata">
+        <allow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.common.annotation" />
+        <allow pkg="org.apache.kafka.common.config" />
+        <allow pkg="org.apache.kafka.common.message" />
+        <allow pkg="org.apache.kafka.common.metadata" />
+        <allow pkg="org.apache.kafka.common.protocol" />
+        <allow pkg="org.apache.kafka.common.record" />
+        <allow pkg="org.apache.kafka.common.requests" />
+        <allow pkg="org.apache.kafka.image" />
+        <allow pkg="org.apache.kafka.metadata" />
+        <allow pkg="org.apache.kafka.metalog" />
+        <allow pkg="org.apache.kafka.queue" />
+        <allow pkg="org.apache.kafka.raft" />
+        <allow pkg="org.apache.kafka.server.authorizer" />
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.server.util"/>
+        <allow pkg="org.apache.kafka.test" />
+        <subpackage name="authorizer">
+            <allow pkg="org.apache.kafka.common.acl" />
+            <allow pkg="org.apache.kafka.common.requests" />
+            <allow pkg="org.apache.kafka.common.resource" />
+            <allow pkg="org.apache.kafka.controller" />
+            <allow pkg="org.apache.kafka.metadata" />
+            <allow pkg="org.apache.kafka.common.internals" />
+        </subpackage>
+        <subpackage name="bootstrap">
+            <allow pkg="org.apache.kafka.snapshot" />
+        </subpackage>
+        <subpackage name="fault">
+            <allow pkg="org.apache.kafka.server.fault" />
+        </subpackage>
+    </subpackage>
+
+    <subpackage name="metalog">
+        <allow pkg="org.apache.kafka.common.metadata" />
+        <allow pkg="org.apache.kafka.common.protocol" />
+        <allow pkg="org.apache.kafka.common.record" />
+        <allow pkg="org.apache.kafka.metadata" />
+        <allow pkg="org.apache.kafka.metalog" />
+        <allow pkg="org.apache.kafka.raft" />
+        <allow pkg="org.apache.kafka.snapshot" />
+        <allow pkg="org.apache.kafka.queue" />
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.test" />
+    </subpackage>
+
+    <subpackage name="clients">
+        <allow pkg="org.apache.kafka.common" />
+        <allow pkg="org.apache.kafka.clients" exact-match="true"/>
+        <allow pkg="org.apache.kafka.test" />
+
+        <subpackage name="consumer">
+            <allow pkg="org.apache.kafka.clients.consumer" />
+        </subpackage>
+
+        <subpackage name="producer">
+            <allow pkg="org.apache.kafka.clients.consumer" />
+            <allow pkg="org.apache.kafka.clients.producer" />
+        </subpackage>
+
+        <subpackage name="admin">
+            <allow pkg="org.apache.kafka.clients.admin" />
+            <allow pkg="org.apache.kafka.clients.consumer.internals" />
+            <allow pkg="org.apache.kafka.clients.consumer" />
+        </subpackage>
+    </subpackage>
+
+    <subpackage name="server">
+        <allow pkg="org.apache.kafka.common" />
+
+        <!-- This is required to make AlterConfigPolicyTest work. -->
+        <allow pkg="org.apache.kafka.server.policy" />
+
+        <subpackage name="common">
+            <allow pkg="org.apache.kafka.server.common" />
+        </subpackage>
+
+        <subpackage name="metrics">
+            <allow pkg="com.yammer.metrics" />
+        </subpackage>
+
+        <subpackage name="log">
+            <allow pkg="com.fasterxml.jackson" />
+            <allow pkg="kafka.api" />
+            <allow pkg="kafka.utils" />
+            <allow pkg="org.apache.kafka.clients" />
+            <allow pkg="org.apache.kafka.server.common" />
+            <allow pkg="org.apache.kafka.server.log" />
+            <allow pkg="org.apache.kafka.test" />
+
+            <subpackage name="remote">
+                <allow pkg="scala.collection" />
+            </subpackage>
+
+        </subpackage>
+    </subpackage>
+
+    <subpackage name="shell">
+        <allow pkg="com.fasterxml.jackson" />
+        <allow pkg="kafka.raft"/>
+        <allow pkg="kafka.server"/>
+        <allow pkg="kafka.tools"/>
+        <allow pkg="net.sourceforge.argparse4j" />
+        <allow pkg="org.apache.kafka.common"/>
+        <allow pkg="org.apache.kafka.metadata"/>
+        <allow pkg="org.apache.kafka.controller.util"/>
+        <allow pkg="org.apache.kafka.queue"/>
+        <allow pkg="org.apache.kafka.raft"/>
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.shell"/>
+        <allow pkg="org.apache.kafka.snapshot"/>
+        <allow pkg="org.jline"/>
+        <allow pkg="scala.compat"/>
+    </subpackage>
+
+    <subpackage name="tools">
+        <allow pkg="org.apache.kafka.common"/>
+        <allow pkg="org.apache.kafka.server.util" />
+        <allow pkg="org.apache.kafka.clients.admin" />
+        <allow pkg="org.apache.kafka.clients.producer" />
+        <allow pkg="org.apache.kafka.clients.consumer" />
+        <allow pkg="com.fasterxml.jackson" />
+        <allow pkg="org.jose4j" />
+        <allow pkg="net.sourceforge.argparse4j" />
+        <allow pkg="org.apache.log4j" />
+    </subpackage>
+
+    <subpackage name="trogdor">
+        <allow pkg="com.fasterxml.jackson" />
+        <allow pkg="javax.servlet" />
+        <allow pkg="javax.ws.rs" />
+        <allow pkg="net.sourceforge.argparse4j" />
+        <allow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.clients.admin" />
+        <allow pkg="org.apache.kafka.clients.consumer" exact-match="true"/>
+        <allow pkg="org.apache.kafka.clients.producer" exact-match="true"/>
+        <allow pkg="org.apache.kafka.common" />
+        <allow pkg="org.apache.kafka.test"/>
+        <allow pkg="org.apache.kafka.trogdor" />
+        <allow pkg="org.eclipse.jetty" />
+        <allow pkg="org.glassfish.jersey" />
+    </subpackage>
+
+    <subpackage name="message">
+        <allow pkg="com.fasterxml.jackson" />
+        <allow pkg="com.fasterxml.jackson.annotation" />
+        <allow pkg="net.sourceforge.argparse4j" />
+        <allow pkg="org.apache.message" />
+    </subpackage>
+
+    <subpackage name="streams">
+        <allow pkg="org.apache.kafka.common"/>
+        <allow pkg="org.apache.kafka.test"/>
+        <allow pkg="org.apache.kafka.clients"/>
+        <allow pkg="org.apache.kafka.clients.producer" exact-match="true"/>
+        <allow pkg="org.apache.kafka.clients.consumer" exact-match="true"/>
+
+        <allow pkg="org.apache.kafka.streams"/>
+
+        <subpackage name="examples">
+            <allow pkg="com.fasterxml.jackson" />
+            <allow pkg="org.apache.kafka.connect.json" />
+        </subpackage>
+
+        <subpackage name="internals">
+            <allow pkg="com.fasterxml.jackson" />
+        </subpackage>
+
+        <subpackage name="perf">
+            <allow pkg="com.fasterxml.jackson.databind" />
+        </subpackage>
+
+        <subpackage name="integration">
+            <allow pkg="kafka.admin" />
+            <allow pkg="kafka.api" />
+            <allow pkg="kafka.cluster" />
+            <allow pkg="kafka.server" />
+            <allow pkg="kafka.tools" />
+            <allow pkg="kafka.utils" />
+            <allow pkg="kafka.log" />
+            <allow pkg="scala" />
+            <allow class="kafka.zk.EmbeddedZookeeper"/>
+            <allow pkg="com.fasterxml.jackson" />
+        </subpackage>
+
+        <subpackage name="test">
+            <allow pkg="kafka.admin" />
+        </subpackage>
+
+        <subpackage name="tools">
+            <allow pkg="kafka.tools" />
+        </subpackage>
+
+        <subpackage name="state">
+            <allow pkg="org.rocksdb" />
+        </subpackage>
+
+        <subpackage name="processor">
+            <subpackage name="internals">
+                <allow pkg="com.fasterxml.jackson" />
+                <allow pkg="kafka.utils" />
+                <allow pkg="org.apache.zookeeper" />
+            </subpackage>
+        </subpackage>
+    </subpackage>
+
+    <subpackage name="log4jappender">
+        <allow pkg="org.apache.log4j" />
+        <allow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.common" />
+        <allow pkg="org.apache.kafka.test" />
+    </subpackage>
+
+    <subpackage name="test">
+        <allow pkg="org.apache.kafka" />
+        <allow pkg="org.bouncycastle" />
+        <allow pkg="org.rocksdb" />
+    </subpackage>
+
+    <subpackage name="raft">
+        <allow pkg="org.apache.kafka.raft" />
+        <allow pkg="org.apache.kafka.metadata" />
+        <allow pkg="org.apache.kafka.snapshot" />
+        <allow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.common.config" />
+        <allow pkg="org.apache.kafka.common.message" />
+        <allow pkg="org.apache.kafka.common.metadata" />
+        <allow pkg="org.apache.kafka.common.metrics" />
+        <allow pkg="org.apache.kafka.common.record" />
+        <allow pkg="org.apache.kafka.common.requests" />
+        <allow pkg="org.apache.kafka.common.protocol" />
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.server.common.serialization" />
+        <allow pkg="org.apache.kafka.test"/>
+        <allow pkg="com.fasterxml.jackson" />
+        <allow pkg="net.jqwik"/>
+    </subpackage>
+
+    <subpackage name="snapshot">
+        <allow pkg="org.apache.kafka.common.record" />
+        <allow pkg="org.apache.kafka.common.message" />
+        <allow pkg="org.apache.kafka.raft" />
+        <allow pkg="org.apache.kafka.server.common" />
+        <allow pkg="org.apache.kafka.test"/>
+    </subpackage>
+
+    <subpackage name="connect">
+        <allow pkg="org.apache.kafka.common" />
+        <allow pkg="org.apache.kafka.connect.data" />
+        <allow pkg="org.apache.kafka.connect.errors" />
+        <allow pkg="org.apache.kafka.connect.header" />
+        <allow pkg="org.apache.kafka.connect.components"/>
+        <allow pkg="org.apache.kafka.clients" />
+        <allow pkg="org.apache.kafka.test"/>
+
+        <subpackage name="source">
+            <allow pkg="org.apache.kafka.connect.connector" />
+            <allow pkg="org.apache.kafka.connect.storage" />
+        </subpackage>
+
+        <subpackage name="sink">
+            <allow pkg="org.apache.kafka.clients.consumer" />
+            <allow pkg="org.apache.kafka.connect.connector" />
+            <allow pkg="org.apache.kafka.connect.storage" />
+        </subpackage>
+
+        <subpackage name="converters">
+            <allow pkg="org.apache.kafka.connect.storage" />
+        </subpackage>
+
+        <subpackage name="connector.policy">
+            <allow pkg="org.apache.kafka.connect.health" />
+            <allow pkg="org.apache.kafka.connect.connector" />
+            <!-- for testing -->
+            <allow pkg="org.apache.kafka.connect.runtime" />
+        </subpackage>
+
+        <subpackage name="rest">
+            <allow pkg="org.apache.kafka.connect.health" />
+            <allow pkg="javax.ws.rs" />
+            <allow pkg= "javax.security.auth"/>
+            <subpackage name="basic">
+                <allow pkg="org.apache.kafka.connect.rest"/>
+            </subpackage>
+        </subpackage>
+
+        <subpackage name="mirror">
+            <allow pkg="org.apache.kafka.clients.consumer" />
+            <allow pkg="org.apache.kafka.connect.source" />
+            <allow pkg="org.apache.kafka.connect.sink" />
+            <allow pkg="org.apache.kafka.connect.storage" />
+            <allow pkg="org.apache.kafka.connect.connector" />
+            <allow pkg="org.apache.kafka.connect.runtime" />
+            <allow pkg="org.apache.kafka.connect.runtime.distributed" />
+            <allow pkg="org.apache.kafka.connect.util" />
+            <allow pkg="org.apache.kafka.connect.converters" />
+            <allow pkg="net.sourceforge.argparse4j" />
+            <!-- for tests -->
+            <allow pkg="org.apache.kafka.connect.integration" />
+            <allow pkg="org.apache.kafka.connect.mirror" />
+            <allow pkg="kafka.server" />
+        </subpackage>
+
+        <subpackage name="runtime">
+            <allow pkg="org.apache.kafka.connect" />
+            <allow pkg="org.reflections"/>
+            <allow pkg="org.reflections.util"/>
+            <allow pkg="javax.crypto"/>
+            <allow pkg="org.eclipse.jetty.util" />
+
+            <subpackage name="rest">
+                <allow pkg="org.eclipse.jetty" />
+                <allow pkg="javax.ws.rs" />
+                <allow pkg="javax.servlet" />
+                <allow pkg="org.glassfish.jersey" />
+                <allow pkg="com.fasterxml.jackson" />
+                <allow pkg="org.apache.http"/>
+                <allow pkg="io.swagger.v3.oas.annotations"/>
+                <subpackage name="resources">
+                    <allow pkg="org.apache.log4j" />
+                </subpackage>
+            </subpackage>
+
+            <subpackage name="isolation">
+                <allow pkg="com.fasterxml.jackson" />
+                <allow pkg="org.apache.maven.artifact.versioning" />
+                <allow pkg="javax.tools" />
+            </subpackage>
+
+            <subpackage name="distributed">
+                <allow pkg="javax.ws.rs.core" />
+            </subpackage>
+        </subpackage>
+
+        <subpackage name="cli">
+            <allow pkg="org.apache.kafka.connect.runtime" />
+            <allow pkg="org.apache.kafka.connect.storage" />
+            <allow pkg="org.apache.kafka.connect.util" />
+            <allow pkg="org.apache.kafka.common" />
+            <allow pkg="org.apache.kafka.connect.connector.policy" />
+        </subpackage>
+
+        <subpackage name="storage">
+            <allow pkg="org.apache.kafka.connect" />
+            <allow pkg="org.apache.kafka.common.serialization" />
+            <allow pkg="javax.crypto.spec"/>
+        </subpackage>
+
+        <subpackage name="util">
+            <allow pkg="org.apache.kafka.connect" />
+            <allow pkg="org.reflections.vfs" />
+            <!-- for annotations to avoid code duplication -->
+            <allow pkg="com.fasterxml.jackson.annotation" />
+            <allow pkg="com.fasterxml.jackson.databind" />
+            <subpackage name="clusters">
+                <allow pkg="kafka.cluster" />
+                <allow pkg="kafka.server" />
+                <allow pkg="kafka.zk" />
+                <allow pkg="kafka.utils" />
+                <allow class="javax.servlet.http.HttpServletResponse" />
+                <allow class="javax.ws.rs.core.Response" />
+                <allow pkg="com.fasterxml.jackson.core.type" />
+                <allow pkg="org.apache.kafka.metadata" />
+            </subpackage>
+        </subpackage>
+
+        <subpackage name="integration">
+            <allow pkg="org.apache.kafka.connect.util.clusters" />
+            <allow pkg="org.apache.kafka.connect" />
+            <allow pkg="org.apache.kafka.tools" />
+            <allow pkg="javax.ws.rs" />
+        </subpackage>
+
+        <subpackage name="json">
+            <allow pkg="com.fasterxml.jackson" />
+            <allow pkg="org.apache.kafka.common.serialization" />
+            <allow pkg="org.apache.kafka.common.errors" />
+            <allow pkg="org.apache.kafka.connect.storage" />
+        </subpackage>
+
+        <subpackage name="file">
+            <allow pkg="org.apache.kafka.connect" />
+            <allow pkg="org.apache.kafka.clients.consumer" />
+            <!-- for tests -->
+            <allow pkg="org.easymock" />
+            <allow pkg="org.powermock" />
+        </subpackage>
+
+        <subpackage name="tools">
+            <allow pkg="org.apache.kafka.connect" />
+            <allow pkg="org.apache.kafka.tools" />
+            <allow pkg="com.fasterxml.jackson" />
+        </subpackage>
+
+        <subpackage name="transforms">
+            <allow class="org.apache.kafka.connect.connector.ConnectRecord" />
+            <allow class="org.apache.kafka.connect.source.SourceRecord" />
+            <allow class="org.apache.kafka.connect.sink.SinkRecord" />
+            <allow pkg="org.apache.kafka.connect.transforms.util" />
+        </subpackage>
+    </subpackage>
+
+</import-control>

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -26,17 +26,10 @@
   <allow pkg="java" />
   <allow pkg="javax.management" />
   <allow pkg="org.slf4j" />
-  <allow pkg="org.junit" />
-  <allow pkg="org.opentest4j" />
-  <allow pkg="org.hamcrest" />
-  <allow pkg="org.mockito" />
-  <allow pkg="org.easymock" />
-  <allow pkg="org.powermock" />
   <allow pkg="java.security" />
   <allow pkg="javax.net.ssl" />
   <allow pkg="javax.security" />
   <allow pkg="org.ietf.jgss" />
-  <allow pkg="net.jqwik.api" />
 
   <!-- no one depends on the server -->
   <disallow pkg="kafka" />
@@ -57,7 +50,6 @@
     <allow pkg="org.apache.kafka.common.annotation" />
     <allow pkg="org.apache.kafka.common.config" exact-match="true" />
     <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
-    <allow pkg="org.apache.kafka.test" />
 
     <subpackage name="acl">
       <allow pkg="org.apache.kafka.common.annotation" />
@@ -67,8 +59,6 @@
 
     <subpackage name="config">
       <allow pkg="org.apache.kafka.common.config" />
-      <!-- for testing -->
-      <allow pkg="org.apache.kafka.common.metrics" />
     </subpackage>
 
     <!-- Third-party compression libraries should only be references from this package -->
@@ -186,8 +176,6 @@
       <allow pkg="org.apache.kafka.server.authorizer" />
       <!-- for IncrementalAlterConfigsRequest Builder -->
       <allow pkg="org.apache.kafka.clients.admin" />
-      <!-- for testing -->
-      <allow pkg="org.apache.kafka.common.errors" />
     </subpackage>
 
     <subpackage name="serialization">
@@ -237,7 +225,6 @@
     <allow pkg="org.apache.kafka.server.policy"/>
     <allow pkg="org.apache.kafka.server.util"/>
     <allow pkg="org.apache.kafka.snapshot" />
-    <allow pkg="org.apache.kafka.test" />
     <allow pkg="org.apache.kafka.timeline" />
   </subpackage>
 
@@ -275,7 +262,6 @@
     <allow pkg="org.apache.kafka.server.authorizer" />
     <allow pkg="org.apache.kafka.server.common" />
     <allow pkg="org.apache.kafka.server.util"/>
-    <allow pkg="org.apache.kafka.test" />
     <subpackage name="authorizer">
       <allow pkg="org.apache.kafka.common.acl" />
       <allow pkg="org.apache.kafka.common.requests" />
@@ -302,13 +288,11 @@
     <allow pkg="org.apache.kafka.snapshot" />
     <allow pkg="org.apache.kafka.queue" />
     <allow pkg="org.apache.kafka.server.common" />
-    <allow pkg="org.apache.kafka.test" />
   </subpackage>
 
   <subpackage name="clients">
     <allow pkg="org.apache.kafka.common" />
     <allow pkg="org.apache.kafka.clients" exact-match="true"/>
-    <allow pkg="org.apache.kafka.test" />
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.clients.consumer" />
@@ -329,8 +313,6 @@
   <subpackage name="server">
     <allow pkg="org.apache.kafka.common" />
 
-    <!-- This is required to make AlterConfigPolicyTest work. -->
-    <allow pkg="org.apache.kafka.server.policy" />
 
     <subpackage name="common">
       <allow pkg="org.apache.kafka.server.common" />
@@ -347,7 +329,6 @@
       <allow pkg="org.apache.kafka.clients" />
       <allow pkg="org.apache.kafka.server.common" />
       <allow pkg="org.apache.kafka.server.log" />
-      <allow pkg="org.apache.kafka.test" />
 
       <subpackage name="remote">
         <allow pkg="scala.collection" />
@@ -396,7 +377,6 @@
     <allow pkg="org.apache.kafka.clients.consumer" exact-match="true"/>
     <allow pkg="org.apache.kafka.clients.producer" exact-match="true"/>
     <allow pkg="org.apache.kafka.common" />
-    <allow pkg="org.apache.kafka.test"/>
     <allow pkg="org.apache.kafka.trogdor" />
     <allow pkg="org.eclipse.jetty" />
     <allow pkg="org.glassfish.jersey" />
@@ -411,7 +391,6 @@
 
   <subpackage name="streams">
     <allow pkg="org.apache.kafka.common"/>
-    <allow pkg="org.apache.kafka.test"/>
     <allow pkg="org.apache.kafka.clients"/>
     <allow pkg="org.apache.kafka.clients.producer" exact-match="true"/>
     <allow pkg="org.apache.kafka.clients.consumer" exact-match="true"/>
@@ -444,10 +423,6 @@
       <allow pkg="com.fasterxml.jackson" />
     </subpackage>
 
-    <subpackage name="test">
-      <allow pkg="kafka.admin" />
-    </subpackage>
-
     <subpackage name="tools">
       <allow pkg="kafka.tools" />
     </subpackage>
@@ -469,13 +444,6 @@
     <allow pkg="org.apache.log4j" />
     <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.common" />
-    <allow pkg="org.apache.kafka.test" />
-  </subpackage>
-
-  <subpackage name="test">
-    <allow pkg="org.apache.kafka" />
-    <allow pkg="org.bouncycastle" />
-    <allow pkg="org.rocksdb" />
   </subpackage>
 
   <subpackage name="raft">
@@ -492,7 +460,6 @@
     <allow pkg="org.apache.kafka.common.protocol" />
     <allow pkg="org.apache.kafka.server.common" />
     <allow pkg="org.apache.kafka.server.common.serialization" />
-    <allow pkg="org.apache.kafka.test"/>
     <allow pkg="com.fasterxml.jackson" />
     <allow pkg="net.jqwik"/>
   </subpackage>
@@ -502,7 +469,6 @@
     <allow pkg="org.apache.kafka.common.message" />
     <allow pkg="org.apache.kafka.raft" />
     <allow pkg="org.apache.kafka.server.common" />
-    <allow pkg="org.apache.kafka.test"/>
   </subpackage>
 
   <subpackage name="connect">
@@ -512,7 +478,6 @@
     <allow pkg="org.apache.kafka.connect.header" />
     <allow pkg="org.apache.kafka.connect.components"/>
     <allow pkg="org.apache.kafka.clients" />
-    <allow pkg="org.apache.kafka.test"/>
 
     <subpackage name="source">
       <allow pkg="org.apache.kafka.connect.connector" />
@@ -532,8 +497,6 @@
     <subpackage name="connector.policy">
       <allow pkg="org.apache.kafka.connect.health" />
       <allow pkg="org.apache.kafka.connect.connector" />
-      <!-- for testing -->
-      <allow pkg="org.apache.kafka.connect.runtime" />
     </subpackage>
 
     <subpackage name="rest">
@@ -556,8 +519,6 @@
       <allow pkg="org.apache.kafka.connect.util" />
       <allow pkg="org.apache.kafka.connect.converters" />
       <allow pkg="net.sourceforge.argparse4j" />
-      <!-- for tests -->
-      <allow pkg="org.apache.kafka.connect.integration" />
       <allow pkg="org.apache.kafka.connect.mirror" />
       <allow pkg="kafka.server" />
     </subpackage>
@@ -642,9 +603,6 @@
     <subpackage name="file">
       <allow pkg="org.apache.kafka.connect" />
       <allow pkg="org.apache.kafka.clients.consumer" />
-      <!-- for tests -->
-      <allow pkg="org.easymock" />
-      <allow pkg="org.powermock" />
     </subpackage>
 
     <subpackage name="tools">


### PR DESCRIPTION
Currently in Kafka we have a global import-control.xml that is used for both main source code and tests. This change move test related allow import rules from import-control.xml to import-control-test.xml so that one cannot accidentally use test imports in the main Kafka source code.

Note that `import-control-test.xml` is a carbon copy of the current `import-test.xml` with `<disallow pkg="kafka" />` removed since we are dealing with tests. There are valid arguments that `import-control-test.xml` doesn't need to be so strict with import rules since it only applies for tests and it also adds a bit of friction when one needs to modify an import rule (will need to add it both to `import-control.xml` and `import-control-test.xml`)