### PR TITLE
KAFKA-14353: Allow configuring request timeouts for create/update/validate Kafka Connect REST endpoints

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -59,6 +59,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.io.File;
 
+import static org.apache.kafka.connect.runtime.rest.resources.ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS;
+
 /**
  *  Entry point for "MirrorMaker 2.0".
  *  <p>
@@ -212,7 +214,7 @@ public class MirrorMaker {
                     } else {
                         log.info("Connector {} configured.", sourceAndTarget, e);
                     }
-                });
+                }, DEFAULT_REST_REQUEST_TIMEOUT_MS);
     }
 
     private void checkHerder(SourceAndTarget sourceAndTarget) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -42,6 +42,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.apache.kafka.connect.runtime.rest.resources.ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS;
+
 /**
  * <p>
  * Command line utility that runs Kafka Connect as a standalone process. In this mode, work is not
@@ -113,7 +115,7 @@ public class ConnectStandalone {
                     });
                     herder.putConnectorConfig(
                             connectorProps.get(ConnectorConfig.NAME_CONFIG),
-                            connectorProps, false, cb);
+                            connectorProps, false, cb, DEFAULT_REST_REQUEST_TIMEOUT_MS);
                     cb.get();
                 }
             } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -101,8 +101,9 @@ public interface Herder {
      * @param allowReplace if true, allow overwriting previous configs; if false, throw AlreadyExistsException if a connector
      *                     with the same name already exists
      * @param callback callback to invoke when the configuration has been written
+     * @param requestTimeoutMs the request timeout in milliseconds
      */
-    void putConnectorConfig(String connName, Map<String, String> config, boolean allowReplace, Callback<Created<ConnectorInfo>> callback);
+    void putConnectorConfig(String connName, Map<String, String> config, boolean allowReplace, Callback<Created<ConnectorInfo>> callback, long requestTimeoutMs);
 
     /**
      * Delete a connector and its configuration.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Range;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslClientAuth;
@@ -49,6 +50,7 @@ import org.eclipse.jetty.util.StringUtil;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 import static org.apache.kafka.connect.runtime.SourceConnectorConfig.TOPIC_CREATION_PREFIX;
+import static org.apache.kafka.connect.runtime.rest.resources.ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS;
 
 /**
  * Common base class providing configuration for Kafka Connect workers, whether standalone or distributed.
@@ -231,6 +233,11 @@ public class WorkerConfig extends AbstractConfig {
     protected static final String RESPONSE_HTTP_HEADERS_DOC = "Rules for REST API HTTP response headers";
     protected static final String RESPONSE_HTTP_HEADERS_DEFAULT = "";
 
+    public static final String REST_REQUEST_MAX_TIMEOUT_MS_CONFIG = "rest.max.request.timeout.ms";
+    protected static final String REST_REQUEST_MAX_TIMEOUT_MS_DOC = "The maximum REST API request timeout in milliseconds that can be "
+            + "set via the 'timeout' query parameter on supported endpoints.";
+    public static final Long REST_REQUEST_MAX_TIMEOUT_MS_DEFAULT = 600_000L;
+
     /**
      * Get a basic ConfigDef for a WorkerConfig. This includes all the common settings. Subclasses can use this to
      * bootstrap their own ConfigDef.
@@ -262,6 +269,9 @@ public class WorkerConfig extends AbstractConfig {
                 .define(REST_ADVERTISED_HOST_NAME_CONFIG, Type.STRING,  null, Importance.LOW, REST_ADVERTISED_HOST_NAME_DOC)
                 .define(REST_ADVERTISED_PORT_CONFIG, Type.INT,  null, Importance.LOW, REST_ADVERTISED_PORT_DOC)
                 .define(REST_ADVERTISED_LISTENER_CONFIG, Type.STRING,  null, Importance.LOW, REST_ADVERTISED_LISTENER_DOC)
+                .define(REST_REQUEST_MAX_TIMEOUT_MS_CONFIG, Type.LONG,
+                        REST_REQUEST_MAX_TIMEOUT_MS_DEFAULT, Range.atLeast(DEFAULT_REST_REQUEST_TIMEOUT_MS),
+                        Importance.LOW, REST_REQUEST_MAX_TIMEOUT_MS_DOC)
                 .define(ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, Type.STRING,
                         ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT, Importance.LOW,
                         ACCESS_CONTROL_ALLOW_ORIGIN_DOC)
@@ -455,6 +465,14 @@ public class WorkerConfig extends AbstractConfig {
             kafkaClusterId = lookupKafkaClusterId(this);
         }
         return kafkaClusterId;
+    }
+
+    /**
+     * @return the maximum REST request timeout in milliseconds that can be set via the 'timeout' query
+     * parameter on endpoints that support it.
+     */
+    public long maxRestRequestTimeoutMs() {
+        return getLong(REST_REQUEST_MAX_TIMEOUT_MS_CONFIG);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -219,7 +219,7 @@ public class RestServer {
         this.resources = new ArrayList<>();
         resources.add(new RootResource(herder));
         resources.add(new ConnectorsResource(herder, config));
-        resources.add(new ConnectorPluginsResource(herder));
+        resources.add(new ConnectorPluginsResource(herder, config));
         resources.forEach(resourceConfig::register);
 
         resourceConfig.register(ConnectExceptionMapper.class);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectResource.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.runtime.rest.resources;
 
 import java.util.concurrent.TimeUnit;
+import javax.ws.rs.BadRequestException;
 
 /**
  * This interface defines shared logic for all Connect REST resources.
@@ -36,5 +37,15 @@ public interface ConnectResource {
      * @param requestTimeoutMs the new timeout in milliseconds; must be positive
      */
     void requestTimeout(long requestTimeoutMs);
+
+    default void validateTimeout(long requestTimeoutMs, long maxRequestTimeoutMs) {
+        if (requestTimeoutMs <= 0) {
+            throw new BadRequestException("The request timeout must be positive");
+        }
+
+        if (requestTimeoutMs > maxRequestTimeoutMs) {
+            throw new BadRequestException("The request timeout cannot be greater than: " + maxRequestTimeoutMs);
+        }
+    }
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.connector.Task;
@@ -64,6 +65,8 @@ public class MonitorableSourceConnector extends SampleSourceConnector {
     public static final String TRANSACTION_BOUNDARIES_UNSUPPORTED = "unsupported";
     public static final String TRANSACTION_BOUNDARIES_NULL = "null";
     public static final String TRANSACTION_BOUNDARIES_FAIL = "fail";
+
+    public static final String VALIDATION_BLOCK_MS_CONFIG = "validation.block.ms";
 
     private String connectorName;
     private ConnectorHandle connectorHandle;
@@ -140,6 +143,16 @@ public class MonitorableSourceConnector extends SampleSourceConnector {
             case TRANSACTION_BOUNDARIES_UNSUPPORTED:
                 return ConnectorTransactionBoundaries.UNSUPPORTED;
         }
+    }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        try {
+            Thread.sleep(Long.parseLong(connectorConfigs.getOrDefault(VALIDATION_BLOCK_MS_CONFIG, "0")));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return super.validate(connectorConfigs);
     }
 
     public static String taskId(String connectorName, int taskId) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -71,11 +71,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.kafka.connect.runtime.WorkerConfig.REST_REQUEST_MAX_TIMEOUT_MS_DEFAULT;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ALLOW_RESET_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -100,6 +102,7 @@ public class ConnectorsResourceTest {
     private static final String CONNECTOR_NAME_ALL_WHITESPACES = "   \t\n  \b";
     private static final String CONNECTOR_NAME_PADDING_WHITESPACES = "   " + CONNECTOR_NAME + "  \n  ";
     private static final Boolean FORWARD = true;
+    private static final Long TIMEOUT = null;
     private static final Map<String, String> CONNECTOR_CONFIG_SPECIAL_CHARS = new HashMap<>();
     private static final HttpHeaders NULL_HEADERS = null;
     static {
@@ -284,9 +287,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture(), anyLong());
 
-        connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
+        connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, body);
     }
 
     @Test
@@ -295,12 +298,12 @@ public class ConnectorsResourceTest {
 
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackNotLeaderException(cb).when(herder)
-            .putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
+            .putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture(), anyLong());
 
         verifyRestRequestWithCall(
             () -> RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any(), any(WorkerConfig.class)),
             new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)),
-            () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, body)
+            () -> connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, body)
         );
     }
 
@@ -310,12 +313,12 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         HttpHeaders httpHeaders = mock(HttpHeaders.class);
         expectAndCallbackNotLeaderException(cb)
-            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture(), anyLong());
 
         verifyRestRequestWithCall(
             () -> RestClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any(), any(WorkerConfig.class)),
             new RestClient.HttpResponse<>(202, new HashMap<>(), null),
-            () -> connectorsResource.createConnector(FORWARD, httpHeaders, body)
+            () -> connectorsResource.createConnector(FORWARD, TIMEOUT, httpHeaders, body)
         );
     }
 
@@ -325,8 +328,8 @@ public class ConnectorsResourceTest {
 
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackException(cb, new AlreadyExistsException("already exists"))
-            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture());
-        assertThrows(AlreadyExistsException.class, () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, body));
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(false), cb.capture(), anyLong());
+        assertThrows(AlreadyExistsException.class, () -> connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, body));
     }
 
     @Test
@@ -340,9 +343,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture(), anyLong());
 
-        connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
+        connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, bodyIn);
     }
 
     @Test
@@ -356,9 +359,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture(), anyLong());
 
-        connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
+        connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, bodyIn);
     }
 
     @Test
@@ -372,9 +375,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), eq(false), cb.capture(), anyLong());
 
-        connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
+        connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, bodyIn);
     }
 
     @Test
@@ -485,9 +488,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(false, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES,
             ConnectorType.SINK))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(CONNECTOR_CONFIG), eq(true), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(CONNECTOR_CONFIG), eq(true), cb.capture(), anyLong());
 
-        connectorsResource.putConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD, CONNECTOR_CONFIG);
+        connectorsResource.putConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD, TIMEOUT, CONNECTOR_CONFIG);
     }
 
     @Test
@@ -497,9 +500,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_SPECIAL_CHARS, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(body.config()), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(body.config()), eq(false), cb.capture(), anyLong());
 
-        String rspLocation = connectorsResource.createConnector(FORWARD, NULL_HEADERS, body).getLocation().toString();
+        String rspLocation = connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, body).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_SPECIAL_CHARS, decoded);
     }
@@ -511,9 +514,9 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_CONTROL_SEQUENCES1, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(body.config()), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(body.config()), eq(false), cb.capture(), anyLong());
 
-        String rspLocation = connectorsResource.createConnector(FORWARD, NULL_HEADERS, body).getLocation().toString();
+        String rspLocation = connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, body).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_CONTROL_SEQUENCES1, decoded);
     }
@@ -524,9 +527,9 @@ public class ConnectorsResourceTest {
 
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_SPECIAL_CHARS, CONNECTOR_CONFIG_SPECIAL_CHARS, CONNECTOR_TASK_NAMES,
             ConnectorType.SINK))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(CONNECTOR_CONFIG_SPECIAL_CHARS), eq(true), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(CONNECTOR_CONFIG_SPECIAL_CHARS), eq(true), cb.capture(), anyLong());
 
-        String rspLocation = connectorsResource.putConnectorConfig(CONNECTOR_NAME_SPECIAL_CHARS, NULL_HEADERS, FORWARD, CONNECTOR_CONFIG_SPECIAL_CHARS).getLocation().toString();
+        String rspLocation = connectorsResource.putConnectorConfig(CONNECTOR_NAME_SPECIAL_CHARS, NULL_HEADERS, FORWARD, TIMEOUT, CONNECTOR_CONFIG_SPECIAL_CHARS).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_SPECIAL_CHARS, decoded);
     }
@@ -537,9 +540,9 @@ public class ConnectorsResourceTest {
 
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_CONTROL_SEQUENCES1, CONNECTOR_CONFIG_CONTROL_SEQUENCES, CONNECTOR_TASK_NAMES,
             ConnectorType.SINK))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(CONNECTOR_CONFIG_CONTROL_SEQUENCES), eq(true), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(CONNECTOR_CONFIG_CONTROL_SEQUENCES), eq(true), cb.capture(), anyLong());
 
-        String rspLocation = connectorsResource.putConnectorConfig(CONNECTOR_NAME_CONTROL_SEQUENCES1, NULL_HEADERS, FORWARD, CONNECTOR_CONFIG_CONTROL_SEQUENCES).getLocation().toString();
+        String rspLocation = connectorsResource.putConnectorConfig(CONNECTOR_NAME_CONTROL_SEQUENCES1, NULL_HEADERS, FORWARD, TIMEOUT, CONNECTOR_CONFIG_CONTROL_SEQUENCES).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
         Assert.assertEquals("/connectors/" + CONNECTOR_NAME_CONTROL_SEQUENCES1, decoded);
     }
@@ -549,7 +552,16 @@ public class ConnectorsResourceTest {
         Map<String, String> connConfig = new HashMap<>(CONNECTOR_CONFIG);
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         assertThrows(BadRequestException.class, () -> connectorsResource.putConnectorConfig(CONNECTOR_NAME,
-            NULL_HEADERS, FORWARD, connConfig));
+            NULL_HEADERS, FORWARD, TIMEOUT, connConfig));
+    }
+
+    @Test
+    public void testPutConnectorInvalidTimeout() {
+        Map<String, String> connConfig = new HashMap<>(CONNECTOR_CONFIG);
+        assertThrows(BadRequestException.class, () -> connectorsResource.putConnectorConfig(CONNECTOR_NAME,
+                NULL_HEADERS, FORWARD, -1L, connConfig));
+        assertThrows(BadRequestException.class, () -> connectorsResource.putConnectorConfig(CONNECTOR_NAME,
+                NULL_HEADERS, FORWARD, REST_REQUEST_MAX_TIMEOUT_MS_DEFAULT + 1, connConfig));
     }
 
     @Test
@@ -557,7 +569,15 @@ public class ConnectorsResourceTest {
         Map<String, String> connConfig = new HashMap<>();
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         CreateConnectorRequest request = new CreateConnectorRequest(CONNECTOR_NAME, connConfig);
-        assertThrows(BadRequestException.class, () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, request));
+        assertThrows(BadRequestException.class, () -> connectorsResource.createConnector(FORWARD, TIMEOUT, NULL_HEADERS, request));
+    }
+
+    @Test
+    public void testCreateConnectorInvalidTimeout() {
+        Map<String, String> connConfig = new HashMap<>();
+        CreateConnectorRequest request = new CreateConnectorRequest(CONNECTOR_NAME, connConfig);
+        assertThrows(BadRequestException.class, () -> connectorsResource.createConnector(FORWARD, -1L, NULL_HEADERS, request));
+        assertThrows(BadRequestException.class, () -> connectorsResource.createConnector(FORWARD, REST_REQUEST_MAX_TIMEOUT_MS_DEFAULT + 1, NULL_HEADERS, request));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -328,6 +328,10 @@ public class EmbeddedConnectCluster {
         return putConnectorConfig(url, connConfig);
     }
 
+    public ConfigInfos validateConnectorConfig(String connClassName, Map<String, String> connConfig) {
+        return validateConnectorConfig(connClassName, connConfig, null);
+    }
+
     /**
      * Validate a given connector configuration. If the configuration validates or
      * has a configuration error, an instance of {@link ConfigInfos} is returned. If the validation fails
@@ -335,11 +339,16 @@ public class EmbeddedConnectCluster {
      *
      * @param connClassName the name of the connector class
      * @param connConfig    the intended configuration
+     * @param requestTimeoutMs the request timeout in milliseconds, can be {@code null}.
      * @throws ConnectRestException if the REST api returns error status
      * @throws ConnectException if the configuration fails to serialize/deserialize or if the request failed to send
      */
-    public ConfigInfos validateConnectorConfig(String connClassName, Map<String, String> connConfig) {
-        String url = endpointForResource(String.format("connector-plugins/%s/config/validate", connClassName));
+    public ConfigInfos validateConnectorConfig(String connClassName, Map<String, String> connConfig, Long requestTimeoutMs) {
+        String validateResource = String.format("connector-plugins/%s/config/validate", connClassName);
+        if (requestTimeoutMs != null) {
+            validateResource += String.format("?timeout=%d", requestTimeoutMs);
+        }
+        String url = endpointForResource(validateResource);
         String response = putConnectorConfig(url, connConfig);
         ConfigInfos configInfos;
         try {


### PR DESCRIPTION
- [KIP-882](https://cwiki.apache.org/confluence/display/KAFKA/KIP-882%3A+Make+Kafka+Connect+REST+API+request+timeouts+configurable)
- Add a request query parameter `timeout` to the endpoints: `PUT
/connector-plugins/{pluginName}/config/validate`, `POST /connectors` and `PUT /connectors/{connector}/config`
- Add a new worker configuration to set an upper bound for the `timeout` query parameter allowing users to potentially configure a longer timeout for exceptional situations (the existing default timeout was 90 seconds).
- Forward `POST /connectors` and `PUT /connectors/{connector}/config` requests to the leader even before doing a config validation to avoid doing double config validations when the requests are made to a non-leader worker.
- Abort `POST /connectors` and `PUT /connectors/{connector}/config` requests if the request timeout is exceeded by the config validation that is done before writing the config to the config backing store. Before this change, users would get a `500` response with a timeout error message, but the connector would still be created / updated if the config validation eventually completed successfully which is very counter-intuitive.
- Add unit tests and basic integration tests wherever applicable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
