### PR TITLE
Using Timer class to track expiry in IncrementalCooperativeAssignor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -179,7 +179,9 @@ public class Timer {
      *
      * @return The deadline time in milliseconds at which the timer would expire.
      */
-    public long deadlineMs() {return deadlineMs;}
+    public long deadlineMs() {
+        return deadlineMs;
+    }
 
     /**
      * Get the amount of time that has elapsed since the timer began. If the timer was reset, this

--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -173,6 +173,15 @@ public class Timer {
     }
 
     /**
+     * Get the deadline time in milliseconds when this timer would expire. The deadlineMs time
+     * is generally updated through {@link #reset(long)} method or {@link #updateAndReset(long)}
+     * method call.
+     *
+     * @return The deadline time in milliseconds at which the timer would expire.
+     */
+    public long deadlineMs() {return deadlineMs;}
+
+    /**
      * Get the amount of time that has elapsed since the timer began. If the timer was reset, this
      * will be the amount of time since the last reset.
      *

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -86,7 +86,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         this.delay = 0;
         this.previousGenerationId = -1;
         this.previousMembers = Collections.emptySet();
-        //this.timer = time.timer(maxDelay);
     }
 
     @Override
@@ -535,25 +534,19 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         } else {
             candidateWorkersForReassignment
                     .addAll(candidateWorkersForReassignment(completeWorkerAssignment));
-            if (timer != null) {
-                if (timer.notExpired()) {
-                    // a delayed rebalance is in progress, but it's not yet time to reassign
-                    // unaccounted resources
-                    updateTimer();
-                    log.debug("Delayed rebalance in progress. Task reassignment is postponed. New computed rebalance delay: {}", timer.remainingMs());
-                } else {
-                    // We could also extract the current minimum delay from the group, to make
-                    // independent of consecutive leader failures, but this optimization is skipped
-                    // at the moment
-                    timer.updateAndReset(maxDelay);
-                    log.debug("Resetting rebalance delay to the max: {}. scheduledRebalance: {} now: {} diff scheduledRebalance - now: {}",
-                            delay, timer.deadlineMs(), now, timer.deadlineMs() - now);
-                }
-            } else {
+
+            if (timer == null) {
+                // We could also extract the current minimum delay from the group, to make
+                // independent of consecutive leader failures, but this optimization is skipped
+                // at the moment
                 timer = time.timer(maxDelay);
                 log.debug("Resetting rebalance delay to the max: {}. scheduledRebalance: {} now: {} diff scheduledRebalance - now: {}",
                         delay, timer.deadlineMs(), now, timer.deadlineMs() - now);
-
+            } else {
+                // a delayed rebalance is in progress, but it's not yet time to reassign
+                // unaccounted resources
+                updateTimer();
+                log.debug("Delayed rebalance in progress. Task reassignment is postponed. New computed rebalance delay: {}", timer.remainingMs());
             }
             /*if (now < scheduledRebalance) {
                 // a delayed rebalance is in progress, but it's not yet time to reassign

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -576,8 +576,8 @@ public class IncrementalCooperativeAssignorTest {
         initAssignor();
 
         assertTrue(assignor.candidateWorkersForReassignment.isEmpty());
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         Map<String, WorkerLoad> configuredAssignment = new HashMap<>();
         configuredAssignment.put("worker0", workerLoad("worker0", 0, 2, 0, 4));
@@ -594,8 +594,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
 
@@ -611,8 +611,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(memberAssignments.keySet());
         time.sleep(rebalanceDelay / 2);
@@ -625,8 +625,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         time.sleep(rebalanceDelay);
 
@@ -640,8 +640,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
     }
 
     @Test
@@ -651,8 +651,8 @@ public class IncrementalCooperativeAssignorTest {
         initAssignor();
 
         assertTrue(assignor.candidateWorkersForReassignment.isEmpty());
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         Map<String, WorkerLoad> configuredAssignment = new HashMap<>();
         configuredAssignment.put("worker0", workerLoad("worker0", 0, 2, 0, 4));
@@ -669,8 +669,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
 
@@ -689,8 +689,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.singleton(newWorker),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
         time.sleep(rebalanceDelay / 2);
@@ -706,8 +706,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 expectedWorkers,
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
         time.sleep(rebalanceDelay);
@@ -738,8 +738,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
             Collections.emptySet(),
             assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
     }
 
     @Test
@@ -749,8 +749,8 @@ public class IncrementalCooperativeAssignorTest {
         initAssignor();
 
         assertTrue(assignor.candidateWorkersForReassignment.isEmpty());
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         Map<String, WorkerLoad> configuredAssignment = new HashMap<>();
         configuredAssignment.put("worker0", workerLoad("worker0", 0, 2, 0, 4));
@@ -767,8 +767,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
 
@@ -784,8 +784,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
         time.sleep(rebalanceDelay / 2);
@@ -799,8 +799,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.singleton(veryFlakyWorker),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
         time.sleep(rebalanceDelay);
@@ -817,8 +817,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -494,8 +494,8 @@ public class IncrementalCooperativeAssignorTest {
         initAssignor();
 
         assertTrue(assignor.candidateWorkersForReassignment.isEmpty());
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         Map<String, WorkerLoad> configuredAssignment = new HashMap<>();
         configuredAssignment.put("worker0", workerLoad("worker0", 0, 2, 0, 4));
@@ -512,8 +512,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
 
@@ -529,8 +529,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
         time.sleep(rebalanceDelay / 2);
@@ -544,8 +544,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.singleton(flakyWorker),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(time.milliseconds() + rebalanceDelay, assignor.scheduledRebalance);
-        assertEquals(rebalanceDelay, assignor.delay);
+        assertEquals(time.milliseconds() + rebalanceDelay, assignor.getScheduledRebalance());
+        assertEquals(rebalanceDelay, assignor.getDelay());
 
         assignor.previousMembers = new HashSet<>(configuredAssignment.keySet());
         time.sleep(rebalanceDelay);
@@ -565,8 +565,8 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
-        assertEquals(0, assignor.scheduledRebalance);
-        assertEquals(0, assignor.delay);
+        assertEquals(0, assignor.getScheduledRebalance());
+        assertEquals(0, assignor.getDelay());
     }
 
     @Test
@@ -1217,7 +1217,7 @@ public class IncrementalCooperativeAssignorTest {
         assertEquals(
                 "Wrong rebalance delay",
                 expectedDelay,
-                assignor.delay
+                assignor.getDelay()
         );
     }
 


### PR DESCRIPTION
Currently, the `IncrementalCooperativeAssignor` keeps track of time i.e scheduledRebalance and delay within the class itself. While that has worked successfully, sometimes it is not very intuitive when reading the code. For example condition like 
`if (scheduledRebalance > 0 && now >= scheduledRebalance) {` is used to check if the scheduled rebalance delay is expired for example. Similarly, the IncrementalCooperativeAssignor also calculates delay/scheduledRebalanceDelay within the codebase. This has worked in general but there could be edge cases when the underlying clock is subject to time slips for example. 
The kafka codebase already has a Timer class which can be used for tracking time and is used by other components in Kafka like Consumer, NetworkClient, AbstractCoordinator etc. It exposes methods like `isExpired`, `notExpired`, `remainingTimeMs`, `elapsedTimeMs`, `deadlineMs` and does the calculations internally. Moreover, `remainingTimeMs` maps directly to `delay` in the IncrementalCooperativeAssignor and `deadlineMs` to `scheduledRebalance`. One last nice thing about the Timer class is that it guarantees monotonic behaviour even if the underlying clock is not.

This draft PR is an attempt to use `Timer` constructs in `IncrementalCooperativeAssignor` .