### PR TITLE
KAFKA-14338: Use MockTime in RetryUtilTest to eliminate flakiness

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +38,7 @@ import java.util.function.Supplier;
 @RunWith(PowerMockRunner.class)
 public class RetryUtilTest {
 
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private final Time mockTime = new MockTime();
 
     private Callable<String> mockCallable;
     private final Supplier<String> testMsg = () -> "Test";
@@ -50,16 +52,15 @@ public class RetryUtilTest {
     @Test
     public void testSuccess() throws Exception {
         Mockito.when(mockCallable.call()).thenReturn("success");
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 1));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 1, mockTime));
         Mockito.verify(mockCallable, Mockito.times(1)).call();
     }
 
-    // timeout the test after 1000ms if unable to complete within a reasonable time frame
-    @Test(timeout = 1000)
+    @Test
     public void testExhaustingRetries() throws Exception {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException());
         ConnectException e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 10));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 10, mockTime));
         Mockito.verify(mockCallable, Mockito.atLeastOnce()).call();
     }
 
@@ -71,7 +72,7 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException())
                 .thenReturn("success");
 
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, 1));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 1, mockTime));
         Mockito.verify(mockCallable, Mockito.times(4)).call();
     }
 
@@ -85,7 +86,7 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException("timeout"))
                 .thenThrow(new NullPointerException("Non retriable"));
         NullPointerException e = assertThrows(NullPointerException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, 0));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 0, mockTime));
         assertEquals("Non retriable", e.getMessage());
         Mockito.verify(mockCallable, Mockito.times(6)).call();
     }
@@ -94,7 +95,7 @@ public class RetryUtilTest {
     public void noRetryAndSucceed() throws Exception {
         Mockito.when(mockCallable.call()).thenReturn("success");
 
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(0), 100));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(0), 100, mockTime));
         Mockito.verify(mockCallable, Mockito.times(1)).call();
     }
 
@@ -103,7 +104,7 @@ public class RetryUtilTest {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
 
         TimeoutException e = assertThrows(TimeoutException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(0), 100));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(0), 100, mockTime));
         Mockito.verify(mockCallable, Mockito.times(1)).call();
         assertEquals("timeout exception", e.getMessage());
     }
@@ -116,16 +117,20 @@ public class RetryUtilTest {
                 .thenThrow(new TimeoutException())
                 .thenReturn("success");
 
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, 0));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), 0, mockTime));
         Mockito.verify(mockCallable, Mockito.times(4)).call();
     }
 
     @Test
     public void testNoBackoffTimeAndFail() throws Exception {
-        Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
+        Mockito.when(mockCallable.call()).thenAnswer(invocation -> {
+            // Without any backoff time, the speed of the operation itself limits the number of retries and retry rate.
+            mockTime.sleep(30);
+            throw new TimeoutException("timeout exception");
+        });
 
         ConnectException e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(80), 0));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(80), 0, mockTime));
         Mockito.verify(mockCallable, Mockito.atLeastOnce()).call();
         assertTrue(e.getMessage().contains("Reason: timeout exception"));
     }
@@ -135,7 +140,7 @@ public class RetryUtilTest {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
 
         TimeoutException e = assertThrows(TimeoutException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 100));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 100, mockTime));
         Mockito.verify(mockCallable, Mockito.times(1)).call();
     }
 
@@ -143,8 +148,8 @@ public class RetryUtilTest {
     public void testInvalidTimeDuration() throws Exception {
         Mockito.when(mockCallable.call()).thenReturn("success");
 
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, null, 10));
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(-1), 10));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, null, 10, mockTime));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(-1), 10, mockTime));
         Mockito.verify(mockCallable, Mockito.times(2)).call();
     }
 
@@ -153,7 +158,7 @@ public class RetryUtilTest {
         Mockito.when(mockCallable.call())
                 .thenThrow(new TimeoutException("timeout"))
                 .thenReturn("success");
-        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, TIMEOUT, -1));
+        assertEquals("success", RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(100), -1, mockTime));
         Mockito.verify(mockCallable, Mockito.times(2)).call();
     }
 
@@ -162,15 +167,15 @@ public class RetryUtilTest {
         Mockito.when(mockCallable.call()).thenThrow(new TimeoutException("timeout exception"));
 
         ConnectException e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, null, Duration.ofMillis(100), 10));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, null, Duration.ofMillis(100), 10, mockTime));
         assertTrue(e.getMessage().startsWith("Fail to callable"));
 
         e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, () -> null, Duration.ofMillis(100), 10));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, () -> null, Duration.ofMillis(100), 10, mockTime));
         assertTrue(e.getMessage().startsWith("Fail to callable"));
 
         e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, () -> "execute lambda", Duration.ofMillis(500), 10));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, () -> "execute lambda", Duration.ofMillis(500), 10, mockTime));
         assertTrue(e.getMessage().startsWith("Fail to execute lambda"));
         Mockito.verify(mockCallable, Mockito.atLeast(3)).call();
     }
@@ -180,7 +185,7 @@ public class RetryUtilTest {
         Mockito.when(mockCallable.call()).thenThrow(new WakeupException());
 
         ConnectException e = assertThrows(ConnectException.class,
-                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 10));
+                () -> RetryUtil.retryUntilTimeout(mockCallable, testMsg, Duration.ofMillis(50), 10, mockTime));
         Mockito.verify(mockCallable, Mockito.atLeastOnce()).call();
     }
 }


### PR DESCRIPTION
Signed-off-by: Greg Harris <greg.harris@aiven.io>

There is existing flakiness in this test even with the previous patch to address flakiness https://github.com/apache/kafka/pull/11871
This should resolve the observed flakiness because the MockTime will only progress time when the test interacts with it.

One small change to the test was necessary: adding an explicit sleep within the retried operation in testNoBackoffTimeAndFail. Because the no-backoff case does not call the mockTime sleep, the test as-written would enter into an infinite retry loop, with every retry happening on the same mockTime timestamp. The test needed to be modified such that the retried operation advances the clock slightly to prevent this.

Additionally, revert the previous flakiness patch to restore the original 100ms timeouts, down from 10 seconds.

This should be backported to every branch that the previous flakiness fix was applied to: 2.6, 2.7,  2.8, 3.0, 3.1, 3.2, 3.3. Thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
