### PR TITLE
MINOR: Reuse scala compiler between builds (WIP)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -621,6 +621,9 @@ subprojects {
 
   tasks.withType(ScalaCompile) {
 
+    // Gradle 7.6 introduced the keepAliveMode.
+    // Setting it to DAEMON allows re-use of scala compilers between builds
+    scalaCompileOptions.keepAliveMode = KeepAliveMode.DAEMON
     scalaCompileOptions.additionalParameters = [
       "-deprecation",
       "-unchecked",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha=db9c8211ed63f61f60292c69e80d89196f9eb36665e369e7f00ac4cc841c2219
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
gradle `7.6` will be going to introduce a new scala compilation option named `keepAliveMode`. Changing the value of this option from default of `SESSION` to `DAEMON` allows us to reuse scala compilers between build and hence reducing build time. 

As `7.6` pre-release is already out so we are testing the above feature as part of this PR by updating gradle version to `7.6-rc-3`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
