### PR TITLE
MINOR: Fix commitId maybe null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,8 @@ def determineCommitId() {
       headRef = headRef.replaceAll('ref: ', '').trim()
       if (file("$rootDir/.git/$headRef").exists()) {
         file("$rootDir/.git/$headRef").text.trim().take(takeFromHash)
+      } else {
+      	"unknown"
       }
     } else {
       headRef.trim().take(takeFromHash)


### PR DESCRIPTION
Reproduce step:
1. get src.zip
2. unzip and execute `git init`
3. execute `./gradlew jar`

gradle error is:
`Property 'commitId' doesn't have a configured value.`
This is because `.git/HEAD` is `ref: refs/heads/master`, but `.git/refs/heads/master` is not exist

After this patch, commitId will return `unknown` in the above case