### PR TITLE
  [DO NOT MERGE] SaslPlainSslEndToEndAuthorizationTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -46,6 +46,7 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   val consumerConfig = new Properties
   val adminClientConfig = new Properties
   val serverConfig = new Properties
+  val controllerConfig = new Properties
 
   private val consumers = mutable.Buffer[KafkaConsumer[_, _]]()
   private val producers = mutable.Buffer[KafkaProducer[_, _]]()
@@ -64,6 +65,10 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     modifyConfigs(cfgs)
     insertControllerListenersIfNeeded(cfgs)
     cfgs.map(KafkaConfig.fromProps)
+  }
+
+  override protected def kraftControllerConfigs(): Seq[Properties] = {
+    Seq(controllerConfig)
   }
 
   protected def configureListeners(props: Seq[Properties]): Unit = {

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -35,14 +35,19 @@ abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
+    println("SaslEndToEndAuthorizationTest setUp")
     // create static config including client login context with credentials for JaasTestUtils 'client2'
     startSasl(jaasSections(kafkaServerSaslMechanisms, Option(kafkaClientSaslMechanism), Both))
     // set dynamic properties with credentials for JaasTestUtils 'client1' so that dynamic JAAS configuration is also
     // tested by this set of tests
     val clientLoginContext = jaasClientLoginModule(kafkaClientSaslMechanism)
+    println("clientLoginContext = " + clientLoginContext)
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
     consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
-    adminClientConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+    clientAdminProperties.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+    // This needs a different value
+    val adminLoginContext = jaasAdminLoginModule(kafkaClientSaslMechanism)
+    adminClientConfig.put(SaslConfigs.SASL_JAAS_CONFIG, adminLoginContext)
     super.setUp(testInfo)
   }
 

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -48,6 +48,7 @@ abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
     // This needs a different value
     val adminLoginContext = jaasAdminLoginModule(kafkaClientSaslMechanism)
     adminClientConfig.put(SaslConfigs.SASL_JAAS_CONFIG, adminLoginContext)
+    superUserConfig.put(SaslConfigs.SASL_JAAS_CONFIG, adminLoginContext)
     super.setUp(testInfo)
   }
 

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -95,6 +95,7 @@ object SaslPlainSslEndToEndAuthorizationTest {
       val subject = Subject.getSubject(AccessController.getContext)
       val username = subject.getPublicCredentials(classOf[String]).iterator().next()
       for (callback <- callbacks) {
+        println("TestClientCallbackHandler = " + callback + " " + username)
         callback match {
           case nameCallback: NameCallback => nameCallback.setName(username)
           case passwordCallback: PasswordCallback =>
@@ -131,6 +132,7 @@ class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
   this.producerConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)
   this.consumerConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)
   this.adminClientConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)
+  this.superUserConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)
 
   override protected def kafkaClientSaslMechanism = "PLAIN"
   override protected def kafkaServerSaslMechanisms = List("PLAIN")

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -105,6 +105,7 @@ trait SaslSetup {
       (kafkaServerSaslMechanisms.contains("GSSAPI") || kafkaClientSaslMechanism.contains("GSSAPI"))
     if (hasKerberos)
       maybeCreateEmptyKeytabFiles()
+    System.out.println("This is a test " + mode)
     mode match {
       case ZkSasl => JaasTestUtils.zkSections
       case KafkaSasl =>
@@ -117,6 +118,7 @@ trait SaslSetup {
 
   private def writeJaasConfigurationToFile(jaasSections: Seq[JaasSection]): Unit = {
     val file = JaasTestUtils.writeJaasContextsToFile(jaasSections)
+    System.out.println("writeJaasConfigurationToFile " + file.getAbsolutePath)
     System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, file.getAbsolutePath)
     // This will cause a reload of the Configuration singleton when `getConfiguration` is called
     Configuration.setConfiguration(null)
@@ -154,6 +156,13 @@ trait SaslSetup {
       JaasTestUtils.clientLoginModule(clientSaslMechanism, clientKeytabFile)
   }
 
+  def jaasAdminLoginModule(clientSaslMechanism: String, serviceName: Option[String] = None): String = {
+    if (serviceName.isDefined)
+      JaasTestUtils.adminLoginModule(clientSaslMechanism, clientKeytabFile, serviceName.get)
+    else
+      JaasTestUtils.adminLoginModule(clientSaslMechanism, clientKeytabFile)
+  }
+
   def jaasScramClientLoginModule(clientSaslScramMechanism: String, scramUser: String, scramPassword: String): String = {
     JaasTestUtils.scramClientLoginModule(clientSaslScramMechanism, scramUser, scramPassword)
   }
@@ -171,6 +180,7 @@ trait SaslSetup {
       TestUtils.adminClientSecurityConfigs(securityProtocol, trustStoreFile, clientSaslProperties)
     securityProps.forEach { (key, value) => config.put(key.asInstanceOf[String], value) }
     config.put(SaslConfigs.SASL_JAAS_CONFIG, jaasScramClientLoginModule(scramMechanism, user, password))
+    System.out.println("Created admin client in " + workDir)
     Admin.create(config)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -184,6 +184,12 @@ object JaasTestUtils {
   def clientLoginModule(mechanism: String, keytabLocation: Option[File], serviceName: String = serviceName): String =
     kafkaClientModule(mechanism, keytabLocation, KafkaClientPrincipal, KafkaPlainUser, KafkaPlainPassword, KafkaScramUser, KafkaScramPassword, KafkaOAuthBearerUser, serviceName).toString
 
+
+  // Returns the dynamic configuration, using credentials for admin
+  def adminLoginModule(mechanism: String, keytabLocation: Option[File], serviceName: String = serviceName): String =
+    kafkaClientModule(mechanism, keytabLocation, KafkaClientPrincipal, KafkaPlainAdmin, KafkaPlainAdminPassword,
+    KafkaScramAdmin, KafkaScramAdminPassword, KafkaOAuthBearerAdmin, serviceName).toString
+
   def tokenClientLoginModule(tokenId: String, password: String): String = {
     ScramLoginModule(
       tokenId,


### PR DESCRIPTION
    Changes needed to get SaslPlainSslEndToEndAuthorizationTest to pass in KRAFT

    Removed direct calls in EndToEndAuthorizationTest to zookeeper and instead
    use the superuser principal to update the Acls through the brokers. This
    removes use of deprecated featuer --authorizer-properties
