### PR TITLE
KAFKA-14352: Rack-aware consumer partition assignment (KIP-881)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -66,7 +66,7 @@
     <suppress checks="ParameterNumber"
               files="(NetworkClient|FieldSpec|KafkaRaftClient).java"/>
     <suppress checks="ParameterNumber"
-              files="KafkaConsumer.java"/>
+              files="(KafkaConsumer|ConsumerCoordinator).java"/>
     <suppress checks="ParameterNumber"
               files="Fetcher.java"/>
     <suppress checks="ParameterNumber"
@@ -90,7 +90,7 @@
               files="(ConsumerCoordinator|Fetcher|KafkaProducer|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
+              files="(AbstractRequest|AbstractResponse|KerberosLogin|AbstractStickyAssignor|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
 
     <suppress checks="NPathComplexity"
               files="(ConsumerCoordinator|BufferPool|Fetcher|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler).java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -103,27 +103,29 @@ public interface ConsumerPartitionAssignor {
         private final List<String> topics;
         private final ByteBuffer userData;
         private final List<TopicPartition> ownedPartitions;
+        private final Optional<String> rackId;
         private Optional<String> groupInstanceId;
         private final Optional<Integer> generationId;
 
-        public Subscription(List<String> topics, ByteBuffer userData, List<TopicPartition> ownedPartitions, int generationId) {
+        public Subscription(List<String> topics, ByteBuffer userData, List<TopicPartition> ownedPartitions, int generationId, Optional<String> rackId) {
             this.topics = topics;
             this.userData = userData;
             this.ownedPartitions = ownedPartitions;
             this.groupInstanceId = Optional.empty();
             this.generationId = generationId < 0 ? Optional.empty() : Optional.of(generationId);
+            this.rackId = rackId;
         }
 
         public Subscription(List<String> topics, ByteBuffer userData, List<TopicPartition> ownedPartitions) {
-            this(topics, userData, ownedPartitions, DEFAULT_GENERATION);
+            this(topics, userData, ownedPartitions, DEFAULT_GENERATION, Optional.empty());
         }
 
         public Subscription(List<String> topics, ByteBuffer userData) {
-            this(topics, userData, Collections.emptyList(), DEFAULT_GENERATION);
+            this(topics, userData, Collections.emptyList(), DEFAULT_GENERATION, Optional.empty());
         }
 
         public Subscription(List<String> topics) {
-            this(topics, null, Collections.emptyList(), DEFAULT_GENERATION);
+            this(topics, null, Collections.emptyList(), DEFAULT_GENERATION, Optional.empty());
         }
 
         public List<String> topics() {
@@ -136,6 +138,10 @@ public interface ConsumerPartitionAssignor {
 
         public List<TopicPartition> ownedPartitions() {
             return ownedPartitions;
+        }
+
+        public Optional<String> rackId() {
+            return rackId;
         }
 
         public void setGroupInstanceId(Optional<String> groupInstanceId) {
@@ -158,6 +164,7 @@ public interface ConsumerPartitionAssignor {
                 ", ownedPartitions=" + ownedPartitions +
                 ", groupInstanceId=" + groupInstanceId.map(String::toString).orElse("null") +
                 ", generationId=" + generationId.orElse(-1) +
+                ", rackId=" + (rackId.orElse("null")) +
                 ")";
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
@@ -101,13 +102,13 @@ public class CooperativeStickyAssignor extends AbstractStickyAssignor {
                 encodedGeneration = Optional.of(DEFAULT_GENERATION);
             }
         }
-        return new MemberData(subscription.ownedPartitions(), encodedGeneration);
+        return new MemberData(subscription.ownedPartitions(), encodedGeneration, subscription.rackId());
     }
 
     @Override
-    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
-                                                    Map<String, Subscription> subscriptions) {
-        Map<String, List<TopicPartition>> assignments = super.assign(partitionsPerTopic, subscriptions);
+    public Map<String, List<TopicPartition>> assignPartitions(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                                              Map<String, Subscription> subscriptions) {
+        Map<String, List<TopicPartition>> assignments = super.assignPartitions(partitionsPerTopic, subscriptions);
 
         Map<TopicPartition, String> partitionsTransferringOwnership = super.partitionsTransferringOwnership == null ?
             computePartitionsTransferringOwnership(subscriptions, assignments) :

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -790,7 +790,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                         enableAutoCommit,
                         config.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG),
                         this.interceptors,
-                        config.getBoolean(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED));
+                        config.getBoolean(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED),
+                        config.getString(ConsumerConfig.CLIENT_RACK_CONFIG));
             }
             this.fetcher = new Fetcher<>(
                     logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
@@ -17,13 +17,18 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * <p>The range assignor works on a per-topic basis. For each topic, we lay out the available partitions in numeric order
@@ -63,6 +68,13 @@ import java.util.Map;
  * <li><code>I0: [t0p0, t0p1, t1p0, t1p1]</code>
  * <li><code>I1: [t0p2, t1p2]</code>
  * </ul>
+ * <p>
+ * If racks are specified for consumers, we attempt to match consumer racks with partition replica
+ * racks on a best-effort basis, prioritizing balanced assignment over rack alignment. We use
+ * rack-aware assignment if both consumer and partition racks are available and some partitions
+ * have replicas only on a subset of racks. In this case, we apply the standard range assignor
+ * algorithm on each rack with rack matching first, up to the limit per consumer per topic.
+ * Remaining partitions are then allocated using the same algorithm without rack matching.
  */
 public class RangeAssignor extends AbstractPartitionAssignor {
     public static final String RANGE_ASSIGNOR_NAME = "range";
@@ -76,8 +88,9 @@ public class RangeAssignor extends AbstractPartitionAssignor {
         Map<String, List<MemberInfo>> topicToConsumers = new HashMap<>();
         for (Map.Entry<String, Subscription> subscriptionEntry : consumerMetadata.entrySet()) {
             String consumerId = subscriptionEntry.getKey();
-            MemberInfo memberInfo = new MemberInfo(consumerId, subscriptionEntry.getValue().groupInstanceId());
-            for (String topic : subscriptionEntry.getValue().topics()) {
+            Subscription subscription = subscriptionEntry.getValue();
+            MemberInfo memberInfo = new MemberInfo(consumerId, subscription.groupInstanceId(), subscription.rackId());
+            for (String topic : subscription.topics()) {
                 put(topicToConsumers, topic, memberInfo);
             }
         }
@@ -85,34 +98,135 @@ public class RangeAssignor extends AbstractPartitionAssignor {
     }
 
     @Override
-    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
-                                                    Map<String, Subscription> subscriptions) {
+    public Map<String, List<TopicPartition>> assignPartitions(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                                              Map<String, Subscription> subscriptions) {
         Map<String, List<MemberInfo>> consumersPerTopic = consumersPerTopic(subscriptions);
+        Map<String, TopicAssignmentState> topicAssignmentStates = partitionsPerTopic.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> new TopicAssignmentState(e.getValue(), consumersPerTopic.get(e.getKey()))));
 
         Map<String, List<TopicPartition>> assignment = new HashMap<>();
         for (String memberId : subscriptions.keySet())
             assignment.put(memberId, new ArrayList<>());
 
-        for (Map.Entry<String, List<MemberInfo>> topicEntry : consumersPerTopic.entrySet()) {
+        for (Map.Entry<String, TopicAssignmentState> topicEntry : topicAssignmentStates.entrySet()) {
             String topic = topicEntry.getKey();
-            List<MemberInfo> consumersForTopic = topicEntry.getValue();
+            TopicAssignmentState topicAssignmentState = topicEntry.getValue();
 
-            Integer numPartitionsForTopic = partitionsPerTopic.get(topic);
-            if (numPartitionsForTopic == null)
+            List<PartitionInfo> partitionsForTopic = partitionsPerTopic.get(topic);
+            if (partitionsForTopic == null || partitionsForTopic.isEmpty())
                 continue;
 
-            Collections.sort(consumersForTopic);
-
-            int numPartitionsPerConsumer = numPartitionsForTopic / consumersForTopic.size();
-            int consumersWithExtraPartition = numPartitionsForTopic % consumersForTopic.size();
-
-            List<TopicPartition> partitions = AbstractPartitionAssignor.partitions(topic, numPartitionsForTopic);
-            for (int i = 0, n = consumersForTopic.size(); i < n; i++) {
-                int start = numPartitionsPerConsumer * i + Math.min(i, consumersWithExtraPartition);
-                int length = numPartitionsPerConsumer + (i + 1 > consumersWithExtraPartition ? 0 : 1);
-                assignment.get(consumersForTopic.get(i).memberId).addAll(partitions.subList(start, start + length));
+            // Assign based on racks first, but limit to each consumer's quota since we
+            // prioritize balanced assignment over locality.
+            for (String rackId : topicAssignmentState.racks) {
+                List<String> consumersForRack = topicAssignmentState.consumersByRack.get(rackId);
+                List<TopicPartition> partitionsForRack = topicAssignmentState.partitionsByRack.get(rackId);
+                doAssign(consumersForRack, partitionsForRack, assignment, topicAssignmentState);
             }
+
+            // Assign any remaining partitions without matching racks, still maintaining balanced assignment
+            doAssign(topicAssignmentState.consumers, new ArrayList<>(topicAssignmentState.unassignedPartitions), assignment, topicAssignmentState);
         }
         return assignment;
+    }
+
+    private void doAssign(List<String> consumers,
+                         List<TopicPartition> assignablePartitions,
+                         Map<String, List<TopicPartition>> assignment,
+                         TopicAssignmentState assignmentState) {
+        assignablePartitions.removeIf(tp -> !assignmentState.unassignedPartitions.contains(tp));
+        if (consumers.isEmpty() || assignmentState.unassignedPartitions.isEmpty() || assignablePartitions.isEmpty())
+            return;
+
+        int start = 0;
+        for (String consumer : consumers) {
+            List<TopicPartition> consumerAssignment = assignment.get(consumer);
+            int numAssignable = Math.min(assignmentState.maxAssignable(consumer), assignablePartitions.size());
+            if (numAssignable <= 0)
+                continue;
+
+            List<TopicPartition> partitionsToAssign = assignablePartitions.subList(start, start + numAssignable);
+            consumerAssignment.addAll(partitionsToAssign);
+            assignmentState.onAssigned(consumer, partitionsToAssign);
+            start += numAssignable;
+            if (start >= assignablePartitions.size())
+                break;
+        }
+    }
+
+    @Override
+    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+                                                    Map<String, Subscription> subscriptions) {
+        return assignPartitions(partitionInfosWithoutRacks(partitionsPerTopic), subscriptions);
+    }
+
+    private class TopicAssignmentState {
+        private final List<String> consumers;
+        private final List<String> racks;
+        private final Map<String, List<TopicPartition>> partitionsByRack;
+        private final Map<String, List<String>> consumersByRack;
+
+        private final List<TopicPartition> unassignedPartitions;
+        private final Map<String, Integer> numAssignedByConsumer;
+        private final int numPartitionsPerConsumer;
+        private final int numConsumersWithExtraPartition;
+
+        public TopicAssignmentState(List<PartitionInfo> partitionInfos, List<MemberInfo> membersOrNull) {
+            List<MemberInfo> members = membersOrNull == null ? Collections.emptyList() : membersOrNull;
+            Collections.sort(members);
+            consumers = members.stream().map(c -> c.memberId).collect(Collectors.toList());
+
+            this.unassignedPartitions = partitionInfos.stream().map(p -> new TopicPartition(p.topic(), p.partition()))
+                    .collect(Collectors.toCollection(LinkedList::new));
+            this.numAssignedByConsumer = consumers.stream().collect(Collectors.toMap(Function.identity(), c -> 0));
+            numPartitionsPerConsumer = consumers.isEmpty() ? 0 : partitionInfos.size() / consumers.size();
+            numConsumersWithExtraPartition = consumers.isEmpty() ? 0 : partitionInfos.size() % consumers.size();
+
+            Map<String, List<String>> consumersByRack = new HashMap<>();
+            members.forEach(consumer -> put(consumersByRack, consumer.rackId.orElse(""), consumer.memberId));
+            consumersByRack.remove("");
+            Map<String, List<TopicPartition>> partitionsByRack = consumersByRack.isEmpty() ? Collections.emptyMap() : partitionsByRack(partitionInfos, null);
+            consumersByRack.keySet().removeIf(r -> !partitionsByRack.containsKey(r));
+            partitionsByRack.keySet().removeIf(r -> !consumersByRack.containsKey(r));
+
+            boolean useRackAwareAssignment = useRackAwareAssignment(consumersByRack, partitionsByRack);
+            if (useRackAwareAssignment) {
+                racks = new ArrayList<>(consumersByRack.keySet());
+                this.consumersByRack = consumersByRack;
+                this.partitionsByRack = partitionsByRack;
+                racks.sort(Comparator.comparing(this::partitionsPerConsumerOnRack));
+            } else {
+                racks = Collections.emptyList();
+                this.consumersByRack = Collections.emptyMap();
+                this.partitionsByRack = Collections.emptyMap();
+            }
+        }
+
+        private double partitionsPerConsumerOnRack(String rackId) {
+            int partitions = partitionsByRack.containsKey(rackId) ? partitionsByRack.get(rackId).size() : 0;
+            int consumers = consumersByRack.containsKey(rackId) ? consumersByRack.get(rackId).size() : 1;
+            return (double) partitions / consumers;
+
+        }
+
+        int maxAssignable(String consumer) {
+            boolean hasExtra = numAssignedByConsumer.values().stream().filter(p -> p > numPartitionsPerConsumer).count() < numConsumersWithExtraPartition;
+            int maxForConsumer = numPartitionsPerConsumer + (hasExtra ? 1 : 0) - numAssignedByConsumer.get(consumer);
+            return Math.max(0, maxForConsumer);
+        }
+
+        void onAssigned(String consumer, List<TopicPartition> newlyAssignedPartitions) {
+            unassignedPartitions.removeAll(newlyAssignedPartitions);
+            numAssignedByConsumer.compute(consumer, (c, n) -> n + newlyAssignedPartitions.size());
+        }
+
+        @Override
+        public String toString() {
+            return "TopicAssignmentState(" +
+                    "consumersByRack=" + consumersByRack +
+                    ", partitionsByRack=" + partitionsByRack +
+                    ", unassignedPartitions=" + unassignedPartitions +
+                    ")";
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -220,7 +220,7 @@ public class StickyAssignor extends AbstractStickyAssignor {
         // since StickyAssignor is an eager rebalance protocol that will revoke all existing partitions before joining group
         ByteBuffer userData = subscription.userData();
         if (userData == null || !userData.hasRemaining()) {
-            return new MemberData(Collections.emptyList(), Optional.empty());
+            return new MemberData(Collections.emptyList(), Optional.empty(), subscription.rackId());
         }
         return deserializeTopicPartitionAssignment(userData);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
@@ -18,17 +18,25 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Abstract assignor implementation which does some common grunt work (in particular collecting
@@ -36,6 +44,10 @@ import java.util.Set;
  */
 public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssignor {
     private static final Logger log = LoggerFactory.getLogger(AbstractPartitionAssignor.class);
+    private static final Node[] NO_NODES = new Node[] {Node.noNode()};
+
+    // Used only in unit tests to verify rack-aware assignment when all racks have all partitions.
+    boolean preferRackAwareLogic;
 
     /**
      * Perform the group assignment given the partition counts and member subscriptions
@@ -47,6 +59,18 @@ public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssi
     public abstract Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
                                                              Map<String, Subscription> subscriptions);
 
+    /**
+     * Default implementation of assignPartitions() that does not include racks. This is only
+     * included to avoid breaking any custom implementation that extends AbstractPartitionAssignor.
+     * Note that this class is internal, but to be safe, we are maintaining compatibility.
+     */
+    public Map<String, List<TopicPartition>> assignPartitions(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                                              Map<String, Subscription> subscriptions) {
+        Map<String, Integer> partitionCountPerTopic = partitionsPerTopic.entrySet().stream()
+                        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().size()));
+        return assign(partitionCountPerTopic, subscriptions);
+    }
+
     @Override
     public GroupAssignment assign(Cluster metadata, GroupSubscription groupSubscription) {
         Map<String, Subscription> subscriptions = groupSubscription.groupSubscription();
@@ -54,16 +78,18 @@ public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssi
         for (Map.Entry<String, Subscription> subscriptionEntry : subscriptions.entrySet())
             allSubscribedTopics.addAll(subscriptionEntry.getValue().topics());
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (String topic : allSubscribedTopics) {
-            Integer numPartitions = metadata.partitionCountForTopic(topic);
-            if (numPartitions != null && numPartitions > 0)
-                partitionsPerTopic.put(topic, numPartitions);
-            else
+            List<PartitionInfo> partitions = metadata.partitionsForTopic(topic);
+            if (partitions != null) {
+                partitions = new ArrayList<>(partitions);
+                partitions.sort(Comparator.comparing(PartitionInfo::partition));
+                partitionsPerTopic.put(topic, partitions);
+            } else
                 log.debug("Skipping assignment for topic {} since no metadata is available", topic);
         }
 
-        Map<String, List<TopicPartition>> rawAssignments = assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> rawAssignments = assignPartitions(partitionsPerTopic, subscriptions);
 
         // this class maintains no user data, so just wrap the results
         Map<String, Assignment> assignments = new HashMap<>();
@@ -84,13 +110,65 @@ public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssi
         return partitions;
     }
 
+    protected static Map<String, List<PartitionInfo>> partitionInfosWithoutRacks(Map<String, Integer> partitionsPerTopic) {
+        return partitionsPerTopic.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> {
+            String topic = e.getKey();
+            int numPartitions = e.getValue();
+            List<PartitionInfo> partitionInfos = new ArrayList<>(numPartitions);
+            for (int i = 0; i < numPartitions; i++)
+                partitionInfos.add(new PartitionInfo(topic, i, Node.noNode(), NO_NODES, NO_NODES));
+            return partitionInfos;
+        }));
+    }
+
+    protected static Map<String, List<TopicPartition>> partitionsByRack(List<PartitionInfo> partitionInfos, Map<TopicPartition, Set<String>> partitionRacks) {
+        Map<String, List<TopicPartition>> partitionsByRack = new HashMap<>();
+        partitionInfos.forEach(p -> {
+            TopicPartition tp = new TopicPartition(p.topic(), p.partition());
+            Set<String> racks;
+            if (partitionRacks != null) {
+                racks = new HashSet<>(p.replicas().length);
+                partitionRacks.put(tp, racks);
+            } else
+                racks = null;
+            Arrays.stream(p.replicas())
+                    .map(Node::rack)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet())
+                    .forEach(rackId -> {
+                        put(partitionsByRack, rackId, tp);
+                        if (racks != null)
+                            racks.add(rackId);
+                    });
+        });
+        return partitionsByRack;
+    }
+
+    protected boolean useRackAwareAssignment(Map<String, List<String>> consumersByRack,
+                                             Map<String, List<TopicPartition>> partitionsByRack) {
+        if (consumersByRack.isEmpty() || partitionsByRack.keySet().stream().noneMatch(consumersByRack::containsKey))
+            return false;
+        else if (preferRackAwareLogic)
+            return true;
+        else {
+            return partitionsByRack.values().stream().flatMap(Collection::stream).anyMatch(tp ->
+                partitionsByRack.values().stream().anyMatch(partitions -> !partitions.contains(tp)));
+        }
+    }
+
     public static class MemberInfo implements Comparable<MemberInfo> {
         public final String memberId;
         public final Optional<String> groupInstanceId;
+        public final Optional<String> rackId;
 
-        public MemberInfo(String memberId, Optional<String> groupInstanceId) {
+        public MemberInfo(String memberId, Optional<String> groupInstanceId, Optional<String> rackId) {
             this.memberId = memberId;
             this.groupInstanceId = groupInstanceId;
+            this.rackId = rackId;
+        }
+
+        public MemberInfo(String memberId, Optional<String> groupInstanceId) {
+            this(memberId, groupInstanceId, Optional.empty());
         }
 
         @Override
@@ -126,6 +204,7 @@ public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssi
         public String toString() {
             return "MemberInfo [member.id: " + memberId
                     + ", group.instance.id: " + groupInstanceId.orElse("{}")
+                    + ", rack.id: " + rackId.orElse("{}")
                     + "]";
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
@@ -81,7 +81,7 @@ public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssi
         Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (String topic : allSubscribedTopics) {
             List<PartitionInfo> partitions = metadata.partitionsForTopic(topic);
-            if (partitions != null) {
+            if (partitions != null && !partitions.isEmpty()) {
                 partitions = new ArrayList<>(partitions);
                 partitions.sort(Comparator.comparing(PartitionInfo::partition));
                 partitionsPerTopic.put(topic, partitions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocol.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocol.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * ConsumerProtocol contains the schemas for consumer subscriptions and assignments for use with
@@ -89,6 +90,7 @@ public class ConsumerProtocol {
             }
             partition.partitions().add(tp.partition());
         }
+        subscription.rackId().ifPresent(data::setRackId);
 
         data.setGenerationId(subscription.generationId().orElse(-1));
         return MessageUtil.toVersionPrefixedByteBuffer(version, data);
@@ -112,7 +114,8 @@ public class ConsumerProtocol {
                 data.topics(),
                 data.userData() != null ? data.userData().duplicate() : null,
                 ownedPartitions,
-                data.generationId());
+                data.generationId(),
+                data.rackId() == null || data.rackId().isEmpty() ? Optional.empty() : Optional.of(data.rackId()));
         } catch (BufferUnderflowException e) {
             throw new SchemaException("Buffer underflow while parsing consumer protocol's subscription", e);
         }

--- a/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
+++ b/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
@@ -23,6 +23,7 @@
   // that new versions cannot remove or reorder any of the existing fields.
   //
   // Version 2 is to support a new field "GenerationId" in ConsumerProtocolSubscription.
+  // Version 3 adds rack id to ConsumerProtocolSubscription.
   "validVersions": "0-2",
   "flexibleVersions": "none",
   "fields": [

--- a/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
+++ b/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
@@ -24,6 +24,7 @@
 
   // Version 1 added the "OwnedPartitions" field to allow assigner know what partitions each member owned
   // Version 2 added a new field "GenerationId" to indicate if the member has out-of-date ownedPartitions.
+  // Version 3 adds rack id to enable rack-aware assignment.
   "validVersions": "0-2",
   "flexibleVersions": "none",
   "fields": [
@@ -36,6 +37,7 @@
         { "name": "Partitions", "type": "[]int32", "versions": "1+"}
       ]
     },
-    { "name": "GenerationId", "type": "int32", "versions": "2+", "default": "-1", "ignorable": true }
+    { "name": "GenerationId", "type": "int32", "versions": "2+", "default": "-1", "ignorable": true },
+    { "name": "RackId", "type": "string", "versions": "3+", "nullableVersions": "3+", "default": "null", "ignorable": true }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -17,11 +17,15 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.RackConfig;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignorTest;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,7 +34,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_RACK_CONFIG;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,20 +53,20 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
     }
 
     @Override
-    public Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId) {
+    public Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
         // cooperative sticky assignor only supports ConsumerProtocolSubscription V1 or above
         return null;
     }
 
     @Override
-    public Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId) {
+    public Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
         assignor.onAssignment(new ConsumerPartitionAssignor.Assignment(partitions), new ConsumerGroupMetadata(groupId, generationId, consumer1, Optional.empty()));
-        return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions, DEFAULT_GENERATION);
+        return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions, DEFAULT_GENERATION, consumerRackId(consumerIndex));
     }
 
     @Override
-    public Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generationId) {
-        return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions, generationId);
+    public Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
+        return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions, generationId, consumerRackId(consumerIndex));
     }
 
     @Override
@@ -92,16 +99,18 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         assertFalse(((CooperativeStickyAssignor) assignor).memberData(subscription).generation.isPresent());
     }
 
-    @Test
-    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithEqualPartitionsPerConsumer() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithEqualPartitionsPerConsumer(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         // In the cooperative assignor, topic-0 has to be considered "owned" and so it cant be assigned until both have "revoked" it
@@ -111,16 +120,18 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithUnequalPartitionsPerConsumer() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 4);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithUnequalPartitionsPerConsumer(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 4));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 1), tp(topic, 3)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         // In the cooperative assignor, topic-0 has to be considered "owned" and so it cant be assigned until both have "revoked" it
@@ -132,8 +143,6 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
     @Test
     public void testMemberDataWithInconsistentData() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
         List<TopicPartition> ownedPartitionsInUserdata = partitions(tp1);
         List<TopicPartition> ownedPartitionsInSubscription = partitions(tp0);
 
@@ -156,7 +165,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
         // subscription containing empty owned partitions and the same generation id, and non-empty owned partition in user data,
         // member data should honor the one in subscription since cooperativeStickyAssignor only supports ConsumerProtocolSubscription v1 and above
-        Subscription subscription = new Subscription(topics, generateUserData(topics, ownedPartitions, generationId), Collections.emptyList(), generationId);
+        Subscription subscription = new Subscription(topics, generateUserData(topics, ownedPartitions, generationId), Collections.emptyList(), generationId, Optional.empty());
 
         AbstractStickyAssignor.MemberData memberData = memberData(subscription);
         assertEquals(Collections.emptyList(), memberData.partitions, "subscription: " + subscription + " doesn't have expected owned partition");
@@ -170,7 +179,8 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
         // subscription containing empty owned partitions and a higher generation id, and non-empty owned partition in user data,
         // member data should honor the one in subscription since generation id is higher
-        Subscription subscription = new Subscription(topics, generateUserData(topics, ownedPartitions, generationId - 1), Collections.emptyList(), generationId);
+        Subscription subscription = new Subscription(topics, generateUserData(topics, ownedPartitions, generationId - 1),
+                Collections.emptyList(), generationId, Optional.empty());
 
         AbstractStickyAssignor.MemberData memberData = memberData(subscription);
         assertEquals(Collections.emptyList(), memberData.partitions, "subscription: " + subscription + " doesn't have expected owned partition");
@@ -179,17 +189,17 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
     @Test
     public void testAssignorWithOldVersionSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
 
         List<String> subscribedTopics = topics(topic1);
 
         // cooperative sticky assignor only supports ConsumerProtocolSubscription V1 or above
-        subscriptions.put(consumer1, buildSubscriptionV1(subscribedTopics, partitions(tp(topic1, 0)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV1(subscribedTopics, partitions(tp(topic1, 1)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV1(subscribedTopics, partitions(tp(topic1, 0)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV1(subscribedTopics, partitions(tp(topic1, 1)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic1, 2)), assignment.get(consumer3));
@@ -211,7 +221,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
     @Override
     public void verifyValidityAndBalance(Map<String, Subscription> subscriptions,
                                          Map<String, List<TopicPartition>> assignments,
-                                         Map<String, Integer> partitionsPerTopic) {
+                                         Map<String, List<PartitionInfo>> partitionsPerTopic) {
         int rebalances = 0;
         // partitions are being revoked, we must go through another assignment to get the final state
         while (verifyCooperativeValidity(subscriptions, assignments)) {
@@ -220,11 +230,12 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
             for (Map.Entry<String, List<TopicPartition>> entry : assignments.entrySet()) {
                 String consumer = entry.getKey();
                 Subscription oldSubscription = subscriptions.get(consumer);
-                subscriptions.put(consumer, buildSubscriptionV2Above(oldSubscription.topics(), entry.getValue(), generationId));
+                int rackIndex = oldSubscription.rackId().isPresent() ? Arrays.asList(AbstractPartitionAssignorTest.ALL_RACKS).indexOf(oldSubscription.rackId().get()) : -1;
+                subscriptions.put(consumer, buildSubscriptionV2Above(oldSubscription.topics(), entry.getValue(), generationId, rackIndex));
             }
 
             assignments.clear();
-            assignments.putAll(assignor.assign(partitionsPerTopic, subscriptions));
+            assignments.putAll(assignor.assignPartitions(partitionsPerTopic, subscriptions));
             ++rebalances;
 
             assertTrue(rebalances <= 4);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2614,7 +2614,8 @@ public class KafkaConsumerTest {
                 autoCommitEnabled,
                 autoCommitIntervalMs,
                 interceptors,
-                throwOnStableOffsetNotSupported);
+                throwOnStableOffsetNotSupported,
+                null);
         }
         Fetcher<String, String> fetcher = new Fetcher<>(
                 loggerFactory,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -19,9 +19,15 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.RackConfig;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,16 +38,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_CONSUMER_RACK;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_RACK_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.partitionsPerTopic;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.racks;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.nullRacks;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAwareWithNonEqualSubscription;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAwareWithUniformSubscription;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RangeAssignorTest {
 
-    private RangeAssignor assignor = new RangeAssignor();
+    private final RangeAssignor assignor = new RangeAssignor();
 
     // For plural tests
-    private String topic1 = "topic1";
-    private String topic2 = "topic2";
+    private final String topic1 = "topic1";
+    private final String topic2 = "topic2";
     private final String consumer1 = "consumer1";
     private final String instance1 = "instance1";
     private final String consumer2 = "consumer2";
@@ -49,7 +63,11 @@ public class RangeAssignorTest {
     private final String consumer3 = "consumer3";
     private final String instance3 = "instance3";
 
+    private int numBrokerRacks;
+    private boolean hasConsumerRack;
+
     private List<MemberInfo> staticMemberInfos;
+    private int replicationFactor = 3;
 
     @BeforeEach
     public void setUp() {
@@ -59,188 +77,205 @@ public class RangeAssignorTest {
         staticMemberInfos.add(new MemberInfo(consumer3, Optional.of(instance3)));
     }
 
-    @Test
-    public void testOneConsumerNoTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {true, false})
+    public void testOneConsumerNoTopic(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumer1, new Subscription(Collections.emptyList())));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic,
+                Collections.singletonMap(consumer1, subscription(Collections.emptyList(), 0)));
 
         assertEquals(Collections.singleton(consumer1), assignment.keySet());
         assertTrue(assignment.get(consumer1).isEmpty());
     }
 
-    @Test
-    public void testOneConsumerNonexistentTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {true, false})
+    public void testOneConsumerNonexistentTopic(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic,
+                Collections.singletonMap(consumer1, subscription(topics(topic1), 0)));
         assertEquals(Collections.singleton(consumer1), assignment.keySet());
         assertTrue(assignment.get(consumer1).isEmpty());
     }
 
-    @Test
-    public void testOneConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
+    @ParameterizedTest(name = "rackConfig = {0}")
+    @EnumSource(RackConfig.class)
+    public void testOneConsumerOneTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic,
+                Collections.singletonMap(consumer1, subscription(topics(topic1), 0)));
 
         assertEquals(Collections.singleton(consumer1), assignment.keySet());
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer1));
     }
 
-    @Test
-    public void testOnlyAssignsPartitionsFromSubscribedTopics() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOnlyAssignsPartitionsFromSubscribedTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         String otherTopic = "other";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(otherTopic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(otherTopic, partitionInfos(otherTopic, 3));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic,
+                Collections.singletonMap(consumer1, subscription(topics(topic1), 0)));
         assertEquals(Collections.singleton(consumer1), assignment.keySet());
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer1));
     }
 
-    @Test
-    public void testOneConsumerMultipleTopics() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(1, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOneConsumerMultipleTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(1, 2);
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumer1, new Subscription(topics(topic1, topic2))));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic,
+                Collections.singletonMap(consumer1, subscription(topics(topic1, topic2), 0)));
 
         assertEquals(Collections.singleton(consumer1), assignment.keySet());
         assertAssignment(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
     }
 
-    @Test
-    public void testTwoConsumersOneTopicOnePartition() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersOneTopicOnePartition(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 1));
 
         Map<String, Subscription> consumers = new HashMap<>();
-        consumers.put(consumer1, new Subscription(topics(topic1)));
-        consumers.put(consumer2, new Subscription(topics(topic1)));
+        consumers.put(consumer1, subscription(topics(topic1), 0));
+        consumers.put(consumer2, subscription(topics(topic1), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0)), assignment.get(consumer1));
         assertAssignment(Collections.emptyList(), assignment.get(consumer2));
     }
 
 
-    @Test
-    public void testTwoConsumersOneTopicTwoPartitions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersOneTopicTwoPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
 
         Map<String, Subscription> consumers = new HashMap<>();
-        consumers.put(consumer1, new Subscription(topics(topic1)));
-        consumers.put(consumer2, new Subscription(topics(topic1)));
+        consumers.put(consumer1, subscription(topics(topic1), 0));
+        consumers.put(consumer2, subscription(topics(topic1), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0)), assignment.get(consumer1));
         assertAssignment(partitions(tp(topic1, 1)), assignment.get(consumer2));
     }
 
-    @Test
-    public void testMultipleConsumersMixedTopics() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMultipleConsumersMixedTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 2);
 
         Map<String, Subscription> consumers = new HashMap<>();
-        consumers.put(consumer1, new Subscription(topics(topic1)));
-        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
-        consumers.put(consumer3, new Subscription(topics(topic1)));
+        consumers.put(consumer1, subscription(topics(topic1), 0));
+        consumers.put(consumer2, subscription(topics(topic1, topic2), 1));
+        consumers.put(consumer3, subscription(topics(topic1), 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0)), assignment.get(consumer1));
         assertAssignment(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer2));
         assertAssignment(partitions(tp(topic1, 2)), assignment.get(consumer3));
     }
 
-    @Test
-    public void testTwoConsumersTwoTopicsSixPartitions() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersTwoTopicsSixPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         String topic1 = "topic1";
         String topic2 = "topic2";
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
-        consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
-        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer1, subscription(topics(topic1, topic2), 0));
+        consumers.put(consumer2, subscription(topics(topic1, topic2), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
         assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
     }
 
-    @Test
-    public void testTwoStaticConsumersTwoTopicsSixPartitions() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoStaticConsumersTwoTopicsSixPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         // although consumer high has a higher rank than consumer low, the comparison happens on
         // instance id level.
         String consumerIdLow = "consumer-b";
         String consumerIdHigh = "consumer-a";
 
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
-        Subscription consumerLowSubscription = new Subscription(topics(topic1, topic2),
-                                                              null,
-                                                              Collections.emptyList());
+        Subscription consumerLowSubscription = subscription(topics(topic1, topic2), 0);
         consumerLowSubscription.setGroupInstanceId(Optional.of(instance1));
         consumers.put(consumerIdLow, consumerLowSubscription);
-        Subscription consumerHighSubscription = new Subscription(topics(topic1, topic2),
-                                                              null,
-                                                              Collections.emptyList());
+        Subscription consumerHighSubscription = subscription(topics(topic1, topic2), 1);
         consumerHighSubscription.setGroupInstanceId(Optional.of(instance2));
         consumers.put(consumerIdHigh, consumerHighSubscription);
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerIdLow));
         assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumerIdHigh));
     }
 
-    @Test
-    public void testOneStaticConsumerAndOneDynamicConsumerTwoTopicsSixPartitions() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOneStaticConsumerAndOneDynamicConsumerTwoTopicsSixPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         // although consumer high has a higher rank than low, consumer low will win the comparison
         // because it has instance id while consumer 2 doesn't.
         String consumerIdLow = "consumer-b";
         String consumerIdHigh = "consumer-a";
 
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
 
-        Subscription consumerLowSubscription = new Subscription(topics(topic1, topic2),
-                                                              null,
-                                                              Collections.emptyList());
+        Subscription consumerLowSubscription = subscription(topics(topic1, topic2), 0);
         consumerLowSubscription.setGroupInstanceId(Optional.of(instance1));
         consumers.put(consumerIdLow, consumerLowSubscription);
-        consumers.put(consumerIdHigh, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumerIdHigh, subscription(topics(topic1, topic2), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerIdLow));
         assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumerIdHigh));
     }
 
-    @Test
-    public void testStaticMemberRangeAssignmentPersistent() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 4);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testStaticMemberRangeAssignmentPersistent(RackConfig rackConfig) {
+        initializeRacks(rackConfig, 5);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 4);
 
         Map<String, Subscription> consumers = new HashMap<>();
+        int consumerIndex = 0;
         for (MemberInfo m : staticMemberInfos) {
-            Subscription subscription = new Subscription(topics(topic1, topic2),
-                                                         null,
-                                                         Collections.emptyList());
+            Subscription subscription = subscription(topics(topic1, topic2), consumerIndex++);
             subscription.setGroupInstanceId(m.groupInstanceId);
             consumers.put(m.memberId, subscription);
         }
         // Consumer 4 is a dynamic member.
         String consumer4 = "consumer4";
-        consumers.put(consumer4, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer4, subscription(topics(topic1, topic2), consumerIndex++));
 
         Map<String, List<TopicPartition>> expectedAssignment = new HashMap<>();
         // Have 3 static members instance1, instance2, instance3 to be persistent
@@ -250,29 +285,30 @@ public class RangeAssignorTest {
         expectedAssignment.put(consumer3, partitions(tp(topic1, 3), tp(topic2, 2)));
         expectedAssignment.put(consumer4, partitions(tp(topic1, 4), tp(topic2, 3)));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertEquals(expectedAssignment, assignment);
 
         // Replace dynamic member 4 with a new dynamic member 5.
         consumers.remove(consumer4);
         String consumer5 = "consumer5";
-        consumers.put(consumer5, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer5, subscription(topics(topic1, topic2), consumerIndex++));
 
         expectedAssignment.remove(consumer4);
         expectedAssignment.put(consumer5, partitions(tp(topic1, 4), tp(topic2, 3)));
-        assignment = assignor.assign(partitionsPerTopic, consumers);
+        assignment = assignor.assignPartitions(partitionsPerTopic, consumers);
         assertEquals(expectedAssignment, assignment);
     }
 
-    @Test
-    public void testStaticMemberRangeAssignmentPersistentAfterMemberIdChanges() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 5);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testStaticMemberRangeAssignmentPersistentAfterMemberIdChanges(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 5);
 
         Map<String, Subscription> consumers = new HashMap<>();
+        int consumerIndex = 0;
         for (MemberInfo m : staticMemberInfos) {
-            Subscription subscription = new Subscription(topics(topic1, topic2),
-                                                         null,
-                                                         Collections.emptyList());
+            Subscription subscription = subscription(topics(topic1, topic2), consumerIndex++);
             subscription.setGroupInstanceId(m.groupInstanceId);
             consumers.put(m.memberId, subscription);
         }
@@ -302,10 +338,66 @@ public class RangeAssignorTest {
         assertEquals(staticAssignment, newStaticAssignment);
     }
 
+    @Test
+    public void testRackAwareAssignmentWithUniformSubscription() {
+        List<String> nonRackAwareAssignment = asList(
+                "t1-0, t1-1, t2-0, t2-1, t2-2, t3-0",
+                "t1-2, t1-3, t2-3, t2-4, t3-1",
+                "t1-4, t1-5, t2-5, t2-6"
+        );
+        verifyRackAwareWithUniformSubscription(assignor, 3, nullRacks(3), racks(3), null, nonRackAwareAssignment, -1);
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(3), nullRacks(3), null, nonRackAwareAssignment, -1);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(3), racks(3), null, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyRackAwareWithUniformSubscription(assignor, 4, racks(4), racks(3), null, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(3), racks(3), null, nonRackAwareAssignment, 0);
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(3), asList("d", "e", "f"), null, nonRackAwareAssignment, -1);
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(3), asList(null, "e", "f"), null, nonRackAwareAssignment, -1);
+
+        // Verify assignment is rack-aligned for lower replication factor where brokers have a subset of partitions
+        verifyRackAwareWithUniformSubscription(assignor, 1, racks(3), racks(3), null,
+                asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1"), 0);
+        verifyRackAwareWithUniformSubscription(assignor, 2, racks(3), racks(3), null,
+                asList("t1-0, t1-2, t2-0, t2-3, t3-1", "t1-1, t1-3, t2-5, t2-6, t3-0", "t1-4, t1-5, t2-1, t2-2, t2-4"), 1);
+
+        // One consumer on a rack with no partitions
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(2), racks(3), null,
+                asList("t1-0, t1-1, t2-0, t2-1, t2-2, t3-0", "t1-2, t1-3, t2-3, t2-4, t3-1", "t1-4, t1-5, t2-5, t2-6"), 4);
+    }
+
+    @Test
+    public void testRackAwareAssignmentWithNonEqualSubscription() {
+        List<String> nonRackAwareAssignment = asList(
+            "t1-0, t1-1, t2-0, t2-1, t2-2, t2-3, t3-0", "t1-2, t1-3, t2-4, t2-5, t2-6, t3-1", "t1-4, t1-5"
+        );
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, nullRacks(3), racks(3), null, nonRackAwareAssignment, -1);
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), nullRacks(3), null, nonRackAwareAssignment, -1);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), null, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyRackAwareWithNonEqualSubscription(assignor, 4, racks(4), racks(3), null, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), null, nonRackAwareAssignment, 0);
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), asList("d", "e", "f"), null, nonRackAwareAssignment, -1);
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), asList(null, "e", "f"), null, nonRackAwareAssignment, -1);
+
+        // Verify assignment is rack-aligned for lower replication factor where brokers have a subset of partitions
+        verifyRackAwareWithNonEqualSubscription(assignor, 1, racks(3), racks(3), null,
+                asList("t1-0, t1-3, t2-0, t2-2, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t2-5, t3-0", "t1-2, t1-5, t3-1"), 2);
+        verifyRackAwareWithNonEqualSubscription(assignor, 2, racks(3), racks(3), null,
+                asList("t1-0, t1-2, t2-0, t2-2, t2-3, t2-5, t3-1", "t1-1, t1-3, t2-1, t2-4, t2-6, t3-0", "t1-4, t1-5"), 0);
+
+        // One consumer on a rack with no partitions
+        verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(2), racks(3), null,
+                asList("t1-0, t1-1, t2-0, t2-1, t2-2, t2-3, t3-0", "t1-2, t1-3, t2-4, t2-5, t2-6, t3-1", "t1-4, t1-5"), 2);
+    }
+
     static Map<String, List<TopicPartition>> checkStaticAssignment(AbstractPartitionAssignor assignor,
-                                                                   Map<String, Integer> partitionsPerTopic,
+                                                                   Map<String, List<PartitionInfo>> partitionsPerTopic,
                                                                    Map<String, Subscription> consumers) {
-        Map<String, List<TopicPartition>> assignmentByMemberId = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignmentByMemberId = assignor.assignPartitions(partitionsPerTopic, consumers);
         Map<String, List<TopicPartition>> assignmentByInstanceId = new HashMap<>();
         for (Map.Entry<String, Subscription> entry : consumers.entrySet()) {
             String memberId = entry.getKey();
@@ -320,11 +412,21 @@ public class RangeAssignorTest {
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 
-    private Map<String, Integer> setupPartitionsPerTopicWithTwoTopics(int numberOfPartitions1, int numberOfPartitions2) {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, numberOfPartitions1);
-        partitionsPerTopic.put(topic2, numberOfPartitions2);
+    private Map<String, List<PartitionInfo>> setupPartitionsPerTopicWithTwoTopics(int numberOfPartitions1, int numberOfPartitions2) {
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, numberOfPartitions1));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, numberOfPartitions2));
         return partitionsPerTopic;
+    }
+
+    private List<PartitionInfo> partitionInfos(String topic, int numberOfPartitions) {
+        return partitionsPerTopic(topic, numberOfPartitions, replicationFactor, numBrokerRacks, 0);
+    }
+
+    private Subscription subscription(List<String> topics, int consumerIndex) {
+        int numRacks = numBrokerRacks > 0 ? numBrokerRacks : AbstractPartitionAssignorTest.ALL_RACKS.length;
+        Optional<String> rackId = Optional.ofNullable(hasConsumerRack ? AbstractPartitionAssignorTest.ALL_RACKS[consumerIndex % numRacks] : null);
+        return new Subscription(topics, null, Collections.emptyList(), -1, rackId);
     }
 
     private static List<String> topics(String... topics) {
@@ -337,5 +439,18 @@ public class RangeAssignorTest {
 
     private static TopicPartition tp(String topic, int partition) {
         return new TopicPartition(topic, partition);
+    }
+
+    void initializeRacks(RackConfig rackConfig) {
+        initializeRacks(rackConfig, 3);
+    }
+
+    void initializeRacks(RackConfig rackConfig, int maxConsumers) {
+        this.replicationFactor = maxConsumers;
+        this.numBrokerRacks = rackConfig != RackConfig.NO_BROKER_RACK ? maxConsumers : 0;
+        this.hasConsumerRack = rackConfig != RackConfig.NO_CONSUMER_RACK;
+        // Rack and consumer ordering are the same in all the tests, so we can verify
+        // rack-aware logic using the same tests.
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 
@@ -28,9 +30,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
-import static org.apache.kafka.clients.consumer.RangeAssignorTest.checkStaticAssignment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -334,5 +337,13 @@ public class RoundRobinAssignorTest {
         partitionsPerTopic.put(topic1, numberOfPartitions1);
         partitionsPerTopic.put(topic2, numberOfPartitions2);
         return partitionsPerTopic;
+    }
+
+    static Map<String, List<TopicPartition>> checkStaticAssignment(AbstractPartitionAssignor assignor,
+                                                                   Map<String, Integer> partitionsPerTopic,
+                                                                   Map<String, Subscription> consumers) {
+        Map<String, List<PartitionInfo>> partitionInfos = partitionsPerTopic.entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, e -> AbstractPartitionAssignorTest.partitionsPerTopic(e.getKey(), e.getValue(), 1, 0, 0)));
+        return RangeAssignorTest.checkStaticAssignment(assignor, partitionInfos, consumers);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer;
 
 import static org.apache.kafka.clients.consumer.StickyAssignor.serializeTopicPartitionAssignment;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_RACK_CONFIG;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -24,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,15 +34,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.RackConfig;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.MemberData;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignorTest;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.util.Collections.emptyList;
 
@@ -51,21 +58,21 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
     }
 
     @Override
-    public Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId) {
+    public Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
         return new Subscription(topics, serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(generationId))),
-            Collections.emptyList(), DEFAULT_GENERATION);
+            Collections.emptyList(), DEFAULT_GENERATION, consumerRackId(consumerIndex));
     }
 
     @Override
-    public Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId) {
+    public Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
         return new Subscription(topics, serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(generationId))),
-            partitions, DEFAULT_GENERATION);
+            partitions, DEFAULT_GENERATION, consumerRackId(consumerIndex));
     }
 
     @Override
-    public Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generationId) {
+    public Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
         return new Subscription(topics, serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(generationId))),
-            partitions, generationId);
+            partitions, generationId, consumerRackId(consumerIndex));
     }
 
     @Override
@@ -73,16 +80,18 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         return serializeTopicPartitionAssignment(new MemberData(partitions, Optional.of(generation)));
     }
 
-    @Test
-    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithEqualPartitionsPerConsumer() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithEqualPartitionsPerConsumer(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
@@ -91,16 +100,18 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithUnequalPartitionsPerConsumer() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 4);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersHaveOwnedPartitionInvalidatedWhenClaimedByMultipleConsumersInSameGenerationWithUnequalPartitionsPerConsumer(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 4));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 1), tp(topic, 3)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
@@ -109,20 +120,21 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @ParameterizedTest(name = "testAssignmentWithMultipleGenerations1 with isAllSubscriptionsEqual: {0}")
-    @ValueSource(booleans = {true, false})
-    public void testAssignmentWithMultipleGenerations1(boolean isAllSubscriptionsEqual) {
+    @ParameterizedTest(name = "{displayName}.rackConfig = {0}, isAllSubscriptionsEqual = {1}")
+    @MethodSource("rackAndSubscriptionCombinations")
+    public void testAssignmentWithMultipleGenerations1(RackConfig rackConfig, boolean isAllSubscriptionsEqual) {
+        initializeRacks(rackConfig);
         List<String> allTopics = topics(topic, topic2);
         List<String> consumer2SubscribedTopics = isAllSubscriptionsEqual ? allTopics : topics(topic);
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 6);
-        partitionsPerTopic.put(topic2, 6);
-        subscriptions.put(consumer1, new Subscription(allTopics));
-        subscriptions.put(consumer2, new Subscription(consumer2SubscribedTopics));
-        subscriptions.put(consumer3, new Subscription(allTopics));
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 6));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 6));
+        subscriptions.put(consumer1, subscription(allTopics, 0));
+        subscriptions.put(consumer2, subscription(consumer2SubscribedTopics, 1));
+        subscriptions.put(consumer3, subscription(allTopics, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> r1partitions1 = assignment.get(consumer1);
         List<TopicPartition> r1partitions2 = assignment.get(consumer2);
         List<TopicPartition> r1partitions3 = assignment.get(consumer3);
@@ -130,11 +142,11 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(allTopics, r1partitions1, generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(consumer2SubscribedTopics, r1partitions2, generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(allTopics, r1partitions1, generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(consumer2SubscribedTopics, r1partitions2, generationId, 1));
         subscriptions.remove(consumer3);
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> r2partitions1 = assignment.get(consumer1);
         List<TopicPartition> r2partitions2 = assignment.get(consumer2);
         assertTrue(r2partitions1.size() == 6 && r2partitions2.size() == 6);
@@ -148,10 +160,10 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertFalse(Collections.disjoint(r2partitions2, r1partitions3));
 
         subscriptions.remove(consumer1);
-        subscriptions.put(consumer2, buildSubscriptionV2Above(consumer2SubscribedTopics, r2partitions2, 2));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, r1partitions3, 1));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(consumer2SubscribedTopics, r2partitions2, 2, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, r1partitions3, 1, 2));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> r3partitions2 = assignment.get(consumer2);
         List<TopicPartition> r3partitions3 = assignment.get(consumer3);
         assertTrue(r3partitions2.size() == 6 && r3partitions3.size() == 6);
@@ -160,22 +172,23 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @ParameterizedTest(name = "testAssignmentWithMultipleGenerations2 with isAllSubscriptionsEqual: {0}")
-    @ValueSource(booleans = {true, false})
-    public void testAssignmentWithMultipleGenerations2(boolean isAllSubscriptionsEqual) {
+    @ParameterizedTest(name = "{displayName}.rackConfig = {0}, isAllSubscriptionsEqual = {1}")
+    @MethodSource("rackAndSubscriptionCombinations")
+    public void testAssignmentWithMultipleGenerations2(RackConfig rackConfig, boolean isAllSubscriptionsEqual) {
+        initializeRacks(rackConfig);
         List<String> allTopics = topics(topic, topic2, topic3);
         List<String> consumer1SubscribedTopics = isAllSubscriptionsEqual ? allTopics : topics(topic);
         List<String> consumer3SubscribedTopics = isAllSubscriptionsEqual ? allTopics : topics(topic, topic2);
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 4);
-        partitionsPerTopic.put(topic2, 4);
-        partitionsPerTopic.put(topic3, 4);
-        subscriptions.put(consumer1, new Subscription(consumer1SubscribedTopics));
-        subscriptions.put(consumer2, new Subscription(allTopics));
-        subscriptions.put(consumer3, new Subscription(consumer3SubscribedTopics));
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 4));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 4));
+        partitionsPerTopic.put(topic3, partitionInfos(topic3, 4));
+        subscriptions.put(consumer1, subscription(consumer1SubscribedTopics, 0));
+        subscriptions.put(consumer2, subscription(allTopics, 1));
+        subscriptions.put(consumer3, subscription(consumer3SubscribedTopics, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> r1partitions1 = assignment.get(consumer1);
         List<TopicPartition> r1partitions2 = assignment.get(consumer2);
         List<TopicPartition> r1partitions3 = assignment.get(consumer3);
@@ -184,21 +197,21 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
 
         subscriptions.remove(consumer1);
-        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, r1partitions2, 1));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, r1partitions2, 1, 1));
         subscriptions.remove(consumer3);
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> r2partitions2 = assignment.get(consumer2);
         assertEquals(12, r2partitions2.size());
         assertTrue(r2partitions2.containsAll(r1partitions2));
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(consumer1SubscribedTopics, r1partitions1, 1));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, r2partitions2, 2));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(consumer3SubscribedTopics, r1partitions3, 1));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(consumer1SubscribedTopics, r1partitions1, 1, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, r2partitions2, 2, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(consumer3SubscribedTopics, r1partitions3, 1, 2));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> r3partitions1 = assignment.get(consumer1);
         List<TopicPartition> r3partitions2 = assignment.get(consumer2);
         List<TopicPartition> r3partitions3 = assignment.get(consumer3);
@@ -207,21 +220,22 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @ParameterizedTest(name = "testAssignmentWithConflictingPreviousGenerations with isAllSubscriptionsEqual: {0}")
-    @ValueSource(booleans = {true, false})
-    public void testAssignmentWithConflictingPreviousGenerations(boolean isAllSubscriptionsEqual) {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 4);
-        partitionsPerTopic.put(topic2, 4);
-        partitionsPerTopic.put(topic3, 4);
+    @ParameterizedTest(name = "{displayName}.rackConfig = {0}, isAllSubscriptionsEqual = {1}")
+    @MethodSource("rackAndSubscriptionCombinations")
+    public void testAssignmentWithConflictingPreviousGenerations(RackConfig rackConfig, boolean isAllSubscriptionsEqual) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 4));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 4));
+        partitionsPerTopic.put(topic3, partitionInfos(topic3, 4));
 
         List<String> allTopics = topics(topic, topic2, topic3);
         List<String> consumer1SubscribedTopics = isAllSubscriptionsEqual ? allTopics : topics(topic);
         List<String> consumer2SubscribedTopics = isAllSubscriptionsEqual ? allTopics : topics(topic, topic2);
 
-        subscriptions.put(consumer1, new Subscription(consumer1SubscribedTopics));
-        subscriptions.put(consumer2, new Subscription(consumer2SubscribedTopics));
-        subscriptions.put(consumer3, new Subscription(allTopics));
+        subscriptions.put(consumer1, subscription(consumer1SubscribedTopics, 0));
+        subscriptions.put(consumer2, subscription(consumer2SubscribedTopics, 1));
+        subscriptions.put(consumer3, subscription(allTopics, 2));
 
         TopicPartition tp0 = new TopicPartition(topic, 0);
         TopicPartition tp1 = new TopicPartition(topic, 1);
@@ -240,11 +254,11 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
             partitions(tp0, tp1, tp2, tp3);
         List<TopicPartition> c2partitions0 = partitions(tp0, tp1, t2p0, t2p1, t2p2, t2p3);
         List<TopicPartition> c3partitions0 = partitions(tp2, tp3, t3p0, t3p1, t3p2, t3p3);
-        subscriptions.put(consumer1, buildSubscriptionV2Above(consumer1SubscribedTopics, c1partitions0, 1));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(consumer2SubscribedTopics, c2partitions0, 2));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, c3partitions0, 2));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(consumer1SubscribedTopics, c1partitions0, 1, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(consumer2SubscribedTopics, c2partitions0, 2, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, c3partitions0, 2, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> c1partitions = assignment.get(consumer1);
         List<TopicPartition> c2partitions = assignment.get(consumer2);
         List<TopicPartition> c3partitions = assignment.get(consumer3);
@@ -256,13 +270,15 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testSchemaBackwardCompatibility() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
-        subscriptions.put(consumer3, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testSchemaBackwardCompatibility(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
+        subscriptions.put(consumer3, subscription(topics(topic), 2));
 
         TopicPartition tp0 = new TopicPartition(topic, 0);
         TopicPartition tp1 = new TopicPartition(topic, 1);
@@ -270,9 +286,9 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
 
         List<TopicPartition> c1partitions0 = partitions(tp0, tp2);
         List<TopicPartition> c2partitions0 = partitions(tp1);
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), c1partitions0, 1));
-        subscriptions.put(consumer2, buildSubscriptionWithOldSchema(topics(topic), c2partitions0));
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), c1partitions0, 1, 0));
+        subscriptions.put(consumer2, buildSubscriptionWithOldSchema(topics(topic), c2partitions0, 1));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         List<TopicPartition> c1partitions = assignment.get(consumer1);
         List<TopicPartition> c2partitions = assignment.get(consumer2);
         List<TopicPartition> c3partitions = assignment.get(consumer3);
@@ -284,10 +300,10 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testMemberDataWithInconsistentData() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMemberDataWithInconsistentData(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         List<TopicPartition> ownedPartitionsInUserdata = partitions(tp1);
         List<TopicPartition> ownedPartitionsInSubscription = partitions(tp0);
 
@@ -308,7 +324,7 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         List<TopicPartition> ownedPartitions = partitions(tp(topic1, 0), tp(topic2, 1));
         int generationIdInUserData = generationId - 1;
 
-        Subscription subscription = new Subscription(topics, generateUserData(topics, ownedPartitions, generationIdInUserData), Collections.emptyList(), generationId);
+        Subscription subscription = new Subscription(topics, generateUserData(topics, ownedPartitions, generationIdInUserData), Collections.emptyList(), generationId, Optional.empty());
         AbstractStickyAssignor.MemberData memberData = memberData(subscription);
         // in StickyAssignor with eager rebalance protocol, we'll always honor data in user data
         assertEquals(ownedPartitions, memberData.partitions, "subscription: " + subscription + " doesn't have expected owned partition");
@@ -317,16 +333,16 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
 
     @Test
     public void testAssignorWithOldVersionSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
 
         List<String> subscribedTopics = topics(topic1);
 
-        subscriptions.put(consumer1, buildSubscriptionV0(subscribedTopics, partitions(tp(topic1, 0)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV1(subscribedTopics, partitions(tp(topic1, 1)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV0(subscribedTopics, partitions(tp(topic1, 0)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV1(subscribedTopics, partitions(tp(topic1, 1)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic1, 2)), assignment.get(consumer3));
@@ -335,7 +351,7 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    private static Subscription buildSubscriptionWithOldSchema(List<String> topics, List<TopicPartition> partitions) {
+    private Subscription buildSubscriptionWithOldSchema(List<String> topics, List<TopicPartition> partitions, int consumerIndex) {
         Struct struct = new Struct(StickyAssignor.STICKY_ASSIGNOR_USER_DATA_V0);
         List<Struct> topicAssignments = new ArrayList<>();
         for (Map.Entry<String, List<Integer>> topicEntry : CollectionUtils.groupPartitionsByTopic(partitions).entrySet()) {
@@ -349,6 +365,16 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         StickyAssignor.STICKY_ASSIGNOR_USER_DATA_V0.write(buffer, struct);
         buffer.flip();
 
-        return new Subscription(topics, buffer);
+        return new Subscription(topics, buffer, Collections.emptyList(), DEFAULT_GENERATION, consumerRackId(consumerIndex));
+    }
+
+    public static Collection<Arguments> rackAndSubscriptionCombinations() {
+        return Arrays.asList(
+                Arguments.of(RackConfig.NO_BROKER_RACK, true),
+                Arguments.of(RackConfig.NO_CONSUMER_RACK, true),
+                Arguments.of(RackConfig.BROKER_AND_CONSUMER_RACK, true),
+                Arguments.of(RackConfig.NO_BROKER_RACK, false),
+                Arguments.of(RackConfig.NO_CONSUMER_RACK, false),
+                Arguments.of(RackConfig.BROKER_AND_CONSUMER_RACK, false));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignorTest.java
@@ -16,20 +16,44 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
+import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractPartitionAssignorTest {
+
+    public static final String TEST_NAME_WITH_RACK_CONFIG = "{displayName}.rackConfig = {0}";
+    public static final String TEST_NAME_WITH_CONSUMER_RACK = "{displayName}.hasConsumerRack = {0}";
+    public static final String[] ALL_RACKS = {"a", "b", "c", "d", "e", "f"};
+
+    public enum RackConfig {
+        NO_BROKER_RACK,
+        NO_CONSUMER_RACK,
+        BROKER_AND_CONSUMER_RACK
+    }
 
     @Test
     public void testMemberInfoSortingWithoutGroupInstanceId() {
@@ -85,5 +109,199 @@ public class AbstractPartitionAssignorTest {
         staticMemberList.addAll(dynamicMemberList);
         Collections.shuffle(memberInfoList);
         assertEquals(staticMemberList, Utils.sorted(memberInfoList));
+    }
+
+    @Test
+    public void testUseRackAwareAssignment() {
+        AbstractPartitionAssignor assignor = new RangeAssignor();
+        Map<String, List<String>> rackConsumers = new HashMap<>();
+        String[] racks = new String[] {"a", "b", "c"};
+        rackConsumers.put(racks[0], Collections.singletonList("consumer1"));
+        rackConsumers.put(racks[1], Arrays.asList("consumer2", "consumer3"));
+        Map<String, List<TopicPartition>> rackPartitionsOnAllRacks = Arrays.stream(racks)
+                .collect(Collectors.toMap(Function.identity(), r -> new ArrayList<>()));
+        Map<String, List<TopicPartition>> rackPartitionsOnSubsetOfRacks = Arrays.stream(racks)
+                .collect(Collectors.toMap(Function.identity(), r -> new ArrayList<>()));
+        for (int i = 0; i < 10; i++) {
+            TopicPartition tp = new TopicPartition("topic", i);
+            rackPartitionsOnAllRacks.values().forEach(list -> list.add(tp));
+            rackPartitionsOnSubsetOfRacks.get(racks[i % racks.length]).add(tp);
+        }
+        assertFalse(assignor.useRackAwareAssignment(Collections.emptyMap(), Collections.emptyMap()));
+        assertFalse(assignor.useRackAwareAssignment(Collections.emptyMap(), rackPartitionsOnAllRacks));
+        assertFalse(assignor.useRackAwareAssignment(rackConsumers, Collections.emptyMap()));
+        assertFalse(assignor.useRackAwareAssignment(Collections.singletonMap("d", Collections.singletonList("consumer1")), rackPartitionsOnSubsetOfRacks));
+        assertFalse(assignor.useRackAwareAssignment(rackConsumers, rackPartitionsOnAllRacks));
+        assertTrue(assignor.useRackAwareAssignment(rackConsumers, rackPartitionsOnSubsetOfRacks));
+
+        assignor.preferRackAwareLogic = true;
+        assertFalse(assignor.useRackAwareAssignment(Collections.emptyMap(), Collections.emptyMap()));
+        assertFalse(assignor.useRackAwareAssignment(Collections.emptyMap(), rackPartitionsOnAllRacks));
+        assertFalse(assignor.useRackAwareAssignment(rackConsumers, Collections.emptyMap()));
+        assertFalse(assignor.useRackAwareAssignment(Collections.singletonMap("d", Collections.singletonList("consumer1")), rackPartitionsOnSubsetOfRacks));
+        assertTrue(assignor.useRackAwareAssignment(rackConsumers, rackPartitionsOnAllRacks));
+        assertTrue(assignor.useRackAwareAssignment(rackConsumers, rackPartitionsOnSubsetOfRacks));
+    }
+
+    public static List<String> racks(int numRacks) {
+        List<String> racks = new ArrayList<>(numRacks);
+        for (int i = 0; i < numRacks; i++)
+            racks.add(ALL_RACKS[i % ALL_RACKS.length]);
+        return racks;
+    }
+
+    public static List<String> nullRacks(int numRacks) {
+        List<String> racks = new ArrayList<>(numRacks);
+        for (int i = 0; i < numRacks; i++)
+            racks.add(null);
+        return racks;
+    }
+
+    public static void verifyRackAwareWithUniformSubscription(AbstractPartitionAssignor assignor,
+                                                              int replicationFactor,
+                                                              List<String> brokerRacks,
+                                                              List<String> consumerRacks,
+                                                              List<String> consumerOwnedPartitions,
+                                                              List<String> expectedAssignments,
+                                                              int numPartitionsWithRackMismatch) {
+        String topic1 = "t1";
+        String topic2 = "t2";
+        String topic3 = "t3";
+        List<String> consumers = asList("consumer1", "consumer2", "consumer3");
+        List<List<TopicPartition>> owedPartitions = ownedPartitions(consumerOwnedPartitions, 3);
+        List<Subscription> subscriptions = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++)
+            subscriptions.add(new Subscription(asList(topic1, topic2, topic3), null, owedPartitions.get(i), DEFAULT_GENERATION, Optional.ofNullable(consumerRacks.get(i))));
+
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionsPerTopic(topic1, 6, replicationFactor, brokerRacks, 0));
+        partitionsPerTopic.put(topic2, partitionsPerTopic(topic2, 7, replicationFactor, brokerRacks, 6));
+        partitionsPerTopic.put(topic3, partitionsPerTopic(topic3, 2, replicationFactor, brokerRacks, 13));
+
+        verifyAssignment(assignor, consumers, subscriptions, consumerRacks,
+                partitionsPerTopic, expectedAssignments, numPartitionsWithRackMismatch);
+    }
+
+    public static void verifyRackAwareWithNonEqualSubscription(AbstractPartitionAssignor assignor,
+                                                               int replicationFactor,
+                                                               List<String> brokerRacks,
+                                                               List<String> consumerRacks,
+                                                               List<String> consumerOwnedPartitions,
+                                                               List<String> expectedAssignments,
+                                                               int numPartitionsWithRackMismatch) {
+        String topic1 = "t1";
+        String topic2 = "t2";
+        String topic3 = "t3";
+        List<String> consumers = asList("consumer1", "consumer2", "consumer3");
+        List<List<TopicPartition>> owedPartitions = ownedPartitions(consumerOwnedPartitions, 3);
+        Subscription subscription1 = new Subscription(asList(topic1, topic2, topic3), null, owedPartitions.get(0), DEFAULT_GENERATION, Optional.ofNullable(consumerRacks.get(0)));
+        Subscription subscription2 = new Subscription(asList(topic1, topic2, topic3), null, owedPartitions.get(1), DEFAULT_GENERATION, Optional.ofNullable(consumerRacks.get(1)));
+        Subscription subscription3 = new Subscription(asList(topic1, topic3), null, owedPartitions.get(2), DEFAULT_GENERATION, Optional.ofNullable(consumerRacks.get(2)));
+        List<Subscription> subscriptions = asList(subscription1, subscription2, subscription3);
+
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionsPerTopic(topic1, 6, replicationFactor, brokerRacks, 0));
+        partitionsPerTopic.put(topic2, partitionsPerTopic(topic2, 7, replicationFactor, brokerRacks, 6));
+        partitionsPerTopic.put(topic3, partitionsPerTopic(topic3, 2, replicationFactor, brokerRacks, 13));
+
+        verifyAssignment(assignor, consumers, subscriptions, consumerRacks,
+                partitionsPerTopic, expectedAssignments, numPartitionsWithRackMismatch);
+    }
+
+    private static List<List<TopicPartition>> ownedPartitions(List<String> consumerOwnedPartitions, int numConsumers) {
+        List<List<TopicPartition>> owedPartitions = new ArrayList<>(numConsumers);
+        for (int i = 0; i < 3; i++) {
+            List<TopicPartition> owned = Collections.emptyList();
+            if (consumerOwnedPartitions == null || consumerOwnedPartitions.size() <= i)
+                owedPartitions.add(owned);
+            else {
+                String[] partitions = consumerOwnedPartitions.get(i).split(", ");
+                List<TopicPartition> topicPartitions = new ArrayList<>(partitions.length);
+                for (String partition : partitions) {
+                    String topic = partition.substring(0, partition.lastIndexOf('-'));
+                    int p = Integer.parseInt(partition.substring(partition.lastIndexOf('-') + 1));
+                    topicPartitions.add(new TopicPartition(topic, p));
+                }
+                owedPartitions.add(topicPartitions);
+            }
+        }
+        return owedPartitions;
+    }
+
+    public static void verifyAssignment(AbstractPartitionAssignor assignor,
+                                        List<String> consumers,
+                                        List<Subscription> subscriptions,
+                                        List<String> consumerRacks,
+                                        Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                        List<String> expectedAssignments,
+                                        int numPartitionsWithRackMismatch) {
+        Map<String, Subscription> subscriptionsByConsumer = new HashMap<>(consumers.size());
+        for (int i = 0; i < subscriptions.size(); i++)
+            subscriptionsByConsumer.put(consumers.get(i), subscriptions.get(i));
+
+        Map<String, String> expectedAssignment = new HashMap<>(consumers.size());
+        for (int i = 0; i < consumers.size(); i++)
+            expectedAssignment.put(consumers.get(i), expectedAssignments.get(i));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptionsByConsumer);
+        Map<String, String> actualAssignment = assignment.entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, e -> toSortedString(e.getValue())));
+        assertEquals(expectedAssignment, actualAssignment);
+
+        if (numPartitionsWithRackMismatch >= 0) {
+            List<TopicPartition> numMismatched = new ArrayList<>();
+            for (int i = 0; i < consumers.size(); i++) {
+                String rack = consumerRacks.get(i);
+                if (rack != null) {
+                    List<TopicPartition> partitions = assignment.get(consumers.get(i));
+                    for (TopicPartition tp : partitions) {
+                        PartitionInfo partitionInfo = AbstractPartitionAssignorTest.partitionInfo(tp, partitionsPerTopic.get(tp.topic()));
+                        if (Arrays.stream(partitionInfo.replicas()).noneMatch(n -> rack.equals(n.rack())))
+                            numMismatched.add(tp);
+                    }
+                }
+            }
+            assertEquals(numPartitionsWithRackMismatch, numMismatched.size(), "Partitions with rack mismatch " + numMismatched);
+        }
+    }
+
+    private static String toSortedString(List<?> partitions) {
+        return Utils.join(partitions.stream().map(Object::toString).sorted().collect(Collectors.toList()), ", ");
+    }
+
+    public static List<PartitionInfo> partitionsPerTopic(String topic, int numberOfPartitions, int replicationFactor, int numBrokerRacks, int nextNodeIndex) {
+        int numBrokers = numBrokerRacks <= 0 ? replicationFactor : numBrokerRacks * replicationFactor;
+        List<String> brokerRacks = new ArrayList<>(numBrokers);
+        for (int i = 0; i < numBrokers; i++) {
+            brokerRacks.add(numBrokerRacks <= 0 ? null : ALL_RACKS[i % numBrokerRacks]);
+        }
+        return partitionsPerTopic(topic, numberOfPartitions, replicationFactor, brokerRacks, nextNodeIndex);
+    }
+
+    public static List<PartitionInfo> partitionsPerTopic(String topic, int numberOfPartitions, int replicationFactor, List<String> brokerRacks, int nextNodeIndex) {
+        int numBrokers = brokerRacks.size();
+        List<Node> nodes = new ArrayList<>(numBrokers);
+        for (int i = 0; i < brokerRacks.size(); i++) {
+            nodes.add(new Node(i, "", i, brokerRacks.get(i)));
+        }
+        List<PartitionInfo> partitionInfos = new ArrayList<>(numberOfPartitions);
+        for (int i = 0; i < numberOfPartitions; i++) {
+            Node[] replicas = new Node[replicationFactor];
+            for (int j = 0; j < replicationFactor; j++) {
+                replicas[j] = nodes.get((i + j + nextNodeIndex) % nodes.size());
+            }
+            partitionInfos.add(new PartitionInfo(topic, i, replicas[0], replicas, replicas));
+        }
+        return partitionInfos;
+    }
+
+    public static PartitionInfo partitionInfo(TopicPartition tp, List<PartitionInfo> partitionInfos) {
+        return partitionInfos.stream()
+                .filter(p -> p.topic().equals(tp.topic()) && p.partition() == tp.partition())
+                .findFirst().get();
+    }
+
+    public static void preferRackAwareLogic(AbstractPartitionAssignor assignor, boolean value) {
+        assignor.preferRackAwareLogic = value;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -24,18 +24,32 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.StickyAssignor;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.RackConfig;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_RACK_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_CONSUMER_RACK;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.nullRacks;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.racks;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAwareWithNonEqualSubscription;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAwareWithUniformSubscription;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -62,16 +76,21 @@ public abstract class AbstractStickyAssignorTest {
     protected String groupId = "group";
     protected int generationId = 1;
 
+    protected int numBrokerRacks;
+    protected boolean hasConsumerRack;
+    protected int replicationFactor = 2;
+    private int nextPartitionIndex;
+
     protected abstract AbstractStickyAssignor createAssignor();
 
     // simulate ConsumerProtocolSubscription V0 protocol
-    protected abstract Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId);
+    protected abstract Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex);
 
     // simulate ConsumerProtocolSubscription V1 protocol
-    protected abstract Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId);
+    protected abstract Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex);
 
     // simulate ConsumerProtocolSubscription V2 or above protocol
-    protected abstract Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generation);
+    protected abstract Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generation, int consumerIndex);
 
     protected abstract ByteBuffer generateUserData(List<String> topics, List<TopicPartition> partitions, int generation);
 
@@ -92,9 +111,9 @@ public abstract class AbstractStickyAssignorTest {
         List<TopicPartition> ownedPartitions = partitions(tp(topic1, 0), tp(topic2, 1));
         List<Subscription> subscriptions = new ArrayList<>();
         // add subscription in all ConsumerProtocolSubscription versions
-        subscriptions.add(buildSubscriptionV0(topics, ownedPartitions, generationId));
-        subscriptions.add(buildSubscriptionV1(topics, ownedPartitions, generationId));
-        subscriptions.add(buildSubscriptionV2Above(topics, ownedPartitions, generationId));
+        subscriptions.add(buildSubscriptionV0(topics, ownedPartitions, generationId, 0));
+        subscriptions.add(buildSubscriptionV1(topics, ownedPartitions, generationId, 1));
+        subscriptions.add(buildSubscriptionV2Above(topics, ownedPartitions, generationId, 2));
         for (Subscription subscription : subscriptions) {
             if (subscription != null) {
                 AbstractStickyAssignor.MemberData memberData = assignor.memberData(subscription);
@@ -104,12 +123,14 @@ public abstract class AbstractStickyAssignorTest {
         }
     }
 
-    @Test
-    public void testOneConsumerNoTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(Collections.emptyList()));
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testOneConsumerNoTopic(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        subscriptions = Collections.singletonMap(consumerId, subscription(Collections.emptyList(), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(assignment.get(consumerId).isEmpty());
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -118,13 +139,15 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOneConsumerNonexistentTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 0);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testOneConsumerNonexistentTopic(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, Collections.emptyList());
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(assignment.get(consumerId).isEmpty());
@@ -134,13 +157,15 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOneConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOneConsumerOneTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
@@ -148,21 +173,23 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOnlyAssignsPartitionsFromSubscribedTopics() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOnlyAssignsPartitionsFromSubscribedTopics(RackConfig rackConfig) {
         String otherTopic = "other";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 2));
         subscriptions = mkMap(
                 mkEntry(consumerId, buildSubscriptionV2Above(
                         topics(topic),
                         Arrays.asList(tp(topic, 0), tp(topic, 1), tp(otherTopic, 0), tp(otherTopic, 1)),
-                        generationId)
+                        generationId, 0)
                 )
         );
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumerId));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
@@ -170,14 +197,16 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOneConsumerMultipleTopics() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOneConsumerMultipleTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 1));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 2));
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic1, topic2), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerId));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
@@ -185,30 +214,34 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testTwoConsumersOneTopicOnePartition() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersOneTopicOnePartition(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 1));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testTwoConsumersOneTopicTwoPartitions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersOneTopicTwoPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 2));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 1)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -217,17 +250,19 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testMultipleConsumersMixedTopicSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMultipleConsumersMixedTopicSubscriptions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 2));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic1)));
-        subscriptions.put(consumer2, new Subscription(topics(topic1, topic2)));
-        subscriptions.put(consumer3, new Subscription(topics(topic1)));
+        subscriptions.put(consumer1, subscription(topics(topic1), 0));
+        subscriptions.put(consumer2, subscription(topics(topic1, topic2), 1));
+        subscriptions.put(consumer3, subscription(topics(topic1), 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic1, 1)), assignment.get(consumer3));
@@ -237,16 +272,18 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testTwoConsumersTwoTopicsSixPartitions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersTwoTopicsSixPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic1, topic2)));
-        subscriptions.put(consumer2, new Subscription(topics(topic1, topic2)));
+        subscriptions.put(consumer1, subscription(topics(topic1, topic2), 0));
+        subscriptions.put(consumer2, subscription(topics(topic1, topic2), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -258,20 +295,22 @@ public abstract class AbstractStickyAssignorTest {
     /**
      * This unit test is testing consumer owned minQuota partitions, and expected to have maxQuota partitions situation
      */
-    @Test
-    public void testConsumerOwningMinQuotaExpectedMaxQuota() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testConsumerOwningMinQuotaExpectedMaxQuota(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         List<String> subscribedTopics = topics(topic1, topic2);
 
         subscriptions.put(consumer1,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 1)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 1)), generationId, 0));
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 2)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 2)), generationId, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 1), tp(topic2, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 2)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -283,21 +322,23 @@ public abstract class AbstractStickyAssignorTest {
     /**
      * This unit test is testing consumers owned maxQuota partitions are more than numExpectedMaxCapacityMembers situation
      */
-    @Test
-    public void testMaxQuotaConsumerMoreThanNumExpectedMaxCapacityMembers() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
-        partitionsPerTopic.put(topic2, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMaxQuotaConsumerMoreThanNumExpectedMaxCapacityMembers(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 2));
 
         List<String> subscribedTopics = topics(topic1, topic2);
 
         subscriptions.put(consumer1,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 0)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 0)), generationId, 0));
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 1)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 1)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singletonMap(tp(topic2, 0), consumer3), assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -311,21 +352,23 @@ public abstract class AbstractStickyAssignorTest {
     /**
      * This unit test is testing all consumers owned less than minQuota partitions situation
      */
-    @Test
-    public void testAllConsumersAreUnderMinQuota() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersAreUnderMinQuota(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         List<String> subscribedTopics = topics(topic1, topic2);
 
         subscriptions.put(consumer1,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0)), generationId, 0));
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -336,21 +379,23 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testAddRemoveConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAddRemoveConsumerOneTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumer1));
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId, 1));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singletonMap(tp(topic, 2), consumer2), assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -359,8 +404,8 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
 
         subscriptions.remove(consumer1);
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), assignment.get(consumer2), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), assignment.get(consumer2), generationId, 1));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 2), tp(topic, 1), tp(topic, 0))),
             new HashSet<>(assignment.get(consumer2)));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -369,17 +414,19 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testAddRemoveTwoConsumersTwoTopics() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAddRemoveTwoConsumersTwoTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         List<String> allTopics = topics(topic1, topic2);
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 4);
-        subscriptions.put(consumer1, new Subscription(allTopics));
-        subscriptions.put(consumer2, new Subscription(allTopics));
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 4));
+        subscriptions.put(consumer1, subscription(allTopics, 0));
+        subscriptions.put(consumer2, subscription(allTopics, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1), tp(topic2, 3)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -388,11 +435,11 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
 
         // add 2 consumers
-        subscriptions.put(consumer1, buildSubscriptionV2Above(allTopics, assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, assignment.get(consumer2), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId));
-        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer1, buildSubscriptionV2Above(allTopics, assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, assignment.get(consumer2), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId, 2));
+        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId, 3));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         Map<TopicPartition, String> expectedPartitionsTransferringOwnership = new HashMap<>();
         expectedPartitionsTransferringOwnership.put(tp(topic2, 1), consumer3);
@@ -410,9 +457,9 @@ public abstract class AbstractStickyAssignorTest {
         // remove 2 consumers
         subscriptions.remove(consumer1);
         subscriptions.remove(consumer2);
-        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, assignment.get(consumer3), generationId));
-        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, assignment.get(consumer4), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, assignment.get(consumer3), generationId, 2));
+        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, assignment.get(consumer4), generationId, 3));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic2, 1), tp(topic2, 3), tp(topic1, 0), tp(topic2, 0)), assignment.get(consumer3));
         assertEquals(partitions(tp(topic2, 2), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer4));
 
@@ -441,33 +488,39 @@ public abstract class AbstractStickyAssignorTest {
      *  - consumer3: topic1-1, topic5-0
      *  - consumer4: topic4-0, topic5-1
      */
-    @Test
-    public void testPoorRoundRobinAssignmentScenario() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i <= 5; i++)
-            partitionsPerTopic.put(String.format("topic%d", i), (i % 2) + 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testPoorRoundRobinAssignmentScenario(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            String topicName = String.format("topic%d", i);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, (i % 2) + 1));
+        }
 
         subscriptions.put("consumer1",
-            new Subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5")));
+            subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5"), 0));
         subscriptions.put("consumer2",
-            new Subscription(topics("topic1", "topic3", "topic5")));
+            subscription(topics("topic1", "topic3", "topic5"), 1));
         subscriptions.put("consumer3",
-            new Subscription(topics("topic1", "topic3", "topic5")));
+            subscription(topics("topic1", "topic3", "topic5"), 2));
         subscriptions.put("consumer4",
-            new Subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5")));
+            subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5"), 3));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test
-    public void testAddRemoveTopicTwoConsumers() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAddRemoveTopicTwoConsumers(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         assertTrue(isFullyBalanced(assignment));
@@ -478,11 +531,11 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue((consumer1Assignment1.size() == 1 && consumer2Assignment1.size() == 2) ||
             (consumer1Assignment1.size() == 2 && consumer2Assignment1.size() == 1));
 
-        partitionsPerTopic.put(topic2, 3);
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer2), generationId));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer2), generationId, 1));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -495,10 +548,10 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(consumer2assignment.containsAll(consumer2Assignment1));
 
         partitionsPerTopic.remove(topic);
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer2), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer2), generationId, 1));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -512,246 +565,275 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(consumer2assignment.containsAll(consumer2Assignment3));
     }
 
-    @Test
-    public void testReassignmentAfterOneConsumerLeaves() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 20; i++)
-            partitionsPerTopic.put(getTopicName(i, 20), i);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testReassignmentAfterOneConsumerLeaves(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 20; i++) {
+            String topicName = getTopicName(i, 20);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, i));
+        }
 
         for (int i = 1; i < 20; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = 1; j <= i; j++)
                 topics.add(getTopicName(j, 20));
-            subscriptions.put(getConsumerName(i, 20), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, 20), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < 20; i++) {
             String consumer = getConsumerName(i, 20);
             subscriptions.put(consumer,
-                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId));
+                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId, i));
         }
         subscriptions.remove("consumer10");
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(assignor.isSticky());
     }
 
 
-    @Test
-    public void testReassignmentAfterOneConsumerAdded() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put("topic", 20);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testReassignmentAfterOneConsumerAdded(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put("topic", partitionInfos("topic", 20));
 
         for (int i = 1; i < 10; i++)
             subscriptions.put(getConsumerName(i, 10),
-                new Subscription(topics("topic")));
+                subscription(topics("topic"), i));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         // add a new consumer
-        subscriptions.put(getConsumerName(10, 10), new Subscription(topics("topic")));
+        subscriptions.put(getConsumerName(10, 10), subscription(topics("topic"), 10));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test
-    public void testSameSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 15; i++)
-            partitionsPerTopic.put(getTopicName(i, 15), i);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testSameSubscriptions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 15; i++) {
+            String topicName = getTopicName(i, 15);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, i));
+        }
 
         for (int i = 1; i < 9; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = 1; j <= partitionsPerTopic.size(); j++)
                 topics.add(getTopicName(j, 15));
-            subscriptions.put(getConsumerName(i, 9), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, 9), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < 9; i++) {
             String consumer = getConsumerName(i, 9);
             subscriptions.put(consumer,
-                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId));
+                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId, i));
         }
         subscriptions.remove(getConsumerName(5, 9));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
     @Timeout(30)
-    @Test
-    public void testLargeAssignmentAndGroupWithUniformSubscription() {
-        // 1 million partitions!
-        int topicCount = 500;
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testLargeAssignmentAndGroupWithUniformSubscription(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        // 1 million partitions for non-rack-aware! For rack-aware, use smaller number of partitions to reduce test run time.
+        int topicCount = hasConsumerRack ? 50 : 500;
         int partitionCount = 2_000;
         int consumerCount = 2_000;
 
         List<String> topics = new ArrayList<>();
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (int i = 0; i < topicCount; i++) {
             String topicName = getTopicName(i, topicCount);
             topics.add(topicName);
-            partitionsPerTopic.put(topicName, partitionCount);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, partitionCount));
         }
 
         for (int i = 0; i < consumerCount; i++) {
-            subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, consumerCount), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         for (int i = 1; i < consumerCount; i++) {
             String consumer = getConsumerName(i, consumerCount);
-            subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId));
+            subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId, i));
         }
 
-        assignor.assign(partitionsPerTopic, subscriptions);
+        assignor.assignPartitions(partitionsPerTopic, subscriptions);
     }
 
     @Timeout(60)
-    @Test
-    public void testLargeAssignmentAndGroupWithNonEqualSubscription() {
-        // 1 million partitions!
-        int topicCount = 500;
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testLargeAssignmentAndGroupWithNonEqualSubscription(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        // 1 million partitions for non-rack-aware! For rack-aware, use smaller number of partitions to reduce test run time.
+        int topicCount = hasConsumerRack ? 50 : 500;
         int partitionCount = 2_000;
         int consumerCount = 2_000;
 
         List<String> topics = new ArrayList<>();
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (int i = 0; i < topicCount; i++) {
             String topicName = getTopicName(i, topicCount);
             topics.add(topicName);
-            partitionsPerTopic.put(topicName, partitionCount);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, partitionCount));
         }
         for (int i = 0; i < consumerCount; i++) {
             if (i == consumerCount - 1) {
-                subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics.subList(0, 1)));
+                subscriptions.put(getConsumerName(i, consumerCount), subscription(topics.subList(0, 1), i));
             } else {
-                subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics));
+                subscriptions.put(getConsumerName(i, consumerCount), subscription(topics, i));
             }
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         for (int i = 1; i < consumerCount; i++) {
             String consumer = getConsumerName(i, consumerCount);
             if (i == consumerCount - 1) {
-                subscriptions.put(consumer, buildSubscriptionV2Above(topics.subList(0, 1), assignment.get(consumer), generationId));
+                subscriptions.put(consumer, buildSubscriptionV2Above(topics.subList(0, 1), assignment.get(consumer), generationId, i));
             } else {
-                subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId));
+                subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId, i));
             }
         }
 
-        assignor.assign(partitionsPerTopic, subscriptions);
+        assignor.assignPartitions(partitionsPerTopic, subscriptions);
     }
 
-    @Test
-    public void testLargeAssignmentWithMultipleConsumersLeavingAndRandomSubscription() {
+    @Timeout(60)
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testLargeAssignmentWithMultipleConsumersLeavingAndRandomSubscription(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
         Random rand = new Random();
         int topicCount = 40;
         int consumerCount = 200;
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 0; i < topicCount; i++)
-            partitionsPerTopic.put(getTopicName(i, topicCount), rand.nextInt(10) + 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 0; i < topicCount; i++) {
+            String topicName = getTopicName(i, topicCount);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, rand.nextInt(10) + 1));
+        }
 
         for (int i = 0; i < consumerCount; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = 0; j < rand.nextInt(20); j++)
                 topics.add(getTopicName(rand.nextInt(topicCount), topicCount));
-            subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, consumerCount), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < consumerCount; i++) {
             String consumer = getConsumerName(i, consumerCount);
             subscriptions.put(consumer,
-                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId));
+                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId, i));
         }
         for (int i = 0; i < 50; ++i) {
             String c = getConsumerName(rand.nextInt(consumerCount), consumerCount);
             subscriptions.remove(c);
         }
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(assignor.isSticky());
     }
 
-    @Test
-    public void testNewSubscription() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 5; i++)
-            partitionsPerTopic.put(getTopicName(i, 5), 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testNewSubscription(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 5; i++) {
+            String topicName = getTopicName(i, 5);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, 1));
+        }
 
         for (int i = 0; i < 3; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = i; j <= 3 * i - 2; j++)
                 topics.add(getTopicName(j, 5));
-            subscriptions.put(getConsumerName(i, 3), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, 3), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         subscriptions.get(getConsumerName(0, 3)).topics().add(getTopicName(1, 5));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(assignor.isSticky());
     }
 
-    @Test
-    public void testMoveExistingAssignments() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMoveExistingAssignments(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         String topic4 = "topic4";
         String topic5 = "topic5";
         String topic6 = "topic6";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i <= 6; i++)
-            partitionsPerTopic.put(String.format("topic%d", i), 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i <= 6; i++) {
+            String topicName = String.format("topic%d", i);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, 1));
+        }
 
         subscriptions.put(consumer1,
             buildSubscriptionV2Above(topics(topic1, topic2),
-                partitions(tp(topic1, 0)), generationId));
+                partitions(tp(topic1, 0)), generationId, 0));
         subscriptions.put(consumer2,
             buildSubscriptionV2Above(topics(topic1, topic2, topic3, topic4),
-                partitions(tp(topic2, 0), tp(topic3, 0)), generationId));
+                partitions(tp(topic2, 0), tp(topic3, 0)), generationId, 1));
         subscriptions.put(consumer3,
             buildSubscriptionV2Above(topics(topic2, topic3, topic4, topic5, topic6),
-                partitions(tp(topic4, 0), tp(topic5, 0), tp(topic6, 0)), generationId));
+                partitions(tp(topic4, 0), tp(topic5, 0), tp(topic6, 0)), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertNull(assignor.partitionsTransferringOwnership);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test
-    public void testStickiness() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testStickiness(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic1)));
-        subscriptions.put(consumer2, new Subscription(topics(topic1)));
-        subscriptions.put(consumer3, new Subscription(topics(topic1)));
-        subscriptions.put(consumer4, new Subscription(topics(topic1)));
+        subscriptions.put(consumer1, subscription(topics(topic1), 0));
+        subscriptions.put(consumer2, subscription(topics(topic1), 1));
+        subscriptions.put(consumer3, subscription(topics(topic1), 2));
+        subscriptions.put(consumer4, subscription(topics(topic1), 3));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         Map<String, TopicPartition> partitionsAssigned = new HashMap<>();
@@ -769,14 +851,14 @@ public abstract class AbstractStickyAssignorTest {
         // removing the potential group leader
         subscriptions.remove(consumer1);
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer2), generationId));
+            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer2), generationId, 1));
         subscriptions.put(consumer3,
-            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer3), generationId));
+            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer3), generationId, 2));
         subscriptions.put(consumer4,
-            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer4), generationId));
+            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer4), generationId, 3));
 
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
@@ -790,28 +872,32 @@ public abstract class AbstractStickyAssignorTest {
         }
     }
 
-    @Test
-    public void testAssignmentUpdatedForDeletedTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic3, 100);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2, topic3)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAssignmentUpdatedForDeletedTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 1));
+        partitionsPerTopic.put(topic3, partitionInfos(topic3, 100));
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic1, topic2, topic3), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         assertEquals(assignment.values().stream().mapToInt(List::size).sum(), 1 + 100);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testNoExceptionThrownWhenOnlySubscribedTopicDeleted() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumerId, new Subscription(topics(topic)));
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testNoExceptionThrownWhenOnlySubscribedTopicDeleted(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumerId, subscription(topics(topic), 0));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
-        subscriptions.put(consumerId, buildSubscriptionV2Above(topics(topic), assignment.get(consumerId), generationId));
+        subscriptions.put(consumerId, buildSubscriptionV2Above(topics(topic), assignment.get(consumerId), generationId, 0));
 
         assignment = assignor.assign(Collections.emptyMap(), subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -819,8 +905,10 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(assignment.get(consumerId).isEmpty());
     }
 
-    @Test
-    public void testReassignmentWithRandomSubscriptionsAndChanges() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testReassignmentWithRandomSubscriptionsAndChanges(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         final int minNumConsumers = 20;
         final int maxNumConsumers = 40;
         final int minNumTopics = 10;
@@ -831,47 +919,50 @@ public abstract class AbstractStickyAssignorTest {
 
             ArrayList<String> topics = new ArrayList<>();
 
-            Map<String, Integer> partitionsPerTopic = new HashMap<>();
+            Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
             for (int i = 0; i < numTopics; ++i) {
-                topics.add(getTopicName(i, maxNumTopics));
-                partitionsPerTopic.put(getTopicName(i, maxNumTopics), i + 1);
+                String topicName = getTopicName(i, maxNumTopics);
+                topics.add(topicName);
+                partitionsPerTopic.put(topicName, partitionInfos(topicName, i + 1));
             }
 
             int numConsumers = minNumConsumers + new Random().nextInt(maxNumConsumers - minNumConsumers);
 
             for (int i = 0; i < numConsumers; ++i) {
                 List<String> sub = Utils.sorted(getRandomSublist(topics));
-                subscriptions.put(getConsumerName(i, maxNumConsumers), new Subscription(sub));
+                subscriptions.put(getConsumerName(i, maxNumConsumers), subscription(sub, i));
             }
 
             assignor = createAssignor();
 
-            Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+            Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
             verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
             subscriptions.clear();
             for (int i = 0; i < numConsumers; ++i) {
                 List<String> sub = Utils.sorted(getRandomSublist(topics));
                 String consumer = getConsumerName(i, maxNumConsumers);
-                subscriptions.put(consumer, buildSubscriptionV2Above(sub, assignment.get(consumer), generationId));
+                subscriptions.put(consumer, buildSubscriptionV2Above(sub, assignment.get(consumer), generationId, i));
             }
 
-            assignment = assignor.assign(partitionsPerTopic, subscriptions);
+            assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
             verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
             assertTrue(assignor.isSticky());
         }
     }
 
-    @Test
-    public void testAllConsumersReachExpectedQuotaAndAreConsideredFilled() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 4);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersReachExpectedQuotaAndAreConsideredFilled(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 4));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 3)), assignment.get(consumer3));
@@ -881,18 +972,20 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOwnedPartitionsAreInvalidatedForConsumerWithStaleGeneration() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOwnedPartitionsAreInvalidatedForConsumerWithStaleGeneration(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         int currentGeneration = 10;
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration - 1));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration - 1, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1))), new HashSet<>(assignment.get(consumer1)));
         assertEquals(new HashSet<>(partitions(tp(topic, 1), tp(topic2, 0), tp(topic2, 2))), new HashSet<>(assignment.get(consumer2)));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -901,18 +994,20 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOwnedPartitionsAreInvalidatedForConsumerWithNoGeneration() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOwnedPartitionsAreInvalidatedForConsumerWithNoGeneration(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         int currentGeneration = 10;
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), DEFAULT_GENERATION));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), DEFAULT_GENERATION, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1))), new HashSet<>(assignment.get(consumer1)));
         assertEquals(new HashSet<>(partitions(tp(topic, 1), tp(topic2, 0), tp(topic2, 2))), new HashSet<>(assignment.get(consumer2)));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -921,17 +1016,19 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testPartitionsTransferringOwnershipIncludeThePartitionClaimedByMultipleConsumersInSameGeneration() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testPartitionsTransferringOwnershipIncludeThePartitionClaimedByMultipleConsumersInSameGeneration(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
 
         // partition topic-0 is owned by multiple consumer
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         // we should include the partitions claimed by multiple consumers in partitionsTransferringOwnership
         assertEquals(Collections.singletonMap(tp(topic, 0), consumer3), assignor.partitionsTransferringOwnership);
 
@@ -940,6 +1037,129 @@ public abstract class AbstractStickyAssignorTest {
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
         assertTrue(isFullyBalanced(assignment));
+    }
+
+    @Test
+    public void testRackAwareAssignmentWithUniformSubscription() {
+        List<String> nonRackAwareAssignment = asList(
+                "t1-0, t1-3, t2-0, t2-3, t2-6",
+                "t1-1, t1-4, t2-1, t2-4, t3-0",
+                "t1-2, t1-5, t2-2, t2-5, t3-1"
+        );
+        verifyUniformSubscription(assignor, 3, nullRacks(3), racks(3), nonRackAwareAssignment, -1);
+        verifyUniformSubscription(assignor, 3, racks(3), nullRacks(3), nonRackAwareAssignment, -1);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyUniformSubscription(assignor, 3, racks(3), racks(3), nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyUniformSubscription(assignor, 4, racks(4), racks(3), nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+        verifyUniformSubscription(assignor, 3, racks(3), racks(3), nonRackAwareAssignment, 0);
+        verifyUniformSubscription(assignor, 3, racks(3), asList("d", "e", "f"), nonRackAwareAssignment, -1);
+        verifyUniformSubscription(assignor, 3, racks(3), asList(null, "e", "f"), nonRackAwareAssignment, -1);
+
+        // Verify assignment is rack-aligned for lower replication factor where brokers have a subset of partitions
+        List<String> assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        verifyUniformSubscription(assignor, 1, racks(3), racks(3), assignment, 0);
+        assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        verifyUniformSubscription(assignor, 2, racks(3), racks(3), assignment, 0);
+
+        // One consumer on a rack with no partitions. We allocate with misaligned rack to this consumer to maintain balance.
+        assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        verifyUniformSubscription(assignor, 3, racks(2), racks(3), assignment, 5);
+
+        // Verify that rack-awareness is improved if already owned partitions are misaligned
+        assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        List<String> owned = asList("t1-0, t1-1, t1-2, t1-3, t1-4", "t1-5, t2-0, t2-1, t2-2, t2-3", "t2-4, t2-5, t2-6, t3-0, t3-1");
+        verifyRackAwareWithUniformSubscription(assignor, 1, racks(3), racks(3), owned, assignment, 0);
+        // Verify that stickiness is retained when racks match
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyRackAwareWithUniformSubscription(assignor, 3, racks(3), racks(3), assignment, assignment, 0);
+    }
+
+    private void verifyUniformSubscription(AbstractStickyAssignor assignor,
+                                           int replicationFactor,
+                                           List<String> brokerRacks,
+                                           List<String> consumerRacks,
+                                           List<String> expectedAssignments,
+                                           int numPartitionsWithRackMismatch) {
+        verifyRackAwareWithUniformSubscription(assignor, replicationFactor, brokerRacks,
+                consumerRacks, null, expectedAssignments, numPartitionsWithRackMismatch);
+        verifyRackAwareWithUniformSubscription(assignor, replicationFactor, brokerRacks,
+                consumerRacks, expectedAssignments, expectedAssignments, numPartitionsWithRackMismatch);
+    }
+
+    @Test
+    public void testRackAwareAssignmentWithNonEqualSubscription() {
+        List<String> nonRackAwareAssignment = asList(
+                "t1-5, t2-0, t2-2, t2-4, t2-6",
+                "t1-3, t2-1, t2-3, t2-5, t3-0",
+                "t1-0, t1-1, t1-2, t1-4, t3-1"
+        );
+        verifyNonEqualSubscription(assignor, 3, nullRacks(3), racks(3), nonRackAwareAssignment, -1);
+        verifyNonEqualSubscription(assignor, 3, racks(3), nullRacks(3), nonRackAwareAssignment, -1);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyNonEqualSubscription(assignor, 3, racks(3), racks(3), nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyNonEqualSubscription(assignor, 4, racks(4), racks(3), nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+        verifyNonEqualSubscription(assignor, 3, racks(3), racks(3), nonRackAwareAssignment, 0);
+        verifyNonEqualSubscription(assignor, 3, racks(3), asList("d", "e", "f"), nonRackAwareAssignment, -1);
+        verifyNonEqualSubscription(assignor, 3, racks(3), asList(null, "e", "f"), nonRackAwareAssignment, -1);
+
+        // Verify assignment is rack-aligned for lower replication factor where brokers have a subset of partitions
+        // Rack-alignment is best-effort, misalignments can occur when number of rack choices is low.
+        List<String> assignment = asList("t1-3, t2-0, t2-2, t2-3, t2-6", "t1-4, t2-1, t2-4, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-5, t3-1");
+        verifyNonEqualSubscription(assignor, 1, racks(3), racks(3), assignment, 4);
+        assignment = asList("t1-3, t2-0, t2-2, t2-5, t2-6", "t1-0, t2-1, t2-3, t2-4, t3-0", "t1-1, t1-2, t1-4, t1-5, t3-1");
+        verifyNonEqualSubscription(assignor, 2, racks(3), racks(3), assignment, 0);
+
+        // One consumer on a rack with no partitions. We allocate with misaligned rack to this consumer to maintain balance.
+        verifyNonEqualSubscription(assignor, 3, racks(2), racks(3),
+                asList("t1-5, t2-0, t2-2, t2-4, t2-6", "t1-3, t2-1, t2-3, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-4, t3-1"), 5);
+
+        // Verify that rack-awareness is improved if already owned partitions are misaligned.
+        // Rack alignment is attempted, but not guaranteed.
+        List<String> owned = asList("t1-0, t1-1, t1-2, t1-3, t1-4", "t1-5, t2-0, t2-1, t2-2, t2-3", "t2-4, t2-5, t2-6, t3-0, t3-1");
+        if (assignor instanceof StickyAssignor) {
+            assignment = asList("t1-3, t2-0, t2-2, t2-3, t2-6", "t1-4, t2-1, t2-4, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-5, t3-1");
+            verifyRackAwareWithNonEqualSubscription(assignor, 1, racks(3), racks(3), owned, assignment, 4);
+        } else {
+            List<String> intermediate = asList("t1-3", "t2-1", "t3-1");
+            verifyRackAwareWithNonEqualSubscription(assignor, 1, racks(3), racks(3), owned, intermediate, 0);
+            assignment = asList("t1-3, t2-0, t2-2, t2-3, t2-6", "t1-4, t2-1, t2-4, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-5, t3-1");
+            verifyRackAwareWithNonEqualSubscription(assignor, 1, racks(3), racks(3), intermediate, assignment, 4);
+        }
+
+        // Verify that result is same as non-rack-aware assignment if all racks match
+        if (assignor instanceof StickyAssignor) {
+            assignment = asList("t1-5, t2-0, t2-2, t2-4, t2-6", "t1-3, t2-1, t2-3, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-4, t3-1");
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+            verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), owned, assignment, 0);
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+            verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), owned, assignment, 0);
+        } else {
+            assignment = asList("t1-2, t1-3, t1-4, t2-4, t2-5", "t2-0, t2-1, t2-2, t2-3, t2-6", "t1-0, t1-1, t1-5, t3-0, t3-1");
+            List<String> intermediate = asList("t1-2, t1-3, t1-4", "t2-0, t2-1, t2-2, t2-3", "t3-0, t3-1");
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+            verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), owned, intermediate, 0);
+            verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), intermediate, assignment, 0);
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+            verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), owned, intermediate, 0);
+            verifyRackAwareWithNonEqualSubscription(assignor, 3, racks(3), racks(3), intermediate, assignment, 0);
+        }
+    }
+
+    private void verifyNonEqualSubscription(AbstractStickyAssignor assignor,
+            int replicationFactor,
+            List<String> brokerRacks,
+            List<String> consumerRacks,
+            List<String> expectedAssignments,
+            int numPartitionsWithRackMismatch) {
+
+        verifyRackAwareWithNonEqualSubscription(assignor, replicationFactor, brokerRacks,
+                consumerRacks, null, expectedAssignments, numPartitionsWithRackMismatch);
+        verifyRackAwareWithNonEqualSubscription(assignor, replicationFactor, brokerRacks,
+                consumerRacks, expectedAssignments, expectedAssignments, numPartitionsWithRackMismatch);
     }
 
     private String getTopicName(int i, int maxNum) {
@@ -975,6 +1195,15 @@ public abstract class AbstractStickyAssignorTest {
 
     protected static TopicPartition tp(String topic, int partition) {
         return new TopicPartition(topic, partition);
+    }
+
+    protected Optional<String> consumerRackId(int consumerIndex) {
+        int numRacks = numBrokerRacks > 0 ? numBrokerRacks : AbstractPartitionAssignorTest.ALL_RACKS.length;
+        return Optional.ofNullable(hasConsumerRack ? AbstractPartitionAssignorTest.ALL_RACKS[consumerIndex % numRacks] : null);
+    }
+
+    protected Subscription subscription(List<String> topics, int consumerIndex) {
+        return new Subscription(topics, null, Collections.emptyList(), DEFAULT_GENERATION, consumerRackId(consumerIndex));
     }
 
     protected static boolean isFullyBalanced(Map<String, List<TopicPartition>> assignment) {
@@ -1017,7 +1246,7 @@ public abstract class AbstractStickyAssignorTest {
      */
     protected void verifyValidityAndBalance(Map<String, Subscription> subscriptions,
                                             Map<String, List<TopicPartition>> assignments,
-                                            Map<String, Integer> partitionsPerTopic) {
+                                            Map<String, List<PartitionInfo>> partitionsPerTopic) {
         int size = subscriptions.size();
         assert size == assignments.size();
 
@@ -1068,7 +1297,22 @@ public abstract class AbstractStickyAssignorTest {
         }
     }
 
+
     protected AbstractStickyAssignor.MemberData memberData(Subscription subscription) {
         return assignor.memberData(subscription);
+    }
+
+    protected List<PartitionInfo> partitionInfos(String topic, int numberOfPartitions) {
+        int nextIndex = nextPartitionIndex;
+        nextPartitionIndex += 1;
+        return AbstractPartitionAssignorTest.partitionsPerTopic(topic, numberOfPartitions,
+                replicationFactor, numBrokerRacks, nextIndex);
+    }
+
+    protected void initializeRacks(RackConfig rackConfig) {
+        this.replicationFactor = 3;
+        this.numBrokerRacks = rackConfig != RackConfig.NO_BROKER_RACK ? 3 : 0;
+        this.hasConsumerRack = rackConfig != RackConfig.NO_CONSUMER_RACK;
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3514,7 +3514,8 @@ public abstract class ConsumerCoordinatorTest {
             false,
             autoCommitIntervalMs,
             null,
-            true);
+            true,
+            null);
 
         client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         client.setNodeApiVersions(NodeApiVersions.create(ApiKeys.OFFSET_FETCH.id, (short) 0, upperVersion));
@@ -3675,7 +3676,8 @@ public abstract class ConsumerCoordinatorTest {
                 autoCommitEnabled,
                 autoCommitIntervalMs,
                 null,
-                false);
+                false,
+                null);
     }
 
     private Collection<TopicPartition> getRevoked(final List<TopicPartition> owned,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
@@ -56,7 +56,7 @@ public class ConsumerProtocolTest {
             new TopicPartition("foo", 0),
             new TopicPartition("bar", 0));
         Subscription subscription = new Subscription(Arrays.asList("foo", "bar"),
-            ByteBuffer.wrap("hello".getBytes()), ownedPartitions, generationId);
+            ByteBuffer.wrap("hello".getBytes()), ownedPartitions, generationId, Optional.empty());
 
         for (short version = ConsumerProtocolSubscription.LOWEST_SUPPORTED_VERSION; version <= ConsumerProtocolSubscription.HIGHEST_SUPPORTED_VERSION; version++) {
             ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription, version);
@@ -153,7 +153,7 @@ public class ConsumerProtocolTest {
     public void deserializeNewSubscriptionWithOldVersion(boolean hasGenerationId) {
         Subscription subscription;
         if (hasGenerationId) {
-            subscription = new Subscription(Arrays.asList("foo", "bar"), null, Collections.singletonList(tp2), generationId);
+            subscription = new Subscription(Arrays.asList("foo", "bar"), null, Collections.singletonList(tp2), generationId, Optional.empty());
         } else {
             subscription = new Subscription(Arrays.asList("foo", "bar"), null, Collections.singletonList(tp2));
         }


### PR DESCRIPTION
This PR adds consumer group protocol changes for supporting rack-aware assignment for consumers. It also enables rack-aware assignment in the range assignor and sticky assignors so that default assignors are rack-aware when consumer rack is configured, improving locality with fetch-from-follower when some racks only contain replicas of a subset of partitions. Rack-aware assignment is performed on a best-effort basis and we prioritize balanced assignment over locality. With sticky assignors, we may perform reassignment to improve locality.

All unit tests for range assignor and sticky assignor have been updated to run using both non-rack-aware and rack-aware logic where all partitions are on all racks. This verifies that assignment result  with the old logic in preserved with this PR. Additional unit tests have been added for rack-aware assignment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
