### PR TITLE
MINOR: Handle JoinGroupResponseData.protocolName backward compatibility in JoinGroupResponse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -119,7 +119,7 @@ public class JoinGroupRequest extends AbstractRequest {
         else
             data.setProtocolName(UNKNOWN_PROTOCOL_NAME);
 
-        return new JoinGroupResponse(data);
+        return new JoinGroupResponse(data, version());
     }
 
     public static JoinGroupRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
@@ -28,9 +28,15 @@ public class JoinGroupResponse extends AbstractResponse {
 
     private final JoinGroupResponseData data;
 
-    public JoinGroupResponse(JoinGroupResponseData data) {
+    public JoinGroupResponse(JoinGroupResponseData data, short version) {
         super(ApiKeys.JOIN_GROUP);
         this.data = data;
+
+        // All versions prior to version 7 do not support nullable
+        // string for the protocol name. Empty string should be used.
+        if (version < 7 && data.protocolName() == null) {
+            data.setProtocolName("");
+        }
     }
 
     @Override
@@ -62,7 +68,7 @@ public class JoinGroupResponse extends AbstractResponse {
     }
 
     public static JoinGroupResponse parse(ByteBuffer buffer, short version) {
-        return new JoinGroupResponse(new JoinGroupResponseData(new ByteBufferAccessor(buffer), version));
+        return new JoinGroupResponse(new JoinGroupResponseData(new ByteBufferAccessor(buffer), version), version);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1725,7 +1725,8 @@ public class KafkaConsumerTest {
                                         .setMemberId(memberId)
                                         .setMetadata(byteBuffer.array())
                                 )
-                        )
+                        ),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
 
         client.prepareResponseFrom(leaderResponse, coordinator);
@@ -2438,7 +2439,8 @@ public class KafkaConsumerTest {
                         .setProtocolName(assignor.name())
                         .setLeader(leaderId)
                         .setMemberId(memberId)
-                        .setMembers(Collections.emptyList())
+                        .setMembers(Collections.emptyList()),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
@@ -1605,7 +1606,8 @@ public class AbstractCoordinatorTest {
                         .setProtocolName(PROTOCOL_NAME)
                         .setMemberId(memberId)
                         .setLeader(leaderId)
-                        .setMembers(Collections.emptyList())
+                        .setMembers(Collections.emptyList()),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3758,7 +3758,8 @@ public abstract class ConsumerCoordinatorTest {
                         .setLeader(memberId)
                         .setSkipAssignment(skipAssignment)
                         .setMemberId(memberId)
-                        .setMembers(metadata)
+                        .setMembers(metadata),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
     }
 
@@ -3770,7 +3771,8 @@ public abstract class ConsumerCoordinatorTest {
                         .setProtocolName(partitionAssignor.name())
                         .setLeader(leaderId)
                         .setMemberId(memberId)
-                        .setMembers(Collections.emptyList())
+                        .setMembers(Collections.emptyList()),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupResponseTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class JoinGroupResponseTest {
+    @ParameterizedTest
+    @ApiKeyVersionsSource(apiKey = ApiKeys.JOIN_GROUP)
+    public void testProtocolNameBackwardCompatibility(short version) {
+        JoinGroupResponseData data = new JoinGroupResponseData()
+            .setProtocolName(null);
+
+        JoinGroupResponse joinGroupResponse = new JoinGroupResponse(data, version);
+
+        if (version < 7) {
+            assertEquals("", joinGroupResponse.data().protocolName());
+        } else {
+            assertNull(joinGroupResponse.data().protocolName());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1777,7 +1777,7 @@ public class RequestResponseTest {
         if (version >= 1)
             data.setThrottleTimeMs(1000);
 
-        return new JoinGroupResponse(data);
+        return new JoinGroupResponse(data, version);
     }
 
     private SyncGroupRequest createSyncGroupRequest(short version) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.JoinGroupResponse;
@@ -538,11 +539,12 @@ public class WorkerCoordinatorTest {
         }
         return new JoinGroupResponse(
                 new JoinGroupResponseData().setErrorCode(error.code())
-                .setGenerationId(generationId)
-                .setProtocolName(EAGER.protocol())
-                .setLeader(memberId)
-                .setMemberId(memberId)
-                .setMembers(metadata)
+                        .setGenerationId(generationId)
+                        .setProtocolName(EAGER.protocol())
+                        .setLeader(memberId)
+                        .setMemberId(memberId)
+                        .setMembers(metadata),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
     }
 
@@ -553,7 +555,8 @@ public class WorkerCoordinatorTest {
                         .setProtocolName(EAGER.protocol())
                         .setLeader(leaderId)
                         .setMemberId(memberId)
-                        .setMembers(Collections.emptyList())
+                        .setMembers(Collections.emptyList()),
+                ApiKeys.JOIN_GROUP.latestVersion()
         );
     }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1652,22 +1652,18 @@ class KafkaApis(val requestChannel: RequestChannel,
     // the callback for sending a join-group response
     def sendResponseCallback(joinResult: JoinGroupResult): Unit = {
       def createResponse(requestThrottleMs: Int): AbstractResponse = {
-        val protocolName = if (request.context.apiVersion() >= 7)
-          joinResult.protocolName.orNull
-        else
-          joinResult.protocolName.getOrElse(GroupCoordinator.NoProtocol)
-
         val responseBody = new JoinGroupResponse(
           new JoinGroupResponseData()
             .setThrottleTimeMs(requestThrottleMs)
             .setErrorCode(joinResult.error.code)
             .setGenerationId(joinResult.generationId)
             .setProtocolType(joinResult.protocolType.orNull)
-            .setProtocolName(protocolName)
+            .setProtocolName(joinResult.protocolName.orNull)
             .setLeader(joinResult.leaderId)
             .setSkipAssignment(joinResult.skipAssignment)
             .setMemberId(joinResult.memberId)
-            .setMembers(joinResult.members.asJava)
+            .setMembers(joinResult.members.asJava),
+          request.context.apiVersion
         )
 
         trace("Sending join group response %s for correlation id %d to client %s."

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2637,6 +2637,7 @@ class KafkaApisTest {
     assertEquals(GroupCoordinator.NoGeneration, response.data.generationId)
     assertEquals(GroupCoordinator.NoLeader, response.data.leader)
     assertNull(response.data.protocolType)
+
     if (version >= 7) {
       assertNull(response.data.protocolName)
     } else {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2637,7 +2637,7 @@ class KafkaApisTest {
     assertEquals(GroupCoordinator.NoGeneration, response.data.generationId)
     assertEquals(GroupCoordinator.NoLeader, response.data.leader)
     assertNull(response.data.protocolType)
-
+    println(response.data)
     if (version >= 7) {
       assertNull(response.data.protocolName)
     } else {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2637,7 +2637,6 @@ class KafkaApisTest {
     assertEquals(GroupCoordinator.NoGeneration, response.data.generationId)
     assertEquals(GroupCoordinator.NoLeader, response.data.leader)
     assertNull(response.data.protocolType)
-    println(response.data)
     if (version >= 7) {
       assertNull(response.data.protocolName)
     } else {


### PR DESCRIPTION
This is a small refactor extracted from https://github.com/apache/kafka/pull/12845. It basically moves the logic to handle the backward compatibility of `JoinGroupResponseData.protocolName` from `KafkaApis` to `JoinGroupResponse`.

The patch adds a new unit test for `JoinGroupResponse` and relies on existing tests as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
