### PR TITLE
MINOR: Avoid highestSupportedVersion outside tests

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClientQuotaControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClientQuotaControlManager.java
@@ -45,8 +45,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.metadata.MetadataRecordType.CLIENT_QUOTA_RECORD;
-
 
 public class ClientQuotaControlManager {
     private final SnapshotRegistry snapshotRegistry;

--- a/metadata/src/main/java/org/apache/kafka/controller/ClientQuotaControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClientQuotaControlManager.java
@@ -160,7 +160,7 @@ public class ClientQuotaControlManager {
                             .setEntity(recordEntitySupplier.get())
                             .setKey(key)
                             .setRemove(true),
-                        CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+                        (short) 0));
                 }
             } else {
                 ApiError validationError = validateQuotaKeyValue(configKeys, key, newValue);
@@ -175,7 +175,7 @@ public class ClientQuotaControlManager {
                                 .setEntity(recordEntitySupplier.get())
                                 .setKey(key)
                                 .setValue(newValue),
-                            CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+                            (short) 0));
                     }
                 }
             }
@@ -321,8 +321,7 @@ public class ClientQuotaControlManager {
                 record.setKey(quotaEntry.getKey());
                 record.setValue(quotaEntry.getValue());
                 record.setRemove(false);
-                records.add(new ApiMessageAndVersion(record,
-                    CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+                records.add(new ApiMessageAndVersion(record, (short) 0));
             }
             return records;
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -236,7 +236,7 @@ public class ConfigurationControlManager {
                     setResourceType(configResource.type().id()).
                     setResourceName(configResource.name()).
                     setName(key).
-                    setValue(newValue), CONFIG_RECORD.highestSupportedVersion()));
+                    setValue(newValue), (short) 0));
             }
         }
         ApiError error = validateAlterConfig(configResource, newRecords, Collections.emptyList(), newlyCreatedResource);
@@ -338,7 +338,7 @@ public class ConfigurationControlManager {
                     setResourceType(configResource.type().id()).
                     setResourceName(configResource.name()).
                     setName(key).
-                    setValue(newValue), CONFIG_RECORD.highestSupportedVersion()));
+                    setValue(newValue), (short) 0));
             }
         }
         List<ApiMessageAndVersion> recordsImplicitlyDeleted = new ArrayList<>();
@@ -348,7 +348,7 @@ public class ConfigurationControlManager {
                     setResourceType(configResource.type().id()).
                     setResourceName(configResource.name()).
                     setName(key).
-                    setValue(null), CONFIG_RECORD.highestSupportedVersion()));
+                    setValue(null), (short) 0));
             }
         }
         ApiError error = validateAlterConfig(configResource, recordsExplicitlyAltered, recordsImplicitlyDeleted, newlyCreatedResource);
@@ -501,7 +501,7 @@ public class ConfigurationControlManager {
                     setResourceName(resource.name()).
                     setResourceType(resource.type().id()).
                     setName(configEntry.getKey()).
-                    setValue(configEntry.getValue()), CONFIG_RECORD.highestSupportedVersion()));
+                    setValue(configEntry.getValue()), (short) 0));
             }
             return records;
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -49,7 +49,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.APPEND;
-import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
 import static org.apache.kafka.common.protocol.Errors.INVALID_CONFIG;
 
 

--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -212,11 +212,9 @@ public class FeatureControlManager {
             // Perform additional checks if we're updating metadata.version
             return updateMetadataVersion(newVersion, upgradeType.equals(FeatureUpdate.UpgradeType.UNSAFE_DOWNGRADE), records::add);
         } else {
-            records.add(new ApiMessageAndVersion(
-                new FeatureLevelRecord()
-                    .setName(featureName)
-                    .setFeatureLevel(newVersion),
-                FEATURE_LEVEL_RECORD.highestSupportedVersion()));
+            records.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(featureName).
+                setFeatureLevel(newVersion), (short) 0));
             return ApiError.NONE;
         }
     }
@@ -342,7 +340,7 @@ public class FeatureControlManager {
             Entry<String, Short> entry = iterator.next();
             return Collections.singletonList(new ApiMessageAndVersion(new FeatureLevelRecord()
                 .setName(entry.getKey())
-                .setFeatureLevel(entry.getValue()), FEATURE_LEVEL_RECORD.highestSupportedVersion()));
+                .setFeatureLevel(entry.getValue()), (short) 0));
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_CHANGE_RECORD;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -327,8 +327,7 @@ public class PartitionChangeBuilder {
         if (changeRecordIsNoOp(record)) {
             return Optional.empty();
         } else {
-            return Optional.of(new ApiMessageAndVersion(record,
-                PARTITION_CHANGE_RECORD.highestSupportedVersion()));
+            return Optional.of(new ApiMessageAndVersion(record, (short) 0));
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -763,7 +763,7 @@ public class ReplicationControlManager {
         successes.put(topic.name(), result);
         records.add(new ApiMessageAndVersion(new TopicRecord().
             setName(topic.name()).
-            setTopicId(topicId), TOPIC_RECORD.highestSupportedVersion()));
+            setTopicId(topicId), (short) 0));
         for (Entry<Integer, PartitionRegistration> partEntry : newParts.entrySet()) {
             int partitionIndex = partEntry.getKey();
             PartitionRegistration info = partEntry.getValue();
@@ -898,7 +898,7 @@ public class ReplicationControlManager {
             throw new UnknownTopicIdException(UNKNOWN_TOPIC_ID.message());
         }
         records.add(new ApiMessageAndVersion(new RemoveTopicRecord().
-            setTopicId(id), REMOVE_TOPIC_RECORD.highestSupportedVersion()));
+            setTopicId(id), (short) 0));
     }
 
     // VisibleForTesting
@@ -1597,7 +1597,7 @@ public class ReplicationControlManager {
                 setAddingReplicas(Collections.emptyList()).
                 setLeader(isr.get(0)).
                 setLeaderEpoch(0).
-                setPartitionEpoch(0), PARTITION_RECORD.highestSupportedVersion()));
+                setPartitionEpoch(0), (short) 0));
             partitionId++;
         }
     }
@@ -1932,7 +1932,7 @@ public class ReplicationControlManager {
             List<ApiMessageAndVersion> records = new ArrayList<>();
             records.add(new ApiMessageAndVersion(new TopicRecord().
                 setName(topic.name).
-                setTopicId(topic.id), TOPIC_RECORD.highestSupportedVersion()));
+                setTopicId(topic.id), (short) 0));
             for (Entry<Integer, PartitionRegistration> entry : topic.parts.entrySet(epoch)) {
                 records.add(entry.getValue().toRecord(topic.id, entry.getKey()));
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -116,9 +116,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
-import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_RECORD;
-import static org.apache.kafka.common.metadata.MetadataRecordType.REMOVE_TOPIC_RECORD;
-import static org.apache.kafka.common.metadata.MetadataRecordType.TOPIC_RECORD;
 import static org.apache.kafka.common.protocol.Errors.FENCED_LEADER_EPOCH;
 import static org.apache.kafka.common.protocol.Errors.INELIGIBLE_REPLICA;
 import static org.apache.kafka.common.protocol.Errors.INVALID_REQUEST;


### PR DESCRIPTION
We should avoid using Message.highestSupportedVersion to generate metadata records. Instead, we need to pick the correct record version based on the current metadata version which is in effect. In cases where there is only one record version that we know how to generate, we can hard code that version, but it should just be a simple constant zero.