### PR TITLE
KAFKA-14386: Return TopicAssignment from the ReplicaPlacer

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1567,12 +1567,11 @@ public class ReplicationControlManager {
                 isrs.add(isr);
             }
         } else {
-            partitionAssignments = clusterControl.replicaPlacer().place(new PlacementSpec(
-                startPartitionId,
-                additional,
-                replicationFactor
-            ), clusterDescriber).assignments();
-            isrs = partitionAssignments.stream().map(x -> x.replicas()).collect(Collectors.toList());
+            partitionAssignments = clusterControl.replicaPlacer().place(
+                new PlacementSpec(startPartitionId, additional, replicationFactor),
+                clusterDescriber
+            ).assignments();
+            isrs = partitionAssignments.stream().map(PartitionAssignment::replicas).collect(Collectors.toList());
         }
         int partitionId = startPartitionId;
         for (int i = 0; i < partitionAssignments.size(); i++) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -84,7 +84,9 @@ import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.metadata.placement.ClusterDescriber;
+import org.apache.kafka.metadata.placement.PartitionAssignment;
 import org.apache.kafka.metadata.placement.PlacementSpec;
+import org.apache.kafka.metadata.placement.TopicAssignment;
 import org.apache.kafka.metadata.placement.UsableBroker;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -694,13 +696,14 @@ public class ReplicationControlManager {
             short replicationFactor = topic.replicationFactor() == -1 ?
                 defaultReplicationFactor : topic.replicationFactor();
             try {
-                List<List<Integer>> partitions = clusterControl.replicaPlacer().place(new PlacementSpec(
+                TopicAssignment topicAssignment = clusterControl.replicaPlacer().place(new PlacementSpec(
                     0,
                     numPartitions,
                     replicationFactor
                 ), clusterDescriber);
-                for (int partitionId = 0; partitionId < partitions.size(); partitionId++) {
-                    List<Integer> replicas = partitions.get(partitionId);
+                for (int partitionId = 0; partitionId < topicAssignment.assignments().size(); partitionId++) {
+                    PartitionAssignment partitionAssignment = topicAssignment.assignments().get(partitionId);
+                    List<Integer> replicas = partitionAssignment.replicas();
                     List<Integer> isr = replicas.stream().
                         filter(clusterControl::active).collect(Collectors.toList());
                     // If the ISR is empty, it means that all brokers are fenced or
@@ -1544,16 +1547,16 @@ public class ReplicationControlManager {
         short replicationFactor = (short) partitionInfo.replicas.length;
         int startPartitionId = topicInfo.parts.size();
 
-        List<List<Integer>> placements;
+        List<PartitionAssignment> partitionAssignments;
         List<List<Integer>> isrs;
         if (topic.assignments() != null) {
-            placements = new ArrayList<>();
+            partitionAssignments = new ArrayList<>();
             isrs = new ArrayList<>();
             for (int i = 0; i < topic.assignments().size(); i++) {
                 CreatePartitionsAssignment assignment = topic.assignments().get(i);
                 validateManualPartitionAssignment(assignment.brokerIds(),
                     OptionalInt.of(replicationFactor));
-                placements.add(assignment.brokerIds());
+                partitionAssignments.add(new PartitionAssignment(assignment.brokerIds()));
                 List<Integer> isr = assignment.brokerIds().stream().
                     filter(clusterControl::active).collect(Collectors.toList());
                 if (isr.isEmpty()) {
@@ -1564,16 +1567,17 @@ public class ReplicationControlManager {
                 isrs.add(isr);
             }
         } else {
-            placements = clusterControl.replicaPlacer().place(new PlacementSpec(
+            partitionAssignments = clusterControl.replicaPlacer().place(new PlacementSpec(
                 startPartitionId,
                 additional,
                 replicationFactor
-            ), clusterDescriber);
-            isrs = placements;
+            ), clusterDescriber).assignments();
+            isrs = partitionAssignments.stream().map(x -> x.replicas()).collect(Collectors.toList());
         }
         int partitionId = startPartitionId;
-        for (int i = 0; i < placements.size(); i++) {
-            List<Integer> replicas = placements.get(i);
+        for (int i = 0; i < partitionAssignments.size(); i++) {
+            PartitionAssignment partitionAssignment = partitionAssignments.get(i);
+            List<Integer> replicas = partitionAssignment.replicas();
             List<Integer> isr = isrs.get(i).stream().
                 filter(clusterControl::active).collect(Collectors.toList());
             // If the ISR is empty, it means that all brokers are fenced or

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.metadata.placement;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -31,7 +32,7 @@ public class PartitionAssignment {
     private final List<Integer> replicas;
 
     public PartitionAssignment(final List<Integer> replicas) {
-        this.replicas = Collections.unmodifiableList(replicas);
+        this.replicas = Collections.unmodifiableList(new ArrayList<>(replicas));
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -17,27 +17,24 @@
 
 package org.apache.kafka.metadata.placement;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.errors.InvalidReplicationFactorException;
-
+import java.util.List;
 
 /**
- * The interface which a Kafka replica placement policy must implement.
+ * The KRaft partition assignment.
+ *
+ * The assignment is represented as a list of integers where each integer is the replica ID.
  */
-@InterfaceStability.Unstable
-public interface ReplicaPlacer {
+public class PartitionAssignment {
+    private List<Integer> replicas;
+
+    public PartitionAssignment(List<Integer> replicas) {
+        this.replicas = replicas;
+    }
+
     /**
-     * Create a new replica placement.
-     *
-     * @param placement     What we're trying to place.
-     * @param cluster       A description of the cluster we're trying to place in.
-     *
-     * @return              A topic assignment.
-     *
-     * @throws InvalidReplicationFactorException    If too many replicas were requested.
+     * @return The partition assignment that consists of a list of replica IDs.
      */
-    TopicAssignment place(
-        PlacementSpec placement,
-        ClusterDescriber cluster
-    ) throws InvalidReplicationFactorException;
+    public List<Integer> replicas() {
+        return replicas;
+    }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -24,7 +24,8 @@ import java.util.Objects;
 /**
  * The partition assignment.
  *
- * The assignment is represented as a list of integers where each integer is the replica ID.
+ * The assignment is represented as a list of integers where each integer is the replica ID. This class is immutable.
+ * It's internal state does not change.
  */
 public class PartitionAssignment {
     private final List<Integer> replicas;

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.metadata.placement;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,7 +30,7 @@ public class PartitionAssignment {
     private final List<Integer> replicas;
 
     public PartitionAssignment(final List<Integer> replicas) {
-        this.replicas = replicas;
+        this.replicas = Collections.unmodifiableList(replicas);
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -18,16 +18,17 @@
 package org.apache.kafka.metadata.placement;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
- * The KRaft partition assignment.
+ * The partition assignment.
  *
  * The assignment is represented as a list of integers where each integer is the replica ID.
  */
 public class PartitionAssignment {
-    private List<Integer> replicas;
+    private final List<Integer> replicas;
 
-    public PartitionAssignment(List<Integer> replicas) {
+    public PartitionAssignment(final List<Integer> replicas) {
         this.replicas = replicas;
     }
 
@@ -36,5 +37,17 @@ public class PartitionAssignment {
      */
     public List<Integer> replicas() {
         return replicas;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PartitionAssignment)) return false;
+        PartitionAssignment other = (PartitionAssignment) o;
+        return replicas.equals(other.replicas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(replicas);
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.metadata.OptionalStringComparator;
@@ -427,7 +428,7 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
     }
 
     @Override
-    public List<List<Integer>> place(
+    public TopicAssignment place(
         PlacementSpec placement,
         ClusterDescriber cluster
     ) throws InvalidReplicationFactorException {
@@ -440,6 +441,6 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
         for (int partition = 0; partition < placement.numPartitions(); partition++) {
             placements.add(rackList.place(placement.numReplicas()));
         }
-        return placements;
+        return new TopicAssignment(placements.stream().map(x -> new PartitionAssignment(x)).collect(Collectors.toList()));
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
@@ -441,6 +441,8 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
         for (int partition = 0; partition < placement.numPartitions(); partition++) {
             placements.add(rackList.place(placement.numReplicas()));
         }
-        return new TopicAssignment(placements.stream().map(x -> new PartitionAssignment(x)).collect(Collectors.toList()));
+        return new TopicAssignment(
+            placements.stream().map(PartitionAssignment::new).collect(Collectors.toList())
+        );
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.metadata.placement;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,7 +28,7 @@ public class TopicAssignment {
     private final List<PartitionAssignment> assignments;
 
     public TopicAssignment(final List<PartitionAssignment> assignments) {
-        this.assignments = assignments;
+        this.assignments = Collections.unmodifiableList(assignments);
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.metadata.placement;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -30,7 +31,7 @@ public class TopicAssignment {
     private final List<PartitionAssignment> assignments;
 
     public TopicAssignment(final List<PartitionAssignment> assignments) {
-        this.assignments = Collections.unmodifiableList(assignments);
+        this.assignments = Collections.unmodifiableList(new ArrayList<>(assignments));
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -20,6 +20,7 @@ package org.apache.kafka.metadata.placement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * The topic assignment.
@@ -28,7 +29,8 @@ public class TopicAssignment {
     private final List<PartitionAssignment> assignments;
 
     public TopicAssignment(final List<PartitionAssignment> assignments) {
-        this.assignments = Collections.unmodifiableList(assignments);
+        this.assignments = Collections.unmodifiableList(
+            assignments.stream().map(p -> new PartitionAssignment(Collections.unmodifiableList(p.replicas()))).collect(Collectors.toList()));
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -17,27 +17,23 @@
 
 package org.apache.kafka.metadata.placement;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.errors.InvalidReplicationFactorException;
-
+import java.util.List;
 
 /**
- * The interface which a Kafka replica placement policy must implement.
+ * The KRaft topic assignment.
  */
-@InterfaceStability.Unstable
-public interface ReplicaPlacer {
+public class TopicAssignment {
+    private List<PartitionAssignment> assignments;
+
+    public TopicAssignment(List<PartitionAssignment> assignments) {
+        this.assignments = assignments;
+    }
+
     /**
-     * Create a new replica placement.
-     *
-     * @param placement     What we're trying to place.
-     * @param cluster       A description of the cluster we're trying to place in.
-     *
-     * @return              A topic assignment.
-     *
-     * @throws InvalidReplicationFactorException    If too many replicas were requested.
+     * @return The replica assignment for each partition, where the index in the list corresponds to different partition.
      */
-    TopicAssignment place(
-        PlacementSpec placement,
-        ClusterDescriber cluster
-    ) throws InvalidReplicationFactorException;
+    public List<PartitionAssignment> assignments() {
+        return assignments;
+    }
+
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -20,17 +20,17 @@ package org.apache.kafka.metadata.placement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * The topic assignment.
+ *
+ * This class is immutable. It's internal state does not change.
  */
 public class TopicAssignment {
     private final List<PartitionAssignment> assignments;
 
     public TopicAssignment(final List<PartitionAssignment> assignments) {
-        this.assignments = Collections.unmodifiableList(
-            assignments.stream().map(p -> new PartitionAssignment(Collections.unmodifiableList(p.replicas()))).collect(Collectors.toList()));
+        this.assignments = Collections.unmodifiableList(assignments);
     }
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -18,14 +18,15 @@
 package org.apache.kafka.metadata.placement;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
- * The KRaft topic assignment.
+ * The topic assignment.
  */
 public class TopicAssignment {
-    private List<PartitionAssignment> assignments;
+    private final List<PartitionAssignment> assignments;
 
-    public TopicAssignment(List<PartitionAssignment> assignments) {
+    public TopicAssignment(final List<PartitionAssignment> assignments) {
         this.assignments = assignments;
     }
 
@@ -36,4 +37,15 @@ public class TopicAssignment {
         return assignments;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TopicAssignment)) return false;
+        TopicAssignment other = (TopicAssignment) o;
+        return assignments.equals(other.assignments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(assignments);
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.metadata.BrokerRegistrationReply;
 import org.apache.kafka.metadata.FinalizedControllerFeatures;
 import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.metadata.VersionRange;
+import org.apache.kafka.metadata.placement.PartitionAssignment;
 import org.apache.kafka.metadata.placement.PlacementSpec;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -56,7 +57,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_3_IV2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -401,14 +401,14 @@ public class ClusterControlManagerTest {
                 String.format("broker %d was not unfenced.", i));
         }
         for (int i = 0; i < 100; i++) {
-            List<List<Integer>> results = clusterControl.replicaPlacer().place(
+            List<PartitionAssignment> results = clusterControl.replicaPlacer().place(
                 new PlacementSpec(0,
                     1,
                     (short) 3),
                     () -> clusterControl.usableBrokers()
-            ).assignments().stream().map(x -> x.replicas()).collect(Collectors.toList());
+            ).assignments();
             HashSet<Integer> seen = new HashSet<>();
-            for (Integer result : results.get(0)) {
+            for (Integer result : results.get(0).replicas()) {
                 assertTrue(result >= 0);
                 assertTrue(result < numUsableBrokers);
                 assertTrue(seen.add(result));

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -41,9 +41,7 @@ import org.apache.kafka.metadata.BrokerRegistrationReply;
 import org.apache.kafka.metadata.FinalizedControllerFeatures;
 import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.metadata.VersionRange;
-import org.apache.kafka.metadata.placement.ClusterDescriber;
 import org.apache.kafka.metadata.placement.PlacementSpec;
-import org.apache.kafka.metadata.placement.UsableBroker;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -56,9 +54,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_3_IV2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -407,13 +405,8 @@ public class ClusterControlManagerTest {
                 new PlacementSpec(0,
                     1,
                     (short) 3),
-                new ClusterDescriber() {
-                    @Override
-                    public Iterator<UsableBroker> usableBrokers() {
-                        return clusterControl.usableBrokers();
-                    }
-                }
-            );
+                    () -> clusterControl.usableBrokers()
+            ).assignments().stream().map(x -> x.replicas()).collect(Collectors.toList());
             HashSet<Integer> seen = new HashSet<>();
             for (Integer result : results.get(0)) {
                 assertTrue(result >= 0);

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -405,7 +405,7 @@ public class ClusterControlManagerTest {
                 new PlacementSpec(0,
                     1,
                     (short) 3),
-                    () -> clusterControl.usableBrokers()
+                    clusterControl::usableBrokers
             ).assignments();
             HashSet<Integer> seen = new HashSet<>();
             for (Integer result : results.get(0).replicas()) {

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
@@ -37,10 +37,10 @@ public class PartitionAssignmentTest {
     public void testConsistentEqualsAndHashCode() {
         List<PartitionAssignment> partitionAssignments = Arrays.asList(
             new PartitionAssignment(
-                    Arrays.asList(0, 1, 2)
+                Arrays.asList(0, 1, 2)
             ),
             new PartitionAssignment(
-                    Arrays.asList(1, 2, 0)
+                Arrays.asList(1, 2, 0)
             )
         );
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
@@ -48,6 +48,7 @@ public class PartitionAssignmentTest {
             for (int j = 0; j < partitionAssignments.size(); j++) {
                 if (i == j) {
                     assertEquals(partitionAssignments.get(i), partitionAssignments.get(j));
+                    assertEquals(partitionAssignments.get(i), new PartitionAssignment(partitionAssignments.get(i).replicas()));
                     assertEquals(partitionAssignments.get(i).hashCode(), partitionAssignments.get(j).hashCode());
                 } else {
                     assertNotEquals(partitionAssignments.get(i), partitionAssignments.get(j));

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.placement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PartitionAssignmentTest {
+
+    @Test
+    public void testPartitionAssignmentReplicas() {
+        List<Integer> replicas = Arrays.asList(0, 1, 2);
+        assertEquals(replicas, new PartitionAssignment(replicas).replicas());
+    }
+
+    @Test
+    public void testConsistentEqualsAndHashCode() {
+        List<PartitionAssignment> partitionAssignments = Arrays.asList(
+            new PartitionAssignment(
+                    Arrays.asList(0, 1, 2)
+            ),
+            new PartitionAssignment(
+                    Arrays.asList(1, 2, 0)
+            )
+        );
+
+        for (int i = 0; i < partitionAssignments.size(); i++) {
+            for (int j = 0; j < partitionAssignments.size(); j++) {
+                if (i == j) {
+                    assertEquals(partitionAssignments.get(i), partitionAssignments.get(j));
+                    assertEquals(partitionAssignments.get(i).hashCode(), partitionAssignments.get(j).hashCode());
+                } else {
+                    assertNotEquals(partitionAssignments.get(i), partitionAssignments.get(j));
+                    assertNotEquals(partitionAssignments.get(i).hashCode(), partitionAssignments.get(j).hashCode());
+                }
+            }
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
@@ -48,7 +48,6 @@ public class PartitionAssignmentTest {
             for (int j = 0; j < partitionAssignments.size(); j++) {
                 if (i == j) {
                     assertEquals(partitionAssignments.get(i), partitionAssignments.get(j));
-                    assertEquals(partitionAssignments.get(i), new PartitionAssignment(partitionAssignments.get(i).replicas()));
                     assertEquals(partitionAssignments.get(i).hashCode(), partitionAssignments.get(j).hashCode());
                 } else {
                     assertNotEquals(partitionAssignments.get(i), partitionAssignments.get(j));

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
@@ -94,8 +94,7 @@ public class StripedReplicaPlacerTest {
         PlacementSpec placementSpec = new PlacementSpec(startPartition,
             numPartitions,
             replicationFactor);
-        ClusterDescriber cluster = () -> brokers.iterator();
-        return placer.place(placementSpec, cluster);
+        return placer.place(placementSpec, brokers::iterator);
     }
 
     /**

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,7 +102,7 @@ public class StripedReplicaPlacerTest {
                 return brokers.iterator();
             }
         };
-        return placer.place(placementSpec, cluster);
+        return placer.place(placementSpec, cluster).assignments().stream().map(x -> x.replicas()).collect(Collectors.toList());
     }
 
     /**

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
@@ -61,6 +61,7 @@ public class TopicAssignmentTest {
             for (int j = 0; j < topicAssignments.size(); j++) {
                 if (i == j) {
                     assertEquals(topicAssignments.get(i), topicAssignments.get(j));
+                    assertEquals(topicAssignments.get(i), new TopicAssignment(topicAssignments.get(i).assignments()));
                     assertEquals(topicAssignments.get(i).hashCode(), topicAssignments.get(j).hashCode());
                 } else {
                     assertNotEquals(topicAssignments.get(i), topicAssignments.get(j));

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.placement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TopicAssignmentTest {
+
+    @Test
+    public void testTopicAssignmentReplicas() {
+        List<Integer> replicasP0 = Arrays.asList(0, 1, 2);
+        List<Integer> replicasP1 = Arrays.asList(1, 2, 0);
+        List<PartitionAssignment> partitionAssignments = Arrays.asList(
+            new PartitionAssignment(replicasP0),
+             new PartitionAssignment(replicasP1)
+        );
+        assertEquals(partitionAssignments, new TopicAssignment(partitionAssignments).assignments());
+    }
+
+    @Test
+    public void testConsistentEqualsAndHashCode() {
+        List<TopicAssignment> topicAssignments = Arrays.asList(
+            new TopicAssignment(
+                Arrays.asList(
+                    new PartitionAssignment(
+                        Arrays.asList(0, 1, 2)
+                    )
+                )
+            ),
+            new TopicAssignment(
+                Arrays.asList(
+                    new PartitionAssignment(
+                            Arrays.asList(1, 2, 0)
+                    )
+                 )
+            )
+        );
+
+        for (int i = 0; i < topicAssignments.size(); i++) {
+            for (int j = 0; j < topicAssignments.size(); j++) {
+                if (i == j) {
+                    assertEquals(topicAssignments.get(i), topicAssignments.get(j));
+                    assertEquals(topicAssignments.get(i).hashCode(), topicAssignments.get(j).hashCode());
+                } else {
+                    assertNotEquals(topicAssignments.get(i), topicAssignments.get(j));
+                    assertNotEquals(topicAssignments.get(i).hashCode(), topicAssignments.get(j).hashCode());
+                }
+            }
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
@@ -61,7 +61,6 @@ public class TopicAssignmentTest {
             for (int j = 0; j < topicAssignments.size(); j++) {
                 if (i == j) {
                     assertEquals(topicAssignments.get(i), topicAssignments.get(j));
-                    assertEquals(topicAssignments.get(i), new TopicAssignment(topicAssignments.get(i).assignments()));
                     assertEquals(topicAssignments.get(i).hashCode(), topicAssignments.get(j).hashCode());
                 } else {
                     assertNotEquals(topicAssignments.get(i), topicAssignments.get(j));

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
@@ -51,7 +51,7 @@ public class TopicAssignmentTest {
             new TopicAssignment(
                 Arrays.asList(
                     new PartitionAssignment(
-                            Arrays.asList(1, 2, 0)
+                        Arrays.asList(1, 2, 0)
                     )
                  )
             )


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/KAFKA-14386

### Summary
This changes the `ReplicaPlacer` interface to return a class instead of a list of list of integers. There are two reasons for the suggestion. First, as mentioned in the JIRA, it will make the interface, arguably, a bit more readable and understandable by explicitly modeling the idea of topic and partition. Second and more importantly, it makes the interface more extendable in the future. Right now it would be challenging to add more metadata to the response. By having classes, we can easily add fields to them without breaking/changing the interface. For example, in the CreatePartitions RPC we are adding partitions to an existing topic and we might want to add some metadata to response making it clear which partition the assignment starts at which could look something like:

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
