### PR TITLE
KAFKA-14336: MetadataResponse#convertToNodeArray uses iteration

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -177,8 +177,10 @@ public class MetadataResponse extends AbstractResponse {
     }
 
     private static Node[] convertToNodeArray(List<Integer> replicaIds, Map<Integer, Node> nodesById) {
-        Node[] nodes = new Node[replicaIds.size()];
-        for (int i = 0; i < replicaIds.size(); i++) {
+        // Since this is on hot path for partition info, use indexed iteration to avoid allocation overhead of Streams.
+        int size = replicaIds.size();
+        Node[] nodes = new Node[size];
+        for (int i = 0; i < size; i++) {
             Integer replicaId = replicaIds.get(i);
             Node node = nodesById.get(replicaId);
             if (node == null)

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -177,12 +177,15 @@ public class MetadataResponse extends AbstractResponse {
     }
 
     private static Node[] convertToNodeArray(List<Integer> replicaIds, Map<Integer, Node> nodesById) {
-        return replicaIds.stream().map(replicaId -> {
+        Node[] nodes = new Node[replicaIds.size()];
+        for (int i = 0; i < replicaIds.size(); i++) {
+            Integer replicaId = replicaIds.get(i);
             Node node = nodesById.get(replicaId);
             if (node == null)
-                return new Node(replicaId, "", -1);
-            return node;
-        }).toArray(Node[]::new);
+                node = new Node(replicaId, "", -1);
+            nodes[i] = node;
+        }
+        return nodes;
     }
 
     /**

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.common;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataResponse;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MetadataResponseBenchmark {
+    @Param({"10", "500", "1000"})
+    private int nodes;
+
+    private MetadataResponse.PartitionMetadata metadata;
+    private Map<Integer, Node> nodesById;
+
+    @Setup
+    public void setup() {
+        metadata = new MetadataResponse.PartitionMetadata(Errors.UNKNOWN_SERVER_ERROR,
+                new TopicPartition("benchmark", 42),
+                Optional.of(4),
+                Optional.of(42),
+                IntStream.range(0, nodes).boxed().collect(Collectors.toList()),
+                IntStream.range(0, nodes).filter(i1 -> i1 % 3!=0).boxed().collect(Collectors.toList()),
+                IntStream.range(0, nodes).filter(i2 -> i2 % 3==0).boxed().collect(Collectors.toList()));
+        nodesById = new HashMap<>(nodes);
+        for (int i = 0; i < nodes; i++) {
+            nodesById.put(i, new Node(i, "localhost", 1234));
+        }
+        nodesById = Collections.unmodifiableMap(nodesById);
+    }
+
+    @Benchmark
+    public PartitionInfo toPartitionInfo() {
+        return MetadataResponse.toPartitionInfo(metadata, nodesById);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(MetadataResponseBenchmark.class.getSimpleName()).build()).run();
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
@@ -84,4 +84,5 @@ public class MetadataResponseBenchmark {
     public static void main(String[] args) throws RunnerException {
         new Runner(new OptionsBuilder().include(MetadataResponseBenchmark.class.getSimpleName()).build()).run();
     }
+
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
@@ -53,6 +53,7 @@ import java.util.stream.IntStream;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class MetadataResponseBenchmark {
+
     @Param({"10", "500", "1000"})
     private int nodes;
 
@@ -66,8 +67,8 @@ public class MetadataResponseBenchmark {
                 Optional.of(4),
                 Optional.of(42),
                 IntStream.range(0, nodes).boxed().collect(Collectors.toList()),
-                IntStream.range(0, nodes).filter(i1 -> i1 % 3!=0).boxed().collect(Collectors.toList()),
-                IntStream.range(0, nodes).filter(i2 -> i2 % 3==0).boxed().collect(Collectors.toList()));
+                IntStream.range(0, nodes).filter(i1 -> i1 % 3 != 0).boxed().collect(Collectors.toList()),
+                IntStream.range(0, nodes).filter(i2 -> i2 % 3 == 0).boxed().collect(Collectors.toList()));
         nodesById = new HashMap<>(nodes);
         for (int i = 0; i < nodes; i++) {
             nodesById.put(i, new Node(i, "localhost", 1234));

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
@@ -85,4 +85,3 @@ public class MetadataResponseBenchmark {
         new Runner(new OptionsBuilder().include(MetadataResponseBenchmark.class.getSimpleName()).build()).run();
     }
 }
-

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/MetadataResponseBenchmark.java
@@ -85,3 +85,4 @@ public class MetadataResponseBenchmark {
         new Runner(new OptionsBuilder().include(MetadataResponseBenchmark.class.getSimpleName()).build()).run();
     }
 }
+


### PR DESCRIPTION
Avoids stream allocation on hot code path.

[KAFKA-14336:](https://issues.apache.org/jira/browse/KAFKA-14336)

While profiling a Kafka consumer application that utilizes `org.apache.kafka.clients.admin.Admin#listOffsets(java.util.Map<org.apache.kafka.common.TopicPartition,org.apache.kafka.clients.admin.OffsetSpec>)`, one of the largest aggregate memory allocations are coming from `org.apache.kafka.common.requests.MetadataResponse.convertToNodeArray(List, Map)` due to the use of stream reference pipeline. We can avoid allocating the stream reference pipeline & spliterator for this case by explicitly allocating the presized `Node[]` and using a for loop with `int` induction over the specified IDs `List` argument.

```
java.util.stream.ReferencePipeline$3
at java.util.stream.ReferencePipeline.map(Function)
at org.apache.kafka.common.requests.MetadataResponse.convertToNodeArray(List, Map)
   at org.apache.kafka.common.requests.MetadataResponse.toPartitionInfo(MetadataResponse$PartitionMetadata, Map)
   at org.apache.kafka.common.requests.MetadataResponse.cluster()
   at org.apache.kafka.clients.admin.KafkaAdminClient.getListOffsetsCalls(MetadataOperationContext, Map, Map)
   at org.apache.kafka.clients.admin.KafkaAdminClient.lambda$listOffsets$21(MetadataOperationContext, Map, Map)
   at org.apache.kafka.clients.admin.KafkaAdminClient$$Lambda$3539+0x000000080142d120.1364252822.get()
   at org.apache.kafka.clients.admin.KafkaAdminClient$23.handleResponse(AbstractResponse)
   at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.handleResponses(long, List)
   at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.processRequests()
   at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.run()
   at java.lang.Thread.run()
```

JFR snippet:
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/54594/197595744-f8db5e9b-2f91-4d5e-a4d2-b8a0a4919124.png">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
