### PR TITLE
MINOR: Fix log message used in version probing system test

### DIFF
--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -523,8 +523,8 @@ class StreamsUpgradeTest(Test):
                     version_probing_message = "Sent a version " + str(highest_version + 1) + " subscription and got version " + str(highest_version) + " assignment back (successful version probing). Downgrade subscription metadata to commonly supported version " + str(highest_version) + " and trigger new rebalance."
                     end_of_upgrade_message = "Sent a version " + str(highest_version) + " subscription and group.s latest commonly supported version is " + str(highest_version + 1) + " (successful version probing and end of rolling upgrade). Upgrading subscription metadata version to " + str(highest_version + 1) + " for next rebalance."
                     end_of_upgrade_error_message = "Could not detect 'successful version probing and end of rolling upgrade' at upgraded node "
-                    followup_rebalance_message = "Triggering the followup rebalance scheduled for 0 ms."
-                    followup_rebalance_error_message = "Could not detect 'Triggering followup rebalance' at node "
+                    followup_rebalance_message = "Triggering the followup rebalance scheduled for"
+                    followup_rebalance_error_message = "Could not detect '" + followup_rebalance_message + "' at node "
                     if len(self.old_processors) > 0:
                         log_monitor.wait_until(version_probing_message,
                                                timeout_sec=60,


### PR DESCRIPTION
PR #12684 introduced a better format for timestamps in log messages. Unfortunately, we missed that one of the modified log messages is used by system test kafkatest.tests.streams.streams_upgrade_test.StreamsUpgradeTest.test_version_probing_upgrade for validation.

This PR adapts the system test to look for the modified log message.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
