### PR TITLE
KAFKA-14294: check whether a transaction is in flight before skipping a commit

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -146,6 +146,10 @@ public class StreamsProducer {
         return StreamsConfigUtils.eosEnabled(processingMode);
     }
 
+    boolean transactionInFlight() {
+        return transactionInFlight;
+    }
+
     /**
      * @throws IllegalStateException if EOS is disabled
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -175,72 +175,74 @@ public class TaskExecutor {
 
         final Set<TaskId> corruptedTasks = new HashSet<>();
 
-        if (!offsetsPerTask.isEmpty()) {
             if (executionMetadata.processingMode() == EXACTLY_ONCE_ALPHA) {
-                for (final Map.Entry<Task, Map<TopicPartition, OffsetAndMetadata>> taskToCommit : offsetsPerTask.entrySet()) {
-                    final Task task = taskToCommit.getKey();
-                    try {
-                        taskManager.streamsProducerForTask(task.id())
-                            .commitTransaction(taskToCommit.getValue(), taskManager.mainConsumer().groupMetadata());
-                        updateTaskCommitMetadata(taskToCommit.getValue());
-                    } catch (final TimeoutException timeoutException) {
-                        log.error(
-                            String.format("Committing task %s failed.", task.id()),
-                            timeoutException
-                        );
-                        corruptedTasks.add(task.id());
+                for (final Task task : taskManager.activeTaskIterable()) {
+                    final Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = offsetsPerTask.get(task);
+                    if (offsetsToCommit != null || taskManager.streamsProducerForTask(task.id()).transactionInFlight()) {
+                        try {
+                            taskManager.streamsProducerForTask(task.id())
+                                .commitTransaction(offsetsToCommit, taskManager.mainConsumer().groupMetadata());
+                            updateTaskCommitMetadata(offsetsToCommit);
+                        } catch (final TimeoutException timeoutException) {
+                            log.error(
+                                String.format("Committing task %s failed.", task.id()),
+                                timeoutException
+                            );
+                            corruptedTasks.add(task.id());
+                        }
                     }
                 }
             } else {
-                final Map<TopicPartition, OffsetAndMetadata> allOffsets = offsetsPerTask.values().stream()
-                    .flatMap(e -> e.entrySet().stream()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                if (!offsetsPerTask.isEmpty() || taskManager.threadProducer().transactionInFlight()) {
 
-                if (executionMetadata.processingMode() == EXACTLY_ONCE_V2) {
-                    try {
-                        taskManager.threadProducer().commitTransaction(allOffsets, taskManager.mainConsumer().groupMetadata());
-                        updateTaskCommitMetadata(allOffsets);
-                    } catch (final TimeoutException timeoutException) {
-                        log.error(
-                            String.format("Committing task(s) %s failed.",
-                                offsetsPerTask
-                                    .keySet()
-                                    .stream()
-                                    .map(t -> t.id().toString())
-                                    .collect(Collectors.joining(", "))),
-                            timeoutException
-                        );
-                        offsetsPerTask
-                            .keySet()
-                            .forEach(task -> corruptedTasks.add(task.id()));
-                    }
-                } else {
-                    try {
-                        taskManager.mainConsumer().commitSync(allOffsets);
-                        updateTaskCommitMetadata(allOffsets);
-                    } catch (final CommitFailedException error) {
-                        throw new TaskMigratedException("Consumer committing offsets failed, " +
-                            "indicating the corresponding thread is no longer part of the group", error);
-                    } catch (final TimeoutException timeoutException) {
-                        log.error(
-                            String.format("Committing task(s) %s failed.",
-                                offsetsPerTask
-                                    .keySet()
-                                    .stream()
-                                    .map(t -> t.id().toString())
-                                    .collect(Collectors.joining(", "))),
-                            timeoutException
-                        );
-                        throw timeoutException;
-                    } catch (final KafkaException error) {
-                        throw new StreamsException("Error encountered committing offsets via consumer", error);
+                    final Map<TopicPartition, OffsetAndMetadata> allOffsets = offsetsPerTask.values().stream()
+                        .flatMap(e -> e.entrySet().stream()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                    if (executionMetadata.processingMode() == EXACTLY_ONCE_V2) {
+                        try {
+                            taskManager.threadProducer().commitTransaction(allOffsets, taskManager.mainConsumer().groupMetadata());
+                            updateTaskCommitMetadata(allOffsets);
+                        } catch (final TimeoutException timeoutException) {
+                            log.error(
+                                String.format("Committing task(s) %s failed.",
+                                              offsetsPerTask
+                                                  .keySet()
+                                                  .stream()
+                                                  .map(t -> t.id().toString())
+                                                  .collect(Collectors.joining(", "))),
+                                timeoutException
+                            );
+                            offsetsPerTask
+                                .keySet()
+                                .forEach(task -> corruptedTasks.add(task.id()));
+                        }
+                    } else {
+                        try {
+                            taskManager.mainConsumer().commitSync(allOffsets);
+                            updateTaskCommitMetadata(allOffsets);
+                        } catch (final CommitFailedException error) {
+                            throw new TaskMigratedException("Consumer committing offsets failed, " +
+                                                                "indicating the corresponding thread is no longer part of the group", error);
+                        } catch (final TimeoutException timeoutException) {
+                            log.error(
+                                String.format("Committing task(s) %s failed.",
+                                              offsetsPerTask
+                                                  .keySet()
+                                                  .stream()
+                                                  .map(t -> t.id().toString())
+                                                  .collect(Collectors.joining(", "))),
+                                timeoutException
+                            );
+                            throw timeoutException;
+                        } catch (final KafkaException error) {
+                            throw new StreamsException("Error encountered committing offsets via consumer", error);
+                        }
                     }
                 }
             }
-
             if (!corruptedTasks.isEmpty()) {
                 throw new TaskCorruptedException(corruptedTasks);
             }
-        }
     }
 
     private void updateTaskCommitMetadata(final Map<TopicPartition, OffsetAndMetadata> allOffsets) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
@@ -148,8 +149,12 @@ public class TaskManager {
         return topologyMetadata;
     }
 
-    Consumer<byte[], byte[]> mainConsumer() {
-        return mainConsumer;
+    ConsumerGroupMetadata consumerGroupMetadata() {
+        return mainConsumer.groupMetadata();
+    }
+
+    void consumerCommitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        mainConsumer.commitSync(offsets);
     }
 
     StreamsProducer streamsProducerForTask(final TaskId taskId) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -17,11 +17,19 @@
 
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.processor.TaskId;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.util.Collections;
+
+import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA;
+import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TaskExecutorTest {
     @Test
@@ -34,5 +42,52 @@ public class TaskExecutorTest {
 
         taskExecutor.punctuate();
         verify(tasks).activeTasks();
+    }
+
+    @Test
+    public void testCommitWithOpenTransactionButNoOffsetsEOSV2() {
+        final Tasks tasks = mock(Tasks.class);
+        final TaskManager taskManager = mock(TaskManager.class);
+        final ConsumerGroupMetadata groupMetadata = mock(ConsumerGroupMetadata.class);
+        when(taskManager.consumerGroupMetadata()).thenReturn(groupMetadata);
+
+        final TaskExecutionMetadata metadata = mock(TaskExecutionMetadata.class);
+        final StreamsProducer producer = mock(StreamsProducer.class);
+        when(metadata.processingMode()).thenReturn(EXACTLY_ONCE_V2);
+        when(taskManager.threadProducer()).thenReturn(producer);
+        when(producer.transactionInFlight()).thenReturn(true);
+
+        producer.commitTransaction(Collections.emptyMap(), groupMetadata);
+
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
+        taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
+
+        verify(producer);
+    }
+
+    @Test
+    public void testCommitWithOpenTransactionButNoOffsetsEOSV1() {
+        final TaskId taskId = new TaskId(0, 0);
+        final Task task = mock(Task.class);
+        when(task.id()).thenReturn(taskId);
+
+        final Tasks tasks = mock(Tasks.class);
+        final ConsumerGroupMetadata groupMetadata = mock(ConsumerGroupMetadata.class);
+        final TaskManager taskManager = mock(TaskManager.class);
+        when(taskManager.activeTaskIterable()).thenReturn(Collections.singletonList(task));
+        when(taskManager.consumerGroupMetadata()).thenReturn(groupMetadata);
+
+        final StreamsProducer producer = mock(StreamsProducer.class);
+        final TaskExecutionMetadata metadata = mock(TaskExecutionMetadata.class);
+        when(metadata.processingMode()).thenReturn(EXACTLY_ONCE_ALPHA);
+        when(taskManager.streamsProducerForTask(taskId)).thenReturn(producer);
+        when(producer.transactionInFlight()).thenReturn(true);
+
+        producer.commitTransaction(Mockito.isNull(), groupMetadata);
+
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
+        taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
+
+        verify(producer);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
+
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,12 +59,10 @@ public class TaskExecutorTest {
         when(taskManager.threadProducer()).thenReturn(producer);
         when(producer.transactionInFlight()).thenReturn(true);
 
-        producer.commitTransaction(Collections.emptyMap(), groupMetadata);
-
         final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
-        verify(producer);
+        verify(producer).commitTransaction(Collections.emptyMap(), groupMetadata);
     }
 
     @Test
@@ -83,11 +83,9 @@ public class TaskExecutorTest {
         when(taskManager.streamsProducerForTask(taskId)).thenReturn(producer);
         when(producer.transactionInFlight()).thenReturn(true);
 
-        producer.commitTransaction(Mockito.isNull(), groupMetadata);
-
         final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
-        verify(producer);
+        verify(producer).commitTransaction(Mockito.isNull(), eq(groupMetadata));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -21,14 +21,12 @@ import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,6 +84,6 @@ public class TaskExecutorTest {
         final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
-        verify(producer).commitTransaction(Mockito.isNull(), eq(groupMetadata));
+        verify(producer).commitTransaction(Collections.emptyMap(), groupMetadata);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -4450,10 +4450,10 @@ public class TaskManagerTest {
         final StateMachineTask task01 = new StateMachineTask(taskId01, taskId01Partitions, true);
         task01.setCommittableOffsetsAndMetadata(offsetsT01);
         final StateMachineTask task02 = new StateMachineTask(taskId02, taskId02Partitions, true);
-
-        expect(tasks.allTasks()).andStubReturn(mkSet(task00, task01, task02));
+        when(tasks.allTasks()).thenReturn(mkSet(task00, task01, task02));
+        
         expect(consumer.groupMetadata()).andStubReturn(null);
-        replay(activeTaskCreator, consumer, tasks);
+        replay(activeTaskCreator, consumer);
 
         task00.setCommitNeeded();
         task01.setCommitNeeded();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -4424,8 +4424,6 @@ public class TaskManagerTest {
 
     @Test
     public void shouldNotFailForTimeoutExceptionOnCommitWithEosAlpha() {
-        final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_ALPHA, false);
-
         final StreamsProducer producer = mock(StreamsProducer.class);
         expect(activeTaskCreator.streamsProducerForTask(anyObject(TaskId.class)))
             .andReturn(producer)
@@ -4449,6 +4447,10 @@ public class TaskManagerTest {
         final StateMachineTask task01 = new StateMachineTask(taskId01, taskId01Partitions, true);
         task01.setCommittableOffsetsAndMetadata(offsetsT01);
         final StateMachineTask task02 = new StateMachineTask(taskId02, taskId02Partitions, true);
+
+        final Tasks tasks = new Tasks(new LogContext());
+        tasks.addActiveTasks(asList(task00, task01, task02));
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_ALPHA, tasks, false);
 
         expect(consumer.groupMetadata()).andStubReturn(null);
         replay(activeTaskCreator, consumer);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -4424,6 +4424,9 @@ public class TaskManagerTest {
 
     @Test
     public void shouldNotFailForTimeoutExceptionOnCommitWithEosAlpha() {
+        final Tasks tasks = mock(Tasks.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_ALPHA, tasks, false);
+
         final StreamsProducer producer = mock(StreamsProducer.class);
         expect(activeTaskCreator.streamsProducerForTask(anyObject(TaskId.class)))
             .andReturn(producer)
@@ -4448,12 +4451,9 @@ public class TaskManagerTest {
         task01.setCommittableOffsetsAndMetadata(offsetsT01);
         final StateMachineTask task02 = new StateMachineTask(taskId02, taskId02Partitions, true);
 
-        final Tasks tasks = new Tasks(new LogContext());
-        tasks.addActiveTasks(asList(task00, task01, task02));
-        final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_ALPHA, tasks, false);
-
+        expect(tasks.allTasks()).andStubReturn(mkSet(task00, task01, task02));
         expect(consumer.groupMetadata()).andStubReturn(null);
-        replay(activeTaskCreator, consumer);
+        replay(activeTaskCreator, consumer, tasks);
 
         task00.setCommitNeeded();
         task01.setCommitNeeded();


### PR DESCRIPTION
Add a new `#transactionInFlight` API to the StreamsProducer to expose the flag of the same name, then check whether there is an open transaction when we determine whether or not to perform a commit in TaskExecutor. This is to avoid unnecessarily dropping out of the group on transaction timeout in the case a transaction was begun outside of regular processing, eg when a punctuator forwards records but there are no newly consumer records and thus no new offsets to commit
