### PR TITLE
try-finally around super call in http.py

### DIFF
--- a/tests/kafkatest/services/monitor/http.py
+++ b/tests/kafkatest/services/monitor/http.py
@@ -94,13 +94,14 @@ class HttpMetricsCollector(object):
         super(HttpMetricsCollector, self).start_node(node)
 
     def stop(self):
-        super(HttpMetricsCollector, self).stop()
-
-        if self._http_metrics_thread:
-            self.logger.debug("Shutting down metrics httpd")
-            self._httpd.shutdown()
-            self._http_metrics_thread.join()
-            self.logger.debug("Finished shutting down metrics httpd")
+        try:
+            super(HttpMetricsCollector, self).stop()
+        finally:
+            if self._http_metrics_thread:
+                self.logger.debug("Shutting down metrics httpd")
+                self._httpd.shutdown()
+                self._http_metrics_thread.join()
+                self.logger.debug("Finished shutting down metrics httpd")
 
     def stop_node(self, node):
         super(HttpMetricsCollector, self).stop_node(node)


### PR DESCRIPTION
Adds a safety check in `HttpMetricsCollector` - if the `super()` call fails we still want to shut down httpd thread.

The issue with `HttpMetricsCollector` is that it starts httpd thread on object creation, not inside `start()` method. However, it's been like that for many years, and I don't want to change the logic since it might introduce issues in other places - I don't have bandwidth to hunt them down, unfortunately.

So instead I'm adding a try-finally block in `stop()` which will make sure that http metrics thread is shutdown regardless of whether  or not the super() call was successful.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
