### PR TITLE
KAFKA-14346: Remove difficult to mock Plugins.compareAndSwapLoader usages 

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePo
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigRequest;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.runtime.isolation.LoaderSwap;
 import org.apache.kafka.connect.runtime.isolation.PluginType;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
@@ -455,10 +456,10 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
         Connector connector = getConnector(connType);
         org.apache.kafka.connect.health.ConnectorType connectorType;
-        ClassLoader savedLoader = plugins().compareAndSwapLoaders(connector);
+        ClassLoader connectorLoader = plugins().connectorLoader(connType);
         ConfigDef enrichedConfigDef;
         Map<String, ConfigValue> validatedConnectorConfig;
-        try {
+        try (LoaderSwap loaderSwap = plugins().withClassLoader(connectorLoader)) {
             if (connector instanceof SourceConnector) {
                 connectorType = org.apache.kafka.connect.health.ConnectorType.SOURCE;
                 enrichedConfigDef = ConnectorConfig.enrich(plugins(), SourceConnectorConfig.configDef(), connectorProps, false);
@@ -546,8 +547,6 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                     connectorClientConfigOverridePolicy);
             }
             return mergeConfigInfos(connType, configInfos, producerConfigInfos, consumerConfigInfos, adminConfigInfos);
-        } finally {
-            Plugins.compareAndSwapLoaders(savedLoader);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -455,11 +455,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             throw new BadRequestException("Connector config " + connectorProps + " contains no connector type");
 
         Connector connector = getConnector(connType);
-        org.apache.kafka.connect.health.ConnectorType connectorType;
         ClassLoader connectorLoader = plugins().connectorLoader(connType);
-        ConfigDef enrichedConfigDef;
-        Map<String, ConfigValue> validatedConnectorConfig;
         try (LoaderSwap loaderSwap = plugins().withClassLoader(connectorLoader)) {
+            org.apache.kafka.connect.health.ConnectorType connectorType;
+            ConfigDef enrichedConfigDef;
+            Map<String, ConfigValue> validatedConnectorConfig;
             if (connector instanceof SourceConnector) {
                 connectorType = org.apache.kafka.connect.health.ConnectorType.SOURCE;
                 enrichedConfigDef = ConnectorConfig.enrich(plugins(), SourceConnectorConfig.configDef(), connectorProps, false);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -21,7 +21,6 @@ import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
-import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.sink.SinkConnectorContext;
 import org.apache.kafka.connect.source.SourceConnectorContext;
 import org.apache.kafka.connect.storage.CloseableOffsetStorageReader;
@@ -116,14 +115,12 @@ public class WorkerConnector implements Runnable {
         LoggingContext.clear();
 
         try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
-            ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
             String savedName = Thread.currentThread().getName();
             try {
                 Thread.currentThread().setName(THREAD_NAME_PREFIX + connName);
                 doRun();
             } finally {
                 Thread.currentThread().setName(savedName);
-                Plugins.compareAndSwapLoaders(savedLoader);
             }
         } finally {
             // In the rare case of an exception being thrown outside the doRun() method, or an

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -29,7 +29,6 @@ import org.apache.kafka.connect.runtime.errors.ErrorHandlingMetrics;
 import org.apache.kafka.connect.runtime.AbstractStatus.State;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator;
-import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.LoggingContext;
@@ -252,7 +251,6 @@ abstract class WorkerTask implements Runnable {
         LoggingContext.clear();
 
         try (LoggingContext loggingContext = LoggingContext.forTask(id())) {
-            ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
             String savedName = Thread.currentThread().getName();
             try {
                 Thread.currentThread().setName(THREAD_NAME_PREFIX + id);
@@ -265,7 +263,6 @@ abstract class WorkerTask implements Runnable {
                     throw (Error) t;
             } finally {
                 Thread.currentThread().setName(savedName);
-                Plugins.compareAndSwapLoaders(savedLoader);
                 shutdownLatch.countDown();
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -179,7 +179,8 @@ public class DelegatingClassLoader extends URLClassLoader {
      * @param name The fully qualified class name of the plugin
      * @return the PluginClassLoader that should be used to load this, or null if the plugin is not isolated.
      */
-    public PluginClassLoader pluginClassLoader(String name) {
+    // VisibleForTesting
+    PluginClassLoader pluginClassLoader(String name) {
         if (!PluginUtils.shouldLoadInIsolation(name)) {
             return null;
         }
@@ -193,7 +194,7 @@ public class DelegatingClassLoader extends URLClassLoader {
                : null;
     }
 
-    public ClassLoader connectorLoader(String connectorClassOrAlias) {
+    ClassLoader connectorLoader(String connectorClassOrAlias) {
         String fullName = aliases.getOrDefault(connectorClassOrAlias, connectorClassOrAlias);
         ClassLoader classLoader = pluginClassLoader(fullName);
         if (classLoader == null) classLoader = this;
@@ -205,7 +206,8 @@ public class DelegatingClassLoader extends URLClassLoader {
         return classLoader;
     }
 
-    protected PluginClassLoader newPluginClassLoader(
+    // VisibleForTesting
+    PluginClassLoader newPluginClassLoader(
             final URL pluginLocation,
             final URL[] urls,
             final ClassLoader parent

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -193,10 +193,6 @@ public class DelegatingClassLoader extends URLClassLoader {
                : null;
     }
 
-    public ClassLoader connectorLoader(Connector connector) {
-        return connectorLoader(connector.getClass().getName());
-    }
-
     public ClassLoader connectorLoader(String connectorClassOrAlias) {
         String fullName = aliases.getOrDefault(connectorClassOrAlias, connectorClassOrAlias);
         ClassLoader classLoader = pluginClassLoader(fullName);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -133,6 +133,21 @@ public class Plugins {
         return current;
     }
 
+    /**
+     * Perform the following operations with a specified thread context classloader.
+     * <p>
+     * Intended for use in a try-with-resources block such as the following:
+     * <pre>{@code
+     * try (LoaderSwap loaderSwap = plugins.withClassLoader(loader)) {
+     *     // operation(s) sensitive to the thread context classloader
+     * }
+     * }</pre>
+     * After the completion of the try block, the previous context classloader will be restored.
+     * @see Thread#getContextClassLoader()
+     * @see LoaderSwap
+     * @param loader ClassLoader to use as the thread context classloader
+     * @return A {@link LoaderSwap} handle which restores the prior classloader on {@link LoaderSwap#close()}.
+     */
     public LoaderSwap withClassLoader(ClassLoader loader) {
         ClassLoader savedLoader = compareAndSwapLoaders(loader);
         try {
@@ -143,6 +158,13 @@ public class Plugins {
         }
     }
 
+    /**
+     * Wrap a {@link Runnable} such that it is performed with the specified thread context classloader
+     * @see Thread#getContextClassLoader()
+     * @param classLoader {@link ClassLoader} to use as the thread context classloader
+     * @param operation {@link Runnable} which is sensitive to the thread context classloader
+     * @return A wrapper {@link Runnable} which will execute the wrapped operation
+     */
     public Runnable withClassLoader(ClassLoader classLoader, Runnable operation) {
         return () -> {
             try (LoaderSwap loaderSwap = withClassLoader(classLoader)) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -421,24 +421,19 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     private void updateConnectorTasks(String connName) {
-        try {
-            if (!worker.isRunning(connName)) {
-                log.info("Skipping update of connector {} since it is not running", connName);
-                return;
-            }
+        if (!worker.isRunning(connName)) {
+            log.info("Skipping update of connector {} since it is not running", connName);
+            return;
+        }
 
-            List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
-            List<Map<String, String>> oldTaskConfigs = configState.allTaskConfigs(connName);
+        List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
+        List<Map<String, String>> oldTaskConfigs = configState.allTaskConfigs(connName);
 
-            if (!newTaskConfigs.equals(oldTaskConfigs)) {
-                removeConnectorTasks(connName);
-                List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
-                configBackingStore.putTaskConfigs(connName, rawTaskConfigs);
-                createConnectorTasks(connName);
-            }
-        } catch (Throwable t) {
-            // TODO: when this throws errors where do they go
-            log.error("Unable to update connector tasks", t);
+        if (!newTaskConfigs.equals(oldTaskConfigs)) {
+            removeConnectorTasks(connName);
+            List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
+            configBackingStore.putTaskConfigs(connName, rawTaskConfigs);
+            createConnectorTasks(connName);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -421,19 +421,24 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     private void updateConnectorTasks(String connName) {
-        if (!worker.isRunning(connName)) {
-            log.info("Skipping update of connector {} since it is not running", connName);
-            return;
-        }
+        try {
+            if (!worker.isRunning(connName)) {
+                log.info("Skipping update of connector {} since it is not running", connName);
+                return;
+            }
 
-        List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
-        List<Map<String, String>> oldTaskConfigs = configState.allTaskConfigs(connName);
+            List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
+            List<Map<String, String>> oldTaskConfigs = configState.allTaskConfigs(connName);
 
-        if (!newTaskConfigs.equals(oldTaskConfigs)) {
-            removeConnectorTasks(connName);
-            List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
-            configBackingStore.putTaskConfigs(connName, rawTaskConfigs);
-            createConnectorTasks(connName);
+            if (!newTaskConfigs.equals(oldTaskConfigs)) {
+                removeConnectorTasks(connName);
+                List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
+                configBackingStore.putTaskConfigs(connName, rawTaskConfigs);
+                createConnectorTasks(connName);
+            }
+        } catch (Throwable t) {
+            // TODO: when this throws errors where do they go
+            log.error("Unable to update connector tasks", t);
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -151,19 +151,6 @@ public class AbstractHerderTest {
     @Mock private LoaderSwap loaderSwap;
     @Mock private Plugins plugins;
 
-    private ClassLoader loader;
-    private Connector connector;
-
-    @Before
-    public void before() {
-        loader = Utils.getContextOrKafkaClassLoader();
-    }
-
-    @After
-    public void tearDown() {
-        if (loader != null) Plugins.compareAndSwapLoaders(loader);
-    }
-
     @Test
     public void testConnectors() {
         AbstractHerder herder = mock(AbstractHerder.class, withSettings()
@@ -1085,7 +1072,6 @@ public class AbstractHerderTest {
             when(plugins.connectorLoader(connectorClass.getName())).thenReturn(classLoader);
             when(plugins.withClassLoader(classLoader)).thenReturn(loaderSwap);
         }
-        this.connector = connector;
         return herder;
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverri
 import org.apache.kafka.connect.connector.policy.PrincipalConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.runtime.isolation.LoaderSwap;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
@@ -147,6 +148,7 @@ public class AbstractHerderTest {
     @Mock private ConfigBackingStore configStore;
     @Mock private StatusBackingStore statusStore;
     @Mock private ClassLoader classLoader;
+    @Mock private LoaderSwap loaderSwap;
     @Mock private Plugins plugins;
 
     private ClassLoader loader;
@@ -452,7 +454,8 @@ public class AbstractHerderTest {
         assertEquals(1, infos.get("required").configValue().errors().size());
 
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -468,7 +471,8 @@ public class AbstractHerderTest {
         assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
 
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -484,7 +488,8 @@ public class AbstractHerderTest {
         assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
 
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -500,7 +505,8 @@ public class AbstractHerderTest {
         assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
 
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -553,7 +559,8 @@ public class AbstractHerderTest {
 
         verify(plugins, times(2)).transformations();
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -616,7 +623,8 @@ public class AbstractHerderTest {
         verify(plugins).transformations();
         verify(plugins, times(2)).predicates();
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -669,7 +677,8 @@ public class AbstractHerderTest {
             configInfo -> saslConfigKey.equals(configInfo.configValue().name()) && configInfo.configValue().errors().isEmpty()));
 
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -720,7 +729,8 @@ public class AbstractHerderTest {
         assertEquals(rawOverriddenClientConfigs, validatedOverriddenClientConfigs);
 
         verify(plugins).newConnector(connectorClass.getName());
-        verify(plugins).compareAndSwapLoaders(connector);
+        verify(plugins).withClassLoader(classLoader);
+        verify(loaderSwap).close();
     }
 
     @Test
@@ -1072,7 +1082,8 @@ public class AbstractHerderTest {
         }
         if (countOfCallingNewConnector > 0) {
             when(plugins.newConnector(connectorClass.getName())).thenReturn(connector);
-            when(plugins.compareAndSwapLoaders(connector)).thenReturn(classLoader);
+            when(plugins.connectorLoader(connectorClass.getName())).thenReturn(classLoader);
+            when(plugins.withClassLoader(classLoader)).thenReturn(loaderSwap);
         }
         this.connector = connector;
         return herder;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -31,7 +31,9 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
@@ -130,6 +132,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -302,14 +305,8 @@ public class WorkerTest {
         connectorProps.put(CONNECTOR_CLASS_CONFIG, connectorClass);
 
         // Create
-        when(plugins.connectorLoader(connectorClass)).thenReturn(pluginLoader);
-        when(plugins.newConnector(connectorClass)).thenReturn(sourceConnector);
-        when(sourceConnector.version()).thenReturn("1.0");
-
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
-        // this test expects the runnable to be run by the executor, make withClassLoader(cl, runnable) a passthrough.
-        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        when(plugins.withClassLoader(same(pluginLoader), runnableCaptor.capture())).thenReturn(() -> runnableCaptor.getValue().run());
+        mockConnectorIsolation(connectorClass, sourceConnector);
+        mockExecutorSubmit(true);
         workerConfigMockedStatic.when(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)))
                                 .thenReturn(CLUSTER_ID);
 
@@ -349,16 +346,12 @@ public class WorkerTest {
         assertStatistics(worker, 0, 0);
 
 
-        verify(plugins).connectorLoader(connectorClass);
-        verify(plugins).newConnector(connectorClass);
-        verify(sourceConnector, times(2)).version();
+        verifyConnectorIsolation(sourceConnector);
+        verifyExecutorSubmit();
         verify(sourceConnector).initialize(any(ConnectorContext.class));
         verify(sourceConnector).start(connectorProps);
         verify(connectorStatusListener).onStartup(CONNECTOR_ID);
 
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
-        verify(plugins).withClassLoader(same(pluginLoader), any(WorkerConnector.class));
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
 
         verify(sourceConnector).stop();
@@ -382,9 +375,7 @@ public class WorkerTest {
         connectorProps.put(CONNECTOR_CLASS_CONFIG, nonConnectorClass); // Bad connector class name
 
         Exception exception = new ConnectException("Failed to find Connector");
-
-        when(plugins.connectorLoader(nonConnectorClass)).thenReturn(pluginLoader);
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockGenericIsolation();
         workerConfigMockedStatic.when(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)))
                                 .thenReturn("test-cluster");
 
@@ -413,26 +404,17 @@ public class WorkerTest {
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
 
-        verify(plugins).connectorLoader(nonConnectorClass);
         verify(plugins).newConnector(anyString());
+        verifyGenericIsolation();
         verify(connectorStatusListener).onFailure(eq(CONNECTOR_ID), any(ConnectException.class));
-        verify(plugins, times(1)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(1)).close();
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
     }
 
     @Test
     public void testAddConnectorByAlias() throws Throwable {
         final String connectorAlias = "SampleSourceConnector";
-
-        when(plugins.newConnector(connectorAlias)).thenReturn(sinkConnector);
-        when(plugins.connectorLoader(connectorAlias)).thenReturn(pluginLoader);
-        when(sinkConnector.version()).thenReturn("1.0");
-
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
-        // this test expects the runnable to be run by the executor, make withClassLoader(cl, runnable) a passthrough.
-        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        when(plugins.withClassLoader(same(pluginLoader), runnableCaptor.capture())).thenReturn(() -> runnableCaptor.getValue().run());
+        mockConnectorIsolation(connectorAlias, sinkConnector);
+        mockExecutorSubmit(true);
         workerConfigMockedStatic.when(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)))
                                 .thenReturn("test-cluster");
 
@@ -462,17 +444,13 @@ public class WorkerTest {
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
 
-        verify(plugins).newConnector(connectorAlias);
-        verify(plugins).connectorLoader(connectorAlias);
-        verify(sinkConnector, times(2)).version();
+        verifyConnectorIsolation(sinkConnector);
+        verifyExecutorSubmit();
         verify(sinkConnector).initialize(any(ConnectorContext.class));
         verify(sinkConnector).start(connectorProps);
         verify(sinkConnector).stop();
         verify(connectorStatusListener).onStartup(CONNECTOR_ID);
         verify(ctx).close();
-
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
     }
 
@@ -480,13 +458,8 @@ public class WorkerTest {
     public void testAddConnectorByShortAlias() throws Throwable {
         final String shortConnectorAlias = "WorkerTest";
 
-        when(plugins.newConnector(shortConnectorAlias)).thenReturn(sinkConnector);
-        when(plugins.connectorLoader(shortConnectorAlias)).thenReturn(pluginLoader);
-        when(sinkConnector.version()).thenReturn("1.0");
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
-        // this test expects the runnable to be run by the executor, make withClassLoader(cl, runnable) a passthrough.
-        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        when(plugins.withClassLoader(same(pluginLoader), runnableCaptor.capture())).thenReturn(() -> runnableCaptor.getValue().run());
+        mockConnectorIsolation(shortConnectorAlias, sinkConnector);
+        mockExecutorSubmit(true);
         connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, shortConnectorAlias);
 
         connectorProps.put(SinkConnectorConfig.TOPICS_CONFIG, "gfieyls, wfru");
@@ -511,18 +484,14 @@ public class WorkerTest {
         worker.stop();
         assertStatistics(worker, 0, 0);
 
-        verify(plugins).newConnector(shortConnectorAlias);
-        verify(plugins).connectorLoader(shortConnectorAlias);
-        verify(sinkConnector, times(2)).version();
+        verifyConnectorIsolation(sinkConnector);
         verify(sinkConnector).initialize(any(ConnectorContext.class));
         verify(sinkConnector).start(connectorProps);
         verify(connectorStatusListener).onStartup(CONNECTOR_ID);
         verify(sinkConnector).stop();
         verify(connectorStatusListener).onShutdown(CONNECTOR_ID);
         verify(ctx).close();
-
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
+        verifyExecutorSubmit();
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
     }
 
@@ -541,9 +510,7 @@ public class WorkerTest {
     public void testReconfigureConnectorTasks() throws Throwable {
         final String connectorClass = SampleSourceConnector.class.getName();
 
-        when(plugins.connectorLoader(connectorClass)).thenReturn(pluginLoader);
-        when(plugins.newConnector(connectorClass)).thenReturn(sinkConnector);
-        when(sinkConnector.version()).thenReturn("1.0");
+        mockConnectorIsolation(connectorClass, sinkConnector);
 
         Map<String, String> taskProps = Collections.singletonMap("foo", "bar");
         when(sinkConnector.taskConfigs(2)).thenReturn(Arrays.asList(taskProps, taskProps));
@@ -551,10 +518,7 @@ public class WorkerTest {
         // Use doReturn().when() syntax due to when().thenReturn() not being able to return wildcard generic types
         doReturn(TestSourceTask.class).when(sinkConnector).taskClass();
 
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
-        // this test expects the runnable to be run by the executor, make withClassLoader(cl, runnable) a passthrough.
-        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        when(plugins.withClassLoader(same(pluginLoader), runnableCaptor.capture())).thenReturn(() -> runnableCaptor.getValue().run());
+        mockExecutorSubmit(true);
 
         connectorProps.put(SinkConnectorConfig.TOPICS_CONFIG, "foo,bar");
         connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass);
@@ -602,9 +566,8 @@ public class WorkerTest {
         worker.stop();
         assertStatistics(worker, 0, 0);
 
-        verify(plugins).connectorLoader(connectorClass);
-        verify(plugins).newConnector(connectorClass);
-        verify(sinkConnector, times(2)).version();
+        verifyConnectorIsolation(sinkConnector);
+        verifyExecutorSubmit();
         verify(sinkConnector).initialize(any(ConnectorContext.class));
         verify(sinkConnector).start(connectorProps);
         verify(connectorStatusListener).onStartup(CONNECTOR_ID);
@@ -613,24 +576,15 @@ public class WorkerTest {
         verify(sinkConnector).stop();
         verify(connectorStatusListener).onShutdown(CONNECTOR_ID);
         verify(ctx).close();
-
-        verify(plugins, times(3)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(3)).close();
     }
 
     @Test
     public void testAddRemoveSourceTask() {
-        when(plugins.connectorLoader(SampleSourceConnector.class.getName())).thenReturn(pluginLoader);
-
-        when(plugins.newTask(TestSourceTask.class)).thenReturn(task);
-        when(task.version()).thenReturn("1.0");
+        mockTaskIsolation(SampleSourceConnector.class, TestSourceTask.class, task);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, taskKeyConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, taskValueConverter);
         mockTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
-        when(plugins.withClassLoader(same(pluginLoader), any(WorkerSourceTask.class))).thenReturn(isolatedRunnable);
-        when(executorService.submit(isolatedRunnable)).thenReturn(null);
-        doReturn(SampleSourceConnector.class).when(plugins).connectorClass(SampleSourceConnector.class.getName());
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockExecutorSubmit(false);
 
         Map<String, String> origProps = Collections.singletonMap(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
 
@@ -651,37 +605,25 @@ public class WorkerTest {
         worker.stop();
         assertStatistics(worker, 0, 0);
 
-        verify(plugins).newTask(TestSourceTask.class);
-        verify(task).version();
+        verifyTaskIsolation(task);
         verifyTaskConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG);
         verifyTaskConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG);
         verifyTaskHeaderConverter();
 
-        verify(plugins).withClassLoader(same(pluginLoader), any(WorkerSourceTask.class));
-        verify(executorService).submit(isolatedRunnable);
-        verify(plugins).connectorLoader(SampleSourceConnector.class.getName());
-        verify(plugins).connectorClass(SampleSourceConnector.class.getName());
+        verifyExecutorSubmit();
 
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
     }
 
     @Test
     public void testAddRemoveSinkTask() {
         // Most of the other cases use source tasks; we make sure to get code coverage for sink tasks here as well
-        when(plugins.connectorLoader(SampleSinkConnector.class.getName())).thenReturn(pluginLoader);
-
         SinkTask task = mock(TestSinkTask.class);
-        when(plugins.newTask(TestSinkTask.class)).thenReturn(task);
-        when(task.version()).thenReturn("1.0");
+        mockTaskIsolation(SampleSinkConnector.class, TestSinkTask.class, task);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, taskKeyConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, taskValueConverter);
         mockTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
-        when(plugins.withClassLoader(same(pluginLoader), any(WorkerSinkTask.class))).thenReturn(isolatedRunnable);
-        when(executorService.submit(isolatedRunnable)).thenReturn(null);
-        doReturn(SampleSinkConnector.class).when(plugins).connectorClass(SampleSinkConnector.class.getName());
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockExecutorSubmit(false);
 
         Map<String, String> origProps = Collections.singletonMap(TaskConfig.TASK_CLASS_CONFIG, TestSinkTask.class.getName());
 
@@ -706,19 +648,11 @@ public class WorkerTest {
         worker.stop();
         assertStatistics(worker, 0, 0);
 
-        verify(plugins).newTask(TestSinkTask.class);
-        verify(task).version();
+        verifyTaskIsolation(task);
         verifyTaskConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG);
         verifyTaskConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG);
         verifyTaskHeaderConverter();
-
-        verify(plugins).withClassLoader(same(pluginLoader), any(WorkerSinkTask.class));
-        verify(executorService).submit(isolatedRunnable);
-        verify(plugins).connectorLoader(SampleSinkConnector.class.getName());
-        verify(plugins).connectorClass(SampleSinkConnector.class.getName());
-
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
+        verifyExecutorSubmit();
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
     }
 
@@ -741,17 +675,11 @@ public class WorkerTest {
         workerProps.put(EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "enabled");
         config = new DistributedConfig(workerProps);
 
-        when(plugins.connectorLoader(SampleSourceConnector.class.getName())).thenReturn(pluginLoader);
-
-        when(plugins.newTask(TestSourceTask.class)).thenReturn(task);
-        when(task.version()).thenReturn("1.0");
+        mockTaskIsolation(SampleSourceConnector.class, TestSourceTask.class, task);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, taskKeyConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, taskValueConverter);
         mockTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
-        when(plugins.withClassLoader(same(pluginLoader), any(ExactlyOnceWorkerSourceTask.class))).thenReturn(isolatedRunnable);
-        when(executorService.submit(isolatedRunnable)).thenReturn(null);
-        doReturn(SampleSourceConnector.class).when(plugins).connectorClass(SampleSourceConnector.class.getName());
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockExecutorSubmit(false);
 
         Runnable preProducer = mock(Runnable.class);
         Runnable postProducer = mock(Runnable.class);
@@ -775,19 +703,11 @@ public class WorkerTest {
         worker.stop();
         assertStatistics(worker, 0, 0);
 
-        verify(plugins).newTask(TestSourceTask.class);
-        verify(task).version();
+        verifyTaskIsolation(task);
         verifyTaskConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG);
         verifyTaskConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG);
         verifyTaskHeaderConverter();
-
-        verify(plugins).withClassLoader(same(pluginLoader), any(ExactlyOnceWorkerSourceTask.class));
-        verify(executorService).submit(isolatedRunnable);
-        verify(plugins).connectorLoader(SampleSourceConnector.class.getName());
-        verify(plugins).connectorClass(SampleSourceConnector.class.getName());
-
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
+        verifyExecutorSubmit();
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)));
     }
 
@@ -801,23 +721,12 @@ public class WorkerTest {
 
         TaskConfig taskConfig = new TaskConfig(origProps);
 
-        when(plugins.newTask(TestSourceTask.class)).thenReturn(task);
-        when(task.version()).thenReturn("1.0");
-
+        mockTaskIsolation(SampleSourceConnector.class, TestSourceTask.class, task);
         // Expect that the worker will create converters and will find them using the current classloader ...
-        assertNotNull(taskKeyConverter);
-        assertNotNull(taskValueConverter);
-        assertNotNull(taskHeaderConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, taskKeyConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, taskValueConverter);
         mockTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
-
-        when(plugins.withClassLoader(same(pluginLoader), any(WorkerSourceTask.class))).thenReturn(isolatedRunnable);
-        when(executorService.submit(isolatedRunnable)).thenReturn(null);
-        when(plugins.connectorLoader(SampleSourceConnector.class.getName())).thenReturn(pluginLoader);
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
-
-        doReturn(SampleSourceConnector.class).when(plugins).connectorClass(SampleSourceConnector.class.getName());
+        mockExecutorSubmit(false);
 
 
         // Each time we check the task metrics, the worker will call the herder
@@ -867,12 +776,8 @@ public class WorkerTest {
         WorkerSourceTask instantiatedTask = sourceTaskMockedConstruction.constructed().get(0);
         verify(instantiatedTask).initialize(taskConfig);
         verify(herder, times(5)).taskStatus(TASK_ID);
-        verify(plugins).connectorLoader(SampleSourceConnector.class.getName());
-        verify(plugins).withClassLoader(same(pluginLoader), same(instantiatedTask));
-        verify(executorService).submit(isolatedRunnable);
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
-        verify(plugins).connectorClass(SampleSourceConnector.class.getName());
+        verifyTaskIsolation(task);
+        verifyExecutorSubmit();
         verify(instantiatedTask, atLeastOnce()).id();
         verify(instantiatedTask).awaitStop(anyLong());
         verify(instantiatedTask).removeMetrics();
@@ -922,9 +827,7 @@ public class WorkerTest {
 
         Map<String, String> origProps = Collections.singletonMap(TaskConfig.TASK_CLASS_CONFIG, "missing.From.This.Workers.Classpath");
 
-        when(plugins.connectorLoader(SampleSourceConnector.class.getName())).thenReturn(pluginLoader);
-
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockGenericIsolation();
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, noneConnectorClientConfigOverridePolicy);
         worker.herder = herder;
@@ -940,8 +843,7 @@ public class WorkerTest {
         assertEquals(Collections.emptySet(), worker.taskIds());
 
         verify(taskStatusListener).onFailure(eq(TASK_ID), any(ConfigException.class));
-        verify(plugins).withClassLoader(pluginLoader);
-        verify(loaderSwap).close();
+        verifyGenericIsolation();
     }
 
     @Test
@@ -950,27 +852,15 @@ public class WorkerTest {
         mockStorage();
         mockFileConfigProvider();
 
-        when(plugins.newTask(TestSourceTask.class)).thenReturn(task);
-        when(task.version()).thenReturn("1.0");
-
+        mockTaskIsolation(SampleSourceConnector.class, TestSourceTask.class, task);
         // Expect that the worker will create converters and will not initially find them using the current classloader ...
-        assertNotNull(taskKeyConverter);
-        assertNotNull(taskValueConverter);
-        assertNotNull(taskHeaderConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, null);
         mockTaskConverter(ClassLoaderUsage.PLUGINS, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, taskKeyConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, null);
         mockTaskConverter(ClassLoaderUsage.PLUGINS, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, taskValueConverter);
         mockTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, null);
         mockTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
-
-        when(plugins.withClassLoader(same(pluginLoader), any(WorkerSourceTask.class))).thenReturn(isolatedRunnable);
-        when(executorService.submit(isolatedRunnable)).thenReturn(null);
-
-        when(plugins.connectorLoader(SampleSourceConnector.class.getName())).thenReturn(pluginLoader);
-        doReturn(SampleSourceConnector.class).when(plugins).connectorClass(SampleSourceConnector.class.getName());
-
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockExecutorSubmit(false);
 
         Map<String, String> origProps = Collections.singletonMap(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
 
@@ -989,21 +879,14 @@ public class WorkerTest {
         verifyStorage();
 
         WorkerSourceTask constructedMockTask = sourceTaskMockedConstruction.constructed().get(0);
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
-        verify(plugins).newTask(TestSourceTask.class);
-
-        verify(plugins).connectorLoader(SampleSourceConnector.class.getName());
-        verify(plugins).connectorClass(SampleSourceConnector.class.getName());
         verify(constructedMockTask).initialize(taskConfig);
         verify(constructedMockTask).loader();
         verify(constructedMockTask).stop();
         verify(constructedMockTask).awaitStop(anyLong());
         verify(constructedMockTask).removeMetrics();
+        verifyTaskIsolation(task);
         verifyConverters();
-
-        verify(plugins).withClassLoader(same(pluginLoader), any(WorkerSourceTask.class));
-        verify(executorService).submit(isolatedRunnable);
+        verifyExecutorSubmit();
     }
 
     @Test
@@ -1015,28 +898,15 @@ public class WorkerTest {
         Map<String, String> origProps = Collections.singletonMap(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
         TaskConfig taskConfig = new TaskConfig(origProps);
 
-        when(plugins.newTask(TestSourceTask.class)).thenReturn(task);
-        when(task.version()).thenReturn("1.0");
-
+        mockTaskIsolation(SampleSourceConnector.class, TestSourceTask.class, task);
         // Expect that the worker will create converters and will not initially find them using the current classloader ...
-        assertNotNull(taskKeyConverter);
-        assertNotNull(taskValueConverter);
-        assertNotNull(taskHeaderConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, null);
         mockTaskConverter(ClassLoaderUsage.PLUGINS, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, taskKeyConverter);
         mockTaskConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, null);
         mockTaskConverter(ClassLoaderUsage.PLUGINS, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, taskValueConverter);
         mockTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, null);
         mockTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
-
-        when(plugins.withClassLoader(same(pluginLoader), any(WorkerSourceTask.class))).thenReturn(isolatedRunnable);
-        when(executorService.submit(isolatedRunnable)).thenReturn(null);
-
-        when(plugins.connectorLoader(SampleSourceConnector.class.getName())).thenReturn(pluginLoader);
-        doReturn(SampleSourceConnector.class).when(plugins).connectorClass(SampleSourceConnector.class.getName());
-
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
-
+        mockExecutorSubmit(false);
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, executorService,
                             noneConnectorClientConfigOverridePolicy);
@@ -1058,21 +928,16 @@ public class WorkerTest {
         assertStatistics(worker, 0, 0);
 
         // We've mocked the Plugin.newConverter method, so we don't currently configure the converters
-        verify(plugins).newTask(TestSourceTask.class);
         WorkerSourceTask instantiatedTask = sourceTaskMockedConstruction.constructed().get(0);
         verify(instantiatedTask).initialize(taskConfig);
-        verify(plugins).withClassLoader(same(pluginLoader), any(WorkerSourceTask.class));
-        verify(executorService).submit(isolatedRunnable);
-        verify(plugins).connectorLoader(SampleSourceConnector.class.getName());
-        verify(plugins, times(2)).withClassLoader(pluginLoader);
-        verify(loaderSwap, times(2)).close();
-        verify(plugins).connectorClass(SampleSourceConnector.class.getName());
 
         // Remove
         verify(instantiatedTask).stop();
         verify(instantiatedTask).awaitStop(anyLong());
         verify(instantiatedTask).removeMetrics();
 
+        verifyTaskIsolation(task);
+        verifyExecutorSubmit();
         verifyStorage();
     }
 
@@ -1805,8 +1670,7 @@ public class WorkerTest {
         when(fenceProducersResult.all()).thenReturn(fenceProducersFuture);
         when(fenceProducersFuture.whenComplete(any())).thenReturn(expectedZombieFenceFuture);
 
-        when(plugins.connectorLoader(anyString())).thenReturn(pluginLoader);
-        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+        mockGenericIsolation();
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, executorService,
                 allConnectorClientConfigOverridePolicy);
@@ -1831,6 +1695,8 @@ public class WorkerTest {
                 "4761",
                 adminConfig.get().get(RETRY_BACKOFF_MS_CONFIG)
         );
+
+        verifyGenericIsolation();
     }
 
     private void assertStatusMetrics(long expected, String metricName) {
@@ -1921,6 +1787,61 @@ public class WorkerTest {
 
     private void verifyTaskHeaderConverter() {
         verify(plugins).newHeaderConverter(any(AbstractConfig.class), eq(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG), eq(ClassLoaderUsage.CURRENT_CLASSLOADER));
+    }
+
+    private void mockGenericIsolation() {
+        when(plugins.connectorLoader(anyString())).thenReturn(pluginLoader);
+        when(plugins.withClassLoader(pluginLoader)).thenReturn(loaderSwap);
+    }
+
+    private void verifyGenericIsolation() {
+        verify(plugins, atLeastOnce()).withClassLoader(pluginLoader);
+        verify(loaderSwap, atLeastOnce()).close();
+    }
+
+    private void mockConnectorIsolation(String connectorClass, Connector connector) {
+        mockGenericIsolation();
+        when(plugins.newConnector(connectorClass)).thenReturn(connector);
+        when(connector.version()).thenReturn("1.0");
+    }
+
+    private void verifyConnectorIsolation(Connector connector) {
+        verifyGenericIsolation();
+        verify(plugins).newConnector(anyString());
+        verify(connector, atLeastOnce()).version();
+    }
+
+    private void mockTaskIsolation(Class<? extends Connector> connector, Class<? extends Task> taskClass, Task task) {
+        mockGenericIsolation();
+        doReturn(connector).when(plugins).connectorClass(connector.getName());
+        when(plugins.newTask(taskClass)).thenReturn(task);
+        when(task.version()).thenReturn("1.0");
+    }
+
+    private void verifyTaskIsolation(Task task) {
+        verifyGenericIsolation();
+        verify(plugins).connectorClass(anyString());
+        verify(plugins).newTask(any());
+        verify(task).version();
+    }
+
+    private void mockExecutorSubmit(boolean startRunnable) {
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(plugins.withClassLoader(same(pluginLoader), runnableCaptor.capture())).thenReturn(isolatedRunnable);
+        if (startRunnable) {
+            // This test expects the runnable to be executed, so have the isolated runnable pass-through.
+            doAnswer(invocation -> {
+                runnableCaptor.getValue().run();
+                return null;
+            }).when(isolatedRunnable).run();
+        } else {
+            // This test does not expect the runnable to be executed, so skip it.
+            when(executorService.submit(isolatedRunnable)).thenReturn(null);
+        }
+    }
+
+    private void verifyExecutorSubmit() {
+        verify(plugins).withClassLoader(same(pluginLoader), any(Runnable.class));
     }
 
     private Map<String, String> anyConnectorConfigMap() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -43,8 +43,6 @@ import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder.HerderMetrics;
-import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
-import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.RestClient;
@@ -124,7 +122,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({DistributedHerder.class, Plugins.class, RestClient.class})
+@PrepareForTest({DistributedHerder.class, RestClient.class})
 @PowerMockIgnore({"javax.management.*", "javax.crypto.*"})
 public class DistributedHerderTest {
     private static final Map<String, String> HERDER_CONFIG = new HashMap<>();
@@ -214,8 +212,6 @@ public class DistributedHerderTest {
     @Mock private WorkerConfigTransformer transformer;
     @Mock private Callback<Herder.Created<ConnectorInfo>> putConnectorCallback;
     @Mock private Plugins plugins;
-    @Mock private PluginClassLoader pluginLoader;
-    @Mock private DelegatingClassLoader delegatingLoader;
     private CountDownLatch shutdownCalled = new CountDownLatch(1);
 
     private ConfigBackingStore.UpdateListener configUpdateListener;
@@ -253,9 +249,6 @@ public class DistributedHerderTest {
         conn1SinkConfig = new SinkConnectorConfig(plugins, CONN1_CONFIG);
         conn1SinkConfigUpdated = new SinkConnectorConfig(plugins, CONN1_CONFIG_UPDATED);
         EasyMock.expect(herder.connectorType(EasyMock.anyObject())).andReturn(ConnectorType.SOURCE).anyTimes();
-        pluginLoader = PowerMock.createMock(PluginClassLoader.class);
-        delegatingLoader = PowerMock.createMock(DelegatingClassLoader.class);
-        PowerMock.mockStatic(Plugins.class);
         PowerMock.expectPrivate(herder, "updateDeletedConnectorStatus").andVoid().anyTimes();
         PowerMock.expectPrivate(herder, "updateDeletedTaskStatus").andVoid().anyTimes();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -249,9 +249,9 @@ public class PluginsTest {
         TestPlugins.assertAvailable();
         props.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, TestPlugins.SAMPLING_CONVERTER);
         ClassLoader classLoader = plugins.delegatingLoader().pluginClassLoader(TestPlugins.SAMPLING_CONVERTER);
-        ClassLoader savedLoader = Plugins.compareAndSwapLoaders(classLoader);
-        createConfig();
-        Plugins.compareAndSwapLoaders(savedLoader);
+        try (LoaderSwap loaderSwap = plugins.withClassLoader(classLoader)) {
+            createConfig();
+        }
 
         Converter plugin = plugins.newConverter(
             config,
@@ -273,9 +273,9 @@ public class PluginsTest {
 
         PluginClassLoader classLoader = plugins.delegatingLoader().pluginClassLoader(TestPlugins.SAMPLING_CONFIG_PROVIDER);
         assertNotNull(classLoader);
-        ClassLoader savedLoader = Plugins.compareAndSwapLoaders(classLoader);
-        createConfig();
-        Plugins.compareAndSwapLoaders(savedLoader);
+        try (LoaderSwap loaderSwap = plugins.withClassLoader(classLoader)) {
+            createConfig();
+        }
 
         ConfigProvider plugin = plugins.newConfigProvider(
             config,
@@ -294,9 +294,9 @@ public class PluginsTest {
         TestPlugins.assertAvailable();
         props.put(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, TestPlugins.SAMPLING_HEADER_CONVERTER);
         ClassLoader classLoader = plugins.delegatingLoader().pluginClassLoader(TestPlugins.SAMPLING_HEADER_CONVERTER);
-        ClassLoader savedLoader = Plugins.compareAndSwapLoaders(classLoader);
-        createConfig();
-        Plugins.compareAndSwapLoaders(savedLoader);
+        try (LoaderSwap loaderSwap = plugins.withClassLoader(classLoader)) {
+            createConfig();
+        }
 
         HeaderConverter plugin = plugins.newHeaderConverter(
             config,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -41,8 +41,8 @@ import org.apache.kafka.connect.runtime.TaskStatus;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.WorkerConnector;
+import org.apache.kafka.connect.runtime.isolation.LoaderSwap;
 import org.apache.kafka.connect.storage.ClusterConfigState;
-import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -96,7 +96,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
 @SuppressWarnings("unchecked")
-@PrepareForTest({StandaloneHerder.class, Plugins.class, WorkerConnector.class})
+@PrepareForTest({StandaloneHerder.class, WorkerConnector.class})
 public class StandaloneHerderTest {
     private static final String CONNECTOR_NAME = "test";
     private static final String TOPICS_LIST_STR = "topic1,topic2";
@@ -116,7 +116,7 @@ public class StandaloneHerderTest {
     @Mock
     private PluginClassLoader pluginLoader;
     @Mock
-    private DelegatingClassLoader delegatingLoader;
+    private LoaderSwap loaderSwap;
     protected FutureCallback<Herder.Created<ConnectorInfo>> createCallback;
     @Mock protected StatusBackingStore statusBackingStore;
 
@@ -133,8 +133,7 @@ public class StandaloneHerderTest {
         createCallback = new FutureCallback<>();
         plugins = PowerMock.createMock(Plugins.class);
         pluginLoader = PowerMock.createMock(PluginClassLoader.class);
-        delegatingLoader = PowerMock.createMock(DelegatingClassLoader.class);
-        PowerMock.mockStatic(Plugins.class);
+        loaderSwap = PowerMock.createMock(LoaderSwap.class);
         PowerMock.mockStatic(WorkerConnector.class);
         Capture<Map<String, String>> configCapture = Capture.newInstance();
         EasyMock.expect(transformer.transform(eq(CONNECTOR_NAME), EasyMock.capture(configCapture))).andAnswer(configCapture::getValue).anyTimes();
@@ -170,22 +169,26 @@ public class StandaloneHerderTest {
         EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
         final Capture<Map<String, String>> configCapture = EasyMock.newCapture();
         EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
+        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(4);
         EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
+        EasyMock.expect(plugins.connectorLoader(EasyMock.anyString())).andReturn(pluginLoader);
+        EasyMock.expect(plugins.withClassLoader(pluginLoader)).andReturn(loaderSwap);
 
         EasyMock.expect(connectorMock.config()).andStubReturn(new ConfigDef());
 
         ConfigValue validatedValue = new ConfigValue("foo.bar");
         EasyMock.expect(connectorMock.validate(config)).andReturn(new Config(singletonList(validatedValue)));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
+        loaderSwap.close();
+        EasyMock.expectLastCall();
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
 
         ExecutionException exception = assertThrows(ExecutionException.class, () -> createCallback.get(1000L, TimeUnit.SECONDS));
-        assertEquals(BadRequestException.class, exception.getCause().getClass());
+        if (BadRequestException.class != exception.getCause().getClass()) {
+            throw new AssertionError(exception.getCause());
+        }
         PowerMock.verifyAll();
     }
 
@@ -202,10 +205,12 @@ public class StandaloneHerderTest {
         EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
         final Capture<Map<String, String>> configCapture = EasyMock.newCapture();
         EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(2);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
+        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
+        EasyMock.expect(plugins.connectorLoader(EasyMock.anyString())).andReturn(pluginLoader);
+        EasyMock.expect(plugins.withClassLoader(pluginLoader)).andReturn(loaderSwap);
         // No new connector is created
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
+        loaderSwap.close();
+        EasyMock.expectLastCall();
 
         PowerMock.replayAll();
 
@@ -217,7 +222,9 @@ public class StandaloneHerderTest {
         FutureCallback<Herder.Created<ConnectorInfo>> failedCreateCallback = new FutureCallback<>();
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, failedCreateCallback);
         ExecutionException exception = assertThrows(ExecutionException.class, () -> failedCreateCallback.get(1000L, TimeUnit.SECONDS));
-        assertEquals(AlreadyExistsException.class, exception.getCause().getClass());
+        if (AlreadyExistsException.class != exception.getCause().getClass()) {
+            throw new AssertionError(exception.getCause());
+        }
         PowerMock.verifyAll();
     }
 
@@ -903,11 +910,13 @@ public class StandaloneHerderTest {
         final Capture<Map<String, String>> configCapture = EasyMock.newCapture();
         EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
         EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
+        EasyMock.expect(plugins.connectorLoader(EasyMock.anyString())).andReturn(pluginLoader);
+        EasyMock.expect(plugins.withClassLoader(pluginLoader)).andReturn(loaderSwap);
         EasyMock.expect(worker.getPlugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
         EasyMock.expect(connectorMock.config()).andStubReturn(configDef);
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
+        loaderSwap.close();
+        EasyMock.expectLastCall();
 
         PowerMock.replayAll();
 
@@ -1042,8 +1051,9 @@ public class StandaloneHerderTest {
         EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
         final Capture<Map<String, String>> configCapture = EasyMock.newCapture();
         EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
+        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(4);
+        EasyMock.expect(plugins.connectorLoader(EasyMock.anyString())).andReturn(pluginLoader);
+        EasyMock.expect(plugins.withClassLoader(pluginLoader)).andReturn(loaderSwap);
         if (shouldCreateConnector) {
             EasyMock.expect(worker.getPlugins()).andReturn(plugins);
             EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
@@ -1052,7 +1062,8 @@ public class StandaloneHerderTest {
 
         for (Map<String, String> config : configs)
             EasyMock.expect(connectorMock.validate(config)).andReturn(new Config(Collections.emptyList()));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
+        loaderSwap.close();
+        EasyMock.expectLastCall();
     }
 
     // We need to use a real class here due to some issue with mocking java.lang.Class


### PR DESCRIPTION
The current dominant compareAndSwapClassLoader usage idiom in the codebase is as follows:
```
ClassLoader savedLoader = plugins.compareAndSwapLoaders(loader);
try {
     // operations which are sensitive to the thread context classloader
} finally {
    Plugins.compareAndSwapLoader(savedLoader);
}
```
This is difficult to mock in tests due to the static method call used to swap back to the previous classloader.
Instead, this operation should be managed by a non-static try-with-resources call which is more easily mocked:
```
try (LoaderSwap loaderSwap = plugins.withClassLoader(loader)) {
    // operations which are sensitive to the thread context classloader
}
```
This should also be less error-prone, as there is only one statement needed to safely create a special classloading context, rather than two.
I also experimented with combining the plugins.connectorLoader(String) functionality into a similar withClassLoader() call, but omitted this from the PR as it complicated error handling. As-is, the withClassLoader call should not fail due to missing plugins, whereas the connectorLoader class will intentionally fail if a connector is not found.

In addition to the title change, also clean up some unnecessary calls to Plugins::delegatingLoader, a now unused Plugins::currentThreadLoader, and a now trivial Worker::executeStateTransition. And remove the static mocking from the tests which was the impetus for this change.

Also, moved the WorkerConnector/WorkerTask thread classloader ownership out to the Worker, as all other thread classloader management was already handled from the worker side. Mechanically, this is because a WorkerConnector/WorkerTask does not have access to the Plugins object of the worker, and is effectively in a single-plugin environment. Rather than inject the Plugins instance into each of the WorkerConnector/WorkerTask, I chose to pull the isolation functionality out of the WorkerConnector/WorkerTask entirely.

Signed-off-by: Greg Harris <greg.harris@aiven.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
