### PR TITLE
KAFKA-14133: Replace EasyMock with Mockito in streams tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
@@ -44,9 +43,11 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.PositionSerde;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -62,27 +63,29 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextImpl.BYTEARRAY_VALUE_SERIALIZER;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextImpl.BYTES_KEY_SERIALIZER;
-import static org.easymock.EasyMock.anyLong;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ProcessorContextImplTest {
     private ProcessorContextImpl context;
 
     private final StreamsConfig streamsConfig = streamsConfigMock();
 
-    private final RecordCollector recordCollector = mock(RecordCollector.class);
-    private final ProcessorStateManager stateManager = mock(ProcessorStateManager.class);
+    @Mock
+    private RecordCollector recordCollector;
+    @Mock
+    private ProcessorStateManager stateManager;
 
     private static final String KEY = "key";
     private static final Bytes KEY_BYTES = Bytes.wrap(KEY.getBytes());
@@ -103,16 +106,23 @@ public class ProcessorContextImplTest {
     private boolean deleteExecuted;
     private boolean removeExecuted;
 
+    @Mock
     private KeyValueIterator<String, Long> rangeIter;
+    @Mock
     private KeyValueIterator<String, ValueAndTimestamp<Long>> timestampedRangeIter;
+    @Mock
     private KeyValueIterator<String, Long> allIter;
+    @Mock
     private KeyValueIterator<String, ValueAndTimestamp<Long>> timestampedAllIter;
+    @Mock
+    private WindowStoreIterator windowStoreIter;
 
     private final List<KeyValueIterator<Windowed<String>, Long>> iters = new ArrayList<>(7);
     private final List<KeyValueIterator<Windowed<String>, ValueAndTimestamp<Long>>> timestampedIters = new ArrayList<>(7);
-    private WindowStoreIterator windowStoreIter;
+
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() {
         flushExecuted = false;
         putExecuted = false;
@@ -121,33 +131,25 @@ public class ProcessorContextImplTest {
         deleteExecuted = false;
         removeExecuted = false;
 
-        rangeIter = mock(KeyValueIterator.class);
-        timestampedRangeIter = mock(KeyValueIterator.class);
-        allIter = mock(KeyValueIterator.class);
-        timestampedAllIter = mock(KeyValueIterator.class);
-        windowStoreIter = mock(WindowStoreIterator.class);
-
         for (int i = 0; i < 7; i++) {
             iters.add(i, mock(KeyValueIterator.class));
             timestampedIters.add(i, mock(KeyValueIterator.class));
         }
 
-        expect(stateManager.taskType()).andStubReturn(TaskType.ACTIVE);
+        when(stateManager.taskType()).thenReturn(TaskType.ACTIVE);
 
-        expect(stateManager.getGlobalStore("GlobalKeyValueStore")).andReturn(keyValueStoreMock());
-        expect(stateManager.getGlobalStore("GlobalTimestampedKeyValueStore")).andReturn(timestampedKeyValueStoreMock());
-        expect(stateManager.getGlobalStore("GlobalWindowStore")).andReturn(windowStoreMock());
-        expect(stateManager.getGlobalStore("GlobalTimestampedWindowStore")).andReturn(timestampedWindowStoreMock());
-        expect(stateManager.getGlobalStore("GlobalSessionStore")).andReturn(sessionStoreMock());
-        expect(stateManager.getGlobalStore(anyString())).andReturn(null);
-        expect(stateManager.getStore("LocalKeyValueStore")).andReturn(keyValueStoreMock());
-        expect(stateManager.getStore("LocalTimestampedKeyValueStore")).andReturn(timestampedKeyValueStoreMock());
-        expect(stateManager.getStore("LocalWindowStore")).andReturn(windowStoreMock());
-        expect(stateManager.getStore("LocalTimestampedWindowStore")).andReturn(timestampedWindowStoreMock());
-        expect(stateManager.getStore("LocalSessionStore")).andReturn(sessionStoreMock());
-        expect(stateManager.registeredChangelogPartitionFor(REGISTERED_STORE_NAME)).andStubReturn(CHANGELOG_PARTITION);
-
-        replay(stateManager);
+        when(stateManager.getGlobalStore(anyString())).thenReturn(null);
+        when(stateManager.getGlobalStore("GlobalKeyValueStore")).thenAnswer(answer -> keyValueStoreMock());
+        when(stateManager.getGlobalStore("GlobalTimestampedKeyValueStore")).thenAnswer(answer -> timestampedKeyValueStoreMock());
+        when(stateManager.getGlobalStore("GlobalWindowStore")).thenAnswer(answer -> windowStoreMock());
+        when(stateManager.getGlobalStore("GlobalTimestampedWindowStore")).thenAnswer(answer -> timestampedWindowStoreMock());
+        when(stateManager.getGlobalStore("GlobalSessionStore")).thenAnswer(answer -> sessionStoreMock());
+        when(stateManager.getStore("LocalKeyValueStore")).thenAnswer(answer -> keyValueStoreMock());
+        when(stateManager.getStore("LocalTimestampedKeyValueStore")).thenAnswer(answer -> timestampedKeyValueStoreMock());
+        when(stateManager.getStore("LocalWindowStore")).thenAnswer(answer -> windowStoreMock());
+        when(stateManager.getStore("LocalTimestampedWindowStore")).thenAnswer(answer -> timestampedWindowStoreMock());
+        when(stateManager.getStore("LocalSessionStore")).thenAnswer(answer -> sessionStoreMock());
+        when(stateManager.registeredChangelogPartitionFor(REGISTERED_STORE_NAME)).thenReturn(CHANGELOG_PARTITION);
 
         context = new ProcessorContextImpl(
             mock(TaskId.class),
@@ -158,10 +160,8 @@ public class ProcessorContextImplTest {
         );
 
         final StreamTask task = mock(StreamTask.class);
-        expect(task.streamTime()).andReturn(STREAM_TIME);
-        EasyMock.expect(task.recordCollector()).andStubReturn(recordCollector);
-        replay(task);
-        ((InternalProcessorContext) context).transitionToActive(task, null, null);
+        when(task.streamTime()).thenReturn(STREAM_TIME);
+        context.transitionToActive(task, null, null);
 
         context.setCurrentNode(
             new ProcessorNode<>(
@@ -181,9 +181,8 @@ public class ProcessorContextImplTest {
     }
 
     private ProcessorContextImpl getStandbyContext() {
-        final ProcessorStateManager stateManager = EasyMock.createNiceMock(ProcessorStateManager.class);
-        expect(stateManager.taskType()).andStubReturn(TaskType.STANDBY);
-        replay(stateManager);
+        final ProcessorStateManager stateManager = mock(ProcessorStateManager.class);
+        when(stateManager.taskType()).thenReturn(TaskType.STANDBY);
         return new ProcessorContextImpl(
             mock(TaskId.class),
             streamsConfig,
@@ -244,7 +243,6 @@ public class ProcessorContextImplTest {
             assertEquals(iters.get(2), store.all());
         });
     }
-
 
     @Test
     public void globalTimestampedWindowStoreShouldBeReadOnly() {
@@ -396,7 +394,12 @@ public class ProcessorContextImplTest {
 
     @Test
     public void shouldNotSendRecordHeadersToChangelogTopic() {
-        recordCollector.send(
+        final StreamTask task = mock(StreamTask.class);
+
+        context.transitionToActive(task, recordCollector, null);
+        context.logChange(REGISTERED_STORE_NAME, KEY_BYTES, VALUE_BYTES, TIMESTAMP, Position.emptyPosition());
+
+        verify(recordCollector).send(
             CHANGELOG_PARTITION.topic(),
             KEY_BYTES,
             VALUE_BYTES,
@@ -407,14 +410,6 @@ public class ProcessorContextImplTest {
             BYTEARRAY_VALUE_SERIALIZER,
             null,
             null);
-
-        final StreamTask task = EasyMock.createNiceMock(StreamTask.class);
-
-        replay(recordCollector, task);
-        context.transitionToActive(task, recordCollector, null);
-        context.logChange(REGISTERED_STORE_NAME, KEY_BYTES, VALUE_BYTES, TIMESTAMP, Position.emptyPosition());
-
-        verify(recordCollector);
     }
 
     @Test
@@ -424,21 +419,9 @@ public class ProcessorContextImplTest {
         headers.add(ChangelogRecordDeserializationHelper.CHANGELOG_VERSION_HEADER_RECORD_CONSISTENCY);
         headers.add(new RecordHeader(ChangelogRecordDeserializationHelper.CHANGELOG_POSITION_HEADER_KEY,
                 PositionSerde.serialize(position).array()));
-        recordCollector.send(
-            CHANGELOG_PARTITION.topic(),
-            KEY_BYTES,
-            VALUE_BYTES,
-            headers,
-            CHANGELOG_PARTITION.partition(),
-            TIMESTAMP,
-            BYTES_KEY_SERIALIZER,
-            BYTEARRAY_VALUE_SERIALIZER,
-            null,
-            null);
 
-        final StreamTask task = EasyMock.createNiceMock(StreamTask.class);
+        final StreamTask task = mock(StreamTask.class);
 
-        replay(recordCollector, task);
         context = new ProcessorContextImpl(
                 mock(TaskId.class),
                 streamsConfigWithConsistencyMock(),
@@ -450,7 +433,17 @@ public class ProcessorContextImplTest {
         context.transitionToActive(task, recordCollector, null);
         context.logChange(REGISTERED_STORE_NAME, KEY_BYTES, VALUE_BYTES, TIMESTAMP, position);
 
-        verify(recordCollector);
+        verify(recordCollector).send(
+            CHANGELOG_PARTITION.topic(),
+            KEY_BYTES,
+            VALUE_BYTES,
+            headers,
+            CHANGELOG_PARTITION.partition(),
+            TIMESTAMP,
+            BYTES_KEY_SERIALIZER,
+            BYTEARRAY_VALUE_SERIALIZER,
+            null,
+            null);
     }
 
     @Test
@@ -610,38 +603,31 @@ public class ProcessorContextImplTest {
 
         initStateStoreMock(keyValueStoreMock);
 
-        expect(keyValueStoreMock.get(KEY)).andReturn(VALUE);
-        expect(keyValueStoreMock.approximateNumEntries()).andReturn(VALUE);
+        when(keyValueStoreMock.get(KEY)).thenReturn(VALUE);
+        when(keyValueStoreMock.approximateNumEntries()).thenReturn(VALUE);
 
-        expect(keyValueStoreMock.range("one", "two")).andReturn(rangeIter);
-        expect(keyValueStoreMock.all()).andReturn(allIter);
+        when(keyValueStoreMock.range("one", "two")).thenReturn(rangeIter);
+        when(keyValueStoreMock.all()).thenReturn(allIter);
 
-
-        keyValueStoreMock.put(anyString(), anyLong());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putExecuted = true;
             return null;
-        });
+        }).when(keyValueStoreMock).put(anyString(), anyLong());
 
-        keyValueStoreMock.putIfAbsent(anyString(), anyLong());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putIfAbsentExecuted = true;
             return null;
-        });
+        }).when(keyValueStoreMock).putIfAbsent(anyString(), anyLong());
 
-        keyValueStoreMock.putAll(anyObject(List.class));
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putAllExecuted = true;
             return null;
-        });
+        }).when(keyValueStoreMock).putAll(any(List.class));
 
-        keyValueStoreMock.delete(anyString());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             deleteExecuted = true;
             return null;
-        });
-
-        replay(keyValueStoreMock);
+        }).when(keyValueStoreMock).delete(anyString());
 
         return keyValueStoreMock;
     }
@@ -652,38 +638,31 @@ public class ProcessorContextImplTest {
 
         initStateStoreMock(timestampedKeyValueStoreMock);
 
-        expect(timestampedKeyValueStoreMock.get(KEY)).andReturn(VALUE_AND_TIMESTAMP);
-        expect(timestampedKeyValueStoreMock.approximateNumEntries()).andReturn(VALUE);
+        when(timestampedKeyValueStoreMock.get(KEY)).thenReturn(VALUE_AND_TIMESTAMP);
+        when(timestampedKeyValueStoreMock.approximateNumEntries()).thenReturn(VALUE);
 
-        expect(timestampedKeyValueStoreMock.range("one", "two")).andReturn(timestampedRangeIter);
-        expect(timestampedKeyValueStoreMock.all()).andReturn(timestampedAllIter);
+        when(timestampedKeyValueStoreMock.range("one", "two")).thenReturn(timestampedRangeIter);
+        when(timestampedKeyValueStoreMock.all()).thenReturn(timestampedAllIter);
 
-
-        timestampedKeyValueStoreMock.put(anyString(), anyObject(ValueAndTimestamp.class));
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putExecuted = true;
             return null;
-        });
+        }).when(timestampedKeyValueStoreMock).put(anyString(), any(ValueAndTimestamp.class));
 
-        timestampedKeyValueStoreMock.putIfAbsent(anyString(), anyObject(ValueAndTimestamp.class));
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putIfAbsentExecuted = true;
             return null;
-        });
+        }).when(timestampedKeyValueStoreMock).putIfAbsent(anyString(), any(ValueAndTimestamp.class));
 
-        timestampedKeyValueStoreMock.putAll(anyObject(List.class));
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putAllExecuted = true;
             return null;
-        });
+        }).when(timestampedKeyValueStoreMock).putAll(any(List.class));
 
-        timestampedKeyValueStoreMock.delete(anyString());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             deleteExecuted = true;
             return null;
-        });
-
-        replay(timestampedKeyValueStoreMock);
+        }).when(timestampedKeyValueStoreMock).delete(anyString());
 
         return timestampedKeyValueStoreMock;
     }
@@ -694,19 +673,16 @@ public class ProcessorContextImplTest {
 
         initStateStoreMock(windowStore);
 
-        expect(windowStore.fetchAll(anyLong(), anyLong())).andReturn(iters.get(0));
-        expect(windowStore.fetch(anyString(), anyString(), anyLong(), anyLong())).andReturn(iters.get(1));
-        expect(windowStore.fetch(anyString(), anyLong(), anyLong())).andReturn(windowStoreIter);
-        expect(windowStore.fetch(anyString(), anyLong())).andReturn(VALUE);
-        expect(windowStore.all()).andReturn(iters.get(2));
+        when(windowStore.fetchAll(anyLong(), anyLong())).thenReturn(iters.get(0));
+        when(windowStore.fetch(anyString(), anyString(), anyLong(), anyLong())).thenReturn(iters.get(1));
+        when(windowStore.fetch(anyString(), anyLong(), anyLong())).thenReturn(windowStoreIter);
+        when(windowStore.fetch(anyString(), anyLong())).thenReturn(VALUE);
+        when(windowStore.all()).thenReturn(iters.get(2));
 
-        windowStore.put(anyString(), anyLong(), anyLong());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putExecuted = true;
             return null;
-        });
-
-        replay(windowStore);
+        }).when(windowStore).put(anyString(), anyLong(), anyLong());
 
         return windowStore;
     }
@@ -717,25 +693,19 @@ public class ProcessorContextImplTest {
 
         initStateStoreMock(windowStore);
 
-        expect(windowStore.fetchAll(anyLong(), anyLong())).andReturn(timestampedIters.get(0));
-        expect(windowStore.fetch(anyString(), anyString(), anyLong(), anyLong())).andReturn(timestampedIters.get(1));
-        expect(windowStore.fetch(anyString(), anyLong(), anyLong())).andReturn(windowStoreIter);
-        expect(windowStore.fetch(anyString(), anyLong())).andReturn(VALUE_AND_TIMESTAMP);
-        expect(windowStore.all()).andReturn(timestampedIters.get(2));
+        when(windowStore.fetchAll(anyLong(), anyLong())).thenReturn(timestampedIters.get(0));
+        when(windowStore.fetch(anyString(), anyString(), anyLong(), anyLong())).thenReturn(timestampedIters.get(1));
+        when(windowStore.fetch(anyString(), anyLong(), anyLong())).thenReturn(windowStoreIter);
+        when(windowStore.fetch(anyString(), anyLong())).thenReturn(VALUE_AND_TIMESTAMP);
+        when(windowStore.all()).thenReturn(timestampedIters.get(2));
 
-        windowStore.put(anyString(), anyObject(ValueAndTimestamp.class), anyLong());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putExecuted = true;
             return null;
-        });
-
-        windowStore.put(anyString(), anyObject(ValueAndTimestamp.class), anyLong());
-        expectLastCall().andAnswer(() -> {
+        }).doAnswer(answer -> {
             putWithTimestampExecuted = true;
             return null;
-        });
-
-        replay(windowStore);
+        }).when(windowStore).put(anyString(), any(ValueAndTimestamp.class), anyLong());
 
         return windowStore;
     }
@@ -746,36 +716,29 @@ public class ProcessorContextImplTest {
 
         initStateStoreMock(sessionStore);
 
-        expect(sessionStore.findSessions(anyString(), anyLong(), anyLong())).andReturn(iters.get(3));
-        expect(sessionStore.findSessions(anyString(), anyString(), anyLong(), anyLong())).andReturn(iters.get(4));
-        expect(sessionStore.fetch(anyString())).andReturn(iters.get(5));
-        expect(sessionStore.fetch(anyString(), anyString())).andReturn(iters.get(6));
+        when(sessionStore.findSessions(anyString(), anyLong(), anyLong())).thenReturn(iters.get(3));
+        when(sessionStore.findSessions(anyString(), anyString(), anyLong(), anyLong())).thenReturn(iters.get(4));
+        when(sessionStore.fetch(anyString())).thenReturn(iters.get(5));
+        when(sessionStore.fetch(anyString(), anyString())).thenReturn(iters.get(6));
 
-        sessionStore.put(anyObject(Windowed.class), anyLong());
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             putExecuted = true;
             return null;
-        });
+        }).when(sessionStore).put(any(), any());
 
-        sessionStore.remove(anyObject(Windowed.class));
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             removeExecuted = true;
             return null;
-        });
-
-        replay(sessionStore);
+        }).when(sessionStore).remove(any());
 
         return sessionStore;
     }
 
     private StreamsConfig streamsConfigMock() {
         final StreamsConfig streamsConfig = mock(StreamsConfig.class);
-        expect(streamsConfig.originals()).andStubReturn(Collections.emptyMap());
-        expect(streamsConfig.values()).andStubReturn(Collections.emptyMap());
-        expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andStubReturn("add-id");
-        expect(streamsConfig.defaultValueSerde()).andStubReturn(Serdes.ByteArray());
-        expect(streamsConfig.defaultKeySerde()).andStubReturn(Serdes.ByteArray());
-        replay(streamsConfig);
+        when(streamsConfig.originals()).thenReturn(Collections.emptyMap());
+        when(streamsConfig.values()).thenReturn(Collections.emptyMap());
+        when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");
         return streamsConfig;
     }
 
@@ -784,25 +747,21 @@ public class ProcessorContextImplTest {
 
         final Map<String, Object> myValues = new HashMap<>();
         myValues.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
-        expect(streamsConfig.originals()).andStubReturn(myValues);
-        expect(streamsConfig.values()).andStubReturn(Collections.emptyMap());
-        expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andStubReturn("add-id");
-        expect(streamsConfig.defaultValueSerde()).andStubReturn(Serdes.ByteArray());
-        expect(streamsConfig.defaultKeySerde()).andStubReturn(Serdes.ByteArray());
-        replay(streamsConfig);
+        when(streamsConfig.originals()).thenReturn(myValues);
+        when(streamsConfig.values()).thenReturn(Collections.emptyMap());
+        when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");
         return streamsConfig;
     }
 
     private void initStateStoreMock(final StateStore stateStore) {
-        expect(stateStore.name()).andReturn(STORE_NAME);
-        expect(stateStore.persistent()).andReturn(true);
-        expect(stateStore.isOpen()).andReturn(true);
+        when(stateStore.name()).thenReturn(STORE_NAME);
+        when(stateStore.persistent()).thenReturn(true);
+        when(stateStore.isOpen()).thenReturn(true);
 
-        stateStore.flush();
-        expectLastCall().andAnswer(() -> {
+        doAnswer(answer -> {
             flushExecuted = true;
             return null;
-        });
+        }).when(stateStore).flush();
     }
 
     private <T extends StateStore> void doTest(final String name, final Consumer<T> checker) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
@@ -39,9 +39,10 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockInternalTopicManager;
 import org.apache.kafka.test.MockKeyValueStoreBuilder;
-import org.easymock.EasyMock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,11 +59,14 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getInfo;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
-import static org.easymock.EasyMock.expect;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Category({IntegrationTest.class})
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class StreamsAssignmentScaleTest {
     final static long MAX_ASSIGNMENT_DURATION = 60 * 1000L; //each individual assignment should complete within 20s
     final static String APPLICATION_ID = "streams-assignment-scale-test";
@@ -169,17 +173,18 @@ public class StreamsAssignmentScaleTest {
         final TopologyMetadata topologyMetadata = new TopologyMetadata(builder, new StreamsConfig(configMap));
         topologyMetadata.buildAndRewriteTopology();
 
-        final Consumer<byte[], byte[]> mainConsumer = EasyMock.createNiceMock(Consumer.class);
-        final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-        expect(taskManager.topologyMetadata()).andStubReturn(topologyMetadata);
-        expect(mainConsumer.committed(new HashSet<>())).andStubReturn(Collections.emptyMap());
+        @SuppressWarnings("unchecked")
+        final Consumer<byte[], byte[]> mainConsumer = mock(Consumer.class);
+        final TaskManager taskManager = mock(TaskManager.class);
+        when(taskManager.topologyMetadata()).thenReturn(topologyMetadata);
+        when(mainConsumer.committed(anySet())).thenReturn(Collections.emptyMap());
         final AdminClient adminClient = createMockAdminClientForAssignor(changelogEndOffsets);
 
         final ReferenceContainer referenceContainer = new ReferenceContainer();
         referenceContainer.mainConsumer = mainConsumer;
         referenceContainer.adminClient = adminClient;
         referenceContainer.taskManager = taskManager;
-        referenceContainer.streamsMetadataState = EasyMock.createNiceMock(StreamsMetadataState.class);
+        referenceContainer.streamsMetadataState = mock(StreamsMetadataState.class);
         referenceContainer.time = new MockTime();
         configMap.put(InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
         configMap.put(InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, taskAssignor.getName());
@@ -191,7 +196,6 @@ public class StreamsAssignmentScaleTest {
             new MockClientSupplier().restoreConsumer,
             false
         );
-        EasyMock.replay(taskManager, adminClient, mainConsumer);
 
         final StreamsPartitionAssignor partitionAssignor = new StreamsPartitionAssignor();
         partitionAssignor.configure(configMap);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/WriteConsistencyVectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/WriteConsistencyVectorTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
@@ -31,35 +30,45 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.internals.PositionSerde;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.processor.internals.InternalProcessorContext.BYTEARRAY_VALUE_SERIALIZER;
 import static org.apache.kafka.streams.processor.internals.InternalProcessorContext.BYTES_KEY_SERIALIZER;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class WriteConsistencyVectorTest {
 
+    @Mock
+    private StreamsConfig streamsConfig;
+    @Mock
+    private ProcessorStateManager stateManager;
+    @Mock
+    private RecordCollector recordCollector;
+    @Mock
+    private StreamTask task;
+    @Mock
+    private TaskId taskId;
+    @Mock
+    private StreamsMetricsImpl streamsMetrics;
+    @Mock
+    private ThreadCache threadCache;
     private ProcessorContextImpl context;
-    private final StreamsConfig streamsConfig = streamsConfigMock();
-    private final RecordCollector recordCollector = mock(RecordCollector.class);
 
     private static final String KEY = "key";
     private static final Bytes KEY_BYTES = Bytes.wrap(KEY.getBytes());
     private static final long VALUE = 42L;
     private static final byte[] VALUE_BYTES = String.valueOf(VALUE).getBytes();
     private static final long TIMESTAMP = 21L;
-    private static final long STREAM_TIME = 50L;
     private static final String REGISTERED_STORE_NAME = "registered-store";
     private static final TopicPartition CHANGELOG_PARTITION = new TopicPartition("store-changelog", 1);
     private static final String INPUT_TOPIC_NAME = "input-topic";
@@ -68,24 +77,22 @@ public class WriteConsistencyVectorTest {
 
     @Before
     public void setup() {
-        final ProcessorStateManager stateManager = mock(ProcessorStateManager.class);
-        expect(stateManager.taskType()).andStubReturn(TaskType.ACTIVE);
-        expect(stateManager.registeredChangelogPartitionFor(REGISTERED_STORE_NAME)).andStubReturn(CHANGELOG_PARTITION);
-        replay(stateManager);
+        when(streamsConfig.originals()).thenReturn(Collections.singletonMap(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true));
+        when(streamsConfig.values()).thenReturn(Collections.emptyMap());
+        when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");
+
+        when(stateManager.taskType()).thenReturn(TaskType.ACTIVE);
+        when(stateManager.registeredChangelogPartitionFor(REGISTERED_STORE_NAME)).thenReturn(CHANGELOG_PARTITION);
 
         context = new ProcessorContextImpl(
-                mock(TaskId.class),
+                taskId,
                 streamsConfig,
                 stateManager,
-                mock(StreamsMetricsImpl.class),
-                mock(ThreadCache.class)
+                streamsMetrics,
+                threadCache
         );
 
-        final StreamTask task = mock(StreamTask.class);
-        expect(task.streamTime()).andReturn(STREAM_TIME);
-        EasyMock.expect(task.recordCollector()).andStubReturn(recordCollector);
-        replay(task);
-        ((InternalProcessorContext) context).transitionToActive(task, null, null);
+        context.transitionToActive(task, null, null);
 
         context.setCurrentNode(
                 new ProcessorNode<>(
@@ -114,39 +121,21 @@ public class WriteConsistencyVectorTest {
         headers.add(new RecordHeader(
                 ChangelogRecordDeserializationHelper.CHANGELOG_POSITION_HEADER_KEY,
                 PositionSerde.serialize(position).array()));
-        recordCollector.send(
-            CHANGELOG_PARTITION.topic(),
-            KEY_BYTES,
-            VALUE_BYTES,
-            headers,
-            CHANGELOG_PARTITION.partition(),
-            TIMESTAMP,
-            BYTES_KEY_SERIALIZER,
-            BYTEARRAY_VALUE_SERIALIZER,
-            null,
-            null);
 
-        final StreamTask task = EasyMock.createNiceMock(StreamTask.class);
-
-        replay(recordCollector, task);
         context.transitionToActive(task, recordCollector, null);
 
         context.logChange(REGISTERED_STORE_NAME, KEY_BYTES, VALUE_BYTES, TIMESTAMP, position);
 
-        verify(recordCollector);
-    }
-
-    private StreamsConfig streamsConfigMock() {
-        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
-
-        final Map<String, Object> myValues = new HashMap<>();
-        myValues.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
-        expect(streamsConfig.originals()).andStubReturn(myValues);
-        expect(streamsConfig.values()).andStubReturn(Collections.emptyMap());
-        expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andStubReturn("add-id");
-        expect(streamsConfig.defaultValueSerde()).andStubReturn(Serdes.ByteArray());
-        expect(streamsConfig.defaultKeySerde()).andStubReturn(Serdes.ByteArray());
-        replay(streamsConfig);
-        return streamsConfig;
+        verify(recordCollector).send(
+                CHANGELOG_PARTITION.topic(),
+                KEY_BYTES,
+                VALUE_BYTES,
+                headers,
+                CHANGELOG_PARTITION.partition(),
+                TIMESTAMP,
+                BYTES_KEY_SERIALIZER,
+                BYTEARRAY_VALUE_SERIALIZER,
+                null,
+                null);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 
-import org.easymock.EasyMock;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -51,11 +50,13 @@ import static java.util.Collections.emptySet;
 import static org.apache.kafka.common.utils.Utils.entriesToMap;
 import static org.apache.kafka.common.utils.Utils.intersection;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.expect;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class AssignmentTestUtils {
 
@@ -125,24 +126,22 @@ public final class AssignmentTestUtils {
     // If you don't care about setting the end offsets for each specific topic partition, the helper method
     // getTopicPartitionOffsetMap is useful for building this input map for all partitions
     public static AdminClient createMockAdminClientForAssignor(final Map<TopicPartition, Long> changelogEndOffsets) {
-        final AdminClient adminClient = EasyMock.createMock(AdminClient.class);
+        final AdminClient adminClient = mock(AdminClient.class);
 
-        final ListOffsetsResult result = EasyMock.createNiceMock(ListOffsetsResult.class);
+        final ListOffsetsResult result = mock(ListOffsetsResult.class);
         final KafkaFutureImpl<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = new KafkaFutureImpl<>();
         allFuture.complete(changelogEndOffsets.entrySet().stream().collect(Collectors.toMap(
             Entry::getKey,
             t -> {
-                final ListOffsetsResultInfo info = EasyMock.createNiceMock(ListOffsetsResultInfo.class);
-                expect(info.offset()).andStubReturn(t.getValue());
-                EasyMock.replay(info);
+                final ListOffsetsResultInfo info = mock(ListOffsetsResultInfo.class);
+                lenient().when(info.offset()).thenReturn(t.getValue());
                 return info;
             }))
         );
 
-        expect(adminClient.listOffsets(anyObject())).andStubReturn(result);
-        expect(result.all()).andStubReturn(allFuture);
+        when(adminClient.listOffsets(any())).thenReturn(result);
+        when(result.all()).thenReturn(allFuture);
 
-        EasyMock.replay(result);
         return adminClient;
     }
 


### PR DESCRIPTION
Batch 6 of the tests detailed in https://issues.apache.org/jira/browse/KAFKA-14133 which use EasyMock and need to be moved to Mockito.