### PR TITLE
KAFKA-14414: Remove unnecessary usage of ObjectSerializationCache

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 /**
  * The header for a request in the Kafka protocol

--- a/clients/src/main/java/org/apache/kafka/common/requests/ResponseHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ResponseHeader.java
@@ -27,8 +27,10 @@ import java.util.Objects;
  * A response header in the kafka protocol.
  */
 public class ResponseHeader implements AbstractRequestResponse {
+    private final static int SIZE_NOT_INITIALIZED = -1;
     private final ResponseHeaderData data;
     private final short headerVersion;
+    private int size = SIZE_NOT_INITIALIZED;
 
     public ResponseHeader(int correlationId, short headerVersion) {
         this(new ResponseHeaderData().setCorrelationId(correlationId), headerVersion);
@@ -39,8 +41,33 @@ public class ResponseHeader implements AbstractRequestResponse {
         this.headerVersion = headerVersion;
     }
 
-    public int size(ObjectSerializationCache serializationCache) {
+    /**
+     * Calculates the size of {@link ResponseHeader} in bytes.
+     *
+     * This method to calculate size should be only when it is immediately followed by
+     * {@link #write(ByteBuffer, ObjectSerializationCache)} method call. In such cases, ObjectSerializationCache
+     * helps to avoid the serialization twice. In all other cases, {@link #size()} should be preferred instead.
+     *
+     * Calls to this method leads to calculation of size every time it is invoked. {@link #size()} should be preferred
+     * instead.
+     *
+     * Visible for testing.
+     */
+    int size(ObjectSerializationCache serializationCache) {
         return data().size(serializationCache, headerVersion);
+    }
+
+    /**
+     * Returns the size of {@link ResponseHeader} in bytes.
+     *
+     * Calls to this method are idempotent and inexpensive since it returns the cached value of size after the first
+     * invocation.
+     */
+    public int size() {
+        if (this.size == SIZE_NOT_INITIALIZED) {
+            this.size = size(new ObjectSerializationCache());
+        }
+        return size;
     }
 
     public int correlationId() {
@@ -55,7 +82,8 @@ public class ResponseHeader implements AbstractRequestResponse {
         return data;
     }
 
-    public void write(ByteBuffer buffer, ObjectSerializationCache serializationCache) {
+    // visible for testing
+    void write(ByteBuffer buffer, ObjectSerializationCache serializationCache) {
         data.write(new ByteBufferAccessor(buffer), serializationCache, headerVersion);
     }
 
@@ -68,9 +96,10 @@ public class ResponseHeader implements AbstractRequestResponse {
     }
 
     public static ResponseHeader parse(ByteBuffer buffer, short headerVersion) {
-        return new ResponseHeader(
-            new ResponseHeaderData(new ByteBufferAccessor(buffer), headerVersion),
-                headerVersion);
+        final ResponseHeader header = new ResponseHeader(
+            new ResponseHeaderData(new ByteBufferAccessor(buffer), headerVersion), headerVersion);
+        header.size = buffer.remaining();
+        return header;
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
@@ -25,6 +25,9 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class RequestHeaderTest {
 
@@ -112,5 +115,31 @@ public class RequestHeaderTest {
         assertEquals(123, parsed.correlationId());
         assertEquals(ApiKeys.FIND_COORDINATOR, parsed.apiKey());
         assertEquals((short) 10, parsed.apiVersion());
+    }
+
+    @Test
+    public void verifySizeMethodsReturnSameValue() {
+        // Create a dummy RequestHeaderData
+        RequestHeaderData headerData = new RequestHeaderData().
+            setClientId("hakuna-matata").
+            setCorrelationId(123).
+            setRequestApiKey(ApiKeys.FIND_COORDINATOR.id).
+            setRequestApiVersion((short) 10);
+
+        // Serialize RequestHeaderData to a buffer
+        ObjectSerializationCache serializationCache = new ObjectSerializationCache();
+        ByteBuffer buffer = ByteBuffer.allocate(headerData.size(serializationCache, (short) 2));
+        headerData.write(new ByteBufferAccessor(buffer), serializationCache, (short) 2);
+        buffer.flip();
+
+        // actual call to generate the RequestHeader from buffer containing RequestHeaderData
+        RequestHeader parsed = spy(RequestHeader.parse(buffer));
+
+        // verify that the result of cached value is same as actual calculation of size
+        assertEquals(parsed.size(), parsed.size(new ObjectSerializationCache()));
+
+        // verify that size(ObjectSerializationCache) is only called once, i.e. during assertEquals call. This validates
+        // that size() method does not calculate the size instead it uses the cached value
+        verify(parsed).size(any(ObjectSerializationCache.class));
     }
 }

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.message.EnvelopeResponseData
 import org.apache.kafka.common.network.Send
-import org.apache.kafka.common.protocol.{ApiKeys, Errors, ObjectSerializationCache}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{Sanitizer, Time}
@@ -110,7 +110,7 @@ object RequestChannel extends Logging {
 
     def sizeOfBodyInBytes: Int = bodyAndSize.size
 
-    def sizeInBytes: Int = header.size(new ObjectSerializationCache) + sizeOfBodyInBytes
+    def sizeInBytes: Int = header.size + sizeOfBodyInBytes
 
     //most request types are parsed entirely into objects at this point. for those we can release the underlying buffer.
     //some (like produce, or any time the schema contains fields of types BYTES or NULLABLE_BYTES) retain a reference

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -545,7 +545,6 @@ class KafkaApis(val requestChannel: RequestChannel,
    */
   def handleProduceRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     val produceRequest = request.body[ProduceRequest]
-    val requestSize = request.sizeInBytes
 
     if (RequestUtils.hasTransactionalRecords(produceRequest)) {
       val isAuthorizedTransactional = produceRequest.transactionalId != null &&
@@ -608,6 +607,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       // have been violated. If both quotas have been violated, use the max throttle time between the two quotas. Note
       // that the request quota is not enforced if acks == 0.
       val timeMs = time.milliseconds()
+      val requestSize = request.sizeInBytes
       val bandwidthThrottleTimeMs = quotas.produce.maybeRecordAndGetThrottleTimeMs(request, requestSize, timeMs)
       val requestThrottleTimeMs =
         if (produceRequest.acks == 0) 0


### PR DESCRIPTION
## Motivation 
We create an instance of ObjectSerializationCache  at https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/network/RequestChannel.scala#L113 which does not get used at all. We always "add" to the cache but never retrieve from it (as is evident by the fact that we don't store the reference of the cache anywhere).

Adding information to the cache is expensive because it uses `System.identityHashCode(Object)` which is expensive as demonstrated by the flame graph of producer requests over Apache Kafka 3.3.1 plaintext broker.

<img width="1712" alt="Screenshot 2022-11-24 at 13 57 31" src="https://user-images.githubusercontent.com/71267/203790570-af710c66-b091-416f-ae0c-c1d7dc9ab732.png">

The above graph is a stack where below the yellow line are all callers of the function. The horizontal axis demonstrates the amount of CPU used by each caller. As you will observe, `KafkaAPIs.handleProduceRequest` is a major contributor to the CPU usage.


## Change
Currently, the header of a request is parsed by the processor thread prior to adding it to RequestChannel. With this change, we cache the computed size in the `RequestHeader` object itself at the time of parsing the bytebuffer into a `RequestHeader` object. The cached size is re-used when it is required at `RequestChannel`.

## After the change
Note that the CPU utilization by the above hotspot has been eliminated.
<img width="1710" alt="Screenshot 2022-11-24 at 13 59 10" src="https://user-images.githubusercontent.com/71267/203790623-88bb1842-fad8-4047-8823-29b96a1e6090.png">

Please note how the CPU utilization by `KafkaAPIs.handleProduceRequest` has been eliminated since we don't use `ObjectSerializationCache` in that code path now.



