### PR TITLE
KAFKA-14346: Remove hard-to-mock RestClient calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2590,6 +2590,7 @@ project(':connect:runtime') {
     testImplementation libs.httpclient
 
     testRuntimeOnly libs.slf4jlog4j
+    testRuntimeOnly libs.bcpkix
   }
 
   javadoc {

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -630,6 +630,8 @@
       <allow pkg="org.apache.kafka.connect" />
       <allow pkg="org.apache.kafka.tools" />
       <allow pkg="javax.ws.rs" />
+      <allow pkg="org.apache.http"/>
+      <allow pkg="org.eclipse.jetty.util"/>
     </subpackage>
 
     <subpackage name="json">

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -26,6 +26,7 @@ import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
+import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.storage.KafkaOffsetBackingStore;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.storage.KafkaStatusBackingStore;
@@ -250,12 +251,13 @@ public class MirrorMaker {
                 distributedConfig,
                 configTransformer,
                 sharedAdmin);
+        RestClient restClient = new RestClient(distributedConfig);
         // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
         // herder is stopped. MirrorMaker has multiple herders, and having the herder own the close responsibility is much easier than
         // tracking the various shared admin objects in this class.
         Herder herder = new DistributedHerder(distributedConfig, time, worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl, CLIENT_CONFIG_OVERRIDE_POLICY, sharedAdmin);
+                advertisedUrl, restClient, CLIENT_CONFIG_OVERRIDE_POLICY, sharedAdmin, restClient);
         herders.put(sourceAndTarget, herder);
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -26,7 +26,6 @@ import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
-import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.storage.KafkaOffsetBackingStore;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.storage.KafkaStatusBackingStore;
@@ -251,13 +250,13 @@ public class MirrorMaker {
                 distributedConfig,
                 configTransformer,
                 sharedAdmin);
-        RestClient restClient = new RestClient(distributedConfig);
         // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
         // herder is stopped. MirrorMaker has multiple herders, and having the herder own the close responsibility is much easier than
         // tracking the various shared admin objects in this class.
+        // Do not provide a restClient to the DistributedHerder to indicate that request forwarding is disabled
         Herder herder = new DistributedHerder(distributedConfig, time, worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl, restClient, CLIENT_CONFIG_OVERRIDE_POLICY, sharedAdmin, restClient);
+                advertisedUrl, null, CLIENT_CONFIG_OVERRIDE_POLICY, sharedAdmin);
         herders.put(sourceAndTarget, herder);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -28,6 +28,7 @@ import org.apache.kafka.connect.runtime.WorkerInfo;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.storage.Converter;
@@ -97,7 +98,9 @@ public class ConnectDistributed {
         String kafkaClusterId = config.kafkaClusterId();
         log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
-        RestServer rest = new RestServer(config);
+        RestClient restClient = new RestClient(config);
+
+        RestServer rest = new RestServer(config, restClient);
         rest.initializeServer();
 
         URI advertisedUrl = rest.advertisedUrl();
@@ -132,7 +135,7 @@ public class ConnectDistributed {
         // herder is stopped. This is easier than having to track and own the lifecycle ourselves.
         DistributedHerder herder = new DistributedHerder(config, time, worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl.toString(), connectorClientConfigOverridePolicy, sharedAdmin);
+                advertisedUrl.toString(), restClient, connectorClientConfigOverridePolicy, sharedAdmin, restClient);
 
         final Connect connect = new Connect(herder, rest);
         log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -141,7 +141,7 @@ public class ConnectDistributed {
         // herder is stopped. This is easier than having to track and own the lifecycle ourselves.
         DistributedHerder herder = new DistributedHerder(config, time, worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl.toString(), restClient, connectorClientConfigOverridePolicy, sharedAdmin, restClient);
+                advertisedUrl.toString(), restClient, connectorClientConfigOverridePolicy, sharedAdmin);
 
         final Connect connect = new Connect(herder, rest);
         log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -82,7 +82,8 @@ public class ConnectStandalone {
             String kafkaClusterId = config.kafkaClusterId();
             log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
-            RestServer rest = new RestServer(config);
+            // Do not initialize a RestClient because the ConnectorsResource will not use it in standalone mode.
+            RestServer rest = new RestServer(config, null);
             rest.initializeServer();
 
             URI advertisedUrl = rest.advertisedUrl();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -778,6 +778,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             super.stopServices();
         } finally {
             this.uponShutdown.forEach(closeable -> Utils.closeQuietly(closeable, closeable != null ? closeable.toString() : "<unknown>"));
+            Utils.closeQuietly(restClient, "RestClient");
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -778,7 +778,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             super.stopServices();
         } finally {
             this.uponShutdown.forEach(closeable -> Utils.closeQuietly(closeable, closeable != null ? closeable.toString() : "<unknown>"));
-            Utils.closeQuietly(restClient, "RestClient");
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -43,6 +43,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * Client for outbound REST requests to other members of a Connect cluster
+ * This class is thread-safe.
+ */
 public class RestClient implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(RestClient.class);
     private static final ObjectMapper JSON_SERDE = new ObjectMapper();
@@ -67,12 +71,8 @@ public class RestClient implements AutoCloseable {
     }
 
     @Override
-    public void close() {
-        try {
-            client.stop();
-        } catch (Exception e) {
-            log.error("Failed to stop HTTP client", e);
-        }
+    public void close() throws Exception {
+        client.stop();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -85,6 +85,8 @@ public class RestServer {
     private static final String PROTOCOL_HTTPS = "https";
 
     private final WorkerConfig config;
+
+    private final RestClient restClient;
     private final ContextHandlerCollection handlers;
     private final Server jettyServer;
 
@@ -94,8 +96,9 @@ public class RestServer {
     /**
      * Create a REST server for this herder using the specified configs.
      */
-    public RestServer(WorkerConfig config) {
+    public RestServer(WorkerConfig config, RestClient restClient) {
         this.config = config;
+        this.restClient = restClient;
 
         List<String> listeners = config.getList(WorkerConfig.LISTENERS_CONFIG);
         List<String> adminListeners = config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG);
@@ -218,7 +221,7 @@ public class RestServer {
 
         this.resources = new ArrayList<>();
         resources.add(new RootResource(herder));
-        resources.add(new ConnectorsResource(herder, config));
+        resources.add(new ConnectorsResource(herder, config, restClient));
         resources.add(new ConnectorPluginsResource(herder));
         resources.forEach(resourceConfig::register);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -357,6 +357,8 @@ public class RestServer {
             builder.port(advertisedPort);
         else if (serverConnector != null && serverConnector.getPort() > 0)
             builder.port(serverConnector.getPort());
+        else if (serverConnector != null && serverConnector.getLocalPort() > 0)
+            builder.port(serverConnector.getLocalPort());
 
         log.info("Advertised URI: {}", builder.build());
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -89,9 +89,6 @@ public class ConnectorsResource implements ConnectResource {
     private final boolean isTopicTrackingDisabled;
     private final boolean isTopicTrackingResetDisabled;
 
-    public ConnectorsResource(Herder herder, WorkerConfig config) {
-        this(herder, config, new RestClient(config));
-    }
     public ConnectorsResource(Herder herder, WorkerConfig config, RestClient restClient) {
         this.herder = herder;
         this.restClient = restClient;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -82,7 +82,7 @@ public class ConnectorsResource implements ConnectResource {
         new TypeReference<List<Map<String, String>>>() { };
 
     private final Herder herder;
-    private final WorkerConfig config;
+    private final RestClient restClient;
     private long requestTimeoutMs;
     @javax.ws.rs.core.Context
     private ServletContext context;
@@ -90,8 +90,11 @@ public class ConnectorsResource implements ConnectResource {
     private final boolean isTopicTrackingResetDisabled;
 
     public ConnectorsResource(Herder herder, WorkerConfig config) {
+        this(herder, config, new RestClient(config));
+    }
+    public ConnectorsResource(Herder herder, WorkerConfig config, RestClient restClient) {
         this.herder = herder;
-        this.config = config;
+        this.restClient = restClient;
         isTopicTrackingDisabled = !config.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG);
         isTopicTrackingResetDisabled = !config.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG);
         this.requestTimeoutMs = DEFAULT_REST_REQUEST_TIMEOUT_MS;
@@ -425,7 +428,7 @@ public class ConnectorsResource implements ConnectResource {
                     }
                     String forwardUrl = uriBuilder.build().toString();
                     log.debug("Forwarding request {} {} {}", forwardUrl, method, body);
-                    return translator.translate(RestClient.httpRequest(forwardUrl, method, headers, body, resultType, config));
+                    return translator.translate(restClient.httpRequest(forwardUrl, method, headers, body, resultType));
                 } else {
                     // we should find the right target for the query within two hops, so if
                     // we don't, it probably means that a rebalance has taken place.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -407,7 +407,10 @@ public class ConnectorsResource implements ConnectResource {
             Throwable cause = e.getCause();
 
             if (cause instanceof RequestTargetException) {
-                if (forward == null || forward) {
+                if (restClient == null) {
+                    throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                            "Cannot complete request as non-leader with request forwarding disabled");
+                } else if (forward == null || forward) {
                     // the only time we allow recursive forwarding is when no forward flag has
                     // been set, which should only be seen by the first worker to handle a user request.
                     // this gives two total hops to resolve the request before giving up.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
@@ -108,9 +108,7 @@ public class RestForwardingIntegrationTest {
                 firstException,
                 "clientsAndServers",
                 httpClient,
-                followerClient,
                 followerServer != null ? followerServer::stop : null,
-                leaderClient,
                 leaderServer != null ? leaderServer::stop : null,
                 factory != null ? factory::stop : null
         );

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
+import org.apache.kafka.connect.runtime.distributed.RequestTargetException;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.util.SSLUtils;
+import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestSslUtils;
+import org.apache.kafka.test.TestUtils;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@SuppressWarnings("unchecked")
+@Category(IntegrationTest.class)
+public class RestForwardingIntegrationTest {
+
+    @Mock
+    private Plugins plugins;
+    private RestClient followerClient;
+    private RestServer followerServer;
+    @Mock
+    private Herder followerHerder;
+    private RestClient leaderClient;
+    private RestServer leaderServer;
+    @Mock
+    private Herder leaderHerder;
+
+    private SslContextFactory factory;
+    private CloseableHttpClient httpClient;
+    private Collection<CloseableHttpResponse> responses = new ArrayList<>();
+
+    @After
+    public void tearDown() throws IOException {
+        for (CloseableHttpResponse response: responses) {
+            response.close();
+        }
+        AtomicReference<Throwable> firstException = new AtomicReference<>();
+        Utils.closeAllQuietly(
+                firstException,
+                "clientsAndServers",
+                httpClient,
+                followerClient,
+                followerServer != null ? followerServer::stop : null,
+                leaderClient,
+                leaderServer != null ? leaderServer::stop : null,
+                factory != null ? factory::stop : null
+        );
+        if (firstException.get() != null) {
+            throw new RuntimeException("Unable to cleanly close resources", firstException.get());
+        }
+    }
+
+    @Test
+    public void testRestForwardNoSsl() throws Exception {
+        testRestForwardToLeader(false, false);
+    }
+
+    @Test
+    public void testRestForwardSsl() throws Exception {
+        testRestForwardToLeader(true, true);
+    }
+
+    @Test
+    public void testRestForwardLeaderSsl() throws Exception {
+        testRestForwardToLeader(false, true);
+    }
+
+    @Test
+    public void testRestForwardFollowerSsl() throws Exception {
+        testRestForwardToLeader(true, false);
+    }
+
+    public void testRestForwardToLeader(boolean followerSsl, boolean leaderSsl) throws Exception {
+        DistributedConfig followerConfig = new DistributedConfig(baseWorkerProps(followerSsl));
+        DistributedConfig leaderConfig = new DistributedConfig(baseWorkerProps(leaderSsl));
+
+        // Follower worker setup
+        followerClient = new RestClient(followerConfig);
+        followerServer = new RestServer(followerConfig, followerClient);
+        followerServer.initializeServer();
+        when(followerHerder.plugins()).thenReturn(plugins);
+        followerServer.initializeResources(followerHerder);
+
+        // Leader worker setup
+        leaderClient = new RestClient(leaderConfig);
+        leaderServer = new RestServer(leaderConfig, leaderClient);
+        leaderServer.initializeServer();
+        when(leaderHerder.plugins()).thenReturn(plugins);
+        leaderServer.initializeResources(leaderHerder);
+
+        // External client setup
+        factory = SSLUtils.createClientSideSslContextFactory(followerConfig);
+        factory.start();
+        SSLContext ssl = factory.getSslContext();
+        httpClient = HttpClients.custom()
+                .setSSLContext(ssl)
+                .build();
+
+        // Follower will forward to the leader
+        URI leaderUrl = leaderServer.advertisedUrl();
+        RequestTargetException forwardException = new NotLeaderException("Not leader", leaderUrl.toString());
+        ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> followerCallbackCaptor = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            followerCallbackCaptor.getValue().onCompletion(forwardException, null);
+            return null;
+        }).when(followerHerder)
+                .putConnectorConfig(any(), any(), anyBoolean(), followerCallbackCaptor.capture());
+
+        // Leader will reply
+        Herder.Created<ConnectorInfo> leaderAnswer = new Herder.Created<>(true, null);
+        ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> leaderCallbackCaptor = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            leaderCallbackCaptor.getValue().onCompletion(null, leaderAnswer);
+            return null;
+        }).when(followerHerder)
+                .putConnectorConfig(any(), any(), anyBoolean(), leaderCallbackCaptor.capture());
+
+        // Client makes request to the follower
+        URI followerUrl = followerServer.advertisedUrl();
+        HttpPost request = new HttpPost("/connectors");
+        String jsonBody = "{" +
+                "\"name\": \"blah\"," +
+                "\"config\": {}" +
+                "}";
+        StringEntity entity = new StringEntity(jsonBody, StandardCharsets.UTF_8.name());
+        entity.setContentType("application/json");
+        request.setEntity(entity);
+        HttpResponse httpResponse = executeRequest(followerUrl, request);
+
+        // And sees the success from the leader
+        assertEquals(201, httpResponse.getStatusLine().getStatusCode());
+    }
+
+    private Map<String, String> baseWorkerProps(boolean ssl) throws IOException, GeneralSecurityException {
+        Map<String, String> workerProps = new HashMap<>();
+        workerProps.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "status-topic");
+        workerProps.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "config-topic");
+        workerProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        workerProps.put(DistributedConfig.GROUP_ID_CONFIG, "connect-test-group");
+        workerProps.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "connect-offsets");
+        if (ssl) {
+            Map<String, Object> sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, TestUtils.tempFile(), "testCert");
+            for (String k : sslConfig.keySet()) {
+                if (sslConfig.get(k) instanceof Password) {
+                    workerProps.put(k, ((Password) sslConfig.get(k)).value());
+                } else if (sslConfig.get(k) instanceof List) {
+                    workerProps.put(k, String.join(",", (List<String>) sslConfig.get(k)));
+                } else {
+                    workerProps.put(k, sslConfig.get(k).toString());
+                }
+            }
+            workerProps.put(WorkerConfig.LISTENERS_CONFIG, "HTTPS://localhost:0");
+        } else {
+            workerProps.put(WorkerConfig.LISTENERS_CONFIG, "HTTP://localhost:0");
+        }
+
+        return workerProps;
+    }
+
+    private HttpResponse executeRequest(URI serverUrl, HttpRequest request) throws IOException {
+        HttpHost httpHost = new HttpHost(serverUrl.getHost(), serverUrl.getPort(), serverUrl.getScheme());
+        CloseableHttpResponse response = httpClient.execute(httpHost, request);
+        responses.add(response);
+        return response;
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -2971,11 +2971,9 @@ public class DistributedHerderTest {
         member.wakeup();
         EasyMock.expectLastCall();
 
-        PowerMock.mockStatic(RestClient.class);
-
         org.easymock.IExpectationSetters<RestClient.HttpResponse<Object>> expectRequest = EasyMock.expect(
                 restClient.httpRequest(
-                        EasyMock.eq("PUT"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.isNull(), anyObject(), anyObject(), anyObject()
+                        anyObject(), EasyMock.eq("PUT"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.isNull(), anyObject(), anyObject()
                 ));
         if (succeed) {
             expectRequest.andReturn(null);
@@ -3837,7 +3835,7 @@ public class DistributedHerderTest {
         return PowerMock.createPartialMock(DistributedHerder.class,
                 new String[]{"connectorType", "updateDeletedConnectorStatus", "updateDeletedTaskStatus", "validateConnectorConfig"},
                 new DistributedConfig(config), worker, WORKER_ID, KAFKA_CLUSTER_ID,
-                statusBackingStore, configBackingStore, member, MEMBER_URL, metrics, time, noneConnectorClientConfigOverridePolicy,
+                statusBackingStore, configBackingStore, member, MEMBER_URL, restClient, metrics, time, noneConnectorClientConfigOverridePolicy,
                 new AutoCloseable[0]);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -231,7 +231,6 @@ public class DistributedHerderTest {
     public void setUp() throws Exception {
         time = new MockTime();
         metrics = new MockConnectMetrics(time);
-        restClient = PowerMock.createMock(RestClient.class);
         worker = PowerMock.createMock(Worker.class);
         EasyMock.expect(worker.isSinkConnector(CONN1)).andStubReturn(Boolean.TRUE);
         AutoCloseable uponShutdown = () -> shutdownCalled.countDown();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -74,15 +74,16 @@ public class RestClientTest {
     }
 
     private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient, String requestSignatureAlgorithm) {
-        return RestClient.httpRequest(
-                httpClient,
-                "https://localhost:1234/api/endpoint",
-                "GET",
-                null,
-                new TestDTO("requestBodyData"),
-                TEST_TYPE,
-                MOCK_SECRET_KEY,
-                requestSignatureAlgorithm);
+        try (RestClient client = new RestClient(httpClient)) {
+            return client.httpRequest(
+                    "https://localhost:1234/api/endpoint",
+                    "GET",
+                    null,
+                    new TestDTO("requestBodyData"),
+                    TEST_TYPE,
+                    MOCK_SECRET_KEY,
+                    requestSignatureAlgorithm);
+        }
     }
 
     private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -73,7 +73,7 @@ public class RestClientTest {
         return mockKey;
     }
 
-    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient, String requestSignatureAlgorithm) {
+    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient, String requestSignatureAlgorithm) throws Exception {
         try (RestClient client = new RestClient(httpClient)) {
             return client.httpRequest(
                     "https://localhost:1234/api/endpoint",
@@ -86,7 +86,7 @@ public class RestClientTest {
         }
     }
 
-    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient) {
+    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient) throws Exception {
         String validRequestSignatureAlgorithm = "HmacSHA1";
         return httpRequest(httpClient, validRequestSignatureAlgorithm);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -50,7 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(Enclosed.class)
@@ -73,17 +75,18 @@ public class RestClientTest {
         return mockKey;
     }
 
-    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient, String requestSignatureAlgorithm) throws Exception {
-        try (RestClient client = new RestClient(httpClient)) {
-            return client.httpRequest(
-                    "https://localhost:1234/api/endpoint",
-                    "GET",
-                    null,
-                    new TestDTO("requestBodyData"),
-                    TEST_TYPE,
-                    MOCK_SECRET_KEY,
-                    requestSignatureAlgorithm);
-        }
+    private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient, String requestSignatureAlgorithm) {
+        RestClient client = spy(new RestClient(null));
+        doReturn(httpClient).when(client).httpClient();
+        return client.httpRequest(
+                        "https://localhost:1234/api/endpoint",
+                        "GET",
+                        null,
+                        new TestDTO("requestBodyData"),
+                        TEST_TYPE,
+                        MOCK_SECRET_KEY,
+                        requestSignatureAlgorithm
+                );
     }
 
     private static RestClient.HttpResponse<TestDTO> httpRequest(HttpClient httpClient) throws Exception {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -125,7 +125,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
         DistributedConfig config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, null);
         Assert.assertEquals("http://localhost:8080/", server.advertisedUrl().toString());
         server.stop();
 
@@ -135,7 +135,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "https");
         config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, null);
         Assert.assertEquals("https://localhost:8443/", server.advertisedUrl().toString());
         server.stop();
 
@@ -144,7 +144,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://localhost:8443");
         config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, null);
         Assert.assertEquals("https://localhost:8443/", server.advertisedUrl().toString());
         server.stop();
 
@@ -156,7 +156,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.REST_ADVERTISED_PORT_CONFIG, "10000");
         config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, null);
         Assert.assertEquals("http://somehost:10000/", server.advertisedUrl().toString());
         server.stop();
 
@@ -165,7 +165,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://encrypted-localhost:42069,http://plaintext-localhost:4761");
         configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "http");
         config = new DistributedConfig(configMap);
-        server = new RestServer(config);
+        server = new RestServer(config, null);
         Assert.assertEquals("http://plaintext-localhost:4761/", server.advertisedUrl().toString());
         server.stop();
     }
@@ -179,7 +179,7 @@ public class RestServerTest {
         doReturn(plugins).when(herder).plugins();
         doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -207,7 +207,7 @@ public class RestServerTest {
         doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
         doReturn(Arrays.asList("a", "b")).when(herder).connectors();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
         URI serverUrl = server.advertisedUrl();
@@ -251,7 +251,7 @@ public class RestServerTest {
         doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
         doReturn(Arrays.asList("a", "b")).when(herder).connectors();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
         HttpRequest request = new HttpGet("/connectors");
@@ -272,7 +272,7 @@ public class RestServerTest {
         // create some loggers in the process
         LoggerFactory.getLogger("a.b.c.s.W");
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -307,7 +307,7 @@ public class RestServerTest {
         LoggerFactory.getLogger("a.b.c.p.Y");
         LoggerFactory.getLogger("a.b.c.p.Z");
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -331,7 +331,7 @@ public class RestServerTest {
         doReturn(plugins).when(herder).plugins();
         doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -351,7 +351,7 @@ public class RestServerTest {
         doReturn(plugins).when(herder).plugins();
         doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -398,7 +398,7 @@ public class RestServerTest {
         doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
         doReturn(Arrays.asList("a", "b")).when(herder).connectors();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, null);
         server.initializeServer();
         server.initializeResources(herder);
         HttpRequest request = new HttpGet("/connectors");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -159,7 +159,6 @@ public class ConnectorsResourceTest {
 
     @Before
     public void setUp() throws NoSuchMethodException {
-        restClient = mock(RestClient.class);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
         connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
@@ -297,7 +296,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any()))
                 .thenReturn(new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
-        verify(restClient).httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any());
     }
 
     @Test
@@ -311,7 +309,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any()))
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
         connectorsResource.createConnector(FORWARD, httpHeaders, body);
-        verify(restClient).httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any());
     }
 
     @Test
@@ -389,7 +386,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null))
                 .thenReturn(new RestClient.HttpResponse<>(204, new HashMap<>(), null));
         connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
-        verify(restClient).httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null);
     }
 
     // Not found exceptions should pass through to caller so they can be processed for 404s
@@ -652,7 +648,6 @@ public class ConnectorsResourceTest {
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null);
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
-        verify(restClient).httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()), eq("POST"), isNull(), isNull(), any());
     }
 
     @Test
@@ -757,7 +752,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"), eq("POST"), isNull(), isNull(), any()))
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null);
-        verify(restClient).httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"), eq("POST"), isNull(), isNull(), any());
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 
@@ -770,7 +764,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"), eq("POST"), isNull(), isNull(), any()))
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true);
-        verify(restClient).httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"), eq("POST"), isNull(), isNull(), any());
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 
@@ -795,7 +788,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"), eq("POST"), isNull(), isNull(), any()))
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
         connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, null);
-        verify(restClient).httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"), eq("POST"), isNull(), isNull(), any());
     }
 
     @Test
@@ -810,7 +802,6 @@ public class ConnectorsResourceTest {
         when(restClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"), eq("POST"), isNull(), isNull(), any()))
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
         connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, true);
-        verify(restClient).httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"), eq("POST"), isNull(), isNull(), any());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -48,7 +48,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Stubber;
 
@@ -82,7 +81,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -156,15 +154,15 @@ public class ConnectorsResourceTest {
     private UriInfo forward;
     @Mock
     private WorkerConfig workerConfig;
-
-    private MockedStatic<RestClient> restClientStatic;
+    @Mock
+    private RestClient restClient;
 
     @Before
     public void setUp() throws NoSuchMethodException {
-        restClientStatic = mockStatic(RestClient.class);
+        restClient = mock(RestClient.class);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
-        connectorsResource = new ConnectorsResource(herder, workerConfig);
+        connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
         forward = mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.putSingle("forward", "true");
@@ -173,7 +171,6 @@ public class ConnectorsResourceTest {
 
     @After
     public void teardown() {
-        restClientStatic.close();
         verifyNoMoreInteractions(herder);
     }
 
@@ -297,11 +294,10 @@ public class ConnectorsResourceTest {
         expectAndCallbackNotLeaderException(cb).when(herder)
             .putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
 
-        verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)),
-            () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, body)
-        );
+        when(restClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any()))
+                .thenReturn(new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
+        connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
+        verify(restClient).httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any());
     }
 
     @Test
@@ -312,11 +308,10 @@ public class ConnectorsResourceTest {
         expectAndCallbackNotLeaderException(cb)
             .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
 
-        verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> connectorsResource.createConnector(FORWARD, httpHeaders, body)
-        );
+        when(restClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any()))
+                .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+        connectorsResource.createConnector(FORWARD, httpHeaders, body);
+        verify(restClient).httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any());
     }
 
     @Test
@@ -391,14 +386,10 @@ public class ConnectorsResourceTest {
         expectAndCallbackNotLeaderException(cb).when(herder)
             .deleteConnectorConfig(eq(CONNECTOR_NAME), cb.capture());
         // Should forward request
-        verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null, workerConfig),
-            new RestClient.HttpResponse<>(204, new HashMap<>(), null),
-            () -> {
-                connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
-                return null;
-            }
-        );
+        when(restClient.httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null))
+                .thenReturn(new RestClient.HttpResponse<>(204, new HashMap<>(), null));
+        connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        verify(restClient).httpRequest(LEADER_URL + "connectors/" + CONNECTOR_NAME + "?forward=false", "DELETE", NULL_HEADERS, null, null);
     }
 
     // Not found exceptions should pass through to caller so they can be processed for 404s
@@ -657,13 +648,11 @@ public class ConnectorsResourceTest {
         expectAndCallbackNotLeaderException(cb).when(herder)
             .restartConnectorAndTasks(eq(restartRequest), cb.capture());
 
-        Response response = verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()),
-                    eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null)
-        );
+        when(restClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()), eq("POST"), isNull(), isNull(), any()))
+                .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+        Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null);
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
+        verify(restClient).httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()), eq("POST"), isNull(), isNull(), any());
     }
 
     @Test
@@ -765,11 +754,10 @@ public class ConnectorsResourceTest {
         expectAndCallbackNotLeaderException(cb).when(herder)
             .restartConnector(eq(CONNECTOR_NAME), cb.capture());
 
-        Response response = verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"), eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null)
-        );
+        when(restClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"), eq("POST"), isNull(), isNull(), any()))
+                .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+        Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null);
+        verify(restClient).httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/restart?forward=true"), eq("POST"), isNull(), isNull(), any());
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 
@@ -779,11 +767,10 @@ public class ConnectorsResourceTest {
         String ownerUrl = "http://owner:8083";
         expectAndCallbackException(cb, new NotAssignedException("not owner test", ownerUrl))
             .when(herder).restartConnector(eq(CONNECTOR_NAME), cb.capture());
-        Response response = verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"), eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true)
-        );
+        when(restClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"), eq("POST"), isNull(), isNull(), any()))
+                .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+        Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true);
+        verify(restClient).httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=false"), eq("POST"), isNull(), isNull(), any());
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 
@@ -805,14 +792,10 @@ public class ConnectorsResourceTest {
         expectAndCallbackNotLeaderException(cb).when(herder)
             .restartTask(eq(taskId), cb.capture());
 
-        verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"), eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> {
-                connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, null);
-                return null;
-            }
-        );
+        when(restClient.httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"), eq("POST"), isNull(), isNull(), any()))
+                .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+        connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, null);
+        verify(restClient).httpRequest(eq(LEADER_URL + "connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=true"), eq("POST"), isNull(), isNull(), any());
     }
 
     @Test
@@ -824,21 +807,17 @@ public class ConnectorsResourceTest {
         expectAndCallbackException(cb, new NotAssignedException("not owner test", ownerUrl))
             .when(herder).restartTask(eq(taskId), cb.capture());
 
-        verifyRestRequestWithCall(
-            () -> RestClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"), eq("POST"), isNull(), isNull(), any(), any(WorkerConfig.class)),
-            new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> {
-                connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, true);
-                return null;
-            }
-        );
+        when(restClient.httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"), eq("POST"), isNull(), isNull(), any()))
+                .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+        connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, true);
+        verify(restClient).httpRequest(eq("http://owner:8083/connectors/" + CONNECTOR_NAME + "/tasks/0/restart?forward=false"), eq("POST"), isNull(), isNull(), any());
     }
 
     @Test
     public void testConnectorActiveTopicsWithTopicTrackingDisabled() {
         when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(false);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(false);
-        connectorsResource = new ConnectorsResource(herder, workerConfig);
+        connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
 
         Exception e = assertThrows(ConnectRestException.class,
             () -> connectorsResource.getConnectorActiveTopics(CONNECTOR_NAME));
@@ -850,7 +829,7 @@ public class ConnectorsResourceTest {
         when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(false);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
         HttpHeaders headers = mock(HttpHeaders.class);
-        connectorsResource = new ConnectorsResource(herder, workerConfig);
+        connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
 
         Exception e = assertThrows(ConnectRestException.class,
             () -> connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers));
@@ -862,7 +841,7 @@ public class ConnectorsResourceTest {
         when(workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG)).thenReturn(true);
         when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(false);
         HttpHeaders headers = mock(HttpHeaders.class);
-        connectorsResource = new ConnectorsResource(herder, workerConfig);
+        connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
 
         Exception e = assertThrows(ConnectRestException.class,
             () -> connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers));
@@ -875,7 +854,7 @@ public class ConnectorsResourceTest {
         when(workerConfig.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG)).thenReturn(true);
         when(herder.connectorActiveTopics(CONNECTOR_NAME))
             .thenReturn(new ActiveTopicsInfo(CONNECTOR_NAME, CONNECTOR_ACTIVE_TOPICS));
-        connectorsResource = new ConnectorsResource(herder, workerConfig);
+        connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
 
         Response response = connectorsResource.getConnectorActiveTopics(CONNECTOR_NAME);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -888,7 +867,7 @@ public class ConnectorsResourceTest {
     @Test
     public void testResetConnectorActiveTopics() {
         HttpHeaders headers = mock(HttpHeaders.class);
-        connectorsResource = new ConnectorsResource(herder, workerConfig);
+        connectorsResource = new ConnectorsResource(herder, workerConfig, restClient);
 
         Response response = connectorsResource.resetConnectorActiveTopics(CONNECTOR_NAME, headers);
         verify(herder).resetConnectorActiveTopics(CONNECTOR_NAME);
@@ -934,19 +913,4 @@ public class ConnectorsResourceTest {
         T run() throws Throwable;
     }
 
-    /**
-     * Used to verify that a provided restCall actually gets executed with a given RestClient verification
-     * @param verification The RestClient method being mocked
-     * @param mockReturn What the mocked method returns
-     * @param restCall The call against the RestClient to execute
-     * @return The return value of restCall
-     */
-    private <T> T verifyRestRequestWithCall(MockedStatic.Verification verification,
-                                            RestClient.HttpResponse<Object> mockReturn,
-                                            RunnableWithThrowable<T> restCall) throws Throwable {
-        restClientStatic.when(verification).thenReturn(mockReturn);
-        final T value = restCall.run();
-        restClientStatic.verify(verification);
-        return value;
-    }
 }


### PR DESCRIPTION
Currently, all RestClient methods are static, and require more complicated mocking mechanisms compared to an implementation which uses instance methods.

This change refactors all of the static methods into instance methods, and passes around a single initialized RestClient throughout the RestServer, ConnectorsResource, and DistributedHerder. This restClient can be more easily mocked by dependency injection rather than static mocking.

Note: This has one potential change in semantics: Previously the HttpClient was initialized for SSL only when a remote `https://` url was provided, and otherwise just created an HTTP client without an ssl context. Now, the HttpClient is unconditionally created with an SSL context, even if the worker/other workers are configured to use HTTP listeners. The HttpClient javadoc indicates that an HttpClient which is configured with an ssl context can still make outbound requests to destinations over http. Thus this _should_ be a lateral change.

During the implementation, I realized that the ConnectorsResource handles request forwarding to other nodes in a distributed cluster, and uses the RestClient to do so. In a standalone connect instance, this error handling is still present on the code-path, but because no standalone herder calls throw RequestTargetException, the error handling is not used.

This appears in the refactor where in Connect Standalone, the RestClient is not used in the StandaloneHerder, but a RestClient is expected in the RestServer signature. This also appears in the refactor where in MirrorMaker, the RestClient is used in the DistributedHerder, but no RestServer is started which would handle those requests. Both of these situations are left as-is in this PR, and will need follow-ups to address.

A new RestForwardingIntegrationTest verifies that the restclient->restserver forwarding flow works through all stages of a rolling upgrade from HTTP to HTTPS/SSL.

Signed-off-by: Greg Harris <greg.harris@aiven.io>


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
