### PR TITLE
KAFKA-14339 : Do not perform prodcuerCommit on serializationError when trying offsetWriter flush

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 
@@ -262,7 +261,6 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
         maybeBeginTransaction();
 
         AtomicReference<Throwable> flushError = new AtomicReference<>();
-        Future<Void> flushFuture = null;
         if (offsetWriter.beginFlush()) {
             // Now we can actually write the offsets to the internal topic.
             // No need to track the flush future here since it's guaranteed to complete by the time
@@ -270,7 +268,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
             // We do have to track failures for that callback though, since they may originate from outside
             // the producer (i.e., the offset writer or the backing offset store), and would not cause
             // Producer::commitTransaction to fail
-            flushFuture = offsetWriter.doFlush((error, result) -> {
+            offsetWriter.doFlush((error, result) -> {
                 if (error != null) {
                     log.error("{} Failed to flush offsets to storage: ", ExactlyOnceWorkerSourceTask.this, error);
                     flushError.compareAndSet(null, error);
@@ -282,17 +280,18 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
 
         // Commit the transaction
         // Blocks until all outstanding records have been sent and ack'd
-        if (flushFuture != null) {
+        Throwable error = flushError.get();
+        if (error == null) {
             try {
                 producer.commitTransaction();
             } catch (Throwable t) {
                 log.error("{} Failed to commit producer transaction", ExactlyOnceWorkerSourceTask.this, t);
                 flushError.compareAndSet(null, t);
             }
-            transactionOpen = false;
         }
+        transactionOpen = false;
 
-        Throwable error = flushError.get();
+        error = flushError.get();
         if (error != null) {
             recordCommitFailure(time.milliseconds() - started, null);
             offsetWriter.cancelFlush();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -1188,7 +1188,6 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
                 expectCall(sourceTask::commit).anyTimes();
                 break;
             case FAIL_FLUSH_CALLBACK:
-                expectCall(producer::commitTransaction);
                 offsetFlush.andAnswer(() -> {
                     flushCallback.getValue().onCompletion(new RecordTooLargeException(), null);
                     return null;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -1156,6 +1156,7 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
         FAIL_TRANSACTION_COMMIT
     }
 
+    @SuppressWarnings("unchecked")
     private CountDownLatch expectFlush(FlushOutcome outcome, AtomicInteger flushCount) {
         CountDownLatch result = new CountDownLatch(1);
         org.easymock.IExpectationSetters<Boolean> flushBegin = EasyMock
@@ -1172,17 +1173,18 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
         Capture<Callback<Void>> flushCallback = EasyMock.newCapture();
         org.easymock.IExpectationSetters<Future<Void>> offsetFlush =
                 EasyMock.expect(offsetWriter.doFlush(EasyMock.capture(flushCallback)));
+        Future<Void> flushFuture = PowerMock.createMock(Future.class);
         switch (outcome) {
             case SUCCEED:
                 // The worker task doesn't actually use the returned future
-                offsetFlush.andReturn(null);
+                offsetFlush.andReturn(flushFuture);
                 expectCall(producer::commitTransaction);
                 expectCall(() -> sourceTask.commitRecord(EasyMock.anyObject(), EasyMock.anyObject()));
                 expectCall(sourceTask::commit);
                 break;
             case SUCCEED_ANY_TIMES:
                 // The worker task doesn't actually use the returned future
-                offsetFlush.andReturn(null).anyTimes();
+                offsetFlush.andReturn(flushFuture).anyTimes();
                 expectCall(producer::commitTransaction).anyTimes();
                 expectCall(() -> sourceTask.commitRecord(EasyMock.anyObject(), EasyMock.anyObject())).anyTimes();
                 expectCall(sourceTask::commit).anyTimes();
@@ -1195,7 +1197,7 @@ public class ExactlyOnceWorkerSourceTaskTest extends ThreadedTest {
                 expectCall(offsetWriter::cancelFlush);
                 break;
             case FAIL_TRANSACTION_COMMIT:
-                offsetFlush.andReturn(null);
+                offsetFlush.andReturn(flushFuture);
                 expectCall(producer::commitTransaction)
                         .andThrow(new RecordTooLargeException());
                 expectCall(offsetWriter::cancelFlush);


### PR DESCRIPTION
We shouldn't commitTransaction() on producer, when offsetWriter faces some issue and returns without sending offsets to producer. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
