### PR TITLE
KAFKA-14430: Specify JMX RMI port system property when not already set

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -212,7 +212,11 @@ fi
 
 # JMX port to use
 if [  $JMX_PORT ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT $KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  if ! echo "$KAFKA_JMX_OPTS" | grep -qF -- '-Dcom.sun.management.jmxremote.rmi.port=' ; then
+    # If unset, set the RMI port to address issues with monitoring Kafka running in containers
+    KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
+  fi
 fi
 
 # Log directory to use

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -212,7 +212,7 @@ fi
 
 # JMX port to use
 if [  $JMX_PORT ]; then
-  KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 
 # Log directory to use

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -212,7 +212,7 @@ fi
 
 # JMX port to use
 if [  $JMX_PORT ]; then
-  KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT $KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 
 # Log directory to use


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

In case the server has a firewall, exposing only 'com.sun.management.jmxremote.port' cannot fetch metrics, and when the rmi port is not specified, it is randomly generated by default, should make the two ports consistent for metrics data reading

https://bugs.openjdk.org/browse/JDK-8035404?page=com.atlassian.jira.plugin.system.issuetabpanels%3Achangehistory-tabpanel
https://www.baeldung.com/jmx-ports

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
