### PR TITLE
KAFKA-14343: Upgrade tests for state updater 

### DIFF
--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -211,13 +211,11 @@ class StreamsUpgradeTest(Test):
         else:
             extra_properties = {}
 
-
         self.set_up_services()
 
         self.driver.start()
 
         self.start_all_nodes_with(from_version, extra_properties)
-
 
         counter = 1
         random.seed()

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -296,7 +296,7 @@ class StreamsUpgradeTest(Test):
         # rolling bounce
         random.shuffle(self.processors)
         for p in self.processors:
-            p.CLEAN_NODE_ENABLED = False
+            p.CLEAN_NODE_ENABLED = True
             self.do_stop_start_bounce(p, None, second_version, counter, extra_properties_second)
             counter = counter + 1
 


### PR DESCRIPTION
[KAFKA-14343](https://issues.apache.org/jira/browse/KAFKA-14343): Upgrade tests for state updater
A test that verifies the upgrade from a version of Streams with
state updater disabled to a version with state updater enabled
and vice versa, so that we can offer a save upgrade path.

 - upgrade test from a version of Streams with state updater
disabled to a version with state updater enabled
 - downgrade test from a version of Streams with state updater
 enabled to a version with state updater disabled

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
