### PR TITLE
MINOR: Remove lock contention while adding sensors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -408,7 +408,7 @@ public class Metrics implements Closeable {
      * @return The sensor that is created
      */
     public Sensor sensor(String name, MetricConfig config, long inactiveSensorExpirationTimeSeconds, Sensor.RecordingLevel recordingLevel, Sensor... parents) {
-        return sensors.computeIfAbsent(name, (ignored) -> {
+        return sensors.computeIfAbsent(name, ignored -> {
             Sensor newSensor = new Sensor(this, name, parents, config == null ? this.config : config, time, inactiveSensorExpirationTimeSeconds, recordingLevel);
             log.trace("Added sensor with name {}", name);
 


### PR DESCRIPTION
When we want to add a sensor to `Metrics.java`, we synchronize the entire method. However both, `sensors` and `childrenSensors` are concurrent hash maps and full method synchronization is not required. 

This PR removes the method level synchronization and uses the properties of concurrent hash map to ensure thread safety. 

The motivation of this change is code hygiene improvement and there is no known bottleneck by this lock contention.

Behaviour after the change:
- sensors with different names can be added to the `sensors` map concurrently (vs. earlier where only one could be added at a time)



