### PR TITLE
HOTFIX: fix compilation error in StreamThreadTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -488,10 +488,8 @@ public class StreamThreadTest {
         final EasyMockConsumerClientSupplier mockClientSupplier = new EasyMockConsumerClientSupplier(mockConsumer);
         mockClientSupplier.setCluster(createCluster());
 
-        final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
-        topologyMetadata.buildAndRewriteTopology();
         final StreamThread thread = StreamThread.create(
-            topologyMetadata,
+            internalTopologyBuilder,
             config,
             mockClientSupplier,
             mockClientSupplier.getAdmin(config.getAdminConfigs(CLIENT_ID)),
@@ -548,8 +546,6 @@ public class StreamThreadTest {
         final EasyMockConsumerClientSupplier mockClientSupplier = new EasyMockConsumerClientSupplier(mockConsumer);
         mockClientSupplier.setCluster(createCluster());
 
-        final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
-        topologyMetadata.buildAndRewriteTopology();
         final StreamThread thread = StreamThread.create(
             internalTopologyBuilder,
             config,


### PR DESCRIPTION
When I was cherrypicking the fix for 
KAFKA-14382 back to older branches, I had been running the StreamThreadTest on all versions before pushing the fix -- but when I got to 3.0, I began to hit some kind of problem with parsing the `settings.gradle` file and was unable to build in my local env. Since everything from 3.3 to 3.1 had passed so far I foolishly assumed 
the fix on 3.0 was fine as well and just pushed it. 

Clearly that was rash, as it turned out a method used in the new test did not exist back in 3.0, causing [this commit](https://github.com/apache/kafka/commit/0ab8847bfcd5be981fb4b38ace1df415a2ec767d) to break the 3.0 branch. I was only able to figure this out when I opened a PR to sync this commit across other forks and the PR build failed due to the real compilation error rather than whatever was going on with my local gradle build. 

Anyways that's the story, and this is the fix.
