### PR TITLE
MINOR: modified ProducerIdExpirationTest to hopefully be less flaky

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ProducerIdExpirationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerIdExpirationTest.scala
@@ -113,7 +113,7 @@ class ProducerIdExpirationTest extends KafkaServerTestHarness {
     producer.flush()
 
     // Ensure producer IDs are added.
-    assertEquals(1, producerState.size)
+    TestUtils.waitUntilTrue(() => producerState.size == 1, "Producer IDs were not added.")
 
     producer.abortTransaction()
 


### PR DESCRIPTION
This test has failed on a few PR runs.

Using a waitUntil instead.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
