### PR TITLE
MINOR: fix the header size calculation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
@@ -118,7 +118,6 @@ public class RequestHeader implements AbstractRequestResponse {
             // We derive the header version from the request api version, so we read that first.
             // The request api version is part of `RequestHeaderData`, so we reset the buffer position after the read.
             int position = buffer.position();
-            int requestHeaderSize = buffer.remaining();
             apiKey = buffer.getShort();
             short apiVersion = buffer.getShort();
             short headerVersion = ApiKeys.forId(apiKey).requestHeaderVersion(apiVersion);
@@ -129,12 +128,7 @@ public class RequestHeader implements AbstractRequestResponse {
             if (headerData.clientId() == null) {
                 headerData.setClientId("");
             }
-            final RequestHeader header = new RequestHeader(headerData, headerVersion);
-            // Size of a buffer required to serialize the information in this header is already known and would not
-            // change since the RequestHeader object is immutable. Instead of computing it again whenever
-            // RequestHeader#size() is called, we choose to cache the size value when available.
-            header.size = requestHeaderSize;
-            return header;
+            return new RequestHeader(headerData, headerVersion);
         } catch (UnsupportedVersionException e) {
             throw new InvalidRequestException("Unknown API key " + apiKey, e);
         } catch (Throwable ex) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/EnvelopeRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/EnvelopeRequestTest.java
@@ -58,7 +58,9 @@ public class EnvelopeRequestTest {
             Send send = request.toSend(header);
             ByteBuffer buffer = TestUtils.toBuffer(send);
             assertEquals(send.size() - 4, buffer.getInt());
-            assertEquals(header, RequestHeader.parse(buffer));
+            RequestHeader parsedHeader = RequestHeader.parse(buffer);
+            assertEquals(header.size(), parsedHeader.size());
+            assertEquals(header, parsedHeader);
 
             EnvelopeRequestData parsedRequestData = new EnvelopeRequestData();
             parsedRequestData.read(new ByteBufferAccessor(buffer), version);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
@@ -136,7 +136,9 @@ public class RequestHeaderTest {
         RequestHeader parsed = spy(RequestHeader.parse(buffer));
 
         // verify that the result of cached value is same as actual calculation of size
-        assertEquals(parsed.size(), parsed.size(new ObjectSerializationCache()));
+        int size = parsed.size(new ObjectSerializationCache());
+        int sizeFromCache = parsed.size();
+        assertEquals(sizeFromCache, size);
 
         // verify that size(ObjectSerializationCache) is only called once, i.e. during assertEquals call. This validates
         // that size() method does not calculate the size instead it uses the cached value

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -708,6 +708,7 @@ public class RequestResponseTest {
         ByteBuffer serializedRequest = createTopicsRequest.serializeWithHeader(requestHeader);
 
         RequestHeader parsedHeader = RequestHeader.parse(serializedRequest);
+        assertEquals(requestHeader.size(), parsedHeader.size());
         assertEquals(requestHeader, parsedHeader);
 
         RequestAndSize parsedRequest = AbstractRequest.parseRequest(


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/12890/ , we have an improvement for the ObjectSerializationCache in request/response header, but the header size is not correct calculated. Fix it and add size check tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
