### PR TITLE
Revert "KAFKA-13891: reset generation when syncgroup failed with REBA…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -825,9 +825,6 @@ public abstract class AbstractCoordinator implements Closeable {
                 } else if (error == Errors.REBALANCE_IN_PROGRESS) {
                     log.info("SyncGroup failed: The group began another rebalance. Need to re-join the group. " +
                                  "Sent generation was {}", sentGeneration);
-                    // consumer didn't get assignment in this generation, so we need to reset generation
-                    // to avoid joinGroup with out-of-data ownedPartitions in cooperative rebalance
-                    resetStateOnResponseError(ApiKeys.SYNC_GROUP, error, false);
                     future.raise(error);
                 } else if (error == Errors.FENCED_INSTANCE_ID) {
                     // for sync-group request, even if the generation has changed we would not expect the instance id

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -505,54 +504,6 @@ public class AbstractCoordinatorTest {
     }
 
     @Test
-    public void testResetGenerationIdAfterSyncGroupFailedWithRebalanceInProgress() throws InterruptedException, ExecutionException {
-        setupCoordinator();
-
-        String memberId = "memberId";
-        int generation = 5;
-
-        // Rebalance once to initialize the generation and memberId
-        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
-        expectJoinGroup("", generation, memberId);
-        expectSyncGroup(generation, memberId);
-        ensureActiveGroup(generation, memberId);
-
-        // Force a rebalance
-        coordinator.requestRejoin("Manual test trigger");
-        assertTrue(coordinator.rejoinNeededOrPending());
-
-        ExecutorService executor = Executors.newFixedThreadPool(1);
-        try {
-            // Return RebalanceInProgress in syncGroup
-            int rejoinedGeneration = 10;
-            expectJoinGroup(memberId, rejoinedGeneration, memberId);
-            expectRebalanceInProgressForSyncGroup(rejoinedGeneration, memberId);
-            Future<Boolean> secondJoin = executor.submit(() ->
-                coordinator.ensureActiveGroup(mockTime.timer(Integer.MAX_VALUE)));
-
-            TestUtils.waitForCondition(() -> {
-                AbstractCoordinator.Generation currentGeneration = coordinator.generation();
-                return currentGeneration.generationId == AbstractCoordinator.Generation.NO_GENERATION.generationId &&
-                        currentGeneration.memberId.equals(memberId);
-            }, 2000, "Generation should be reset");
-
-            rejoinedGeneration = 20;
-            expectSyncGroup(rejoinedGeneration, memberId);
-            mockClient.respond(joinGroupFollowerResponse(
-                    rejoinedGeneration,
-                    memberId,
-                    "leaderId",
-                    Errors.NONE,
-                    PROTOCOL_TYPE
-            ));
-            assertTrue(secondJoin.get());
-        } finally {
-            executor.shutdownNow();
-            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    @Test
     public void testRejoinReason() {
         setupCoordinator();
 
@@ -637,22 +588,6 @@ public class AbstractCoordinatorTest {
                 && syncGroupRequest.protocolType().equals(PROTOCOL_TYPE)
                 && syncGroupRequest.protocolName().equals(PROTOCOL_NAME);
         }, null, true);
-    }
-
-    private void expectRebalanceInProgressForSyncGroup(
-            int expectedGeneration,
-            String expectedMemberId
-    ) {
-        mockClient.prepareResponse(body -> {
-            if (!(body instanceof SyncGroupRequest)) {
-                return false;
-            }
-            SyncGroupRequestData syncGroupRequest = ((SyncGroupRequest) body).data();
-            return syncGroupRequest.generationId() == expectedGeneration
-                    && syncGroupRequest.memberId().equals(expectedMemberId)
-                    && syncGroupRequest.protocolType().equals(PROTOCOL_TYPE)
-                    && syncGroupRequest.protocolName().equals(PROTOCOL_NAME);
-        }, syncGroupResponse(Errors.REBALANCE_IN_PROGRESS, PROTOCOL_TYPE, PROTOCOL_NAME));
     }
 
     private void expectDisconnectInJoinGroup(


### PR DESCRIPTION
…LANCE_IN_PROGRESS (#12140)"

This reverts commit c23d60d56cd73118624192cf03f6e400f59027e7.

As discussed in [KAFKA-14016](https://issues.apache.org/jira/browse/KAFKA-14016). 
The change in [KAFKA-13891](https://issues.apache.org/jira/browse/KAFKA-14016) will lead to revoke more partitions than expected. So revert it. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
