### PR TITLE
KAFKA-14260: add `synchronized` to `prefixScan` method

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -169,7 +169,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     }
 
     @Override
-    public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer) {
+    public synchronized <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer) {
 
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
         final Bytes to = Bytes.increment(from);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -656,10 +656,10 @@ public abstract class AbstractKeyValueStoreTest {
         store.put(1, "one");
         store.put(2, "two");
         store.put(3, "three");
-        store.prefixScan("prefix", serializer);
+        final Iterator iterator = store.prefixScan("prefix", serializer);
         store.delete(2);
-        store.range(0, 3);
-        
+        iterator.next();
+
     }
 }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -656,10 +656,13 @@ public abstract class AbstractKeyValueStoreTest {
         store.put(1, "one");
         store.put(2, "two");
         store.put(3, "three");
-        final Iterator iterator = store.prefixScan("prefix", serializer);
-        store.delete(2);
-        iterator.next();
+        final Iterator iter = store.prefixScan("prefix", serializer);
+        store.delete(2);  
 
-    }
+        while (iter.hasNext()) {
+            iter.next();
+        }
+
+    }                  
 }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -662,8 +662,8 @@ public abstract class AbstractKeyValueStoreTest {
         while (iter.hasNext()) {
             iter.next();
         } 
-        iter.close()
 
+        store.close();
 
     }                  
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -661,7 +661,9 @@ public abstract class AbstractKeyValueStoreTest {
 
         while (iter.hasNext()) {
             iter.next();
-        }
+        } 
+        iter.close()
+
 
     }                  
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -55,7 +55,6 @@ import static org.junit.Assert.fail;
 public abstract class AbstractKeyValueStoreTest {
 
     protected abstract <K, V> KeyValueStore<K, V> createKeyValueStore(final StateStoreContext context);
-
     protected InternalMockProcessorContext context;
     protected KeyValueStore<Integer, String> store;
     protected KeyValueStoreTestDriver<Integer, String> driver;
@@ -648,4 +647,19 @@ public abstract class AbstractKeyValueStoreTest {
             );
         }
     }
+
+    @Test
+    public void prefixScanShouldNotThrowConcurrentModificationException() {
+        final Serializer<String> serializer = new StringSerializer();
+
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+        store.put(3, "three");
+        store.prefixScan("prefix", serializer);
+        store.delete(2);
+        store.range(0, 3);
+        
+    }
 }
+

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -650,21 +651,22 @@ public abstract class AbstractKeyValueStoreTest {
 
     @Test
     public void prefixScanShouldNotThrowConcurrentModificationException() {
-        final Serializer<String> serializer = new StringSerializer();
 
         store.put(0, "zero");
         store.put(1, "one");
+        store.put(222, "two-hundred-twenty-two");
         store.put(2, "two");
+        store.put(22, "twenty-two");
         store.put(3, "three");
-        final Iterator iter = store.prefixScan("prefix", serializer);
-        store.delete(2);  
 
-        while (iter.hasNext()) {
-            iter.next();
-        } 
+        try (final KeyValueIterator<Integer, String> iter = store.prefixScan(2, new IntegerSerializer())) {
 
-        store.close();
+            store.delete(22);
 
+            while (iter.hasNext()) {
+                iter.next();
+            }
+        }
     }                  
 }
 


### PR DESCRIPTION
As a result of "[14260: InMemoryKeyValueStore iterator still throws ConcurrentModificationException](https://issues.apache.org/jira/browse/KAFKA-14260)", I'm adding `synchronized` to `prefixScan` as an alternative to going back to the `ConcurrentSkipList`. 

I've read up on testing multi-threaded behavior and I believe it's best to leave the testing as it is for now as testing whether `synchronized` works doesn't always work. I did make sure `./gradlew test` was green on my branch. Happy to be corrected here. 

This is my first PR. As of the [guidelines](https://cwiki.apache.org/confluence/display/KAFKA/Contributing+Code+Changes), I  that the contribution is my original work and that I license the work to the project under the project's open source license. I see that I also need to make a build trigger request, @ableegoldman I would appreciate one please :) 

I do not believe this requires a documentation update as it is just bringing a method up to standard. Again, happy to help out if it turns out otherwise. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
