### PR TITLE
WIP: Idempotent producer simulation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1276,6 +1276,7 @@ project(':clients') {
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
     testImplementation libs.mockitoInline
+    testImplementation libs.jqwik
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.jacksonDatabind

--- a/clients/src/main/java/org/apache/kafka/clients/ClientRequest.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientRequest.java
@@ -113,6 +113,10 @@ public final class ClientRequest {
         return correlationId;
     }
 
+    public String clientId() {
+        return clientId;
+    }
+
     public int requestTimeoutMs() {
         return requestTimeoutMs;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -31,7 +31,7 @@ public class ClientResponse {
     private final RequestCompletionHandler callback;
     private final String destination;
     private final long receivedTimeMs;
-    private final long latencyMs;
+    private final long createdTimeMs;
     private final boolean disconnected;
     private final UnsupportedVersionException versionMismatch;
     private final AuthenticationException authenticationException;
@@ -61,7 +61,7 @@ public class ClientResponse {
         this.callback = callback;
         this.destination = destination;
         this.receivedTimeMs = receivedTimeMs;
-        this.latencyMs = receivedTimeMs - createdTimeMs;
+        this.createdTimeMs = createdTimeMs;
         this.disconnected = disconnected;
         this.versionMismatch = versionMismatch;
         this.authenticationException = authenticationException;
@@ -101,7 +101,11 @@ public class ClientResponse {
     }
 
     public long requestLatencyMs() {
-        return latencyMs;
+        return Math.max(0, receivedTimeMs - createdTimeMs);
+    }
+
+    public long createdTimeMs() {
+        return createdTimeMs;
     }
 
     public void onComplete() {
@@ -109,11 +113,15 @@ public class ClientResponse {
             callback.onComplete(this);
     }
 
+    public RequestCompletionHandler callback() {
+        return callback;
+    }
+
     @Override
     public String toString() {
         return "ClientResponse(receivedTimeMs=" + receivedTimeMs +
-               ", latencyMs=" +
-               latencyMs +
+               ", createdTimeMs=" +
+               createdTimeMs +
                ", disconnected=" +
                disconnected +
                ", requestHeader=" +

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -791,7 +791,8 @@ public class RecordAccumulator {
     private boolean shouldStopDrainBatchesForPartition(ProducerBatch first, TopicPartition tp) {
         ProducerIdAndEpoch producerIdAndEpoch = null;
         if (transactionManager != null) {
-            if (!transactionManager.isSendToPartitionAllowed(tp))
+
+            if (!first.inRetry() && !transactionManager.isSendToPartitionAllowed(tp))
                 return true;
 
             producerIdAndEpoch = transactionManager.producerIdAndEpoch();
@@ -830,7 +831,7 @@ public class RecordAccumulator {
         int size = 0;
         List<PartitionInfo> parts = cluster.partitionsForNode(node.id());
         List<ProducerBatch> ready = new ArrayList<>();
-        /* to make starvation less likely each node has it's own drainIndex */
+        /* to make starvation less likely each node has its own drainIndex */
         int drainIndex = getDrainIndex(node.idString());
         int start = drainIndex = drainIndex % parts.size();
         do {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -295,7 +295,7 @@ public class Sender implements Runnable {
      * Run a single iteration of sending
      *
      */
-    void runOnce() {
+    public void runOnce() {
         if (transactionManager != null) {
             try {
                 transactionManager.maybeResolveSequences();
@@ -639,7 +639,9 @@ public class Sender implements Runnable {
                 // tell the user the result of their request. We only adjust sequence numbers if the batch didn't exhaust
                 // its retries -- if it did, we don't know whether the sequence number was accepted or not, and
                 // thus it is not safe to reassign the sequence.
-                failBatch(batch, response, batch.attempts() < this.retries);
+                boolean adjustSequenceNumbers = batch.attempts() < this.retries &&
+                    !batch.hasReachedDeliveryTimeout(accumulator.getDeliveryTimeoutMs(), now);
+                failBatch(batch, response, adjustSequenceNumbers);
             }
             if (error.exception() instanceof InvalidMetadataException) {
                 if (error.exception() instanceof UnknownTopicOrPartitionException) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -693,6 +693,10 @@ public class TransactionManager {
         return !txnPartitionMap.getOrCreate(topicPartition).inflightBatchesBySequence.isEmpty();
     }
 
+    private int numInflightBatches(TopicPartition topicPartition) {
+        return txnPartitionMap.getOrCreate(topicPartition).inflightBatchesBySequence.size();
+    }
+
     synchronized boolean hasStaleProducerIdAndEpoch(TopicPartition topicPartition) {
         return !producerIdAndEpoch.equals(txnPartitionMap.getOrCreate(topicPartition).producerIdAndEpoch);
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Crc32C;
+import org.apache.kafka.common.utils.Utils;
 
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -505,6 +506,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
     @Override
     public String toString() {
         return "RecordBatch(magic=" + magic() + ", offsets=[" + baseOffset() + ", " + lastOffset() + "], " +
+                "producerEpoch=" + producerEpoch() + ", " +
                 "sequence=[" + baseSequence() + ", " + lastSequence() + "], " +
                 "isTransactional=" + isTransactional() + ", isControlBatch=" + isControlBatch() + ", " +
                 "compression=" + compressionType() + ", timestampType=" + timestampType() + ", crc=" + checksum() + ")";

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -72,6 +72,9 @@ public class ProduceRequest extends AbstractRequest {
             this.data = data;
         }
 
+        public ProduceRequestData data() {
+            return data;
+        }
         @Override
         public ProduceRequest build(short version) {
             return build(version, true);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2345,4 +2345,35 @@ public class KafkaProducerTest {
         }
     }
 
+    public static <K, V> KafkaProducer<K, V> newKafkaProducer(
+        ProducerConfig config,
+        LogContext logContext,
+        Metrics metrics,
+        Serializer<K> keySerializer,
+        Serializer<V> valueSerializer,
+        ProducerMetadata metadata,
+        RecordAccumulator accumulator,
+        TransactionManager txnManager,
+        Sender sender,
+        Partitioner partitioner,
+        Time time,
+        KafkaThread ioThread
+    ) {
+        return new KafkaProducer<>(
+            config,
+            logContext,
+            metrics,
+            keySerializer,
+            valueSerializer,
+            metadata,
+            accumulator,
+            txnManager,
+            sender,
+            new ProducerInterceptors<>(Collections.emptyList()),
+            partitioner,
+            time,
+            ioThread
+        );
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/BrokerModel.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/BrokerModel.java
@@ -1,0 +1,54 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+class BrokerModel {
+    final Node node;
+    final ClusterModel cluster;
+    final List<ConnectionModel> active;
+    final List<ConnectionModel> disconnecting;
+
+    BrokerModel(
+        Node node,
+        ClusterModel cluster
+    ) {
+        this.node = node;
+        this.cluster = cluster;
+        this.active = new ArrayList<>();
+        this.disconnecting = new ArrayList<>();
+    }
+
+    void connect(ConnectionModel connection) {
+        this.active.add(connection);
+    }
+
+    void disconnect(ConnectionModel connection) {
+        // We want to model delivery of some or all of the requests sent
+        // by the client after a disconnect. Instead of immediately removing
+        // the connection from the active pool, we drop one or more of the
+        // undelivered requests. Once these requests have been processed,
+        // then the connection will be removed.
+        connection.maybeDropUndeliveredRequests();
+        this.disconnecting.add(connection);
+    }
+
+    ConnectionModel randomConnection(Random random) {
+        if (active.isEmpty()) {
+            return null;
+        } else {
+            int randomIdx = random.nextInt(active.size());
+            ConnectionModel connection = active.get(randomIdx);
+
+            if (disconnecting.contains(connection) && !connection.hasUndeliveredRequests()) {
+                active.remove(connection);
+                disconnecting.remove(connection);
+            }
+
+            return connection;
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ClusterModel.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ClusterModel.java
@@ -1,0 +1,225 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.message.InitProducerIdResponseData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.InitProducerIdRequest;
+import org.apache.kafka.common.requests.InitProducerIdResponse;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.utils.MockTime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+class ClusterModel {
+    final List<SimulationEvent> events = new ArrayList<>();
+    final MockTime time;
+    final Random random;
+    final String topic = "test-topic";
+    private final Map<Integer, BrokerModel> brokers;
+    private final Map<Integer, PartitionModel> partitions;
+    private long nextProducerId = 0;
+
+    ClusterModel(
+        MockTime time,
+        Random random,
+        List<Node> brokers,
+        int numPartitions,
+        boolean enableStrictValidation
+    ) {
+        this.time = time;
+        this.random = random;
+        this.brokers = brokers.stream().collect(Collectors.toMap(
+            node -> node.id(),
+            node -> new BrokerModel(node, this)
+        ));
+
+        this.partitions = new HashMap<>(numPartitions);
+
+        for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+            PartitionModel partitionModel = new PartitionModel(partitionId, enableStrictValidation);
+            int randomLeaderId = randomBroker().node.id();
+            partitionModel.setNewLeader(randomLeaderId);
+            this.partitions.put(partitionId, partitionModel);
+        }
+    }
+
+    void assertNoDuplicates() {
+        partitions.values().forEach(PartitionModel::assertNoDuplicates);
+    }
+
+    void assertNoReordering() {
+        partitions.values().forEach(PartitionModel::assertNoReordering);
+    }
+
+    void enableUnderMinIsr(int partitionId, long durationMs) {
+        PartitionModel partitionModel = partitions.get(partitionId);
+        partitionModel.enableUnderMinIsrUntil(time.milliseconds() + durationMs);
+    }
+
+    void enableInvalidRecordError(int partitionId, long durationMs) {
+        PartitionModel partitionModel = partitions.get(partitionId);
+        partitionModel.enableInvalidRecordErrorsUntil(time.milliseconds() + durationMs);
+    }
+
+    boolean isLeader(BrokerModel broker, int partitionId) {
+        return partitions.get(partitionId).leaderId == broker.node.id();
+    }
+
+    InitProducerIdResponse handleInitProducerIdRequest(InitProducerIdRequest request) {
+        return new InitProducerIdResponse(
+            new InitProducerIdResponseData()
+                .setErrorCode(Errors.NONE.code())
+                .setProducerId(nextProducerId++)
+                .setProducerEpoch((short) 0)
+        );
+    }
+
+    MetadataResponse handleMetadataRequest(MetadataRequest request) {
+        MetadataResponseData responseData = new MetadataResponseData();
+        for (BrokerModel broker : brokers.values()) {
+            responseData.brokers().add(
+                new MetadataResponseData.MetadataResponseBroker()
+                    .setHost(broker.node.host())
+                    .setNodeId(broker.node.id())
+                    .setPort(broker.node.port())
+                    .setRack((broker.node.rack()))
+            );
+        }
+
+        for (MetadataRequestData.MetadataRequestTopic requestTopic : request.data().topics()) {
+            if (!requestTopic.name().equals(topic)) {
+                throw new IllegalArgumentException("Unexpected topic " + requestTopic.name());
+            }
+            MetadataResponseData.MetadataResponseTopic responseTopic =
+                new MetadataResponseData.MetadataResponseTopic()
+                    .setName(topic)
+                    .setErrorCode(Errors.NONE.code());
+
+            for (PartitionModel partition : partitions.values()) {
+                responseTopic.partitions().add(
+                    new MetadataResponseData.MetadataResponsePartition()
+                        .setPartitionIndex(partition.partitionId)
+                        .setLeaderId(partition.leaderId)
+                        .setLeaderEpoch(partition.leaderEpoch)
+                        .setReplicaNodes(Collections.singletonList(partition.leaderId))
+                        .setIsrNodes(Collections.singletonList(partition.leaderId))
+                );
+            }
+
+            responseData.topics().add(responseTopic);
+        }
+
+        return new MetadataResponse(responseData, request.version());
+    }
+
+    private ProduceResponse handleProduceRequest(
+        BrokerModel broker,
+        ProduceRequest request,
+        long connectionId
+    ) {
+        ProduceResponseData responseData = new ProduceResponseData();
+
+        for (ProduceRequestData.TopicProduceData requestTopic : request.data().topicData()) {
+            if (!this.topic.equals(requestTopic.name())) {
+                throw new IllegalArgumentException("Unexpected topic " + requestTopic.name());
+            }
+
+            ProduceResponseData.TopicProduceResponse responseTopic =
+                new ProduceResponseData.TopicProduceResponse()
+                    .setName(this.topic);
+
+            for (ProduceRequestData.PartitionProduceData requestPartition : requestTopic.partitionData()) {
+                int partitionId = requestPartition.index();
+                PartitionModel partition = partitions.get(partitionId);
+
+                MemoryRecords records = (MemoryRecords) requestPartition.records();
+                DefaultRecordBatch batch = ((DefaultRecordBatch) records.batches().iterator().next());
+
+                final ProduceResponseData.PartitionProduceResponse responsePartition;
+                if (partition == null) {
+                    responsePartition = new ProduceResponseData.PartitionProduceResponse()
+                        .setIndex(partitionId)
+                        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code());
+                } else if (!isLeader(broker, partitionId)) {
+                    responsePartition = new ProduceResponseData.PartitionProduceResponse()
+                        .setIndex(partitionId)
+                        .setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code());
+                } else if (partition.isUnderMinIsr(time.milliseconds())) {
+                    responsePartition = new ProduceResponseData.PartitionProduceResponse()
+                        .setIndex(partitionId)
+                        .setErrorCode(Errors.NOT_ENOUGH_REPLICAS.code());
+                } else if (partition.hasInvalidRecord(time.milliseconds(), batch)) {
+                    responsePartition = new ProduceResponseData.PartitionProduceResponse()
+                        .setIndex(partitionId)
+                        .setErrorCode(Errors.INVALID_RECORD.code());
+                } else {
+                    responsePartition = partition.tryProduce(batch);
+                }
+
+                this.events.add(new ProduceRequestHandled(
+                    batch,
+                    partitionId,
+                    connectionId,
+                    Errors.forCode(responsePartition.errorCode())
+                ));
+                responseTopic.partitionResponses().add(responsePartition);
+            }
+
+            responseData.responses().add(responseTopic);
+        }
+
+        return new ProduceResponse(responseData);
+    }
+
+    private AbstractResponse handle(
+        BrokerModel broker,
+        AbstractRequest request,
+        long connectionId
+    ) {
+        if (request instanceof InitProducerIdRequest) {
+            return handleInitProducerIdRequest((InitProducerIdRequest) request);
+        } else if (request instanceof MetadataRequest) {
+            return handleMetadataRequest((MetadataRequest) request);
+        } else if (request instanceof ProduceRequest) {
+            return handleProduceRequest(broker, (ProduceRequest) request, connectionId);
+        } else {
+            throw new IllegalArgumentException("Unexpected request type: " + request.getClass());
+        }
+    }
+
+    void poll() {
+        BrokerModel broker = randomBroker();
+        ConnectionModel connection = broker.randomConnection(random);
+        if (connection != null) {
+            connection.maybeHandleRequest(request ->
+                this.handle(broker, request, connection.connectionId)
+            );
+        }
+    }
+
+    BrokerModel broker(int brokerId) {
+        return brokers.get(brokerId);
+    }
+
+    BrokerModel randomBroker() {
+        return SimulationUtils.randomEntry(random, brokers).getValue();
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ConnectionModel.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ConnectionModel.java
@@ -1,0 +1,295 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.function.Function;
+
+class ConnectionModel {
+    final long connectionId;
+    final MockTime time;
+    final Random random;
+    final ClusterModel cluster;
+    private final int maxInflights;
+
+    private boolean isConnected = true;
+    private Deque<ClientRequest> undeliveredRequests = new ArrayDeque<>();
+    private Deque<UndeliveredResponse> undeliveredResponses = new ArrayDeque<>();
+
+    ConnectionModel(
+        long connectionId,
+        MockTime time,
+        Random random,
+        ClusterModel cluster,
+        int maxInflights
+    ) {
+        this.connectionId = connectionId;
+        this.time = time;
+        this.random = random;
+        this.cluster = cluster;
+        this.maxInflights = maxInflights;
+    }
+
+    ClientResponse clientReceive() {
+        UndeliveredResponse undelivered = undeliveredResponses.poll();
+        if (undelivered == null) {
+            return null;
+        } else {
+            emitResponseReceivedEvent(undelivered);
+            return undelivered.response;
+        }
+    }
+
+    void maybeDropUndeliveredRequests() {
+        if (!undeliveredRequests.isEmpty()) {
+            int numRequestsToDrop = random.nextInt(undeliveredRequests.size());
+            for (int i = 0; i < numRequestsToDrop; i++) {
+                ClientRequest dropped = undeliveredRequests.removeLast();
+                if (dropped.requestBuilder() instanceof ProduceRequest.Builder) {
+                    ProduceRequest.Builder produceBldr = (ProduceRequest.Builder) dropped.requestBuilder();
+                    emitProduceRequestEvent(produceBldr, batchEntry -> new ProduceRequestDropped(
+                        batchEntry.getValue(),
+                        batchEntry.getKey().partition(),
+                        connectionId
+                    ));
+                }
+            }
+        }
+    }
+
+    void clientSend(ClientRequest request) {
+        if (!isReady()) {
+            throw new IllegalStateException("Attempt to send before the client is ready");
+        }
+
+        // We need to copy Produce requests since underlying buffers may get re-allocated
+        // after a disconnect before the "server" has processed them.
+        if (request.requestBuilder() instanceof ProduceRequest.Builder) {
+            ProduceRequest.Builder bldr = (ProduceRequest.Builder) request.requestBuilder();
+            ProduceRequest.Builder bldrCopy = deepCopy(bldr);
+
+            undeliveredRequests.add(new ClientRequest(
+                request.destination(),
+                bldrCopy,
+                request.correlationId(),
+                request.clientId(),
+                request.createdTimeMs(),
+                request.expectResponse(),
+                request.requestTimeoutMs(),
+                request.callback()
+            ));
+
+            emitProduceRequestEvent(bldrCopy, batchEntry -> new ProduceRequestSent(
+                batchEntry.getValue(),
+                batchEntry.getKey().partition(),
+                connectionId
+            ));
+        } else {
+            undeliveredRequests.add(request);
+        }
+    }
+
+    private void emitProduceRequestEvent(
+        ProduceRequest.Builder bldr,
+        Function<Map.Entry<TopicPartition, RecordBatch>, SimulationEvent> eventBuilder
+    ) {
+        Map<TopicPartition, RecordBatch> batches = collectBatches(bldr.build().data());
+        for (Map.Entry<TopicPartition, RecordBatch> batchEntry : batches.entrySet()) {
+            SimulationEvent event = eventBuilder.apply(batchEntry);
+            cluster.events.add(event);
+        }
+    }
+
+    void maybeHandleRequest(Function<AbstractRequest, AbstractResponse> func) {
+        ClientRequest request = undeliveredRequests.poll();
+        if (request != null) {
+            AbstractRequest requestBody = request.requestBuilder().build();
+            AbstractResponse responseBody = func.apply(requestBody);
+
+            RequestHeader requestHeader = new RequestHeader(
+                requestBody.apiKey(),
+                requestBody.version(),
+                "",
+                request.correlationId()
+            );
+
+            ClientResponse response = new ClientResponse(
+                requestHeader,
+                request.callback(),
+                request.destination(),
+                request.createdTimeMs(),
+                time.milliseconds(),
+                false,
+                null,
+                null,
+                responseBody
+            );
+
+            undeliveredResponses.add(new UndeliveredResponse(request, response));
+        }
+    }
+
+    private void emitResponseReceivedEvent(UndeliveredResponse undelivered) {
+        if (undelivered.request.requestBuilder() instanceof ProduceRequest.Builder) {
+            ProduceRequest.Builder requestBldr = (ProduceRequest.Builder) undelivered.request.requestBuilder();
+            Map<TopicPartition, RecordBatch> batches = collectBatches(requestBldr.build().data());
+
+            ProduceResponse response = (ProduceResponse) undelivered.response.responseBody();
+            Map<TopicPartition, Errors> errors = collectErrors(response.data());
+
+            for (Map.Entry<TopicPartition, RecordBatch> batchEntry : batches.entrySet()) {
+                Errors error = Objects.requireNonNull(errors.get(batchEntry.getKey()));
+                cluster.events.add(new ProduceResponseReceived(
+                    batchEntry.getValue(),
+                    batchEntry.getKey().partition(),
+                    connectionId,
+                    error
+                ));
+            }
+        }
+    }
+
+    List<ClientResponse> disconnect() {
+        List<ClientResponse> responses = new ArrayList<>();
+        for (UndeliveredResponse undelivered : undeliveredResponses) {
+            ClientResponse response = undelivered.response;
+            responses.add(new ClientResponse(
+                response.requestHeader(),
+                response.callback(),
+                response.destination(),
+                response.createdTimeMs(),
+                time.milliseconds(),
+                true,
+                null,
+                null,
+                null
+            ));
+        }
+
+        for (ClientRequest undelivered : undeliveredRequests) {
+            AbstractRequest requestBody = undelivered.requestBuilder().build();
+            RequestHeader requestHeader = new RequestHeader(
+                requestBody.apiKey(),
+                requestBody.version(),
+                "",
+                undelivered.correlationId()
+            );
+            responses.add(new ClientResponse(
+                requestHeader,
+                undelivered.callback(),
+                undelivered.destination(),
+                undelivered.createdTimeMs(),
+                time.milliseconds(),
+                true,
+                null,
+                null,
+                null
+            ));
+        }
+
+        this.isConnected = false;
+        return responses;
+    }
+
+    boolean hasUndeliveredRequests() {
+        return !undeliveredRequests.isEmpty();
+    }
+
+    boolean isReady() {
+        return isConnected && numInflights() < maxInflights;
+    }
+
+    int numInflights() {
+        return undeliveredRequests.size() + undeliveredResponses.size();
+    }
+
+    private static class UndeliveredResponse {
+        private final ClientRequest request;
+        private final ClientResponse response;
+
+        private UndeliveredResponse(
+            ClientRequest request,
+            ClientResponse response
+        ) {
+            this.request = request;
+            this.response = response;
+        }
+    }
+
+    private static ProduceRequest.Builder deepCopy(ProduceRequest.Builder bldr) {
+        ProduceRequestData copy = bldr.data().duplicate();
+        for (ProduceRequestData.TopicProduceData topicData : copy.topicData()) {
+            for (ProduceRequestData.PartitionProduceData partitionData : topicData.partitionData()) {
+                MemoryRecords records = (MemoryRecords) partitionData.records();
+                ByteBuffer bufferCopy = ByteBuffer.wrap(Utils.toArray(records.buffer().duplicate()));
+                MemoryRecords recordsCopy = MemoryRecords.readableRecords(bufferCopy);
+                partitionData.setRecords(recordsCopy);
+            }
+        }
+        return new ProduceRequest.Builder(
+            bldr.oldestAllowedVersion(),
+            bldr.latestAllowedVersion(),
+            copy
+        );
+    }
+
+    public static Map<TopicPartition, RecordBatch> collectBatches(
+        ProduceRequestData produceRequest
+    ) {
+        Map<TopicPartition, RecordBatch> batches = new HashMap<>();
+        for (ProduceRequestData.TopicProduceData topicData : produceRequest.topicData()) {
+            for (ProduceRequestData.PartitionProduceData partitionData : topicData.partitionData()) {
+                MemoryRecords records = (MemoryRecords) partitionData.records();
+
+                TopicPartition topicPartition = new TopicPartition(
+                    topicData.name(),
+                    partitionData.index()
+                );
+
+                DefaultRecordBatch batch = (DefaultRecordBatch) records.batchIterator().next();
+                batches.put(topicPartition, batch);
+            }
+        }
+        return batches;
+    }
+
+    public static Map<TopicPartition, Errors> collectErrors(
+        ProduceResponseData produceResponse
+    ) {
+        Map<TopicPartition, Errors> errors = new HashMap<>();
+        for (ProduceResponseData.TopicProduceResponse topicData : produceResponse.responses()) {
+            for (ProduceResponseData.PartitionProduceResponse partitionData : topicData.partitionResponses()) {
+                Errors error = Errors.forCode(partitionData.errorCode());
+                TopicPartition topicPartition = new TopicPartition(
+                    topicData.name(),
+                    partitionData.index()
+                );
+                errors.put(topicPartition, error);
+            }
+        }
+        return errors;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/FailedSend.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/FailedSend.java
@@ -1,0 +1,23 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+class FailedSend extends RecordEvent {
+    final Exception exception;
+
+    protected FailedSend(
+        ProducerRecord<Long, Long> record,
+        Exception exception
+    ) {
+        super(record);
+        this.exception = exception;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("FailedSend(value=%d, exception=%s)",
+            record.value(),
+            exception.getClass().getName()
+        );
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/IdempotentProducerSimulationTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/IdempotentProducerSimulationTest.java
@@ -1,0 +1,173 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The idempotent producer is intended to guarantee two properties:
+ *
+ * 1. No duplicates: a record sent by the producer will appear in the
+ *     log no more than once.
+ * 2. No reordering: records will be written to the log in the same order
+ *     that they are sent by the producer.
+ *
+ * The reordering guarantee does not mean that all records sent by
+ * the producer will be successfully written to the log. Individual
+ * records may fail to be written for a number of reasons. For example,
+ * if the delivery timeout is reached before a record could be delivered
+ * to the partition leader, then  . In other words, the failure of
+ * individual records does not prevent subsequent records from being
+ * delivered.
+ */
+public class IdempotentProducerSimulationTest {
+
+    @Property(tries = 10_000)
+    public void testTransientNotEnoughReplicasError(
+        @ForAll Random random,
+        @ForAll @IntRange(min = 1, max = 3) int numPartitions,
+        @ForAll @IntRange(min = 1, max = 5) int maxInflights
+    ) {
+        SimulationContext context = new SimulationContext.Builder(random)
+            .setNumPartitions(numPartitions)
+            .setPartitioner(new RandomPartitioner(random))
+            .addBroker(new Node(0, "localhost", 9092))
+            .setProducerConfig(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInflights)
+            .setProducerConfig(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 100)
+            .setProducerConfig(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 10)
+            .setProducerConfig(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 500)
+            .build();
+
+        context.run(context.random.nextInt(100));
+        context.cluster.enableUnderMinIsr(0, 10);
+        context.runUntilSendsCompleted();
+
+        try {
+            context.cluster.assertNoDuplicates();
+            context.cluster.assertNoReordering();
+            context.assertNoSendFailures();
+        } catch (Throwable t) {
+            context.printEventTrace();
+            throw t;
+        }
+    }
+
+    @Property(tries = 10_000)
+    public void testFatalInvalidRecordErrors(
+        @ForAll Random random,
+        @ForAll @IntRange(min = 1, max = 3) int numPartitions,
+        @ForAll @IntRange(min = 1, max = 5) int maxInflights
+    ) {
+        SimulationContext context = new SimulationContext.Builder(random)
+            .setNumPartitions(numPartitions)
+            .addBroker(new Node(0, "localhost", 9092))
+            .setPartitioner(new RandomPartitioner(random))
+            .setProducerConfig(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInflights)
+            .setProducerConfig(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 100)
+            .setProducerConfig(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 10)
+            .setProducerConfig(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 500)
+            .build();
+
+        context.run(context.random.nextInt(100));
+        context.cluster.enableInvalidRecordError(0, 20);
+        context.run(10);
+        context.client.randomDisconnect();
+        context.runUntilSendsCompleted();
+
+        try {
+            context.cluster.assertNoDuplicates();
+            context.cluster.assertNoReordering();
+            context.assertSendFailuresOnlyWithError(Errors.INVALID_RECORD);
+        } catch (Throwable t) {
+            context.printEventTrace();
+            throw t;
+        }
+    }
+
+    @Property(tries = 10_000)
+    public void testRandomNetworkDisconnects(
+        @ForAll Random random,
+        @ForAll @IntRange(min = 1, max = 3) int numPartitions,
+        @ForAll @IntRange(min = 1, max = 5) int maxInflights
+    ) {
+        SimulationContext context = new SimulationContext.Builder(random)
+            .setNumPartitions(numPartitions)
+            .addBroker(new Node(0, "localhost", 9092))
+            .setPartitioner(new RandomPartitioner(random))
+            .setProducerConfig(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInflights)
+            .setProducerConfig(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 100)
+            .setProducerConfig(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 10)
+            .setProducerConfig(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 500)
+            .build();
+
+        context.actions.add(() -> {
+            context.client.randomDisconnect();
+            return true;
+        });
+        context.runUntilSendsCompleted();
+
+        try {
+            context.cluster.assertNoDuplicates();
+            context.cluster.assertNoReordering();
+
+            // With random disconnects, delivery timeouts are possible
+            context.assertSendFailuresOnlyWithError(Errors.REQUEST_TIMED_OUT);
+        } catch (Throwable t) {
+            context.printEventTrace();
+            throw t;
+        }
+    }
+
+    /**
+     * In tests involving multiple partitions, it's helpful to ensure writes are
+     * interleaved. If an error occurs on only one partition, we want to verify
+     * that the writes to other partitions are not impacted (e.g. we want to ensure
+     * that epoch bumps do cause duplicates). It is difficult to get this coverage
+     * with the default sticky partitioning logic.
+     */
+    private static class RandomPartitioner implements Partitioner {
+        private final Random random;
+
+        private RandomPartitioner(Random random) {
+            this.random = random;
+        }
+
+        @Override
+        public int partition(
+            String topic,
+            Object key,
+            byte[] keyBytes,
+            Object value,
+            byte[] valueBytes,
+            Cluster cluster
+        ) {
+            Integer numPartitions = cluster.partitionCountForTopic(topic);
+            if (numPartitions == null) {
+                throw new IllegalStateException("Could not determine partition count for topic" + topic);
+            } else {
+                return random.nextInt(numPartitions);
+            }
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+
+        }
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/MockKafkaClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/MockKafkaClient.java
@@ -1,0 +1,280 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.RequestCompletionHandler;
+import org.apache.kafka.clients.producer.internals.ProducerMetadata;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.utils.MockTime;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * This mocked version of `KafkaClient` is used to ensure delivery of requests
+ * from the producer to the cluster model, which is responsible for handling
+ * them.
+ */
+class MockKafkaClient implements KafkaClient {
+    private final ClusterModel cluster;
+    private final List<Node> brokers;
+    private final ProducerMetadata metadata;
+    private final MockTime time;
+    private final Random random;
+
+    private final int maxInflights;
+    private final int requestTimeoutMs;
+
+    private final Map<String, ConnectionModel> activeConnections = new HashMap<>();
+    private final List<ClientResponse> disconnectResponses = new ArrayList<>();
+    private boolean isClosed = false;
+    private int correlationId = 0;
+    private long nextConnectionId = 0;
+
+    public MockKafkaClient(
+        ClusterModel cluster,
+        List<Node> brokers,
+        ProducerMetadata metadata,
+        MockTime time,
+        Random random,
+        int maxInflights,
+        int requestTimeoutMs
+    ) {
+        this.cluster = cluster;
+        this.brokers = brokers;
+        this.metadata = metadata;
+        this.time = time;
+        this.random = random;
+        this.maxInflights = maxInflights;
+        this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    @Override
+    public boolean isReady(Node node, long now) {
+        ConnectionModel connection = activeConnections.get(node.idString());
+        return connection != null && connection.isReady();
+    }
+
+    @Override
+    public boolean ready(Node node, long now) {
+        if (!disconnectResponses.isEmpty()) {
+            // Don't allow reconnect until we have delivered notification about
+            // disconnects to the client.
+            return false;
+        }
+
+        ConnectionModel connection = activeConnections.computeIfAbsent(node.idString(), k -> {
+            long connectionId = nextConnectionId++;
+            ConnectionModel newConnection = new ConnectionModel(
+                connectionId,
+                time,
+                random,
+                cluster,
+                maxInflights
+            );
+            cluster.broker(node.id()).connect(newConnection);
+            return newConnection;
+        });
+        return connection.isReady();
+    }
+
+    @Override
+    public long connectionDelay(Node node, long now) {
+        return 0;
+    }
+
+    @Override
+    public long pollDelayMs(Node node, long now) {
+        return 0;
+    }
+
+    @Override
+    public boolean connectionFailed(Node node) {
+        return false;
+    }
+
+    @Override
+    public AuthenticationException authenticationException(Node node) {
+        return null;
+    }
+
+    @Override
+    public void send(ClientRequest request, long now) {
+        String nodeId = request.destination();
+        ConnectionModel connection = activeConnections.get(nodeId);
+        if (connection == null || !connection.isReady()) {
+            throw new IllegalStateException("Connection for nodeId " + nodeId + " is not ready");
+        }
+
+        connection.clientSend(request);
+
+    }
+
+    void randomDisconnect() {
+        if (!activeConnections.isEmpty()) {
+            String nodeId = SimulationUtils.randomEntry(random, activeConnections).getKey();
+            disconnect(nodeId, true);
+            cluster.events.add(new SimulationEvent() {
+                @Override
+                public String toString() {
+                    return "NetworkDisconnect()";
+                }
+            });
+        }
+    }
+
+    @Override
+    public List<ClientResponse> poll(long timeout, long now) {
+        if (metadata.updateRequested()) {
+            int updateVersion = metadata.updateVersion();
+            metadata.update(updateVersion, cluster.handleMetadataRequest(
+                metadata.newMetadataRequestBuilder().build()
+            ), false, time.milliseconds());
+        }
+
+        List<ClientResponse> responses = new ArrayList<>();
+        for (ConnectionModel connection : activeConnections.values()) {
+            ClientResponse clientResponse = connection.clientReceive();
+            if (clientResponse != null) {
+                responses.add(clientResponse);
+            }
+        }
+
+        responses.addAll(this.disconnectResponses);
+        this.disconnectResponses.clear();
+        responses.forEach(ClientResponse::onComplete);
+        return responses;
+    }
+
+    @Override
+    public void disconnect(String nodeId) {
+        disconnect(nodeId, true);
+    }
+
+    @Override
+    public void close(String nodeId) {
+        disconnect(nodeId, false);
+    }
+
+    private void disconnect(String nodeId, boolean returnResponses) {
+        ConnectionModel connection = activeConnections.remove(nodeId);
+        if (connection != null) {
+            List<ClientResponse> disconnectResponses = connection.disconnect();
+            if (returnResponses) {
+                this.disconnectResponses.addAll(disconnectResponses);
+            }
+            int brokerId = Integer.parseInt(nodeId);
+            cluster.broker(brokerId).disconnect(connection);
+        }
+    }
+
+    @Override
+    public Node leastLoadedNode(long now) {
+        int randomIdx = random.nextInt(brokers.size());
+        return brokers.get(randomIdx);
+    }
+
+    @Override
+    public int inFlightRequestCount() {
+        int totalInflights = 0;
+        for (ConnectionModel connection : activeConnections.values()) {
+            totalInflights += connection.numInflights();
+        }
+        return totalInflights;
+    }
+
+    @Override
+    public boolean hasInFlightRequests() {
+        return inFlightRequestCount() > 0;
+    }
+
+    @Override
+    public int inFlightRequestCount(String nodeId) {
+        ConnectionModel connection = activeConnections.get(nodeId);
+        if (connection == null) {
+            return 0;
+        } else {
+            return connection.numInflights();
+        }
+    }
+
+    @Override
+    public boolean hasInFlightRequests(String nodeId) {
+        return inFlightRequestCount(nodeId) > 0;
+    }
+
+    @Override
+    public boolean hasReadyNodes(long now) {
+        for (ConnectionModel connection : activeConnections.values()) {
+            if (connection.isReady()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void wakeup() {
+
+    }
+
+    @Override
+    public ClientRequest newClientRequest(
+        String nodeId,
+        AbstractRequest.Builder<?> requestBuilder,
+        long createdTimeMs,
+        boolean expectResponse
+    ) {
+        return newClientRequest(
+            nodeId,
+            requestBuilder,
+            createdTimeMs,
+            expectResponse,
+            requestTimeoutMs,
+            null
+        );
+    }
+
+    @Override
+    public ClientRequest newClientRequest(
+        String nodeId,
+        AbstractRequest.Builder<?> requestBuilder,
+        long createdTimeMs,
+        boolean expectResponse,
+        int requestTimeoutMs,
+        RequestCompletionHandler callback
+    ) {
+        return new ClientRequest(
+            nodeId,
+            requestBuilder,
+            correlationId++,
+            "",
+            createdTimeMs,
+            expectResponse,
+            requestTimeoutMs,
+            callback
+        );
+    }
+
+    @Override
+    public void initiateClose() {
+        isClosed = true;
+    }
+
+    @Override
+    public boolean active() {
+        return !isClosed;
+    }
+
+    @Override
+    public void close() throws IOException {
+        initiateClose();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/PartitionModel.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/PartitionModel.java
@@ -1,0 +1,165 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class PartitionModel {
+    final int partitionId;
+    final boolean enableStrictValidation;
+    int leaderId;
+    int leaderEpoch;
+    long underMinIsrUntilTimestamp = -1;
+    long invalidRecordsUntilTimestamp = -1;
+    final List<RecordBatch> log = new ArrayList<>();
+    final Map<Long, ProducerStateModel> producers;
+    final Set<Long> invalidRecordValues = new HashSet<>();
+
+    PartitionModel(
+        int partitionId,
+        boolean enableStrictValidation
+    ) {
+        this.partitionId = partitionId;
+        this.enableStrictValidation = enableStrictValidation;
+        this.leaderId = -1;
+        this.leaderEpoch = 0;
+        this.producers = new HashMap<>();
+    }
+
+    void setNewLeader(int brokerId) {
+        this.leaderId = brokerId;
+        this.leaderEpoch++;
+    }
+
+    private long nextOffset() {
+        if (log.isEmpty()) {
+            return 0;
+        } else {
+            return log.get(log.size() - 1).nextOffset();
+        }
+    }
+
+    void enableUnderMinIsrUntil(long underMinIsrUntilTimestamp) {
+        this.underMinIsrUntilTimestamp = underMinIsrUntilTimestamp;
+    }
+
+    void enableRandomInvalidRecordErrors(double probability) {
+    }
+
+    void enableInvalidRecordErrorsUntil(long invalidRecordsUntilTimestamp) {
+        this.invalidRecordsUntilTimestamp = invalidRecordsUntilTimestamp;
+    }
+
+    boolean isUnderMinIsr(long currentTimeMs) {
+        return underMinIsrUntilTimestamp > currentTimeMs;
+    }
+
+    boolean hasInvalidRecord(long currentTimeMs, RecordBatch batch) {
+        Record firstRecord = batch.iterator().next();
+        Long recordValue = firstRecord.value().duplicate().getLong();
+        if (invalidRecordValues.contains(recordValue)) {
+            return true;
+        } else if (invalidRecordsUntilTimestamp > currentTimeMs) {
+            invalidRecordValues.add(recordValue);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private long logStartOffset() {
+        return 0;
+    }
+
+    ProduceResponseData.PartitionProduceResponse tryProduce(DefaultRecordBatch batch) {
+        long producerId = batch.producerId();
+        short epoch = batch.producerEpoch();
+        int sequence = batch.baseSequence();
+        int numRecords = batch.countOrNull();
+
+        ProduceResponseData.PartitionProduceResponse response =
+            new ProduceResponseData.PartitionProduceResponse()
+                .setIndex(this.partitionId);
+
+        ProducerStateModel currentState = producers.get(producerId);
+        if (currentState == null) {
+            if (enableStrictValidation && sequence != 0) {
+                response.setErrorCode(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER.code());
+                return response;
+            } else {
+                currentState = new ProducerStateModel(
+                    producerId,
+                    epoch,
+                    sequence
+                );
+                producers.put(producerId, currentState);
+            }
+        } else {
+            OptionalLong offsetOpt = currentState.checkDuplicateSequence(epoch, sequence, numRecords);
+            if (offsetOpt.isPresent()) {
+                response.setBaseOffset(offsetOpt.getAsLong());
+                response.setErrorCode(Errors.NONE.code());
+                return response;
+            }
+
+            Optional<Errors> errorOpt = currentState.checkNextSequence(epoch, sequence);
+            if (errorOpt.isPresent()) {
+                response.setErrorCode(errorOpt.get().code());
+                return response;
+            }
+        }
+
+        batch.setLastOffset(nextOffset() + batch.countOrNull() - 1);
+        log.add(batch);
+        currentState.onAppend(batch);
+
+        response.setErrorCode(Errors.NONE.code());
+        response.setLogStartOffset(logStartOffset());
+        response.setBaseOffset(batch.baseOffset());
+        return response;
+    }
+
+    void assertNoDuplicates() {
+        Set<Long> storedValues = new HashSet<>();
+        for (RecordBatch batch : log) {
+            for (Long value : recordValues(batch)) {
+                if (!storedValues.add(value)) {
+                    fail("Log contained multiple entries of value " + value);
+                }
+            }
+        }
+    }
+
+    void assertNoReordering() {
+        Long lastValue = null;
+        for (RecordBatch batch : log) {
+            for (Long value : recordValues(batch)) {
+                if (lastValue != null && value < lastValue) {
+                    fail(String.format("Value %d was re-ordered after value %d", value, lastValue));
+                }
+                lastValue = value;
+            }
+        }
+    }
+
+    private static List<Long> recordValues(RecordBatch batch) {
+        List<Long> values = new ArrayList<>(batch.countOrNull());
+        for (Record record : batch) {
+            values.add(record.value().duplicate().getLong());
+        }
+        return values;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceEvent.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceEvent.java
@@ -1,0 +1,19 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.record.RecordBatch;
+
+abstract class ProduceEvent implements SimulationEvent {
+    final RecordBatch batch;
+    final int partitionId;
+    final long connectionId;
+
+    ProduceEvent(
+        RecordBatch batch,
+        int partitionId,
+        long connectionId
+    ) {
+        this.batch = batch;
+        this.partitionId = partitionId;
+        this.connectionId = connectionId;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceRequestDropped.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceRequestDropped.java
@@ -1,0 +1,30 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.record.RecordBatch;
+
+class ProduceRequestDropped extends ProduceEvent {
+    ProduceRequestDropped(
+        RecordBatch batch,
+        int partitionId,
+        long connectionId
+    ) {
+        super(batch, partitionId, connectionId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ProduceRequestDropped(" +
+                "partitionId=%d, " +
+                "connectionId=%d, " +
+                "epoch=%d, " +
+                "seq=[%d, %d], " +
+                "value=%s)",
+            partitionId,
+            connectionId,
+            batch.producerEpoch(),
+            batch.baseSequence(),
+            batch.lastSequence(),
+            SimulationUtils.batchValueRangeAsString(batch)
+        );
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceRequestHandled.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceRequestHandled.java
@@ -1,0 +1,39 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+
+class ProduceRequestHandled extends ProduceEvent {
+    private final Errors error;
+
+    ProduceRequestHandled(
+        RecordBatch batch,
+        int partitionId,
+        long connectionId,
+        Errors error
+    ) {
+        super(batch, partitionId, connectionId);
+        this.error = error;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ProduceRequestHandled(" +
+                "partitionId=%d, " +
+                "connectionId=%d, " +
+                "epoch=%d, " +
+                "seq=[%d, %d], " +
+                "value=%s, " +
+                "offset=%d, " +
+                "error=%s)",
+            partitionId,
+            connectionId,
+            batch.producerEpoch(),
+            batch.baseSequence(),
+            batch.lastSequence(),
+            SimulationUtils.batchValueRangeAsString(batch),
+            batch.baseOffset(),
+            error
+        );
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceRequestSent.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceRequestSent.java
@@ -1,0 +1,30 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.record.RecordBatch;
+
+class ProduceRequestSent extends ProduceEvent {
+    ProduceRequestSent(
+        RecordBatch batch,
+        int partitionId,
+        long connectionId
+    ) {
+        super(batch, partitionId, connectionId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ProduceRequestSent(" +
+                "partitionId=%d, " +
+                "connectionId=%d, " +
+                "epoch=%d, " +
+                "seq=[%d, %d], " +
+                "value=%s)",
+            partitionId,
+            connectionId,
+            batch.producerEpoch(),
+            batch.baseSequence(),
+            batch.lastSequence(),
+            SimulationUtils.batchValueRangeAsString(batch)
+        );
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceResponseReceived.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProduceResponseReceived.java
@@ -1,0 +1,39 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+
+class ProduceResponseReceived extends ProduceEvent {
+    private final Errors error;
+
+    ProduceResponseReceived(
+        RecordBatch batch,
+        int partitionId,
+        long connectionId,
+        Errors error
+    ) {
+        super(batch, partitionId, connectionId);
+        this.error = error;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ProduceResponseReceived(" +
+                "partitionId=%d, " +
+                "connectionId=%d, " +
+                "epoch=%d, " +
+                "seq=[%d, %d], " +
+                "value=%s, " +
+                "offset=%d, " +
+                "error=%s)",
+            partitionId,
+            connectionId,
+            batch.producerEpoch(),
+            batch.baseSequence(),
+            batch.lastSequence(),
+            SimulationUtils.batchValueRangeAsString(batch),
+            batch.baseOffset(),
+            error
+        );
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProducerStateModel.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/ProducerStateModel.java
@@ -1,0 +1,77 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
+
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+class ProducerStateModel {
+    final ArrayDeque<RecordBatch> cache = new ArrayDeque<>();
+    private long producerId;
+    private short epoch;
+    private int sequence;
+
+    ProducerStateModel(
+        long producerId,
+        short epoch,
+        int sequence
+    ) {
+        this.producerId = producerId;
+        this.epoch = epoch;
+        this.sequence = sequence;
+    }
+
+    int sequence() {
+        return sequence;
+    }
+
+    short epoch() {
+        return epoch;
+    }
+
+    long producerId() {
+        return producerId;
+    }
+
+    OptionalLong checkDuplicateSequence(
+        short epoch,
+        int sequence,
+        int numRecords
+    ) {
+        for (RecordBatch batch : cache) {
+            if (batch.producerEpoch() == epoch
+                && batch.baseSequence() == sequence
+                && batch.countOrNull() == numRecords) {
+                return OptionalLong.of(batch.baseOffset());
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    Optional<Errors> checkNextSequence(
+        short epoch,
+        int sequence
+    ) {
+        if (epoch < this.epoch) {
+            return Optional.of(Errors.INVALID_PRODUCER_EPOCH);
+        } else if (epoch == this.epoch && sequence != this.sequence) {
+            return Optional.of(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER);
+        } else if (epoch > this.epoch && sequence != 0) {
+            return Optional.of(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    void onAppend(RecordBatch batch) {
+        this.epoch = batch.producerEpoch();
+        this.sequence = batch.lastSequence() + 1;
+
+        cache.add(batch);
+        if (cache.size() > 5) {
+            cache.pop();
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/RecordEvent.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/RecordEvent.java
@@ -1,0 +1,11 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+abstract class RecordEvent implements SimulationEvent {
+    final ProducerRecord<Long, Long> record;
+
+    RecordEvent(ProducerRecord<Long, Long> record) {
+        this.record = record;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/RecordSent.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/RecordSent.java
@@ -1,0 +1,14 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+class RecordSent extends RecordEvent {
+    protected RecordSent(ProducerRecord<Long, Long> record) {
+        super(record);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RecordSent(value=%d)", record.value());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationAction.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationAction.java
@@ -1,0 +1,5 @@
+package org.apache.kafka.clients.producer.simulation;
+
+interface SimulationAction {
+    boolean maybeRun();
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationContext.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationContext.java
@@ -1,0 +1,334 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.KafkaProducerTest;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.internals.BufferPool;
+import org.apache.kafka.clients.producer.internals.ProducerMetadata;
+import org.apache.kafka.clients.producer.internals.RecordAccumulator;
+import org.apache.kafka.clients.producer.internals.Sender;
+import org.apache.kafka.clients.producer.internals.SenderMetricsRegistry;
+import org.apache.kafka.clients.producer.internals.TransactionManager;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SimulationContext {
+    final LogContext logContext;
+    final Random random;
+    final Metrics metrics;
+    final MockTime time;
+    final MockKafkaClient client;
+    final List<SimulationAction> actions;
+    final ClusterModel cluster;
+    final Partitioner partitioner;
+
+    final ProducerConfig config;
+    final ProducerMetadata metadata;
+    final int maxRecordsToSend;
+
+    private int numPolls = 0;
+    private int numSendsCompleted = 0;
+    private int nextRecordId = 0;
+
+
+    private SimulationContext(
+        Random random,
+        List<Node> brokers,
+        int numPartitions,
+        ProducerConfig config,
+        int maxRecordsToSend,
+        boolean enableStrictValidation,
+        Partitioner partitioner
+    ) {
+        this.config = config;
+        this.logContext = new LogContext();
+        this.random = random;
+        this.maxRecordsToSend = maxRecordsToSend;
+        this.partitioner = partitioner;
+        this.time = new MockTime();
+        this.metrics = new Metrics();
+        this.actions = new ArrayList<>();
+        this.metadata = new ProducerMetadata(
+            config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG),
+            config.getLong(ProducerConfig.METADATA_MAX_AGE_CONFIG),
+            config.getLong(ProducerConfig.METADATA_MAX_IDLE_CONFIG),
+            logContext,
+            new ClusterResourceListeners(),
+            time
+        );
+        this.cluster = new ClusterModel(
+            time,
+            random,
+            brokers,
+            numPartitions,
+            enableStrictValidation
+        );
+        this.client = new MockKafkaClient(
+            cluster,
+            brokers,
+            metadata,
+            time,
+            random,
+            config.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION),
+            config.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG)
+        );
+
+        addProducerActions();
+        addClusterActions();
+    }
+
+    boolean allSendsCompleted() {
+        return nextRecordId == maxRecordsToSend;
+    }
+
+    void addClusterActions() {
+        actions.add(() -> {
+            cluster.poll();
+            return true;
+        });
+    }
+
+    void runRandomAction() {
+        int randomIdx = random.nextInt(actions.size());
+        SimulationAction action = actions.get(randomIdx);
+        if (action.maybeRun()) {
+            time.sleep(1);
+            numPolls++;
+        }
+    }
+
+    void runUntilSendsCompleted() {
+        runUntil(this::allSendsCompleted);
+    }
+
+    void run(int depth) {
+        int currentPolls = numPolls;
+        runWhile(() -> numPolls - currentPolls < depth);
+    }
+
+    void runUntil(Supplier<Boolean> breakCondition) {
+        while (!breakCondition.get()) {
+            runRandomAction();
+        }
+    }
+
+    void runWhile(Supplier<Boolean> loopCondition) {
+        while (loopCondition.get()) {
+            runRandomAction();
+        }
+    }
+
+    void assertNoSendFailures() {
+        List<SimulationEvent> failedSends = cluster.events.stream()
+            .filter(event -> event instanceof FailedSend)
+            .collect(Collectors.toList());
+        assertEquals(Collections.emptyList(), failedSends);
+    }
+
+    void assertSendFailuresOnlyWithError(Errors error) {
+        List<SimulationEvent> failedSends = cluster.events.stream()
+            .filter(event -> {
+                if (event instanceof FailedSend) {
+                    FailedSend failedSend = (FailedSend) event;
+                    return Errors.forException(failedSend.exception) != error;
+                } else {
+                    return false;
+                }
+            })
+            .collect(Collectors.toList());
+        assertEquals(Collections.emptyList(), failedSends);
+    }
+
+    void printEventTrace(int maxEvents) {
+        cluster.events.stream()
+            .limit(maxEvents)
+            .forEach(System.out::println);
+    }
+
+    void printEventTrace() {
+        printEventTrace(Integer.MAX_VALUE);
+    }
+
+    void addProducerActions() {
+        ApiVersions apiVersions = new ApiVersions();
+        long retryBackoffMs = config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG);
+
+        TransactionManager txnManager = new TransactionManager(
+            logContext,
+            config.getString(ProducerConfig.TRANSACTIONAL_ID_CONFIG),
+            config.getInt(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG),
+            retryBackoffMs,
+            apiVersions
+        );
+
+        BufferPool bufferPool = new BufferPool(
+            config.getLong(ProducerConfig.BUFFER_MEMORY_CONFIG),
+            config.getInt(ProducerConfig.BATCH_SIZE_CONFIG),
+            metrics,
+            time,
+            KafkaProducer.PRODUCER_METRIC_GROUP_NAME
+        );
+
+        RecordAccumulator.PartitionerConfig partitionerConfig = new RecordAccumulator.PartitionerConfig(
+            this.partitioner == null,
+            config.getLong(ProducerConfig.PARTITIONER_AVAILABILITY_TIMEOUT_MS_CONFIG)
+        );
+
+        RecordAccumulator accumulator = new RecordAccumulator(
+            logContext,
+            config.getInt(ProducerConfig.BATCH_SIZE_CONFIG),
+            CompressionType.NONE,
+            Math.toIntExact(config.getLong(ProducerConfig.LINGER_MS_CONFIG)),
+            retryBackoffMs,
+            config.getInt(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG),
+            partitionerConfig,
+            metrics,
+            KafkaProducer.PRODUCER_METRIC_GROUP_NAME,
+            time,
+            apiVersions,
+            txnManager,
+            bufferPool
+        );
+
+        // Do an initial metadata update in order to prevent `send` from blocking.
+        metadata.add(cluster.topic, time.milliseconds());
+        int requestVersion = metadata.requestUpdateForTopic(cluster.topic);
+        metadata.update(requestVersion, cluster.handleMetadataRequest(
+            metadata.newMetadataRequestBuilder().build()
+        ), false, time.milliseconds());
+
+        Sender sender = new Sender(
+            logContext,
+            client,
+            metadata,
+            accumulator,
+            false,
+            config.getInt(ProducerConfig.MAX_REQUEST_SIZE_CONFIG),
+            Short.parseShort(config.getString(ProducerConfig.ACKS_CONFIG)),
+            config.getInt(ProducerConfig.RETRIES_CONFIG),
+            new SenderMetricsRegistry(metrics),
+            time,
+            config.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+            retryBackoffMs,
+            txnManager,
+            apiVersions
+        );
+
+        actions.add(() -> {
+            sender.runOnce();
+            return true;
+        });
+
+        KafkaProducer<Long, Long> producer = KafkaProducerTest.newKafkaProducer(
+            config,
+            logContext,
+            metrics,
+            new LongSerializer(),
+            new LongSerializer(),
+            metadata,
+            accumulator,
+            txnManager,
+            sender,
+            partitioner,
+            time,
+            Mockito.mock(KafkaThread.class)
+        );
+
+        actions.add(() -> {
+            if (allSendsCompleted()) {
+                return false;
+            }
+
+            Long value = (long) nextRecordId++;
+            ProducerRecord<Long, Long> record = new ProducerRecord<>(cluster.topic, value);
+            cluster.events.add(new RecordSent(record));
+
+            producer.send(record, (recordMetadata, exception) -> {
+                numSendsCompleted++;
+                if (exception != null) {
+                    cluster.events.add(new FailedSend(record, exception));
+                } else {
+                    cluster.events.add(new SuccessfulSend(record));
+                }
+            });
+
+            return true;
+        });
+    }
+
+    public static class Builder {
+        private final Random random;
+        private final Properties properties;
+        private int maxRecordsToSend = 100;
+        private int numPartitions = 1;
+        private boolean enableStrictValidation = true;
+        private List<Node> brokers = new ArrayList<>();
+
+        private Partitioner partitioner;
+
+        public Builder(Random random) {
+            this.random = random;
+            this.properties = new Properties();
+            this.properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class.getName());
+            this.properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class.getName());
+        }
+
+        Builder setProducerConfig(String config, Object value) {
+            this.properties.put(config, value);
+            return this;
+        }
+
+        Builder addBroker(Node node) {
+            this.brokers.add(node);
+            return this;
+        }
+
+        Builder setNumPartitions(int numPartitions) {
+            this.numPartitions = numPartitions;
+            return this;
+        }
+
+        Builder disableStrictValidation() {
+            this.enableStrictValidation = false;
+            return this;
+        }
+
+        Builder setPartitioner(Partitioner partitioner) {
+            this.partitioner = partitioner;
+            return this;
+        }
+
+        SimulationContext build() {
+            return new SimulationContext(
+                random,
+                brokers,
+                numPartitions,
+                new ProducerConfig(properties),
+                maxRecordsToSend,
+                enableStrictValidation,
+                partitioner
+            );
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationEvent.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationEvent.java
@@ -1,0 +1,4 @@
+package org.apache.kafka.clients.producer.simulation;
+
+interface SimulationEvent {
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SimulationUtils.java
@@ -1,0 +1,46 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+
+public class SimulationUtils {
+    public static <K, V> Map.Entry<K, V> randomEntry(Random random, Map<K, V> map) {
+        if (map.isEmpty()) {
+            throw new IllegalArgumentException("Cannot get random entry from empty map");
+        }
+
+        int randomIdx = random.nextInt(map.size());
+        int idx = 0;
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            if (randomIdx == idx) {
+                return entry;
+            } else {
+                idx++;
+            }
+        }
+        throw new IllegalArgumentException("Cannot reach here");
+    }
+
+    public static String batchValueRangeAsString(RecordBatch batch) {
+        StringBuilder str = new StringBuilder();
+        Iterator<Record> iterator = batch.iterator();
+        while (iterator.hasNext()) {
+            Record record = iterator.next();
+            if (str.length() == 0) {
+                long value = record.value().duplicate().getLong();
+                str.append("[").append(value).append(", ");
+            }
+
+            if (!iterator.hasNext()) {
+                long value = record.value().duplicate().getLong();
+                str.append(value).append("]");
+            }
+        }
+
+        return str.toString();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SuccessfulSend.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/simulation/SuccessfulSend.java
@@ -1,0 +1,16 @@
+package org.apache.kafka.clients.producer.simulation;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+class SuccessfulSend extends RecordEvent {
+    protected SuccessfulSend(
+        ProducerRecord<Long, Long> record
+    ) {
+        super(record);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SuccessfulSend(value=%d)", record.value());
+    }
+}


### PR DESCRIPTION
As many have noticed, the idempotent producer implementation is complex. This patch attempts to introduce a new simulation-based testing methodology with more complex, randomly generated scenarios. We did something similar for the raft implementation.

I'm still working through some of the mechanics, polishing the code, and trying out new scenarios. But it works well enough that it has begun to yield some interesting results, such as https://issues.apache.org/jira/browse/KAFKA-14397.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
