### PR TITLE
MINOR: Reduce tries in RecordsIteratorTest to improve build time

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
@@ -66,7 +66,7 @@ public final class RecordsIteratorTest {
         testIterator(Collections.emptyList(), records, true);
     }
 
-    @Property
+    @Property(tries = 50)
     public void testMemoryRecords(
         @ForAll CompressionType compressionType,
         @ForAll long seed
@@ -77,7 +77,7 @@ public final class RecordsIteratorTest {
         testIterator(batches, memRecords, true);
     }
 
-    @Property
+    @Property(tries = 50)
     public void testFileRecords(
         @ForAll CompressionType compressionType,
         @ForAll long seed
@@ -92,10 +92,10 @@ public final class RecordsIteratorTest {
         fileRecords.close();
     }
 
-    @Property
+    @Property(tries = 50)
     public void testCrcValidation(
-            @ForAll CompressionType compressionType,
-            @ForAll long seed
+        @ForAll CompressionType compressionType,
+        @ForAll long seed
     ) throws IOException {
         List<TestBatch<String>> batches = createBatches(seed);
         MemoryRecords memRecords = buildRecords(compressionType, batches);


### PR DESCRIPTION
I found `RecordsIteratorTest` to take the longest times in recent builds (even including integration tests). The default of 1000 tries from jqwik is probably overkill and causes the test to take 10 minutes locally. Decreasing to 50 tries reduces that to less than 30s. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
