### PR TITLE
MINOR: Add test case for topic recreation with collision chars

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -263,6 +263,10 @@ public class ReplicationControlManager {
         public Uuid topicId() {
             return id;
         }
+
+        public int numPartitions(long epoch) {
+            return parts.size(epoch);
+        }
     }
 
     /**
@@ -527,7 +531,7 @@ public class ReplicationControlManager {
             if (colliding != null) {
                 colliding.remove(topic.name);
                 if (colliding.isEmpty()) {
-                    topicsWithCollisionChars.remove(topic.name);
+                    topicsWithCollisionChars.remove(normalizedName);
                 }
             }
         }


### PR DESCRIPTION
This patch adds a unit test for topic recreation with colliding characters (such as `.`). This was broken up until https://github.com/apache/kafka/pull/12790. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
