### PR TITLE
KAFKA-14342: KafkaOffsetBackingStore should clear offsets for source partitions on tombstone messages

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -286,7 +286,7 @@ public class KafkaOffsetBackingStoreTest {
                     new ConsumerRecord<>(TOPIC, 0, 0, 0L, TimestampType.CREATE_TIME, 0, 0, null, TP0_VALUE.array(),
                             new RecordHeaders(), Optional.empty()));
             capturedConsumedCallback.getValue().onCompletion(null,
-                    new ConsumerRecord<>(TOPIC, 1, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TP1_KEY.array(), null,
+                    new ConsumerRecord<>(TOPIC, 1, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TP1_KEY.array(), TP1_VALUE.array(),
                             new RecordHeaders(), Optional.empty()));
             storeLogCallbackArgumentCaptor.getValue().onCompletion(null, null);
             return null;
@@ -297,10 +297,10 @@ public class KafkaOffsetBackingStoreTest {
 
         verify(storeLog).start();
 
-        // Set offsets using null keys and values
+        // Set some offsets
         Map<ByteBuffer, ByteBuffer> toSet = new HashMap<>();
         toSet.put(null, TP0_VALUE);
-        toSet.put(TP1_KEY, null);
+        toSet.put(TP1_KEY, TP1_VALUE);
         final AtomicBoolean invoked = new AtomicBoolean(false);
         Future<Void> setFuture = store.set(toSet, (error, result) -> invoked.set(true));
         assertFalse(setFuture.isDone());
@@ -309,7 +309,7 @@ public class KafkaOffsetBackingStoreTest {
         ArgumentCaptor<org.apache.kafka.clients.producer.Callback> callback0 = ArgumentCaptor.forClass(org.apache.kafka.clients.producer.Callback.class);
         verify(storeLog).send(isNull(), aryEq(TP0_VALUE.array()), callback0.capture());
         ArgumentCaptor<org.apache.kafka.clients.producer.Callback> callback1 = ArgumentCaptor.forClass(org.apache.kafka.clients.producer.Callback.class);
-        verify(storeLog).send(aryEq(TP1_KEY.array()), isNull(), callback1.capture());
+        verify(storeLog).send(aryEq(TP1_KEY.array()), aryEq(TP1_VALUE.array()), callback1.capture());
         // Out of order callbacks shouldn't matter, should still require all to be invoked before invoking the callback
         // for the store's set callback
         callback1.getValue().onCompletion(null, null);
@@ -320,63 +320,37 @@ public class KafkaOffsetBackingStoreTest {
         // Getting data should read to end of our published data and return it
         Map<ByteBuffer, ByteBuffer> offsets = store.get(Arrays.asList(null, TP1_KEY)).get(10000, TimeUnit.MILLISECONDS);
         assertEquals(TP0_VALUE, offsets.get(null));
-        assertNull(offsets.get(TP1_KEY));
+        assertEquals(TP1_VALUE, offsets.get(TP1_KEY));
 
-        store.stop();
-
-        verify(storeLog).stop();
-    }
-
-    @Test
-    public void testTombstoneOffset() throws Exception {
-        // Second get() should get the produced data and return the new values
-        doAnswer(invocation -> {
-            capturedConsumedCallback.getValue().onCompletion(null,
-                    new ConsumerRecord<>(TOPIC, 1, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TP0_KEY.array(), TP0_VALUE.array(),
-                            new RecordHeaders(), Optional.empty()));
-            storeLogCallbackArgumentCaptor.getValue().onCompletion(null, null);
-            return null;
-        }).when(storeLog).readToEnd(storeLogCallbackArgumentCaptor.capture());
-
-        store.configure(mockConfig(props));
-        store.start();
-
-        verify(storeLog).start();
-
-        Map<ByteBuffer, ByteBuffer> toSet = new HashMap<>();
-        toSet.put(TP0_KEY, TP0_VALUE);
-        final AtomicBoolean invoked = new AtomicBoolean(false);
-        Future<Void> setFuture = store.set(toSet, (error, result) -> invoked.set(true));
+        // set null offset for TP1_KEY
+        toSet.clear();
+        toSet.put(TP1_KEY, null);
+        invoked.set(false);
+        setFuture = store.set(toSet, (error, result) -> invoked.set(true));
         assertFalse(setFuture.isDone());
 
-        // Set offsets
-        ArgumentCaptor<org.apache.kafka.clients.producer.Callback> callback0 = ArgumentCaptor.forClass(org.apache.kafka.clients.producer.Callback.class);
-        verify(storeLog).send(aryEq(TP0_KEY.array()), aryEq(TP0_VALUE.array()), callback0.capture());
+        callback0 = ArgumentCaptor.forClass(org.apache.kafka.clients.producer.Callback.class);
+        verify(storeLog).send(aryEq(TP1_KEY.array()), isNull(), callback0.capture());
         callback0.getValue().onCompletion(null, null);
-        setFuture.get(10000, TimeUnit.MILLISECONDS);
         assertTrue(invoked.get());
 
-        // Getting data should read to end of our published data and return it
-        Map<ByteBuffer, ByteBuffer> offsets = store.get(Arrays.asList(null, TP0_KEY)).get(10000, TimeUnit.MILLISECONDS);
-        assertEquals(TP0_VALUE, offsets.get(TP0_KEY));
-
         doAnswer(invocation -> {
-            // Read null offset for TP0_KEY (tombstone message)
+            // Read null offset for TP1_KEY (tombstone message)
             capturedConsumedCallback.getValue().onCompletion(null,
-                    new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TP0_KEY.array(), null,
+                    new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TP1_KEY.array(), null,
                             new RecordHeaders(), Optional.empty()));
             storeLogCallbackArgumentCaptor.getValue().onCompletion(null, null);
             return null;
         }).when(storeLog).readToEnd(storeLogCallbackArgumentCaptor.capture());
 
         // Getting data should read to end of our published data and return it
-        offsets = store.get(Collections.singletonList(TP0_KEY)).get(10000, TimeUnit.MILLISECONDS);
-        assertNull(offsets.get(TP0_KEY));
+        offsets = store.get(Collections.singletonList(TP1_KEY)).get(10000, TimeUnit.MILLISECONDS);
+        assertNull(offsets.get(TP1_KEY));
 
         // Just verifying that KafkaOffsetBackingStore::get returns null isn't enough, we also need to verify that the mapping for the source partition key is removed.
         // This is because KafkaOffsetBackingStore::get returns null if either there is no existing offset for the source partition or if there is an offset with null value.
         // We need to make sure that tombstoned offsets are removed completely (i.e. that the mapping for the corresponding source partition is removed).
-        assertFalse(store.data.containsKey(TP0_KEY));
+        assertFalse(store.data.containsKey(TP1_KEY));
 
         store.stop();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -320,6 +321,62 @@ public class KafkaOffsetBackingStoreTest {
         Map<ByteBuffer, ByteBuffer> offsets = store.get(Arrays.asList(null, TP1_KEY)).get(10000, TimeUnit.MILLISECONDS);
         assertEquals(TP0_VALUE, offsets.get(null));
         assertNull(offsets.get(TP1_KEY));
+
+        store.stop();
+
+        verify(storeLog).stop();
+    }
+
+    @Test
+    public void testTombstoneOffset() throws Exception {
+        // Second get() should get the produced data and return the new values
+        doAnswer(invocation -> {
+            capturedConsumedCallback.getValue().onCompletion(null,
+                    new ConsumerRecord<>(TOPIC, 1, 0, 0L, TimestampType.CREATE_TIME, 0, 0, TP0_KEY.array(), TP0_VALUE.array(),
+                            new RecordHeaders(), Optional.empty()));
+            storeLogCallbackArgumentCaptor.getValue().onCompletion(null, null);
+            return null;
+        }).when(storeLog).readToEnd(storeLogCallbackArgumentCaptor.capture());
+
+        store.configure(mockConfig(props));
+        store.start();
+
+        verify(storeLog).start();
+
+        Map<ByteBuffer, ByteBuffer> toSet = new HashMap<>();
+        toSet.put(TP0_KEY, TP0_VALUE);
+        final AtomicBoolean invoked = new AtomicBoolean(false);
+        Future<Void> setFuture = store.set(toSet, (error, result) -> invoked.set(true));
+        assertFalse(setFuture.isDone());
+
+        // Set offsets
+        ArgumentCaptor<org.apache.kafka.clients.producer.Callback> callback0 = ArgumentCaptor.forClass(org.apache.kafka.clients.producer.Callback.class);
+        verify(storeLog).send(aryEq(TP0_KEY.array()), aryEq(TP0_VALUE.array()), callback0.capture());
+        callback0.getValue().onCompletion(null, null);
+        setFuture.get(10000, TimeUnit.MILLISECONDS);
+        assertTrue(invoked.get());
+
+        // Getting data should read to end of our published data and return it
+        Map<ByteBuffer, ByteBuffer> offsets = store.get(Arrays.asList(null, TP0_KEY)).get(10000, TimeUnit.MILLISECONDS);
+        assertEquals(TP0_VALUE, offsets.get(TP0_KEY));
+
+        doAnswer(invocation -> {
+            // Read null offset for TP0_KEY (tombstone message)
+            capturedConsumedCallback.getValue().onCompletion(null,
+                    new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0, 0, TP0_KEY.array(), null,
+                            new RecordHeaders(), Optional.empty()));
+            storeLogCallbackArgumentCaptor.getValue().onCompletion(null, null);
+            return null;
+        }).when(storeLog).readToEnd(storeLogCallbackArgumentCaptor.capture());
+
+        // Getting data should read to end of our published data and return it
+        offsets = store.get(Collections.singletonList(TP0_KEY)).get(10000, TimeUnit.MILLISECONDS);
+        assertNull(offsets.get(TP0_KEY));
+
+        // Just verifying that KafkaOffsetBackingStore::get returns null isn't enough, we also need to verify that the mapping for the source partition key is removed.
+        // This is because KafkaOffsetBackingStore::get returns null if either there is no existing offset for the source partition or if there is an offset with null value.
+        // We need to make sure that tombstoned offsets are removed completely (i.e. that the mapping for the corresponding source partition is removed).
+        assertFalse(store.data.containsKey(TP0_KEY));
 
         store.stop();
 


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-14342
- [KafkaOffsetBackingStore](https://github.com/apache/kafka/blob/56d588d55ac313c0efca586a3bcd984c99a89018/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java#L70) is used to track source connector offsets using a backing Kafka topic. It implements interface methods to get and set offsets using a [KafkaBasedLog](https://github.com/apache/kafka/blob/56d588d55ac313c0efca586a3bcd984c99a89018/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java#L80). It also maintains an in-memory map containing {partition, offset} entries for source connectors (which is populated via the consumer callback mechanism from the KafkaBasedLog).
- When a tombstone offset (i.e. Kafka message with a null value) is encountered for a source partition, the map is simply updated to make the value null for the corresponding partition key. For certain source connectors which have a lot of source partitions that are "closed" frequently, this can be very problematic. Imagine a file source connector which reads data from all files in a directory line-by-line (and where file appends are not tracked) - each file corresponds to a source partition here, and the offset would be the line number in the file. If there are millions of files being read, this can bring down the Connect worker due to JVM heap exhaustion (OOM) caused by the in-memory map in KafkaOffsetBackingStore growing too large.
- Even if the connector writes tombstone offsets for the last record in a source partition, this doesn't help completely since we don't currently remove entries from KafkaOffsetBackingStore's in-memory offset map (so the source partition keys will stick around in the map), even though we indicate here that tombstones can be used to "delete" offsets - https://github.com/apache/kafka/blob/56d588d55ac313c0efca586a3bcd984c99a89018/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java#L37
- This shouldn't have any other side effects because [Map::get](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#get-java.lang.Object-) returns `null` if the map contains no mapping for a key.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
