### PR TITLE
KAFKA-14360: Fix links in documentation

### DIFF
--- a/docs/streams/developer-guide/security.html
+++ b/docs/streams/developer-guide/security.html
@@ -40,8 +40,8 @@
                 <li><a class="reference internal" href="#security-example" id="id2">Security example</a></li>
             </ul>
         </div>
-        <p>Kafka Streams natively integrates with the <a class="reference internal" href="../../documentation.html#security"><span class="std std-ref">Kafka&#8217;s security features</span></a> and supports all of the
-            client-side security features in Kafka.  Streams leverages the <a class="reference internal" href="../../clients/index.html#kafka-clients"><span class="std std-ref">Java Producer and Consumer API</span></a>.</p>
+        <p>Kafka Streams natively integrates with the <a class="reference internal" href="../../../documentation.html#security"><span class="std std-ref">Kafka&#8217;s security features</span></a> and supports all of the
+            client-side security features in Kafka.  Streams leverages the <a class="reference internal" href="../../../documentation.html#api"><span class="std std-ref">Java Producer and Consumer API</span></a>.</p>
         <p>To secure your Stream processing applications, configure the security settings in the corresponding Kafka producer
             and consumer clients, and then specify the corresponding configuration settings in your Kafka Streams application.</p>
         <p>Kafka supports cluster encryption and authentication, including a mix of authenticated and unauthenticated,
@@ -61,7 +61,7 @@
                 that only specific applications are allowed to read from a Kafka topic.  You can also restrict write access to Kafka
                 topics to prevent data pollution or fraudulent activities.</dd>
         </dl>
-        <p>For more information about the security features in Apache Kafka, see <a class="reference internal" href="../../documentation.html#security"><span class="std std-ref">Kafka Security</span></a>.</p>
+        <p>For more information about the security features in Apache Kafka, see <a class="reference internal" href="../../../documentation.html#security"><span class="std std-ref">Kafka Security</span></a>.</p>
         <div class="section" id="required-acl-setting-for-secure-kafka-clusters">
             <span id="streams-developer-guide-security-acls"></span><h2><a class="toc-backref" href="#id1">Required ACL setting for secure Kafka clusters</a><a class="headerlink" href="#required-acl-setting-for-secure-kafka-clusters" title="Permalink to this headline"></a></h2>
             <p>Kafka clusters can use ACLs to control access to resources (like the ability to create topics), and for such clusters each client,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-14360

There are two streams doc folder in AK:

- docs/streams/developer-guide
- docs/documentation/streams/developer-guide

The latter seems to be the actual entry point for kafka-site however it is pointing to the former with a virtual link. The relative path is read through the latter path, which resulted in incorrect links like {{site}}/documentation/streams/developer-guide/security.html. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
