### PR TITLE
Add FindCoordinator and Commit Functionalities

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -87,7 +87,7 @@
               files="(Utils|Topic|KafkaLZ4BlockOutputStream|AclData|JoinGroupRequest).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(ConsumerCoordinator|Fetcher|KafkaProducer|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler).java"/>
+              files="(ConsumerCoordinator|DefaultAsyncCoordinator|Fetcher|KafkaProducer|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler).java"/>
 
     <suppress checks="JavaNCSS"
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractAsyncCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractAsyncCoordinator.java
@@ -1,0 +1,587 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Meter;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.HeartbeatRequest;
+import org.apache.kafka.common.requests.HeartbeatResponse;
+import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.slf4j.Logger;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * AbstractAsyncCoordinator implements group management for a single group member by interacting with
+ * a designated Kafka broker (the coordinator). Group semantics are provided by extending this class.
+ * See {@link DefaultAsyncCoordinator} for example usage.
+ * */
+public class AbstractAsyncCoordinator implements Closeable {
+    private final Logger log;
+    private final Time time;
+    final ConsumerNetworkClient networkClient;
+    final GroupRebalanceConfig rebalanceConfig;
+    private final GroupCoordinatorMetrics sensors;
+    private Node coordinator = null;
+    private RequestFuture<Void> findCoordinatorFuture = null;
+    private volatile RuntimeException fatalFindCoordinatorException = null;
+    protected Generation generation = Generation.NO_GENERATION;
+    private long lastRebalanceEndMs = -1L;
+    private long lastTimeOfConnectionMs = -1L;
+
+    public AbstractAsyncCoordinator(
+            final Time time,
+            final LogContext logContext,
+            final GroupRebalanceConfig rebalanceConfig,
+            final ConsumerNetworkClient networkClient,
+            final Metrics metrics,
+            final String metricGrpPrefix) {
+        Objects.requireNonNull(rebalanceConfig.groupId,
+                "Expected a non-null group id for coordinator construction");
+        this.log = logContext.logger(this.getClass());
+        this.time = time;
+        this.rebalanceConfig = rebalanceConfig;
+        this.networkClient = networkClient;
+        this.sensors = new GroupCoordinatorMetrics(metrics, metricGrpPrefix);
+    }
+
+    /**
+     * Check if we know who the coordinator is and we have an active connection
+     * @return true if the coordinator is unknown
+     */
+    public boolean coordinatorUnknown() {
+        return checkAndGetCoordinator() == null;
+    }
+
+    /**
+     * Get the coordinator if its connection is still active. Otherwise mark it unknown and
+     * return null.
+     *
+     * @return the current coordinator or null if it is unknown
+     */
+    protected synchronized Node checkAndGetCoordinator() {
+        if (coordinator != null && networkClient.isUnavailable(coordinator)) {
+            markCoordinatorUnknown(true, "coordinator unavailable");
+            return null;
+        }
+        return this.coordinator;
+    }
+
+    protected synchronized void markCoordinatorUnknown(Errors error) {
+        markCoordinatorUnknown(false, "error response " + error.name());
+    }
+
+    protected synchronized void markCoordinatorUnknown(String cause) {
+        markCoordinatorUnknown(false, cause);
+    }
+
+    protected synchronized void markCoordinatorUnknown(boolean isDisconnected, String cause) {
+        if (this.coordinator != null) {
+            log.info("Group coordinator {} is unavailable or invalid due to cause: {}. "
+                            + "isDisconnected: {}. Rediscovery will be attempted.", this.coordinator,
+                    cause, isDisconnected);
+            Node oldCoordinator = this.coordinator;
+
+            // Mark the coordinator dead before disconnecting requests since the callbacks for any pending
+            // requests may attempt to do likewise. This also prevents new requests from being sent to the
+            // coordinator while the disconnect is in progress.
+            this.coordinator = null;
+
+            // Disconnect from the coordinator to ensure that there are no in-flight requests remaining.
+            // Pending callbacks will be invoked with a DisconnectException on the next call to poll.
+            if (!isDisconnected) {
+                log.info("Requesting disconnect from last known coordinator {}", oldCoordinator);
+                networkClient.disconnectAsync(oldCoordinator);
+            }
+
+            lastTimeOfConnectionMs = time.milliseconds();
+        } else {
+            long durationOfOngoingDisconnect = time.milliseconds() - lastTimeOfConnectionMs;
+            if (durationOfOngoingDisconnect > rebalanceConfig.rebalanceTimeoutMs)
+                log.warn("Consumer has been disconnected from the group coordinator for {}ms", durationOfOngoingDisconnect);
+        }
+    }
+
+    /**
+     * Ensure that the coordinator is ready to receive requests. This will return
+     * immediately without blocking. It is intended to be called in an asynchronous
+     * context when wakeups are not expected.
+     *
+     * @return true If coordinator discovery and initial connection succeeded, false otherwise
+     */
+    protected synchronized boolean ensureCoordinatorReadyAsync() {
+        return ensureCoordinatorReady(time.timer(0), true);
+    }
+
+    /**
+     * Ensure that the coordinator is ready to receive requests.
+     *
+     * @param timer Timer bounding how long this method can block
+     * @return true If coordinator discovery and initial connection succeeded, false otherwise
+     */
+    protected  boolean ensureCoordinatorReady(final Timer timer) {
+        return ensureCoordinatorReady(timer, false);
+    }
+
+    private boolean ensureCoordinatorReady(final Timer timer, boolean disableWakeup) {
+        if (!coordinatorUnknown())
+            return true;
+
+        do {
+            if (fatalFindCoordinatorException != null) {
+                final RuntimeException fatalException = fatalFindCoordinatorException;
+                fatalFindCoordinatorException = null;
+                throw fatalException;
+            }
+            final RequestFuture<Void> future = lookupCoordinator();
+            networkClient.poll(future, timer, disableWakeup);
+
+            if (!future.isDone()) {
+                // ran out of time
+                break;
+            }
+
+            RuntimeException fatalException = null;
+
+            if (future.failed()) {
+                if (future.isRetriable()) {
+                    log.debug("Coordinator discovery failed, refreshing metadata", future.exception());
+                    networkClient.awaitMetadataUpdate(timer);
+                } else {
+                    fatalException = future.exception();
+                    log.info("FindCoordinator request hit fatal exception", fatalException);
+                }
+            } else if (coordinator != null && networkClient.isUnavailable(coordinator)) {
+                // we found the coordinator, but the connection has failed, so mark
+                // it dead and backoff before retrying discovery
+                markCoordinatorUnknown("coordinator unavailable");
+                timer.sleep(rebalanceConfig.retryBackoffMs);
+            }
+
+            clearFindCoordinatorFuture();
+            if (fatalException != null)
+                throw fatalException;
+        } while (coordinatorUnknown() && timer.notExpired());
+
+        return !coordinatorUnknown();
+    }
+
+    private synchronized void clearFindCoordinatorFuture() {
+        findCoordinatorFuture = null;
+    }
+
+    protected RequestFuture<Void> lookupCoordinator() {
+        if (findCoordinatorFuture == null) {
+            // find a node to ask about the coordinator
+            Node node = this.networkClient.leastLoadedNode();
+            if (node == null) {
+                log.debug("No broker available to send FindCoordinator request");
+                return RequestFuture.noBrokersAvailable();
+            } else {
+                findCoordinatorFuture = sendFindCoordinatorRequest(node);
+            }
+        }
+        return findCoordinatorFuture;
+    }
+
+    /**
+     * Discover the current coordinator for the group. Sends a GroupMetadata request to
+     * one of the brokers. The returned future should be polled to get the result of the request.
+     * @return A request future which indicates the completion of the metadata request
+     */
+    private RequestFuture<Void> sendFindCoordinatorRequest(Node node) {
+        // initiate the group metadata request
+        log.debug("Sending FindCoordinator request to broker {}", node);
+        FindCoordinatorRequestData data = new FindCoordinatorRequestData()
+                .setKeyType(FindCoordinatorRequest.CoordinatorType.GROUP.id())
+                .setKey(this.rebalanceConfig.groupId);
+        FindCoordinatorRequest.Builder requestBuilder = new FindCoordinatorRequest.Builder(data);
+        return networkClient.send(node, requestBuilder)
+                .compose(new FindCoordinatorResponseHandler());
+    }
+
+    private class FindCoordinatorResponseHandler extends RequestFutureAdapter<ClientResponse, Void> {
+
+        @Override
+        public void onSuccess(ClientResponse resp, RequestFuture<Void> future) {
+            log.debug("Received FindCoordinator response {}", resp);
+
+            List<FindCoordinatorResponseData.Coordinator> coordinators = ((FindCoordinatorResponse) resp.responseBody()).coordinators();
+            if (coordinators.size() != 1) {
+                log.error("Group coordinator lookup failed: Invalid response containing more than a single coordinator");
+                future.raise(new IllegalStateException("Group coordinator lookup failed: Invalid response containing more than a single coordinator"));
+            }
+            FindCoordinatorResponseData.Coordinator coordinatorData = coordinators.get(0);
+            Errors error = Errors.forCode(coordinatorData.errorCode());
+            if (error == Errors.NONE) {
+                synchronized (AbstractAsyncCoordinator.this) {
+                    // use MAX_VALUE - node.id as the coordinator id to allow separate connections
+                    // for the coordinator in the underlying network client layer
+                    int coordinatorConnectionId = Integer.MAX_VALUE - coordinatorData.nodeId();
+
+                    AbstractAsyncCoordinator.this.coordinator = new Node(
+                            coordinatorConnectionId,
+                            coordinatorData.host(),
+                            coordinatorData.port());
+                    log.info("Discovered group coordinator {}", coordinator);
+                    networkClient.tryConnect(coordinator);
+                    // TODO: implement after adding the HBT
+                    //heartbeat.resetSessionTimeout();
+                }
+                future.complete(null);
+            } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
+                future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));
+            } else {
+                log.debug("Group coordinator lookup failed: {}", coordinatorData.errorMessage());
+                future.raise(error);
+            }
+        }
+
+        @Override
+        public void onFailure(RuntimeException e, RequestFuture<Void> future) {
+            log.debug("FindCoordinator request failed due to {}", e.toString());
+
+            if (!(e instanceof RetriableException)) {
+                // Remember the exception if fatal so we can ensure it gets thrown by the main thread
+                fatalFindCoordinatorException = e;
+            }
+
+            super.onFailure(e, future);
+        }
+    }
+
+    public boolean hasGroup() {
+        // TODO: this.state == stable
+        return true;
+    }
+
+    boolean rebalanceInProgress() {
+        // TODO: state in [rebalance states]
+        return true;
+    }
+
+    private synchronized Node coordinator() {
+        return this.coordinator;
+    }
+
+    synchronized RequestFuture<Void> sendHeartbeatRequest() {
+        log.debug("Sending Heartbeat request with generation {} and member id {} to coordinator {}",
+                generation.generationId, generation.memberId, coordinator);
+        HeartbeatRequest.Builder requestBuilder =
+                new HeartbeatRequest.Builder(new HeartbeatRequestData()
+                        .setGroupId(rebalanceConfig.groupId)
+                        .setMemberId(this.generation.memberId)
+                        .setGroupInstanceId(this.rebalanceConfig.groupInstanceId.orElse(null))
+                        .setGenerationId(this.generation.generationId));
+        return networkClient.send(coordinator, requestBuilder)
+                .compose(new HeartbeatResponseHandler(generation));
+    }
+
+    private class HeartbeatResponseHandler extends CoordinatorResponseHandler<HeartbeatResponse, Void> {
+        private HeartbeatResponseHandler(final Generation generation) {
+            super(generation);
+        }
+
+        @Override
+        public void handle(HeartbeatResponse heartbeatResponse, RequestFuture<Void> future) {
+            sensors.heartbeatSensor.record(response.requestLatencyMs());
+            Errors error = heartbeatResponse.error();
+
+            if (error == Errors.NONE) {
+                log.debug("Received successful Heartbeat response");
+                future.complete(null);
+            } else if (error == Errors.COORDINATOR_NOT_AVAILABLE
+                    || error == Errors.NOT_COORDINATOR) {
+                log.info("Attempt to heartbeat failed since coordinator {} is either not started or not valid",
+                        coordinator());
+                markCoordinatorUnknown(error);
+                future.raise(error);
+            } else if (error == Errors.REBALANCE_IN_PROGRESS) {
+                // TODO: Implement after rebalance protocol
+            } else if (error == Errors.ILLEGAL_GENERATION ||
+                    error == Errors.UNKNOWN_MEMBER_ID ||
+                    error == Errors.FENCED_INSTANCE_ID) {
+                // TODO: Implement after rebalance protocol
+            } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
+                future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));
+            } else {
+                future.raise(new KafkaException("Unexpected error in heartbeat response: " + error.message()));
+            }
+        }
+    }
+
+
+    @Override
+    public void close() {
+    }
+
+    protected Meter createMeter(
+            Metrics metrics,
+            String groupName,
+            String baseName,
+            String descriptiveName) {
+        return new Meter(new WindowedCount(),
+                metrics.metricName(baseName + "-rate", groupName,
+                        String.format("The number of %s per second", descriptiveName)),
+                metrics.metricName(baseName + "-total", groupName,
+                        String.format("The total number of %s", descriptiveName)));
+    }
+
+    protected abstract class CoordinatorResponseHandler<R, T> extends RequestFutureAdapter<ClientResponse, T> {
+
+        final Generation sentGeneration;
+        ClientResponse response;
+
+        CoordinatorResponseHandler(final Generation generation) {
+            this.sentGeneration = generation;
+        }
+
+        public abstract void handle(R response, RequestFuture<T> future);
+
+        @Override
+        public void onFailure(RuntimeException e, RequestFuture<T> future) {
+            // mark the coordinator as dead
+            if (e instanceof DisconnectException) {
+                markCoordinatorUnknown(true, e.getMessage());
+            }
+            future.raise(e);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void onSuccess(ClientResponse clientResponse, RequestFuture<T> future) {
+            try {
+                this.response = clientResponse;
+                R responseObj = (R) clientResponse.responseBody();
+                handle(responseObj, future);
+            } catch (RuntimeException e) {
+                if (!future.isDone())
+                    future.raise(e);
+            }
+        }
+
+        boolean generationUnchanged() {
+            synchronized (AbstractAsyncCoordinator.this) {
+                return generation.equals(sentGeneration);
+            }
+        }
+
+        synchronized void resetStateOnResponseError(ApiKeys api, Errors error, boolean shouldResetMemberId) {
+            /*
+            TODO: to implement
+            final String reason = String.format("encountered %s from %s response", error, api);
+            resetStateAndRejoin(reason, shouldResetMemberId);
+             */
+        }
+
+        private synchronized void resetStateAndRejoin(final String reason, final boolean shouldResetMemberId) {
+            /*
+            TODO: to implement
+            resetStateAndGeneration(reason, shouldResetMemberId);
+            requestRejoin(reason);
+            needsJoinPrepare = true;
+             */
+        }
+    }
+
+
+    protected static class Generation {
+        public static final Generation NO_GENERATION = new Generation(
+                OffsetCommitRequest.DEFAULT_GENERATION_ID,
+                JoinGroupRequest.UNKNOWN_MEMBER_ID,
+                null);
+
+        public final int generationId;
+        public final String memberId;
+        public final String protocolName;
+
+        public Generation(int generationId, String memberId, String protocolName) {
+            this.generationId = generationId;
+            this.memberId = memberId;
+            this.protocolName = protocolName;
+        }
+
+        /**
+         * @return true if this generation has a valid member id, false otherwise. A member might have an id before
+         * it becomes part of a group generation.
+         */
+        public boolean hasMemberId() {
+            return !memberId.isEmpty();
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final Generation that = (Generation) o;
+            return generationId == that.generationId &&
+                    Objects.equals(memberId, that.memberId) &&
+                    Objects.equals(protocolName, that.protocolName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(generationId, memberId, protocolName);
+        }
+
+        @Override
+        public String toString() {
+            return "Generation{" +
+                    "generationId=" + generationId +
+                    ", memberId='" + memberId + '\'' +
+                    ", protocol='" + protocolName + '\'' +
+                    '}';
+        }
+    }
+
+    private class GroupCoordinatorMetrics {
+        public final String metricGrpName;
+        public final Sensor heartbeatSensor;
+        public final Sensor joinSensor;
+        public final Sensor syncSensor;
+        public final Sensor successfulRebalanceSensor;
+        public final Sensor failedRebalanceSensor;
+
+        public GroupCoordinatorMetrics(Metrics metrics, String metricGrpPrefix) {
+            this.metricGrpName = metricGrpPrefix + "-coordinator-metrics";
+
+            this.heartbeatSensor = metrics.sensor("heartbeat-latency");
+            this.heartbeatSensor.add(metrics.metricName("heartbeat-response-time-max",
+                    this.metricGrpName,
+                    "The max time taken to receive a response to a heartbeat request"), new Max());
+            this.heartbeatSensor.add(createMeter(metrics, metricGrpName, "heartbeat", "heartbeats"));
+
+            this.joinSensor = metrics.sensor("join-latency");
+            this.joinSensor.add(metrics.metricName("join-time-avg",
+                    this.metricGrpName,
+                    "The average time taken for a group rejoin"), new Avg());
+            this.joinSensor.add(metrics.metricName("join-time-max",
+                    this.metricGrpName,
+                    "The max time taken for a group rejoin"), new Max());
+            this.joinSensor.add(createMeter(metrics, metricGrpName, "join", "group joins"));
+
+            this.syncSensor = metrics.sensor("sync-latency");
+            this.syncSensor.add(metrics.metricName("sync-time-avg",
+                    this.metricGrpName,
+                    "The average time taken for a group sync"), new Avg());
+            this.syncSensor.add(metrics.metricName("sync-time-max",
+                    this.metricGrpName,
+                    "The max time taken for a group sync"), new Max());
+            this.syncSensor.add(createMeter(metrics, metricGrpName, "sync", "group syncs"));
+
+            this.successfulRebalanceSensor = metrics.sensor("rebalance-latency");
+            this.successfulRebalanceSensor.add(metrics.metricName("rebalance-latency-avg",
+                    this.metricGrpName,
+                    "The average time taken for a group to complete a successful rebalance, which may be composed of " +
+                            "several failed re-trials until it succeeded"), new Avg());
+            this.successfulRebalanceSensor.add(metrics.metricName("rebalance-latency-max",
+                    this.metricGrpName,
+                    "The max time taken for a group to complete a successful rebalance, which may be composed of " +
+                            "several failed re-trials until it succeeded"), new Max());
+            this.successfulRebalanceSensor.add(metrics.metricName("rebalance-latency-total",
+                            this.metricGrpName,
+                            "The total number of milliseconds this consumer has spent in successful rebalances since creation"),
+                    new CumulativeSum());
+            this.successfulRebalanceSensor.add(
+                    metrics.metricName("rebalance-total",
+                            this.metricGrpName,
+                            "The total number of successful rebalance events, each event is composed of " +
+                                    "several failed re-trials until it succeeded"),
+                    new CumulativeCount()
+            );
+            this.successfulRebalanceSensor.add(
+                    metrics.metricName(
+                            "rebalance-rate-per-hour",
+                            this.metricGrpName,
+                            "The number of successful rebalance events per hour, each event is composed of " +
+                                    "several failed re-trials until it succeeded"),
+                    new Rate(TimeUnit.HOURS, new WindowedCount())
+            );
+
+            this.failedRebalanceSensor = metrics.sensor("failed-rebalance");
+            this.failedRebalanceSensor.add(
+                    metrics.metricName("failed-rebalance-total",
+                            this.metricGrpName,
+                            "The total number of failed rebalance events"),
+                    new CumulativeCount()
+            );
+            this.failedRebalanceSensor.add(
+                    metrics.metricName(
+                            "failed-rebalance-rate-per-hour",
+                            this.metricGrpName,
+                            "The number of failed rebalance events per hour"),
+                    new Rate(TimeUnit.HOURS, new WindowedCount())
+            );
+
+            Measurable lastRebalance = (config, now) -> {
+                if (lastRebalanceEndMs == -1L)
+                    // if no rebalance is ever triggered, we just return -1.
+                    return -1d;
+                else
+                    return TimeUnit.SECONDS.convert(now - lastRebalanceEndMs, TimeUnit.MILLISECONDS);
+            };
+            metrics.addMetric(metrics.metricName("last-rebalance-seconds-ago",
+                            this.metricGrpName,
+                            "The number of seconds since the last successful rebalance event"),
+                    lastRebalance);
+            /*
+            Heartbeat metrics will be added in the future PR. This serves the
+             purpose of the reminder
+            Measurable lastHeartbeat = (config, now) -> {
+                if (heartbeat.lastHeartbeatSend() == 0L)
+                    // if no heartbeat is ever triggered, just return -1.
+                    return -1d;
+                else
+                    return TimeUnit.SECONDS.convert(now - heartbeat.lastHeartbeatSend(), TimeUnit.MILLISECONDS);
+            };
+            metrics.addMetric(metrics.metricName("last-heartbeat-seconds-ago",
+                            this.metricGrpName,
+                            "The number of seconds since the last coordinator heartbeat was sent"),
+                    lastHeartbeat);
+             */
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractAsyncCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractAsyncCoordinator.java
@@ -234,9 +234,9 @@ public class AbstractAsyncCoordinator implements Closeable {
     }
 
     /**
-     * Discover the current coordinator for the group. Sends a GroupMetadata request to
-     * one of the brokers. The returned future should be polled to get the result of the request.
-     * @return A request future which indicates the completion of the metadata request
+     * Send a FindCoordinator request to the given node to discover the current coordinator. The
+     * returned future should be polled to get the result of the request.
+     * @return A request future which indicates the completion of the request
      */
     private RequestFuture<Void> sendFindCoordinatorRequest(Node node) {
         log.debug("Sending FindCoordinator request to broker {}", node);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultAsyncCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultAsyncCoordinator.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
+import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.message.OffsetCommitResponseData;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DefaultAsyncCoordinator extends AbstractAsyncCoordinator {
+
+    private final Logger log;
+    private final SubscriptionState subscriptions;
+    private final AtomicInteger pendingAsyncCommits;
+    private final ConsumerCoordinatorMetrics sensors;
+
+    public DefaultAsyncCoordinator(
+            final Time time,
+            final LogContext logContext,
+            final GroupRebalanceConfig rebalanceConfig,
+            final ConsumerNetworkClient networkClient,
+            final SubscriptionState subscriptionState,
+            final Metrics metrics,
+            final String metricGrpPrefix) {
+        super(time, logContext, rebalanceConfig, networkClient, metrics,
+                metricGrpPrefix);
+        this.log = logContext.logger(getClass());
+        // this.defaultOffsetCommitCallback = new DefaultOffsetCommitCallback();
+        this.subscriptions = subscriptionState;
+        this.pendingAsyncCommits = new AtomicInteger();
+        this.sensors = new ConsumerCoordinatorMetrics(metrics, metricGrpPrefix);
+    }
+
+    public void commitOffsets(
+            final Map<TopicPartition, OffsetAndMetadata> offsets,
+            final RequestFuture<Void> future) {
+        // invoke completed offset
+        // invokeCompletedOffsetCommitCallbacks();
+        if (offsets.isEmpty()) {
+            // No need to check coordinator if offsets is empty since commit of empty offsets is completed locally.
+            doCommitOffsets(offsets).chain(future);
+        } else if (!coordinatorUnknownAndUnreadyAsync()) {
+            // we need to make sure coordinator is ready before committing, since
+            // this is for async committing we do not try to block, but just try once to
+            // clear the previous discover-coordinator future, resend, or get responses;
+            // if the coordinator is not ready yet then we would just proceed and put that into the
+            // pending requests, and future poll calls would still try to complete them.
+            //
+            // the key here though is that we have to try sending the discover-coordinator if
+            // it's not known or ready, since this is the only place we can send such request
+            // under manual assignment (there we would not have heartbeat thread trying to auto-rediscover
+            // the coordinator).
+            doCommitOffsets(offsets).chain(future);
+        } else {
+            // we don't know the current coordinator, so we will try to find
+            // it upon the next successful coordinator lookup. If the lookup
+            // succeed, these pending offsets will be committed; otherwise,
+            // they will fail with RetriableCommitFailedException().
+            pendingAsyncCommits.incrementAndGet();
+            lookupCoordinator().addListener(new RequestFutureListener<Void>() {
+                @Override
+                public void onSuccess(Void value) {
+                    pendingAsyncCommits.decrementAndGet();
+                    doCommitOffsets(offsets).chain(future);
+                    networkClient.pollNoWakeup();
+                }
+
+                @Override
+                public void onFailure(RuntimeException e) {
+                    pendingAsyncCommits.decrementAndGet();
+                    future.raise(new RetriableCommitFailedException(e));
+                }
+            });
+        }
+        networkClient.pollNoWakeup();
+    }
+
+    private boolean coordinatorUnknownAndUnreadyAsync() {
+        return coordinatorUnknown() && !ensureCoordinatorReadyAsync();
+    }
+
+    protected RequestFuture<Void> doCommitOffsets(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        RequestFuture<Void> future = sendOffsetCommitRequest(offsets);
+        return future;
+    }
+
+    /**
+     * Commit offsets for the specified list of topics and partitions. This is a non-blocking call
+     * which returns a request future that can be polled in the case of a synchronous commit or ignored in the
+     * asynchronous case.
+     *
+     * NOTE: This is visible only for testing
+     *
+     * @param offsets The list of offsets per partition that should be committed.
+     * @return A request future whose value indicates whether the commit was successful or not
+     */
+    RequestFuture<Void> sendOffsetCommitRequest(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        if (offsets.isEmpty())
+            return RequestFuture.voidSuccess();
+
+        Node coordinator = checkAndGetCoordinator();
+        if (coordinator == null)
+            return RequestFuture.coordinatorNotAvailable();
+
+        // create the offset commit request
+        Map<String, OffsetCommitRequestData.OffsetCommitRequestTopic> requestTopicDataMap = new HashMap<>();
+        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            OffsetAndMetadata offsetAndMetadata = entry.getValue();
+            if (offsetAndMetadata.offset() < 0) {
+                return RequestFuture.failure(new IllegalArgumentException("Invalid offset: " + offsetAndMetadata.offset()));
+            }
+
+            OffsetCommitRequestData.OffsetCommitRequestTopic topic = requestTopicDataMap
+                    .getOrDefault(topicPartition.topic(),
+                            new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                                    .setName(topicPartition.topic())
+                    );
+
+            topic.partitions().add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                    .setPartitionIndex(topicPartition.partition())
+                    .setCommittedOffset(offsetAndMetadata.offset())
+                    .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                    .setCommittedMetadata(offsetAndMetadata.metadata())
+            );
+            requestTopicDataMap.put(topicPartition.topic(), topic);
+        }
+
+        final Generation generation;
+        final String groupInstanceId;
+        if (subscriptions.hasAutoAssignedPartitions()) {
+            generation = generationIfStable();
+            groupInstanceId = rebalanceConfig.groupInstanceId.orElse(null);
+            // if the generation is null, we are not part of an active group (and we expect to be).
+            // the only thing we can do is fail the commit and let the user rejoin the group in poll().
+            if (generation == null) {
+                log.info("Failing OffsetCommit request since the consumer is not part of an active group");
+
+                if (rebalanceInProgress()) {
+                    // if the client knows it is already rebalancing, we can use RebalanceInProgressException instead of
+                    // CommitFailedException to indicate this is not a fatal error
+                    return RequestFuture.failure(new RebalanceInProgressException("Offset commit cannot be completed since the " +
+                            "consumer is undergoing a rebalance for auto partition assignment. You can try completing the rebalance " +
+                            "by calling poll() and then retry the operation."));
+                } else {
+                    return RequestFuture.failure(new CommitFailedException("Offset commit cannot be completed since the " +
+                            "consumer is not part of an active group for auto partition assignment; it is likely that the consumer " +
+                            "was kicked out of the group."));
+                }
+            }
+        } else {
+            generation = Generation.NO_GENERATION;
+            groupInstanceId = null;
+        }
+
+        OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(
+                new OffsetCommitRequestData()
+                        .setGroupId(this.rebalanceConfig.groupId)
+                        .setGenerationId(generation.generationId)
+                        .setMemberId(generation.memberId)
+                        .setGroupInstanceId(groupInstanceId)
+                        .setTopics(new ArrayList<>(requestTopicDataMap.values()))
+        );
+
+        log.trace("Sending OffsetCommit request with {} to coordinator {}", offsets, coordinator);
+
+        return networkClient.send(coordinator, builder)
+                .compose(new OffsetCommitResponseHandler(offsets, generation));
+    }
+
+
+    /**
+     * Get the current generation state if the group is stable, otherwise return null
+     *
+     * @return the current generation or null
+     */
+    protected synchronized Generation generationIfStable() {
+        if (!hasGroup())
+            return null;
+        return this.generation;
+    }
+
+    public void close(final Timer timer) {
+        // we do not need to re-enable wakeups since we are closing already
+        networkClient.disableWakeups();
+        try {
+            // TODO: Add auto-commit logic
+            // maybeAutoCommitOffsetsSync(timer);
+            while (pendingAsyncCommits.get() > 0 && timer.notExpired()) {
+                ensureCoordinatorReady(timer);
+                networkClient.poll(timer);
+            }
+        } finally {
+            super.close();
+        }
+    }
+
+    private class OffsetCommitResponseHandler extends CoordinatorResponseHandler<OffsetCommitResponse, Void> {
+        private final Map<TopicPartition, OffsetAndMetadata> offsets;
+
+        private OffsetCommitResponseHandler(Map<TopicPartition, OffsetAndMetadata> offsets, Generation generation) {
+            super(generation);
+            this.offsets = offsets;
+        }
+
+        @Override
+        public void handle(OffsetCommitResponse commitResponse, RequestFuture<Void> future) {
+            sensors.commitSensor.record(response.requestLatencyMs());
+            Set<String> unauthorizedTopics = new HashSet<>();
+
+            for (OffsetCommitResponseData.OffsetCommitResponseTopic topic : commitResponse.data().topics()) {
+                for (OffsetCommitResponseData.OffsetCommitResponsePartition partition : topic.partitions()) {
+                    TopicPartition tp = new TopicPartition(topic.name(), partition.partitionIndex());
+                    OffsetAndMetadata offsetAndMetadata = this.offsets.get(tp);
+
+                    long offset = offsetAndMetadata.offset();
+
+                    Errors error = Errors.forCode(partition.errorCode());
+                    if (error == Errors.NONE) {
+                        log.debug("Committed offset {} for partition {}", offset, tp);
+                    } else {
+                        if (error.exception() instanceof RetriableException) {
+                            log.warn("Offset commit failed on partition {} at offset {}: {}", tp, offset, error.message());
+                        } else {
+                            log.error("Offset commit failed on partition {} at offset {}: {}", tp, offset, error.message());
+                        }
+
+                        if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
+                            future.raise(GroupAuthorizationException.forGroupId(rebalanceConfig.groupId));
+                            return;
+                        } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
+                            unauthorizedTopics.add(tp.topic());
+                        } else if (error == Errors.OFFSET_METADATA_TOO_LARGE
+                                || error == Errors.INVALID_COMMIT_OFFSET_SIZE) {
+                            // raise the error to the user
+                            future.raise(error);
+                            return;
+                        } else if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS
+                                || error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
+                            // just retry
+                            future.raise(error);
+                            return;
+                        } else if (error == Errors.COORDINATOR_NOT_AVAILABLE
+                                || error == Errors.NOT_COORDINATOR
+                                || error == Errors.REQUEST_TIMED_OUT) {
+                            markCoordinatorUnknown(error);
+                            future.raise(error);
+                            return;
+                        } else if (error == Errors.FENCED_INSTANCE_ID) {
+                            log.info("OffsetCommit failed with {} due to group instance id {} fenced", sentGeneration, rebalanceConfig.groupInstanceId);
+
+                            // if the generation has changed or we are not in rebalancing, do not raise the fatal error but rebalance-in-progress
+                            if (generationUnchanged()) {
+                                future.raise(error);
+                            } else {
+                                // TODO: handle prepare rebalance error
+                                // future.raise(exception);
+                            }
+                            return;
+                        } else if (error == Errors.REBALANCE_IN_PROGRESS) {
+                            // TODO: handle rebalance in progress
+                            return;
+                        } else if (error == Errors.UNKNOWN_MEMBER_ID
+                                || error == Errors.ILLEGAL_GENERATION) {
+                            // TODO: handle invalid generation
+                            return;
+                        } else {
+                            future.raise(new KafkaException("Unexpected error in commit: " + error.message()));
+                            return;
+                        }
+                    }
+                }
+
+                if (!unauthorizedTopics.isEmpty()) {
+                    log.error("Not authorized to commit to topics {}", unauthorizedTopics);
+                    future.raise(new TopicAuthorizationException(unauthorizedTopics));
+                } else {
+                    future.complete(null);
+                }
+            }
+        }
+    }
+
+    private class ConsumerCoordinatorMetrics {
+        private final String metricGrpName;
+        private final Sensor commitSensor;
+        private final Sensor revokeCallbackSensor;
+        private final Sensor assignCallbackSensor;
+        private final Sensor loseCallbackSensor;
+
+        private ConsumerCoordinatorMetrics(Metrics metrics, String metricGrpPrefix) {
+            this.metricGrpName = metricGrpPrefix + "-coordinator-metrics";
+
+            this.commitSensor = metrics.sensor("commit-latency");
+            this.commitSensor.add(metrics.metricName("commit-latency-avg",
+                    this.metricGrpName,
+                    "The average time taken for a commit request"), new Avg());
+            this.commitSensor.add(metrics.metricName("commit-latency-max",
+                    this.metricGrpName,
+                    "The max time taken for a commit request"), new Max());
+            this.commitSensor.add(createMeter(metrics, metricGrpName, "commit", "commit calls"));
+
+            this.revokeCallbackSensor = metrics.sensor("partition-revoked-latency");
+            this.revokeCallbackSensor.add(metrics.metricName("partition-revoked-latency-avg",
+                    this.metricGrpName,
+                    "The average time taken for a partition-revoked rebalance listener callback"), new Avg());
+            this.revokeCallbackSensor.add(metrics.metricName("partition-revoked-latency-max",
+                    this.metricGrpName,
+                    "The max time taken for a partition-revoked rebalance listener callback"), new Max());
+
+            this.assignCallbackSensor = metrics.sensor("partition-assigned-latency");
+            this.assignCallbackSensor.add(metrics.metricName("partition-assigned-latency-avg",
+                    this.metricGrpName,
+                    "The average time taken for a partition-assigned rebalance listener callback"), new Avg());
+            this.assignCallbackSensor.add(metrics.metricName("partition-assigned-latency-max",
+                    this.metricGrpName,
+                    "The max time taken for a partition-assigned rebalance listener callback"), new Max());
+
+            this.loseCallbackSensor = metrics.sensor("partition-lost-latency");
+            this.loseCallbackSensor.add(metrics.metricName("partition-lost-latency-avg",
+                    this.metricGrpName,
+                    "The average time taken for a partition-lost rebalance listener callback"), new Avg());
+            this.loseCallbackSensor.add(metrics.metricName("partition-lost-latency-max",
+                    this.metricGrpName,
+                    "The max time taken for a partition-lost rebalance listener callback"), new Max());
+
+            Measurable numParts = (config, now) -> subscriptions.numAssignedPartitions();
+            metrics.addMetric(metrics.metricName("assigned-partitions",
+                    this.metricGrpName,
+                    "The number of partitions currently assigned to this consumer"), numParts);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
@@ -82,6 +81,7 @@ public class DefaultBackgroundThread extends KafkaThread {
                                    final SubscriptionState subscriptions,
                                    final ConsumerMetadata metadata,
                                    final ConsumerNetworkClient networkClient,
+                                   final DefaultAsyncCoordinator coordinator,
                                    final Metrics metrics) {
         this(
             Time.SYSTEM,
@@ -92,6 +92,7 @@ public class DefaultBackgroundThread extends KafkaThread {
             subscriptions,
             metadata,
             networkClient,
+            coordinator,
             metrics
         );
     }
@@ -104,6 +105,7 @@ public class DefaultBackgroundThread extends KafkaThread {
                                    final SubscriptionState subscriptions,
                                    final ConsumerMetadata metadata,
                                    final ConsumerNetworkClient networkClient,
+                                   final DefaultAsyncCoordinator coordinator,
                                    final Metrics metrics) {
         super(BACKGROUND_THREAD_NAME, true);
         try {
@@ -119,16 +121,7 @@ public class DefaultBackgroundThread extends KafkaThread {
             this.metadata = metadata;
             this.networkClient = networkClient;
             this.metrics = metrics;
-            final GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
-                    GroupRebalanceConfig.ProtocolType.CONSUMER);
-            this.coordinator = new DefaultAsyncCoordinator(
-                    time,
-                    logContext,
-                    groupRebalanceConfig,
-                    networkClient,
-                    subscriptions,
-                    metrics,
-                    METRIC_GRP_PREFIX);
+            this.coordinator = coordinator;
             this.running = true;
         } catch (final Exception e) {
             // now propagate the exception

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -49,7 +49,7 @@ public class DefaultEventHandler implements EventHandler {
     private final DefaultBackgroundThread backgroundThread;
 
     public DefaultEventHandler(final ConsumerConfig config,
-                               final LogContext logContext,
+                               GroupRebalanceConfig groupRebalanceConfig, final LogContext logContext,
                                final SubscriptionState subscriptionState,
                                final ApiVersions apiVersions,
                                final Metrics metrics,
@@ -57,6 +57,7 @@ public class DefaultEventHandler implements EventHandler {
                                final Sensor fetcherThrottleTimeSensor) {
         this(Time.SYSTEM,
                 config,
+                groupRebalanceConfig,
                 logContext,
                 new LinkedBlockingQueue<>(),
                 new LinkedBlockingQueue<>(),
@@ -69,6 +70,7 @@ public class DefaultEventHandler implements EventHandler {
 
     public DefaultEventHandler(final Time time,
                                final ConsumerConfig config,
+                               final GroupRebalanceConfig groupRebalanceConfig,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
                                final BlockingQueue<BackgroundEvent> backgroundEventQueue,
@@ -122,14 +124,13 @@ public class DefaultEventHandler implements EventHandler {
                 config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
                 config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                 config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG));
-        final GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
-                GroupRebalanceConfig.ProtocolType.CONSUMER);
-         final DefaultAsyncCoordinator coordinator = new DefaultAsyncCoordinator(
+        final DefaultAsyncCoordinator coordinator = new DefaultAsyncCoordinator(
                 time,
                 logContext,
                 groupRebalanceConfig,
                 networkClient,
                 subscriptionState,
+                backgroundEventQueue,
                 metrics,
                 METRIC_GRP_PREFIX);
         this.backgroundThread = new DefaultBackgroundThread(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -264,9 +264,37 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         eventHandler.add(commitEvent);
     }
 
+    /**
+     * Commit offsets returned on the last {@link #poll(Duration) poll()} for the subscribed list of topics and partitions.
+     * <p>
+     * This commits offsets only to Kafka. The offsets committed using this API will be used on the first fetch after
+     * every rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
+     * should not be used.
+     * <p>
+     * This is an asynchronous call and will not block. Any errors encountered are either passed to the callback
+     * (if provided) or discarded.
+     * <p>
+     * Offsets committed through multiple calls to this API are guaranteed to be sent in the same order as
+     * the invocations. Corresponding commit callbacks are also invoked in the same order. Additionally note that
+     * offsets committed through this API are guaranteed to complete before a subsequent call to {@link #commitSync()}
+     * (and variants) returns.
+     *
+     * @param callback Callback to invoke when the commit completes
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
+     */
     @Override
     public void commitAsync(OffsetCommitCallback callback) {
-        throw new KafkaException("method not implemented");
+        commitAsync(subscriptions.allConsumed(), callback);
+    }
+
+    /**
+     * Commit offsets returned on the last {@link #poll(Duration)} for all the subscribed list of topics and partition.
+     * Same as {@link #commitAsync(OffsetCommitCallback) commitAsync(null)}
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
+     */
+    @Override
+    public void commitAsync() {
+        commitAsync(null);
     }
 
     @Override
@@ -495,11 +523,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
         throw new KafkaException("method not implemented");
-    }
-
-    @Override
-    public void commitAsync() {
-
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -20,10 +20,20 @@ package org.apache.kafka.clients.consumer.internals.events;
  * This is the abstract definition of the events created by the KafkaConsumer API
  */
 abstract public class ApplicationEvent {
+    public final Type type;
+
+    ApplicationEvent(Type type) {
+        this.type = type;
+    }
     /**
      * process the application event. Return true upon succesful execution,
      * false otherwise.
      * @return true if the event was successfully executed; false otherwise.
      */
     public abstract boolean process();
+
+    public enum Type {
+        NOOP,
+        COMMIT,
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -30,8 +30,11 @@ abstract public class ApplicationEvent {
      * false otherwise.
      * @return true if the event was successfully executed; false otherwise.
      */
-    public abstract boolean process();
 
+    @Override
+    public String toString() {
+        return type + " ApplicationEvent";
+    }
     public enum Type {
         NOOP,
         COMMIT,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.internals.DefaultAsyncCoordinator;
+import org.apache.kafka.clients.consumer.internals.NoopBackgroundEvent;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+
+public class ApplicationEventProcessor {
+    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
+    private final DefaultAsyncCoordinator coordinator;
+
+    public ApplicationEventProcessor(
+            final DefaultAsyncCoordinator coordinator,
+            final BlockingQueue<BackgroundEvent> backgroundEventQueue) {
+        this.coordinator = coordinator;
+        this.backgroundEventQueue = backgroundEventQueue;
+    }
+    public boolean process(final ApplicationEvent event) {
+        Objects.requireNonNull(event);
+        switch (event.type) {
+            case NOOP:
+                return process((NoopApplicationEvent) event);
+            case COMMIT:
+                return process((CommitApplicationEvent) event);
+        }
+        return false;
+    }
+
+    /**
+     * Processes {@link NoopApplicationEvent} and equeue a
+     * {@link NoopBackgroundEvent}. This is intentionally left here for
+     * demonstration purpose.
+     *
+     * @param event a {@link NoopApplicationEvent}
+     */
+    private boolean process(final NoopApplicationEvent event) {
+        return backgroundEventQueue.add(new NoopBackgroundEvent(event.message));
+    }
+
+    private boolean process(final CommitApplicationEvent event) {
+        Map<TopicPartition, OffsetAndMetadata> offsets = event.offsets;
+        coordinator.commitOffsets(offsets, event.callback, event.commitFuture);
+        return true;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
@@ -26,6 +26,6 @@ abstract public class BackgroundEvent {
         this.type = type;
     }
     public enum EventType {
-        NOOP,
+        NOOP, COMPLETED_COMMIT,
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.internals.DefaultAsyncCoordinator;
+import org.apache.kafka.clients.consumer.internals.RequestFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Timer;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class CommitApplicationEvent extends ApplicationEvent {
+    public RequestFuture<Void> commitFuture;
+    public final Map<TopicPartition, OffsetAndMetadata> offsets;
+    public final Optional<OffsetCommitCallback> callback;
+    public final Timer timer;
+    public final boolean isAsync;
+
+    public CommitApplicationEvent(
+            final Map<TopicPartition, OffsetAndMetadata> offsets,
+            final OffsetCommitCallback callback,
+            final Timer timer) {
+        super(Type.COMMIT);
+        this.offsets = offsets;
+        this.callback = Optional.ofNullable(callback);
+        this.commitFuture = new RequestFuture<>();
+        this.timer = timer;
+        this.isAsync = false;
+    }
+
+    public CommitApplicationEvent(
+            final Map<TopicPartition, OffsetAndMetadata> offsets,
+            final OffsetCommitCallback callback) {
+        super(Type.COMMIT);
+        this.offsets = offsets;
+        this.callback = Optional.ofNullable(callback);
+        this.commitFuture = new RequestFuture<>();
+        this.timer = null;
+        this.isAsync = true;
+    }
+
+    @Override
+    public boolean process() {
+        return false;
+    }
+    public boolean process(DefaultAsyncCoordinator coordinator) {
+        coordinator.commitOffsets(offsets, commitFuture);
+        return false;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitBackgroundEvent.java
@@ -40,8 +40,8 @@ public class CommitBackgroundEvent extends BackgroundEvent {
     }
 
     public void invokeCallback() {
-        // Handle FencedInstanceIdException separatedly from the callback invocation
-        // If the consumer is fenced, then we throw the exception immediately
+        // Handle FencedInstanceIdException separately from the callback invocation
+        // If the consumer is fenced, then we throw an exception before invoking the callback
         if (exception instanceof FencedInstanceIdException) {
             throw new FencedInstanceIdException(exception.getMessage());
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.consumer.internals.NoopBackgroundEvent;
-
 import java.util.concurrent.BlockingQueue;
 
 /**
@@ -32,11 +30,6 @@ public class NoopApplicationEvent extends ApplicationEvent {
         super(Type.NOOP);
         this.message = message;
         this.backgroundEventQueue = backgroundEventQueue;
-    }
-
-    @Override
-    public boolean process() {
-        return backgroundEventQueue.add(new NoopBackgroundEvent(message));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
@@ -29,7 +29,7 @@ public class NoopApplicationEvent extends ApplicationEvent {
 
     public NoopApplicationEvent(final BlockingQueue<BackgroundEvent> backgroundEventQueue,
                                 final String message) {
-
+        super(Type.NOOP);
         this.message = message;
         this.backgroundEventQueue = backgroundEventQueue;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncCoordinatorTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncCoordinatorTestUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.HeartbeatResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.HeartbeatResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AsyncCoordinatorTestUtils {
+    static class MockCommitCallback implements OffsetCommitCallback {
+        public int invoked = 0;
+        public Exception exception = null;
+
+        @Override
+        public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
+            invoked++;
+            this.exception = exception;
+        }
+    }
+
+    static GroupRebalanceConfig buildRebalanceConfig(
+            final int sessionTimeoutMs,
+            final int rebalanceTimeoutMs,
+            final int heartbeatIntervalMs,
+            final String groupId,
+            final Optional<String> groupInstanceId,
+            final long retryBackoffMs) {
+        return new GroupRebalanceConfig(sessionTimeoutMs,
+                rebalanceTimeoutMs,
+                heartbeatIntervalMs,
+                groupId,
+                groupInstanceId,
+                retryBackoffMs,
+                !groupInstanceId.isPresent());
+    }
+
+
+    static HeartbeatResponse heartbeatResponse(Errors error) {
+        return new HeartbeatResponse(new HeartbeatResponseData().setErrorCode(error.code()));
+    }
+
+    static FindCoordinatorResponse groupCoordinatorResponse(Node node, Errors error, String groupId) {
+        return FindCoordinatorResponse.prepareResponse(error, groupId, node);
+    }
+
+    static void prepareOffsetCommitRequest(
+            Map<TopicPartition, Long> expectedOffsets,
+            Errors error,
+            MockClient client) {
+        prepareOffsetCommitRequest(expectedOffsets, error, false, client);
+    }
+
+    static void prepareOffsetCommitRequestDisconnect(
+            Map<TopicPartition, Long> expectedOffsets,
+            MockClient client) {
+        prepareOffsetCommitRequest(expectedOffsets, Errors.NONE, true, client);
+    }
+
+    static Map<TopicPartition, Errors> partitionErrors(
+            Collection<TopicPartition> partitions,
+            Errors error) {
+        final Map<TopicPartition, Errors> errors = new HashMap<>();
+        for (TopicPartition partition : partitions) {
+            errors.put(partition, error);
+        }
+        return errors;
+    }
+
+    static void prepareOffsetCommitRequest(
+            final Map<TopicPartition, Long> expectedOffsets,
+            Errors error,
+            boolean disconnected,
+            MockClient client) {
+        Map<TopicPartition, Errors> errors = partitionErrors(expectedOffsets.keySet(), error);
+        client.prepareResponse(offsetCommitRequestMatcher(expectedOffsets), offsetCommitResponse(errors), disconnected);
+    }
+
+    static OffsetCommitResponse offsetCommitResponse(Map<TopicPartition, Errors> responseData) {
+        return new OffsetCommitResponse(responseData);
+    }
+
+    static MockClient.RequestMatcher offsetCommitRequestMatcher(final Map<TopicPartition,
+            Long> expectedOffsets) {
+        return body -> {
+            OffsetCommitRequest req = (OffsetCommitRequest) body;
+            Map<TopicPartition, Long> offsets = req.offsets();
+            if (offsets.size() != expectedOffsets.size()) {
+                return false;
+            }
+
+            for (Map.Entry<TopicPartition, Long> expectedOffset : expectedOffsets.entrySet()) {
+                if (!offsets.containsKey(expectedOffset.getKey())) {
+
+                    return false;
+                } else {
+                    Long actualOffset = offsets.get(expectedOffset.getKey());
+                    if (!actualOffset.equals(expectedOffset.getValue())) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        };
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultAsyncCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultAsyncCoordinatorTest.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.HeartbeatResponseData;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.HeartbeatResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultAsyncCoordinatorTest {
+    private MockTime time;
+    private final int rebalanceTimeoutMs = 60000;
+    private final int sessionTimeoutMs = 10000;
+    private final int heartbeatIntervalMs = 5000;
+    private final long retryBackoffMs = 100;
+    private final int requestTimeoutMs = 30000;
+    private final String topic1 = "test1";
+    private final String topic2 = "test2";
+    private final TopicPartition t1p = new TopicPartition(topic1, 0);
+    private final TopicPartition t2p = new TopicPartition(topic2, 0);
+    private final String groupId = "test-group";
+    private final String consumerId = "consumer";
+    /*
+    private final ThrowOnAssignmentAssignor throwOnAssignmentAssignor;
+    private final ConsumerPartitionAssignor.RebalanceProtocol protocol;
+    private final ThrowOnAssignmentAssignor throwFatalErrorOnAssignmentAssignor;
+    private final List<ConsumerPartitionAssignor> assignors;
+    private final Map<String, MockPartitionAssignor> assignorMap;
+     */
+    private MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(1, new HashMap<String, Integer>() {
+        {
+            put(topic1, 1);
+            put(topic2, 1);
+        }
+    });
+    private Node node = metadataResponse.brokers().iterator().next();
+    private SubscriptionState subscriptions;
+    private ConsumerMetadata metadata;
+    private MockClient client;
+    private ConsumerNetworkClient consumerClient;
+    private Metrics metrics;
+    private MockRebalanceListener rebalanceListener;
+    private MockCommitCallback mockOffsetCommitCallback;
+    private GroupRebalanceConfig rebalanceConfig;
+    private DefaultAsyncCoordinator coordinator;
+
+    @BeforeEach
+    public void setup() {
+        LogContext logContext = new LogContext();
+        this.time = new MockTime(0);
+        this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
+        this.metadata = new ConsumerMetadata(
+                0,
+                Long.MAX_VALUE,
+                false,
+                false,
+                subscriptions,
+                logContext,
+                new ClusterResourceListeners());
+        this.client = new MockClient(time, metadata);
+        this.client.updateMetadata(metadataResponse);
+        this.consumerClient = new ConsumerNetworkClient(
+                logContext,
+                client,
+                metadata,
+                time,
+                100,
+                requestTimeoutMs,
+                Integer.MAX_VALUE);
+        this.metrics = new Metrics(time);
+        this.rebalanceListener = new MockRebalanceListener();
+        this.mockOffsetCommitCallback = new MockCommitCallback();
+        this.rebalanceConfig = buildRebalanceConfig(Optional.empty());
+        this.coordinator = buildCoordinator(
+                rebalanceConfig,
+                metrics,
+                subscriptions);
+    }
+
+    @AfterEach
+    public void teardown() {
+        this.metrics.close();
+        this.coordinator.close(time.timer(0));
+    }
+
+    @Test
+    public void testMetrics() {
+        assertNotNull(getMetric("commit-latency-avg"));
+        assertNotNull(getMetric("commit-latency-max"));
+        assertNotNull(getMetric("commit-rate"));
+        assertNotNull(getMetric("commit-total"));
+        assertNotNull(getMetric("partition-revoked-latency-avg"));
+        assertNotNull(getMetric("partition-revoked-latency-max"));
+        assertNotNull(getMetric("partition-assigned-latency-avg"));
+        assertNotNull(getMetric("partition-assigned-latency-max"));
+        assertNotNull(getMetric("partition-lost-latency-avg"));
+        assertNotNull(getMetric("partition-lost-latency-max"));
+        assertNotNull(getMetric("assigned-partitions"));
+
+        metrics.sensor("commit-latency").record(1.0d);
+        metrics.sensor("commit-latency").record(6.0d);
+        metrics.sensor("commit-latency").record(2.0d);
+
+        assertEquals(3.0d, getMetric("commit-latency-avg").metricValue());
+        assertEquals(6.0d, getMetric("commit-latency-max").metricValue());
+        assertEquals(0.1d, getMetric("commit-rate").metricValue());
+        assertEquals(3.0d, getMetric("commit-total").metricValue());
+
+        metrics.sensor("partition-revoked-latency").record(1.0d);
+        metrics.sensor("partition-revoked-latency").record(2.0d);
+        metrics.sensor("partition-assigned-latency").record(1.0d);
+        metrics.sensor("partition-assigned-latency").record(2.0d);
+        metrics.sensor("partition-lost-latency").record(1.0d);
+        metrics.sensor("partition-lost-latency").record(2.0d);
+
+        assertEquals(1.5d, getMetric("partition-revoked-latency-avg").metricValue());
+        assertEquals(2.0d, getMetric("partition-revoked-latency-max").metricValue());
+        assertEquals(1.5d, getMetric("partition-assigned-latency-avg").metricValue());
+        assertEquals(2.0d, getMetric("partition-assigned-latency-max").metricValue());
+        assertEquals(1.5d, getMetric("partition-lost-latency-avg").metricValue());
+        assertEquals(2.0d, getMetric("partition-lost-latency-max").metricValue());
+
+        assertEquals(0.0d, getMetric("assigned-partitions").metricValue());
+        subscriptions.assignFromUser(Collections.singleton(t1p));
+        assertEquals(1.0d, getMetric("assigned-partitions").metricValue());
+        subscriptions.assignFromUser(Utils.mkSet(t1p, t2p));
+        assertEquals(2.0d, getMetric("assigned-partitions").metricValue());
+    }
+
+    private KafkaMetric getMetric(final String name) {
+        return metrics.metrics().get(metrics.metricName(name, consumerId + groupId + "-coordinator-metrics"));
+    }
+
+    @Test
+    public void testCoordinatorNotAvailable() {
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+
+        // COORDINATOR_NOT_AVAILABLE will mark coordinator as unknown
+        time.sleep(sessionTimeoutMs);
+        RequestFuture<Void> future = coordinator.sendHeartbeatRequest(); // should send out the heartbeat
+        assertEquals(1, consumerClient.pendingRequestCount());
+        assertFalse(future.isDone());
+
+        client.prepareResponse(heartbeatResponse(Errors.COORDINATOR_NOT_AVAILABLE));
+        time.sleep(sessionTimeoutMs);
+        consumerClient.poll(time.timer(0));
+
+        assertTrue(future.isDone());
+        assertTrue(future.failed());
+        assertEquals(Errors.COORDINATOR_NOT_AVAILABLE.exception(), future.exception());
+        assertTrue(coordinator.coordinatorUnknown());
+    }
+
+    @Test
+    public void testManyInFlightAsyncCommitsWithCoordinatorDisconnect() {
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+
+        int numRequests = 1000;
+        TopicPartition tp = new TopicPartition("foo", 0);
+        final AtomicInteger responses = new AtomicInteger(0);
+        List<RequestFuture<Void>> commitFutures = new ArrayList<>();
+
+        for (int i = 0; i < numRequests; i++) {
+            Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(tp, new OffsetAndMetadata(i));
+            RequestFuture<Void> future = new RequestFuture<>();
+            coordinator.commitOffsets(offsets, future);
+            future.addListener(new RequestFutureListener<Void>() {
+                @Override
+                public void onSuccess(Void value) {
+                }
+
+                @Override
+                public void onFailure(RuntimeException e) {
+                    responses.incrementAndGet();
+                    assertTrue(e instanceof DisconnectException,
+                            "Unexpected exception cause type: " + (e == null ? null :
+                                    e.getClass()));
+                }
+            });
+            commitFutures.add(future);
+        }
+
+        coordinator.markCoordinatorUnknown("test cause");
+        consumerClient.pollNoWakeup();
+        assertEquals(numRequests, responses.get());
+    }
+
+    @Test
+    public void testCoordinatorUnknownInUnsentCallbacksAfterCoordinatorDead() {
+        // When the coordinator is marked dead, all unsent or in-flight requests are cancelled
+        // with a disconnect error. This test case ensures that the corresponding callbacks see
+        // the coordinator as unknown which prevents additional retries to the same coordinator.
+
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+
+        final AtomicBoolean asyncCallbackInvoked = new AtomicBoolean(false);
+
+        OffsetCommitRequestData offsetCommitRequestData = new OffsetCommitRequestData()
+                .setGroupId(groupId)
+                .setTopics(Collections.singletonList(new
+                                OffsetCommitRequestData.OffsetCommitRequestTopic()
+                                .setName("foo")
+                                .setPartitions(Collections.singletonList(
+                                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                                                .setPartitionIndex(0)
+                                                .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
+                                                .setCommittedMetadata("")
+                                                .setCommittedOffset(13L)
+                                                .setCommitTimestamp(0)
+                                ))
+                        )
+                );
+
+        consumerClient.send(coordinator.checkAndGetCoordinator(), new OffsetCommitRequest.Builder(offsetCommitRequestData))
+                .compose(new RequestFutureAdapter<ClientResponse, Object>() {
+                    @Override
+                    public void onSuccess(ClientResponse value, RequestFuture<Object> future) {}
+
+                    @Override
+                    public void onFailure(RuntimeException e, RequestFuture<Object> future) {
+                        assertTrue(e instanceof DisconnectException, "Unexpected exception type: " + e.getClass());
+                        assertTrue(coordinator.coordinatorUnknown());
+                        asyncCallbackInvoked.set(true);
+                    }
+                });
+
+        coordinator.markCoordinatorUnknown("test cause");
+        consumerClient.pollNoWakeup();
+        assertTrue(asyncCallbackInvoked.get());
+    }
+
+    @Test
+    public void testNotCoordinator() {
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+
+        // not_coordinator will mark coordinator as unknown
+        time.sleep(sessionTimeoutMs);
+        RequestFuture<Void> future = coordinator.sendHeartbeatRequest(); // should send out the heartbeat
+        assertEquals(1, consumerClient.pendingRequestCount());
+        assertFalse(future.isDone());
+
+        client.prepareResponse(heartbeatResponse(Errors.NOT_COORDINATOR));
+        time.sleep(sessionTimeoutMs);
+        consumerClient.poll(time.timer(0));
+
+        assertTrue(future.isDone());
+        assertTrue(future.failed());
+        assertEquals(Errors.NOT_COORDINATOR.exception(), future.exception());
+        assertTrue(coordinator.coordinatorUnknown());
+    }
+
+    @Test
+    public void testCoordinatorDisconnectAfterNotCoordinatorError() {
+        testInFlightRequestsFailedAfterCoordinatorMarkedDead(Errors.NOT_COORDINATOR);
+    }
+
+    @Test
+    public void testCoordinatorDisconnectAfterCoordinatorNotAvailableError() {
+        testInFlightRequestsFailedAfterCoordinatorMarkedDead(Errors.COORDINATOR_NOT_AVAILABLE);
+    }
+
+    private void testInFlightRequestsFailedAfterCoordinatorMarkedDead(Errors error) {
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        assertTrue(coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE)));
+
+        // Send two async commits and fail the first one with an error.
+        // This should cause a coordinator disconnect which will cancel the second request.
+
+        RequestFuture<Void> firstFuture = new RequestFuture<>();
+        RequestFuture<Void> secondFuture = new RequestFuture<>();
+
+        coordinator.commitOffsets(singletonMap(t1p, new OffsetAndMetadata(100L)), firstFuture);
+        coordinator.commitOffsets(singletonMap(t1p, new OffsetAndMetadata(100L)), secondFuture);
+
+        respondToOffsetCommitRequest(singletonMap(t1p, 100L), error);
+        consumerClient.pollNoWakeup();
+        consumerClient.pollNoWakeup();
+
+        assertTrue(coordinator.coordinatorUnknown());
+        assertTrue(firstFuture.failed());
+        assertTrue(secondFuture.failed());
+    }
+
+    private void respondToOffsetCommitRequest(final Map<TopicPartition, Long> expectedOffsets, Errors error) {
+        Map<TopicPartition, Errors> errors = partitionErrors(expectedOffsets.keySet(), error);
+        client.respond(offsetCommitRequestMatcher(expectedOffsets), offsetCommitResponse(errors));
+    }
+
+    private Map<TopicPartition, Errors> partitionErrors(Collection<TopicPartition> partitions, Errors error) {
+        final Map<TopicPartition, Errors> errors = new HashMap<>();
+        for (TopicPartition partition : partitions) {
+            errors.put(partition, error);
+        }
+        return errors;
+    }
+
+    private MockClient.RequestMatcher offsetCommitRequestMatcher(final Map<TopicPartition, Long> expectedOffsets) {
+        return body -> {
+            OffsetCommitRequest req = (OffsetCommitRequest) body;
+            Map<TopicPartition, Long> offsets = req.offsets();
+            if (offsets.size() != expectedOffsets.size()) {
+                return false;
+            }
+
+            for (Map.Entry<TopicPartition, Long> expectedOffset : expectedOffsets.entrySet()) {
+                if (!offsets.containsKey(expectedOffset.getKey())) {
+
+                    return false;
+                } else {
+                    Long actualOffset = offsets.get(expectedOffset.getKey());
+                    if (!actualOffset.equals(expectedOffset.getValue())) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        };
+    }
+
+    private OffsetCommitResponse offsetCommitResponse(Map<TopicPartition, Errors> responseData) {
+        return new OffsetCommitResponse(responseData);
+    }
+
+    private HeartbeatResponse heartbeatResponse(Errors error) {
+        return new HeartbeatResponse(new HeartbeatResponseData().setErrorCode(error.code()));
+    }
+
+    private FindCoordinatorResponse groupCoordinatorResponse(Node node, Errors error) {
+        return FindCoordinatorResponse.prepareResponse(error, groupId, node);
+    }
+
+    private DefaultAsyncCoordinator buildCoordinator(final GroupRebalanceConfig rebalanceConfig,
+                                                 final Metrics metrics,
+                                                 final SubscriptionState subscriptionState) {
+        return new DefaultAsyncCoordinator(
+                this.time,
+                new LogContext(),
+                rebalanceConfig,
+                this.consumerClient,
+                subscriptionState,
+                metrics,
+                consumerId + groupId);
+    }
+
+    private GroupRebalanceConfig buildRebalanceConfig(Optional<String> groupInstanceId) {
+        return new GroupRebalanceConfig(sessionTimeoutMs,
+                rebalanceTimeoutMs,
+                heartbeatIntervalMs,
+                groupId,
+                groupInstanceId,
+                retryBackoffMs,
+                !groupInstanceId.isPresent());
+    }
+
+    private static class MockCommitCallback implements OffsetCommitCallback {
+        public int invoked = 0;
+        public Exception exception = null;
+
+        @Override
+        public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
+            invoked++;
+            this.exception = exception;
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -57,6 +57,7 @@ public class DefaultBackgroundThreadTest {
     private Metrics metrics;
     private BlockingQueue<BackgroundEvent> backgroundEventsQueue;
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
+    private DefaultAsyncCoordinator coordinator;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -69,6 +70,7 @@ public class DefaultBackgroundThreadTest {
         this.metrics = mock(Metrics.class);
         this.applicationEventsQueue = (BlockingQueue<ApplicationEvent>) mock(BlockingQueue.class);
         this.backgroundEventsQueue = (BlockingQueue<BackgroundEvent>) mock(BlockingQueue.class);
+        this.coordinator = mock(DefaultAsyncCoordinator.class);
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(RETRY_BACKOFF_MS_CONFIG, REFRESH_BACK_OFF_MS);
@@ -160,11 +162,12 @@ public class DefaultBackgroundThreadTest {
             this.time,
             new ConsumerConfig(properties),
             new LogContext(),
-            applicationEventsQueue,
-            backgroundEventsQueue,
+            this.applicationEventsQueue,
+            this.backgroundEventsQueue,
             this.subscriptions,
             this.metadata,
             this.consumerClient,
+            this.coordinator,
             this.metrics
         );
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
@@ -92,6 +92,7 @@ public class DefaultEventHandlerTest {
                 rebalanceConfig,
                 consumerClient,
                 subscriptions,
+                bq,
                 new Metrics(time),
                 "background_thread");
         final DefaultEventHandler handler = new DefaultEventHandler(


### PR DESCRIPTION
[KAFKA-14264](https://issues.apache.org/jira/browse/KAFKA-14264)
In this PR we are adding
1. Commit and move the callback invocation to the application level so that it can be executed by the polling thread
2. Find a coordinator and some related error handling
3. Moved and added tests for commits and find the coordinator 
4. Added tests at the background thread level to ensure commit works

This is a really big PR due, and the best way to understand the top-level logic is by examining the DefaultBackgroundThreadTest and DefaultAsyncCoordinatorTest. Both tests capture the goal of this PR, which are:
1. Realize findCoordinator function
2. Realize commitOffset logic

We removed the `Sync` keyword from a lot of the functions because we will not use such function in the future.

There are a bunch of TODOs in the PR, due to lack of rebalance protocol.  These missing pieces will be added gradually as we continue to complete the coordinator implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
