### PR TITLE
KAFKA-13881: Add Connect package infos

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/components/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/components/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides common interfaces used to describe pluggable components.
+ */
+package org.apache.kafka.connect.components;

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides pluggable interfaces for Connector and Task implementations.
+ * Provides interfaces for Connector and Task implementations.
  */
 package org.apache.kafka.connect.connector;

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides pluggable interfaces for Connector and Task implementations.
+ */
+package org.apache.kafka.connect.connector;

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/package-info.java
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 /**
- * Provides pluggable interfaces for connector security policies.
+ * Provides pluggable interfaces for policies controlling how users can configure connectors.
+ * For example, the
+ * {@link org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy ConnectorClientConfigOverridePolicy}
+ * interface can be used to control which Kafka client properties can be overridden on a per-connector basis.
  */
 package org.apache.kafka.connect.connector.policy;

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides pluggable interfaces for connector security policies.
+ */
+package org.apache.kafka.connect.connector.policy;

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides classes for representing data and schemas handled by Connect.
+ */
+package org.apache.kafka.connect.data;

--- a/connect/api/src/main/java/org/apache/kafka/connect/errors/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/errors/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides common exception classes for Connect.
+ * Provides common exception classes for Connect, used by the framework and plugins to communicate failures.
  */
 package org.apache.kafka.connect.errors;

--- a/connect/api/src/main/java/org/apache/kafka/connect/errors/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/errors/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides common exception classes for Connect.
+ */
+package org.apache.kafka.connect.errors;

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides API for application-defined metadata attached to Connect records.
+ * Provides an API for application-defined metadata attached to Connect records.
  */
 package org.apache.kafka.connect.header;

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides API for application-defined metadata attached to Connect records.
+ */
+package org.apache.kafka.connect.header;

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/package-info.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 /**
- * Provides interface for describing the state of a running Connect cluster.
+ * Provides an API for describing the state of a running Connect cluster to
+ * {@link org.apache.kafka.connect.rest.ConnectRestExtension} instances.
  */
 package org.apache.kafka.connect.health;

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides interface for describing the state of a running Connect cluster.
+ */
+package org.apache.kafka.connect.health;

--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides pluggable interface for altering the behavior of the Connect REST API.
+ * Provides a pluggable interface for altering the behavior of the Connect REST API.
  */
 package org.apache.kafka.connect.rest;

--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides pluggable interface for altering the behavior of the Connect REST API.
+ */
+package org.apache.kafka.connect.rest;

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides API for implementing connectors which write Kafka records to external applications.
+ * Provides an API for implementing sink connectors which write Kafka records to external applications.
  */
 package org.apache.kafka.connect.sink;

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides API for implementing connectors which write Kafka records to external applications.
+ */
+package org.apache.kafka.connect.sink;

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides API for implementing connectors which read data from external applications into Kafka.
+ */
+package org.apache.kafka.connect.source;

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides API for implementing connectors which read data from external applications into Kafka.
+ * Provides an API for implementing source connectors which read data from external applications into Kafka.
  */
 package org.apache.kafka.connect.source;

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides pluggable interfaces and some implementations for (de)serializing data to and from Kafka
+ */
+package org.apache.kafka.connect.storage;

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides pluggable interface for altering data which is being moved by Connect.
+ * Provides a pluggable interface for altering data which is being moved by Connect.
  */
 package org.apache.kafka.connect.transforms;

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides pluggable interface for altering data which is being moved by Connect.
+ */
+package org.apache.kafka.connect.transforms;

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides pluggable interface for describing when a {@link org.apache.kafka.connect.transforms.Transformation} should be applied to a record.
+ */
+package org.apache.kafka.connect.transforms.predicates;

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides pluggable interface for describing when a {@link org.apache.kafka.connect.transforms.Transformation} should be applied to a record.
+ * Provides a pluggable interface for describing when a {@link org.apache.kafka.connect.transforms.Transformation} should be applied to a record.
  */
 package org.apache.kafka.connect.transforms.predicates;

--- a/connect/api/src/main/java/org/apache/kafka/connect/util/package-info.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/util/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides common utilities that can be used in component implementations.
+ */
+package org.apache.kafka.connect.util;


### PR DESCRIPTION
Signed-off-by: Greg Harris <greg.harris@aiven.io>

Split off from #12895 to target only Connect packages.

There are currently no descriptions of packages in the javadocs, which can be intimidating to new users that look at the documentation and see a wall of raw package names. An example of this can be seen here: https://kafka.apache.org/31/javadoc/

This change adds the following package descriptions based on a best-effort reading of the existing javadocs. Please feel free to correct any factual errors in the proposed descriptions, I am not asserting that these descriptions are currently accurate. This PR only covers the `connect` packages.

For clarity of review, I'll summarize the new descriptions in a table. This summary may become stale by accident, so please be sure to view the diff itself or build the changes locally with `./gradlew javadoc`.

Package | Description
--- | ---
org.apache.kafka.connect.components|Provides common interfaces used to describe pluggable components.
org.apache.kafka.connect.connector|Provides interfaces for Connector and Task implementations.
org.apache.kafka.connect.connector.policy|Provides pluggable interfaces for policies controlling how users can configure connectors.
org.apache.kafka.connect.data|Provides classes for representing data and schemas handled by Connect.
org.apache.kafka.connect.errors|Provides common exception classes for Connect, used by the framework and plugins to communicate failures.
org.apache.kafka.connect.header|Provides an API for application-defined metadata attached to Connect records.
org.apache.kafka.connect.health|Provides an API for describing the state of a running Connect cluster to ConnectRestExtension instances.
org.apache.kafka.connect.rest|Provides a pluggable interface for altering the behavior of the Connect REST API.
org.apache.kafka.connect.sink|Provides an API for implementing sink connectors which write Kafka records to external applications.
org.apache.kafka.connect.source|Provides an API for implementing source connectors which read data from external applications into Kafka.
org.apache.kafka.connect.storage|Provides pluggable interfaces and some implementations for (de)serializing data to and from Kafka
org.apache.kafka.connect.transforms|Provides a pluggable interface for altering data which is being moved by Connect.
org.apache.kafka.connect.transforms.predicates|Provides a pluggable interface for describing when a Transformation should be applied to a record.
org.apache.kafka.connect.util|Provides common utilities that can be used in component implementations.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
