### PR TITLE
KAFKA-14132; Replace EasyMock with Mockito in KafkaBasedLogTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -407,7 +407,7 @@ subprojects {
       "**/ConnectorPluginsResourceTest.*",
       "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
       "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
-      "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",
+      "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",
       "**/SourceTaskOffsetCommitterTest.*",
       "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
       "**/WorkerSourceTaskTest.*", "**/AbstractWorkerSourceTaskTest.*", "**/ExactlyOnceWorkerSourceTaskTest.*",

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -98,6 +98,7 @@ public class KafkaBasedLog<K, V> {
     private Optional<Producer<K, V>> producer;
     private TopicAdmin admin;
 
+    // visible for testing
     Thread thread;
     private boolean stopRequested;
     private final Queue<Callback<Void>> readLogEndOffsetCallbacks;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -98,7 +98,7 @@ public class KafkaBasedLog<K, V> {
     private Optional<Producer<K, V>> producer;
     private TopicAdmin admin;
 
-    private Thread thread;
+    Thread thread;
     private boolean stopRequested;
     private final Queue<Callback<Void>> readLogEndOffsetCallbacks;
     private final java.util.function.Consumer<TopicAdmin> initializer;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -167,8 +167,7 @@ public class KafkaBasedLogTest {
     }
 
     @Test
-    public void testStartStop() throws Exception {
-
+    public void testStartStop() {
         Map<TopicPartition, Long> endOffsets = new HashMap<>();
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
@@ -349,7 +348,6 @@ public class KafkaBasedLogTest {
 
     @Test
     public void testPollConsumerError() throws Exception {
-
         final CountDownLatch finishedLatch = new CountDownLatch(1);
         Map<TopicPartition, Long> endOffsets = new HashMap<>();
         endOffsets.put(TP0, 1L);
@@ -509,7 +507,7 @@ public class KafkaBasedLogTest {
     }
 
     @Test
-    public void testReadEndOffsetsUsingAdminThatFailsWithRetriable() throws Exception {
+    public void testReadEndOffsetsUsingAdminThatFailsWithRetriable() {
         // Create a log that uses the admin supplier
         setupWithAdmin();
 


### PR DESCRIPTION
Migrates the tests from EasyMock to Mockito. Notes about non trivial changes below

* Originally the test was using `PowerMock.expectPrivate` to mock protected fields. There is no equivalent for mockito so instead we just subclassed `KafkaBasedLog` with `MockedKafkaBasedLog` and override the fields to be returned.
* ~~The test was using `Whitebox.<Thread>getInternalState(store, "thread")` to access an internal private `thread` field. Similarly mockito has no such method so instead I resorted to using `FieldUtils` from Apache commons whos implementation was abstracted away into a `getStorePrivateThread()` method. I had to also add an exclusion rule to `checkstyle/import-control.xml` for this new import.~~ `Thread` is now package private so no reflection is used.
* Some tests had a `throw Exception` even though they never threw an exception so this was removed.