### PR TITLE
[KAFKA-14328]: KafkaAdminClient should be Changing the exception level …

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -748,6 +748,7 @@ public class KafkaAdminClient extends AdminClient {
         protected int tries;
         private Node curNode = null;
         private long nextAllowedTryMs;
+        private Throwable lastThrowable = null;
 
         Call(boolean internal,
              String callName,
@@ -835,6 +836,10 @@ public class KafkaAdminClient extends AdminClient {
                 log.debug("{} failed: {}. Beginning retry #{}",
                     this, prettyPrintException(throwable), tries);
             }
+            //Temporarily save the last exception of the call,
+            // so that the call can return valid exception information when it times out
+            lastThrowable = throwable;
+
             maybeRetry(now, throwable);
         }
 
@@ -944,7 +949,7 @@ public class KafkaAdminClient extends AdminClient {
                 Call call = iter.next();
                 int remainingMs = calcTimeoutMsRemainingAsInt(now, call.deadlineMs);
                 if (remainingMs < 0) {
-                    call.fail(now, new TimeoutException(msg + " Call: " + call.callName));
+                    call.fail(now, new TimeoutException(msg + " Call: " + call.callName,call.lastThrowable));
                     iter.remove();
                     numTimedOut++;
                 } else {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -836,7 +836,7 @@ public class KafkaAdminClient extends AdminClient {
                 log.debug("{} failed: {}. Beginning retry #{}",
                     this, prettyPrintException(throwable), tries);
             }
-            //Temporarily save the last exception of the call,
+            // Temporarily save the last exception of the call,
             // so that the call can return valid exception information when it times out
             lastThrowable = throwable;
 
@@ -949,7 +949,7 @@ public class KafkaAdminClient extends AdminClient {
                 Call call = iter.next();
                 int remainingMs = calcTimeoutMsRemainingAsInt(now, call.deadlineMs);
                 if (remainingMs < 0) {
-                    call.fail(now, new TimeoutException(msg + " Call: " + call.callName,call.lastThrowable));
+                    call.fail(now, new TimeoutException(msg + " Call: " + call.callName + " , the last error causing retry is: ", call.lastThrowable));
                     iter.remove();
                     numTimedOut++;
                 } else {


### PR DESCRIPTION
[ISSUE: KAFKA-14328](https://issues.apache.org/jira/browse/KAFKA-14328)

PR：
return the real error while we return the timeout error

In the Pending Call timeout scenario, record the last retry timeout exception and print the last retry exception while it is timed out
This helps users locate problems


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
