### PR TITLE
MINOR: Fix rat task verbose output config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ apply from: file('wrapper.gradle')
 
 if (file('.git').exists()) {
   rat {
-    verbose = true
+    verbose.set(true)
     reportDir.set(project.file('build/rat'))
     stylesheet.set(file('gradle/resources/rat-output-to-html.xsl'))
 


### PR DESCRIPTION
Currently we are setting non-existing verbose field of Rat task. Fixed the issue by calling correct Rat task verbose set method.