### PR TITLE
KAFKA-14311: Connect Worker clean shutdown does not cleanly stop connectors/tasks

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -778,7 +778,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     // reading to the end of the config topic + successfully attempting to stop all connectors and tasks and a buffer of 10s
     private long herderExecutorTimeoutMs() {
         return this.workerSyncTimeoutMs +
-                config.getInt(DistributedConfig.WORKER_SYNC_TIMEOUT_MS_CONFIG) +
+                config.getLong(DistributedConfig.TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG) +
                 Worker.CONNECTOR_GRACEFUL_SHUTDOWN_TIMEOUT_MS + 10000;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -776,7 +776,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     // Timeout for herderExecutor to gracefully terminate is set to a value to accommodate
     // reading to the end of the config topic + successfully attempting to stop all connectors and tasks and a buffer of 10s
-    private long getHerderExecutorTimeoutMs() {
+    private long herderExecutorTimeoutMs() {
         return this.workerSyncTimeoutMs +
                 config.getInt(DistributedConfig.WORKER_SYNC_TIMEOUT_MS_CONFIG) +
                 Worker.CONNECTOR_GRACEFUL_SHUTDOWN_TIMEOUT_MS + 10000;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -790,7 +790,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         member.wakeup();
         herderExecutor.shutdown();
         try {
-            if (!herderExecutor.awaitTermination(getHerderExecutorTimeoutMs() , TimeUnit.MILLISECONDS))
+            if (!herderExecutor.awaitTermination(getHerderExecutorTimeoutMs(), TimeUnit.MILLISECONDS))
                 herderExecutor.shutdownNow();
 
             forwardRequestExecutor.shutdown();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -789,7 +789,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         member.wakeup();
         herderExecutor.shutdown();
         try {
-            if (!herderExecutor.awaitTermination(HERDER_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+            if (!herderExecutor.awaitTermination(Math.max(workerTasksShutdownTimeoutMs, HERDER_SHUTDOWN_TIMEOUT_MS), TimeUnit.MILLISECONDS))
                 herderExecutor.shutdownNow();
 
             forwardRequestExecutor.shutdown();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1783,8 +1783,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         };
     }
 
-    // visible for testing
-    Callable<Void> getTaskStoppingCallable(final ConnectorTaskId taskId) {
+    private Callable<Void> getTaskStoppingCallable(final ConnectorTaskId taskId) {
         return () -> {
             worker.stopAndAwaitTask(taskId);
             return null;
@@ -1841,8 +1840,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         };
     }
 
-    // Visible for testing
-    Callable<Void> getConnectorStoppingCallable(final String connectorName) {
+    private Callable<Void> getConnectorStoppingCallable(final String connectorName) {
         return () -> {
             try {
                 worker.stopAndAwaitConnector(connectorName);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -147,7 +147,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private final Logger log;
 
     private static final long FORWARD_REQUEST_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
-    private static final long START_AND_STOP_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
+    private static final long START_AND_STOP_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5);
     private static final long RECONFIGURE_CONNECTOR_TASKS_BACKOFF_MS = 250;
     private static final long CONFIG_TOPIC_WRITE_PRIVILEGES_BACKOFF_MS = 250;
     private static final int START_STOP_THREAD_POOL_SIZE = 8;
@@ -1665,7 +1665,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         } catch (InterruptedException e) {
             // ignore
         } catch (RejectedExecutionException re) {
-            log.error("startAndStopExecutor already shutdown or full. Not invoking explicit connector/task shutdown");
+            log.error("startAndStopExecutor already shutdown or full. Not invoking explicit connector/task start/stop");
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1668,8 +1668,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         } catch (RejectedExecutionException e) {
             // Shutting down. Just log the exception
             if (stopping.get()) {
-                log.debug("RejectedExecutionException thrown while herder is shutting down. This could be " +
-                        "because startAndStopExecutor is either already shutdown or is full.");
+                log.debug("Ignoring RejectedExecutionException thrown while starting/stopping connectors/tasks en masse " +
+                        "as the herder is already in the process of shutting down. This is not indicative of a problem and is normal behavior");
             } else {
                 throw e;
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -790,7 +790,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         member.wakeup();
         herderExecutor.shutdown();
         try {
-            if (!herderExecutor.awaitTermination(getHerderExecutorTimeoutMs(), TimeUnit.MILLISECONDS))
+            if (!herderExecutor.awaitTermination(herderExecutorTimeoutMs(), TimeUnit.MILLISECONDS))
                 herderExecutor.shutdownNow();
 
             forwardRequestExecutor.shutdown();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3630,20 +3630,19 @@ public class DistributedHerderTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = RejectedExecutionException.class)
-    @SuppressWarnings("unchecked")
-    public void shouldThrowWhenStartAndStopExecutorThrowsRejectedExecutionExceptionAndHerderNotStopping() throws InterruptedException {
-        ExecutorService startAndStopExecutor = EasyMock.mock(ExecutorService.class);
-        herder.startAndStopExecutor = startAndStopExecutor;
+    @Test
+    public void shouldThrowWhenStartAndStopExecutorThrowsRejectedExecutionExceptionAndHerderNotStopping() {
+        EasyMock.expect(member.memberId()).andStubReturn("leader");
+        expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList(), true);
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+        EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
 
-        Callable<Void> connectorStartingCallable = () -> null;
+        PowerMock.replayAll();
 
-        EasyMock.expect(startAndStopExecutor.invokeAll(EasyMock.anyObject(Collection.class))).andThrow(new RejectedExecutionException());
+        herder.startAndStopExecutor.shutdown();
+        assertThrows(RejectedExecutionException.class, herder::tick);
 
-        PowerMock.replayAll(startAndStopExecutor);
-
-        herder.startAndStop(Collections.singletonList(connectorStartingCallable));
-
+        PowerMock.verifyAll();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -101,7 +101,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -118,7 +117,6 @@ import static org.apache.kafka.connect.runtime.distributed.IncrementalCooperativ
 import static org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeConnectProtocol.CONNECT_PROTOCOL_V2;
 import static org.apache.kafka.connect.source.SourceTask.TransactionBoundary.CONNECTOR;
 import static org.easymock.EasyMock.anyLong;
-import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.leq;
@@ -3641,37 +3639,6 @@ public class DistributedHerderTest {
 
         herder.startAndStopExecutor.shutdown();
         assertThrows(RejectedExecutionException.class, herder::tick);
-
-        PowerMock.verifyAll();
-    }
-
-    @Test
-    public void shouldHaltCleanlyWhenHerderStartsAndStopsAndConfigTopicReadTimesOut() throws TimeoutException {
-        connectProtocolVersion = CONNECT_PROTOCOL_V1;
-        EasyMock.expect(member.memberId()).andStubReturn("member");
-        EasyMock.expect(member.currentProtocolVersion()).andStubReturn(connectProtocolVersion);
-        final int rebalanceDelayMs = 20000;
-
-        // Assign the connector to this worker, and have it start
-        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList(), rebalanceDelayMs);
-
-        member.wakeup();
-        PowerMock.expectLastCall();
-        member.requestRejoin();
-        PowerMock.expectLastCall();
-        member.maybeLeaveGroup(anyString());
-        PowerMock.expectLastCall();
-
-        // Read to config topic times out
-        configBackingStore.refresh(anyLong(), EasyMock.anyObject(TimeUnit.class));
-        EasyMock.expectLastCall().andThrow(new TimeoutException());
-
-        PowerMock.replayAll();
-
-        // Start the herder
-        herder.tick();
-        // and immediately stop it.
-        herder.stop();
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -711,7 +711,7 @@ public class DistributedHerderTest {
             herder.halt();
             assertTrue(appender.getEvents().stream().anyMatch(
                     event -> event.getLevel().equals("ERROR")
-                    && event.getMessage().contains("startAndStopExecutor already shutdown or full. Not invoking explicit connector/task shutdown")));
+                    && event.getMessage().contains("startAndStopExecutor already shutdown or full. Not invoking explicit connector/task start/stop")));
             PowerMock.verifyAll();
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3673,6 +3673,7 @@ public class DistributedHerderTest {
         // and immediately stop it.
         herder.stop();
 
+        PowerMock.verifyAll();
     }
 
     private void expectRebalance(final long offset,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
@@ -100,6 +101,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -682,6 +684,36 @@ public class DistributedHerderTest {
         herder.halt();
 
         PowerMock.verifyAll();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testStartAndStopExecutorShutdownShouldHaltCleanly() throws InterruptedException {
+        ExecutorService startAndStopExecutor = EasyMock.mock(ExecutorService.class);
+        herder.startAndStopExecutor = startAndStopExecutor;
+
+        EasyMock.expect(worker.connectorNames()).andReturn(Collections.singleton(CONN1));
+        EasyMock.expect(worker.taskIds()).andReturn(Collections.singleton(TASK1));
+        member.stop();
+        PowerMock.expectLastCall();
+        configBackingStore.stop();
+        PowerMock.expectLastCall();
+        statusBackingStore.stop();
+        PowerMock.expectLastCall();
+        worker.stop();
+        PowerMock.expectLastCall();
+
+        EasyMock.expect(startAndStopExecutor.invokeAll(EasyMock.anyObject(Collection.class))).andThrow(new RejectedExecutionException());
+
+        PowerMock.replayAll(startAndStopExecutor);
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(DistributedHerder.class)) {
+            herder.halt();
+            assertTrue(appender.getEvents().stream().anyMatch(
+                    event -> event.getLevel().equals("ERROR")
+                    && event.getMessage().contains("startAndStopExecutor already shutdown or full. Not invoking explicit connector/task shutdown")));
+            PowerMock.verifyAll();
+        }
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3661,18 +3661,6 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
         member.maybeLeaveGroup(anyString());
         PowerMock.expectLastCall();
-        worker.stopAndAwaitConnectors();
-        PowerMock.expectLastCall();
-        worker.stopAndAwaitTasks();
-        PowerMock.expectLastCall();
-        member.stop();
-        PowerMock.expectLastCall();
-        configBackingStore.stop();
-        PowerMock.expectLastCall();
-        statusBackingStore.stop();
-        PowerMock.expectLastCall();
-        worker.stop();
-        PowerMock.expectLastCall();
 
         // Read to config topic times out
         configBackingStore.refresh(anyLong(), EasyMock.anyObject(TimeUnit.class));


### PR DESCRIPTION
When the DistributedHerder::stop() method called, it triggers asynchronous shutdown of the background herder thread, and continues with synchronous shutdown of some other resources, including the stopAndStartExecutor.

This executor is responsible for cleanly stopping connectors and tasks, which it  the DistributedHerder::halt() method. There is a race condition between the halt() method asynchronously submitting these connector/task stop jobs and the stop() method terminating the executor. If the executor is terminated first, this exception appears:

```
[2022-10-17 16:29:23,396] ERROR [Worker clientId=connect-2, groupId=connect-integration-test-connect-cluster-1] Uncaught exception in herder work thread, exiting:  (org.apache.kafka.connect.runtime.distributed.DistributedHerder:366)
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@62878e25[Not completed, task = org.apache.kafka.connect.runtime.distributed.DistributedHerder$$Lambda$2285/0x00000008015046a8@58deade3] rejected from java.util.concurrent.ThreadPoolExecutor@10351ac3[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1]
    at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2065)
    at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:833)
    at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1365)
    at java.base/java.util.concurrent.AbstractExecutorService.invokeAll(AbstractExecutorService.java:247)
    at org.apache.kafka.connect.runtime.distributed.DistributedHerder.startAndStop(DistributedHerder.java:1667)
    at org.apache.kafka.connect.runtime.distributed.DistributedHerder.halt(DistributedHerder.java:765)
    at org.apache.kafka.connect.runtime.distributed.DistributedHerder.run(DistributedHerder.java:361)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:833)
```

This PR aims to handle the above exception cleanly and log the error.