### PR TITLE
KAFKA-14367; Add `SyncGroup` to the new `GroupCoordinator` interface

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -17,11 +17,12 @@
 package kafka.coordinator.group
 
 import kafka.server.RequestLocal
-import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData}
+import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, SyncGroupRequestData, SyncGroupResponseData}
 import org.apache.kafka.common.requests.RequestContext
 import org.apache.kafka.common.utils.BufferSupplier
 
 import java.util.concurrent.CompletableFuture
+import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 
 /**
@@ -78,6 +79,42 @@ class GroupCoordinatorAdapter(
       protocols,
       callback,
       Option(request.reason),
+      RequestLocal(bufferSupplier)
+    )
+
+    future
+  }
+
+  override def syncGroup(
+    context: RequestContext,
+    request: SyncGroupRequestData,
+    bufferSupplier: BufferSupplier
+  ): CompletableFuture[SyncGroupResponseData] = {
+    val future = new CompletableFuture[SyncGroupResponseData]()
+
+    def callback(syncGroupResult: SyncGroupResult): Unit = {
+      future.complete(new SyncGroupResponseData()
+        .setErrorCode(syncGroupResult.error.code)
+        .setProtocolType(syncGroupResult.protocolType.orNull)
+        .setProtocolName(syncGroupResult.protocolName.orNull)
+        .setAssignment(syncGroupResult.memberAssignment)
+      )
+    }
+
+    val assignmentMap = immutable.Map.newBuilder[String, Array[Byte]]
+    request.assignments.forEach { assignment =>
+      assignmentMap += assignment.memberId -> assignment.assignment
+    }
+
+    coordinator.handleSyncGroup(
+      request.groupId,
+      request.generationId,
+      request.memberId,
+      Option(request.protocolType),
+      Option(request.protocolName),
+      Option(request.groupInstanceId),
+      assignmentMap.result(),
+      callback,
       RequestLocal(bufferSupplier)
     )
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1664,10 +1664,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       // Only enable static membership when IBP >= 2.3, because it is not safe for the broker to use the static member logic
       // until we are sure that all brokers support it. If static group being loaded by an older coordinator, it will discard
       // the group.instance.id field, so static members could accidentally become "dynamic", which leads to wrong states.
-      requestHelper.sendResponse(request, joinGroupRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+      requestHelper.sendMaybeThrottle(request, joinGroupRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
       CompletableFuture.completedFuture[Unit](())
     } else if (!authHelper.authorize(request.context, READ, GROUP, joinGroupRequest.data.groupId)) {
-      requestHelper.sendResponse(request, joinGroupRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
+      requestHelper.sendMaybeThrottle(request, joinGroupRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
       CompletableFuture.completedFuture[Unit](())
     } else {
       newGroupCoordinator.joinGroup(
@@ -1676,9 +1676,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         requestLocal.bufferSupplier
       ).handle[Unit] { (response, exception) =>
         if (exception != null) {
-          requestHelper.sendResponse(request, joinGroupRequest.getErrorResponse(exception))
+          requestHelper.sendMaybeThrottle(request, joinGroupRequest.getErrorResponse(exception))
         } else {
-          requestHelper.sendResponse(request, new JoinGroupResponse(response, request.context.apiVersion))
+          requestHelper.sendMaybeThrottle(request, new JoinGroupResponse(response, request.context.apiVersion))
         }
       }
     }
@@ -1694,14 +1694,14 @@ class KafkaApis(val requestChannel: RequestChannel,
       // Only enable static membership when IBP >= 2.3, because it is not safe for the broker to use the static member logic
       // until we are sure that all brokers support it. If static group being loaded by an older coordinator, it will discard
       // the group.instance.id field, so static members could accidentally become "dynamic", which leads to wrong states.
-      requestHelper.sendResponse(request, syncGroupRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+      requestHelper.sendMaybeThrottle(request, syncGroupRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
       CompletableFuture.completedFuture[Unit](())
     } else if (!syncGroupRequest.areMandatoryProtocolTypeAndNamePresent()) {
       // Starting from version 5, ProtocolType and ProtocolName fields are mandatory.
-      requestHelper.sendResponse(request, syncGroupRequest.getErrorResponse(Errors.INCONSISTENT_GROUP_PROTOCOL.exception))
+      requestHelper.sendMaybeThrottle(request, syncGroupRequest.getErrorResponse(Errors.INCONSISTENT_GROUP_PROTOCOL.exception))
       CompletableFuture.completedFuture[Unit](())
     } else if (!authHelper.authorize(request.context, READ, GROUP, syncGroupRequest.data.groupId)) {
-      requestHelper.sendResponse(request, syncGroupRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
+      requestHelper.sendMaybeThrottle(request, syncGroupRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
       CompletableFuture.completedFuture[Unit](())
     } else {
       newGroupCoordinator.syncGroup(
@@ -1710,9 +1710,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         requestLocal.bufferSupplier
       ).handle[Unit] { (response, exception) =>
         if (exception != null) {
-          requestHelper.sendResponse(request, syncGroupRequest.getErrorResponse(exception))
+          requestHelper.sendMaybeThrottle(request, syncGroupRequest.getErrorResponse(exception))
         } else {
-          requestHelper.sendResponse(request, new SyncGroupResponse(response))
+          requestHelper.sendMaybeThrottle(request, new SyncGroupResponse(response))
         }
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -196,7 +196,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.JOIN_GROUP => handleJoinGroupRequest(request, requestLocal).exceptionally(handleError)
         case ApiKeys.HEARTBEAT => handleHeartbeatRequest(request).exceptionally(handleError)
         case ApiKeys.LEAVE_GROUP => handleLeaveGroupRequest(request)
-        case ApiKeys.SYNC_GROUP => handleSyncGroupRequest(request, requestLocal)
+        case ApiKeys.SYNC_GROUP => handleSyncGroupRequest(request, requestLocal).exceptionally(handleError)
         case ApiKeys.DESCRIBE_GROUPS => handleDescribeGroupRequest(request)
         case ApiKeys.LIST_GROUPS => handleListGroupsRequest(request)
         case ApiKeys.SASL_HANDSHAKE => handleSaslHandshakeRequest(request)
@@ -1663,10 +1663,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     def sendResponse(response: AbstractResponse): Unit = {
       trace("Sending join group response %s for correlation id %d to client %s."
         .format(response, request.header.correlationId, request.header.clientId))
-      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => {
-        response.maybeSetThrottleTimeMs(requestThrottleMs)
-        response
-      })
+      requestHelper.sendResponse(request, response)
     }
 
     if (joinGroupRequest.data.groupInstanceId != null && config.interBrokerProtocolVersion.isLessThan(IBP_2_3_IV0)) {
@@ -1693,48 +1690,43 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
   }
 
-  def handleSyncGroupRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
+  def handleSyncGroupRequest(
+    request: RequestChannel.Request,
+    requestLocal: RequestLocal
+  ): CompletableFuture[Unit] = {
     val syncGroupRequest = request.body[SyncGroupRequest]
 
-    def sendResponseCallback(syncGroupResult: SyncGroupResult): Unit = {
-      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
-        new SyncGroupResponse(
-          new SyncGroupResponseData()
-            .setErrorCode(syncGroupResult.error.code)
-            .setProtocolType(syncGroupResult.protocolType.orNull)
-            .setProtocolName(syncGroupResult.protocolName.orNull)
-            .setAssignment(syncGroupResult.memberAssignment)
-            .setThrottleTimeMs(requestThrottleMs)
-        ))
+    def sendResponse(response: AbstractResponse): Unit = {
+      trace("Sending sync group response %s for correlation id %d to client %s."
+        .format(response, request.header.correlationId, request.header.clientId))
+      requestHelper.sendResponse(request, response)
     }
 
     if (syncGroupRequest.data.groupInstanceId != null && config.interBrokerProtocolVersion.isLessThan(IBP_2_3_IV0)) {
       // Only enable static membership when IBP >= 2.3, because it is not safe for the broker to use the static member logic
       // until we are sure that all brokers support it. If static group being loaded by an older coordinator, it will discard
       // the group.instance.id field, so static members could accidentally become "dynamic", which leads to wrong states.
-      sendResponseCallback(SyncGroupResult(Errors.UNSUPPORTED_VERSION))
+      sendResponse(syncGroupRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+      CompletableFuture.completedFuture[Unit](())
     } else if (!syncGroupRequest.areMandatoryProtocolTypeAndNamePresent()) {
       // Starting from version 5, ProtocolType and ProtocolName fields are mandatory.
-      sendResponseCallback(SyncGroupResult(Errors.INCONSISTENT_GROUP_PROTOCOL))
+      sendResponse(syncGroupRequest.getErrorResponse(Errors.INCONSISTENT_GROUP_PROTOCOL.exception))
+      CompletableFuture.completedFuture[Unit](())
     } else if (!authHelper.authorize(request.context, READ, GROUP, syncGroupRequest.data.groupId)) {
-      sendResponseCallback(SyncGroupResult(Errors.GROUP_AUTHORIZATION_FAILED))
+      sendResponse(syncGroupRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
+      CompletableFuture.completedFuture[Unit](())
     } else {
-      val assignmentMap = immutable.Map.newBuilder[String, Array[Byte]]
-      syncGroupRequest.data.assignments.forEach { assignment =>
-        assignmentMap += (assignment.memberId -> assignment.assignment)
+      newGroupCoordinator.syncGroup(
+        request.context,
+        syncGroupRequest.data,
+        requestLocal.bufferSupplier
+      ).handle[Unit] { (response, exception) =>
+        if (exception != null) {
+          sendResponse(syncGroupRequest.getErrorResponse(exception))
+        } else {
+          sendResponse(new SyncGroupResponse(response))
+        }
       }
-
-      groupCoordinator.handleSyncGroup(
-        syncGroupRequest.data.groupId,
-        syncGroupRequest.data.generationId,
-        syncGroupRequest.data.memberId,
-        Option(syncGroupRequest.data.protocolType),
-        Option(syncGroupRequest.data.protocolName),
-        Option(syncGroupRequest.data.groupInstanceId),
-        assignmentMap.result(),
-        sendResponseCallback,
-        requestLocal
-      )
     }
   }
 

--- a/core/src/main/scala/kafka/server/RequestHandlerHelper.scala
+++ b/core/src/main/scala/kafka/server/RequestHandlerHelper.scala
@@ -107,7 +107,7 @@ class RequestHandlerHelper(
 
   // Throttle the channel if the request quota is enabled but has been violated. Regardless of throttling, send the
   // response immediately.
-  def sendResponse(
+  def sendMaybeThrottle(
     request: RequestChannel.Request,
     response: AbstractResponse
   ): Unit = {

--- a/core/src/main/scala/kafka/server/RequestHandlerHelper.scala
+++ b/core/src/main/scala/kafka/server/RequestHandlerHelper.scala
@@ -107,6 +107,18 @@ class RequestHandlerHelper(
 
   // Throttle the channel if the request quota is enabled but has been violated. Regardless of throttling, send the
   // response immediately.
+  def sendResponse(
+    request: RequestChannel.Request,
+    response: AbstractResponse
+  ): Unit = {
+    val throttleTimeMs = maybeRecordAndGetThrottleTimeMs(request)
+    // Only throttle non-forwarded requests
+    if (!request.isForwarded)
+      throttle(quotas.request, request, throttleTimeMs)
+    response.maybeSetThrottleTimeMs(throttleTimeMs)
+    requestChannel.sendResponse(request, response, None)
+  }
+
   def sendResponseMaybeThrottle(request: RequestChannel.Request,
                                 createResponse: Int => AbstractResponse): Unit = {
     val throttleTimeMs = maybeRecordAndGetThrottleTimeMs(request)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -16,9 +16,9 @@
  */
 package kafka.coordinator.group
 
-import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.JoinGroupCallback
+import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.{JoinGroupCallback, SyncGroupCallback}
 import kafka.server.RequestLocal
-import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData}
+import org.apache.kafka.common.message.{HeartbeatRequestData, HeartbeatResponseData, JoinGroupRequestData, JoinGroupResponseData, SyncGroupRequestData, SyncGroupResponseData}
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol
 import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
@@ -140,6 +140,74 @@ class GroupCoordinatorAdapterTest {
 
     assertTrue(future.isDone)
     assertEquals(expectedData, future.get())
+  }
+
+  @ParameterizedTest
+  @ApiKeyVersionsSource(apiKey = ApiKeys.SYNC_GROUP)
+  def testSyncGroup(version: Short): Unit = {
+    val groupCoordinator = mock(classOf[GroupCoordinator])
+    val adapter = new GroupCoordinatorAdapter(groupCoordinator)
+
+    val ctx = makeContext(ApiKeys.SYNC_GROUP, version)
+    val data = new SyncGroupRequestData()
+      .setGroupId("group")
+      .setMemberId("member1")
+      .setGroupInstanceId("instance")
+      .setProtocolType("consumer")
+      .setProtocolName("range")
+      .setGenerationId(10)
+      .setAssignments(List(
+        new SyncGroupRequestData.SyncGroupRequestAssignment()
+          .setMemberId("member1")
+          .setAssignment("member1".getBytes()),
+        new SyncGroupRequestData.SyncGroupRequestAssignment()
+          .setMemberId("member2")
+          .setAssignment("member2".getBytes())
+      ).asJava)
+    val bufferSupplier = BufferSupplier.create()
+
+    val future = adapter.syncGroup(ctx, data, bufferSupplier)
+    assertFalse(future.isDone)
+
+    val capturedAssignment: ArgumentCaptor[Map[String, Array[Byte]]] =
+      ArgumentCaptor.forClass(classOf[Map[String, Array[Byte]]])
+    val capturedCallback: ArgumentCaptor[SyncGroupCallback] =
+      ArgumentCaptor.forClass(classOf[SyncGroupCallback])
+
+    verify(groupCoordinator).handleSyncGroup(
+      ArgumentMatchers.eq(data.groupId),
+      ArgumentMatchers.eq(data.generationId),
+      ArgumentMatchers.eq(data.memberId),
+      ArgumentMatchers.eq(Some(data.protocolType)),
+      ArgumentMatchers.eq(Some(data.protocolName)),
+      ArgumentMatchers.eq(Some(data.groupInstanceId)),
+      capturedAssignment.capture(),
+      capturedCallback.capture(),
+      ArgumentMatchers.eq(RequestLocal(bufferSupplier))
+    )
+
+    assertEquals(Map(
+      "member1" -> "member1",
+      "member2" -> "member2",
+    ), capturedAssignment.getValue.map { case (member, metadata) =>
+      (member, new String(metadata))
+    })
+
+    capturedCallback.getValue.apply(SyncGroupResult(
+      error = Errors.NONE,
+      protocolType = Some("consumer"),
+      protocolName = Some("range"),
+      memberAssignment = "member1".getBytes()
+    ))
+
+    val expectedResponseData = new SyncGroupResponseData()
+      .setErrorCode(Errors.NONE.code)
+      .setProtocolType("consumer")
+      .setProtocolName("range")
+      .setAssignment("member1".getBytes())
+
+    assertTrue(future.isDone)
+    assertEquals(expectedResponseData, future.get())
   }
 
   @Test

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -20,6 +20,8 @@ import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.utils.BufferSupplier;
 
@@ -39,6 +41,21 @@ public interface GroupCoordinator {
     CompletableFuture<JoinGroupResponseData> joinGroup(
         RequestContext context,
         JoinGroupRequestData request,
+        BufferSupplier bufferSupplier
+    );
+
+    /**
+     * Sync a Generic Group.
+     *
+     * @param context           The coordinator request context.
+     * @param request           The SyncGroupRequest data.
+     * @param bufferSupplier    The buffer supplier tight to the request thread.
+     *
+     * @return A future yielding the response or an exception.
+     */
+    CompletableFuture<SyncGroupResponseData> syncGroup(
+        RequestContext context,
+        SyncGroupRequestData request,
         BufferSupplier bufferSupplier
     );
 


### PR DESCRIPTION
This patch adds `syncGroup` to the new `GroupCoordinator` interface and updates `KafkaApis` to use it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
