### PR TITLE
KAFKA-14282: stop tracking Produced sensors by processor node id 

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -239,12 +239,12 @@ public class RecordCollectorTest {
     public void shouldSendToSpecificPartition() {
         final Headers headers = new RecordHeaders(new Header[] {new RecordHeader("key", "value".getBytes())});
 
-        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", headers, 1, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", headers, 1, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", headers, 2, null, stringSerializer, stringSerializer, null, null);
+        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", headers, 1, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", headers, 1, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", headers, 2, null, stringSerializer, stringSerializer, null, context);
 
         Map<TopicPartition, Long> offsets = collector.offsets();
 
@@ -253,9 +253,9 @@ public class RecordCollectorTest {
         assertEquals(0L, (long) offsets.get(new TopicPartition(topic, 2)));
         assertEquals(6, mockProducer.history().size());
 
-        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", null, 1, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", headers, 2, null, stringSerializer, stringSerializer, null, null);
+        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", null, 1, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", headers, 2, null, stringSerializer, stringSerializer, null, context);
 
         offsets = collector.offsets();
 
@@ -295,15 +295,15 @@ public class RecordCollectorTest {
     public void shouldSendWithNoPartition() {
         final Headers headers = new RecordHeaders(new Header[] {new RecordHeader("key", "value".getBytes())});
 
-        collector.send(topic, "3", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "9", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "27", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "81", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "243", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "28", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "82", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "244", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "245", "0", headers, null, null, stringSerializer, stringSerializer, null, null);
+        collector.send(topic, "3", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "9", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "27", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "81", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "243", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "28", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "82", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "244", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "245", "0", headers, null, null, stringSerializer, stringSerializer, null, context);
 
         final Map<TopicPartition, Long> offsets = collector.offsets();
 
@@ -318,9 +318,9 @@ public class RecordCollectorTest {
     public void shouldUpdateOffsetsUponCompletion() {
         Map<TopicPartition, Long> offsets = collector.offsets();
 
-        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", null, 1, null, stringSerializer, stringSerializer, null, null);
-        collector.send(topic, "999", "0", null, 2, null, stringSerializer, stringSerializer, null, null);
+        collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", null, 1, null, stringSerializer, stringSerializer, null, context);
+        collector.send(topic, "999", "0", null, 2, null, stringSerializer, stringSerializer, null, context);
 
         assertEquals(Collections.<TopicPartition, Long>emptyMap(), offsets);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -269,15 +269,15 @@ public class RecordCollectorTest {
     public void shouldSendWithPartitioner() {
         final Headers headers = new RecordHeaders(new Header[] {new RecordHeader("key", "value".getBytes())});
 
-        collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "9", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "27", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "81", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "243", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "28", "0", headers, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "82", "0", headers, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "244", "0", headers, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
-        collector.send(topic, "245", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner);
+        collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "9", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "27", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "81", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "243", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "28", "0", headers, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "82", "0", headers, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "244", "0", headers, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
+        collector.send(topic, "245", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner);
 
         final Map<TopicPartition, Long> offsets = collector.offsets();
 
@@ -338,7 +338,7 @@ public class RecordCollectorTest {
         final CustomStringSerializer valueSerializer = new CustomStringSerializer();
         keySerializer.configure(Collections.emptyMap(), true);
 
-        collector.send(topic, "3", "0", new RecordHeaders(), null, keySerializer, valueSerializer, null, null, streamPartitioner);
+        collector.send(topic, "3", "0", new RecordHeaders(), null, keySerializer, valueSerializer, null, context, streamPartitioner);
 
         final List<ProducerRecord<byte[], byte[]>> recordHistory = mockProducer.history();
         for (final ProducerRecord<byte[], byte[]> sentRecord : recordHistory) {
@@ -571,7 +571,7 @@ public class RecordCollectorTest {
 
         final StreamsException exception = assertThrows(
             StreamsException.class,
-            () -> collector.send(topic, "0", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner)
+            () -> collector.send(topic, "0", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner)
         );
         assertThat(
             exception.getMessage(),


### PR DESCRIPTION
Users have been seeing a large number of these error messages being logged by the RecordCollectorImpl:

```
Unable to records bytes produced to topic XXX by sink node YYY as the node is not recognized.
```

It seems like we try to save all known sink nodes when the record collector is constructed, by we do so by going through the known sink topics which means we could miss some nodes, for example if dynamic topic routing is used. Previously we were logging an error and would skip recording the metric if we tried to `send` a record from a sink node it didn't recognize, but there's not really any reason to have been tracking the sensors by node in the first place -- we can just track the actual sink topics themselves.
