### PR TITLE
KAFKA-14370: Simplify the ImageWriter API by adding freeze

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
@@ -128,7 +128,7 @@ public final class MetadataImage {
         clientQuotas.write(writer, options);
         producerIds.write(writer, options);
         acls.write(writer, options);
-        writer.close(true);
+        writer.freeze();
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/image/writer/ImageWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/writer/ImageWriter.java
@@ -48,18 +48,13 @@ public interface ImageWriter extends AutoCloseable {
     void write(ApiMessageAndVersion record);
 
     /**
-     * Close the image writer, dicarding all progress. Calling this function more than once has
-     * no effect.
+     * Successfully complete the image. Calling this function more than once has no effect.
      */
-    default void close() {
-        close(false);
-    }
+    void freeze();
 
    /**
     * Close the image writer. Calling this function more than once has no effect.
-    *
-    * @param complete               True if we should complete the image successfully.
-    *                               False if we should discard all progress.
+    * If this is called before freeze() has been called, all progress may be lost.
     */
-    void close(boolean complete);
+    void close();
 }

--- a/metadata/src/main/java/org/apache/kafka/image/writer/RaftSnapshotWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/writer/RaftSnapshotWriter.java
@@ -52,10 +52,19 @@ public class RaftSnapshotWriter implements ImageWriter {
     }
 
     @Override
-    public void close(boolean complete) {
+    public void freeze() {
+        cleanup(true);
+    }
+
+    @Override
+    public void close() {
+        cleanup(false);
+    }
+
+    private void cleanup(boolean freeze) {
         if (records == null) return;
         try {
-            if (complete) {
+            if (freeze) {
                 if (!records.isEmpty()) {
                     snapshotWriter.append(records);
                 }

--- a/metadata/src/main/java/org/apache/kafka/image/writer/RecordListWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/writer/RecordListWriter.java
@@ -41,11 +41,14 @@ public class RecordListWriter implements ImageWriter {
     }
 
     @Override
-    public void close(boolean complete) {
+    public void freeze() {
+        closed = true;
+    }
+
+    @Override
+    public void close() {
         if (closed) return;
         closed = true;
-        if (!complete) {
-            records.clear();
-        }
+        records.clear();
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/writer/RaftSnapshotWriterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/writer/RaftSnapshotWriterTest.java
@@ -84,7 +84,8 @@ public class RaftSnapshotWriterTest {
         writer.write(testRecord(0));
         writer.write(testRecord(1));
         writer.write(testRecord(2));
-        writer.close(true);
+        writer.freeze();
+        writer.close();
         assertTrue(snapshotWriter.frozen);
         assertTrue(snapshotWriter.closed);
         assertEquals(Arrays.asList(

--- a/metadata/src/test/java/org/apache/kafka/image/writer/RecordListWriterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/writer/RecordListWriterTest.java
@@ -37,8 +37,9 @@ public class RecordListWriterTest {
         RecordListWriter writer = new RecordListWriter();
         writer.write(testRecord(0));
         writer.write(testRecord(1));
-        writer.close(true);
+        writer.freeze();
         assertEquals(Arrays.asList(testRecord(0), testRecord(1)), writer.records());
+        writer.close();
     }
 
     @Test
@@ -52,10 +53,11 @@ public class RecordListWriterTest {
     @Test
     public void testWriteAfterClose() {
         RecordListWriter writer = new RecordListWriter();
-        writer.close(true);
+        writer.freeze();
         assertThrows(ImageWriterClosedException.class, () ->
                 writer.write(0, new TopicRecord().
                         setName("foo").
                         setTopicId(Uuid.fromString("3B134hrsQgKtz8Sp6QBIfg"))));
+        writer.close();
     }
 }


### PR DESCRIPTION
Simplify the ImageWriter API by adding ImageWriter#freeze() instead of requiring a call to an
overload of ImageWriter#close().