### PR TITLE
KAFKA-12476: Prevent herder tick thread from sleeping excessively after slow operations

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -444,7 +444,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             } else if (now >= next.at) {
                 requests.pollFirst();
             } else {
-                scheduledTick = Math.min(scheduledTick, next.at);
+                scheduledTick = next.at;
                 break;
             }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -2553,7 +2553,6 @@ public class DistributedHerderTest {
         expectQueueHerderOperation();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
-        // list connectors, get connector info, get connector config, get task configs
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -3538,14 +3537,14 @@ public class DistributedHerderTest {
     public void testPollDurationOnSlowConnectorOperations() {
         connectProtocolVersion = CONNECT_PROTOCOL_V1;
         // If an operation during tick() takes some amount of time, that time should count against the rebalance delay
-        int rebalanceDelayMs = 20000;
-        long operationDelayMs = 10000;
-        long maxPollWaitMs = rebalanceDelayMs - operationDelayMs;
+        final int rebalanceDelayMs = 20000;
+        final long operationDelayMs = 10000;
+        final long maxPollWaitMs = rebalanceDelayMs - operationDelayMs;
         EasyMock.expect(member.memberId()).andStubReturn("member");
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(connectProtocolVersion);
 
         // Assign the connector to this worker, and have it start
-        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, Arrays.asList(CONN1), Collections.emptyList(), rebalanceDelayMs);
+        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList(), rebalanceDelayMs);
         expectConfigRefreshAndSnapshot(SNAPSHOT);
         Capture<Callback<TargetState>> onFirstStart = newCapture();
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
@@ -3564,7 +3563,7 @@ public class DistributedHerderTest {
 
         // Rebalance again due to config update
         expectQueueHerderOperation();
-        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, Arrays.asList(CONN1), Collections.emptyList(), rebalanceDelayMs);
+        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList(), rebalanceDelayMs);
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT_UPDATED_CONN1_CONFIG);
 
         worker.stopAndAwaitConnector(CONN1);
@@ -3583,7 +3582,7 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
 
         // Third tick should resolve all outstanding requests
-        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, Collections.singletonList(CONN1), Collections.emptyList(), rebalanceDelayMs);
+        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList(), rebalanceDelayMs);
         // which includes querying the connector task configs after the update
         expectExecuteTaskReconfiguration(true, conn1SinkConfigUpdated, () -> {
             time.sleep(operationDelayMs);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -214,7 +214,6 @@ public class DistributedHerderTest {
     private DistributedHerder herder;
     private MockConnectMetrics metrics;
     @Mock private Worker worker;
-    @Mock private WorkerConfigTransformer transformer;
     @Mock private Callback<Herder.Created<ConnectorInfo>> putConnectorCallback;
     @Mock private Plugins plugins;
     @Mock private RestClient restClient;
@@ -2138,7 +2137,6 @@ public class DistributedHerderTest {
             onPause.getValue().onCompletion(null, TargetState.PAUSED);
             return null;
         });
-        PowerMock.expectLastCall();
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -2718,7 +2716,6 @@ public class DistributedHerderTest {
             TASK_CONFIGS_MAP, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), Collections.emptySet());
         expectConfigRefreshAndSnapshot(snapshotWithKey);
         // First rebalance: poll for a limited time as worker is leader and must wake up for key expiration
-        Capture<Long> firstPollTimeout = EasyMock.newCapture();
         member.poll(leq(rotationTtlDelay));
         EasyMock.expectLastCall();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -282,7 +282,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
@@ -313,7 +314,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
@@ -332,7 +334,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -379,7 +382,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
@@ -481,7 +485,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
@@ -518,7 +523,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
@@ -537,7 +543,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(false, null, null);
 
         // worker is not running, so we should see no call to connectorTaskConfigs()
@@ -585,7 +592,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
@@ -635,7 +643,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -1105,7 +1114,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         // And delete the connector
@@ -1167,7 +1177,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         // now handle the connector restart
@@ -1187,7 +1198,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         PowerMock.replayAll();
@@ -1509,7 +1521,8 @@ public class DistributedHerderTest {
             stateCallback.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
 
 
         herder.onRestart(CONN1);
@@ -1790,7 +1803,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -1824,7 +1838,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -1845,7 +1860,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -1886,13 +1902,15 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
         // apply config
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
         // During the next tick, throw an error from the transformer
@@ -1950,13 +1968,15 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
         // handle the state change
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
 
@@ -2024,7 +2044,8 @@ public class DistributedHerderTest {
             onResume.getValue().onCompletion(null, TargetState.STARTED);
             return null;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -2164,7 +2185,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return null;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(false, null, null);
 
         member.poll(EasyMock.anyInt());
@@ -2253,7 +2275,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
@@ -2315,7 +2338,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
@@ -2404,7 +2428,8 @@ public class DistributedHerderTest {
             onStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         worker.startSourceTask(EasyMock.eq(TASK1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
@@ -2534,10 +2559,12 @@ public class DistributedHerderTest {
     @Test
     public void testPutConnectorConfig() throws Exception {
         // connectorConfig uses an async request
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
 
         // putConnectorConfig uses an async request
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
 
         EasyMock.expect(member.memberId()).andStubReturn("leader");
         expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList(), true);
@@ -2550,7 +2577,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
 
         member.poll(EasyMock.anyInt());
@@ -2568,7 +2596,8 @@ public class DistributedHerderTest {
             validateCallback.getValue().onCompletion(null, CONN1_CONFIG_INFOS);
             return null;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         configBackingStore.putConnectorConfig(CONN1, CONN1_CONFIG_UPDATED);
         PowerMock.expectLastCall().andAnswer(() -> {
             // Simulate response to writing config + waiting until end of log to be read
@@ -2588,7 +2617,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -3554,7 +3584,8 @@ public class DistributedHerderTest {
             onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
         // We should poll for less than the delay - time to start the connector, meaning that a long connector start
         // does not delay the poll timeout
@@ -3562,7 +3593,8 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
 
         // Rebalance again due to config update
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList(), rebalanceDelayMs);
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT_UPDATED_CONN1_CONFIG);
 
@@ -3577,7 +3609,8 @@ public class DistributedHerderTest {
             onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
-        expectQueueHerderOperation();
+        member.wakeup();
+        PowerMock.expectLastCall();
         member.poll(leq(maxPollWaitMs));
         PowerMock.expectLastCall();
 
@@ -3738,11 +3771,6 @@ public class DistributedHerderTest {
         return new ClusterConfigState(1, sessionKey, taskCounts,
                 connectorConfigs, Collections.singletonMap(CONN1, TargetState.STARTED),
                 taskConfigs, taskCountRecords, taskConfigGenerations, pendingFencing, Collections.emptySet());
-    }
-
-    private void expectQueueHerderOperation() {
-        member.wakeup();
-        PowerMock.expectLastCall();
     }
 
     private void expectExecuteTaskReconfiguration(boolean running, ConnectorConfig connectorConfig, IAnswer<List<Map<String, String>>> answer) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3551,8 +3551,8 @@ public class DistributedHerderTest {
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onFirstStart));
         PowerMock.expectLastCall().andAnswer(() -> {
-            onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             time.sleep(operationDelayMs);
+            onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
         expectQueueHerderOperation();
@@ -3574,8 +3574,8 @@ public class DistributedHerderTest {
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onSecondStart));
         PowerMock.expectLastCall().andAnswer(() -> {
-            onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             time.sleep(operationDelayMs);
+            onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
             return true;
         });
         expectQueueHerderOperation();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -118,7 +118,6 @@ import static org.apache.kafka.connect.source.SourceTask.TransactionBoundary.CON
 import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.geq;
 import static org.easymock.EasyMock.leq;
 import static org.easymock.EasyMock.newCapture;
 import static org.junit.Assert.assertEquals;
@@ -2640,7 +2639,7 @@ public class DistributedHerderTest {
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
         // First rebalance: poll indefinitely as no key has been read yet, so expiration doesn't come into play
-        member.poll(geq(rotationTtlDelay));
+        member.poll(Long.MAX_VALUE);
         EasyMock.expectLastCall();
 
         expectRebalance(2, Collections.emptyList(), Collections.emptyList());
@@ -2650,7 +2649,7 @@ public class DistributedHerderTest {
             TASK_CONFIGS_MAP, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), Collections.emptySet());
         expectConfigRefreshAndSnapshot(snapshotWithKey);
         // Second rebalance: poll indefinitely as worker is follower, so expiration still doesn't come into play
-        member.poll(geq(rotationTtlDelay));
+        member.poll(Long.MAX_VALUE);
         EasyMock.expectLastCall();
 
         expectRebalance(2, Collections.emptyList(), Collections.emptyList(), "member", MEMBER_URL, true);
@@ -2696,7 +2695,7 @@ public class DistributedHerderTest {
 
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         // Second rebalance: poll indefinitely as worker is no longer leader, so key expiration doesn't come into play
-        member.poll(geq(rotationTtlDelay));
+        member.poll(Long.MAX_VALUE);
         EasyMock.expectLastCall();
 
         PowerMock.replayAll(initialSecretKey);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -2115,18 +2115,11 @@ public class DistributedHerderTest {
         Capture<Callback<TargetState>> onPause = newCapture();
         worker.setTargetState(EasyMock.eq(CONN1), EasyMock.eq(TargetState.PAUSED), capture(onPause));
         PowerMock.expectLastCall().andAnswer(() -> {
-            onPause.getValue().onCompletion(null, TargetState.STARTED);
+            onPause.getValue().onCompletion(null, TargetState.PAUSED);
             return null;
         });
-        expectQueueHerderOperation();
-
-        member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
-        expectExecuteTaskReconfiguration(true, conn1SinkConfig, () -> TASK_CONFIGS);
-
-        member.ensureActive();
-        PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -2135,7 +2128,6 @@ public class DistributedHerderTest {
         herder.tick(); // join
         configUpdateListener.onConnectorTargetStateChange(CONN1); // state changes to paused
         herder.tick(); // apply state change
-        herder.tick();
 
         PowerMock.verifyAll();
     }


### PR DESCRIPTION
The current method of computing the member poll duration does not take into account the time spent on connector operations in tick(), which may be significant. This can cause a worker to sleep for longer than intended, and miss execution of background operations such as retries, REST calls, cooperative rebalance delays, and internal signing key rotations.

Instead, the computation should measure the system time at the end of tick() and use that for computing the time to the next background operation.

In addition to the title change, add a repro test which fails when the patch is not applied, and refactor the DistributedHerderTest with more accurate expectations for background operations being queued and task configurations being generated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
