### PR TITLE
MINOR: Reduce impact of trace logging produce request hot path

### DIFF
--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -706,7 +706,10 @@ class ProducerStateManager(
       throw new IllegalArgumentException(s"Invalid producer id ${appendInfo.producerId} passed to update " +
         s"for partition $topicPartition")
 
-    trace(s"Updated producer ${appendInfo.producerId} state to $appendInfo")
+    if (isTraceEnabled) {
+      trace(s"Updated producer ${appendInfo.producerId} state to $appendInfo")
+    }
+    
     val updatedEntry = appendInfo.toEntry
     producers.get(appendInfo.producerId) match {
       case Some(currentEntry) =>

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -465,7 +465,10 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       producerStateManager.onHighWatermarkUpdated(newHighWatermark.messageOffset)
       maybeIncrementFirstUnstableOffset()
     }
-    trace(s"Setting high watermark $newHighWatermark")
+
+    if (isTraceEnabled) {
+      trace(s"Setting high watermark $newHighWatermark")
+    }
   }
 
   /**

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1035,7 +1035,8 @@ private[kafka] class Processor(
   // `protected` for test usage
   protected[network] def sendResponse(response: RequestChannel.Response, responseSend: Send): Unit = {
     val connectionId = response.request.context.connectionId
-    trace(s"Socket server received response to send to $connectionId, registering for write and sending data: $response")
+    if (isTraceEnabled)
+      trace(s"Socket server received response to send to $connectionId, registering for write and sending data: $response")
     // `channel` can be None if the connection was closed remotely or if selector closed it for being idle for too long
     if (channel(connectionId).isEmpty) {
       warn(s"Attempting to send response via channel for which there is no open connection, connection id $connectionId")

--- a/core/src/main/scala/kafka/server/DelayedProduce.scala
+++ b/core/src/main/scala/kafka/server/DelayedProduce.scala
@@ -67,7 +67,9 @@ class DelayedProduce(delayMs: Long,
       status.acksPending = false
     }
 
-    trace(s"Initial partition status for $topicPartition is $status")
+    if (isTraceEnabled) {
+      trace(s"Initial partition status for $topicPartition is $status")
+    }
   }
 
   /**
@@ -84,7 +86,11 @@ class DelayedProduce(delayMs: Long,
   override def tryComplete(): Boolean = {
     // check for each partition if it still has pending acks
     produceMetadata.produceStatus.forKeyValue { (topicPartition, status) =>
-      trace(s"Checking produce satisfaction for $topicPartition, current status $status")
+
+      if (isTraceEnabled) {
+        trace(s"Checking produce satisfaction for $topicPartition, current status $status")
+      }
+
       // skip those partitions that have already been satisfied
       if (status.acksPending) {
         val (hasEnough, error) = replicaManager.getPartitionOrError(topicPartition) match {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -162,8 +162,10 @@ class KafkaApis(val requestChannel: RequestChannel,
    */
   override def handle(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     try {
-      trace(s"Handling request:${request.requestDesc(true)} from connection ${request.context.connectionId};" +
-        s"securityProtocol:${request.context.securityProtocol},principal:${request.context.principal}")
+      if (isTraceEnabled) {
+        trace(s"Handling request:${request.requestDesc(true)} from connection ${request.context.connectionId};" +
+          s"securityProtocol:${request.context.securityProtocol},principal:${request.context.principal}")
+      }
 
       if (!apiVersionManager.isApiEnabled(request.header.apiKey)) {
         // The socket server will reject APIs which are not exposed in this scope and close the connection

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -71,7 +71,11 @@ class KafkaRequestHandler(id: Int,
         case request: RequestChannel.Request =>
           try {
             request.requestDequeueTimeNanos = endTime
-            trace(s"Kafka request handler $id on broker $brokerId handling request $request")
+
+            if (isTraceEnabled) {
+              trace(s"Kafka request handler $id on broker $brokerId handling request $request")
+            }
+
             apis.handle(request, requestLocal)
           } catch {
             case e: FatalExitError =>


### PR DESCRIPTION
The impact of trace logging is normally small, however this adds up with trace is called multiple times per produce request in the produce request hot path.

This PR adds a conditional check for trace logging in the produce request code hot path.

<img width="2067" alt="Screenshot 2022-11-22 at 16 58 48" src="https://user-images.githubusercontent.com/71267/203364025-7c29cb7e-c9e8-477b-918e-c80d4b6d4e73.png">

