### PR TITLE
KAFKA-14418: Do not allow modifying partition of internal topics from admin commands

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -659,6 +659,9 @@ public interface Admin extends AutoCloseable {
      * <p>
      * This operation is not transactional so it may succeed for some topics while fail for others.
      * <p>
+     * Partitions for internal topics such as __consumer_offsets cannot be modified using this API. Use
+     * configuration `offsets.topic.num.partitions` and restart the cluster if you wish to modify the internal topics.
+     * <p>
      * It may take several seconds after this method returns
      * success for all the brokers to become aware that the partitions have been created.
      * During this time, {@link #describeTopics(Collection)}

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -24,10 +24,7 @@ import kafka.common.AdminCommandFailedException
 import kafka.log.LogConfig
 import kafka.utils._
 import org.apache.kafka.clients.CommonClientConfigs
-import org.apache.kafka.clients.admin.CreatePartitionsOptions
-import org.apache.kafka.clients.admin.CreateTopicsOptions
-import org.apache.kafka.clients.admin.DeleteTopicsOptions
-import org.apache.kafka.clients.admin.{Admin, ListTopicsOptions, NewPartitions, NewTopic, PartitionReassignment, Config => JConfig}
+import org.apache.kafka.clients.admin.{Admin, CreatePartitionsOptions, CreateTopicsOptions, DeleteTopicsOptions, ListTopicsOptions, NewPartitions, NewTopic, PartitionReassignment, Config => JConfig}
 import org.apache.kafka.common.{TopicCollection, TopicPartition, TopicPartitionInfo, Uuid}
 import org.apache.kafka.common.config.ConfigResource.Type
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
@@ -265,7 +262,7 @@ object TopicCommand extends Logging {
 
       if (topics.nonEmpty) {
         val topicsInfo = adminClient.describeTopics(topics.asJavaCollection).topicNameValues()
-        val newPartitions = topics.filterNot(Topic.isInternal).map { topicName =>
+        val newPartitions = topics.map { topicName =>
           if (topic.hasReplicaAssignment) {
             val startPartitionId = topicsInfo.get(topicName).get().partitions().size()
             val newAssignment = {

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -265,7 +265,7 @@ object TopicCommand extends Logging {
 
       if (topics.nonEmpty) {
         val topicsInfo = adminClient.describeTopics(topics.asJavaCollection).topicNameValues()
-        val newPartitions = topics.map { topicName =>
+        val newPartitions = topics.filterNot(Topic.isInternal).map { topicName =>
           if (topic.hasReplicaAssignment) {
             val startPartitionId = topicsInfo.get(topicName).get().partitions().size()
             val newAssignment = {

--- a/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
@@ -378,8 +378,14 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))
   def testAlterForInternalTopics(quorum: String): Unit = {
+    // create the offset topic
+    val createOffsetTopicOpts = new TopicCommandOptions(Array("--partitions", "3",
+      "--replication-factor", "1",
+      "--topic", Topic.GROUP_METADATA_TOPIC_NAME))
+    createAndWaitTopic(createOffsetTopicOpts)
+
     // altering an internal topic is not allowed
-    val alterOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME, "--partitions", "1"))
+    val alterOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME, "--partitions", "5"))
     val topicService = TopicService(adminClient)
     assertThrows(classOf[IllegalArgumentException], () => topicService.alterTopic(alterOpts))
   }

--- a/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
@@ -377,6 +377,15 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))
+  def testAlterForInternalTopics(quorum: String): Unit = {
+    // altering an internal topic is not allowed
+    val alterOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME, "--partitions", "1"))
+    val topicService = TopicService(adminClient)
+    assertThrows(classOf[IllegalArgumentException], () => topicService.alterTopic(alterOpts))
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
   def testAlterWhenTopicDoesntExistWithIfExists(quorum: String): Unit = {
     topicService.alterTopic(new TopicCommandOptions(
       Array("--topic", testTopicName, "--partitions", "1", "--if-exists")))

--- a/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
@@ -384,10 +384,11 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
       "--topic", Topic.GROUP_METADATA_TOPIC_NAME))
     createAndWaitTopic(createOffsetTopicOpts)
 
+    val alteredNumPartitions = 5
     // altering an internal topic is not allowed
-    val alterOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME, "--partitions", "5"))
+    val alterOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME, "--partitions", alteredNumPartitions.toString))
     val topicService = TopicService(adminClient)
-    assertThrows(classOf[IllegalArgumentException], () => topicService.alterTopic(alterOpts))
+    assertThrows(classOf[ExecutionException], () => topicService.alterTopic(alterOpts))
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)


### PR DESCRIPTION
Today a user can change the number of partitions of `__consumer_offsets` topic by changing the configuration value for `offsets.topic.num.partitions` or manually by using `./bin/kafka-topics.sh`. For example, the following command changes the number of partitions to 60 for `__consumer_offsets` topic.
`./bin/kafka-topics.sh --topic __consumer_offsets --alter --partitions 60 --bootstrap-server=localhost:9092`

Changing offsets of this reserved topic leads to problems with consumer group detection of coordinator unless you restart all brokers.  Thus, there is a high probability that is this operations is not done right (i.e. if it is not followed by a cluster restart), users may shoot themselves in the foot. Example scenario: https://stackoverflow.com/questions/73944561/kafka-consumer-group-coordinator-inconsistent.

Same goes for [transaction.state.log.num.partitions](https://kafka.apache.org/documentation/#brokerconfigs_transaction.state.log.num.partitions)

## Change
This is one of multiple changes to address this problem. In the current PR we disallow modification of number of partitions via the admin command so that the modification is only allowed via the provided configuration `transaction.state.log.num.partitions` and `offsets.topic.num.partitions`