### PR TITLE
KAFKA-14334: complete delayed purgatory after replication

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -378,8 +378,8 @@ class Partition(val topicPartition: TopicPartition,
         info(s"No checkpointed highwatermark is found for partition $topicPartition")
         0L
       }
-      val initialHighWatermark = log.updateHighWatermark(checkpointHighWatermark)
-      info(s"Log loaded for partition $topicPartition with initial high watermark $initialHighWatermark")
+      val highWatermarkUpdate = log.updateHighWatermark(checkpointHighWatermark)
+      info(s"Log loaded for partition $topicPartition with initial high watermark ${highWatermarkUpdate.highWatermark}")
     }
 
     logManager.initializingLog(topicPartition)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -373,13 +373,13 @@ class Partition(val topicPartition: TopicPartition,
 
   // Visible for testing
   private[cluster] def createLog(isNew: Boolean, isFutureReplica: Boolean, offsetCheckpoints: OffsetCheckpoints, topicId: Option[Uuid]): UnifiedLog = {
-    def updateHighWatermark(log: UnifiedLog) = {
+    def updateHighWatermark(log: UnifiedLog): Unit = {
       val checkpointHighWatermark = offsetCheckpoints.fetch(log.parentDir, topicPartition).getOrElse {
         info(s"No checkpointed highwatermark is found for partition $topicPartition")
         0L
       }
-      val highWatermarkUpdate = log.updateHighWatermark(checkpointHighWatermark)
-      info(s"Log loaded for partition $topicPartition with initial high watermark ${highWatermarkUpdate.highWatermark}")
+      val initialHighWatermark = log.updateHighWatermark(checkpointHighWatermark)
+      info(s"Log loaded for partition $topicPartition with initial high watermark $initialHighWatermark")
     }
 
     logManager.initializingLog(topicPartition)

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -373,8 +373,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    * Update the high watermark to a new offset. The new high watermark will be lower
    * bounded by the log start offset and upper bounded by the log end offset.
    *
-   * This is intended to be called when initializing the high watermark or when updating
-   * it on a follower after receiving a Fetch response from the leader.
+   * This is intended to be called by the leader when initializing the high watermark.
    *
    * @param hw the suggested new value for the high watermark
    * @return the updated high watermark offset
@@ -437,15 +436,20 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    * Update high watermark with a new value. The new high watermark will be lower
    * bounded by the log start offset and upper bounded by the log end offset.
    *
-   * This method is intended to be used by the follower to update its high watermark after replicating.
+   * This method is intended to be used by the follower to update its high watermark after
+   * replication from the leader.
    *
-   * @return true if the high watermark changed, false otherwise.
+   * @return the new high watermark if the high watermark changed, None otherwise.
    */
-  def maybeUpdateHighWatermark(hw: Long): Boolean = {
+  def maybeUpdateHighWatermark(hw: Long): Option[Long] = {
     lock.synchronized {
       val oldHighWatermark = fetchHighWatermarkMetadata
-      val newHighWatermark = updateHighWatermark(LogOffsetMetadata(hw))
-      oldHighWatermark.messageOffset != newHighWatermark
+      updateHighWatermark(LogOffsetMetadata(hw)) match {
+        case oldHighWatermark.messageOffset =>
+          None
+        case newHighWatermark =>
+          Some(newHighWatermark)
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -443,7 +443,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    */
   def maybeUpdateHighWatermark(hw: Long): Option[Long] = {
     lock.synchronized {
-      val oldHighWatermark = fetchHighWatermarkMetadata
+      val oldHighWatermark = highWatermarkMetadata
       updateHighWatermark(LogOffsetMetadata(hw)) match {
         case oldHighWatermark.messageOffset =>
           None

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -267,13 +267,6 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
     numCompleted
   }
 
-  def checkAndComplete(keys: List[Any]): Int = {
-    val wls: ArrayBuffer[WatcherList] = ArrayBuffer.empty
-    for (key <- keys) {
-      wls += watcherList(key)
-    }
-  }
-
   /**
    * Return the total size of watch lists the purgatory. Since an operation may be watched
    * on multiple lists, and some of its watched entries may still be in the watch lists

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -20,13 +20,14 @@ package kafka.server
 import java.util.concurrent._
 import java.util.concurrent.atomic._
 import java.util.concurrent.locks.{Lock, ReentrantLock}
+
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.CoreUtils.inLock
 import kafka.utils._
 import kafka.utils.timer._
 
 import scala.collection._
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ListBuffer
 
 /**
  * An operation whose processing needs to be delayed for at most the given delayMs. For example

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -20,14 +20,13 @@ package kafka.server
 import java.util.concurrent._
 import java.util.concurrent.atomic._
 import java.util.concurrent.locks.{Lock, ReentrantLock}
-
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.CoreUtils.inLock
 import kafka.utils._
 import kafka.utils.timer._
 
 import scala.collection._
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 /**
  * An operation whose processing needs to be delayed for at most the given delayMs. For example
@@ -266,6 +265,13 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
       debug(s"Request key $key unblocked $numCompleted $purgatoryName operations")
     }
     numCompleted
+  }
+
+  def checkAndComplete(keys: List[Any]): Int = {
+    val wls: ArrayBuffer[WatcherList] = ArrayBuffer.empty
+    for (key <- keys) {
+      wls += watcherList(key)
+    }
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -246,6 +246,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       // try to complete delayed action. In order to avoid conflicting locking, the actions to complete delayed requests
       // are kept in a queue. We add the logic to check the ReplicaManager queue at the end of KafkaApis.handle() and the
       // expiration thread for certain delayed operations (e.g. DelayedJoin)
+      // Delayed fetches are also completed by ReplicaFetcherThread.
       replicaManager.tryCompleteActions()
       // The local completion time may be set while processing the request. Only record it if it's unset.
       if (request.apiLocalCompleteTimeNanos < 0)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -153,9 +153,7 @@ class ReplicaFetcherThread(name: String,
 
   private def completeDelayedFetchRequests(): Unit = {
     if (partitionsWithNewHighWatermark.nonEmpty) {
-      // Scala 2.12 Buffer.toSeq returns a mutable Seq object whereas 2.13 returns an immutable copy.
-      // Forcing a copy to unify the behavior.
-      replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.clone)
+      replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.toSeq)
       partitionsWithNewHighWatermark.clear()
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -153,7 +153,9 @@ class ReplicaFetcherThread(name: String,
 
   private def completeDelayedFetchRequests(): Unit = {
     if (partitionsWithNewHighWatermark.nonEmpty) {
-      replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.toSeq)
+      // Scala 2.12 Buffer.toSeq returns a mutable Seq object whereas 2.13 returns an immutable copy.
+      // Forcing a copy to unify the behavior.
+      replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.clone)
       partitionsWithNewHighWatermark.clear()
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -43,7 +43,8 @@ class ReplicaFetcherThread(name: String,
 
   this.logIdent = logPrefix
 
-  private val partitionsWithNewRecords = mutable.Buffer[TopicPartition]()
+  // Visible for testing
+  private[server] val partitionsWithNewRecords = mutable.Buffer[TopicPartition]()
 
   override protected val isOffsetForLeaderEpochSupported: Boolean = metadataVersionSupplier().isOffsetForLeaderEpochSupported
 

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -139,11 +139,11 @@ class ReplicaFetcherThread(name: String,
 
     brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
 
-    val highWatermarkChanged = log.maybeUpdateHighWatermark(partitionData.highWatermark)
-    if (highWatermarkChanged) {
-      logAppendInfo.foreach { _ => partitionsWithNewHighWatermark += topicPartition }
+    log.maybeUpdateHighWatermark(partitionData.highWatermark).foreach { newHighWatermark =>
+      partitionsWithNewHighWatermark += topicPartition
       if (logTrace)
-        trace(s"Follower updated replica high watermark for partition $topicPartition to ${partitionData.highWatermark}")
+        trace(s"Follower received high watermark ${partitionData.highWatermark} from the leader and " +
+          s"updated replica high watermark to $newHighWatermark for partition $topicPartition")
     }
     logAppendInfo
   }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -331,6 +331,15 @@ class ReplicaManager(val config: KafkaConfig,
     delayedFetchPurgatory.checkAndComplete(topicPartitionOperationKey)
   }
 
+  /**
+   * Complete any local follower fetches that have been unblocked since new data is available
+   * from the leader for one or more partitions. Called in ReplicaFetcherThread after successfully
+   * replicating from the leader.
+   */
+  private[server] def completeDelayedFetchRequests(topicPartitions: Seq[TopicPartition]): Unit = {
+    topicPartitions.foreach(tp => delayedFetchPurgatory.checkAndComplete(TopicPartitionOperationKey(tp)))
+  }
+
   def stopReplicas(correlationId: Int,
                    controllerId: Int,
                    controllerEpoch: Int,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -333,8 +333,8 @@ class ReplicaManager(val config: KafkaConfig,
 
   /**
    * Complete any local follower fetches that have been unblocked since new data is available
-   * from the leader for one or more partitions. Called in ReplicaFetcherThread after successfully
-   * replicating from the leader.
+   * from the leader for one or more partitions. Should only be called by ReplicaFetcherThread
+   * after successfully replicating from the leader.
    */
   private[server] def completeDelayedFetchRequests(topicPartitions: Seq[TopicPartition]): Unit = {
     topicPartitions.foreach(tp => delayedFetchPurgatory.checkAndComplete(TopicPartitionOperationKey(tp)))

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -18,7 +18,6 @@ package integration.kafka.server
 
 import kafka.server.{BaseFetchRequestTest, KafkaConfig}
 import kafka.utils.{TestInfoUtils, TestUtils}
-import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.FetchResponse

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -16,21 +16,18 @@
  */
 package integration.kafka.server
 
-import kafka.integration.KafkaServerTestHarness
-import kafka.server.KafkaConfig
+import kafka.server.{BaseFetchRequestTest, BrokerTopicStats, KafkaConfig}
 import kafka.utils.{TestInfoUtils, TestUtils}
-import org.apache.kafka.clients.admin.{Admin, NewPartitionReassignment}
-import org.apache.kafka.common.{ElectionType, TopicPartition}
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.{AfterEach, BeforeEach}
+import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.protocol.ApiKeys
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-import java.util.{Optional, Properties}
-import scala.collection._
-import scala.jdk.CollectionConverters._
+import java.util.Properties
 
-class FetchFromFollowerIntegrationTest extends KafkaServerTestHarness {
+class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
   val numNodes = 2
   val numParts = 1
   val initialMessages = 100
@@ -52,39 +49,17 @@ class FetchFromFollowerIntegrationTest extends KafkaServerTestHarness {
     TestUtils.createBrokerConfigs(numNodes, zkConnectOrNull, enableControlledShutdown = false, enableFetchFromFollower = true)
       .map(KafkaConfig.fromProps(_, overridingProps))
 
-  // Create a 2 broker cluster where broker 0 is the leader and 1 is the follower.
-  // Create a topic with a single partition. Access brokers via `brokers`
   @BeforeEach
   def initializeFetchFromFollowerCluster(): Unit = {
-    createTopic(topic, numParts, numNodes)
-    TestUtils.generateAndProduceMessages(brokers, topic, initialMessages)
+    // Create a 2 broker cluster where broker 0 is the leader and 1 is the follower.
 
-    // Make broker 1 the follower
     admin = TestUtils.createAdminClient(brokers, listenerName)
-    val topicDescription = TestUtils.describeTopic(admin, topic)
-    topicDescription.partitions.forEach(partition => {
-      // only reelect if leader is not broker 0
-      if (partition.leader().id() != leaderBrokerId) {
-        val reassignment = Map(new TopicPartition(topic, 0) -> Optional.of(
-          new NewPartitionReassignment(List[Integer](leaderBrokerId, followerBrokerId).asJava))).asJava
-        admin.alterPartitionReassignments(reassignment).all.get
-        TestUtils.waitUntilTrue(() => {
-          val reassigned = admin.listPartitionReassignments.reassignments.get
-          reassigned.isEmpty
-        }, "reassignment did not complete.")
-        admin.electLeaders(ElectionType.PREFERRED, Set(new TopicPartition(topic, 0)).asJava).all.get
-      }
-    })
-
-    // Check the log size for each broker so that we can distinguish between failures caused by replication issues
-    // versus failures caused by the metrics
-    val topicPartition = new TopicPartition(topic, 0)
-    brokers.foreach { broker =>
-      val log = broker.logManager.getLog(topicPartition)
-      val brokerId = broker.config.brokerId
-      val logSize = log.map(_.size)
-      assertTrue(logSize.exists(_ > 0), s"Expected broker $brokerId to have a Log for $topicPartition with positive size, actual: $logSize")
-    }
+    TestUtils.createTopicWithAdminRaw(
+      admin,
+      topic,
+      replicaAssignment = Map(0 -> Seq(leaderBrokerId, followerBrokerId))
+    )
+    TestUtils.generateAndProduceMessages(brokers, topic, initialMessages)
   }
 
   @AfterEach
@@ -96,11 +71,27 @@ class FetchFromFollowerIntegrationTest extends KafkaServerTestHarness {
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))
+  @Timeout(30)
   def testFollowerCompleteDelayedPurgatoryOnReplication(quorum: String): Unit = {
     TestUtils.generateAndProduceMessages(brokers, topic, nMessages)
-    // set fetch.max.wait.ms to a value greater than test utils wait time (15 seconds) to ensure that the
-    // delayed fetch purgatory is completed after successfully replicating from the leader.
-    val messages = initialMessages + nMessages
-    TestUtils.consumeTopicRecords(brokers, topic, messages, rackId = followerBrokerId.toString, fetchMaxWaitMs = 60000)
+    // set fetch.max.wait.ms to a value (45 seconds) greater than the timeout (30 seconds) to ensure that the
+    // test only passes when the delayed fetch purgatory is completed after successfully replicating from the leader.
+
+    val totalMessages = initialMessages + nMessages
+    val topicPartition = new TopicPartition(topic, 0)
+    val offsetMap = Map[TopicPartition, Long](
+      topicPartition -> (totalMessages - 1)
+    )
+
+    val fetchRequest = createFetchRequest(
+      maxResponseBytes = 1000,
+      maxPartitionBytes = 1000,
+      Seq(topicPartition),
+      offsetMap,
+      ApiKeys.FETCH.latestVersion(),
+      maxWaitMs = 45000,
+      minBytes = 1
+    )
+    sendFetchRequest(followerBrokerId, fetchRequest)
   }
 }

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package integration.kafka.server
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.server.KafkaConfig
+import kafka.utils.{TestInfoUtils, TestUtils}
+import org.apache.kafka.clients.admin.{Admin, NewPartitionReassignment}
+import org.apache.kafka.common.{ElectionType, TopicPartition}
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.{AfterEach, BeforeEach}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+import java.util.{Optional, Properties}
+import scala.collection._
+import scala.jdk.CollectionConverters._
+
+class FetchFromFollowerIntegrationTest extends KafkaServerTestHarness {
+  val numNodes = 2
+  val numParts = 1
+  val initialMessages = 100
+  val nMessages = 100
+
+  val topic = "test-fetch-from-follower"
+  val leaderBrokerId = 0
+  val followerBrokerId = 1
+  var admin: Admin = null
+
+  def overridingProps: Properties = {
+    val props = new Properties
+    props.put(KafkaConfig.NumPartitionsProp, numParts.toString)
+
+    props
+  }
+
+  override def generateConfigs: collection.Seq[KafkaConfig] =
+    TestUtils.createBrokerConfigs(numNodes, zkConnectOrNull, enableControlledShutdown = false, enableFetchFromFollower = true)
+      .map(KafkaConfig.fromProps(_, overridingProps))
+
+  // Create a 2 broker cluster where broker 0 is the leader and 1 is the follower.
+  // Create a topic with a single partition. Access brokers via `brokers`
+  @BeforeEach
+  def initializeFetchFromFollowerCluster(): Unit = {
+    createTopic(topic, numParts, numNodes)
+    TestUtils.generateAndProduceMessages(brokers, topic, initialMessages)
+
+    // Make broker 1 the follower
+    admin = TestUtils.createAdminClient(brokers, listenerName)
+    val topicDescription = TestUtils.describeTopic(admin, topic)
+    topicDescription.partitions.forEach(partition => {
+      // only reelect if leader is not broker 0
+      if (partition.leader().id() != leaderBrokerId) {
+        val reassignment = Map(new TopicPartition(topic, 0) -> Optional.of(
+          new NewPartitionReassignment(List[Integer](leaderBrokerId, followerBrokerId).asJava))).asJava
+        admin.alterPartitionReassignments(reassignment).all.get
+        TestUtils.waitUntilTrue(() => {
+          val reassigned = admin.listPartitionReassignments.reassignments.get
+          reassigned.isEmpty
+        }, "reassignment did not complete.")
+        admin.electLeaders(ElectionType.PREFERRED, Set(new TopicPartition(topic, 0)).asJava).all.get
+      }
+    })
+
+    // Check the log size for each broker so that we can distinguish between failures caused by replication issues
+    // versus failures caused by the metrics
+    val topicPartition = new TopicPartition(topic, 0)
+    brokers.foreach { broker =>
+      val log = broker.logManager.getLog(topicPartition)
+      val brokerId = broker.config.brokerId
+      val logSize = log.map(_.size)
+      assertTrue(logSize.exists(_ > 0), s"Expected broker $brokerId to have a Log for $topicPartition with positive size, actual: $logSize")
+    }
+  }
+
+  @AfterEach
+  def close(): Unit = {
+    if (admin != null) {
+      admin.close()
+    }
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testFollowerCompleteDelayedPurgatoryOnReplication(quorum: String): Unit = {
+    TestUtils.generateAndProduceMessages(brokers, topic, nMessages)
+    // set fetch.max.wait.ms to a value greater than test utils wait time (15 seconds) to ensure that the
+    // delayed fetch purgatory is completed after successfully replicating from the leader.
+    val messages = initialMessages + nMessages
+    TestUtils.consumeTopicRecords(brokers, topic, messages, rackId = followerBrokerId.toString, fetchMaxWaitMs = 60000)
+  }
+}

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -16,22 +16,23 @@
  */
 package integration.kafka.server
 
-import kafka.server.{BaseFetchRequestTest, BrokerTopicStats, KafkaConfig}
+import kafka.server.{BaseFetchRequestTest, KafkaConfig}
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.FetchResponse
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.Properties
+import scala.jdk.CollectionConverters._
 
 class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
   val numNodes = 2
   val numParts = 1
-  val initialMessages = 100
-  val nMessages = 100
 
   val topic = "test-fetch-from-follower"
   val leaderBrokerId = 0
@@ -54,12 +55,12 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
     // Create a 2 broker cluster where broker 0 is the leader and 1 is the follower.
 
     admin = TestUtils.createAdminClient(brokers, listenerName)
-    TestUtils.createTopicWithAdminRaw(
+    TestUtils.createTopicWithAdmin(
       admin,
       topic,
+      brokers,
       replicaAssignment = Map(0 -> Seq(leaderBrokerId, followerBrokerId))
     )
-    TestUtils.generateAndProduceMessages(brokers, topic, initialMessages)
   }
 
   @AfterEach
@@ -73,14 +74,15 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
   @ValueSource(strings = Array("zk", "kraft"))
   @Timeout(30)
   def testFollowerCompleteDelayedPurgatoryOnReplication(quorum: String): Unit = {
-    TestUtils.generateAndProduceMessages(brokers, topic, nMessages)
-    // set fetch.max.wait.ms to a value (45 seconds) greater than the timeout (30 seconds) to ensure that the
-    // test only passes when the delayed fetch purgatory is completed after successfully replicating from the leader.
+    // Set fetch.max.wait.ms to a value (45 seconds) greater than the timeout (30 seconds).
+    // Send a fetch request before the record is replicated to ensure that the replication
+    // triggers purgatory completion.
 
-    val totalMessages = initialMessages + nMessages
+    val numMessages = 1
+    val version = ApiKeys.FETCH.latestVersion()
     val topicPartition = new TopicPartition(topic, 0)
     val offsetMap = Map[TopicPartition, Long](
-      topicPartition -> (totalMessages - 1)
+      topicPartition -> 0
     )
 
     val fetchRequest = createFetchRequest(
@@ -88,10 +90,21 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
       maxPartitionBytes = 1000,
       Seq(topicPartition),
       offsetMap,
-      ApiKeys.FETCH.latestVersion(),
+      version,
       maxWaitMs = 45000,
       minBytes = 1
     )
-    sendFetchRequest(followerBrokerId, fetchRequest)
+
+    val socket = connect(brokerSocketServer(followerBrokerId))
+    try {
+      send(fetchRequest, socket)
+      TestUtils.generateAndProduceMessages(brokers, topic, numMessages)
+      val response = receive[FetchResponse](socket, ApiKeys.FETCH, version)
+      assertEquals(Errors.NONE, response.error())
+      response.errorCounts().keySet().asScala.foreach { error => assertEquals(Errors.NONE, error)}
+
+    } finally {
+      socket.close()
+    }
   }
 }

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -37,7 +37,6 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
   val topic = "test-fetch-from-follower"
   val leaderBrokerId = 0
   val followerBrokerId = 1
-  var admin: Admin = null
 
   def overridingProps: Properties = {
     val props = new Properties
@@ -55,7 +54,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
   @Timeout(15)
   def testFollowerCompleteDelayedFetchesOnReplication(quorum: String): Unit = {
     // Create a topic with 2 replicas where broker 0 is the leader and 1 is the follower.
-    admin = createAdminClient()
+    val admin = createAdminClient()
     TestUtils.createTopicWithAdmin(
       admin,
       topic,
@@ -85,7 +84,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
       send(fetchRequest, socket)
       TestUtils.generateAndProduceMessages(brokers, topic, numMessages = 1)
       val response = receive[FetchResponse](socket, ApiKeys.FETCH, version)
-      assertEquals(Errors.NONE, response.error())
+      assertEquals(Errors.NONE, response.error)
       assertEquals(Map(Errors.NONE -> 2).asJava, response.errorCounts())
     } finally {
       socket.close()

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3468,6 +3468,7 @@ class UnifiedLogTest {
     assertEquals(Some(100L), log.maybeUpdateHighWatermark(100L))
     assertEquals(Some(99L), log.maybeUpdateHighWatermark(99L))
     assertEquals(None, log.maybeUpdateHighWatermark(99L))
+    assertEquals(Some(100L), log.maybeUpdateHighWatermark(101L))
     assertEquals(None, log.maybeUpdateHighWatermark(101L))
   }
 

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3341,13 +3341,13 @@ class UnifiedLogTest {
       log.appendAsLeader(records, leaderEpoch = 0)
     }
 
-    val initialHighWatermark = log.updateHighWatermark(25L)
-    assertEquals(25L, initialHighWatermark)
+    val initialHighWatermarkUpdate = log.updateHighWatermark(25L)
+    assertEquals(25L, initialHighWatermarkUpdate.highWatermark)
 
     val initialNumSegments = log.numberOfSegments
     log.deleteOldSegments()
     assertTrue(log.numberOfSegments < initialNumSegments)
-    assertTrue(log.logStartOffset <= initialHighWatermark)
+    assertTrue(log.logStartOffset <= initialHighWatermarkUpdate.highWatermark)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3341,13 +3341,13 @@ class UnifiedLogTest {
       log.appendAsLeader(records, leaderEpoch = 0)
     }
 
-    val initialHighWatermarkUpdate = log.updateHighWatermark(25L)
-    assertEquals(25L, initialHighWatermarkUpdate.highWatermark)
+    val initialHighWatermark = log.updateHighWatermark(25L)
+    assertEquals(25L, initialHighWatermark)
 
     val initialNumSegments = log.numberOfSegments
     log.deleteOldSegments()
     assertTrue(log.numberOfSegments < initialNumSegments)
-    assertTrue(log.logStartOffset <= initialHighWatermarkUpdate.highWatermark)
+    assertTrue(log.logStartOffset <= initialHighWatermark)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3466,7 +3466,8 @@ class UnifiedLogTest {
     }
 
     assertEquals(Some(100L), log.maybeUpdateHighWatermark(100L))
-    assertEquals(None, log.maybeUpdateHighWatermark(100L))
+    assertEquals(Some(99L), log.maybeUpdateHighWatermark(99L))
+    assertEquals(None, log.maybeUpdateHighWatermark(99L))
     assertEquals(None, log.maybeUpdateHighWatermark(101L))
   }
 

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3455,6 +3455,21 @@ class UnifiedLogTest {
     assertFalse(newDir.exists())
   }
 
+  @Test
+  def testMaybeUpdateHighWatermarkAsFollower(): Unit = {
+    val logConfig = LogTestUtils.createLogConfig()
+    val log = createLog(logDir, logConfig)
+
+    for (i <- 0 until 100) {
+      val records = TestUtils.singletonRecords(value = s"test$i".getBytes)
+      log.appendAsLeader(records, leaderEpoch = 0)
+    }
+
+    assertEquals(Some(100L), log.maybeUpdateHighWatermark(100L))
+    assertEquals(None, log.maybeUpdateHighWatermark(100L))
+    assertEquals(None, log.maybeUpdateHighWatermark(101L))
+  }
+
   private def appendTransactionalToBuffer(buffer: ByteBuffer,
                                           producerId: Long,
                                           producerEpoch: Short,

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3465,10 +3465,13 @@ class UnifiedLogTest {
       log.appendAsLeader(records, leaderEpoch = 0)
     }
 
-    assertEquals(Some(100L), log.maybeUpdateHighWatermark(100L))
     assertEquals(Some(99L), log.maybeUpdateHighWatermark(99L))
     assertEquals(None, log.maybeUpdateHighWatermark(99L))
-    assertEquals(Some(100L), log.maybeUpdateHighWatermark(101L))
+
+    assertEquals(Some(100L), log.maybeUpdateHighWatermark(100L))
+    assertEquals(None, log.maybeUpdateHighWatermark(100L))
+
+    // bound by the log end offset
     assertEquals(None, log.maybeUpdateHighWatermark(101L))
   }
 

--- a/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
@@ -46,7 +46,7 @@ class BaseFetchRequestTest extends BaseRequestTest {
     super.tearDown()
   }
 
-  protected def createFetchRequest(maxResponseBytes: Int, maxPartitionBytes: Int, topicPartitions: Seq[TopicPartition],
+  protected def createConsumerFetchRequest(maxResponseBytes: Int, maxPartitionBytes: Int, topicPartitions: Seq[TopicPartition],
                                    offsetMap: Map[TopicPartition, Long],
                                    version: Short,
                                    maxWaitMs: Int = Int.MaxValue,

--- a/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
@@ -48,8 +48,10 @@ class BaseFetchRequestTest extends BaseRequestTest {
 
   protected def createFetchRequest(maxResponseBytes: Int, maxPartitionBytes: Int, topicPartitions: Seq[TopicPartition],
                                    offsetMap: Map[TopicPartition, Long],
-                                   version: Short): FetchRequest = {
-    FetchRequest.Builder.forConsumer(version, Int.MaxValue, 0, createPartitionMap(maxPartitionBytes, topicPartitions, offsetMap))
+                                   version: Short,
+                                   maxWaitMs: Int = Int.MaxValue,
+                                   minBytes: Int = 0): FetchRequest = {
+    FetchRequest.Builder.forConsumer(version, maxWaitMs, minBytes, createPartitionMap(maxPartitionBytes, topicPartitions, offsetMap))
       .setMaxBytes(maxResponseBytes).build()
   }
 
@@ -64,8 +66,8 @@ class BaseFetchRequestTest extends BaseRequestTest {
     partitionMap
   }
 
-  protected def sendFetchRequest(leaderId: Int, request: FetchRequest): FetchResponse = {
-    connectAndReceive[FetchResponse](request, destination = brokerSocketServer(leaderId))
+  protected def sendFetchRequest(brokerId: Int, request: FetchRequest): FetchResponse = {
+    connectAndReceive[FetchResponse](request, destination = brokerSocketServer(brokerId))
   }
 
   protected def initProducer(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
@@ -46,11 +46,15 @@ class BaseFetchRequestTest extends BaseRequestTest {
     super.tearDown()
   }
 
-  protected def createConsumerFetchRequest(maxResponseBytes: Int, maxPartitionBytes: Int, topicPartitions: Seq[TopicPartition],
-                                   offsetMap: Map[TopicPartition, Long],
-                                   version: Short,
-                                   maxWaitMs: Int = Int.MaxValue,
-                                   minBytes: Int = 0): FetchRequest = {
+  protected def createConsumerFetchRequest(
+    maxResponseBytes: Int,
+    maxPartitionBytes: Int,
+    topicPartitions: Seq[TopicPartition],
+    offsetMap: Map[TopicPartition, Long],
+    version: Short,
+    maxWaitMs: Int = Int.MaxValue,
+    minBytes: Int = 0
+  ): FetchRequest = {
     FetchRequest.Builder.forConsumer(version, maxWaitMs, minBytes, createPartitionMap(maxPartitionBytes, topicPartitions, offsetMap))
       .setMaxBytes(maxResponseBytes).build()
   }

--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -51,7 +51,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
 
     def createFetchRequest(topicPartitions: Seq[TopicPartition], offsetMap: Map[TopicPartition, Long] = Map.empty,
                            version: Short = ApiKeys.FETCH.latestVersion()): FetchRequest =
-      this.createFetchRequest(maxResponseBytes, maxPartitionBytes, topicPartitions, offsetMap, version)
+      this.createConsumerFetchRequest(maxResponseBytes, maxPartitionBytes, topicPartitions, offsetMap, version)
 
     val topicPartitionToLeader = createTopics(numTopics = 5, numPartitions = 6)
     val random = new Random(0)

--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -49,7 +49,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     val maxResponseBytes = 800
     val maxPartitionBytes = 190
 
-    def createFetchRequest(topicPartitions: Seq[TopicPartition], offsetMap: Map[TopicPartition, Long] = Map.empty,
+    def createConsumerFetchRequest(topicPartitions: Seq[TopicPartition], offsetMap: Map[TopicPartition, Long] = Map.empty,
                            version: Short = ApiKeys.FETCH.latestVersion()): FetchRequest =
       this.createConsumerFetchRequest(maxResponseBytes, maxPartitionBytes, topicPartitions, offsetMap, version)
 
@@ -77,28 +77,28 @@ class FetchRequestTest extends BaseFetchRequestTest {
 
     // 1. Partitions with large messages at the end
     val shuffledTopicPartitions1 = random.shuffle(partitionsWithoutLargeMessages) ++ partitionsWithLargeMessages
-    val fetchRequest1 = createFetchRequest(shuffledTopicPartitions1)
+    val fetchRequest1 = createConsumerFetchRequest(shuffledTopicPartitions1)
     val fetchResponse1 = sendFetchRequest(leaderId, fetchRequest1)
     checkFetchResponse(shuffledTopicPartitions1, fetchResponse1, maxPartitionBytes, maxResponseBytes, messagesPerPartition)
-    val fetchRequest1V12 = createFetchRequest(shuffledTopicPartitions1, version = 12)
+    val fetchRequest1V12 = createConsumerFetchRequest(shuffledTopicPartitions1, version = 12)
     val fetchResponse1V12 = sendFetchRequest(leaderId, fetchRequest1V12)
     checkFetchResponse(shuffledTopicPartitions1, fetchResponse1V12, maxPartitionBytes, maxResponseBytes, messagesPerPartition, 12)
 
     // 2. Same as 1, but shuffled again
     val shuffledTopicPartitions2 = random.shuffle(partitionsWithoutLargeMessages) ++ partitionsWithLargeMessages
-    val fetchRequest2 = createFetchRequest(shuffledTopicPartitions2)
+    val fetchRequest2 = createConsumerFetchRequest(shuffledTopicPartitions2)
     val fetchResponse2 = sendFetchRequest(leaderId, fetchRequest2)
     checkFetchResponse(shuffledTopicPartitions2, fetchResponse2, maxPartitionBytes, maxResponseBytes, messagesPerPartition)
-    val fetchRequest2V12 = createFetchRequest(shuffledTopicPartitions2, version = 12)
+    val fetchRequest2V12 = createConsumerFetchRequest(shuffledTopicPartitions2, version = 12)
     val fetchResponse2V12 = sendFetchRequest(leaderId, fetchRequest2V12)
     checkFetchResponse(shuffledTopicPartitions2, fetchResponse2V12, maxPartitionBytes, maxResponseBytes, messagesPerPartition, 12)
 
     // 3. Partition with message larger than the partition limit at the start of the list
     val shuffledTopicPartitions3 = Seq(partitionWithLargeMessage1, partitionWithLargeMessage2) ++
       random.shuffle(partitionsWithoutLargeMessages)
-    val fetchRequest3 = createFetchRequest(shuffledTopicPartitions3, Map(partitionWithLargeMessage1 -> messagesPerPartition))
+    val fetchRequest3 = createConsumerFetchRequest(shuffledTopicPartitions3, Map(partitionWithLargeMessage1 -> messagesPerPartition))
     val fetchResponse3 = sendFetchRequest(leaderId, fetchRequest3)
-    val fetchRequest3V12 = createFetchRequest(shuffledTopicPartitions3, Map(partitionWithLargeMessage1 -> messagesPerPartition), 12)
+    val fetchRequest3V12 = createConsumerFetchRequest(shuffledTopicPartitions3, Map(partitionWithLargeMessage1 -> messagesPerPartition), 12)
     val fetchResponse3V12 = sendFetchRequest(leaderId, fetchRequest3V12)
     def evaluateResponse3(response: FetchResponse, version: Short = ApiKeys.FETCH.latestVersion()) = {
       val responseData = response.responseData(topicNames, version)
@@ -121,9 +121,9 @@ class FetchRequestTest extends BaseFetchRequestTest {
     // 4. Partition with message larger than the response limit at the start of the list
     val shuffledTopicPartitions4 = Seq(partitionWithLargeMessage2, partitionWithLargeMessage1) ++
       random.shuffle(partitionsWithoutLargeMessages)
-    val fetchRequest4 = createFetchRequest(shuffledTopicPartitions4, Map(partitionWithLargeMessage2 -> messagesPerPartition))
+    val fetchRequest4 = createConsumerFetchRequest(shuffledTopicPartitions4, Map(partitionWithLargeMessage2 -> messagesPerPartition))
     val fetchResponse4 = sendFetchRequest(leaderId, fetchRequest4)
-    val fetchRequest4V12 = createFetchRequest(shuffledTopicPartitions4, Map(partitionWithLargeMessage2 -> messagesPerPartition), 12)
+    val fetchRequest4V12 = createConsumerFetchRequest(shuffledTopicPartitions4, Map(partitionWithLargeMessage2 -> messagesPerPartition), 12)
     val fetchResponse4V12 = sendFetchRequest(leaderId, fetchRequest4V12)
     def evaluateResponse4(response: FetchResponse, version: Short = ApiKeys.FETCH.latestVersion()) = {
       val responseData = response.responseData(topicNames, version)
@@ -507,7 +507,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
    */
   @Test
   def testCreateIncrementalFetchWithPartitionsInErrorV12(): Unit = {
-    def createFetchRequest(topicPartitions: Seq[TopicPartition],
+    def createConsumerFetchRequest(topicPartitions: Seq[TopicPartition],
                            metadata: JFetchMetadata,
                            toForget: Seq[TopicIdPartition]): FetchRequest =
       FetchRequest.Builder.forConsumer(12, Int.MaxValue, 0,
@@ -521,7 +521,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     val topicNames = Map[Uuid, String]().asJava
     createTopicWithAssignment("foo", Map(0 -> List(0, 1), 1 -> List(0, 2)))
     val bar0 = new TopicPartition("bar", 0)
-    val req1 = createFetchRequest(List(foo0, foo1, bar0), JFetchMetadata.INITIAL, Nil)
+    val req1 = createConsumerFetchRequest(List(foo0, foo1, bar0), JFetchMetadata.INITIAL, Nil)
     val resp1 = sendFetchRequest(0, req1)
     assertEquals(Errors.NONE, resp1.error())
     assertTrue(resp1.sessionId() > 0, "Expected the broker to create a new incremental fetch session")
@@ -533,7 +533,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     assertEquals(Errors.NONE.code, responseData1.get(foo0).errorCode)
     assertEquals(Errors.NONE.code, responseData1.get(foo1).errorCode)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, responseData1.get(bar0).errorCode)
-    val req2 = createFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 1), Nil)
+    val req2 = createConsumerFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 1), Nil)
     val resp2 = sendFetchRequest(0, req2)
     assertEquals(Errors.NONE, resp2.error())
     assertEquals(resp1.sessionId(),
@@ -544,7 +544,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     assertTrue(responseData2.containsKey(bar0))
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, responseData2.get(bar0).errorCode)
     createTopicWithAssignment("bar", Map(0 -> List(0, 1)))
-    val req3 = createFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 2), Nil)
+    val req3 = createConsumerFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 2), Nil)
     val resp3 = sendFetchRequest(0, req3)
     assertEquals(Errors.NONE, resp3.error())
     val responseData3 = resp3.responseData(topicNames, 12)
@@ -552,7 +552,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     assertFalse(responseData3.containsKey(foo1))
     assertTrue(responseData3.containsKey(bar0))
     assertEquals(Errors.NONE.code, responseData3.get(bar0).errorCode)
-    val req4 = createFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 3), Nil)
+    val req4 = createConsumerFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 3), Nil)
     val resp4 = sendFetchRequest(0, req4)
     assertEquals(Errors.NONE, resp4.error())
     val responseData4 = resp4.responseData(topicNames, 12)
@@ -566,7 +566,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
    */
   @Test
   def testFetchWithPartitionsWithIdError(): Unit = {
-    def createFetchRequest(fetchData: util.LinkedHashMap[TopicPartition, FetchRequest.PartitionData],
+    def createConsumerFetchRequest(fetchData: util.LinkedHashMap[TopicPartition, FetchRequest.PartitionData],
                            metadata: JFetchMetadata,
                            toForget: Seq[TopicIdPartition]): FetchRequest = {
       FetchRequest.Builder.forConsumer(ApiKeys.FETCH.latestVersion(), Int.MaxValue, 0, fetchData)
@@ -593,7 +593,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
       partitionMap
     }
 
-    val req1 = createFetchRequest( createPartitionMap(Integer.MAX_VALUE, List(foo0, foo1, bar0), Map.empty), JFetchMetadata.INITIAL, Nil)
+    val req1 = createConsumerFetchRequest( createPartitionMap(Integer.MAX_VALUE, List(foo0, foo1, bar0), Map.empty), JFetchMetadata.INITIAL, Nil)
     val resp1 = sendFetchRequest(0, req1)
     assertEquals(Errors.NONE, resp1.error())
     val topicNames1 = topicIdsWithUnknown.map(_.swap).asJava

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -1129,11 +1129,14 @@ class ReplicaFetcherThreadTest {
     when(mockBlockingSend.brokerEndPoint()).thenReturn(brokerEndPoint)
 
     val log: UnifiedLog = mock(classOf[UnifiedLog])
+    val records = MemoryRecords.withRecords(CompressionType.NONE,
+      new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8)))
 
     val partition: Partition = mock(classOf[Partition])
     when(partition.localLogOrException).thenReturn(log)
     when(partition.isReassigning).thenReturn(isReassigning)
     when(partition.isAddingLocalReplica).thenReturn(isReassigning)
+    when(partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false)).thenReturn(None)
 
     val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
     when(replicaManager.getPartitionOrException(any[TopicPartition])).thenReturn(partition)
@@ -1152,8 +1155,6 @@ class ReplicaFetcherThreadTest {
       mockBlockingSend
     )
 
-    val records = MemoryRecords.withRecords(CompressionType.NONE,
-      new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8)))
     val partitionData: thread.FetchData = new FetchResponseData.PartitionData()
       .setPartitionIndex(t1p0.partition)
       .setLastStableOffset(0)

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -1112,9 +1112,13 @@ class ReplicaFetcherThreadTest {
     val mockBlockingSend: BlockingSend = mock(classOf[BlockingSend])
     when(mockBlockingSend.brokerEndPoint()).thenReturn(brokerEndPoint)
 
+    var maybeNewHighWatermark: Option[Long] = None
+    if (highWatermarkUpdated) {
+      maybeNewHighWatermark = Some(highWatermarkReceivedFromLeader)
+    }
     val log: UnifiedLog = mock(classOf[UnifiedLog])
     when(log.maybeUpdateHighWatermark(highWatermarkReceivedFromLeader))
-      .thenReturn(highWatermarkUpdated)
+      .thenReturn(maybeNewHighWatermark)
 
     val appendInfo: Option[LogAppendInfo] = Some(mock(classOf[LogAppendInfo]))
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -1112,9 +1112,10 @@ class ReplicaFetcherThreadTest {
     val mockBlockingSend: BlockingSend = mock(classOf[BlockingSend])
     when(mockBlockingSend.brokerEndPoint()).thenReturn(brokerEndPoint)
 
-    var maybeNewHighWatermark: Option[Long] = None
-    if (highWatermarkUpdated) {
-      maybeNewHighWatermark = Some(highWatermarkReceivedFromLeader)
+    val maybeNewHighWatermark = if (highWatermarkUpdated) {
+      Some(highWatermarkReceivedFromLeader)
+    } else {
+      None
     }
     val log: UnifiedLog = mock(classOf[UnifiedLog])
     when(log.maybeUpdateHighWatermark(highWatermarkReceivedFromLeader))

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -1152,8 +1152,9 @@ class ReplicaFetcherThreadTest {
 
     thread.processPartitionData(tp0, 0, partitionData.setPartitionIndex(0))
     thread.processPartitionData(tp1, 0, partitionData.setPartitionIndex(1))
-    thread.doWork()
+    verify(replicaManager, times(0)).completeDelayedFetchRequests(any[Seq[TopicPartition]])
 
+    thread.doWork()
     if (highWatermarkUpdated) {
       verify(replicaManager, times(1)).completeDelayedFetchRequests(Seq(tp0, tp1))
     } else {

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -34,8 +34,12 @@ import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRec
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.utils.{LogContext, SystemTime}
+import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyBoolean, anyLong}
 import org.mockito.Mockito.{mock, never, times, verify, when}
@@ -43,10 +47,6 @@ import org.mockito.Mockito.{mock, never, times, verify, when}
 import java.nio.charset.StandardCharsets
 import java.util
 import java.util.{Collections, Optional}
-import org.apache.kafka.server.common.MetadataVersion
-import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 
 import scala.collection.{Map, mutable}
 import scala.jdk.CollectionConverters._
@@ -1194,6 +1194,7 @@ class ReplicaFetcherThreadTest {
     val log: UnifiedLog = mock(classOf[UnifiedLog])
     val records = MemoryRecords.withRecords(CompressionType.NONE,
       new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8)))
+    when(log.maybeUpdateHighWatermark(hw = 0)).thenReturn(None)
 
     val partition: Partition = mock(classOf[Partition])
     when(partition.localLogOrException).thenReturn(log)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -824,9 +824,7 @@ object TestUtils extends Logging {
                            trustStoreFile: Option[File] = None,
                            saslProperties: Option[Properties] = None,
                            keyDeserializer: Deserializer[K] = new ByteArrayDeserializer,
-                           valueDeserializer: Deserializer[V] = new ByteArrayDeserializer,
-                           rackId: String = null,
-                           fetchMaxWaitMs: Int = 500): KafkaConsumer[K, V] = {
+                           valueDeserializer: Deserializer[V] = new ByteArrayDeserializer): KafkaConsumer[K, V] = {
     val consumerProps = new Properties
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset)
@@ -835,10 +833,6 @@ object TestUtils extends Logging {
     consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
     consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, if (readCommitted) "read_committed" else "read_uncommitted")
     consumerProps ++= consumerSecurityConfigs(securityProtocol, trustStoreFile, saslProperties)
-    if (rackId != null) {
-      consumerProps.put(ConsumerConfig.CLIENT_RACK_CONFIG, rackId)
-    }
-    consumerProps.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, fetchMaxWaitMs)
     new KafkaConsumer[K, V](consumerProps, keyDeserializer, valueDeserializer)
   }
 
@@ -1731,15 +1725,11 @@ object TestUtils extends Logging {
       groupId: String = "group",
       securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT,
       trustStoreFile: Option[File] = None,
-      waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS,
-      rackId: String = null,
-      fetchMaxWaitMs: Int = 500): Seq[ConsumerRecord[Array[Byte], Array[Byte]]] = {
+      waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Seq[ConsumerRecord[Array[Byte], Array[Byte]]] = {
     val consumer = createConsumer(bootstrapServers(brokers, ListenerName.forSecurityProtocol(securityProtocol)),
       groupId = groupId,
       securityProtocol = securityProtocol,
-      trustStoreFile = trustStoreFile,
-      rackId = rackId,
-      fetchMaxWaitMs = fetchMaxWaitMs)
+      trustStoreFile = trustStoreFile)
     try {
       consumer.subscribe(Collections.singleton(topic))
       consumeRecords(consumer, numMessages, waitTime)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -99,7 +99,7 @@ public class CheckpointBench {
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
                 0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
-                (short) 1));
+                (short) 1, false));
         this.metrics = new Metrics();
         this.time = new MockTime();
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -110,7 +110,7 @@ public class PartitionCreationBench {
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
                 0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
-                (short) 1));
+                (short) 1, false));
         this.metrics = new Metrics();
         this.time = Time.SYSTEM;
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());


### PR DESCRIPTION
When a consumer makes a fetch request to a follower (for [KIP-392](https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica#KIP392:Allowconsumerstofetchfromclosestreplica-ConsumerAPI)) the fetch request will sit in the purgatory until `fetch.max.wait.ms` because the purgatory is not completed after replication. This patch aims to complete the delayed fetch purgatory after successfully replicating from the leader.

Confirmed that the integration test fails when purgatory is not completed after replication.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
