### PR TITLE
KAFKA-14437: Enhance StripedReplicaPlacer to account for existing partition assignments when creating new partitions

### DIFF
--- a/core/src/test/scala/unit/kafka/server/CreatePartitionsRackAwareTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreatePartitionsRackAwareTest.scala
@@ -1,0 +1,67 @@
+package kafka.server
+
+import kafka.utils.{TestInfoUtils, TestUtils}
+import org.apache.kafka.clients.admin.NewPartitions
+import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+import java.util.Collections
+import scala.jdk.CollectionConverters._
+
+class CreatePartitionsRackAwareTest extends BaseRequestTest {
+
+  val brokerIdToRack = Map(
+    0 -> "rack1",
+    1 -> "rack1",
+    2 -> "rack1",
+    3 -> "rack1",
+    4 -> "rack2",
+    5 -> "rack2",
+    6 -> "rack2",
+    7 -> "rack2",
+    8 -> "rack3",
+    9 -> "rack3",
+    10 -> "rack3",
+    11 -> "rack3"
+  )
+
+  override def generateConfigs: collection.Seq[KafkaConfig] = {
+    brokerIdToRack.map { case (id, rack) =>
+      KafkaConfig.fromProps(TestUtils.createBrokerConfig(id, zkConnectOrNull, rack = Some(rack)))
+    }.toSeq
+  }
+
+  // This test does not pass reliably for ZK - see https://issues.apache.org/jira/browse/KAFKA-14456.
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft"))
+  def testRackAwarePartitionAssignment(quorum: String): Unit = {
+    val topicName = "topic-1"
+    createTopic(topicName, 1, 1)
+    TestUtils.waitForPartitionMetadata(brokers, topicName, 0)
+
+    val admin = createAdminClient()
+    admin.createPartitions(Collections.singletonMap(topicName, NewPartitions.increaseTo(2)))
+    TestUtils.waitForPartitionMetadata(brokers, topicName, 1)
+
+    val response = connectAndReceive[MetadataResponse](
+      new MetadataRequest.Builder(Seq(topicName).asJava, false).build)
+    assertEquals(1, response.topicMetadata.size)
+    val partitions = response.topicMetadata.asScala.head.partitionMetadata.asScala.sortBy(_.partition)
+    assertEquals(partitions.size, 2)
+    assertEquals(0, partitions(0).partition)
+    assertEquals(1, partitions(1).partition)
+
+    val p0Assignment = partitions(0)
+    val p0LeaderRack = brokerIdToRack(p0Assignment.leaderId.get())
+    val p1Assignment = partitions(1)
+    val p1LeaderRack = brokerIdToRack(p1Assignment.leaderId.get())
+    // Just make sure the new partition leader is put on a different rack. We don't need to do deep validation here,
+    // as that should be done by testing of the assignment implementation components e.g. AdminUtils or
+    // StripedReplicaPlacer.
+    assertNotEquals(p0LeaderRack, p1LeaderRack)
+  }
+
+  override def brokerCount: Int = brokerIdToRack.keys.size
+}

--- a/core/src/test/scala/unit/kafka/server/CreatePartitionsRackUnawareTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreatePartitionsRackUnawareTest.scala
@@ -1,0 +1,40 @@
+package kafka.server
+
+import kafka.utils.{TestInfoUtils, TestUtils}
+import org.apache.kafka.clients.admin.NewPartitions
+import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+import java.util.Collections
+import scala.jdk.CollectionConverters._
+
+class CreatePartitionsRackUnawareTest extends BaseRequestTest {
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testRackUnawarePartitionAssignment(quorum: String): Unit = {
+    val topicName = "topic-1"
+    createTopic(topicName, 1, 1)
+    TestUtils.waitForPartitionMetadata(brokers, topicName, 0)
+
+    val admin = createAdminClient()
+    admin.createPartitions(Collections.singletonMap(topicName, NewPartitions.increaseTo(2)))
+    TestUtils.waitForPartitionMetadata(brokers, topicName, 1)
+
+    val response = connectAndReceive[MetadataResponse](
+      new MetadataRequest.Builder(Seq(topicName).asJava, false).build)
+    assertEquals(1, response.topicMetadata.size)
+    val partitions = response.topicMetadata.asScala.head.partitionMetadata.asScala.sortBy(_.partition)
+
+    val p0Assignment = partitions(0)
+    val p1Assignment = partitions(1)
+    // Just make sure the new partition leader is put on a different broker. We don't need to do deep validation here,
+    // as that should be done by testing of the assignment implementation components e.g. AdminUtils or
+    // StripedReplicaPlacer.
+    assertNotEquals(p0Assignment.leaderId.get(), p1Assignment.leaderId.get())
+  }
+
+  override def brokerCount: Int = 2
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -102,6 +102,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -227,6 +228,30 @@ public class ReplicationControlManager {
         @Override
         public Iterator<UsableBroker> usableBrokers() {
             return clusterControl.usableBrokers();
+        }
+
+        @Override
+        public List<PartitionAssignment> replicasForTopicName(String topicName) {
+            Uuid id = topicsByName.get(topicName);
+            if (id == null) {
+                return Collections.emptyList();
+            }
+            TopicControlInfo topicInfo = topics.get(id);
+            if (topicInfo == null) {
+                return Collections.emptyList();
+            }
+            List<Entry<Integer, List<Integer>>> partInfo = new ArrayList<>();
+            for (Entry<Integer, PartitionRegistration> entry : topicInfo.parts.entrySet()) {
+                PartitionRegistration registration = entry.getValue();
+                partInfo.add(new SimpleImmutableEntry<>(entry.getKey(),
+                        Replicas.toList(registration.replicas)));
+            }
+            partInfo.sort(Comparator.comparingInt(Entry::getKey));
+            List<List<Integer>> results = new ArrayList<>();
+            for (Entry<Integer, List<Integer>> entry : partInfo) {
+                results.add(entry.getValue());
+            }
+            return results.stream().map(PartitionAssignment::new).collect(Collectors.toList());
         }
     }
 
@@ -686,6 +711,7 @@ public class ReplicationControlManager {
                 defaultReplicationFactor : topic.replicationFactor();
             try {
                 TopicAssignment topicAssignment = clusterControl.replicaPlacer().place(new PlacementSpec(
+                    topic.name(),
                     0,
                     numPartitions,
                     replicationFactor
@@ -1635,7 +1661,7 @@ public class ReplicationControlManager {
             }
         } else {
             partitionAssignments = clusterControl.replicaPlacer().place(
-                new PlacementSpec(startPartitionId, additional, replicationFactor),
+                new PlacementSpec(topic.name(), startPartitionId, additional, replicationFactor),
                 clusterDescriber
             ).assignments();
             isrs = partitionAssignments.stream().map(PartitionAssignment::replicas).collect(Collectors.toList());

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -244,7 +244,7 @@ public class ReplicationControlManager {
             for (Entry<Integer, PartitionRegistration> entry : topicInfo.parts.entrySet()) {
                 PartitionRegistration registration = entry.getValue();
                 partInfo.add(new SimpleImmutableEntry<>(entry.getKey(),
-                        Replicas.toList(registration.replicas)));
+                    Replicas.toList(registration.replicas)));
             }
             partInfo.sort(Comparator.comparingInt(Entry::getKey));
             List<List<Integer>> results = new ArrayList<>();

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/ClusterDescriber.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/ClusterDescriber.java
@@ -20,6 +20,7 @@ package org.apache.kafka.metadata.placement;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Iterator;
+import java.util.List;
 
 
 /**
@@ -31,4 +32,6 @@ public interface ClusterDescriber {
      * Get an iterator through the usable brokers.
      */
     Iterator<UsableBroker> usableBrokers();
+
+    List<PartitionAssignment> replicasForTopicName(String topicName);
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PlacementSpec.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PlacementSpec.java
@@ -27,6 +27,8 @@ import java.util.Objects;
  */
 @InterfaceStability.Unstable
 public class PlacementSpec {
+    private final String topic;
+
     private final int startPartition;
 
     private final int numPartitions;
@@ -34,10 +36,12 @@ public class PlacementSpec {
     private final short numReplicas;
 
     public PlacementSpec(
+        String topic,
         int startPartition,
         int numPartitions,
         short numReplicas
     ) {
+        this.topic = topic;
         this.startPartition = startPartition;
         this.numPartitions = numPartitions;
         this.numReplicas = numReplicas;
@@ -55,19 +59,25 @@ public class PlacementSpec {
         return numReplicas;
     }
 
+    public String topic() {
+        return topic;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null) return false;
         if (!(o.getClass().equals(this.getClass()))) return false;
         PlacementSpec other = (PlacementSpec) o;
-        return startPartition == other.startPartition &&
+        return topic.equals(other.topic) &&
+            startPartition == other.startPartition &&
             numPartitions == other.numPartitions &&
             numReplicas == other.numReplicas;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(startPartition,
+        return Objects.hash(topic,
+            startPartition,
             numPartitions,
             numReplicas);
     }
@@ -75,7 +85,8 @@ public class PlacementSpec {
     @Override
     public String toString() {
         return "PlacementSpec" +
-            "(startPartition=" + startPartition +
+            "(topic=" + topic +
+            ", startPartition=" + startPartition +
             ", numPartitions=" + numPartitions +
             ", numReplicas=" + numReplicas +
             ")";

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
@@ -353,9 +353,10 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
             }
         }
 
-        protected static Optional<Integer> tryGetPreviousRackOffset(Map<Integer, Optional<String>> brokerIdToRack,
-                                                           List<PartitionAssignment> existingPartitionAssignments,
-                                                           List<Optional<String>> racks) {
+        protected static Optional<Integer> tryGetPreviousRackOffset(
+            Map<Integer, Optional<String>> brokerIdToRack,
+            List<PartitionAssignment> existingPartitionAssignments,
+            List<Optional<String>> racks) {
             if (existingPartitionAssignments.isEmpty()) {
                 return Optional.empty();
             }
@@ -372,10 +373,11 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
             return Optional.empty();
         }
 
-        protected static Optional<Integer> tryGetPreviousBrokerOffset(Map<Integer, Optional<String>> brokerIdToRack,
-                                                             List<PartitionAssignment> existingPartitionAssignments,
-                                                             Optional<String> rack,
-                                                             List<Integer> unfencedBrokers) {
+        protected static Optional<Integer> tryGetPreviousBrokerOffset(
+            Map<Integer, Optional<String>> brokerIdToRack,
+            List<PartitionAssignment> existingPartitionAssignments,
+            Optional<String> rack,
+            List<Integer> unfencedBrokers) {
             for (int i = existingPartitionAssignments.size() - 1; i >= 0; i--) {
                 List<Integer> partitionAssignment = existingPartitionAssignments.get(i).replicas();
                 for (int j = 0; j < partitionAssignment.size(); j++) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
@@ -353,6 +353,21 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
             }
         }
 
+        /**
+         * This method tries to get an offset within the list of racks to start making assignments from.
+         *
+         * It works by looking at the leader of the highest number partition, which is the last partition that an
+         * assignment was made for, and returning the offset of that rack from within the list of racks. The idea is
+         * we should start making assignments for the next partition starting from this offset plus one.
+         *
+         * Note, if this method is called during topic creation, not partition addition/creation, then no offset will
+         * be returned. There will be no existing partition assignments, so it will always return an empty Optional.
+         *
+         * @param brokerIdToRack A Map from broker ID to rack.
+         * @param existingPartitionAssignments The existing partition assignments.
+         * @param racks The list of racks
+         * @return
+         */
         protected static Optional<Integer> tryGetPreviousRackOffset(
             Map<Integer, Optional<String>> brokerIdToRack,
             List<PartitionAssignment> existingPartitionAssignments,
@@ -373,6 +388,22 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
             return Optional.empty();
         }
 
+        /**
+         * This method tries to get an offset, for a specific rack, within the list of unfenced brokers to start making assignments from.
+         *
+         * It works by iterating through the existing partition assignments, and finding the last assigned broker for
+         * the given rack. If it finds one, it returns that offset that can be used as the starting offset, plus one,
+         * to start making assignments for new partitions.
+         *
+         * Note, if this method is called during topic creation, not partition addition/creation, then no offset will
+         * be returned. There will be no existing partition assignments, so it will always return an empty Optional.
+         *
+         * @param brokerIdToRack Map from broker ID to rack.
+         * @param existingPartitionAssignments Topic's exsiting partition assignments, if any.
+         * @param rack The rack to get the broker offset from.
+         * @param unfencedBrokers The unfenced brokers to get the broker offset from within.
+         * @return The offset in the unfenced broker list to start assignments from.
+         */
         protected static Optional<Integer> tryGetPreviousBrokerOffset(
             Map<Integer, Optional<String>> brokerIdToRack,
             List<PartitionAssignment> existingPartitionAssignments,

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
@@ -476,7 +476,7 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
     private static void throwInvalidReplicationFactorIfNonPositive(int replicationFactor) {
         if (replicationFactor <= 0) {
             throw new InvalidReplicationFactorException("Invalid replication factor " +
-                    replicationFactor + ": the replication factor must be positive.");
+                replicationFactor + ": the replication factor must be positive.");
         }
     }
 
@@ -489,8 +489,8 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
     private static void throwInvalidReplicationFactorIfTooFewBrokers(int replicationFactor, int numTotalBrokers) {
         if (replicationFactor > numTotalBrokers) {
             throw new InvalidReplicationFactorException("The target replication factor " +
-                    "of " + replicationFactor + " cannot be reached because only " +
-                    numTotalBrokers + " broker(s) are registered.");
+                "of " + replicationFactor + " cannot be reached because only " +
+                numTotalBrokers + " broker(s) are registered.");
         }
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
@@ -25,11 +25,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -89,12 +93,33 @@ public class StripedReplicaPlacerTest {
         int startPartition,
         int numPartitions,
         short replicationFactor,
-        List<UsableBroker> brokers
+        List<UsableBroker> brokers,
+        List<PartitionAssignment> existingPartitionAssignments
     ) {
-        PlacementSpec placementSpec = new PlacementSpec(startPartition,
+        PlacementSpec placementSpec = new PlacementSpec("topic", startPartition,
             numPartitions,
             replicationFactor);
-        return placer.place(placementSpec, brokers::iterator);
+        ClusterDescriber cluster = new ClusterDescriber() {
+            @Override
+            public Iterator<UsableBroker> usableBrokers() {
+                return brokers.iterator();
+            }
+            @Override
+            public List<PartitionAssignment> replicasForTopicName(String topicName) {
+                return existingPartitionAssignments;
+            }
+        };
+        return placer.place(placementSpec, cluster);
+    }
+
+    private TopicAssignment place(
+        ReplicaPlacer placer,
+        int startPartition,
+        int numPartitions,
+        short replicationFactor,
+        List<UsableBroker> brokers
+    ) {
+        return place(placer, startPartition, numPartitions, replicationFactor, brokers, new ArrayList<>());
     }
 
     /**
@@ -151,6 +176,114 @@ public class StripedReplicaPlacerTest {
     }
 
     @Test
+    public void testPlaceShiftsInitialOffsetsRackUnaware() {
+        List<UsableBroker> usableBrokers = Arrays.asList(
+            new UsableBroker(0, Optional.empty(), false),
+            new UsableBroker(1, Optional.empty(), false),
+            new UsableBroker(2, Optional.empty(), false),
+            new UsableBroker(3, Optional.empty(), false),
+            new UsableBroker(4, Optional.empty(), false),
+            new UsableBroker(5, Optional.empty(), false),
+            new UsableBroker(6, Optional.empty(), false),
+            new UsableBroker(7, Optional.empty(), false),
+            new UsableBroker(8, Optional.empty(), false),
+            new UsableBroker(9, Optional.empty(), false),
+            new UsableBroker(10, Optional.empty(), false),
+            new UsableBroker(11, Optional.empty(), false));
+
+        List<PartitionAssignment> partitionAssignments = place(new StripedReplicaPlacer(new MockRandom()), 0, 2, (short) 3, usableBrokers).assignments();
+        assertEquals(Arrays.asList(7, 8, 9), partitionAssignments.get(0).replicas());
+        assertEquals(Arrays.asList(8, 9, 10), partitionAssignments.get(1).replicas());
+
+        // Add two partitions
+        int startPartitionId = partitionAssignments.size();
+        List<PartitionAssignment> nextTwoPartitionAssignments = place(
+                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 2, (short) 3, usableBrokers, partitionAssignments).assignments();
+        assertEquals(Arrays.asList(9, 10, 11), nextTwoPartitionAssignments.get(0).replicas());
+        assertEquals(Arrays.asList(10, 11, 0), nextTwoPartitionAssignments.get(1).replicas());
+
+        // Add four more partitions and make sure we handle starting from index 0 correctly.
+        List<PartitionAssignment> currPartitionAssignments = new ArrayList<>(partitionAssignments);
+        for (PartitionAssignment partitionAssignment : nextTwoPartitionAssignments) {
+            currPartitionAssignments.add(partitionAssignment);
+        }
+        List<PartitionAssignment> nextFourPartitionAssignments = place(
+                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 4, (short) 3, usableBrokers, currPartitionAssignments).assignments();
+        assertEquals(Arrays.asList(11, 0, 1), nextFourPartitionAssignments.get(0).replicas());
+        assertEquals(Arrays.asList(0, 1, 2), nextFourPartitionAssignments.get(1).replicas());
+        assertEquals(Arrays.asList(1, 2, 3), nextFourPartitionAssignments.get(2).replicas());
+        assertEquals(Arrays.asList(2, 3, 4), nextFourPartitionAssignments.get(3).replicas());
+    }
+
+    @Test
+    public void testPlaceShiftsInitialOffsetsRackAware() {
+        List<UsableBroker> usableBrokers = Arrays.asList(
+            new UsableBroker(0, Optional.of("1"), false),
+            new UsableBroker(1, Optional.of("1"), false),
+            new UsableBroker(2, Optional.of("1"), false),
+            new UsableBroker(3, Optional.of("1"), false),
+            new UsableBroker(4, Optional.of("2"), false),
+            new UsableBroker(5, Optional.of("2"), false),
+            new UsableBroker(6, Optional.of("2"), false),
+            new UsableBroker(7, Optional.of("2"), false),
+            new UsableBroker(8, Optional.of("3"), false),
+            new UsableBroker(9, Optional.of("3"), false),
+            new UsableBroker(10, Optional.of("3"), false),
+            new UsableBroker(11, Optional.of("3"), false));
+
+        List<PartitionAssignment> partitionAssignments = place(new StripedReplicaPlacer(new MockRandom()), 0, 2, (short) 3, usableBrokers).assignments();
+        assertEquals(Arrays.asList(6, 8, 2), partitionAssignments.get(0).replicas());
+        assertEquals(Arrays.asList(9, 3, 7), partitionAssignments.get(1).replicas());
+        Set<Integer> assignedBrokers = new HashSet<>();
+
+        assignedBrokers.addAll(partitionAssignments.get(0).replicas());
+        assignedBrokers.addAll(partitionAssignments.get(1).replicas());
+
+        // Add partitions
+        int startPartitionId = partitionAssignments.size();
+        List<PartitionAssignment> newPartitionAssignments = place(
+            new StripedReplicaPlacer(new MockRandom()), startPartitionId, 2, (short) 3, usableBrokers, partitionAssignments).assignments();
+        assertEquals(Arrays.asList(0, 4, 10), newPartitionAssignments.get(0).replicas());
+        assertEquals(Arrays.asList(5, 11, 1), newPartitionAssignments.get(1).replicas());
+        assignedBrokers.addAll(newPartitionAssignments.get(0).replicas());
+        assignedBrokers.addAll(newPartitionAssignments.get(1).replicas());
+
+        assertEquals(usableBrokers.size(), assignedBrokers.size());
+    }
+
+    @Test
+    public void testPlaceShiftsInitialOffsetsRackAwareAndUsesUnusedRacks() {
+        List<UsableBroker> usableBrokers = Arrays.asList(
+                new UsableBroker(0, Optional.of("1"), false),
+                new UsableBroker(1, Optional.of("2"), false),
+                new UsableBroker(2, Optional.of("3"), false),
+                new UsableBroker(3, Optional.of("4"), false));
+
+        List<PartitionAssignment> partitionAssignments = place(new StripedReplicaPlacer(new MockRandom()), 0, 1, (short) 2, usableBrokers).assignments();
+        assertEquals(Arrays.asList(0, 1), partitionAssignments.get(0).replicas());
+
+        List<PartitionAssignment> fullPartitionAssignments = new ArrayList<>(partitionAssignments);
+
+        // Add partitions
+        int startPartitionId = partitionAssignments.size();
+        partitionAssignments = place(
+                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
+        assertEquals(Arrays.asList(1, 2), partitionAssignments.get(0).replicas());
+
+        fullPartitionAssignments.addAll(partitionAssignments);
+
+        partitionAssignments = place(
+                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
+        assertEquals(Arrays.asList(2, 3), partitionAssignments.get(0).replicas());
+
+        fullPartitionAssignments.addAll(partitionAssignments);
+
+        partitionAssignments = place(
+                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
+        assertEquals(Arrays.asList(3, 0), partitionAssignments.get(0).replicas());
+    }
+
+    @Test
     public void testRackListWithInvalidRacks() {
         MockRandom random = new MockRandom();
         RackList rackList = new RackList(random, Arrays.asList(
@@ -171,6 +304,126 @@ public class StripedReplicaPlacerTest {
         assertEquals(Arrays.asList(41, 11, 21, 30), rackList.place(4));
         assertEquals(Arrays.asList(10, 20, 31, 41), rackList.place(4));
         assertEquals(Arrays.asList(41, 21, 30, 11), rackList.place(4));
+    }
+
+    @Test
+    public void testTryGetPreviousBrokerOffset() {
+        Map<Integer, Optional<String>> brokerIdToRack = new HashMap<>();
+        brokerIdToRack.put(0, Optional.of("1"));
+        brokerIdToRack.put(1, Optional.of("1"));
+        brokerIdToRack.put(2, Optional.of("1"));
+        brokerIdToRack.put(3, Optional.of("1"));
+        brokerIdToRack.put(4, Optional.of("2"));
+        brokerIdToRack.put(5, Optional.of("2"));
+        brokerIdToRack.put(6, Optional.of("2"));
+        brokerIdToRack.put(7, Optional.of("2"));
+        brokerIdToRack.put(8, Optional.of("3"));
+        brokerIdToRack.put(9, Optional.of("3"));
+        brokerIdToRack.put(10, Optional.of("3"));
+        brokerIdToRack.put(11, Optional.of("3"));
+
+        List<Integer> unfencedBrokersRack1 = Arrays.asList(0, 1, 2, 3);
+        List<Integer> unfencedBrokersRack2 = Arrays.asList(4, 5, 6, 7);
+        List<Integer> unfencedBrokersRack3 = Arrays.asList(8, 9, 10, 11);
+
+        // No existing partitions case.
+        assertEquals(Optional.empty(),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack,
+                        new ArrayList<>(), Optional.of("1"), unfencedBrokersRack1));
+
+        // Case where existing partitions have broker from rack in last partition.
+        assertEquals(Optional.of(1),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                        new PartitionAssignment(Arrays.asList(1, 2, 0))
+                ), Optional.of("1"), unfencedBrokersRack1));
+
+        // Case where existing partitions have broker from rack in last partition but brokers are fenced.
+        assertEquals(Optional.empty(),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                        new PartitionAssignment(Arrays.asList(1, 2, 0))
+                ), Optional.of("1"), new ArrayList<>()));
+
+        // Case where existing partitions have broker from rack in third to last partition.
+        assertEquals(Optional.of(1),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                        new PartitionAssignment(Arrays.asList(1, 2, 0)),
+                        new PartitionAssignment(Arrays.asList(4, 5, 6)),
+                        new PartitionAssignment(Arrays.asList(5, 6, 7))
+                ), Optional.of("1"), unfencedBrokersRack1));
+
+        // Case where existing partitions have broker from rack in last partition but not first replica
+        // in that partition.
+        assertEquals(Optional.of(1),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(4, 5, 1))
+                ), Optional.of("1"), unfencedBrokersRack1));
+
+        // Case where existing partitions have broker from rack in last partition but not first replica
+        // in that partition.
+        assertEquals(Optional.of(1),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(1, 2, 0)),
+                        new PartitionAssignment(Arrays.asList(0, 5, 6)),
+                        new PartitionAssignment(Arrays.asList(0, 1, 2))
+                ), Optional.of("2"), unfencedBrokersRack2));
+
+        // Case where existing partitions do not have broker from rack.
+        assertEquals(Optional.empty(),
+                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                        new PartitionAssignment(Arrays.asList(1, 2, 0)),
+                        new PartitionAssignment(Arrays.asList(4, 5, 6)),
+                        new PartitionAssignment(Arrays.asList(5, 6, 7))
+                ), Optional.of("3"), unfencedBrokersRack3));
+    }
+
+    @Test
+    public void testTryGetPreviousRackOffset() {
+        Map<Integer, Optional<String>> brokerIdToRack = new HashMap<>();
+        brokerIdToRack.put(0, Optional.of("1"));
+        brokerIdToRack.put(1, Optional.of("1"));
+        brokerIdToRack.put(2, Optional.of("1"));
+        brokerIdToRack.put(3, Optional.of("1"));
+        brokerIdToRack.put(4, Optional.of("2"));
+        brokerIdToRack.put(5, Optional.of("2"));
+        brokerIdToRack.put(6, Optional.of("2"));
+        brokerIdToRack.put(7, Optional.of("2"));
+        brokerIdToRack.put(8, Optional.of("3"));
+        brokerIdToRack.put(9, Optional.of("3"));
+        brokerIdToRack.put(10, Optional.of("3"));
+        brokerIdToRack.put(11, Optional.of("3"));
+
+        List<Optional<String>> racks = Arrays.asList(Optional.of("1"), Optional.of("2"), Optional.of("3"));
+
+        // No existing partitions case.
+        assertEquals(Optional.empty(),
+                RackList.tryGetPreviousRackOffset(brokerIdToRack,
+                        new ArrayList<>(), racks));
+
+        // No rack case
+        assertEquals(Optional.empty(),
+                RackList.tryGetPreviousRackOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(6, 8, 2)),
+                        new PartitionAssignment(Arrays.asList(9, 3, 7))
+                ), Arrays.asList(Optional.empty())));
+
+        // Case where existing partitions have previous rack
+        assertEquals(Optional.of(2),
+                RackList.tryGetPreviousRackOffset(brokerIdToRack, Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(6, 8, 2)),
+                        new PartitionAssignment(Arrays.asList(9, 3, 7))
+                ), racks));
+
+        // Case where last leader rack does not exist in brokerIdToRack Map.
+        assertEquals(Optional.empty(),
+                RackList.tryGetPreviousRackOffset(new HashMap<>(), Arrays.asList(
+                        new PartitionAssignment(Arrays.asList(6, 8, 2)),
+                        new PartitionAssignment(Arrays.asList(9, 3, 7))
+                ), racks));
+
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
@@ -254,10 +254,10 @@ public class StripedReplicaPlacerTest {
     @Test
     public void testPlaceShiftsInitialOffsetsRackAwareAndUsesUnusedRacks() {
         List<UsableBroker> usableBrokers = Arrays.asList(
-                new UsableBroker(0, Optional.of("1"), false),
-                new UsableBroker(1, Optional.of("2"), false),
-                new UsableBroker(2, Optional.of("3"), false),
-                new UsableBroker(3, Optional.of("4"), false));
+            new UsableBroker(0, Optional.of("1"), false),
+            new UsableBroker(1, Optional.of("2"), false),
+            new UsableBroker(2, Optional.of("3"), false),
+            new UsableBroker(3, Optional.of("4"), false));
 
         List<PartitionAssignment> partitionAssignments = place(new StripedReplicaPlacer(new MockRandom()), 0, 1, (short) 2, usableBrokers).assignments();
         assertEquals(Arrays.asList(0, 1), partitionAssignments.get(0).replicas());
@@ -267,19 +267,19 @@ public class StripedReplicaPlacerTest {
         // Add partitions
         int startPartitionId = partitionAssignments.size();
         partitionAssignments = place(
-                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
+            new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
         assertEquals(Arrays.asList(1, 2), partitionAssignments.get(0).replicas());
 
         fullPartitionAssignments.addAll(partitionAssignments);
 
         partitionAssignments = place(
-                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
+            new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
         assertEquals(Arrays.asList(2, 3), partitionAssignments.get(0).replicas());
 
         fullPartitionAssignments.addAll(partitionAssignments);
 
         partitionAssignments = place(
-                new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
+            new StripedReplicaPlacer(new MockRandom()), startPartitionId, 1, (short) 2, usableBrokers, partitionAssignments).assignments();
         assertEquals(Arrays.asList(3, 0), partitionAssignments.get(0).replicas());
     }
 
@@ -328,56 +328,56 @@ public class StripedReplicaPlacerTest {
 
         // No existing partitions case.
         assertEquals(Optional.empty(),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack,
-                        new ArrayList<>(), Optional.of("1"), unfencedBrokersRack1));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack,
+                new ArrayList<>(), Optional.of("1"), unfencedBrokersRack1));
 
         // Case where existing partitions have broker from rack in last partition.
         assertEquals(Optional.of(1),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
-                        new PartitionAssignment(Arrays.asList(1, 2, 0))
-                ), Optional.of("1"), unfencedBrokersRack1));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                new PartitionAssignment(Arrays.asList(1, 2, 0))
+            ), Optional.of("1"), unfencedBrokersRack1));
 
         // Case where existing partitions have broker from rack in last partition but brokers are fenced.
         assertEquals(Optional.empty(),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
-                        new PartitionAssignment(Arrays.asList(1, 2, 0))
-                ), Optional.of("1"), new ArrayList<>()));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                new PartitionAssignment(Arrays.asList(1, 2, 0))
+            ), Optional.of("1"), new ArrayList<>()));
 
         // Case where existing partitions have broker from rack in third to last partition.
         assertEquals(Optional.of(1),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
-                        new PartitionAssignment(Arrays.asList(1, 2, 0)),
-                        new PartitionAssignment(Arrays.asList(4, 5, 6)),
-                        new PartitionAssignment(Arrays.asList(5, 6, 7))
-                ), Optional.of("1"), unfencedBrokersRack1));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                new PartitionAssignment(Arrays.asList(1, 2, 0)),
+                new PartitionAssignment(Arrays.asList(4, 5, 6)),
+                new PartitionAssignment(Arrays.asList(5, 6, 7))
+            ), Optional.of("1"), unfencedBrokersRack1));
 
         // Case where existing partitions have broker from rack in last partition but not first replica
         // in that partition.
         assertEquals(Optional.of(1),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(4, 5, 1))
-                ), Optional.of("1"), unfencedBrokersRack1));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(4, 5, 1))
+            ), Optional.of("1"), unfencedBrokersRack1));
 
         // Case where existing partitions have broker from rack in last partition but not first replica
         // in that partition.
         assertEquals(Optional.of(1),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(1, 2, 0)),
-                        new PartitionAssignment(Arrays.asList(0, 5, 6)),
-                        new PartitionAssignment(Arrays.asList(0, 1, 2))
-                ), Optional.of("2"), unfencedBrokersRack2));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(1, 2, 0)),
+                new PartitionAssignment(Arrays.asList(0, 5, 6)),
+                new PartitionAssignment(Arrays.asList(0, 1, 2))
+            ), Optional.of("2"), unfencedBrokersRack2));
 
         // Case where existing partitions do not have broker from rack.
         assertEquals(Optional.empty(),
-                RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(0, 1, 2)),
-                        new PartitionAssignment(Arrays.asList(1, 2, 0)),
-                        new PartitionAssignment(Arrays.asList(4, 5, 6)),
-                        new PartitionAssignment(Arrays.asList(5, 6, 7))
-                ), Optional.of("3"), unfencedBrokersRack3));
+            RackList.tryGetPreviousBrokerOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(0, 1, 2)),
+                new PartitionAssignment(Arrays.asList(1, 2, 0)),
+                new PartitionAssignment(Arrays.asList(4, 5, 6)),
+                new PartitionAssignment(Arrays.asList(5, 6, 7))
+            ), Optional.of("3"), unfencedBrokersRack3));
     }
 
     @Test
@@ -400,29 +400,29 @@ public class StripedReplicaPlacerTest {
 
         // No existing partitions case.
         assertEquals(Optional.empty(),
-                RackList.tryGetPreviousRackOffset(brokerIdToRack,
-                        new ArrayList<>(), racks));
+            RackList.tryGetPreviousRackOffset(brokerIdToRack,
+                new ArrayList<>(), racks));
 
         // No rack case
         assertEquals(Optional.empty(),
-                RackList.tryGetPreviousRackOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(6, 8, 2)),
-                        new PartitionAssignment(Arrays.asList(9, 3, 7))
-                ), Arrays.asList(Optional.empty())));
+            RackList.tryGetPreviousRackOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(6, 8, 2)),
+                new PartitionAssignment(Arrays.asList(9, 3, 7))
+            ), Arrays.asList(Optional.empty())));
 
         // Case where existing partitions have previous rack
         assertEquals(Optional.of(2),
-                RackList.tryGetPreviousRackOffset(brokerIdToRack, Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(6, 8, 2)),
-                        new PartitionAssignment(Arrays.asList(9, 3, 7))
-                ), racks));
+            RackList.tryGetPreviousRackOffset(brokerIdToRack, Arrays.asList(
+                new PartitionAssignment(Arrays.asList(6, 8, 2)),
+                new PartitionAssignment(Arrays.asList(9, 3, 7))
+            ), racks));
 
         // Case where last leader rack does not exist in brokerIdToRack Map.
         assertEquals(Optional.empty(),
-                RackList.tryGetPreviousRackOffset(new HashMap<>(), Arrays.asList(
-                        new PartitionAssignment(Arrays.asList(6, 8, 2)),
-                        new PartitionAssignment(Arrays.asList(9, 3, 7))
-                ), racks));
+            RackList.tryGetPreviousRackOffset(new HashMap<>(), Arrays.asList(
+                new PartitionAssignment(Arrays.asList(6, 8, 2)),
+                new PartitionAssignment(Arrays.asList(9, 3, 7))
+            ), racks));
 
     }
 


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/KAFKA-14437

### Details
This is a solution to https://issues.apache.org/jira/browse/KAFKA-14437. The idea is to enhance `StripedReplicaPlacer` to use previous partition assignments to set the initial `RackList` and `BrokerList` state such that we don't create the same assignments for new partitions. This is done by making a best effort attempt at determining what the last offset was when the previous partition assignment(s) were made. By offset I'm referring to the `offset` variable in both `BrokerList` and `RackList`. Currently, whenever `place` is called we randomly choose an offset to start from. With this change, we'll instead use a topics previous partition assignments to try and determine an offset that makes it appear as though we're continuing from where we left off when last making assignments for the topic. Comments are in the code to explain the logic.

`ClusterDescriber` was updated to have a new method `replicasForTopicName` that is used by `StripedReplicaPlacer` to get a topics existing partition assignments, if any. This means in practice it returns the pre-existing partition assignments when servicing `CreatePartitions` requests.  

This change ultimately improves how balanced partitions are when `CreatePartitions` is called by users.

Note, this results in no change to topic creation as there would be no existing partition assignments. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
