### PR TITLE
KAFKA-14413: Separate MirrorMaker configurations for each connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1062,7 +1062,9 @@ project(':core') {
                                ':connect:runtime:genConnectPredicateDocs',
                                ':connect:runtime:genSinkConnectorConfigDocs', ':connect:runtime:genSourceConnectorConfigDocs',
                                ':streams:genStreamsConfigDocs', 'genConsumerMetricsDocs', 'genProducerMetricsDocs',
-                               ':connect:runtime:genConnectMetricsDocs', ':connect:runtime:genConnectOpenAPIDocs'], type: Tar) {
+                               ':connect:runtime:genConnectMetricsDocs', ':connect:runtime:genConnectOpenAPIDocs',
+                               ':connect:mirror:genMirrorSourceConfigDocs', ':connect:mirror:genMirrorCheckpointConfigDocs',
+                               ':connect:mirror:genMirrorHeartbeatConfigDocs'], type: Tar) {
     archiveClassifier = 'site-docs'
     compression = Compression.GZIP
     from project.file("$rootDir/docs")
@@ -2831,6 +2833,27 @@ project(':connect:mirror') {
     }
     into "$buildDir/dependant-libs"
     duplicatesStrategy 'exclude'
+  }
+
+  task genMirrorSourceConfigDocs(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'org.apache.kafka.connect.mirror.MirrorSourceConfig'
+    if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
+    standardOutput = new File(generatedDocsDir, "mirror_source_config.html").newOutputStream()
+  }
+
+  task genMirrorCheckpointConfigDocs(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'org.apache.kafka.connect.mirror.MirrorCheckpointConfig'
+    if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
+    standardOutput = new File(generatedDocsDir, "mirror_checkpoint_config.html").newOutputStream()
+  }
+
+  task genMirrorHeartbeatConfigDocs(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'org.apache.kafka.connect.mirror.MirrorHeartbeatConfig'
+    if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
+    standardOutput = new File(generatedDocsDir, "mirror_heartbeat_config.html").newOutputStream()
   }
 
   jar {

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.ConfigUtils;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+public class MirrorCheckpointConfig extends MirrorConnectorConfig {
+
+    public static final String TOPIC_FILTER_CLASS = "topic.filter.class";
+    private static final String TOPIC_FILTER_CLASS_DOC = "TopicFilter to use. Selects topics to replicate.";
+    public static final Class<?> TOPIC_FILTER_CLASS_DEFAULT = DefaultTopicFilter.class;
+
+    protected static final String REFRESH_GROUPS = "refresh.groups";
+    protected static final String EMIT_CHECKPOINTS = "emit.checkpoints";
+    protected static final String SYNC_GROUP_OFFSETS = "sync.group.offsets";
+
+    public static final String GROUPS = DefaultGroupFilter.GROUPS_INCLUDE_CONFIG;
+    public static final String GROUPS_DEFAULT = DefaultGroupFilter.GROUPS_INCLUDE_DEFAULT;
+    private static final String GROUPS_DOC = "Consumer groups to replicate. Supports comma-separated group IDs and regexes.";
+    public static final String GROUPS_EXCLUDE = DefaultGroupFilter.GROUPS_EXCLUDE_CONFIG;
+    public static final String GROUPS_EXCLUDE_ALIAS = DefaultGroupFilter.GROUPS_EXCLUDE_CONFIG_ALIAS;
+
+    public static final String GROUPS_EXCLUDE_DEFAULT = DefaultGroupFilter.GROUPS_EXCLUDE_DEFAULT;
+    private static final String GROUPS_EXCLUDE_DOC = "Exclude groups. Supports comma-separated group IDs and regexes."
+            + " Excludes take precedence over includes.";
+
+    public static final String CHECKPOINTS_TOPIC_REPLICATION_FACTOR = "checkpoints.topic.replication.factor";
+    public static final String CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for checkpoints topic.";
+    public static final short CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
+
+    protected static final String TASK_CONSUMER_GROUPS = "task.assigned.groups";
+
+    public static final String CONSUMER_POLL_TIMEOUT_MILLIS = "consumer.poll.timeout.ms";
+    private static final String CONSUMER_POLL_TIMEOUT_MILLIS_DOC = "Timeout when polling source cluster.";
+    public static final long CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT = 1000L;
+
+    public static final String REFRESH_GROUPS_ENABLED = REFRESH_GROUPS + ENABLED_SUFFIX;
+    private static final String REFRESH_GROUPS_ENABLED_DOC = "Whether to periodically check for new consumer groups.";
+    public static final boolean REFRESH_GROUPS_ENABLED_DEFAULT = true;
+    public static final String REFRESH_GROUPS_INTERVAL_SECONDS = REFRESH_GROUPS + INTERVAL_SECONDS_SUFFIX;
+    private static final String REFRESH_GROUPS_INTERVAL_SECONDS_DOC = "Frequency of group refresh.";
+    public static final long REFRESH_GROUPS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
+
+    public static final String EMIT_CHECKPOINTS_ENABLED = EMIT_CHECKPOINTS + ENABLED_SUFFIX;
+    private static final String EMIT_CHECKPOINTS_ENABLED_DOC = "Whether to replicate consumer offsets to target cluster.";
+    public static final boolean EMIT_CHECKPOINTS_ENABLED_DEFAULT = true;
+    public static final String EMIT_CHECKPOINTS_INTERVAL_SECONDS = EMIT_CHECKPOINTS + INTERVAL_SECONDS_SUFFIX;
+    private static final String EMIT_CHECKPOINTS_INTERVAL_SECONDS_DOC = "Frequency of checkpoints.";
+    public static final long EMIT_CHECKPOINTS_INTERVAL_SECONDS_DEFAULT = 60;
+
+    public static final String SYNC_GROUP_OFFSETS_ENABLED = SYNC_GROUP_OFFSETS + ENABLED_SUFFIX;
+    private static final String SYNC_GROUP_OFFSETS_ENABLED_DOC = "Whether to periodically write the translated offsets to __consumer_offsets topic in target cluster, as long as no active consumers in that group are connected to the target cluster";
+    public static final boolean SYNC_GROUP_OFFSETS_ENABLED_DEFAULT = false;
+    public static final String SYNC_GROUP_OFFSETS_INTERVAL_SECONDS = SYNC_GROUP_OFFSETS + INTERVAL_SECONDS_SUFFIX;
+    private static final String SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DOC = "Frequency of consumer group offset sync.";
+    public static final long SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DEFAULT = 60;
+
+    public static final String GROUP_FILTER_CLASS = "group.filter.class";
+    private static final String GROUP_FILTER_CLASS_DOC = "GroupFilter to use. Selects consumer groups to replicate.";
+    public static final Class<?> GROUP_FILTER_CLASS_DEFAULT = DefaultGroupFilter.class;
+
+    private static final String OFFSET_SYNCS_TOPIC_LOCATION = "offset-syncs.topic.location";
+    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
+    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
+
+    public MirrorCheckpointConfig(Map<String, String> props) {
+        super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{
+                {GROUPS_EXCLUDE, GROUPS_EXCLUDE_ALIAS},
+        }));
+    }
+
+    public MirrorCheckpointConfig(ConfigDef configDef, Map<String, String> props) {
+        super(configDef, props);
+    }
+
+    Duration emitCheckpointsInterval() {
+        if (getBoolean(EMIT_CHECKPOINTS_ENABLED)) {
+            return Duration.ofSeconds(getLong(EMIT_CHECKPOINTS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    Duration refreshGroupsInterval() {
+        if (getBoolean(REFRESH_GROUPS_ENABLED)) {
+            return Duration.ofSeconds(getLong(REFRESH_GROUPS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    short checkpointsTopicReplicationFactor() {
+        return getShort(CHECKPOINTS_TOPIC_REPLICATION_FACTOR);
+    }
+
+    GroupFilter groupFilter() {
+        return getConfiguredInstance(GROUP_FILTER_CLASS, GroupFilter.class);
+    }
+
+    TopicFilter topicFilter() {
+        return getConfiguredInstance(TOPIC_FILTER_CLASS, TopicFilter.class);
+    }
+
+    Duration syncGroupOffsetsInterval() {
+        if (getBoolean(SYNC_GROUP_OFFSETS_ENABLED)) {
+            return Duration.ofSeconds(getLong(SYNC_GROUP_OFFSETS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    Map<String, String> taskConfigForConsumerGroups(List<String> groups) {
+        Map<String, String> props = originalsStrings();
+        props.put(TASK_CONSUMER_GROUPS, String.join(",", groups));
+        return props;
+    }
+
+    String offsetSyncsTopic() {
+        String otherClusterAlias = SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
+                ? targetClusterAlias()
+                : sourceClusterAlias();
+        return replicationPolicy().offsetSyncsTopic(otherClusterAlias);
+    }
+
+    String offsetSyncsTopicLocation() {
+        return getString(OFFSET_SYNCS_TOPIC_LOCATION);
+    }
+
+    String checkpointsTopic() {
+        return replicationPolicy().checkpointsTopic(sourceClusterAlias());
+    }
+
+    Map<String, Object> offsetSyncsTopicConsumerConfig() {
+        return SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
+                ? sourceConsumerConfig()
+                : targetConsumerConfig();
+    }
+
+    Duration consumerPollTimeout() {
+        return Duration.ofMillis(getLong(CONSUMER_POLL_TIMEOUT_MILLIS));
+    }
+
+    protected static final ConfigDef CONNECTOR_CONFIG_DEF = new ConfigDef(BASE_CONNECTOR_CONFIG_DEF)
+            .define(
+                    CONSUMER_POLL_TIMEOUT_MILLIS,
+                    ConfigDef.Type.LONG,
+                    CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    CONSUMER_POLL_TIMEOUT_MILLIS_DOC)
+            .define(
+                    GROUPS,
+                    ConfigDef.Type.LIST,
+                    GROUPS_DEFAULT,
+                    ConfigDef.Importance.HIGH,
+                    GROUPS_DOC)
+            .define(
+                    GROUPS_EXCLUDE,
+                    ConfigDef.Type.LIST,
+                    GROUPS_EXCLUDE_DEFAULT,
+                    ConfigDef.Importance.HIGH,
+                    GROUPS_EXCLUDE_DOC)
+            .define(
+                    GROUPS_EXCLUDE_ALIAS,
+                    ConfigDef.Type.LIST,
+                    null,
+                    ConfigDef.Importance.HIGH,
+                    "Deprecated. Use " + GROUPS_EXCLUDE + " instead.")
+            .define(
+                    GROUP_FILTER_CLASS,
+                    ConfigDef.Type.CLASS,
+                    GROUP_FILTER_CLASS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    GROUP_FILTER_CLASS_DOC)
+            .define(
+                    REFRESH_GROUPS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    REFRESH_GROUPS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    REFRESH_GROUPS_ENABLED_DOC)
+            .define(
+                    REFRESH_GROUPS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    REFRESH_GROUPS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    REFRESH_GROUPS_INTERVAL_SECONDS_DOC)
+            .define(
+                    EMIT_CHECKPOINTS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    EMIT_CHECKPOINTS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    EMIT_CHECKPOINTS_ENABLED_DOC)
+            .define(
+                    EMIT_CHECKPOINTS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    EMIT_CHECKPOINTS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    EMIT_CHECKPOINTS_INTERVAL_SECONDS_DOC)
+            .define(
+                    SYNC_GROUP_OFFSETS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    SYNC_GROUP_OFFSETS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    SYNC_GROUP_OFFSETS_ENABLED_DOC)
+            .define(
+                    SYNC_GROUP_OFFSETS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DOC)
+            .define(
+                    CHECKPOINTS_TOPIC_REPLICATION_FACTOR,
+                    ConfigDef.Type.SHORT,
+                    CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DOC)
+            .define(
+                    OFFSET_SYNCS_TOPIC_LOCATION,
+                    ConfigDef.Type.STRING,
+                    OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT,
+                    ConfigDef.ValidString.in(SOURCE_CLUSTER_ALIAS_DEFAULT, TARGET_CLUSTER_ALIAS_DEFAULT),
+                    ConfigDef.Importance.LOW,
+                    OFFSET_SYNCS_TOPIC_LOCATION_DOC)
+            .define(
+                    TOPIC_FILTER_CLASS,
+                    ConfigDef.Type.CLASS,
+                    TOPIC_FILTER_CLASS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    TOPIC_FILTER_CLASS_DOC);
+
+    public static void main(String[] args) {
+        System.out.println(CONNECTOR_CONFIG_DEF.toHtml(4, config -> "mirror_checkpoint_" + config));
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
@@ -25,10 +25,6 @@ import java.util.Map;
 
 public class MirrorCheckpointConfig extends MirrorConnectorConfig {
 
-    public static final String TOPIC_FILTER_CLASS = "topic.filter.class";
-    private static final String TOPIC_FILTER_CLASS_DOC = "TopicFilter to use. Selects topics to replicate.";
-    public static final Class<?> TOPIC_FILTER_CLASS_DEFAULT = DefaultTopicFilter.class;
-
     protected static final String REFRESH_GROUPS = "refresh.groups";
     protected static final String EMIT_CHECKPOINTS = "emit.checkpoints";
     protected static final String SYNC_GROUP_OFFSETS = "sync.group.offsets";
@@ -77,10 +73,6 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
     public static final String GROUP_FILTER_CLASS = "group.filter.class";
     private static final String GROUP_FILTER_CLASS_DOC = "GroupFilter to use. Selects consumer groups to replicate.";
     public static final Class<?> GROUP_FILTER_CLASS_DEFAULT = DefaultGroupFilter.class;
-
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION = "offset-syncs.topic.location";
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
 
     public MirrorCheckpointConfig(Map<String, String> props) {
         super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -45,7 +45,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
     private static final Logger log = LoggerFactory.getLogger(MirrorCheckpointConnector.class);
 
     private Scheduler scheduler;
-    private MirrorConnectorConfig config;
+    private MirrorCheckpointConfig config;
     private GroupFilter groupFilter;
     private Admin sourceAdminClient;
     private SourceAndTarget sourceAndTarget;
@@ -56,14 +56,14 @@ public class MirrorCheckpointConnector extends SourceConnector {
     }
 
     // visible for testing
-    MirrorCheckpointConnector(List<String> knownConsumerGroups, MirrorConnectorConfig config) {
+    MirrorCheckpointConnector(List<String> knownConsumerGroups, MirrorCheckpointConfig config) {
         this.knownConsumerGroups = knownConsumerGroups;
         this.config = config;
     }
 
     @Override
     public void start(Map<String, String> props) {
-        config = new MirrorConnectorConfig(props);
+        config = new MirrorCheckpointConfig(props);
         if (!config.enabled()) {
             return;
         }
@@ -113,7 +113,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
 
     @Override
     public ConfigDef config() {
-        return MirrorConnectorConfig.CONNECTOR_CONFIG_DEF;
+        return MirrorCheckpointConfig.CONNECTOR_CONFIG_DEF;
     }
 
     @Override

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 /** Replicate consumer group state between clusters. Emits checkpoint records.
  *
- *  @see MirrorConnectorConfig for supported config properties.
+ *  @see MirrorCheckpointConfig for supported config properties.
  */
 public class MirrorCheckpointConnector extends SourceConnector {
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Value;
+import org.apache.kafka.common.metrics.stats.Min;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+/** Metrics for replicated topic-partitions */
+class MirrorCheckpointMetrics implements AutoCloseable {
+
+    private static final String CHECKPOINT_CONNECTOR_GROUP = MirrorCheckpointConnector.class.getSimpleName();
+
+    private static final Set<String> GROUP_TAGS = new HashSet<>(Arrays.asList("source", "target", "group", "topic", "partition"));
+
+    private static final MetricNameTemplate CHECKPOINT_LATENCY = new MetricNameTemplate(
+            "checkpoint-latency-ms", CHECKPOINT_CONNECTOR_GROUP,
+            "Time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
+    private static final MetricNameTemplate CHECKPOINT_LATENCY_MAX = new MetricNameTemplate(
+            "checkpoint-latency-ms-max", CHECKPOINT_CONNECTOR_GROUP,
+            "Max time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
+    private static final MetricNameTemplate CHECKPOINT_LATENCY_MIN = new MetricNameTemplate(
+            "checkpoint-latency-ms-min", CHECKPOINT_CONNECTOR_GROUP,
+            "Min time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
+    private static final MetricNameTemplate CHECKPOINT_LATENCY_AVG = new MetricNameTemplate(
+            "checkpoint-latency-ms-avg", CHECKPOINT_CONNECTOR_GROUP,
+            "Average time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
+
+
+    private final Metrics metrics;
+    private final Map<String, GroupMetrics> groupMetrics = new HashMap<>();
+    private final String source;
+    private final String target;
+
+    MirrorCheckpointMetrics(MirrorCheckpointTaskConfig taskConfig) {
+        this.target = taskConfig.targetClusterAlias();
+        this.source = taskConfig.sourceClusterAlias();
+        this.metrics = new Metrics();
+
+        // for side-effect
+        metrics.sensor("record-count");
+        metrics.sensor("byte-rate");
+        metrics.sensor("record-age");
+        metrics.sensor("replication-latency");
+    }
+
+    @Override
+    public void close() {
+        metrics.close();
+    }
+
+    void checkpointLatency(TopicPartition topicPartition, String group, long millis) {
+        group(topicPartition, group).checkpointLatencySensor.record((double) millis);
+    }
+
+    GroupMetrics group(TopicPartition topicPartition, String group) {
+        return groupMetrics.computeIfAbsent(String.join("-", topicPartition.toString(), group),
+            x -> new GroupMetrics(topicPartition, group));
+    }
+
+    void addReporter(MetricsReporter reporter) {
+        metrics.addReporter(reporter);
+    }
+
+    private class GroupMetrics {
+        private final Sensor checkpointLatencySensor;
+
+        GroupMetrics(TopicPartition topicPartition, String group) {
+            Map<String, String> tags = new LinkedHashMap<>();
+            tags.put("source", source); 
+            tags.put("target", target); 
+            tags.put("group", group);
+            tags.put("topic", topicPartition.topic());
+            tags.put("partition", Integer.toString(topicPartition.partition()));
+ 
+            checkpointLatencySensor = metrics.sensor("checkpoint-latency");
+            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY, tags), new Value());
+            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_MAX, tags), new Max());
+            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_MIN, tags), new Min());
+            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_AVG, tags), new Avg());
+        }
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -64,7 +64,7 @@ public class MirrorCheckpointTask extends SourceTask {
     private ReplicationPolicy replicationPolicy;
     private OffsetSyncStore offsetSyncStore;
     private boolean stopping;
-    private MirrorMetrics metrics;
+    private MirrorCheckpointMetrics metrics;
     private Scheduler scheduler;
     private Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset;
     private Map<String, List<Checkpoint>> checkpointsPerConsumerGroup;
@@ -85,7 +85,7 @@ public class MirrorCheckpointTask extends SourceTask {
 
     @Override
     public void start(Map<String, String> props) {
-        MirrorTaskConfig config = new MirrorTaskConfig(props);
+        MirrorCheckpointTaskConfig config = new MirrorCheckpointTaskConfig(props);
         stopping = false;
         sourceClusterAlias = config.sourceClusterAlias();
         targetClusterAlias = config.targetClusterAlias();

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Collections;
+
+public class MirrorCheckpointTaskConfig extends MirrorCheckpointConfig {
+
+    private static final String TASK_CONSUMER_GROUPS_DOC = "Consumer groups assigned to this task to replicate.";
+
+    public MirrorCheckpointTaskConfig(Map<String, String> props) {
+        super(TASK_CONFIG_DEF, props);
+    }
+
+    Set<String> taskConsumerGroups() {
+        List<String> fields = getList(TASK_CONSUMER_GROUPS);
+        if (fields == null || fields.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(fields);
+    }
+
+    MirrorCheckpointMetrics metrics() {
+        MirrorCheckpointMetrics metrics = new MirrorCheckpointMetrics(this);
+        metricsReporters().forEach(metrics::addReporter);
+        return metrics;
+    }
+
+    protected static final ConfigDef TASK_CONFIG_DEF = new ConfigDef(CONNECTOR_CONFIG_DEF)
+            .define(
+                    TASK_CONSUMER_GROUPS,
+                    ConfigDef.Type.LIST,
+                    null,
+                    ConfigDef.Importance.LOW,
+                    TASK_CONSUMER_GROUPS_DOC);
+}
+

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -100,6 +100,14 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     protected static final String CONSUMER_CLIENT_PREFIX = "consumer.";
     protected static final String ADMIN_CLIENT_PREFIX = "admin.";
 
+    public static final String TOPIC_FILTER_CLASS = "topic.filter.class";
+    public static final String TOPIC_FILTER_CLASS_DOC = "TopicFilter to use. Selects topics to replicate.";
+    public static final Class<?> TOPIC_FILTER_CLASS_DEFAULT = DefaultTopicFilter.class;
+
+    public static final String OFFSET_SYNCS_TOPIC_LOCATION = "offset-syncs.topic.location";
+    public static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
+    public static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
+
     protected MirrorConnectorConfig(ConfigDef configDef, Map<String, String> props) {
         super(configDef, props, true);
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -20,14 +20,11 @@ import org.apache.kafka.clients.admin.ForwardingAdmin;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.ValidString;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.utils.ConfigUtils;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
@@ -37,7 +34,6 @@ import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.time.Duration;
 
 /** Shared config properties used by MirrorSourceConnector, MirrorCheckpointConnector, and MirrorHeartbeatConnector.
@@ -66,27 +62,20 @@ import java.time.Duration;
  *      }
  *  </pre>
  */
-public class MirrorConnectorConfig extends AbstractConfig {
+public abstract class MirrorConnectorConfig extends AbstractConfig {
 
-    protected static final String ENABLED_SUFFIX = ".enabled";
-    protected static final String INTERVAL_SECONDS_SUFFIX = ".interval.seconds";
+    static final String ENABLED_SUFFIX = ".enabled";
+    static final String INTERVAL_SECONDS_SUFFIX = ".interval.seconds";
 
-    protected static final String REFRESH_TOPICS = "refresh.topics";
-    protected static final String REFRESH_GROUPS = "refresh.groups";
-    protected static final String SYNC_TOPIC_CONFIGS = "sync.topic.configs";
-    protected static final String SYNC_TOPIC_ACLS = "sync.topic.acls";
-    protected static final String EMIT_HEARTBEATS = "emit.heartbeats";
-    protected static final String EMIT_CHECKPOINTS = "emit.checkpoints";
-    protected static final String SYNC_GROUP_OFFSETS = "sync.group.offsets";
-
-    public static final String ENABLED = "enabled";
-    private static final String ENABLED_DOC = "Whether to replicate source->target.";
+    static final String ENABLED = "enabled";
+    static final String ENABLED_DOC = "Whether to replicate source->target.";
     public static final String SOURCE_CLUSTER_ALIAS = "source.cluster.alias";
     public static final String SOURCE_CLUSTER_ALIAS_DEFAULT = "source";
     private static final String SOURCE_CLUSTER_ALIAS_DOC = "Alias of source cluster";
     public static final String TARGET_CLUSTER_ALIAS = "target.cluster.alias";
     public static final String TARGET_CLUSTER_ALIAS_DEFAULT = "target";
     private static final String TARGET_CLUSTER_ALIAS_DOC = "Alias of target cluster. Used in metrics reporting.";
+
     public static final String REPLICATION_POLICY_CLASS = MirrorClientConfig.REPLICATION_POLICY_CLASS;
     public static final Class<?> REPLICATION_POLICY_CLASS_DEFAULT = MirrorClientConfig.REPLICATION_POLICY_CLASS_DEFAULT;
     private static final String REPLICATION_POLICY_CLASS_DOC = "Class which defines the remote topic naming convention.";
@@ -94,126 +83,14 @@ public class MirrorConnectorConfig extends AbstractConfig {
     private static final String REPLICATION_POLICY_SEPARATOR_DOC = "Separator used in remote topic naming convention.";
     public static final String REPLICATION_POLICY_SEPARATOR_DEFAULT =
             MirrorClientConfig.REPLICATION_POLICY_SEPARATOR_DEFAULT;
-    public static final String FORWARDING_ADMIN_CLASS = MirrorClientConfig.FORWARDING_ADMIN_CLASS;
-    public static final Class<?> FORWARDING_ADMIN_CLASS_DEFAULT = MirrorClientConfig.FORWARDING_ADMIN_CLASS_DEFAULT;
-    private static final String FORWARDING_ADMIN_CLASS_DOC = MirrorClientConfig.FORWARDING_ADMIN_CLASS_DOC;
-    public static final String REPLICATION_FACTOR = "replication.factor";
-    private static final String REPLICATION_FACTOR_DOC = "Replication factor for newly created remote topics.";
-    public static final int REPLICATION_FACTOR_DEFAULT = 2;
-    public static final String TOPICS = DefaultTopicFilter.TOPICS_INCLUDE_CONFIG;
-    public static final String TOPICS_DEFAULT = DefaultTopicFilter.TOPICS_INCLUDE_DEFAULT;
-    private static final String TOPICS_DOC = "Topics to replicate. Supports comma-separated topic names and regexes.";
-    public static final String TOPICS_EXCLUDE = DefaultTopicFilter.TOPICS_EXCLUDE_CONFIG;
-    public static final String TOPICS_EXCLUDE_ALIAS = DefaultTopicFilter.TOPICS_EXCLUDE_CONFIG_ALIAS;
-    public static final String TOPICS_EXCLUDE_DEFAULT = DefaultTopicFilter.TOPICS_EXCLUDE_DEFAULT;
-    private static final String TOPICS_EXCLUDE_DOC = "Excluded topics. Supports comma-separated topic names and regexes."
-                                                     + " Excludes take precedence over includes.";
-    public static final String GROUPS = DefaultGroupFilter.GROUPS_INCLUDE_CONFIG;
-    public static final String GROUPS_DEFAULT = DefaultGroupFilter.GROUPS_INCLUDE_DEFAULT;
-    private static final String GROUPS_DOC = "Consumer groups to replicate. Supports comma-separated group IDs and regexes.";
-    public static final String GROUPS_EXCLUDE = DefaultGroupFilter.GROUPS_EXCLUDE_CONFIG;
-    public static final String GROUPS_EXCLUDE_ALIAS = DefaultGroupFilter.GROUPS_EXCLUDE_CONFIG_ALIAS;
-
-    public static final String GROUPS_EXCLUDE_DEFAULT = DefaultGroupFilter.GROUPS_EXCLUDE_DEFAULT;
-    private static final String GROUPS_EXCLUDE_DOC = "Exclude groups. Supports comma-separated group IDs and regexes."
-                                                     + " Excludes take precedence over includes.";
-    public static final String CONFIG_PROPERTIES_EXCLUDE = DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG;
-    public static final String CONFIG_PROPERTIES_EXCLUDE_ALIAS = DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_ALIAS_CONFIG;
-    public static final String CONFIG_PROPERTIES_EXCLUDE_DEFAULT = DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_DEFAULT;
-    private static final String CONFIG_PROPERTIES_EXCLUDE_DOC = "Topic config properties that should not be replicated. Supports "
-                                        + "comma-separated property names and regexes.";
-
-    public static final String HEARTBEATS_TOPIC_REPLICATION_FACTOR = "heartbeats.topic.replication.factor";
-    public static final String HEARTBEATS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for heartbeats topic.";
-    public static final short HEARTBEATS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
-
-    public static final String CHECKPOINTS_TOPIC_REPLICATION_FACTOR = "checkpoints.topic.replication.factor";
-    public static final String CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for checkpoints topic.";
-    public static final short CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
-
-    public static final String OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR = "offset-syncs.topic.replication.factor";
-    public static final String OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for offset-syncs topic.";
-    public static final short OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
-
-    protected static final String TASK_TOPIC_PARTITIONS = "task.assigned.partitions";
-    protected static final String TASK_CONSUMER_GROUPS = "task.assigned.groups";
-
-    public static final String CONSUMER_POLL_TIMEOUT_MILLIS = "consumer.poll.timeout.ms";
-    private static final String CONSUMER_POLL_TIMEOUT_MILLIS_DOC = "Timeout when polling source cluster.";
-    public static final long CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT = 1000L;
 
     public static final String ADMIN_TASK_TIMEOUT_MILLIS = "admin.timeout.ms";
     private static final String ADMIN_TASK_TIMEOUT_MILLIS_DOC = "Timeout for administrative tasks, e.g. detecting new topics.";
     public static final long ADMIN_TASK_TIMEOUT_MILLIS_DEFAULT = 60000L;
 
-    public static final String REFRESH_TOPICS_ENABLED = REFRESH_TOPICS + ENABLED_SUFFIX;
-    private static final String REFRESH_TOPICS_ENABLED_DOC = "Whether to periodically check for new topics and partitions.";
-    public static final boolean REFRESH_TOPICS_ENABLED_DEFAULT = true;
-    public static final String REFRESH_TOPICS_INTERVAL_SECONDS = REFRESH_TOPICS + INTERVAL_SECONDS_SUFFIX;
-    private static final String REFRESH_TOPICS_INTERVAL_SECONDS_DOC = "Frequency of topic refresh.";
-    public static final long REFRESH_TOPICS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
-
-    public static final String REFRESH_GROUPS_ENABLED = REFRESH_GROUPS + ENABLED_SUFFIX;
-    private static final String REFRESH_GROUPS_ENABLED_DOC = "Whether to periodically check for new consumer groups.";
-    public static final boolean REFRESH_GROUPS_ENABLED_DEFAULT = true;
-    public static final String REFRESH_GROUPS_INTERVAL_SECONDS = REFRESH_GROUPS + INTERVAL_SECONDS_SUFFIX;
-    private static final String REFRESH_GROUPS_INTERVAL_SECONDS_DOC = "Frequency of group refresh.";
-    public static final long REFRESH_GROUPS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
-
-    public static final String SYNC_TOPIC_CONFIGS_ENABLED = SYNC_TOPIC_CONFIGS + ENABLED_SUFFIX;
-    private static final String SYNC_TOPIC_CONFIGS_ENABLED_DOC = "Whether to periodically configure remote topics to match their corresponding upstream topics.";
-    public static final boolean SYNC_TOPIC_CONFIGS_ENABLED_DEFAULT = true;
-    public static final String SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS = SYNC_TOPIC_CONFIGS + INTERVAL_SECONDS_SUFFIX;
-    private static final String SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DOC = "Frequency of topic config sync.";
-    public static final long SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
-
-    public static final String SYNC_TOPIC_ACLS_ENABLED = SYNC_TOPIC_ACLS + ENABLED_SUFFIX;
-    private static final String SYNC_TOPIC_ACLS_ENABLED_DOC = "Whether to periodically configure remote topic ACLs to match their corresponding upstream topics.";
-    public static final boolean SYNC_TOPIC_ACLS_ENABLED_DEFAULT = true;
-    public static final String SYNC_TOPIC_ACLS_INTERVAL_SECONDS = SYNC_TOPIC_ACLS + INTERVAL_SECONDS_SUFFIX;
-    private static final String SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DOC = "Frequency of topic ACL sync.";
-    public static final long SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
-
-    public static final String EMIT_HEARTBEATS_ENABLED = EMIT_HEARTBEATS + ENABLED_SUFFIX;
-    private static final String EMIT_HEARTBEATS_ENABLED_DOC = "Whether to emit heartbeats to target cluster.";
-    public static final boolean EMIT_HEARTBEATS_ENABLED_DEFAULT = true;
-    public static final String EMIT_HEARTBEATS_INTERVAL_SECONDS = EMIT_HEARTBEATS + INTERVAL_SECONDS_SUFFIX;
-    private static final String EMIT_HEARTBEATS_INTERVAL_SECONDS_DOC = "Frequency of heartbeats.";
-    public static final long EMIT_HEARTBEATS_INTERVAL_SECONDS_DEFAULT = 1;
-
-    public static final String EMIT_CHECKPOINTS_ENABLED = EMIT_CHECKPOINTS + ENABLED_SUFFIX;
-    private static final String EMIT_CHECKPOINTS_ENABLED_DOC = "Whether to replicate consumer offsets to target cluster.";
-    public static final boolean EMIT_CHECKPOINTS_ENABLED_DEFAULT = true;
-    public static final String EMIT_CHECKPOINTS_INTERVAL_SECONDS = EMIT_CHECKPOINTS + INTERVAL_SECONDS_SUFFIX;
-    private static final String EMIT_CHECKPOINTS_INTERVAL_SECONDS_DOC = "Frequency of checkpoints.";
-    public static final long EMIT_CHECKPOINTS_INTERVAL_SECONDS_DEFAULT = 60;
-
-
-    public static final String SYNC_GROUP_OFFSETS_ENABLED = SYNC_GROUP_OFFSETS + ENABLED_SUFFIX;
-    private static final String SYNC_GROUP_OFFSETS_ENABLED_DOC = "Whether to periodically write the translated offsets to __consumer_offsets topic in target cluster, as long as no active consumers in that group are connected to the target cluster";
-    public static final boolean SYNC_GROUP_OFFSETS_ENABLED_DEFAULT = false;
-    public static final String SYNC_GROUP_OFFSETS_INTERVAL_SECONDS = SYNC_GROUP_OFFSETS + INTERVAL_SECONDS_SUFFIX;
-    private static final String SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DOC = "Frequency of consumer group offset sync.";
-    public static final long SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DEFAULT = 60;
-
-    public static final String TOPIC_FILTER_CLASS = "topic.filter.class";
-    private static final String TOPIC_FILTER_CLASS_DOC = "TopicFilter to use. Selects topics to replicate.";
-    public static final Class<?> TOPIC_FILTER_CLASS_DEFAULT = DefaultTopicFilter.class;
-    public static final String GROUP_FILTER_CLASS = "group.filter.class";
-    private static final String GROUP_FILTER_CLASS_DOC = "GroupFilter to use. Selects consumer groups to replicate.";
-    public static final Class<?> GROUP_FILTER_CLASS_DEFAULT = DefaultGroupFilter.class;
-    public static final String CONFIG_PROPERTY_FILTER_CLASS = "config.property.filter.class";
-    private static final String CONFIG_PROPERTY_FILTER_CLASS_DOC = "ConfigPropertyFilter to use. Selects topic config "
-            + " properties to replicate.";
-    public static final Class<?> CONFIG_PROPERTY_FILTER_CLASS_DEFAULT = DefaultConfigPropertyFilter.class;
-
-    public static final String OFFSET_LAG_MAX = "offset.lag.max";
-    private static final String OFFSET_LAG_MAX_DOC = "How out-of-sync a remote partition can be before it is resynced.";
-    public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
-
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION = "offset-syncs.topic.location";
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
+    public static final String FORWARDING_ADMIN_CLASS = MirrorClientConfig.FORWARDING_ADMIN_CLASS;
+    public static final Class<?> FORWARDING_ADMIN_CLASS_DEFAULT = MirrorClientConfig.FORWARDING_ADMIN_CLASS_DEFAULT;
+    private static final String FORWARDING_ADMIN_CLASS_DOC = MirrorClientConfig.FORWARDING_ADMIN_CLASS_DOC;
 
     protected static final String SOURCE_CLUSTER_PREFIX = MirrorMakerConfig.SOURCE_CLUSTER_PREFIX;
     protected static final String TARGET_CLUSTER_PREFIX = MirrorMakerConfig.TARGET_CLUSTER_PREFIX;
@@ -222,13 +99,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
     protected static final String PRODUCER_CLIENT_PREFIX = "producer.";
     protected static final String CONSUMER_CLIENT_PREFIX = "consumer.";
     protected static final String ADMIN_CLIENT_PREFIX = "admin.";
-
-    public MirrorConnectorConfig(Map<String, String> props) {
-        this(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{
-            {TOPICS_EXCLUDE, TOPICS_EXCLUDE_ALIAS},
-            {GROUPS_EXCLUDE, GROUPS_EXCLUDE_ALIAS},
-            {CONFIG_PROPERTIES_EXCLUDE, CONFIG_PROPERTIES_EXCLUDE_ALIAS}}));
-    }
 
     protected MirrorConnectorConfig(ConfigDef configDef, Map<String, String> props) {
         super(configDef, props, true);
@@ -242,12 +112,20 @@ public class MirrorConnectorConfig extends AbstractConfig {
         return getBoolean(ENABLED);
     }
 
-    Duration consumerPollTimeout() {
-        return Duration.ofMillis(getLong(CONSUMER_POLL_TIMEOUT_MILLIS));
-    }
-
     Duration adminTimeout() {
         return Duration.ofMillis(getLong(ADMIN_TASK_TIMEOUT_MILLIS));
+    }
+
+    String sourceClusterAlias() {
+        return getString(SOURCE_CLUSTER_ALIAS);
+    }
+
+    String targetClusterAlias() {
+        return getString(TARGET_CLUSTER_ALIAS);
+    }
+
+    ReplicationPolicy replicationPolicy() {
+        return getConfiguredInstance(REPLICATION_POLICY_CLASS, ReplicationPolicy.class);
     }
 
     Map<String, Object> sourceProducerConfig() {
@@ -267,21 +145,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_PREFIX + CONSUMER_CLIENT_PREFIX));
         props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
         props.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
-        return props;
-    }
-
-    Map<String, String> taskConfigForTopicPartitions(List<TopicPartition> topicPartitions) {
-        Map<String, String> props = originalsStrings();
-        String topicPartitionsString = topicPartitions.stream()
-                .map(MirrorUtils::encodeTopicPartition)
-                .collect(Collectors.joining(","));
-        props.put(TASK_TOPIC_PARTITIONS, topicPartitionsString);
-        return props;
-    }
-
-    Map<String, String> taskConfigForConsumerGroups(List<String> groups) {
-        Map<String, String> props = originalsStrings();
-        props.put(TASK_CONSUMER_GROUPS, String.join(",", groups));
         return props;
     }
 
@@ -334,113 +197,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
         return reporters;
     }
 
-    String sourceClusterAlias() {
-        return getString(SOURCE_CLUSTER_ALIAS);
-    }
-
-    String targetClusterAlias() {
-        return getString(TARGET_CLUSTER_ALIAS);
-    }
-
-    String offsetSyncsTopic() {
-        String otherClusterAlias = SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
-                ? targetClusterAlias()
-                : sourceClusterAlias();
-        return replicationPolicy().offsetSyncsTopic(otherClusterAlias);
-    }
-
-    String offsetSyncsTopicLocation() {
-        return getString(OFFSET_SYNCS_TOPIC_LOCATION);
-    }
-
-    Map<String, Object> offsetSyncsTopicAdminConfig() {
-        return SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
-                ? sourceAdminConfig()
-                : targetAdminConfig();
-    }
-
-    Map<String, Object> offsetSyncsTopicProducerConfig() {
-        return SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
-                ? sourceProducerConfig()
-                : targetProducerConfig();
-    }
-
-    Map<String, Object> offsetSyncsTopicConsumerConfig() {
-        return SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
-                ? sourceConsumerConfig()
-                : targetConsumerConfig();
-    }
-
-    String heartbeatsTopic() {
-        return replicationPolicy().heartbeatsTopic();
-    }
-
-    String checkpointsTopic() {
-        return replicationPolicy().checkpointsTopic(sourceClusterAlias());
-    }
-
-    long maxOffsetLag() {
-        return getLong(OFFSET_LAG_MAX);
-    }
-
-    Duration emitHeartbeatsInterval() {
-        if (getBoolean(EMIT_HEARTBEATS_ENABLED)) {
-            return Duration.ofSeconds(getLong(EMIT_HEARTBEATS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
-    Duration emitCheckpointsInterval() {
-        if (getBoolean(EMIT_CHECKPOINTS_ENABLED)) {
-            return Duration.ofSeconds(getLong(EMIT_CHECKPOINTS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
-    Duration refreshTopicsInterval() {
-        if (getBoolean(REFRESH_TOPICS_ENABLED)) {
-            return Duration.ofSeconds(getLong(REFRESH_TOPICS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
-    Duration refreshGroupsInterval() {
-        if (getBoolean(REFRESH_GROUPS_ENABLED)) {
-            return Duration.ofSeconds(getLong(REFRESH_GROUPS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
-    Duration syncTopicConfigsInterval() {
-        if (getBoolean(SYNC_TOPIC_CONFIGS_ENABLED)) {
-            return Duration.ofSeconds(getLong(SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
-    Duration syncTopicAclsInterval() {
-        if (getBoolean(SYNC_TOPIC_ACLS_ENABLED)) {
-            return Duration.ofSeconds(getLong(SYNC_TOPIC_ACLS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
-    ReplicationPolicy replicationPolicy() {
-        return getConfiguredInstance(REPLICATION_POLICY_CLASS, ReplicationPolicy.class);
-    }
-
     @SuppressWarnings({"unchecked", "rawtypes"})
     ForwardingAdmin forwardingAdmin(Map<String, Object> config) {
         try {
@@ -452,117 +208,14 @@ public class MirrorConnectorConfig extends AbstractConfig {
         }
     }
 
-    int replicationFactor() {
-        return getInt(REPLICATION_FACTOR);
-    }
-
-    short heartbeatsTopicReplicationFactor() {
-        return getShort(HEARTBEATS_TOPIC_REPLICATION_FACTOR);
-    }
-
-    short checkpointsTopicReplicationFactor() {
-        return getShort(CHECKPOINTS_TOPIC_REPLICATION_FACTOR);
-    }
-
-    short offsetSyncsTopicReplicationFactor() {
-        return getShort(OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR);
-    }
-
-    TopicFilter topicFilter() {
-        return getConfiguredInstance(TOPIC_FILTER_CLASS, TopicFilter.class);
-    }
-
-    GroupFilter groupFilter() {
-        return getConfiguredInstance(GROUP_FILTER_CLASS, GroupFilter.class);
-    }
-
-    ConfigPropertyFilter configPropertyFilter() {
-        return getConfiguredInstance(CONFIG_PROPERTY_FILTER_CLASS, ConfigPropertyFilter.class);
-    }
-
-    Duration syncGroupOffsetsInterval() {
-        if (getBoolean(SYNC_GROUP_OFFSETS_ENABLED)) {
-            return Duration.ofSeconds(getLong(SYNC_GROUP_OFFSETS_INTERVAL_SECONDS));
-        } else {
-            // negative interval to disable
-            return Duration.ofMillis(-1);
-        }
-    }
-
     @SuppressWarnings("deprecation")
-    protected static final ConfigDef CONNECTOR_CONFIG_DEF = ConnectorConfig.configDef()
+    protected static final ConfigDef BASE_CONNECTOR_CONFIG_DEF = new ConfigDef(ConnectorConfig.configDef())
             .define(
                     ENABLED,
                     ConfigDef.Type.BOOLEAN,
                     true,
                     ConfigDef.Importance.LOW,
                     ENABLED_DOC)
-            .define(
-                    TOPICS,
-                    ConfigDef.Type.LIST,
-                    TOPICS_DEFAULT,
-                    ConfigDef.Importance.HIGH,
-                    TOPICS_DOC) 
-            .define(
-                    TOPICS_EXCLUDE,
-                    ConfigDef.Type.LIST,
-                    TOPICS_EXCLUDE_DEFAULT,
-                    ConfigDef.Importance.HIGH,
-                    TOPICS_EXCLUDE_DOC)
-            .define(
-                    TOPICS_EXCLUDE_ALIAS,
-                    ConfigDef.Type.LIST,
-                    null,
-                    ConfigDef.Importance.HIGH,
-                    "Deprecated. Use " + TOPICS_EXCLUDE + " instead.")
-            .define(
-                    GROUPS,
-                    ConfigDef.Type.LIST,
-                    GROUPS_DEFAULT,
-                    ConfigDef.Importance.HIGH,
-                    GROUPS_DOC) 
-            .define(
-                    GROUPS_EXCLUDE,
-                    ConfigDef.Type.LIST,
-                    GROUPS_EXCLUDE_DEFAULT,
-                    ConfigDef.Importance.HIGH,
-                    GROUPS_EXCLUDE_DOC)
-            .define(
-                    GROUPS_EXCLUDE_ALIAS,
-                    ConfigDef.Type.LIST,
-                    null,
-                    ConfigDef.Importance.HIGH,
-                    "Deprecated. Use " + GROUPS_EXCLUDE + " instead.")
-            .define(
-                    CONFIG_PROPERTIES_EXCLUDE,
-                    ConfigDef.Type.LIST,
-                    CONFIG_PROPERTIES_EXCLUDE_DEFAULT,
-                    ConfigDef.Importance.HIGH,
-                    CONFIG_PROPERTIES_EXCLUDE_DOC)
-            .define(
-                    CONFIG_PROPERTIES_EXCLUDE_ALIAS,
-                    ConfigDef.Type.LIST,
-                    null,
-                    ConfigDef.Importance.HIGH,
-                    "Deprecated. Use " + CONFIG_PROPERTIES_EXCLUDE + " instead.")
-            .define(
-                    TOPIC_FILTER_CLASS,
-                    ConfigDef.Type.CLASS,
-                    TOPIC_FILTER_CLASS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    TOPIC_FILTER_CLASS_DOC)
-            .define(
-                    GROUP_FILTER_CLASS,
-                    ConfigDef.Type.CLASS,
-                    GROUP_FILTER_CLASS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    GROUP_FILTER_CLASS_DOC)
-            .define(
-                    CONFIG_PROPERTY_FILTER_CLASS,
-                    ConfigDef.Type.CLASS,
-                    CONFIG_PROPERTY_FILTER_CLASS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    CONFIG_PROPERTY_FILTER_CLASS_DOC)
             .define(
                     SOURCE_CLUSTER_ALIAS,
                     ConfigDef.Type.STRING,
@@ -575,101 +228,11 @@ public class MirrorConnectorConfig extends AbstractConfig {
                     ConfigDef.Importance.HIGH,
                     TARGET_CLUSTER_ALIAS_DOC)
             .define(
-                    CONSUMER_POLL_TIMEOUT_MILLIS,
-                    ConfigDef.Type.LONG,
-                    CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    CONSUMER_POLL_TIMEOUT_MILLIS_DOC)
-            .define(
                     ADMIN_TASK_TIMEOUT_MILLIS,
                     ConfigDef.Type.LONG,
                     ADMIN_TASK_TIMEOUT_MILLIS_DEFAULT,
                     ConfigDef.Importance.LOW,
                     ADMIN_TASK_TIMEOUT_MILLIS_DOC)
-            .define(
-                    REFRESH_TOPICS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    REFRESH_TOPICS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    REFRESH_TOPICS_ENABLED_DOC)
-            .define(
-                    REFRESH_TOPICS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    REFRESH_TOPICS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    REFRESH_TOPICS_INTERVAL_SECONDS_DOC)
-            .define(
-                    REFRESH_GROUPS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    REFRESH_GROUPS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    REFRESH_GROUPS_ENABLED_DOC)
-            .define(
-                    REFRESH_GROUPS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    REFRESH_GROUPS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    REFRESH_GROUPS_INTERVAL_SECONDS_DOC)
-            .define(
-                    SYNC_TOPIC_CONFIGS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    SYNC_TOPIC_CONFIGS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    SYNC_TOPIC_CONFIGS_ENABLED_DOC)
-            .define(
-                    SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DOC)
-            .define(
-                    SYNC_TOPIC_ACLS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    SYNC_TOPIC_ACLS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    SYNC_TOPIC_ACLS_ENABLED_DOC)
-            .define(
-                    SYNC_TOPIC_ACLS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DOC)
-            .define(
-                    EMIT_HEARTBEATS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    EMIT_HEARTBEATS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    EMIT_HEARTBEATS_ENABLED_DOC)
-            .define(
-                    EMIT_HEARTBEATS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    EMIT_HEARTBEATS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    EMIT_HEARTBEATS_INTERVAL_SECONDS_DOC)
-            .define(
-                    EMIT_CHECKPOINTS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    EMIT_CHECKPOINTS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    EMIT_CHECKPOINTS_ENABLED_DOC)
-            .define(
-                    EMIT_CHECKPOINTS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    EMIT_CHECKPOINTS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    EMIT_CHECKPOINTS_INTERVAL_SECONDS_DOC)
-            .define(
-                    SYNC_GROUP_OFFSETS_ENABLED,
-                    ConfigDef.Type.BOOLEAN,
-                    SYNC_GROUP_OFFSETS_ENABLED_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    SYNC_GROUP_OFFSETS_ENABLED_DOC)
-            .define(
-                    SYNC_GROUP_OFFSETS_INTERVAL_SECONDS,
-                    ConfigDef.Type.LONG,
-                    SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    SYNC_GROUP_OFFSETS_INTERVAL_SECONDS_DOC)
             .define(
                     REPLICATION_POLICY_CLASS,
                     ConfigDef.Type.CLASS,
@@ -688,43 +251,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
                     FORWARDING_ADMIN_CLASS_DEFAULT,
                     ConfigDef.Importance.LOW,
                     FORWARDING_ADMIN_CLASS_DOC)
-            .define(
-                    REPLICATION_FACTOR,
-                    ConfigDef.Type.INT,
-                    REPLICATION_FACTOR_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    REPLICATION_FACTOR_DOC)
-            .define(
-                    HEARTBEATS_TOPIC_REPLICATION_FACTOR,
-                    ConfigDef.Type.SHORT,
-                    HEARTBEATS_TOPIC_REPLICATION_FACTOR_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    HEARTBEATS_TOPIC_REPLICATION_FACTOR_DOC)
-            .define(
-                    CHECKPOINTS_TOPIC_REPLICATION_FACTOR,
-                    ConfigDef.Type.SHORT,
-                    CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DOC)
-            .define(
-                    OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR,
-                    ConfigDef.Type.SHORT,
-                    OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DOC)
-            .define(
-                    OFFSET_LAG_MAX,
-                    ConfigDef.Type.LONG,
-                    OFFSET_LAG_MAX_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    OFFSET_LAG_MAX_DOC)
-            .define(
-                    OFFSET_SYNCS_TOPIC_LOCATION,
-                    ConfigDef.Type.STRING,
-                    OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT,
-                    ValidString.in(SOURCE_CLUSTER_ALIAS_DEFAULT, TARGET_CLUSTER_ALIAS_DEFAULT),
-                    ConfigDef.Importance.LOW,
-                    OFFSET_SYNCS_TOPIC_LOCATION_DOC)
             .define(
                     CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
                     ConfigDef.Type.LIST,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.time.Duration;
+import java.util.Map;
+
+public class MirrorHeartbeatConfig extends MirrorConnectorConfig {
+
+    protected static final String EMIT_HEARTBEATS = "emit.heartbeats";
+
+    public static final String HEARTBEATS_TOPIC_REPLICATION_FACTOR = "heartbeats.topic.replication.factor";
+    public static final String HEARTBEATS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for heartbeats topic.";
+    public static final short HEARTBEATS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
+
+    public static final String EMIT_HEARTBEATS_ENABLED = EMIT_HEARTBEATS + ENABLED_SUFFIX;
+    private static final String EMIT_HEARTBEATS_ENABLED_DOC = "Whether to emit heartbeats to target cluster.";
+    public static final boolean EMIT_HEARTBEATS_ENABLED_DEFAULT = true;
+    public static final String EMIT_HEARTBEATS_INTERVAL_SECONDS = EMIT_HEARTBEATS + INTERVAL_SECONDS_SUFFIX;
+    private static final String EMIT_HEARTBEATS_INTERVAL_SECONDS_DOC = "Frequency of heartbeats.";
+    public static final long EMIT_HEARTBEATS_INTERVAL_SECONDS_DEFAULT = 1;
+
+    public MirrorHeartbeatConfig(Map<String, String> props) {
+        super(CONNECTOR_CONFIG_DEF, props);
+    }
+
+    String connectorName() {
+        return getString(ConnectorConfig.NAME_CONFIG);
+    }
+
+    String heartbeatsTopic() {
+        return replicationPolicy().heartbeatsTopic();
+    }
+
+    Duration emitHeartbeatsInterval() {
+        if (getBoolean(EMIT_HEARTBEATS_ENABLED)) {
+            return Duration.ofSeconds(getLong(EMIT_HEARTBEATS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    short heartbeatsTopicReplicationFactor() {
+        return getShort(HEARTBEATS_TOPIC_REPLICATION_FACTOR);
+    }
+
+    protected static final ConfigDef CONNECTOR_CONFIG_DEF = new ConfigDef(BASE_CONNECTOR_CONFIG_DEF)
+            .define(
+                    EMIT_HEARTBEATS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    EMIT_HEARTBEATS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    EMIT_HEARTBEATS_ENABLED_DOC)
+            .define(
+                    EMIT_HEARTBEATS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    EMIT_HEARTBEATS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    EMIT_HEARTBEATS_INTERVAL_SECONDS_DOC)
+            .define(
+                    HEARTBEATS_TOPIC_REPLICATION_FACTOR,
+                    ConfigDef.Type.SHORT,
+                    HEARTBEATS_TOPIC_REPLICATION_FACTOR_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    HEARTBEATS_TOPIC_REPLICATION_FACTOR_DOC);
+
+    public static void main(String[] args) {
+        System.out.println(CONNECTOR_CONFIG_DEF.toHtml(4, config -> "mirror_heartbeat_" + config));
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConnector.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 /** Emits heartbeats to Kafka.
  */
 public class MirrorHeartbeatConnector extends SourceConnector {
-    private MirrorConnectorConfig config;
+    private MirrorHeartbeatConfig config;
     private Scheduler scheduler;
     
     public MirrorHeartbeatConnector() {
@@ -37,13 +37,13 @@ public class MirrorHeartbeatConnector extends SourceConnector {
     }
 
     // visible for testing
-    MirrorHeartbeatConnector(MirrorConnectorConfig config) {
+    MirrorHeartbeatConnector(MirrorHeartbeatConfig config) {
         this.config = config;
     }
 
     @Override
     public void start(Map<String, String> props) {
-        config = new MirrorConnectorConfig(props);
+        config = new MirrorHeartbeatConfig(props);
         scheduler = new Scheduler(MirrorHeartbeatConnector.class, config.adminTimeout());
         scheduler.execute(this::createInternalTopics, "creating internal topics");
     }
@@ -71,7 +71,7 @@ public class MirrorHeartbeatConnector extends SourceConnector {
 
     @Override
     public ConfigDef config() {
-        return MirrorConnectorConfig.CONNECTOR_CONFIG_DEF;
+        return MirrorHeartbeatConfig.CONNECTOR_CONFIG_DEF;
     }
 
     @Override

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConnector.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Collections;
 
 /** Emits heartbeats to Kafka.
+ *
+ *  @see MirrorHeartbeatConfig for supported config properties.
  */
 public class MirrorHeartbeatConnector extends SourceConnector {
     private MirrorHeartbeatConfig config;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatTask.java
@@ -39,7 +39,7 @@ public class MirrorHeartbeatTask extends SourceTask {
     @Override
     public void start(Map<String, String> props) {
         stopped = new CountDownLatch(1);
-        MirrorTaskConfig config = new MirrorTaskConfig(props);
+        MirrorHeartbeatConfig config = new MirrorHeartbeatConfig(props);
         sourceClusterAlias = config.sourceClusterAlias();
         targetClusterAlias = config.targetClusterAlias();
         heartbeatsTopic = config.heartbeatsTopic();

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.ConfigUtils;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MirrorSourceConfig extends MirrorConnectorConfig {
+
+    protected static final String REFRESH_TOPICS = "refresh.topics";
+    protected static final String SYNC_TOPIC_CONFIGS = "sync.topic.configs";
+    protected static final String SYNC_TOPIC_ACLS = "sync.topic.acls";
+
+    public static final String REPLICATION_FACTOR = "replication.factor";
+    private static final String REPLICATION_FACTOR_DOC = "Replication factor for newly created remote topics.";
+    public static final int REPLICATION_FACTOR_DEFAULT = 2;
+    public static final String TOPICS = DefaultTopicFilter.TOPICS_INCLUDE_CONFIG;
+    public static final String TOPICS_DEFAULT = DefaultTopicFilter.TOPICS_INCLUDE_DEFAULT;
+    private static final String TOPICS_DOC = "Topics to replicate. Supports comma-separated topic names and regexes.";
+    public static final String TOPICS_EXCLUDE = DefaultTopicFilter.TOPICS_EXCLUDE_CONFIG;
+    public static final String TOPICS_EXCLUDE_ALIAS = DefaultTopicFilter.TOPICS_EXCLUDE_CONFIG_ALIAS;
+    public static final String TOPICS_EXCLUDE_DEFAULT = DefaultTopicFilter.TOPICS_EXCLUDE_DEFAULT;
+    private static final String TOPICS_EXCLUDE_DOC = "Excluded topics. Supports comma-separated topic names and regexes."
+            + " Excludes take precedence over includes.";
+
+    public static final String CONFIG_PROPERTIES_EXCLUDE = DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG;
+    public static final String CONFIG_PROPERTIES_EXCLUDE_ALIAS = DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_ALIAS_CONFIG;
+    public static final String CONFIG_PROPERTIES_EXCLUDE_DEFAULT = DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_DEFAULT;
+    private static final String CONFIG_PROPERTIES_EXCLUDE_DOC = "Topic config properties that should not be replicated. Supports "
+            + "comma-separated property names and regexes.";
+
+    public static final String OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR = "offset-syncs.topic.replication.factor";
+    public static final String OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for offset-syncs topic.";
+    public static final short OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
+
+    static final String TASK_TOPIC_PARTITIONS = "task.assigned.partitions";
+
+    public static final String CONSUMER_POLL_TIMEOUT_MILLIS = "consumer.poll.timeout.ms";
+    private static final String CONSUMER_POLL_TIMEOUT_MILLIS_DOC = "Timeout when polling source cluster.";
+    public static final long CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT = 1000L;
+
+    public static final String REFRESH_TOPICS_ENABLED = REFRESH_TOPICS + ENABLED_SUFFIX;
+    private static final String REFRESH_TOPICS_ENABLED_DOC = "Whether to periodically check for new topics and partitions.";
+    public static final boolean REFRESH_TOPICS_ENABLED_DEFAULT = true;
+    public static final String REFRESH_TOPICS_INTERVAL_SECONDS = REFRESH_TOPICS + INTERVAL_SECONDS_SUFFIX;
+    private static final String REFRESH_TOPICS_INTERVAL_SECONDS_DOC = "Frequency of topic refresh.";
+    public static final long REFRESH_TOPICS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
+
+    public static final String SYNC_TOPIC_CONFIGS_ENABLED = SYNC_TOPIC_CONFIGS + ENABLED_SUFFIX;
+    private static final String SYNC_TOPIC_CONFIGS_ENABLED_DOC = "Whether to periodically configure remote topics to match their corresponding upstream topics.";
+    public static final boolean SYNC_TOPIC_CONFIGS_ENABLED_DEFAULT = true;
+    public static final String SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS = SYNC_TOPIC_CONFIGS + INTERVAL_SECONDS_SUFFIX;
+    private static final String SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DOC = "Frequency of topic config sync.";
+    public static final long SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
+
+    public static final String SYNC_TOPIC_ACLS_ENABLED = SYNC_TOPIC_ACLS + ENABLED_SUFFIX;
+    private static final String SYNC_TOPIC_ACLS_ENABLED_DOC = "Whether to periodically configure remote topic ACLs to match their corresponding upstream topics.";
+    public static final boolean SYNC_TOPIC_ACLS_ENABLED_DEFAULT = true;
+    public static final String SYNC_TOPIC_ACLS_INTERVAL_SECONDS = SYNC_TOPIC_ACLS + INTERVAL_SECONDS_SUFFIX;
+    private static final String SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DOC = "Frequency of topic ACL sync.";
+    public static final long SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
+
+    public static final String TOPIC_FILTER_CLASS = "topic.filter.class";
+    private static final String TOPIC_FILTER_CLASS_DOC = "TopicFilter to use. Selects topics to replicate.";
+    public static final Class<?> TOPIC_FILTER_CLASS_DEFAULT = DefaultTopicFilter.class;
+    public static final String CONFIG_PROPERTY_FILTER_CLASS = "config.property.filter.class";
+    private static final String CONFIG_PROPERTY_FILTER_CLASS_DOC = "ConfigPropertyFilter to use. Selects topic config "
+            + " properties to replicate.";
+    public static final Class<?> CONFIG_PROPERTY_FILTER_CLASS_DEFAULT = DefaultConfigPropertyFilter.class;
+
+    public static final String OFFSET_LAG_MAX = "offset.lag.max";
+    private static final String OFFSET_LAG_MAX_DOC = "How out-of-sync a remote partition can be before it is resynced.";
+    public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
+
+    private static final String OFFSET_SYNCS_TOPIC_LOCATION = "offset-syncs.topic.location";
+    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
+    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
+
+    public MirrorSourceConfig(Map<String, String> props) {
+        super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{
+                {TOPICS_EXCLUDE, TOPICS_EXCLUDE_ALIAS},
+                {CONFIG_PROPERTIES_EXCLUDE, CONFIG_PROPERTIES_EXCLUDE_ALIAS}}));
+    }
+
+    public MirrorSourceConfig(ConfigDef configDef, Map<String, String> props) {
+        super(configDef, props);
+    }
+
+    String connectorName() {
+        return getString(ConnectorConfig.NAME_CONFIG);
+    }
+
+    Map<String, String> taskConfigForTopicPartitions(List<TopicPartition> topicPartitions) {
+        Map<String, String> props = originalsStrings();
+        String topicPartitionsString = topicPartitions.stream()
+                .map(MirrorUtils::encodeTopicPartition)
+                .collect(Collectors.joining(","));
+        props.put(TASK_TOPIC_PARTITIONS, topicPartitionsString);
+        return props;
+    }
+
+    String offsetSyncsTopic() {
+        String otherClusterAlias = SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
+                ? targetClusterAlias()
+                : sourceClusterAlias();
+        return replicationPolicy().offsetSyncsTopic(otherClusterAlias);
+    }
+
+    String offsetSyncsTopicLocation() {
+        return getString(OFFSET_SYNCS_TOPIC_LOCATION);
+    }
+
+    Map<String, Object> offsetSyncsTopicAdminConfig() {
+        return SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
+                ? sourceAdminConfig()
+                : targetAdminConfig();
+    }
+
+    Map<String, Object> offsetSyncsTopicProducerConfig() {
+        return SOURCE_CLUSTER_ALIAS_DEFAULT.equals(offsetSyncsTopicLocation())
+                ? sourceProducerConfig()
+                : targetProducerConfig();
+    }
+
+    String checkpointsTopic() {
+        return replicationPolicy().checkpointsTopic(sourceClusterAlias());
+    }
+
+    long maxOffsetLag() {
+        return getLong(OFFSET_LAG_MAX);
+    }
+
+    Duration refreshTopicsInterval() {
+        if (getBoolean(REFRESH_TOPICS_ENABLED)) {
+            return Duration.ofSeconds(getLong(REFRESH_TOPICS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    Duration syncTopicConfigsInterval() {
+        if (getBoolean(SYNC_TOPIC_CONFIGS_ENABLED)) {
+            return Duration.ofSeconds(getLong(SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    Duration syncTopicAclsInterval() {
+        if (getBoolean(SYNC_TOPIC_ACLS_ENABLED)) {
+            return Duration.ofSeconds(getLong(SYNC_TOPIC_ACLS_INTERVAL_SECONDS));
+        } else {
+            // negative interval to disable
+            return Duration.ofMillis(-1);
+        }
+    }
+
+    ReplicationPolicy replicationPolicy() {
+        return getConfiguredInstance(REPLICATION_POLICY_CLASS, ReplicationPolicy.class);
+    }
+
+    int replicationFactor() {
+        return getInt(REPLICATION_FACTOR);
+    }
+
+    short offsetSyncsTopicReplicationFactor() {
+        return getShort(OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR);
+    }
+
+    TopicFilter topicFilter() {
+        return getConfiguredInstance(TOPIC_FILTER_CLASS, TopicFilter.class);
+    }
+
+    ConfigPropertyFilter configPropertyFilter() {
+        return getConfiguredInstance(CONFIG_PROPERTY_FILTER_CLASS, ConfigPropertyFilter.class);
+    }
+
+    Duration consumerPollTimeout() {
+        return Duration.ofMillis(getLong(CONSUMER_POLL_TIMEOUT_MILLIS));
+    }
+
+    protected static final ConfigDef CONNECTOR_CONFIG_DEF = new ConfigDef(BASE_CONNECTOR_CONFIG_DEF)
+            .define(
+                    TOPICS,
+                    ConfigDef.Type.LIST,
+                    TOPICS_DEFAULT,
+                    ConfigDef.Importance.HIGH,
+                    TOPICS_DOC)
+            .define(
+                    TOPICS_EXCLUDE,
+                    ConfigDef.Type.LIST,
+                    TOPICS_EXCLUDE_DEFAULT,
+                    ConfigDef.Importance.HIGH,
+                    TOPICS_EXCLUDE_DOC)
+            .define(
+                    TOPICS_EXCLUDE_ALIAS,
+                    ConfigDef.Type.LIST,
+                    null,
+                    ConfigDef.Importance.HIGH,
+                    "Deprecated. Use " + TOPICS_EXCLUDE + " instead.")
+            .define(
+                    CONFIG_PROPERTIES_EXCLUDE,
+                    ConfigDef.Type.LIST,
+                    CONFIG_PROPERTIES_EXCLUDE_DEFAULT,
+                    ConfigDef.Importance.HIGH,
+                    CONFIG_PROPERTIES_EXCLUDE_DOC)
+            .define(
+                    CONFIG_PROPERTIES_EXCLUDE_ALIAS,
+                    ConfigDef.Type.LIST,
+                    null,
+                    ConfigDef.Importance.HIGH,
+                    "Deprecated. Use " + CONFIG_PROPERTIES_EXCLUDE + " instead.")
+            .define(
+                    TOPIC_FILTER_CLASS,
+                    ConfigDef.Type.CLASS,
+                    TOPIC_FILTER_CLASS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    TOPIC_FILTER_CLASS_DOC)
+            .define(
+                    CONFIG_PROPERTY_FILTER_CLASS,
+                    ConfigDef.Type.CLASS,
+                    CONFIG_PROPERTY_FILTER_CLASS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    CONFIG_PROPERTY_FILTER_CLASS_DOC)
+            .define(
+                    CONSUMER_POLL_TIMEOUT_MILLIS,
+                    ConfigDef.Type.LONG,
+                    CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    CONSUMER_POLL_TIMEOUT_MILLIS_DOC)
+            .define(
+                    REFRESH_TOPICS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    REFRESH_TOPICS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    REFRESH_TOPICS_ENABLED_DOC)
+            .define(
+                    REFRESH_TOPICS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    REFRESH_TOPICS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    REFRESH_TOPICS_INTERVAL_SECONDS_DOC)
+            .define(
+                    SYNC_TOPIC_CONFIGS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    SYNC_TOPIC_CONFIGS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    SYNC_TOPIC_CONFIGS_ENABLED_DOC)
+            .define(
+                    SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    SYNC_TOPIC_CONFIGS_INTERVAL_SECONDS_DOC)
+            .define(
+                    SYNC_TOPIC_ACLS_ENABLED,
+                    ConfigDef.Type.BOOLEAN,
+                    SYNC_TOPIC_ACLS_ENABLED_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    SYNC_TOPIC_ACLS_ENABLED_DOC)
+            .define(
+                    SYNC_TOPIC_ACLS_INTERVAL_SECONDS,
+                    ConfigDef.Type.LONG,
+                    SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DOC)
+            .define(
+                    REPLICATION_FACTOR,
+                    ConfigDef.Type.INT,
+                    REPLICATION_FACTOR_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    REPLICATION_FACTOR_DOC)
+            .define(
+                    OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR,
+                    ConfigDef.Type.SHORT,
+                    OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    OFFSET_SYNCS_TOPIC_REPLICATION_FACTOR_DOC)
+            .define(
+                    OFFSET_LAG_MAX,
+                    ConfigDef.Type.LONG,
+                    OFFSET_LAG_MAX_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    OFFSET_LAG_MAX_DOC)
+            .define(
+                    OFFSET_SYNCS_TOPIC_LOCATION,
+                    ConfigDef.Type.STRING,
+                    OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT,
+                    ConfigDef.ValidString.in(SOURCE_CLUSTER_ALIAS_DEFAULT, TARGET_CLUSTER_ALIAS_DEFAULT),
+                    ConfigDef.Importance.LOW,
+                    OFFSET_SYNCS_TOPIC_LOCATION_DOC);
+
+    public static void main(String[] args) {
+        System.out.println(CONNECTOR_CONFIG_DEF.toHtml(4, config -> "mirror_source_" + config));
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -81,9 +81,6 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
     private static final String SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DOC = "Frequency of topic ACL sync.";
     public static final long SYNC_TOPIC_ACLS_INTERVAL_SECONDS_DEFAULT = 10 * 60;
 
-    public static final String TOPIC_FILTER_CLASS = "topic.filter.class";
-    private static final String TOPIC_FILTER_CLASS_DOC = "TopicFilter to use. Selects topics to replicate.";
-    public static final Class<?> TOPIC_FILTER_CLASS_DEFAULT = DefaultTopicFilter.class;
     public static final String CONFIG_PROPERTY_FILTER_CLASS = "config.property.filter.class";
     private static final String CONFIG_PROPERTY_FILTER_CLASS_DOC = "ConfigPropertyFilter to use. Selects topic config "
             + " properties to replicate.";
@@ -92,10 +89,6 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
     public static final String OFFSET_LAG_MAX = "offset.lag.max";
     private static final String OFFSET_LAG_MAX_DOC = "How out-of-sync a remote partition can be before it is resynced.";
     public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
-
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION = "offset-syncs.topic.location";
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
-    private static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
 
     public MirrorSourceConfig(Map<String, String> props) {
         super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 
 /** Replicate data, configuration, and ACLs between clusters.
  *
- *  @see MirrorConnectorConfig for supported config properties.
+ *  @see MirrorSourceConfig for supported config properties.
  */
 public class MirrorSourceConnector extends SourceConnector {
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -71,7 +71,7 @@ public class MirrorSourceConnector extends SourceConnector {
     private static final AclBindingFilter ANY_TOPIC_ACL = new AclBindingFilter(ANY_TOPIC, AccessControlEntryFilter.ANY);
 
     private Scheduler scheduler;
-    private MirrorConnectorConfig config;
+    private MirrorSourceConfig config;
     private SourceAndTarget sourceAndTarget;
     private String connectorName;
     private TopicFilter topicFilter;
@@ -88,7 +88,7 @@ public class MirrorSourceConnector extends SourceConnector {
     }
 
     // visible for testing
-    MirrorSourceConnector(List<TopicPartition> knownSourceTopicPartitions, MirrorConnectorConfig config) {
+    MirrorSourceConnector(List<TopicPartition> knownSourceTopicPartitions, MirrorSourceConfig config) {
         this.knownSourceTopicPartitions = knownSourceTopicPartitions;
         this.config = config;
     }
@@ -105,7 +105,7 @@ public class MirrorSourceConnector extends SourceConnector {
     @Override
     public void start(Map<String, String> props) {
         long start = System.currentTimeMillis();
-        config = new MirrorConnectorConfig(props);
+        config = new MirrorSourceConfig(props);
         if (!config.enabled()) {
             return;
         }
@@ -182,7 +182,7 @@ public class MirrorSourceConnector extends SourceConnector {
 
     @Override
     public ConfigDef config() {
-        return MirrorConnectorConfig.CONNECTOR_CONFIG_DEF;
+        return MirrorSourceConfig.CONNECTOR_CONFIG_DEF;
     }
 
     @Override

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
@@ -17,33 +17,30 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Value;
-import org.apache.kafka.common.metrics.stats.Min;
-import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Meter;
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.stats.Min;
+import org.apache.kafka.common.metrics.stats.Value;
 
 import java.util.Arrays;
-import java.util.Set;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /** Metrics for replicated topic-partitions */
-class MirrorMetrics implements AutoCloseable {
+class MirrorSourceMetrics implements AutoCloseable {
 
     private static final String SOURCE_CONNECTOR_GROUP = MirrorSourceConnector.class.getSimpleName();
-    private static final String CHECKPOINT_CONNECTOR_GROUP = MirrorCheckpointConnector.class.getSimpleName();
 
     private static final Set<String> PARTITION_TAGS = new HashSet<>(Arrays.asList("target", "topic", "partition"));
-    private static final Set<String> GROUP_TAGS = new HashSet<>(Arrays.asList("source", "target", "group", "topic", "partition"));
-    
+
     private static final MetricNameTemplate RECORD_COUNT = new MetricNameTemplate(
             "record-count", SOURCE_CONNECTOR_GROUP,
             "Number of source records replicated to the target cluster.", PARTITION_TAGS);
@@ -81,27 +78,13 @@ class MirrorMetrics implements AutoCloseable {
             "replication-latency-ms-avg", SOURCE_CONNECTOR_GROUP,
             "Average time it takes records to replicate from source to target cluster.", PARTITION_TAGS);
 
-    private static final MetricNameTemplate CHECKPOINT_LATENCY = new MetricNameTemplate(
-            "checkpoint-latency-ms", CHECKPOINT_CONNECTOR_GROUP,
-            "Time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
-    private static final MetricNameTemplate CHECKPOINT_LATENCY_MAX = new MetricNameTemplate(
-            "checkpoint-latency-ms-max", CHECKPOINT_CONNECTOR_GROUP,
-            "Max time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
-    private static final MetricNameTemplate CHECKPOINT_LATENCY_MIN = new MetricNameTemplate(
-            "checkpoint-latency-ms-min", CHECKPOINT_CONNECTOR_GROUP,
-            "Min time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
-    private static final MetricNameTemplate CHECKPOINT_LATENCY_AVG = new MetricNameTemplate(
-            "checkpoint-latency-ms-avg", CHECKPOINT_CONNECTOR_GROUP,
-            "Average time it takes consumer group offsets to replicate from source to target cluster.", GROUP_TAGS);
 
-
-    private final Metrics metrics; 
-    private final Map<TopicPartition, PartitionMetrics> partitionMetrics; 
-    private final Map<String, GroupMetrics> groupMetrics = new HashMap<>();
+    private final Metrics metrics;
+    private final Map<TopicPartition, PartitionMetrics> partitionMetrics;
     private final String source;
     private final String target;
 
-    MirrorMetrics(MirrorTaskConfig taskConfig) {
+    MirrorSourceMetrics(MirrorSourceTaskConfig taskConfig) {
         this.target = taskConfig.targetClusterAlias();
         this.source = taskConfig.sourceClusterAlias();
         this.metrics = new Metrics();
@@ -140,15 +123,6 @@ class MirrorMetrics implements AutoCloseable {
         partitionMetrics.get(topicPartition).byteSensor.record((double) bytes);
     }
 
-    void checkpointLatency(TopicPartition topicPartition, String group, long millis) {
-        group(topicPartition, group).checkpointLatencySensor.record((double) millis);
-    }
-
-    GroupMetrics group(TopicPartition topicPartition, String group) {
-        return groupMetrics.computeIfAbsent(String.join("-", topicPartition.toString(), group),
-            x -> new GroupMetrics(topicPartition, group));
-    }
-
     void addReporter(MetricsReporter reporter) {
         metrics.addReporter(reporter);
     }
@@ -184,25 +158,6 @@ class MirrorMetrics implements AutoCloseable {
             replicationLatencySensor.add(metrics.metricInstance(REPLICATION_LATENCY_MAX, tags), new Max());
             replicationLatencySensor.add(metrics.metricInstance(REPLICATION_LATENCY_MIN, tags), new Min());
             replicationLatencySensor.add(metrics.metricInstance(REPLICATION_LATENCY_AVG, tags), new Avg());
-        }
-    }
-
-    private class GroupMetrics {
-        private final Sensor checkpointLatencySensor;
-
-        GroupMetrics(TopicPartition topicPartition, String group) {
-            Map<String, String> tags = new LinkedHashMap<>();
-            tags.put("source", source); 
-            tags.put("target", target); 
-            tags.put("group", group);
-            tags.put("topic", topicPartition.topic());
-            tags.put("partition", Integer.toString(topicPartition.partition()));
- 
-            checkpointLatencySensor = metrics.sensor("checkpoint-latency");
-            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY, tags), new Value());
-            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_MAX, tags), new Max());
-            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_MIN, tags), new Min());
-            checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_AVG, tags), new Avg());
         }
     }
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -60,7 +60,7 @@ public class MirrorSourceTask extends SourceTask {
     private long maxOffsetLag;
     private Map<TopicPartition, PartitionState> partitionStates;
     private ReplicationPolicy replicationPolicy;
-    private MirrorMetrics metrics;
+    private MirrorSourceMetrics metrics;
     private boolean stopping = false;
     private Semaphore outstandingOffsetSyncs;
     private Semaphore consumerAccess;
@@ -68,7 +68,7 @@ public class MirrorSourceTask extends SourceTask {
     public MirrorSourceTask() {}
 
     // for testing
-    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorMetrics metrics, String sourceClusterAlias,
+    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceMetrics metrics, String sourceClusterAlias,
                      ReplicationPolicy replicationPolicy, long maxOffsetLag, KafkaProducer<byte[], byte[]> producer) {
         this.consumer = consumer;
         this.metrics = metrics;
@@ -81,7 +81,7 @@ public class MirrorSourceTask extends SourceTask {
 
     @Override
     public void start(Map<String, String> props) {
-        MirrorTaskConfig config = new MirrorTaskConfig(props);
+        MirrorSourceTaskConfig config = new MirrorSourceTaskConfig(props);
         outstandingOffsetSyncs = new Semaphore(MAX_OUTSTANDING_OFFSET_SYNCS);
         consumerAccess = new Semaphore(1);  // let one thread at a time access the consumer
         sourceClusterAlias = config.sourceClusterAlias();

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTaskConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTaskConfig.java
@@ -22,16 +22,14 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.Map;
 import java.util.Set;
 import java.util.List;
-import java.util.HashSet;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-public class MirrorTaskConfig extends MirrorConnectorConfig {
+public class MirrorSourceTaskConfig extends MirrorSourceConfig {
 
     private static final String TASK_TOPIC_PARTITIONS_DOC = "Topic-partitions assigned to this task to replicate.";
-    private static final String TASK_CONSUMER_GROUPS_DOC = "Consumer groups assigned to this task to replicate.";
 
-    public MirrorTaskConfig(Map<String, String> props) {
+    public MirrorSourceTaskConfig(Map<String, String> props) {
         super(TASK_CONFIG_DEF, props);
     }
 
@@ -45,16 +43,8 @@ public class MirrorTaskConfig extends MirrorConnectorConfig {
             .collect(Collectors.toSet());
     }
 
-    Set<String> taskConsumerGroups() {
-        List<String> fields = getList(TASK_CONSUMER_GROUPS);
-        if (fields == null || fields.isEmpty()) {
-            return Collections.emptySet();
-        }
-        return new HashSet<>(fields);
-    } 
-
-    MirrorMetrics metrics() {
-        MirrorMetrics metrics = new MirrorMetrics(this);
+    MirrorSourceMetrics metrics() {
+        MirrorSourceMetrics metrics = new MirrorSourceMetrics(this);
         metricsReporters().forEach(metrics::addReporter);
         return metrics;
     }
@@ -65,11 +55,5 @@ public class MirrorTaskConfig extends MirrorConnectorConfig {
             ConfigDef.Type.LIST,
             null,
             ConfigDef.Importance.LOW,
-            TASK_TOPIC_PARTITIONS_DOC)
-        .define(
-            TASK_CONSUMER_GROUPS,
-            ConfigDef.Type.LIST,
-            null,
-            ConfigDef.Importance.LOW,
-            TASK_CONSUMER_GROUPS_DOC);
+            TASK_TOPIC_PARTITIONS_DOC);
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -36,7 +36,7 @@ class OffsetSyncStore implements AutoCloseable {
     private final Map<TopicPartition, OffsetSync> offsetSyncs = new HashMap<>();
     private final TopicPartition offsetSyncTopicPartition;
 
-    OffsetSyncStore(MirrorConnectorConfig config) {
+    OffsetSyncStore(MirrorCheckpointConfig config) {
         consumer = new KafkaConsumer<>(config.offsetSyncsTopicConsumerConfig(),
             new ByteArrayDeserializer(), new ByteArrayDeserializer());
         offsetSyncTopicPartition = new TopicPartition(config.offsetSyncsTopic(), 0);

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfigTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MirrorCheckpointConfigTest {
+
+    @Test
+    public void testTaskConfigConsumerGroups() {
+        List<String> groups = Arrays.asList("consumer-1", "consumer-2", "consumer-3");
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
+        Map<String, String> props = config.taskConfigForConsumerGroups(groups);
+        MirrorCheckpointTaskConfig taskConfig = new MirrorCheckpointTaskConfig(props);
+        assertEquals(taskConfig.taskConsumerGroups(), new HashSet<>(groups),
+                "Setting consumer groups property configuration failed");
+    }
+
+    @Test
+    public void testGroupMatching() {
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps("groups", "group1"));
+        assertTrue(config.groupFilter().shouldReplicateGroup("group1"),
+                "topic1 group matching property configuration failed");
+        assertFalse(config.groupFilter().shouldReplicateGroup("group2"),
+                "topic2 group matching property configuration failed");
+    }
+
+    @Test
+    public void testNonMutationOfConfigDef() {
+        // Sanity check to make sure that these properties are actually defined for the task config,
+        // and that the task config class has been loaded and statically initialized by the JVM
+        ConfigDef taskConfigDef = MirrorCheckpointTaskConfig.TASK_CONFIG_DEF;
+        assertTrue(
+                taskConfigDef.names().contains(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
+                MirrorCheckpointConfig.TASK_CONSUMER_GROUPS + " should be defined for task ConfigDef"
+        );
+
+        // Ensure that the task config class hasn't accidentally modified the connector config
+        assertFalse(
+                MirrorCheckpointConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
+                MirrorCheckpointConfig.TASK_CONSUMER_GROUPS + " should not be defined for connector ConfigDef"
+        );
+    }
+
+    @Test
+    public void testConsumerConfigsForOffsetSyncsTopic() {
+        Map<String, String> connectorProps = makeProps(
+                "source.consumer.max.partition.fetch.bytes", "1",
+                "target.consumer.heartbeat.interval.ms", "1",
+                "consumer.max.poll.interval.ms", "1",
+                "fetch.min.bytes", "1"
+        );
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(connectorProps);
+        assertEquals(config.sourceConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorCheckpointConfig(connectorProps);
+        assertEquals(config.targetConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -43,7 +43,7 @@ public class MirrorCheckpointConnectorTest {
     @Test
     public void testMirrorCheckpointConnectorDisabled() {
         // disable the checkpoint emission
-        MirrorConnectorConfig config = new MirrorConnectorConfig(
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(
             makeProps("emit.checkpoints.enabled", "false"));
 
         List<String> knownConsumerGroups = new ArrayList<>();
@@ -59,7 +59,7 @@ public class MirrorCheckpointConnectorTest {
     @Test
     public void testMirrorCheckpointConnectorEnabled() {
         // enable the checkpoint emission
-        MirrorConnectorConfig config = new MirrorConnectorConfig(
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(
                 makeProps("emit.checkpoints.enabled", "true"));
 
         List<String> knownConsumerGroups = new ArrayList<>();
@@ -71,13 +71,13 @@ public class MirrorCheckpointConnectorTest {
         // expect 1 task will be created
         assertEquals(1, output.size(),
                 "MirrorCheckpointConnectorEnabled for " + CONSUMER_GROUP + " has incorrect size");
-        assertEquals(CONSUMER_GROUP, output.get(0).get(MirrorConnectorConfig.TASK_CONSUMER_GROUPS),
+        assertEquals(CONSUMER_GROUP, output.get(0).get(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
                 "MirrorCheckpointConnectorEnabled for " + CONSUMER_GROUP + " failed");
     }
 
     @Test
     public void testNoConsumerGroup() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
         MirrorCheckpointConnector connector = new MirrorCheckpointConnector(new ArrayList<>(), config);
         List<Map<String, String>> output = connector.taskConfigs(1);
         // expect no task will be created
@@ -87,7 +87,7 @@ public class MirrorCheckpointConnectorTest {
     @Test
     public void testReplicationDisabled() {
         // disable the replication
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("enabled", "false"));
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps("enabled", "false"));
 
         List<String> knownConsumerGroups = new ArrayList<>();
         knownConsumerGroups.add(CONSUMER_GROUP);
@@ -101,7 +101,7 @@ public class MirrorCheckpointConnectorTest {
     @Test
     public void testReplicationEnabled() {
         // enable the replication
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("enabled", "true"));
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps("enabled", "true"));
 
         List<String> knownConsumerGroups = new ArrayList<>();
         knownConsumerGroups.add(CONSUMER_GROUP);
@@ -110,13 +110,13 @@ public class MirrorCheckpointConnectorTest {
         List<Map<String, String>> output = connector.taskConfigs(1);
         // expect 1 task will be created
         assertEquals(1, output.size(), "Replication for consumer-group-1 has incorrect size");
-        assertEquals(CONSUMER_GROUP, output.get(0).get(MirrorConnectorConfig.TASK_CONSUMER_GROUPS),
+        assertEquals(CONSUMER_GROUP, output.get(0).get(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
                 "Replication for consumer-group-1 failed");
     }
 
     @Test
     public void testFindConsumerGroups() throws Exception {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
         MirrorCheckpointConnector connector = new MirrorCheckpointConnector(Collections.emptyList(), config);
         connector = spy(connector);
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.common.config.ConfigDef;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -31,6 +32,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -39,6 +42,57 @@ import static org.mockito.Mockito.spy;
 public class MirrorCheckpointConnectorTest {
 
     private static final String CONSUMER_GROUP = "consumer-group-1";
+
+    @Test
+    public void testTaskConfigConsumerGroups() {
+        List<String> groups = Arrays.asList("consumer-1", "consumer-2", "consumer-3");
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
+        Map<String, String> props = config.taskConfigForConsumerGroups(groups);
+        MirrorCheckpointTaskConfig taskConfig = new MirrorCheckpointTaskConfig(props);
+        assertEquals(taskConfig.taskConsumerGroups(), new HashSet<>(groups),
+                "Setting consumer groups property configuration failed");
+    }
+
+    @Test
+    public void testGroupMatching() {
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps("groups", "group1"));
+        assertTrue(config.groupFilter().shouldReplicateGroup("group1"),
+                "topic1 group matching property configuration failed");
+        assertFalse(config.groupFilter().shouldReplicateGroup("group2"),
+                "topic2 group matching property configuration failed");
+    }
+
+    @Test
+    public void testNonMutationOfConfigDef() {
+        // Sanity check to make sure that these properties are actually defined for the task config,
+        // and that the task config class has been loaded and statically initialized by the JVM
+        ConfigDef taskConfigDef = MirrorCheckpointTaskConfig.TASK_CONFIG_DEF;
+        assertTrue(
+                taskConfigDef.names().contains(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
+                MirrorCheckpointConfig.TASK_CONSUMER_GROUPS + " should be defined for task ConfigDef"
+        );
+
+        // Ensure that the task config class hasn't accidentally modified the connector config
+        assertFalse(
+                MirrorCheckpointConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
+                MirrorCheckpointConfig.TASK_CONSUMER_GROUPS + " should not be defined for connector ConfigDef"
+        );
+    }
+
+    @Test
+    public void testConsumerConfigsForOffsetSyncsTopic() {
+        Map<String, String> connectorProps = makeProps(
+                "source.consumer.max.partition.fetch.bytes", "1",
+                "target.consumer.heartbeat.interval.ms", "1",
+                "consumer.max.poll.interval.ms", "1",
+                "fetch.min.bytes", "1"
+        );
+        MirrorCheckpointConfig config = new MirrorCheckpointConfig(connectorProps);
+        assertEquals(config.sourceConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorCheckpointConfig(connectorProps);
+        assertEquals(config.targetConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
+    }
 
     @Test
     public void testMirrorCheckpointConnectorDisabled() {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
-import org.apache.kafka.common.config.ConfigDef;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -32,8 +31,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -42,57 +39,6 @@ import static org.mockito.Mockito.spy;
 public class MirrorCheckpointConnectorTest {
 
     private static final String CONSUMER_GROUP = "consumer-group-1";
-
-    @Test
-    public void testTaskConfigConsumerGroups() {
-        List<String> groups = Arrays.asList("consumer-1", "consumer-2", "consumer-3");
-        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps());
-        Map<String, String> props = config.taskConfigForConsumerGroups(groups);
-        MirrorCheckpointTaskConfig taskConfig = new MirrorCheckpointTaskConfig(props);
-        assertEquals(taskConfig.taskConsumerGroups(), new HashSet<>(groups),
-                "Setting consumer groups property configuration failed");
-    }
-
-    @Test
-    public void testGroupMatching() {
-        MirrorCheckpointConfig config = new MirrorCheckpointConfig(makeProps("groups", "group1"));
-        assertTrue(config.groupFilter().shouldReplicateGroup("group1"),
-                "topic1 group matching property configuration failed");
-        assertFalse(config.groupFilter().shouldReplicateGroup("group2"),
-                "topic2 group matching property configuration failed");
-    }
-
-    @Test
-    public void testNonMutationOfConfigDef() {
-        // Sanity check to make sure that these properties are actually defined for the task config,
-        // and that the task config class has been loaded and statically initialized by the JVM
-        ConfigDef taskConfigDef = MirrorCheckpointTaskConfig.TASK_CONFIG_DEF;
-        assertTrue(
-                taskConfigDef.names().contains(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
-                MirrorCheckpointConfig.TASK_CONSUMER_GROUPS + " should be defined for task ConfigDef"
-        );
-
-        // Ensure that the task config class hasn't accidentally modified the connector config
-        assertFalse(
-                MirrorCheckpointConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorCheckpointConfig.TASK_CONSUMER_GROUPS),
-                MirrorCheckpointConfig.TASK_CONSUMER_GROUPS + " should not be defined for connector ConfigDef"
-        );
-    }
-
-    @Test
-    public void testConsumerConfigsForOffsetSyncsTopic() {
-        Map<String, String> connectorProps = makeProps(
-                "source.consumer.max.partition.fetch.bytes", "1",
-                "target.consumer.heartbeat.interval.ms", "1",
-                "consumer.max.poll.interval.ms", "1",
-                "fetch.min.bytes", "1"
-        );
-        MirrorCheckpointConfig config = new MirrorCheckpointConfig(connectorProps);
-        assertEquals(config.sourceConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorCheckpointConfig(connectorProps);
-        assertEquals(config.targetConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
-    }
 
     @Test
     public void testMirrorCheckpointConnectorDisabled() {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -17,137 +17,26 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.test.MockMetricsReporter;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.HashSet;
 
 import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MirrorConnectorConfigTest {
 
-    @Test
-    public void testTaskConfigTopicPartitions() {
-        List<TopicPartition> topicPartitions = Arrays.asList(new TopicPartition("topic-1", 2),
-            new TopicPartition("topic-3", 4), new TopicPartition("topic-5", 6));
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
-        Map<String, String> props = config.taskConfigForTopicPartitions(topicPartitions);
-        MirrorTaskConfig taskConfig = new MirrorTaskConfig(props);
-        assertEquals(taskConfig.taskTopicPartitions(), new HashSet<>(topicPartitions),
-                "Setting topic property configuration failed");
-    }
+    static class TestMirrorConnectorConfig extends MirrorConnectorConfig {
 
-    @Test
-    public void testTaskConfigConsumerGroups() {
-        List<String> groups = Arrays.asList("consumer-1", "consumer-2", "consumer-3");
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
-        Map<String, String> props = config.taskConfigForConsumerGroups(groups);
-        MirrorTaskConfig taskConfig = new MirrorTaskConfig(props);
-        assertEquals(taskConfig.taskConsumerGroups(), new HashSet<>(groups),
-                "Setting consumer groups property configuration failed");
-    }
-
-    @Test
-    public void testTopicMatching() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("topics", "topic1"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
-                "topic1 replication property configuration failed");
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"),
-                "topic2 replication property configuration failed");
-    }
-
-    @Test
-    public void testGroupMatching() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("groups", "group1"));
-        assertTrue(config.groupFilter().shouldReplicateGroup("group1"),
-                "topic1 group matching property configuration failed");
-        assertFalse(config.groupFilter().shouldReplicateGroup("group2"),
-                "topic2 group matching property configuration failed");
-    }
-
-    @Test
-    public void testConfigPropertyMatching() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(
-            makeProps("config.properties.exclude", "prop2"));
-        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"),
-                "config.properties.exclude incorrectly excluded prop1");
-        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"),
-                "config.properties.exclude incorrectly included prop2");
-    }
-
-    @Test
-    public void testConfigBackwardsCompatibility() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(
-            makeProps("config.properties.blacklist", "prop1",
-                      "groups.blacklist", "group-1",
-                      "topics.blacklist", "topic-1"));
-        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"));
-        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"));
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic-1"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic-2"));
-        assertFalse(config.groupFilter().shouldReplicateGroup("group-1"));
-        assertTrue(config.groupFilter().shouldReplicateGroup("group-2"));
-    }
-
-    @Test
-    public void testNoTopics() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("topics", ""));
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 shouldn't exist");
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 shouldn't exist");
-        assertFalse(config.topicFilter().shouldReplicateTopic(""), "Empty topic shouldn't exist");
-    }
-
-    @Test
-    public void testAllTopics() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("topics", ".*"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
-                "topic1 created from wildcard should exist");
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"),
-                "topic2 created from wildcard should exist");
-    }
-
-    @Test
-    public void testListOfTopics() {
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("topics", "topic1, topic2"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 created from list should exist");
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 created from list should exist");
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic3"), "topic3 created from list should exist");
-    }
-
-    @Test
-    public void testNonMutationOfConfigDef() {
-        Collection<String> taskSpecificProperties = Arrays.asList(
-            MirrorConnectorConfig.TASK_TOPIC_PARTITIONS,
-            MirrorConnectorConfig.TASK_CONSUMER_GROUPS
-        );
-
-        // Sanity check to make sure that these properties are actually defined for the task config,
-        // and that the task config class has been loaded and statically initialized by the JVM
-        ConfigDef taskConfigDef = MirrorTaskConfig.TASK_CONFIG_DEF;
-        taskSpecificProperties.forEach(taskSpecificProperty -> assertTrue(
-            taskConfigDef.names().contains(taskSpecificProperty),
-            taskSpecificProperty + " should be defined for task ConfigDef"
-        ));
-
-        // Ensure that the task config class hasn't accidentally modified the connector config
-        ConfigDef connectorConfigDef = MirrorConnectorConfig.CONNECTOR_CONFIG_DEF;
-        taskSpecificProperties.forEach(taskSpecificProperty -> assertFalse(
-            connectorConfigDef.names().contains(taskSpecificProperty),
-            taskSpecificProperty + " should not be defined for connector ConfigDef"
-        ));
+        protected TestMirrorConnectorConfig(Map<String, String> props) {
+            super(BASE_CONNECTOR_CONFIG_DEF, props);
+        }
     }
 
     @Test
@@ -155,7 +44,7 @@ public class MirrorConnectorConfigTest {
         Map<String, String> connectorProps = makeProps(
                 MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "max.poll.interval.ms", "120000"
         );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorConsumerProps = config.sourceConsumerConfig();
         Map<String, Object> expectedConsumerProps = new HashMap<>();
         expectedConsumerProps.put("enable.auto.commit", "false");
@@ -167,7 +56,7 @@ public class MirrorConnectorConfigTest {
         connectorProps = makeProps(
                 MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "auto.offset.reset", "latest"
         );
-        config = new MirrorConnectorConfig(connectorProps);
+        config = new TestMirrorConnectorConfig(connectorProps);
         connectorConsumerProps = config.sourceConsumerConfig();
         expectedConsumerProps.put("auto.offset.reset", "latest");
         expectedConsumerProps.remove("max.poll.interval.ms");
@@ -182,7 +71,7 @@ public class MirrorConnectorConfigTest {
                 prefix + "auto.offset.reset", "latest",
                 prefix + "max.poll.interval.ms", "100"
         );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorConsumerProps = config.sourceConsumerConfig();
         Map<String, Object> expectedConsumerProps = new HashMap<>();
         expectedConsumerProps.put("enable.auto.commit", "false");
@@ -197,7 +86,7 @@ public class MirrorConnectorConfigTest {
         Map<String, String> connectorProps = makeProps(
                 MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX + "acks", "1"
         );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorProducerProps = config.sourceProducerConfig();
         Map<String, Object> expectedProducerProps = new HashMap<>();
         expectedProducerProps.put("acks", "1");
@@ -209,7 +98,7 @@ public class MirrorConnectorConfigTest {
     public void testSourceProducerConfigWithSourcePrefix() {
         String prefix = MirrorConnectorConfig.SOURCE_PREFIX + MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX;
         Map<String, String> connectorProps = makeProps(prefix + "acks", "1");
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorProducerProps = config.sourceProducerConfig();
         Map<String, Object> expectedProducerProps = new HashMap<>();
         expectedProducerProps.put("acks", "1");
@@ -223,7 +112,7 @@ public class MirrorConnectorConfigTest {
                 MirrorConnectorConfig.ADMIN_CLIENT_PREFIX +
                         "connections.max.idle.ms", "10000"
         );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorAdminProps = config.sourceAdminConfig();
         Map<String, Object> expectedAdminProps = new HashMap<>();
         expectedAdminProps.put("connections.max.idle.ms", "10000");
@@ -235,7 +124,7 @@ public class MirrorConnectorConfigTest {
     public void testSourceAdminConfigWithSourcePrefix() {
         String prefix = MirrorConnectorConfig.SOURCE_PREFIX + MirrorConnectorConfig.ADMIN_CLIENT_PREFIX;
         Map<String, String> connectorProps = makeProps(prefix + "connections.max.idle.ms", "10000");
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorAdminProps = config.sourceAdminConfig();
         Map<String, Object> expectedAdminProps = new HashMap<>();
         expectedAdminProps.put("connections.max.idle.ms", "10000");
@@ -248,7 +137,7 @@ public class MirrorConnectorConfigTest {
                 MirrorConnectorConfig.ADMIN_CLIENT_PREFIX +
                         "connections.max.idle.ms", "10000"
         );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorAdminProps = config.targetAdminConfig();
         Map<String, Object> expectedAdminProps = new HashMap<>();
         expectedAdminProps.put("connections.max.idle.ms", "10000");
@@ -260,7 +149,7 @@ public class MirrorConnectorConfigTest {
     public void testTargetAdminConfigWithSourcePrefix() {
         String prefix = MirrorConnectorConfig.TARGET_PREFIX + MirrorConnectorConfig.ADMIN_CLIENT_PREFIX;
         Map<String, String> connectorProps = makeProps(prefix + "connections.max.idle.ms", "10000");
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorAdminProps = config.targetAdminConfig();
         Map<String, Object> expectedAdminProps = new HashMap<>();
         expectedAdminProps.put("connections.max.idle.ms", "10000");
@@ -268,72 +157,9 @@ public class MirrorConnectorConfigTest {
     }
 
     @Test
-    public void testOffsetSyncsTopic() {
-        // Invalid location
-        Map<String, String> connectorProps = makeProps("offset-syncs.topic.location", "something");
-        assertThrows(ConfigException.class, () -> new MirrorConnectorConfig(connectorProps));
-
-        connectorProps.put("offset-syncs.topic.location", "source");
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
-        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorConnectorConfig(connectorProps);
-        assertEquals("mm2-offset-syncs.source1.internal", config.offsetSyncsTopic());
-        // Default to source
-        connectorProps.remove("offset-syncs.topic.location");
-        config = new MirrorConnectorConfig(connectorProps);
-        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
-    }
-
-    @Test
-    public void testConsumerConfigsForOffsetSyncsTopic() {
-        Map<String, String> connectorProps = makeProps(
-                "source.consumer.max.partition.fetch.bytes", "1",
-                "target.consumer.heartbeat.interval.ms", "1",
-                "consumer.max.poll.interval.ms", "1",
-                "fetch.min.bytes", "1"
-        );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
-        assertEquals(config.sourceConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorConnectorConfig(connectorProps);
-        assertEquals(config.targetConsumerConfig(), config.offsetSyncsTopicConsumerConfig());
-    }
-
-    @Test
-    public void testProducerConfigsForOffsetSyncsTopic() {
-        Map<String, String> connectorProps = makeProps(
-                "source.producer.batch.size", "1",
-                "target.producer.acks", "1",
-                "producer.max.poll.interval.ms", "1",
-                "fetch.min.bytes", "1"
-        );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
-        assertEquals(config.sourceProducerConfig(), config.offsetSyncsTopicProducerConfig());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorConnectorConfig(connectorProps);
-        assertEquals(config.targetProducerConfig(), config.offsetSyncsTopicProducerConfig());
-    }
-
-    @Test
-    public void testAdminConfigsForOffsetSyncsTopic() {
-        Map<String, String> connectorProps = makeProps(
-                "source.admin.request.timeout.ms", "1",
-                "target.admin.send.buffer.bytes", "1",
-                "admin.reconnect.backoff.max.ms", "1",
-                "retries", "123"
-        );
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
-        assertEquals(config.sourceAdminConfig(), config.offsetSyncsTopicAdminConfig());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorConnectorConfig(connectorProps);
-        assertEquals(config.targetAdminConfig(), config.offsetSyncsTopicAdminConfig());
-    }
-
-    @Test
     public void testInvalidSecurityProtocol() {
         ConfigException ce = assertThrows(ConfigException.class,
-                () -> new MirrorConnectorConfig(makeProps(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "abc")));
+                () -> new TestMirrorConnectorConfig(makeProps(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "abc")));
         assertTrue(ce.getMessage().contains(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
     }
 
@@ -341,11 +167,11 @@ public class MirrorConnectorConfigTest {
     @SuppressWarnings("deprecation")
     public void testMetricsReporters() {
         Map<String, String> connectorProps = makeProps("metric.reporters", MockMetricsReporter.class.getName());
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         assertEquals(2, config.metricsReporters().size());
 
         connectorProps.put(CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_CONFIG, "false");
-        config = new MirrorConnectorConfig(connectorProps);
+        config = new TestMirrorConnectorConfig(connectorProps);
         assertEquals(1, config.metricsReporters().size());
     }
 
@@ -353,7 +179,7 @@ public class MirrorConnectorConfigTest {
     public void testExplicitlyEnableJmxReporter() {
         String reporters = MockMetricsReporter.class.getName() + "," + JmxReporter.class.getName();
         Map<String, String> connectorProps = makeProps("metric.reporters", reporters);
-        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         assertEquals(2, config.metricsReporters().size());
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorHeartBeatConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorHeartBeatConnectorTest.java
@@ -27,7 +27,7 @@ public class MirrorHeartBeatConnectorTest {
     @Test
     public void testMirrorHeartbeatConnectorDisabled() {
         // disable the heartbeat emission
-        MirrorConnectorConfig config = new MirrorConnectorConfig(
+        MirrorHeartbeatConfig config = new MirrorHeartbeatConfig(
             makeProps("emit.heartbeats.enabled", "false"));
 
         // MirrorHeartbeatConnector as minimum to run taskConfig()
@@ -40,7 +40,7 @@ public class MirrorHeartBeatConnectorTest {
     @Test
     public void testReplicationDisabled() {
         // disable the replication
-        MirrorConnectorConfig config = new MirrorConnectorConfig(
+        MirrorHeartbeatConfig config = new MirrorHeartbeatConfig(
             makeProps("enabled", "false"));
 
         // MirrorHeartbeatConnector as minimum to run taskConfig()

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
@@ -143,23 +143,26 @@ public class MirrorMakerConfigTest {
         SourceAndTarget sourceAndTarget = new SourceAndTarget("source", "target");
         Map<String, String> connectorProps = mirrorConfig.connectorBaseConfig(sourceAndTarget,
             MirrorSourceConnector.class);
-        MirrorConnectorConfig connectorConfig = new MirrorConnectorConfig(connectorProps);
-        assertEquals(100, (int) connectorConfig.getInt("tasks.max"),
+        MirrorSourceConfig sourceConfig = new MirrorSourceConfig(connectorProps);
+        assertEquals(100, (int) sourceConfig.getInt("tasks.max"),
             "Connector properties like tasks.max should be passed through to underlying Connectors.");
-        assertEquals(Collections.singletonList("topic-1"), connectorConfig.getList("topics"),
+        assertEquals(Collections.singletonList("topic-1"), sourceConfig.getList("topics"),
             "Topics include should be passed through to underlying Connectors.");
-        assertEquals(Collections.singletonList("group-2"), connectorConfig.getList("groups"),
+        assertEquals(Collections.singletonList("property-3"), sourceConfig.getList("config.properties.exclude"),
+                "Config properties exclude should be passed through to underlying Connectors.");
+        assertEquals(Collections.singletonList("FakeMetricsReporter"), sourceConfig.getList("metric.reporters"),
+                "Metrics reporters should be passed through to underlying Connectors.");
+        assertEquals("DefaultTopicFilter", sourceConfig.getClass("topic.filter.class").getSimpleName(),
+                "Filters should be passed through to underlying Connectors.");
+        assertEquals("__", sourceConfig.getString("replication.policy.separator"),
+                "replication policy separator should be passed through to underlying Connectors.");
+        assertFalse(sourceConfig.originals().containsKey("xxx"),
+                "Unknown properties should not be passed through to Connectors.");
+
+        MirrorCheckpointConfig checkpointConfig = new MirrorCheckpointConfig(connectorProps);
+        assertEquals(Collections.singletonList("group-2"), checkpointConfig.getList("groups"),
             "Groups include should be passed through to underlying Connectors.");
-        assertEquals(Collections.singletonList("property-3"), connectorConfig.getList("config.properties.exclude"),
-            "Config properties exclude should be passed through to underlying Connectors.");
-        assertEquals(Collections.singletonList("FakeMetricsReporter"), connectorConfig.getList("metric.reporters"),
-            "Metrics reporters should be passed through to underlying Connectors.");
-        assertEquals("DefaultTopicFilter", connectorConfig.getClass("topic.filter.class").getSimpleName(),
-            "Filters should be passed through to underlying Connectors.");
-        assertEquals("__", connectorConfig.getString("replication.policy.separator"),
-            "replication policy separator should be passed through to underlying Connectors.");
-        assertFalse(connectorConfig.originals().containsKey("xxx"),
-            "Unknown properties should not be passed through to Connectors.");
+
     }
 
     @Test
@@ -173,18 +176,19 @@ public class MirrorMakerConfigTest {
         SourceAndTarget sourceAndTarget = new SourceAndTarget("source", "target");
         Map<String, String> connectorProps = mirrorConfig.connectorBaseConfig(sourceAndTarget,
                                                                               MirrorSourceConnector.class);
-        MirrorConnectorConfig connectorConfig = new MirrorConnectorConfig(connectorProps);
+        MirrorSourceConfig sourceConfig = new MirrorSourceConfig(connectorProps);
         DefaultTopicFilter.TopicFilterConfig filterConfig =
             new DefaultTopicFilter.TopicFilterConfig(connectorProps);
 
         assertEquals(Collections.singletonList("topic3"), filterConfig.getList("topics.exclude"),
             "Topics exclude should be backwards compatible.");
 
-        assertEquals(Collections.singletonList("group-7"), connectorConfig.getList("groups.exclude"),
-            "Groups exclude should be backwards compatible.");
-
-        assertEquals(Collections.singletonList("property-3"), connectorConfig.getList("config.properties.exclude"),
+        assertEquals(Collections.singletonList("property-3"), sourceConfig.getList("config.properties.exclude"),
             "Config properties exclude should be backwards compatible.");
+
+        MirrorCheckpointConfig checkpointConfig = new MirrorCheckpointConfig(connectorProps);
+        assertEquals(Collections.singletonList("group-7"), checkpointConfig.getList("groups.exclude"),
+            "Groups exclude should be backwards compatible.");
 
     }
 
@@ -198,7 +202,7 @@ public class MirrorMakerConfigTest {
         SourceAndTarget sourceAndTarget = new SourceAndTarget("source", "target");
         Map<String, String> connectorProps = mirrorConfig.connectorBaseConfig(sourceAndTarget,
                                                                               MirrorSourceConnector.class);
-        MirrorConnectorConfig connectorConfig = new MirrorConnectorConfig(connectorProps);
+        MirrorCheckpointConfig connectorConfig = new MirrorCheckpointConfig(connectorProps);
         DefaultTopicFilter.TopicFilterConfig filterConfig =
             new DefaultTopicFilter.TopicFilterConfig(connectorProps);
 
@@ -355,6 +359,17 @@ public class MirrorMakerConfigTest {
         ConfigException ce = assertThrows(ConfigException.class,
                 () -> new MirrorClientConfig(makeProps(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "abc")));
         assertTrue(ce.getMessage().contains(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    public void testAllConfigNames() {
+        MirrorMakerConfig mirrorConfig = new MirrorMakerConfig(makeProps(
+                "clusters", "a, b"));
+        Set<String> allNames = mirrorConfig.allConfigNames();
+
+        assertTrue(allNames.contains("topics"));
+        assertTrue(allNames.contains("groups"));
+        assertTrue(allNames.contains("emit.heartbeats.enabled"));
     }
 
     public static class FakeConfigProvider implements ConfigProvider {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MirrorSourceConfigTest {
+
+    @Test
+    public void testTaskConfigTopicPartitions() {
+        List<TopicPartition> topicPartitions = Arrays.asList(new TopicPartition("topic-1", 2),
+                new TopicPartition("topic-3", 4), new TopicPartition("topic-5", 6));
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps());
+        Map<String, String> props = config.taskConfigForTopicPartitions(topicPartitions);
+        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(props);
+        assertEquals(taskConfig.taskTopicPartitions(), new HashSet<>(topicPartitions),
+                "Setting topic property configuration failed");
+    }
+
+    @Test
+    public void testTopicMatching() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", "topic1"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
+                "topic1 replication property configuration failed");
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"),
+                "topic2 replication property configuration failed");
+    }
+
+    @Test
+    public void testConfigPropertyMatching() {
+        MirrorSourceConfig config = new MirrorSourceConfig(
+                makeProps("config.properties.exclude", "prop2"));
+        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"),
+                "config.properties.exclude incorrectly excluded prop1");
+        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"),
+                "config.properties.exclude incorrectly included prop2");
+    }
+
+    @Test
+    public void testConfigBackwardsCompatibility() {
+        MirrorSourceConfig config = new MirrorSourceConfig(
+                makeProps("config.properties.blacklist", "prop1",
+                        "topics.blacklist", "topic-1"));
+        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"));
+        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"));
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic-1"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic-2"));
+    }
+
+    @Test
+    public void testNoTopics() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", ""));
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 shouldn't exist");
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 shouldn't exist");
+        assertFalse(config.topicFilter().shouldReplicateTopic(""), "Empty topic shouldn't exist");
+    }
+
+    @Test
+    public void testAllTopics() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", ".*"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
+                "topic1 created from wildcard should exist");
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"),
+                "topic2 created from wildcard should exist");
+    }
+
+    @Test
+    public void testListOfTopics() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", "topic1, topic2"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 created from list should exist");
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 created from list should exist");
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic3"), "topic3 created from list should exist");
+    }
+
+    @Test
+    public void testNonMutationOfConfigDef() {
+        // Sanity check to make sure that these properties are actually defined for the task config,
+        // and that the task config class has been loaded and statically initialized by the JVM
+        ConfigDef taskConfigDef = MirrorSourceTaskConfig.TASK_CONFIG_DEF;
+        assertTrue(
+                taskConfigDef.names().contains(MirrorSourceConfig.TASK_TOPIC_PARTITIONS),
+                MirrorSourceConfig.TASK_TOPIC_PARTITIONS + " should be defined for task ConfigDef"
+        );
+
+        // Ensure that the task config class hasn't accidentally modified the connector config
+        assertFalse(
+                MirrorSourceConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorSourceConfig.TASK_TOPIC_PARTITIONS),
+                MirrorSourceConfig.TASK_TOPIC_PARTITIONS + " should not be defined for connector ConfigDef"
+        );
+    }
+
+    @Test
+    public void testOffsetSyncsTopic() {
+        // Invalid location
+        Map<String, String> connectorProps = makeProps("offset-syncs.topic.location", "something");
+        assertThrows(ConfigException.class, () -> new MirrorSourceConfig(connectorProps));
+
+        connectorProps.put("offset-syncs.topic.location", "source");
+        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
+        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals("mm2-offset-syncs.source1.internal", config.offsetSyncsTopic());
+        // Default to source
+        connectorProps.remove("offset-syncs.topic.location");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
+    }
+
+    @Test
+    public void testProducerConfigsForOffsetSyncsTopic() {
+        Map<String, String> connectorProps = makeProps(
+                "source.producer.batch.size", "1",
+                "target.producer.acks", "1",
+                "producer.max.poll.interval.ms", "1",
+                "fetch.min.bytes", "1"
+        );
+        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.sourceProducerConfig(), config.offsetSyncsTopicProducerConfig());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.targetProducerConfig(), config.offsetSyncsTopicProducerConfig());
+    }
+
+    @Test
+    public void testAdminConfigsForOffsetSyncsTopic() {
+        Map<String, String> connectorProps = makeProps(
+                "source.admin.request.timeout.ms", "1",
+                "target.admin.send.buffer.bytes", "1",
+                "admin.reconnect.backoff.max.ms", "1",
+                "retries", "123"
+        );
+        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.sourceAdminConfig(), config.offsetSyncsTopicAdminConfig());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.targetAdminConfig(), config.offsetSyncsTopicAdminConfig());
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -21,8 +21,6 @@ import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
@@ -36,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import static org.apache.kafka.connect.mirror.MirrorSourceConfig.TASK_TOPIC_PARTITIONS;
 import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -336,137 +332,6 @@ public class MirrorSourceConnectorTest {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
                 new CustomReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
         assertDoesNotThrow(() -> connector.isCycle(".b"));
-    }
-
-    @Test
-    public void testTaskConfigTopicPartitions() {
-        List<TopicPartition> topicPartitions = Arrays.asList(new TopicPartition("topic-1", 2),
-                new TopicPartition("topic-3", 4), new TopicPartition("topic-5", 6));
-        MirrorSourceConfig config = new MirrorSourceConfig(makeProps());
-        Map<String, String> props = config.taskConfigForTopicPartitions(topicPartitions);
-        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(props);
-        assertEquals(taskConfig.taskTopicPartitions(), new HashSet<>(topicPartitions),
-                "Setting topic property configuration failed");
-    }
-
-    @Test
-    public void testTopicMatching() {
-        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", "topic1"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
-                "topic1 replication property configuration failed");
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"),
-                "topic2 replication property configuration failed");
-    }
-
-    @Test
-    public void testConfigPropertyMatching() {
-        MirrorSourceConfig config = new MirrorSourceConfig(
-                makeProps("config.properties.exclude", "prop2"));
-        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"),
-                "config.properties.exclude incorrectly excluded prop1");
-        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"),
-                "config.properties.exclude incorrectly included prop2");
-    }
-
-    @Test
-    public void testConfigBackwardsCompatibility() {
-        MirrorSourceConfig config = new MirrorSourceConfig(
-                makeProps("config.properties.blacklist", "prop1",
-                        "topics.blacklist", "topic-1"));
-        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"));
-        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"));
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic-1"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic-2"));
-    }
-
-    @Test
-    public void testNoTopics() {
-        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", ""));
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 shouldn't exist");
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 shouldn't exist");
-        assertFalse(config.topicFilter().shouldReplicateTopic(""), "Empty topic shouldn't exist");
-    }
-
-    @Test
-    public void testAllTopics() {
-        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", ".*"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
-                "topic1 created from wildcard should exist");
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"),
-                "topic2 created from wildcard should exist");
-    }
-
-    @Test
-    public void testListOfTopics() {
-        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", "topic1, topic2"));
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 created from list should exist");
-        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 created from list should exist");
-        assertFalse(config.topicFilter().shouldReplicateTopic("topic3"), "topic3 created from list should exist");
-    }
-
-    @Test
-    public void testNonMutationOfConfigDef() {
-        // Sanity check to make sure that these properties are actually defined for the task config,
-        // and that the task config class has been loaded and statically initialized by the JVM
-        ConfigDef taskConfigDef = MirrorSourceTaskConfig.TASK_CONFIG_DEF;
-        assertTrue(
-                taskConfigDef.names().contains(MirrorSourceConfig.TASK_TOPIC_PARTITIONS),
-                MirrorSourceConfig.TASK_TOPIC_PARTITIONS + " should be defined for task ConfigDef"
-        );
-
-        // Ensure that the task config class hasn't accidentally modified the connector config
-        assertFalse(
-                MirrorSourceConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorSourceConfig.TASK_TOPIC_PARTITIONS),
-                MirrorSourceConfig.TASK_TOPIC_PARTITIONS + " should not be defined for connector ConfigDef"
-        );
-    }
-
-    @Test
-    public void testOffsetSyncsTopic() {
-        // Invalid location
-        Map<String, String> connectorProps = makeProps("offset-syncs.topic.location", "something");
-        assertThrows(ConfigException.class, () -> new MirrorSourceConfig(connectorProps));
-
-        connectorProps.put("offset-syncs.topic.location", "source");
-        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
-        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorSourceConfig(connectorProps);
-        assertEquals("mm2-offset-syncs.source1.internal", config.offsetSyncsTopic());
-        // Default to source
-        connectorProps.remove("offset-syncs.topic.location");
-        config = new MirrorSourceConfig(connectorProps);
-        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
-    }
-
-    @Test
-    public void testProducerConfigsForOffsetSyncsTopic() {
-        Map<String, String> connectorProps = makeProps(
-                "source.producer.batch.size", "1",
-                "target.producer.acks", "1",
-                "producer.max.poll.interval.ms", "1",
-                "fetch.min.bytes", "1"
-        );
-        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
-        assertEquals(config.sourceProducerConfig(), config.offsetSyncsTopicProducerConfig());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorSourceConfig(connectorProps);
-        assertEquals(config.targetProducerConfig(), config.offsetSyncsTopicProducerConfig());
-    }
-
-    @Test
-    public void testAdminConfigsForOffsetSyncsTopic() {
-        Map<String, String> connectorProps = makeProps(
-                "source.admin.request.timeout.ms", "1",
-                "target.admin.send.buffer.bytes", "1",
-                "admin.reconnect.backoff.max.ms", "1",
-                "retries", "123"
-        );
-        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
-        assertEquals(config.sourceAdminConfig(), config.offsetSyncsTopicAdminConfig());
-        connectorProps.put("offset-syncs.topic.location", "target");
-        config = new MirrorSourceConfig(connectorProps);
-        assertEquals(config.targetAdminConfig(), config.offsetSyncsTopicAdminConfig());
     }
 
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
@@ -31,9 +33,10 @@ import org.apache.kafka.clients.admin.NewTopic;
 
 import org.junit.jupiter.api.Test;
 
-import static org.apache.kafka.connect.mirror.MirrorConnectorConfig.TASK_TOPIC_PARTITIONS;
+import static org.apache.kafka.connect.mirror.MirrorSourceConfig.TASK_TOPIC_PARTITIONS;
 import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -53,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -222,7 +226,7 @@ public class MirrorSourceConnectorTest {
         knownSourceTopicPartitions.add(new TopicPartition("t2", 1));
 
         // MirrorConnectorConfig example for test
-        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps());
 
         // MirrorSourceConnector as minimum to run taskConfig()
         MirrorSourceConnector connector = new MirrorSourceConnector(knownSourceTopicPartitions, config);
@@ -333,4 +337,136 @@ public class MirrorSourceConnectorTest {
                 new CustomReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
         assertDoesNotThrow(() -> connector.isCycle(".b"));
     }
+
+    @Test
+    public void testTaskConfigTopicPartitions() {
+        List<TopicPartition> topicPartitions = Arrays.asList(new TopicPartition("topic-1", 2),
+                new TopicPartition("topic-3", 4), new TopicPartition("topic-5", 6));
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps());
+        Map<String, String> props = config.taskConfigForTopicPartitions(topicPartitions);
+        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(props);
+        assertEquals(taskConfig.taskTopicPartitions(), new HashSet<>(topicPartitions),
+                "Setting topic property configuration failed");
+    }
+
+    @Test
+    public void testTopicMatching() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", "topic1"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
+                "topic1 replication property configuration failed");
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"),
+                "topic2 replication property configuration failed");
+    }
+
+    @Test
+    public void testConfigPropertyMatching() {
+        MirrorSourceConfig config = new MirrorSourceConfig(
+                makeProps("config.properties.exclude", "prop2"));
+        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"),
+                "config.properties.exclude incorrectly excluded prop1");
+        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"),
+                "config.properties.exclude incorrectly included prop2");
+    }
+
+    @Test
+    public void testConfigBackwardsCompatibility() {
+        MirrorSourceConfig config = new MirrorSourceConfig(
+                makeProps("config.properties.blacklist", "prop1",
+                        "topics.blacklist", "topic-1"));
+        assertFalse(config.configPropertyFilter().shouldReplicateConfigProperty("prop1"));
+        assertTrue(config.configPropertyFilter().shouldReplicateConfigProperty("prop2"));
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic-1"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic-2"));
+    }
+
+    @Test
+    public void testNoTopics() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", ""));
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 shouldn't exist");
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 shouldn't exist");
+        assertFalse(config.topicFilter().shouldReplicateTopic(""), "Empty topic shouldn't exist");
+    }
+
+    @Test
+    public void testAllTopics() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", ".*"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"),
+                "topic1 created from wildcard should exist");
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"),
+                "topic2 created from wildcard should exist");
+    }
+
+    @Test
+    public void testListOfTopics() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps("topics", "topic1, topic2"));
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic1"), "topic1 created from list should exist");
+        assertTrue(config.topicFilter().shouldReplicateTopic("topic2"), "topic2 created from list should exist");
+        assertFalse(config.topicFilter().shouldReplicateTopic("topic3"), "topic3 created from list should exist");
+    }
+
+    @Test
+    public void testNonMutationOfConfigDef() {
+        // Sanity check to make sure that these properties are actually defined for the task config,
+        // and that the task config class has been loaded and statically initialized by the JVM
+        ConfigDef taskConfigDef = MirrorSourceTaskConfig.TASK_CONFIG_DEF;
+        assertTrue(
+                taskConfigDef.names().contains(MirrorSourceConfig.TASK_TOPIC_PARTITIONS),
+                MirrorSourceConfig.TASK_TOPIC_PARTITIONS + " should be defined for task ConfigDef"
+        );
+
+        // Ensure that the task config class hasn't accidentally modified the connector config
+        assertFalse(
+                MirrorSourceConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorSourceConfig.TASK_TOPIC_PARTITIONS),
+                MirrorSourceConfig.TASK_TOPIC_PARTITIONS + " should not be defined for connector ConfigDef"
+        );
+    }
+
+    @Test
+    public void testOffsetSyncsTopic() {
+        // Invalid location
+        Map<String, String> connectorProps = makeProps("offset-syncs.topic.location", "something");
+        assertThrows(ConfigException.class, () -> new MirrorSourceConfig(connectorProps));
+
+        connectorProps.put("offset-syncs.topic.location", "source");
+        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
+        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals("mm2-offset-syncs.source1.internal", config.offsetSyncsTopic());
+        // Default to source
+        connectorProps.remove("offset-syncs.topic.location");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals("mm2-offset-syncs.target2.internal", config.offsetSyncsTopic());
+    }
+
+    @Test
+    public void testProducerConfigsForOffsetSyncsTopic() {
+        Map<String, String> connectorProps = makeProps(
+                "source.producer.batch.size", "1",
+                "target.producer.acks", "1",
+                "producer.max.poll.interval.ms", "1",
+                "fetch.min.bytes", "1"
+        );
+        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.sourceProducerConfig(), config.offsetSyncsTopicProducerConfig());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.targetProducerConfig(), config.offsetSyncsTopicProducerConfig());
+    }
+
+    @Test
+    public void testAdminConfigsForOffsetSyncsTopic() {
+        Map<String, String> connectorProps = makeProps(
+                "source.admin.request.timeout.ms", "1",
+                "target.admin.send.buffer.bytes", "1",
+                "admin.reconnect.backoff.max.ms", "1",
+                "retries", "123"
+        );
+        MirrorSourceConfig config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.sourceAdminConfig(), config.offsetSyncsTopicAdminConfig());
+        connectorProps.put("offset-syncs.topic.location", "target");
+        config = new MirrorSourceConfig(connectorProps);
+        assertEquals(config.targetAdminConfig(), config.offsetSyncsTopicAdminConfig());
+    }
+
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -135,7 +135,7 @@ public class MirrorSourceTaskTest {
         KafkaProducer<byte[], byte[]> producer = mock(KafkaProducer.class);
         when(consumer.poll(any())).thenReturn(consumerRecords);
 
-        MirrorMetrics metrics = mock(MirrorMetrics.class);
+        MirrorSourceMetrics metrics = mock(MirrorSourceMetrics.class);
 
         String sourceClusterName = "cluster1";
         ReplicationPolicy replicationPolicy = new DefaultReplicationPolicy();
@@ -181,7 +181,7 @@ public class MirrorSourceTaskTest {
         KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
         @SuppressWarnings("unchecked")
         KafkaProducer<byte[], byte[]> producer = mock(KafkaProducer.class);
-        MirrorMetrics metrics = mock(MirrorMetrics.class);
+        MirrorSourceMetrics metrics = mock(MirrorSourceMetrics.class);
 
         String sourceClusterName = "cluster1";
         ReplicationPolicy replicationPolicy = new DefaultReplicationPolicy();


### PR DESCRIPTION
This also adds 3 new Gradle tasks (`:connect:mirror:genMirrorSourceConfigDocs`, `:connect:mirror:genMirrorCheckpointConfigDocs` and `:connect:mirror:genMirrorHeartbeatConfigDocs`) to generate the documentation for the configuration of each connector.

I plan to do updates to the documentation in a follow up PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
