### PR TITLE
KAFKA-14303 Producer.send without record key and batch.size=0 goes into infinite loop

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -425,8 +425,11 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 enableAdaptivePartitioning,
                 config.getLong(ProducerConfig.PARTITIONER_AVAILABILITY_TIMEOUT_MS_CONFIG)
             );
+            // As per Kafka producer configuration documentation batch.size may be set to 0 to explicitly disable
+            // batching which in practice actually means using a batch size of 1.
+            int batchSize = Math.max(1, config.getInt(ProducerConfig.BATCH_SIZE_CONFIG));
             this.accumulator = new RecordAccumulator(logContext,
-                    config.getInt(ProducerConfig.BATCH_SIZE_CONFIG),
+                    batchSize,
                     this.compressionType,
                     lingerMs(config),
                     retryBackoffMs,
@@ -437,7 +440,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     time,
                     apiVersions,
                     transactionManager,
-                    new BufferPool(this.totalMemorySize, config.getInt(ProducerConfig.BATCH_SIZE_CONFIG), metrics, time, PRODUCER_METRIC_GROUP_NAME));
+                    new BufferPool(this.totalMemorySize, batchSize, metrics, time, PRODUCER_METRIC_GROUP_NAME));
 
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                     config.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
@@ -56,6 +56,9 @@ public class BuiltInPartitioner {
     public BuiltInPartitioner(LogContext logContext, String topic, int stickyBatchSize) {
         this.log = logContext.logger(BuiltInPartitioner.class);
         this.topic = topic;
+        if (stickyBatchSize < 1) {
+            throw new IllegalArgumentException("stickyBatchSize must be >= 1 but got " + stickyBatchSize);
+        }
         this.stickyBatchSize = stickyBatchSize;
     }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -27,8 +27,11 @@ import org.apache.kafka.common.errors.{InvalidTimestampException, RecordTooLarge
 import org.apache.kafka.common.record.{DefaultRecord, DefaultRecordBatch, Records, TimestampType}
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+
+import java.nio.charset.StandardCharsets
 
 
 class PlaintextProducerSendTest extends BaseProducerSendTest {
@@ -53,6 +56,30 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
       deliveryTimeoutMs = Int.MaxValue,
       batchSize = 0)
     sendAndVerify(producer)
+  }
+
+  @Timeout(value = 15, unit = TimeUnit.SECONDS)
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testBatchSizeZeroNoPartitionNoRecordKey(quorum: String): Unit = {
+    val producer = createProducer(batchSize = 0)
+    val numRecords = 10;
+    try {
+      TestUtils.createTopicWithAdmin(admin, topic, brokers, 2)
+      val futures = for (i <- 1 to numRecords) yield {
+        val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, null, s"value$i".getBytes(StandardCharsets.UTF_8))
+        producer.send(record)
+      }
+      producer.flush()
+      val lastOffset = futures.foldLeft(0) { (offset, future) =>
+        val recordMetadata = future.get
+        assertEquals(topic, recordMetadata.topic)
+        offset + 1
+      }
+      assertEquals(numRecords, lastOffset)
+    } finally {
+      producer.close()
+    }
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)


### PR DESCRIPTION
Cherry-picked and slightly modified commit 5bd556a49b. The change was made in line in  `core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala: 61` to remove the `threadMode` argument, unsupported in junit-jupiter-api:5.8.2.
