### PR TITLE
[WIP][KAFKA-14326] StreamsRestter trim excess white space surrounding topic input

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -326,8 +326,8 @@ public class StreamsResetter {
                                                                     final boolean dryRun)
         throws IOException, ParseException {
 
-        final List<String> inputTopics = options.valuesOf(inputTopicsOption);
-        final List<String> intermediateTopics = options.valuesOf(intermediateTopicsOption);
+        final List<String> inputTopics = options.valuesOf(inputTopicsOption).stream().map(String::trim).collect(Collectors.toList());
+        final List<String> intermediateTopics = options.valuesOf(intermediateTopicsOption).stream().map(String::trim).collect(Collectors.toList());
         int topicNotFound = EXIT_CODE_SUCCESS;
 
         final List<String> notFoundInputTopics = new ArrayList<>();


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*
The goal of the change is to remove excess white space surrounding topic inputs. As an example:
```
% ./kafka-streams-application-reset.sh --application-id streams-wordcount --bootstrap-servers <host>:9092 --input-topics "   streams-plaintext-input,     test" --to-earliest --force
Reset-offsets for input topics [   streams-plaintext-input,      test]
Following input topics are not found, skipping them
Topic:    streams-plaintext-input
Topic:      test
Deleting inferred internal topics [streams-wordcount-KSTREAM-AGGREGATE-STATE-STORE-0000000003-repartition, streams-wordcount-KSTREAM-AGGREGATE-STATE-STORE-0000000003-changelog]
Done.
```
Despite the fact that the streams-plaintext-input topic does exist:
```
% ./kafka-topics.sh --bootstrap-server <host>:9092 --describe --topic streams-plaintext-input
Topic: streams-plaintext-input	TopicId: 2e7WtMnHRrShhT2F7qq7xA	PartitionCount: 1	ReplicationFactor: 1	Configs: min.insync.replicas=1,segment.bytes=1073741824,retention.ms=604800000,max.message.bytes=1000000,min.cleanable.dirty.ratio=0.5,unclean.leader.election.enable=false,retention.bytes=-1,delete.retention.ms=604800000
	Topic: streams-plaintext-input	Partition: 0	Leader: 1546334494	Replicas: 1546334494	Isr: 1546334494
```
This should instead trim the excess white space around the input topics and search for them. 

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
Currently, I've been running this change against a cluster I have access to as a means to test against it. But, I believe there should be tests for the command line tools. Where these tests are, I'm unsure. Perhaps they have to be built. 

I opened this as a WIP to receive input on if there are other areas where these should be trimmed or if the "correct" way is to sift through and better understand how things like the TopicCommand are trimming inputs and then implementing that, presumably, more standardized process in the StreamsResetter code?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
