### PR TITLE
KAFKA-14433 Clear Yammer metrics in QuorumTestHarness#tearDown

### DIFF
--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -386,10 +386,10 @@ abstract class QuorumTestHarness extends Logging {
   def tearDown(): Unit = {
     Exit.resetExitProcedure()
     Exit.resetHaltProcedure()
-    TestUtils.clearYammerMetrics()
     if (implementation != null) {
       implementation.shutdown()
     }
+    TestUtils.clearYammerMetrics()
     System.clearProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)
     Configuration.setConfiguration(null)
     faultHandler.maybeRethrowFirstException()

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -386,6 +386,7 @@ abstract class QuorumTestHarness extends Logging {
   def tearDown(): Unit = {
     Exit.resetExitProcedure()
     Exit.resetHaltProcedure()
+    TestUtils.clearYammerMetrics()
     if (implementation != null) {
       implementation.shutdown()
     }


### PR DESCRIPTION
The anonymous functions we create in classes like Partition will end up getting held by the singleton Yammer metrics registry. 

```
  newGauge("UnderReplicated", () => if (isUnderReplicated) 1 else 0, tags)
  newGauge("InSyncReplicasCount", () => if (isLeader) partitionState.isr.size else 0, tags)
  newGauge("UnderMinIsr", () => if (isUnderMinIsr) 1 else 0, tags)
  newGauge("AtMinIsr", () => if (isAtMinIsr) 1 else 0, tags)
  newGauge("ReplicasCount", () => if (isLeader) assignmentState.replicationFactor else 0, tags)
  newGauge("LastStableOffsetLag", () => log.map(_.lastStableOffsetLag).getOrElse(0), tags)
```

This prevents GC from happening during test runs where we create lots of new BrokerServer/ControllerServer objects. In particular, we were seeing leaks of KafkaRaftClient which retains a fair amount of heap.

This patch is a quick fix is to remove all the Yammer metrics from the registry between each test run. This should allow GC to occur as expected and improve overall heap usage during a test run.