### PR TITLE
KAFKA-14354: Add isDeleted parameter to Connector#stop() 

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/Connector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/Connector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.connector;
 
+import java.lang.invoke.MethodHandles;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
@@ -24,6 +25,8 @@ import org.apache.kafka.connect.components.Versioned;
 
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -44,6 +47,8 @@ import java.util.Map;
  * </p>
  */
 public abstract class Connector implements Versioned {
+
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     protected ConnectorContext context;
 
@@ -129,10 +134,16 @@ public abstract class Connector implements Versioned {
     public abstract void stop();
 
     /**
-     * Callback invoked when the connector is deleted, so connectors can perform any cleanup tasks as
-     * they are removed.
+     * Stop this connector, and also indicate if the connector has been deleted.
+     * <p>
+     * Connectors are not required to override this method, unless they need to perform some cleanup
+     * actions in cases where the connector has been deleted.
+     *
+     * @param isDeleted indicates if the connector has been deleted.
      */
-    public void deleted() {
+    public void stop(boolean isDeleted) {
+        log.debug("Connector has been deleted", isDeleted);
+        stop();
     }
 
     /**

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/Connector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/Connector.java
@@ -129,6 +129,13 @@ public abstract class Connector implements Versioned {
     public abstract void stop();
 
     /**
+     * Callback invoked when the connector is deleted, so connectors can perform any cleanup tasks as
+     * they are removed.
+     */
+    public void deleted() {
+    }
+
+    /**
      * Validate the connector configuration values against configuration definitions.
      * @param connectorConfigs the provided configuration values
      * @return List of Config, each Config contains the updated configuration information given

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -311,6 +311,13 @@ public class WorkerConnector implements Runnable {
         }
     }
 
+    /**
+     * Notify the {@link Connector connector} it has been deleted.
+     */
+    void deleted() {
+        connector.deleted();
+    }
+
     public void transitionTo(TargetState targetState, Callback<TargetState> stateChangeCallback) {
         Callback<TargetState> preEmptedStateChangeCallback;
         TargetState preEmptedState;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -675,7 +675,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             boolean remains = configState.contains(connectorName);
             log.info("Handling connector-only config update by {} connector {}",
                     remains ? "restarting" : "stopping", connectorName);
-            worker.stopAndAwaitConnector(connectorName);
+            worker.stopAndAwaitConnector(connectorName, !remains);
             // The update may be a deletion, so verify we actually need to restart the connector
             if (remains) {
                 connectorsToStart.add(getConnectorStartingCallable(connectorName));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -166,7 +166,7 @@ public class StandaloneHerder extends AbstractHerder {
             }
 
             removeConnectorTasks(connName);
-            worker.stopAndAwaitConnector(connName);
+            worker.stopAndAwaitConnector(connName, true);
             configBackingStore.removeConnectorConfig(connName);
             onDeletion(connName);
             callback.onCompletion(null, new Created<>(false, null));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1100,7 +1100,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testDestroyConnector() throws Exception {
+    public void testDestroyConnector() {
         EasyMock.expect(member.memberId()).andStubReturn("leader");
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
         // Start with one connector
@@ -1819,7 +1819,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testConnectorConfigUpdate() throws Exception {
+    public void testConnectorConfigUpdate() {
         // Connector config can be applied without any rebalance
 
         EasyMock.expect(member.memberId()).andStubReturn("member");
@@ -1849,7 +1849,7 @@ public class DistributedHerderTest {
         member.ensureActive();
         PowerMock.expectLastCall();
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT); // for this test, it doesn't matter if we use the same config snapshot
-        worker.stopAndAwaitConnector(CONN1);
+        worker.stopAndAwaitConnector(CONN1, false);
         PowerMock.expectLastCall();
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
         Capture<Callback<TargetState>> onSecondStart = newCapture();
@@ -2605,7 +2605,7 @@ public class DistributedHerderTest {
         // As a result of reconfig, should need to update snapshot. With only connector updates, we'll just restart
         // connector without rebalance
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT_UPDATED_CONN1_CONFIG).times(2);
-        worker.stopAndAwaitConnector(CONN1);
+        worker.stopAndAwaitConnector(CONN1, false);
         PowerMock.expectLastCall();
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
         Capture<Callback<TargetState>> onSecondStart = newCapture();
@@ -2876,7 +2876,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testFailedToWriteSessionKey() throws Exception {
+    public void testFailedToWriteSessionKey() {
         // First tick -- after joining the group, we try to write a new
         // session key to the config topic, and fail
         EasyMock.expect(member.memberId()).andStubReturn("leader");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -1005,15 +1005,24 @@ public class StandaloneHerderTest {
     }
 
     private void expectStop() {
+        expectStop(false);
+    }
+
+    private void expectStop(boolean deleted) {
         ConnectorTaskId task = new ConnectorTaskId(CONNECTOR_NAME, 0);
         worker.stopAndAwaitTasks(singletonList(task));
         EasyMock.expectLastCall();
-        worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        if (deleted) {
+            worker.stopAndAwaitConnector(CONNECTOR_NAME, true);
+
+        } else {
+            worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        }
         EasyMock.expectLastCall();
     }
 
     private void expectDestroy() {
-        expectStop();
+        expectStop(true);
     }
 
     private static Map<String, String> connectorConfig(SourceSink sourceSink) {


### PR DESCRIPTION
This PR contains a small change to the Connector public API, and a few tweaks on the Worker/WorkerConnector and Herder classes - all this in context of [KIP-893](https://cwiki.apache.org/confluence/display/KAFKA/KIP-883%3A+Add+delete+callback+method+to+Connector+API). Since this KIP is still under discussion, this PR should not be merged to trunk.

Main changes include:

* Adds a new overloaded public void `stop(boolean isDeleted)` method to the `org.apache.kafka.connect.connector.Connector` class
* Changes some internal methods of the Worker and WorkerConnector classes to invoke this method when the connector has been stopped due to a deletion.
* Similarly, updates the Standalone and Distributed Herder classes to pass the `deleted` flag when deleting connectors.
* Updated unit tests to validate the new behavior.

The change is relatively small in nature.; please let me know if you think more tests should be added.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
