### PR TITLE
KAFKA-14358 Do not allow users to create the metadata topic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
@@ -44,7 +44,7 @@ public class Topic {
     }
 
     public static boolean isReserved(String name) {
-	return METADATA_TOPIC_NAME.equals(name);
+        return METADATA_TOPIC_NAME.equals(name);
     }
 
     private static String detectInvalidTopic(String name) {
@@ -59,8 +59,8 @@ public class Topic {
         if (!containsValidPattern(name))
             return "'" + name + "' contains one or more characters other than " +
                 "ASCII alphanumerics, '.', '_' and '-'";
-	if (isReserved(name))
-	    return "'" + name + "' is a reserved topic name";
+        if (isReserved(name))
+            return "'" + name + "' is a reserved topic name";
         return null;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/Topic.java
@@ -43,6 +43,10 @@ public class Topic {
         });
     }
 
+    public static boolean isReserved(String name) {
+	return METADATA_TOPIC_NAME.equals(name);
+    }
+
     private static String detectInvalidTopic(String name) {
         if (name.isEmpty())
             return "the empty string is not allowed";
@@ -55,6 +59,8 @@ public class Topic {
         if (!containsValidPattern(name))
             return "'" + name + "' contains one or more characters other than " +
                 "ASCII alphanumerics, '.', '_' and '-'";
+	if (isReserved(name))
+	    return "'" + name + "' is a reserved topic name";
         return null;
     }
 

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
@@ -103,6 +103,20 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testClusterMetadataTopicFails(quorum: String): Unit = {
+    val clusterMetadata = "__cluster_metadata"
+    validateErrorCreateTopicsRequests(
+      topicsReq(
+        Seq(
+          topicReq(clusterMetadata)
+        )
+      ),
+      Map(clusterMetadata -> error(Errors.INVALID_TOPIC_EXCEPTION, Some("Topic name is invalid: '__cluster_metadata' is a reserved topic name")))
+    )
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk"))
   def testCreateTopicsWithVeryShortTimeouts(quorum: String): Unit = {
     // When using ZooKeeper, we don't expect a request to ever complete within 1ms.


### PR DESCRIPTION
Wanted to try contributing a patch, so here I am :). I noticed that the jira was already assigned, but hadn't had some activity for a bit, so I figured I'd give it a try.

This technically introduces the concept of a "reserved topic", which might not be a good thing? Not sure how these changes are usually handled.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
