### PR TITLE
MINOR: Prevent NPE in SmokeTestDriver (fix flaky test)

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -436,15 +436,19 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
         boolean success;
 
-        final Map<String, Set<Number>> received =
-            events.get("echo")
-                  .entrySet()
-                  .stream()
-                  .map(entry -> mkEntry(
-                      entry.getKey(),
-                      entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
-                  )
-                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Set<Number>> received;
+        if (events.containsKey("echo")) {
+            received = events.get("echo")
+                .entrySet()
+                .stream()
+                .map(entry -> mkEntry(
+                    entry.getKey(),
+                    entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
+                )
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        } else {
+            received = Collections.emptyMap();
+        }
 
         success = inputs.equals(received);
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -420,6 +420,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
             }
         }
         consumer.close();
+
         final long finished = System.currentTimeMillis() - start;
         System.out.println("Verification time=" + finished);
         System.out.println("-------------------");
@@ -434,23 +435,9 @@ public class SmokeTestDriver extends SmokeTestUtil {
             System.out.println("PROCESSED-LESS-THAN-GENERATED");
         }
 
-        boolean success;
+        final Map<String, Set<Number>> received = parseRecordsForEchoTopic(events);
 
-        Map<String, Set<Number>> received;
-        if (events.containsKey("echo")) {
-            received = events.get("echo")
-                .entrySet()
-                .stream()
-                .map(entry -> mkEntry(
-                    entry.getKey(),
-                    entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
-                )
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        } else {
-            received = Collections.emptyMap();
-        }
-
-        success = inputs.equals(received);
+        boolean success = inputs.equals(received);
 
         if (success) {
             System.out.println("ALL-RECORDS-DELIVERED");
@@ -472,6 +459,18 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
         System.out.println(success ? "SUCCESS" : "FAILURE");
         return verificationResult;
+    }
+
+    private static Map<String, Set<Number>> parseRecordsForEchoTopic(final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events) {
+        return events.containsKey("echo") ?
+            events.get("echo")
+                .entrySet()
+                .stream()
+                .map(entry -> mkEntry(
+                    entry.getKey(),
+                    entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
+                )
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)) : Collections.emptyMap();
     }
 
     public static class VerificationResult {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -461,7 +461,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
         return verificationResult;
     }
 
-    private static Map<String, Set<Number>> parseRecordsForEchoTopic(final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events) {
+    private static Map<String, Set<Number>> parseRecordsForEchoTopic(
+        final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events) {
         return events.containsKey("echo") ?
             events.get("echo")
                 .entrySet()


### PR DESCRIPTION
`SmokeTestDriverIntegrationTest.java` can be flaky because a NullPointerException prevents [the retry mechanism](https://github.com/apache/kafka/blob/trunk/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java#L461) that is  added to prevent flakiness for this test. This change, prevents the NullPointerException and hence, allows the test to retry itself.

Build during which NPE was observed: https://ci-builds.apache.org/job/Kafka/job/kafka-pr/job/PR-12890/4/testReport/junit/org.apache.kafka.streams.integration/SmokeTestDriverIntegrationTest/Build___JDK_11_and_Scala_2_13___shouldWorkWithRebalance/?cloudbees-analytics-link=scm-reporting%2Ftests%2Ffailed 