### PR TITLE
MINOR: Remove requirement to specify --bootstrap-server in utility scripts if specified in property file

### DIFF
--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -74,12 +74,13 @@ object BrokerApiVersionsCommand {
       Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt))
     else
       new Properties()
-    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
+    if (opts.options.has(opts.bootstrapServerOpt))
+      props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
     AdminClient.create(props)
   }
 
   class BrokerVersionCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
-    val BootstrapServerDoc = "REQUIRED: The server to connect to."
+    val BootstrapServerDoc = "The server to connect to. Can also be specified with 'bootstrap.servers' in the property file."
     val CommandConfigDoc = "A property file containing configs to be passed to Admin Client."
 
     val commandConfigOpt = parser.accepts("command-config", CommandConfigDoc)
@@ -95,8 +96,6 @@ object BrokerApiVersionsCommand {
 
     def checkArgs(): Unit = {
       CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps to retrieve broker version information.")
-      // check required args
-      CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -691,7 +691,8 @@ object ConsumerGroupCommand extends Logging {
     // Visibility for testing
     protected def createAdminClient(configOverrides: Map[String, String]): Admin = {
       val props = if (opts.options.has(opts.commandConfigOpt)) Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt)) else new Properties()
-      props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
+      if (opts.options.has(opts.bootstrapServerOpt))
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
       configOverrides.forKeyValue { (k, v) => props.put(k, v)}
       Admin.create(props)
     }
@@ -969,7 +970,7 @@ object ConsumerGroupCommand extends Logging {
   }
 
   class ConsumerGroupCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
-    val BootstrapServerDoc = "REQUIRED: The server(s) to connect to."
+    val BootstrapServerDoc = "The server(s) to connect to."
     val GroupDoc = "The consumer group we wish to act on."
     val TopicDoc = "The topic whose consumer group information should be deleted or topic whose should be included in the reset offset process. " +
       "In `reset-offsets` case, partitions can be specified using this format: `topic1:0,1,2`, where 0,1,2 are the partition to be included in the process. " +
@@ -1090,8 +1091,6 @@ object ConsumerGroupCommand extends Logging {
     val allDeleteOffsetsOpts = immutable.Set[OptionSpec[_]](groupOpt, topicOpt)
 
     def checkArgs(): Unit = {
-
-      CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 
       if (options.has(describeOpt)) {
         if (!options.has(groupOpt) && !options.has(allGroupsOpt))

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -487,13 +487,13 @@ object TopicCommand extends Logging {
   }
 
   class TopicCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
-    private val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The Kafka server to connect to.")
+    private val bootstrapServerOpt = parser.accepts("bootstrap-server", "The Kafka server to connect to.")
       .withRequiredArg
       .describedAs("server to connect to")
       .ofType(classOf[String])
 
     private val commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client. " +
-      "This is used only with --bootstrap-server option for describing and altering broker configs.")
+      "This is used for describing and altering broker configs.")
       .withRequiredArg
       .describedAs("command config property file")
       .ofType(classOf[String])
@@ -510,17 +510,17 @@ object TopicCommand extends Logging {
                          .describedAs("topic")
                          .ofType(classOf[String])
     private val topicIdOpt = parser.accepts("topic-id", "The topic-id to describe." +
-      "This is used only with --bootstrap-server option for describing topics.")
+      "This is used for describing topics.")
       .withRequiredArg
       .describedAs("topic-id")
       .ofType(classOf[String])
     private val nl = System.getProperty("line.separator")
     private val kafkaConfigsCanAlterTopicConfigsViaBootstrapServer =
-      " (the kafka-configs CLI supports altering topic configs with a --bootstrap-server option)"
+      " (the kafka-configs CLI supports altering topic configs)"
     private val configOpt = parser.accepts("config", "A topic configuration override for the topic being created or altered." +
                                              " The following is a list of valid configurations: " + nl + LogConfig.configNames.map("\t" + _).mkString(nl) + nl +
                                              "See the Kafka documentation for full details on the topic configs." +
-                                             " It is supported only in combination with --create if --bootstrap-server option is used" +
+                                             " It is supported only in combination with --create" +
                                              kafkaConfigsCanAlterTopicConfigsViaBootstrapServer + ".")
                            .withRequiredArg
                            .describedAs("name=value")
@@ -615,8 +615,6 @@ object TopicCommand extends Logging {
         CommandLineUtils.printUsageAndDie(parser, "Command must include exactly one action: --list, --describe, --create, --alter or --delete")
 
       // check required args
-      if (!has(bootstrapServerOpt))
-        throw new IllegalArgumentException("--bootstrap-server must be specified")
       if (has(describeOpt) && has(ifExistsOpt)) {
         if (!has(topicOpt) && !has(topicIdOpt))
           CommandLineUtils.printUsageAndDie(parser, "--topic or --topic-id is required to describe a topic")

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.regex.Pattern
-import java.util.{Collections, Locale, Map, Optional, Properties, Random, Arrays}
+import java.util.{Collections, Locale, Map, Optional, Properties, Random}
 import com.typesafe.scalalogging.LazyLogging
 import joptsimple._
 import kafka.utils.Implicits._
@@ -220,7 +220,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("consumer_prop")
       .ofType(classOf[String])
-    val consumerConfigOpt = parser.acceptsAll(Arrays.asList("consumer.config", "command-config"), s"Consumer config properties file. Note that $consumerPropertyOpt takes precedence over this config.")
+    val consumerConfigOpt = parser.accepts("consumer.config", s"Consumer config properties file. Note that $consumerPropertyOpt takes precedence over this config.")
       .withRequiredArg
       .describedAs("config file")
       .ofType(classOf[String])

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -19,7 +19,7 @@ package kafka.tools
 
 import java.io._
 import java.nio.charset.StandardCharsets
-import java.util.{Properties, Arrays}
+import java.util.Properties
 import java.util.regex.Pattern
 import joptsimple.{OptionException, OptionParser, OptionSet}
 import kafka.common._
@@ -244,7 +244,7 @@ object ConsoleProducer {
             .withRequiredArg
             .describedAs("producer_prop")
             .ofType(classOf[String])
-    val producerConfigOpt = parser.acceptsAll(Arrays.asList("producer.config", "command-config"), s"Producer config properties file. Note that $producerPropertyOpt takes precedence over this config.")
+    val producerConfigOpt = parser.accepts("producer.config", s"Producer config properties file. Note that $producerPropertyOpt takes precedence over this config.")
       .withRequiredArg
       .describedAs("config file")
       .ofType(classOf[String])


### PR DESCRIPTION
This is a relatively minor quality of life change.

Currently, some of the various `kafka-<x>.sh` commands (which wrap various Kafka admin calls) require that `--bootstrap-server` (or, occasionally `--bootstrap-servers`) be specified in the CLI, regardless of whether that property is specified in a specified property file.

The purpose of this PR is to remove that requirement. This PR may not cover all commands, but will hopefully address the most common ones. I will remove `WIP` when I've completed made these changes to several scripts (likely, kafka-broker-api-versions, kafka-topics, kafka-console-producer, and kafka-console-consumer)

~As an additional quality-of-life change, kafka-console-producer and kafka-console-consumer also now support `--command-config` (in addition to continuing to support `--producer.config` and `--consumer.config`, respectively)~

^ Edit 2023-01-09; this change has been reverted, as it is a change to the public interface and requires a KIP

Scripts updated so far:
* `kafka-broker-api-versions.sh`
* `kafka-topics.sh`
* `kafka-console-producer.sh`
* `kafka-console-consumer.sh`
* `kafka-consumer-groups.sh`

Not yet updated:
* `kafka-configs.sh` - Is slightly more complex than the above, in that it supports alterations on different types of entities depending on the connection mechanism (zookeeper vs. brokers). Might be worth refactoring (or at least until zookeeper is completely removed). Excluded from this PR.

For example, this now works:

```
$ ./kafka_2.13-3.4.0-SNAPSHOT/bin/kafka-broker-api-versions.sh --command-config client.properties
...
```

As does this:

```bash
$ ./kafka_2.13-3.4.0-SNAPSHOT/bin/kafka-topics.sh \
  --command-config client.properties \
  --list
helloworld
```

Notes:

* Many of these scripts aren't separately documented (aside from changelogs), so I'm not currently changing any documentation for these
* There is currently minimal test coverage, so at this point I'm not adding any additional tests (but will adjust tests as applicable)
* These changes should be non-breaking. Specifically:
    * For situations where the flag was previously specified, it will continue to be used (and take precedence over the property file), and the command will continue to work (or not work) as it previously would
    * For situations where the flag was not previously specified AND `bootstrap.servers` was _not_ configured in the property file, the command would previously fail and will continue to fail (with exit code `1`)
    * For situations where the flag was not previously specified AND `bootstrap.servers` was configured in the property file, the command would previously fail; now it will work

For example, specifying ONLY the property file without `bootstrap.servers` specified will result in output that looks like this, which is fairly intuitive to address:

```shell
./kafka_2.13-3.4.0-SNAPSHOT/bin/kafka-broker-api-versions.sh --command-config client-no-bootstrap.properties
Exception in thread "main" org.apache.kafka.common.config.ConfigException: Missing required configuration "bootstrap.servers" which has no default value.
	at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:493)
	at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:483)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:113)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:146)
	at kafka.admin.BrokerApiVersionsCommand$AdminClient$AdminConfig.<init>(BrokerApiVersionsCommand.scala:265)
	at kafka.admin.BrokerApiVersionsCommand$AdminClient$.create(BrokerApiVersionsCommand.scala:269)
	at kafka.admin.BrokerApiVersionsCommand$AdminClient$.create(BrokerApiVersionsCommand.scala:267)
	at kafka.admin.BrokerApiVersionsCommand$.createAdminClient(BrokerApiVersionsCommand.scala:79)
	at kafka.admin.BrokerApiVersionsCommand$.execute(BrokerApiVersionsCommand.scala:60)
	at kafka.admin.BrokerApiVersionsCommand$.main(BrokerApiVersionsCommand.scala:55)
	at kafka.admin.BrokerApiVersionsCommand.main(BrokerApiVersionsCommand.scala)
```


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
