### PR TITLE
KAFKA-14355: Fix integer overflow in ProducerPerformance

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -329,12 +329,13 @@ public class ProducerPerformance {
         return parser;
     }
 
-    private static class Stats {
+    // Visible for testing
+    static class Stats {
         private long start;
         private long windowStart;
         private int[] latencies;
-        private int sampling;
-        private int iteration;
+        private long sampling;
+        private long iteration;
         private int index;
         private long count;
         private long bytes;
@@ -350,7 +351,7 @@ public class ProducerPerformance {
             this.start = System.currentTimeMillis();
             this.windowStart = System.currentTimeMillis();
             this.iteration = 0;
-            this.sampling = (int) (numRecords / Math.min(numRecords, 500000));
+            this.sampling = numRecords / Math.min(numRecords, 500000);
             this.latencies = new int[(int) (numRecords / this.sampling) + 1];
             this.index = 0;
             this.maxLatency = 0;
@@ -363,7 +364,7 @@ public class ProducerPerformance {
             this.reportingInterval = reportingInterval;
         }
 
-        public void record(int iter, int latency, int bytes, long time) {
+        public void record(long iter, int latency, int bytes, long time) {
             this.count++;
             this.bytes += bytes;
             this.totalLatency += latency;
@@ -440,11 +441,11 @@ public class ProducerPerformance {
 
     private static final class PerfCallback implements Callback {
         private final long start;
-        private final int iteration;
+        private final long iteration;
         private final int bytes;
         private final Stats stats;
 
-        public PerfCallback(int iter, long start, int bytes, Stats stats) {
+        public PerfCallback(long iter, long start, int bytes, Stats stats) {
             this.start = start;
             this.stats = stats;
             this.iteration = iter;

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -355,7 +355,6 @@ public class ProducerPerformance {
             this.latencies = new int[(int) (numRecords / this.sampling) + 1];
             this.index = 0;
             this.maxLatency = 0;
-            this.totalLatency = 0;
             this.windowCount = 0;
             this.windowMaxLatency = 0;
             this.windowTotalLatency = 0;

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
@@ -173,5 +174,11 @@ public class ProducerPerformanceTest {
 
         assertNotNull(prop);
         assertEquals("perf-producer-client", prop.getProperty("client.id"));
+    }
+
+    @Test
+    public void testStatsInitializationWithLargeNumRecords() throws Exception {
+        long numRecords = Long.MAX_VALUE;
+        assertDoesNotThrow(() -> new ProducerPerformance.Stats(numRecords, 5000));
     }
 }


### PR DESCRIPTION
In `kafka-producer-perf-test.sh`, an integer overflow occurs if a fairly large value is passed to `--num-records`. It causes a NegativeArraySizeException error. This PR fixed this problem by changing types.

Before:
```
$ ./bin/kafka-producer-perf-test.sh --topic=test --producer-props bootstrap.servers=localhost:9092 --num-records 2000000000000000 --throughput 1 --record-size 10
Exception in thread "main" java.lang.NegativeArraySizeException
    at org.apache.kafka.tools.ProducerPerformance$Stats.<init>(ProducerPerformance.java:354)
    at org.apache.kafka.tools.ProducerPerformance.start(ProducerPerformance.java:97)
    at org.apache.kafka.tools.ProducerPerformance.main(ProducerPerformance.java:52)
```


After:
```
$ ./bin/kafka-producer-perf-test.sh --topic=test --producer-props bootstrap.servers=localhost:9092 --num-records 2000000000000000 --throughput 1 --record-size 10
7 records sent, 1.3 records/sec (0.00 MB/sec), 123.7 ms avg latency, 684.0 ms max latency.
5 records sent, 1.0 records/sec (0.00 MB/sec), 2.2 ms avg latency, 3.0 ms max latency.
5 records sent, 1.0 records/sec (0.00 MB/sec), 2.2 ms avg latency, 3.0 ms max latency.
5 records sent, 1.0 records/sec (0.00 MB/sec), 2.6 ms avg latency, 3.0 ms max latency.
...
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
