### PR TITLE
KAFKA-14427 ZK client support for migrations

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -227,6 +227,7 @@
     <allow pkg="org.apache.kafka.controller" />
     <allow pkg="org.apache.kafka.metadata" />
     <allow pkg="org.apache.kafka.metadata.authorizer" />
+    <allow pkg="org.apache.kafka.metadata.migration" />
     <allow pkg="org.apache.kafka.metalog" />
     <allow pkg="org.apache.kafka.queue" />
     <allow pkg="org.apache.kafka.raft" />

--- a/core/src/main/scala/kafka/migration/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/migration/ZkMigrationClient.scala
@@ -1,0 +1,264 @@
+package kafka.migration
+
+import kafka.api.LeaderAndIsr
+import kafka.controller.{LeaderIsrAndControllerEpoch, ReplicaAssignment}
+import kafka.server.{ConfigEntityName, ConfigType, ZkAdminManager}
+import kafka.utils.Logging
+import kafka.zk.TopicZNode.TopicIdReplicaAssignment
+import kafka.zk._
+import kafka.zookeeper._
+import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData
+import org.apache.kafka.common.metadata._
+import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.metadata.PartitionRegistration
+import org.apache.kafka.metadata.migration.{MigrationClient, ZkMigrationLeadershipState}
+import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
+import org.apache.zookeeper.CreateMode
+
+import java.util
+import java.util.function.Consumer
+import scala.collection.{Seq, mutable}
+import scala.jdk.CollectionConverters._
+
+
+class ZkMigrationClient(zkClient: KafkaZkClient) extends MigrationClient with Logging {
+
+  override def getOrCreateMigrationRecoveryState(initialState: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    zkClient.getOrCreateMigrationState(initialState)
+  }
+
+  override def setMigrationRecoveryState(state: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    zkClient.updateMigrationState(state)
+  }
+
+  def claimControllerLeadership(state: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    val epochZkVersionOpt = zkClient.tryRegisterKRaftControllerAsActiveController(
+      state.kraftControllerId(), state.kraftControllerEpoch())
+    if (epochZkVersionOpt.isDefined) {
+      state.withControllerZkVersion(epochZkVersionOpt.get)
+    } else {
+      state.withControllerZkVersion(-1)
+    }
+  }
+
+  def migrateTopics(metadataVersion: MetadataVersion,
+                    recordConsumer: Consumer[util.List[ApiMessageAndVersion]],
+                    brokerIdConsumer: Consumer[Integer]): Unit = {
+    val topics = zkClient.getAllTopicsInCluster()
+    val topicConfigs = zkClient.getEntitiesConfigs(ConfigType.Topic, topics)
+    val replicaAssignmentAndTopicIds = zkClient.getReplicaAssignmentAndTopicIdForTopics(topics)
+    replicaAssignmentAndTopicIds.foreach { case TopicIdReplicaAssignment(topic, topicIdOpt, assignments) =>
+      val partitions = assignments.keys.toSeq
+      val leaderIsrAndControllerEpochs = zkClient.getTopicPartitionStates(partitions)
+      val topicBatch = new util.ArrayList[ApiMessageAndVersion]()
+      topicBatch.add(new ApiMessageAndVersion(new TopicRecord()
+        .setName(topic)
+        .setTopicId(topicIdOpt.get), TopicRecord.HIGHEST_SUPPORTED_VERSION))
+
+      assignments.foreach { case (topicPartition, replicaAssignment) =>
+        replicaAssignment.replicas.foreach(brokerIdConsumer.accept(_))
+        replicaAssignment.addingReplicas.foreach(brokerIdConsumer.accept(_))
+
+        val leaderIsrAndEpoch = leaderIsrAndControllerEpochs(topicPartition)
+        topicBatch.add(new ApiMessageAndVersion(new PartitionRecord()
+          .setTopicId(topicIdOpt.get)
+          .setPartitionId(topicPartition.partition)
+          .setReplicas(replicaAssignment.replicas.map(Integer.valueOf).asJava)
+          .setAddingReplicas(replicaAssignment.addingReplicas.map(Integer.valueOf).asJava)
+          .setRemovingReplicas(replicaAssignment.removingReplicas.map(Integer.valueOf).asJava)
+          .setIsr(leaderIsrAndEpoch.leaderAndIsr.isr.map(Integer.valueOf).asJava)
+          .setLeader(leaderIsrAndEpoch.leaderAndIsr.leader)
+          .setLeaderEpoch(leaderIsrAndEpoch.leaderAndIsr.leaderEpoch)
+          .setPartitionEpoch(leaderIsrAndEpoch.leaderAndIsr.partitionEpoch)
+          .setLeaderRecoveryState(leaderIsrAndEpoch.leaderAndIsr.leaderRecoveryState.value()), PartitionRecord.HIGHEST_SUPPORTED_VERSION))
+      }
+
+      val props = topicConfigs(topic)
+      props.forEach { case (key: Object, value: Object) =>
+        topicBatch.add(new ApiMessageAndVersion(new ConfigRecord()
+          .setResourceType(ConfigResource.Type.TOPIC.id)
+          .setResourceName(topic)
+          .setName(key.toString)
+          .setValue(value.toString), ConfigRecord.HIGHEST_SUPPORTED_VERSION))
+      }
+
+      recordConsumer.accept(topicBatch)
+    }
+  }
+
+  def migrateBrokerConfigs(metadataVersion: MetadataVersion,
+                           recordConsumer: Consumer[util.List[ApiMessageAndVersion]]): Unit = {
+    val brokerEntities = zkClient.getAllEntitiesWithConfig(ConfigType.Broker)
+    val batch = new util.ArrayList[ApiMessageAndVersion]()
+    zkClient.getEntitiesConfigs(ConfigType.Broker, brokerEntities.toSet).foreach { case (broker, props) =>
+      val brokerResource = if (broker == ConfigEntityName.Default) {
+        ""
+      } else {
+        broker
+      }
+      props.forEach { case (key: Object, value: Object) =>
+        batch.add(new ApiMessageAndVersion(new ConfigRecord()
+          .setResourceType(ConfigResource.Type.BROKER.id)
+          .setResourceName(brokerResource)
+          .setName(key.toString)
+          .setValue(value.toString), ConfigRecord.HIGHEST_SUPPORTED_VERSION))
+      }
+    }
+    recordConsumer.accept(batch)
+  }
+
+  def migrateClientQuotas(metadataVersion: MetadataVersion,
+                          recordConsumer: Consumer[util.List[ApiMessageAndVersion]]): Unit = {
+    val adminZkClient = new AdminZkClient(zkClient)
+
+    def migrateEntityType(entityType: String): Unit = {
+      adminZkClient.fetchAllEntityConfigs(entityType).foreach { case (name, props) =>
+        val entity = new EntityData().setEntityType(entityType).setEntityName(name)
+        val batch = new util.ArrayList[ApiMessageAndVersion]()
+        ZkAdminManager.clientQuotaPropsToDoubleMap(props.asScala).foreach { case (key: String, value: Double) =>
+          batch.add(new ApiMessageAndVersion(new ClientQuotaRecord()
+            .setEntity(List(entity).asJava)
+            .setKey(key)
+            .setValue(value), ClientQuotaRecord.HIGHEST_SUPPORTED_VERSION))
+        }
+        recordConsumer.accept(batch)
+      }
+    }
+
+    migrateEntityType(ConfigType.User)
+    migrateEntityType(ConfigType.Client)
+    adminZkClient.fetchAllChildEntityConfigs(ConfigType.User, ConfigType.Client).foreach { case (name, props) =>
+      // Taken from ZkAdminManager
+      val components = name.split("/")
+      if (components.size != 3 || components(1) != "clients")
+        throw new IllegalArgumentException(s"Unexpected config path: ${name}")
+      val entity = List(
+        new EntityData().setEntityType(ConfigType.User).setEntityName(components(0)),
+        new EntityData().setEntityType(ConfigType.Client).setEntityName(components(2))
+      )
+
+      val batch = new util.ArrayList[ApiMessageAndVersion]()
+      ZkAdminManager.clientQuotaPropsToDoubleMap(props.asScala).foreach { case (key: String, value: Double) =>
+        batch.add(new ApiMessageAndVersion(new ClientQuotaRecord()
+          .setEntity(entity.asJava)
+          .setKey(key)
+          .setValue(value), ClientQuotaRecord.HIGHEST_SUPPORTED_VERSION))
+      }
+      recordConsumer.accept(batch)
+    }
+
+    migrateEntityType(ConfigType.Ip)
+  }
+
+  def migrateProducerId(metadataVersion: MetadataVersion,
+                        recordConsumer: Consumer[util.List[ApiMessageAndVersion]]): Unit = {
+    val (dataOpt, _) = zkClient.getDataAndVersion(ProducerIdBlockZNode.path)
+    dataOpt match {
+      case Some(data) =>
+        val producerIdBlock = ProducerIdBlockZNode.parseProducerIdBlockData(data)
+        recordConsumer.accept(List(new ApiMessageAndVersion(new ProducerIdsRecord()
+          .setBrokerEpoch(-1)
+          .setBrokerId(producerIdBlock.assignedBrokerId)
+          .setNextProducerId(producerIdBlock.firstProducerId), ProducerIdsRecord.HIGHEST_SUPPORTED_VERSION)).asJava)
+      case None => // Nothing to migrate
+    }
+  }
+
+  override def readAllMetadata(batchConsumer: Consumer[util.List[ApiMessageAndVersion]], brokerIdConsumer: Consumer[Integer]): Unit = {
+    migrateTopics(MetadataVersion.latest(), batchConsumer, brokerIdConsumer)
+    migrateBrokerConfigs(MetadataVersion.latest(), batchConsumer)
+    migrateClientQuotas(MetadataVersion.latest(), batchConsumer)
+    migrateProducerId(MetadataVersion.latest(), batchConsumer)
+  }
+
+  override def readBrokerIds(): util.Set[Integer] = {
+    zkClient.getSortedBrokerList.map(Integer.valueOf).toSet.asJava
+  }
+
+  override def readBrokerIdsFromTopicAssignments(): util.Set[Integer] = {
+    val topics = zkClient.getAllTopicsInCluster()
+    val replicaAssignmentAndTopicIds = zkClient.getReplicaAssignmentAndTopicIdForTopics(topics)
+    val brokersWithAssignments = mutable.HashSet[Int]()
+    replicaAssignmentAndTopicIds.foreach { case TopicIdReplicaAssignment(_, _, assignments) =>
+      assignments.values.foreach { assignment => brokersWithAssignments.addAll(assignment.replicas) }
+    }
+    brokersWithAssignments.map(Integer.valueOf).asJava
+  }
+
+  override def createTopic(topicName: String, topicId: Uuid, partitions: util.Map[Integer, PartitionRegistration], state: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    val assignments = partitions.asScala.map { case (partitionId, partition) =>
+      new TopicPartition(topicName, partitionId) -> ReplicaAssignment(partition.replicas, partition.addingReplicas, partition.removingReplicas)
+    }
+
+    val createTopicZNode = {
+      val path = TopicZNode.path(topicName)
+      CreateRequest(
+        path,
+        TopicZNode.encode(Some(topicId), assignments),
+        zkClient.defaultAcls(path),
+        CreateMode.PERSISTENT)
+    }
+    val createPartitionsZNode = {
+      val path = TopicPartitionsZNode.path(topicName)
+      CreateRequest(
+        path,
+        null,
+        zkClient.defaultAcls(path),
+        CreateMode.PERSISTENT)
+    }
+
+    val createPartitionZNodeReqs = partitions.asScala.flatMap { case (partitionId, partition) =>
+      val topicPartition = new TopicPartition(topicName, partitionId)
+      Seq(
+        createTopicPartition(topicPartition),
+        createTopicPartitionState(topicPartition, partition, state.kraftControllerEpoch())
+      )
+    }
+
+    val requests = Seq(createTopicZNode, createPartitionsZNode) ++ createPartitionZNodeReqs
+    val (migrationZkVersion, responses) = zkClient.retryMigrationRequestsUntilConnected(requests, state.controllerZkVersion(), state)
+    state.withMigrationZkVersion(migrationZkVersion)
+  }
+
+  private def createTopicPartition(topicPartition: TopicPartition): CreateRequest = {
+    val path = TopicPartitionZNode.path(topicPartition)
+    CreateRequest(path, null, zkClient.defaultAcls(path), CreateMode.PERSISTENT, Some(topicPartition))
+  }
+
+  private def partitionStatePathAndData(topicPartition: TopicPartition, partitionRegistration: PartitionRegistration, controllerEpoch: Int): (String, Array[Byte]) = {
+    val path = TopicPartitionStateZNode.path(topicPartition)
+    val data = TopicPartitionStateZNode.encode(LeaderIsrAndControllerEpoch(new LeaderAndIsr(
+      partitionRegistration.leader,
+      partitionRegistration.leaderEpoch,
+      partitionRegistration.isr.toList,
+      partitionRegistration.leaderRecoveryState,
+      partitionRegistration.partitionEpoch), controllerEpoch))
+    (path, data)
+  }
+  private def createTopicPartitionState(topicPartition: TopicPartition, partitionRegistration: PartitionRegistration, controllerEpoch: Int): CreateRequest = {
+    val (path, data) = partitionStatePathAndData(topicPartition, partitionRegistration, controllerEpoch)
+    CreateRequest(path, data, zkClient.defaultAcls(path), CreateMode.PERSISTENT, Some(topicPartition))
+  }
+
+  private def updateTopicPartitionState(topicPartition: TopicPartition, partitionRegistration: PartitionRegistration, controllerEpoch: Int): SetDataRequest = {
+    val (path, data) = partitionStatePathAndData(topicPartition, partitionRegistration, controllerEpoch)
+    SetDataRequest(path, data, ZkVersion.MatchAnyVersion, Some(topicPartition))
+  }
+
+  override def updateTopicPartitions(topicPartitions: util.Map[String, util.Map[Integer, PartitionRegistration]],
+                                     state: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    val requests = topicPartitions.asScala.flatMap { case (topicName, partitionRegistrations) =>
+      partitionRegistrations.asScala.flatMap { case (partitionId, partitionRegistration) =>
+        val topicPartition = new TopicPartition(topicName, partitionId)
+        Seq(updateTopicPartitionState(topicPartition, partitionRegistration, state.kraftControllerEpoch()))
+      }
+    }
+    if (requests.isEmpty) {
+      state
+    } else {
+      val (migrationZkVersion, _) = zkClient.retryMigrationRequestsUntilConnected(requests.toSeq, state.controllerZkVersion(), state)
+      state.withMigrationZkVersion(migrationZkVersion)
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -54,6 +54,19 @@ import org.apache.kafka.common.utils.Sanitizer
 import scala.collection.{Map, mutable, _}
 import scala.jdk.CollectionConverters._
 
+object ZkAdminManager {
+  def clientQuotaPropsToDoubleMap(props: Map[String, String]): Map[String, Double] = {
+    props.map { case (key, value) =>
+      val doubleValue = try value.toDouble catch {
+        case _: NumberFormatException =>
+          throw new IllegalStateException(s"Unexpected client quota configuration value: $key -> $value")
+      }
+      key -> doubleValue
+    }
+  }
+}
+
+
 class ZkAdminManager(val config: KafkaConfig,
                      val metrics: Metrics,
                      val metadataCache: MetadataCache,
@@ -636,16 +649,6 @@ class ZkAdminManager(val config: KafkaConfig,
 
   private def sanitized(name: Option[String]): String = name.map(n => sanitizeEntityName(n)).getOrElse("")
 
-  private def fromProps(props: Map[String, String]): Map[String, Double] = {
-    props.map { case (key, value) =>
-      val doubleValue = try value.toDouble catch {
-        case _: NumberFormatException =>
-          throw new IllegalStateException(s"Unexpected client quota configuration value: $key -> $value")
-      }
-      key -> doubleValue
-    }
-  }
-
   def handleDescribeClientQuotas(userComponent: Option[ClientQuotaFilterComponent],
     clientIdComponent: Option[ClientQuotaFilterComponent], strict: Boolean): Map[ClientQuotaEntity, Map[String, Double]] = {
 
@@ -706,7 +709,7 @@ class ZkAdminManager(val config: KafkaConfig,
     (userEntries ++ clientIdEntries ++ bothEntries).flatMap { case ((u, c), p) =>
       val quotaProps = p.asScala.filter { case (key, _) => QuotaConfigs.isClientOrUserQuotaConfig(key) }
       if (quotaProps.nonEmpty && matches(userComponent, u) && matches(clientIdComponent, c))
-        Some(userClientIdToEntity(u, c) -> fromProps(quotaProps))
+        Some(userClientIdToEntity(u, c) -> ZkAdminManager.clientQuotaPropsToDoubleMap(quotaProps))
       else
         None
     }.toMap
@@ -732,7 +735,7 @@ class ZkAdminManager(val config: KafkaConfig,
     ipEntries.flatMap { case (ip, props) =>
       val ipQuotaProps = props.asScala.filter { case (key, _) => DynamicConfig.Ip.names.contains(key) }
       if (ipQuotaProps.nonEmpty)
-        Some(ipToQuotaEntity(ip) -> fromProps(ipQuotaProps))
+        Some(ipToQuotaEntity(ip) -> ZkAdminManager.clientQuotaPropsToDoubleMap(ipQuotaProps))
       else
         None
     }

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -177,7 +177,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     val timestamp = time.milliseconds()
     val curEpochOpt: Option[(Int, Int)] = getControllerEpoch.map(e => (e._1, e._2.getVersion))
     val controllerOpt = getControllerId
-    val controllerEpochToStore = kraftControllerEpoch + 10_000_000 // TODO Remove this after KAFKA-14436
+    val controllerEpochToStore = kraftControllerEpoch + 10000000 // TODO Remove this after KAFKA-14436
     curEpochOpt match {
       case None =>
         throw new IllegalStateException(s"Cannot register KRaft controller $kraftControllerId as the active controller " +

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1963,8 +1963,9 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
               data match {
                 case Some(value) =>
                   val failedPayload = MigrationZNode.decode(value, version, -1)
-                  throw new RuntimeException(s"Conditional update on KRaft Migration ZNode failed. Expected zkVersion = ${version}. " +
-                    s"The failed write was: ${failedPayload}. This indicates that another KRaft controller is making writes to ZooKeeper.")
+                  throw new RuntimeException(
+                    s"Conditional update on KRaft Migration ZNode failed. Expected zkVersion = ${version}. The failed " +
+                    s"write was: ${failedPayload}. This indicates that another KRaft controller is making writes to ZooKeeper.")
                 case None =>
                   throw new RuntimeException(s"Check op on KRaft Migration ZNode failed. Expected zkVersion = ${version}. " +
                     s"This indicates that another KRaft controller is making writes to ZooKeeper.")
@@ -1978,7 +1979,8 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
           } else {
             throw new RuntimeException(s"Got migration result for incorrect path $path")
           }
-        case _ => throw new RuntimeException(s"Expected either CheckResult, SetDataResult, or ErrorResult for migration op, but saw ${migrationResult}")
+        case _ => throw new RuntimeException(
+          s"Expected either CheckResult, SetDataResult, or ErrorResult for migration op, but saw ${migrationResult}")
       }
     }
 
@@ -2003,14 +2005,16 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
             val migrationVersion = handleUnwrappedMigrationResult(migrationOp, migrationResult)
             (handleUnwrappedZkOp(zkOpResult, resultCode, ctx, responseMetadata), migrationVersion)
           case null => throw KeeperException.create(resultCode)
-          case _ => throw new IllegalStateException(s"Cannot unwrap $response because it does not contain the expected operations for a migration operation.")
+          case _ => throw new IllegalStateException(
+            s"Cannot unwrap $response because it does not contain the expected operations for a migration operation.")
         }
         case _ => throw new IllegalStateException(s"Cannot unwrap $response because it is not a MultiResponse")
       }
     }
 
     migrationState.controllerZkVersion() match {
-      case ZkVersion.MatchAnyVersion => throw new IllegalArgumentException(s"Expected a controller epoch zkVersion when making migration writes, not -1.")
+      case ZkVersion.MatchAnyVersion => throw new IllegalArgumentException(
+        s"Expected a controller epoch zkVersion when making migration writes, not -1.")
       case version if version >= 0 =>
         logger.trace(s"Performing ${requests.size} migration update(s) with migrationState=$migrationState")
         val wrappedRequests = requests.map(req => wrapMigrationRequest(req, req == requests.last))
@@ -2020,7 +2024,8 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
         // Return the new version of /migration and the sequence of responses to the original requests
         (migrationZkVersion, unwrappedResults.map(_._1.asInstanceOf[Req#Response]))
       case invalidVersion =>
-        throw new IllegalArgumentException(s"Expected controller epoch zkVersion $invalidVersion should be non-negative or equal to ${ZkVersion.MatchAnyVersion}")
+        throw new IllegalArgumentException(
+          s"Expected controller epoch zkVersion $invalidVersion should be non-negative or equal to ${ZkVersion.MatchAnyVersion}")
     }
   }
 
@@ -2264,7 +2269,10 @@ object KafkaZkClient {
     }
   }
 
-  private def handleUnwrappedZkOp(zkOpResult: ZkOpResult, resultCode: Code, ctx: Option[Any], responseMetadata: ResponseMetadata): AsyncResponse = {
+  private def handleUnwrappedZkOp(zkOpResult: ZkOpResult,
+                                  resultCode: Code,
+                                  ctx: Option[Any],
+                                  responseMetadata: ResponseMetadata): AsyncResponse = {
     val rawOpResult = zkOpResult.rawOpResult
     zkOpResult.zkOp match {
       case createOp: CreateOp =>

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -186,7 +186,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
         if (curEpoch >= kraftControllerEpoch) {
           // TODO KAFKA-14436 Need to ensure KRaft has a higher epoch an ZK
           throw new IllegalStateException(s"Cannot register KRaft controller $kraftControllerId as the active controller " +
-            s"since its epoch is not higher. Current ZK epoch is ${curEpoch}, KRaft epoch is $kraftControllerEpoch.")
+            s"in ZK since its epoch ${kraftControllerEpoch} is not higher than the current ZK epoch ${curEpoch}.")
         }
 
         val response = if (controllerOpt.isDefined) {

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -34,12 +34,13 @@ import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceT
 import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
+import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.zookeeper.KeeperException.{Code, NodeExistsException}
-import org.apache.zookeeper.OpResult.{CreateResult, ErrorResult, SetDataResult}
+import org.apache.zookeeper.OpResult.{CheckResult, CreateResult, ErrorResult, SetDataResult}
 import org.apache.zookeeper.client.ZKClientConfig
 import org.apache.zookeeper.common.ZKConfig
 import org.apache.zookeeper.data.{ACL, Stat}
-import org.apache.zookeeper.{CreateMode, KeeperException, ZooKeeper}
+import org.apache.zookeeper.{CreateMode, KeeperException, OpResult, ZooKeeper}
 
 import scala.collection.{Map, Seq, mutable}
 
@@ -140,20 +141,97 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
 
     def tryCreateControllerZNodeAndIncrementEpoch(): (Int, Int) = {
       val response = retryRequestUntilConnected(
-        MultiRequest(Seq(
-          CreateOp(ControllerZNode.path, ControllerZNode.encode(controllerId, timestamp), defaultAcls(ControllerZNode.path), CreateMode.EPHEMERAL),
-          SetDataOp(ControllerEpochZNode.path, ControllerEpochZNode.encode(newControllerEpoch), expectedControllerEpochZkVersion)))
-      )
+          MultiRequest(Seq(
+            SetDataOp(ControllerEpochZNode.path, ControllerEpochZNode.encode(newControllerEpoch), expectedControllerEpochZkVersion),
+            CreateOp(ControllerZNode.path, ControllerZNode.encode(controllerId, timestamp), defaultAcls(ControllerZNode.path), CreateMode.EPHEMERAL)))
+        )
       response.resultCode match {
         case Code.NODEEXISTS | Code.BADVERSION => checkControllerAndEpoch()
         case Code.OK =>
-          val setDataResult = response.zkOpResults(1).rawOpResult.asInstanceOf[SetDataResult]
+          val setDataResult = response.zkOpResults(0).rawOpResult.asInstanceOf[SetDataResult]
           (newControllerEpoch, setDataResult.getStat.getVersion)
         case code => throw KeeperException.create(code)
       }
     }
 
     tryCreateControllerZNodeAndIncrementEpoch()
+  }
+
+  /**
+   * Registers a given KRaft controller in zookeeper as the active controller. Unlike the ZK equivalent of this method,
+   * this creates /controller as a persistent znode. This prevents ZK brokers from attempting to claim the controller
+   * leadership during a KRaft leadership failover.
+   *
+   * This method is called at the beginning of a KRaft migration and during subsequent KRaft leadership changes during
+   * the migration.
+   *
+   * To ensure that the KRaft controller epoch exceeds the current ZK controller epoch, this registration algorithm
+   * uses a conditional update on the /controller_epoch znode. If a new ZK controller is elected during this method,
+   * the conditional update on /controller_epoch fails which causes the whole multi-op transaction to fail.
+   *
+   * @param kraftControllerId ID of the KRaft controller node
+   * @param kraftControllerEpoch Epoch of the KRaft controller node
+   * @return An optional of the new zkVersion of /controller_epoch. None if we could not register the KRaft controller.
+   */
+  def tryRegisterKRaftControllerAsActiveController(kraftControllerId: Int, kraftControllerEpoch: Int): Option[Int] = {
+    val timestamp = time.milliseconds()
+    val curEpochOpt: Option[(Int, Int)] = getControllerEpoch.map(e => (e._1, e._2.getVersion))
+    val controllerOpt = getControllerId
+
+    curEpochOpt match {
+      case None =>
+        throw new IllegalStateException(s"Cannot register KRaft controller $kraftControllerId as the active controller " +
+          s"since there is no ZK controller epoch present.")
+      case Some((curEpoch: Int, curEpochZk: Int)) =>
+        if (curEpoch >= kraftControllerEpoch) {
+          // TODO KAFKA-14436 Need to ensure KRaft has a higher epoch an ZK
+          throw new IllegalStateException(s"Cannot register KRaft controller $kraftControllerId as the active controller " +
+            s"since its epoch is not higher. Current ZK epoch is ${curEpoch}, KRaft epoch is $kraftControllerEpoch.")
+        }
+
+        val response = if (controllerOpt.isDefined) {
+          info(s"KRaft controller $kraftControllerId overwriting ${ControllerZNode.path} to become the active " +
+            s"controller with epoch $kraftControllerEpoch. The previous controller was ${controllerOpt.get}.")
+          retryRequestUntilConnected(
+            MultiRequest(Seq(
+              SetDataOp(ControllerEpochZNode.path, ControllerEpochZNode.encode(kraftControllerEpoch), curEpochZk),
+              DeleteOp(ControllerZNode.path, ZkVersion.MatchAnyVersion),
+              CreateOp(ControllerZNode.path, ControllerZNode.encode(kraftControllerId, timestamp),
+                defaultAcls(ControllerZNode.path), CreateMode.PERSISTENT)))
+          )
+        } else {
+          info(s"KRaft controller $kraftControllerId creating ${ControllerZNode.path} to become the active " +
+            s"controller with epoch $kraftControllerEpoch. There was no active controller.")
+          retryRequestUntilConnected(
+            MultiRequest(Seq(
+              SetDataOp(ControllerEpochZNode.path, ControllerEpochZNode.encode(kraftControllerEpoch), curEpochZk),
+              CreateOp(ControllerZNode.path, ControllerZNode.encode(kraftControllerId, timestamp),
+                defaultAcls(ControllerZNode.path), CreateMode.PERSISTENT)))
+          )
+        }
+
+        val failureSuffix = s"while trying to register KRaft controller $kraftControllerId with epoch " +
+          s"$kraftControllerEpoch. KRaft controller was not registered."
+        response.resultCode match {
+          case Code.OK =>
+            info(s"Successfully registered KRaft controller $kraftControllerId with epoch $kraftControllerEpoch")
+            // First op is always SetData on /controller_epoch
+            val setDataResult = response.zkOpResults(0).rawOpResult.asInstanceOf[SetDataResult]
+            Some(setDataResult.getStat.getVersion)
+          case Code.BADVERSION =>
+            info(s"The controller epoch changed $failureSuffix")
+            None
+          case Code.NONODE =>
+            info(s"The ephemeral node at ${ControllerZNode.path} went away $failureSuffix")
+            None
+          case Code.NODEEXISTS =>
+            info(s"The ephemeral node at ${ControllerZNode.path} was created by another controller $failureSuffix")
+            None
+          case code =>
+            error(s"ZooKeeper had an error $failureSuffix")
+            throw KeeperException.create(code)
+        }
+    }
   }
 
   private def maybeCreateControllerEpochZNode(): (Int, Int) = {
@@ -338,6 +416,24 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
       case Code.NONODE => new Properties()
       case _ => throw getDataResponse.resultException.get
     }
+  }
+
+  def getEntitiesConfigs(rootEntityType: String, sanitizedEntityNames: Set[String]): Map[String, Properties] = {
+    val getDataRequests: Seq[GetDataRequest] = sanitizedEntityNames.map { entityName =>
+      GetDataRequest(ConfigEntityZNode.path(rootEntityType, entityName), Some(entityName))
+    }.toSeq
+
+    val getDataResponses = retryRequestsUntilConnected(getDataRequests)
+    getDataResponses.map { response =>
+      val entityName = response.ctx.get.asInstanceOf[String]
+      response.resultCode match {
+        case Code.OK =>
+          entityName -> ConfigEntityZNode.decode(response.data)
+        case Code.NONODE =>
+          entityName -> new Properties()
+        case _ => throw response.resultException.get
+      }
+    }.toMap
   }
 
   /**
@@ -1554,6 +1650,36 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     }
   }
 
+  def getOrCreateMigrationState(initialState: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    val getDataRequest = GetDataRequest(MigrationZNode.path)
+    val getDataResponse = retryRequestUntilConnected(getDataRequest)
+    getDataResponse.resultCode match {
+      case Code.OK =>
+        MigrationZNode.decode(getDataResponse.data, getDataResponse.stat.getVersion, getDataResponse.stat.getMtime)
+      case Code.NONODE =>
+        createInitialMigrationState(initialState)
+      case _ => throw getDataResponse.resultException.get
+    }
+  }
+
+  def createInitialMigrationState(initialState: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    val createRequest = CreateRequest(
+      MigrationZNode.path,
+      MigrationZNode.encode(initialState),
+      defaultAcls(MigrationZNode.path),
+      CreateMode.PERSISTENT)
+    val response = retryRequestUntilConnected(createRequest)
+    response.maybeThrow()
+    initialState.withMigrationZkVersion(0)
+  }
+
+  def updateMigrationState(migrationState: ZkMigrationLeadershipState): ZkMigrationLeadershipState = {
+    val req = SetDataRequest(MigrationZNode.path, MigrationZNode.encode(migrationState), migrationState.migrationZkVersion())
+    val resp = retryRequestUntilConnected(req)
+    resp.maybeThrow()
+    migrationState.withMigrationZkVersion(resp.stat.getVersion)
+  }
+
   /**
     * Return the ACLs of the node of the given path
     * @param path the given path for the node
@@ -1767,6 +1893,134 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
       case version if version >= 0 =>
         retryRequestsUntilConnected(requests.map(wrapRequestWithControllerEpochCheck(_, version)))
           .map(unwrapResponseWithControllerEpochCheck(_).asInstanceOf[Req#Response])
+      case invalidVersion =>
+        throw new IllegalArgumentException(s"Expected controller epoch zkVersion $invalidVersion should be non-negative or equal to ${ZkVersion.MatchAnyVersion}")
+    }
+  }
+
+  /**
+   * Safely performs a sequence of writes to ZooKeeper as part of a KRaft migration. For each request in {@code requests}, we
+   * wrap the operation in a multi-op transaction that includes a check op on /controller_epoch and /migration. This ensures
+   * that another KRaft controller or another ZK controller has unexpectedly taken leadership.
+   *
+   * In cases of KRaft failover during a migration, it is possible that a write is attempted before the old KRaft controller
+   * receives the new leader information. In this case, the check op on /migration acts as a guard against multiple writers.
+   *
+   * The multi-op for the last request in {@code requests} is used to update the /migration node with the latest migration
+   * state. This effectively checkpoints the progress of the migration in ZK relative to the metadata log.
+   *
+   * Each multi-op request is atomic. The overall sequence of multi-op requests is not atomic and we may fail during any
+   * of them. When the KRaft controller recovers the migration state, it will re-apply all of the writes needed to update
+   * the ZK state with the latest KRaft state. In the case of Create or Delete operations, these will fail if applied
+   * twice, so we need to ignore NodeExists and NoNode failures for those cases.
+   *
+   * @param requests  A sequence of ZK requests. Only Create, Delete, and SetData are supported.
+   * @param expectedControllerZkVersion The expected zkVersion of the /controller_epoch ZNode. Used for check operations.
+   * @param migrationState The current migration state. This is written out as part of the final multi-op request.
+   * @return  The new version of /migration ZNode and the sequence of responses for the given requests.
+   */
+  def retryMigrationRequestsUntilConnected[Req <: AsyncRequest](requests: Seq[Req],
+                                                                expectedControllerZkVersion: Int,
+                                                                migrationState: ZkMigrationLeadershipState): (Int, Seq[Req#Response]) = {
+
+    if (requests.isEmpty) {
+      throw new IllegalArgumentException("Must specify at least one ZK request for a migration operation.")
+    }
+
+    def wrapMigrationRequest(request: Req, lastRequestInBatch: Boolean): MultiRequest = {
+      // Wrap a single request with the multi-op transactional request.
+      val checkOp = CheckOp(ControllerEpochZNode.path, expectedControllerZkVersion)
+      val migrationOp = if (lastRequestInBatch) {
+        SetDataOp(MigrationZNode.path, MigrationZNode.encode(migrationState), migrationState.migrationZkVersion())
+      } else {
+        CheckOp(MigrationZNode.path, migrationState.migrationZkVersion())
+      }
+
+      request match {
+        case CreateRequest(path, data, acl, createMode, ctx) =>
+          MultiRequest(Seq(checkOp, migrationOp, CreateOp(path, data, acl, createMode)), ctx)
+        case DeleteRequest(path, version, ctx) =>
+          MultiRequest(Seq(checkOp, migrationOp, DeleteOp(path, version)), ctx)
+        case SetDataRequest(path, data, version, ctx) =>
+          MultiRequest(Seq(checkOp, migrationOp, SetDataOp(path, data, version)), ctx)
+        case _ => throw new IllegalStateException(s"$request does not need controller epoch check")
+      }
+    }
+
+    def handleUnwrappedMigrationResult(migrationOp: ZkOp, migrationResult: OpResult): Int = {
+      // Handle just the operation that updated /migration ZNode
+      val (path: String, data: Option[Array[Byte]], version: Int) = migrationOp match {
+        case CheckOp(path, version) => (path, None, version)
+        case SetDataOp(path, data, version) => (path, Some(data), version)
+        case _ => throw new IllegalStateException("Unexpected result on /migration znode")
+      }
+
+      migrationResult match {
+        case _: CheckResult => version
+        case setDataResult: SetDataResult => setDataResult.getStat.getVersion
+        case errorResult: ErrorResult =>
+          if (path.equals(MigrationZNode.path)) {
+            val errorCode = Code.get(errorResult.getErr)
+            if (errorCode == Code.BADVERSION) {
+              data match {
+                case Some(value) =>
+                  val failedPayload = MigrationZNode.decode(value, version, -1)
+                  throw new RuntimeException(s"Conditional update on KRaft Migration ZNode failed. Expected zkVersion = ${version}. " +
+                    s"The failed write was: ${failedPayload}. This indicates that another KRaft controller is making writes to ZooKeeper.")
+                case None =>
+                  throw new RuntimeException(s"Check op on KRaft Migration ZNode failed. Expected zkVersion = ${version}. " +
+                    s"This indicates that another KRaft controller is making writes to ZooKeeper.")
+              }
+            } else if (errorCode == Code.OK) {
+              // This means the Check or SetData op would have been ok, but failed because of another operation in this multi-op
+              version
+            } else {
+              throw KeeperException.create(errorCode, path)
+            }
+          } else {
+            throw new RuntimeException(s"Got migration result for incorrect path $path")
+          }
+        case _ => throw new RuntimeException(s"Expected either CheckResult, SetDataResult, or ErrorResult for migration op, but saw ${migrationResult}")
+      }
+    }
+
+    def unwrapMigrationResponse(response: AsyncResponse, lastRequestInBatch: Boolean): (AsyncResponse, Int) = {
+      response match {
+        case MultiResponse(resultCode, _, ctx, zkOpResults, responseMetadata) =>
+        zkOpResults match {
+            case Seq(ZkOpResult(checkOp: CheckOp, checkOpResult), ZkOpResult(migrationOp: CheckOp, migrationResult), zkOpResult) =>
+              // Matches all requests except or the last one (CheckOp on /migration)
+              if (lastRequestInBatch) {
+                throw new IllegalStateException("Should not see a Check operation on /migration in the last request.")
+              }
+              handleUnwrappedCheckOp(checkOp, checkOpResult)
+              val migrationVersion = handleUnwrappedMigrationResult(migrationOp, migrationResult)
+              (handleUnwrappedZkOp(zkOpResult, resultCode, ctx, responseMetadata), migrationVersion)
+            case Seq(ZkOpResult(checkOp: CheckOp, checkOpResult), ZkOpResult(migrationOp: SetDataOp, migrationResult), zkOpResult) =>
+              // Matches the last request in a batch (SetDataOp on /migration)
+              if (!lastRequestInBatch) {
+                throw new IllegalStateException("Should only see a SetData operation on /migration in the last request.")
+              }
+              handleUnwrappedCheckOp(checkOp, checkOpResult)
+              val migrationVersion = handleUnwrappedMigrationResult(migrationOp, migrationResult)
+              (handleUnwrappedZkOp(zkOpResult, resultCode, ctx, responseMetadata), migrationVersion)
+            case null => throw KeeperException.create(resultCode)
+            case _ => throw new IllegalStateException(s"Cannot unwrap $response because it does not contain the expected operations for a migration operation.")
+          }
+        case _ => throw new IllegalStateException(s"Cannot unwrap $response because it is not a MultiResponse")
+      }
+    }
+
+    expectedControllerZkVersion match {
+      case ZkVersion.MatchAnyVersion => throw new IllegalArgumentException(s"Expected a controller epoch zkVersion when making migration writes, not -1.")
+      case version if version >= 0 =>
+        logger.trace(s"Performing ${requests.size} migration update(s) with controllerEpochZkVersion=$expectedControllerZkVersion and migrationState=$migrationState")
+        val wrappedRequests = requests.map(req => wrapMigrationRequest(req, req == requests.last))
+        val results = retryRequestsUntilConnected(wrappedRequests)
+        val unwrappedResults = results.map(resp => unwrapMigrationResponse(resp, resp == results.last))
+        val migrationZkVersion = unwrappedResults.last._2
+        // Return the new version of /migration and the sequence of responses to the original requests
+        (migrationZkVersion, unwrappedResults.map(_._1.asInstanceOf[Req#Response]))
       case invalidVersion =>
         throw new IllegalArgumentException(s"Expected controller epoch zkVersion $invalidVersion should be non-negative or equal to ${ZkVersion.MatchAnyVersion}")
     }
@@ -1997,6 +2251,42 @@ object KafkaZkClient {
       }
   }
 
+  private def handleUnwrappedCheckOp(checkOp: CheckOp, checkOpResult: OpResult): Unit = {
+    checkOpResult match {
+      case errorResult: ErrorResult =>
+        if (checkOp.path.equals(ControllerEpochZNode.path)) {
+          val errorCode = Code.get(errorResult.getErr)
+          if (errorCode == Code.BADVERSION)
+          // Throw ControllerMovedException when the zkVersionCheck is performed on the controller epoch znode and the check fails
+            throw new ControllerMovedException(s"Controller epoch zkVersion check fails. Expected zkVersion = ${checkOp.version}")
+          else if (errorCode != Code.OK)
+            throw KeeperException.create(errorCode, checkOp.path)
+        }
+      case _ =>
+    }
+  }
+
+  private def handleUnwrappedZkOp(zkOpResult: ZkOpResult, resultCode: Code, ctx: Option[Any], responseMetadata: ResponseMetadata): AsyncResponse = {
+    val rawOpResult = zkOpResult.rawOpResult
+    zkOpResult.zkOp match {
+      case createOp: CreateOp =>
+        val name = rawOpResult match {
+          case c: CreateResult => c.getPath
+          case _ => null
+        }
+        CreateResponse(resultCode, createOp.path, ctx, name, responseMetadata)
+      case deleteOp: DeleteOp =>
+        DeleteResponse(resultCode, deleteOp.path, ctx, responseMetadata)
+      case setDataOp: SetDataOp =>
+        val stat = rawOpResult match {
+          case s: SetDataResult => s.getStat
+          case _ => null
+        }
+        SetDataResponse(resultCode, setDataOp.path, ctx, stat, responseMetadata)
+      case zkOp => throw new IllegalStateException(s"Unexpected zkOp: $zkOp")
+    }
+  }
+
   // A helper function to transform a MultiResponse with the check on
   // controller epoch znode zkVersion back into a regular response.
   // ControllerMovedException will be thrown if the controller epoch
@@ -2006,37 +2296,10 @@ object KafkaZkClient {
     response match {
       case MultiResponse(resultCode, _, ctx, zkOpResults, responseMetadata) =>
         zkOpResults match {
+          // In normal ZK writes, we just have a MultiOp with a CheckOp and the actual operation we're performing
           case Seq(ZkOpResult(checkOp: CheckOp, checkOpResult), zkOpResult) =>
-            checkOpResult match {
-              case errorResult: ErrorResult =>
-                if (checkOp.path.equals(ControllerEpochZNode.path)) {
-                  val errorCode = Code.get(errorResult.getErr)
-                  if (errorCode == Code.BADVERSION)
-                  // Throw ControllerMovedException when the zkVersionCheck is performed on the controller epoch znode and the check fails
-                    throw new ControllerMovedException(s"Controller epoch zkVersion check fails. Expected zkVersion = ${checkOp.version}")
-                  else if (errorCode != Code.OK)
-                    throw KeeperException.create(errorCode, checkOp.path)
-                }
-              case _ =>
-            }
-            val rawOpResult = zkOpResult.rawOpResult
-            zkOpResult.zkOp match {
-              case createOp: CreateOp =>
-                val name = rawOpResult match {
-                  case c: CreateResult => c.getPath
-                  case _ => null
-                }
-                CreateResponse(resultCode, createOp.path, ctx, name, responseMetadata)
-              case deleteOp: DeleteOp =>
-                DeleteResponse(resultCode, deleteOp.path, ctx, responseMetadata)
-              case setDataOp: SetDataOp =>
-                val stat = rawOpResult match {
-                  case s: SetDataResult => s.getStat
-                  case _ => null
-                }
-                SetDataResponse(resultCode, setDataOp.path, ctx, stat, responseMetadata)
-              case zkOp => throw new IllegalStateException(s"Unexpected zkOp: $zkOp")
-            }
+            handleUnwrappedCheckOp(checkOp, checkOpResult)
+            handleUnwrappedZkOp(zkOpResult, resultCode, ctx, responseMetadata)
           case null => throw KeeperException.create(resultCode)
           case _ => throw new IllegalStateException(s"Cannot unwrap $response because the first zookeeper op is not check op in original MultiRequest")
         }

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -1048,7 +1048,7 @@ object MigrationZNode {
       val controllerEpoch = js("kraft_controller_epoch").to[Int]
       val metadataOffset = js("kraft_metadata_offset").to[Long]
       val metadataEpoch = js("kraft_metadata_epoch").to[Int]
-      Some(new ZkMigrationLeadershipState(controllerId, controllerEpoch, metadataOffset, metadataEpoch, modifyTimeMs, zkVersion, -2))
+      Some(new ZkMigrationLeadershipState(controllerId, controllerEpoch, metadataOffset, metadataEpoch, modifyTimeMs, zkVersion, ZkVersion.UnknownVersion))
     }.getOrElse(throw new KafkaException(s"Failed to parse the migration json $jsonDataAsString"))
   }
 }

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -1048,7 +1048,14 @@ object MigrationZNode {
       val controllerEpoch = js("kraft_controller_epoch").to[Int]
       val metadataOffset = js("kraft_metadata_offset").to[Long]
       val metadataEpoch = js("kraft_metadata_epoch").to[Int]
-      Some(new ZkMigrationLeadershipState(controllerId, controllerEpoch, metadataOffset, metadataEpoch, modifyTimeMs, zkVersion, ZkVersion.UnknownVersion))
+      Some(new ZkMigrationLeadershipState(
+        controllerId,
+        controllerEpoch,
+        metadataOffset,
+        metadataEpoch,
+        modifyTimeMs,
+        zkVersion,
+        ZkVersion.UnknownVersion))
     }.getOrElse(throw new KafkaException(s"Failed to parse the migration json $jsonDataAsString"))
   }
 }

--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.zk
 
 import kafka.api.LeaderAndIsr

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.zk
+
+import kafka.test.ClusterInstance
+import kafka.test.annotation.{ClusterTest, Type}
+import kafka.test.junit.ClusterTestExtensions
+import kafka.test.junit.ZkClusterInvocationContext.ZkClusterInstance
+import kafka.zk.ZkMigrationClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.common.config.TopicConfig
+import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
+import org.apache.kafka.image.{MetadataDelta, MetadataImage}
+import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
+import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull}
+import org.junit.jupiter.api.extension.ExtendWith
+
+import java.util
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
+
+@ExtendWith(value = Array(classOf[ClusterTestExtensions]))
+class ZkMigrationIntegrationTest {
+
+  class MetadataDeltaVerifier {
+    val metadataDelta = new MetadataDelta(MetadataImage.EMPTY)
+    var offset = 0
+    def accept(batch: java.util.List[ApiMessageAndVersion]): Unit = {
+      batch.forEach(message => {
+        metadataDelta.replay(offset, 0, message.message())
+        offset += 1
+      })
+    }
+
+    def verify(verifier: MetadataImage => Unit): Unit = {
+      val image = metadataDelta.apply()
+      verifier.apply(image)
+    }
+  }
+
+  @ClusterTest(brokers = 3, clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_4_IV0)
+  def testMigrateCluster(clusterInstance: ClusterInstance): Unit = {
+    val admin = clusterInstance.createAdminClient()
+    val newTopics = new util.ArrayList[NewTopic]()
+    newTopics.add(new NewTopic("test-topic-1", 2, 3.toShort)
+      .configs(Map(TopicConfig.SEGMENT_BYTES_CONFIG -> "102400", TopicConfig.SEGMENT_MS_CONFIG -> "300000").asJava))
+    newTopics.add(new NewTopic("test-topic-2", 1, 3.toShort))
+    newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
+    val createTopicResult = admin.createTopics(newTopics)
+    createTopicResult.all().get(60, TimeUnit.SECONDS)
+
+    val quotas = new util.ArrayList[ClientQuotaAlteration]()
+    quotas.add(new ClientQuotaAlteration(
+      new ClientQuotaEntity(Map("user" -> "user1").asJava),
+      List(new ClientQuotaAlteration.Op("consumer_byte_rate", 1000.0)).asJava))
+    quotas.add(new ClientQuotaAlteration(
+      new ClientQuotaEntity(Map("user" -> "user1", "client-id" -> "clientA").asJava),
+      List(new ClientQuotaAlteration.Op("consumer_byte_rate", 800.0), new ClientQuotaAlteration.Op("producer_byte_rate", 100.0)).asJava))
+    quotas.add(new ClientQuotaAlteration(
+      new ClientQuotaEntity(Map("ip" -> "8.8.8.8").asJava),
+      List(new ClientQuotaAlteration.Op("connection_creation_rate", 10.0)).asJava))
+    admin.alterClientQuotas(quotas)
+
+    val zkClient = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
+    val migrationClient = new ZkMigrationClient(zkClient)
+    var migrationState = migrationClient.getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState.EMPTY)
+    migrationState = migrationState.withNewKRaftController(3000, 42)
+    migrationState = migrationClient.claimControllerLeadership(migrationState)
+
+    val brokers = new java.util.HashSet[Integer]()
+    val verifier = new MetadataDeltaVerifier()
+    migrationClient.readAllMetadata(batch => verifier.accept(batch), brokerId => brokers.add(brokerId))
+    assertEquals(Seq(0, 1, 2), brokers.asScala.toSeq)
+
+    verifier.verify { image =>
+      assertNotNull(image.topics().getTopic("test-topic-1"))
+      assertEquals(2, image.topics().getTopic("test-topic-1").partitions().size())
+
+      assertNotNull(image.topics().getTopic("test-topic-2"))
+      assertEquals(1, image.topics().getTopic("test-topic-2").partitions().size())
+
+      assertNotNull(image.topics().getTopic("test-topic-3"))
+      assertEquals(10, image.topics().getTopic("test-topic-3").partitions().size())
+    }
+
+    migrationState = migrationClient.releaseControllerLeadership(migrationState)
+  }
+}

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -20,7 +20,6 @@ import kafka.test.ClusterInstance
 import kafka.test.annotation.{ClusterTest, Type}
 import kafka.test.junit.ClusterTestExtensions
 import kafka.test.junit.ZkClusterInvocationContext.ZkClusterInstance
-import kafka.zk.ZkMigrationClient
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
@@ -54,7 +53,7 @@ class ZkMigrationIntegrationTest {
   }
 
   @ClusterTest(brokers = 3, clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_4_IV0)
-  def testMigrateCluster(clusterInstance: ClusterInstance): Unit = {
+  def testMigrate(clusterInstance: ClusterInstance): Unit = {
     val admin = clusterInstance.createAdminClient()
     val newTopics = new util.ArrayList[NewTopic]()
     newTopics.add(new NewTopic("test-topic-1", 2, 3.toShort)
@@ -96,6 +95,9 @@ class ZkMigrationIntegrationTest {
 
       assertNotNull(image.topics().getTopic("test-topic-3"))
       assertEquals(10, image.topics().getTopic("test-topic-3").partitions().size())
+
+      val clientQuotas = image.clientQuotas().entities()
+      assertEquals(3, clientQuotas.size())
     }
 
     migrationState = migrationClient.releaseControllerLeadership(migrationState)

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -1388,7 +1388,8 @@ class KafkaZkClientTest extends QuorumTestHarness {
       CreateRequest("/foo", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
     )
 
-    zkClient.retryMigrationRequestsUntilConnected(requests_bad, stat.getVersion, migrationState) match {
+    migrationState = migrationState.withControllerZkVersion(stat.getVersion)
+    zkClient.retryMigrationRequestsUntilConnected(requests_bad, migrationState) match {
       case (zkVersion: Int, requests: Seq[AsyncRequest#Response]) =>
         assertEquals(0, zkVersion)
         assert(requests.take(3).forall(resp => resp.resultCode.equals(Code.OK)))
@@ -1409,7 +1410,8 @@ class KafkaZkClientTest extends QuorumTestHarness {
       CreateRequest("/foo/bar/eggs", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
     )
 
-    zkClient.retryMigrationRequestsUntilConnected(requests_good, stat.getVersion, migrationState) match {
+    migrationState = migrationState.withControllerZkVersion(stat.getVersion)
+    zkClient.retryMigrationRequestsUntilConnected(requests_good, migrationState) match {
       case (zkVersion: Int, requests: Seq[AsyncRequest#Response]) =>
         assertEquals(1, zkVersion)
         assert(requests.take(3).forall(resp => resp.resultCode.equals(Code.NODEEXISTS)))

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -19,7 +19,6 @@ package kafka.zk
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.{Collections, Properties}
-
 import kafka.api.LeaderAndIsr
 import kafka.cluster.{Broker, EndPoint}
 import kafka.controller.{LeaderIsrAndControllerEpoch, ReplicaAssignment}
@@ -43,9 +42,10 @@ import org.apache.kafka.common.security.token.delegation.TokenInformation
 import org.apache.kafka.common.utils.{SecurityUtils, Time}
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
+import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.zookeeper.KeeperException.{Code, NoAuthException, NoNodeException, NodeExistsException}
-import org.apache.zookeeper.ZooDefs
+import org.apache.zookeeper.{CreateMode, ZooDefs}
 import org.apache.zookeeper.client.ZKClientConfig
 import org.apache.zookeeper.common.ZKConfig
 import org.apache.zookeeper.data.Stat
@@ -1371,6 +1371,51 @@ class KafkaZkClientTest extends QuorumTestHarness {
       assertJuteMaxBufferConfig(new ZKClientConfig, expectedValue = "3072000")
 
     } finally System.clearProperty(ZKConfig.JUTE_MAXBUFFER)
+  }
+
+  @Test
+  def testFailToUpdateMigrationZNode(): Unit = {
+    val (_, stat) = zkClient.getControllerEpoch.get
+    var migrationState = new ZkMigrationLeadershipState(3000, 42, 100, 42, Time.SYSTEM.milliseconds(), -1, stat.getVersion)
+    migrationState = zkClient.getOrCreateMigrationState(migrationState)
+    assertEquals(0, migrationState.migrationZkVersion())
+
+    // A batch of migration writes to make. The last one will fail causing the migration znode to not be updated
+    val requests_bad = Seq(
+      CreateRequest("/foo", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+      CreateRequest("/foo/bar", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+      CreateRequest("/foo/bar/spam", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+      CreateRequest("/foo", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+    )
+
+    zkClient.retryMigrationRequestsUntilConnected(requests_bad, stat.getVersion, migrationState) match {
+      case (zkVersion: Int, requests: Seq[AsyncRequest#Response]) =>
+        assertEquals(0, zkVersion)
+        assert(requests.take(3).forall(resp => resp.resultCode.equals(Code.OK)))
+        assertEquals(Code.NODEEXISTS, requests.last.resultCode)
+      case _ => fail()
+    }
+
+    // Check state again
+    val loadedState = zkClient.getOrCreateMigrationState(ZkMigrationLeadershipState.EMPTY)
+    assertEquals(0, loadedState.migrationZkVersion())
+
+    // Resend the same requests, with the last one succeeding this time. This will result in NODEEXISTS, but
+    // should still update the migration state
+    val requests_good = Seq(
+      CreateRequest("/foo", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+      CreateRequest("/foo/bar", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+      CreateRequest("/foo/bar/spam", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+      CreateRequest("/foo/bar/eggs", Array(), zkClient.defaultAcls("/foo"), CreateMode.PERSISTENT),
+    )
+
+    zkClient.retryMigrationRequestsUntilConnected(requests_good, stat.getVersion, migrationState) match {
+      case (zkVersion: Int, requests: Seq[AsyncRequest#Response]) =>
+        assertEquals(1, zkVersion)
+        assert(requests.take(3).forall(resp => resp.resultCode.equals(Code.NODEEXISTS)))
+        assertEquals(Code.OK, requests.last.resultCode)
+      case _ => fail()
+    }
   }
 
   class ExpiredKafkaZkClient private (zooKeeperClient: ZooKeeperClient, isSecure: Boolean, time: Time)

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -241,11 +241,11 @@ class ZkMigrationClientTest extends QuorumTestHarness {
 
     migrationState = migrationState.withNewKRaftController(3000, 40)
     val t1 = assertThrows(classOf[IllegalStateException], () => migrationClient.claimControllerLeadership(migrationState))
-    assertEquals("Cannot register KRaft controller 3000 as the active controller in ZK since its epoch 40 is not higher than the current ZK epoch 42.", t1.getMessage)
+    assertEquals("Cannot register KRaft controller 3000 as the active controller in ZK since its epoch 10000040 is not higher than the current ZK epoch 10000042.", t1.getMessage)
 
     migrationState = migrationState.withNewKRaftController(3000, 42)
     val t2 = assertThrows(classOf[IllegalStateException], () => migrationClient.claimControllerLeadership(migrationState))
-    assertEquals("Cannot register KRaft controller 3000 as the active controller in ZK since its epoch 42 is not higher than the current ZK epoch 42.", t2.getMessage)
+    assertEquals("Cannot register KRaft controller 3000 as the active controller in ZK since its epoch 10000042 is not higher than the current ZK epoch 10000042.", t2.getMessage)
   }
 
   @Test
@@ -260,7 +260,7 @@ class ZkMigrationClientTest extends QuorumTestHarness {
     assertEquals(2, migrationState.controllerZkVersion())
     zkClient.getControllerEpoch match {
       case Some((kraftEpoch, stat)) =>
-        assertEquals(42, kraftEpoch)
+        assertEquals(10000042, kraftEpoch)
         assertEquals(2, stat.getVersion)
       case None => fail()
     }
@@ -269,7 +269,7 @@ class ZkMigrationClientTest extends QuorumTestHarness {
 
     migrationState = migrationClient.releaseControllerLeadership(migrationState)
     val (epoch1, zkVersion1) = zkClient.registerControllerAndIncrementControllerEpoch(100)
-    assertEquals(epoch1, 43)
+    assertEquals(epoch1, 10000043)
     assertEquals(zkVersion1, 3)
   }
 

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -16,29 +16,114 @@
  */
 package kafka.zk
 
+import kafka.api.LeaderAndIsr
+import kafka.controller.LeaderIsrAndControllerEpoch
 import kafka.server.{ConfigType, QuorumTestHarness, ZkAdminManager}
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.config.internals.QuotaConfigs
 import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
 
 import java.util.Properties
+import scala.collection.Map
 import scala.jdk.CollectionConverters._
 
+/**
+ * ZooKeeper integration tests that verify the interoperability of KafkaZkClient and ZkMigrationClient.
+ */
 class ZkMigrationClientTest extends QuorumTestHarness {
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
     super.setUp(testInfo)
     zkClient.createControllerEpochRaw(1)
-
    }
 
   private def initialMigrationState: ZkMigrationLeadershipState = {
     val (_, stat) = zkClient.getControllerEpoch.get
     new ZkMigrationLeadershipState(3000, 42, 100, 42, Time.SYSTEM.milliseconds(), -1, stat.getVersion)
+  }
+
+  @Test
+  def testEmptyWrite(): Unit = {
+    val migrationClient = new ZkMigrationClient(zkClient)
+    var migrationState = initialMigrationState
+    migrationState = migrationClient.getOrCreateMigrationRecoveryState(migrationState)
+    val (zkVersion, responses) = zkClient.retryMigrationRequestsUntilConnected(Seq(), migrationState)
+    assertEquals(migrationState.migrationZkVersion(), zkVersion)
+    assertTrue(responses.isEmpty)
+  }
+
+  @Test
+  def testUpdateExistingPartitions(): Unit = {
+    // Create a topic and partition state in ZK like KafkaController would
+    val assignment = Map(
+      new TopicPartition("test", 0) -> List(0, 1, 2),
+      new TopicPartition("test", 1) -> List(1, 2, 3)
+    )
+    zkClient.createTopicAssignment("test", Some(Uuid.randomUuid()), assignment)
+
+    val leaderAndIsrs = Map(
+      new TopicPartition("test", 0) -> LeaderIsrAndControllerEpoch(
+        new LeaderAndIsr(0, 5, List(0, 1, 2), LeaderRecoveryState.RECOVERED, -1), 1),
+      new TopicPartition("test", 1) -> LeaderIsrAndControllerEpoch(
+        new LeaderAndIsr(1, 5, List(1, 2, 3), LeaderRecoveryState.RECOVERED, -1), 1)
+    )
+    zkClient.createTopicPartitionStatesRaw(leaderAndIsrs, 0)
+
+    // Now verify that we can update it with migration client
+    val migrationClient = new ZkMigrationClient(zkClient)
+    var migrationState = initialMigrationState
+    migrationState = migrationClient.getOrCreateMigrationRecoveryState(migrationState)
+    assertEquals(0, migrationState.migrationZkVersion())
+
+    val partitions = Map(
+      0 -> new PartitionRegistration(Array(0, 1, 2), Array(1, 2), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 6, -1),
+      1 -> new PartitionRegistration(Array(1, 2, 3), Array(3), Array(), Array(), 3, LeaderRecoveryState.RECOVERED, 7, -1)
+    ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
+    migrationState = migrationClient.updateTopicPartitions(Map("test" -> partitions).asJava, migrationState)
+    assertEquals(1, migrationState.migrationZkVersion())
+
+    // Read back with Zk client
+    val partition0 = zkClient.getTopicPartitionState(new TopicPartition("test", 0)).get.leaderAndIsr
+    assertEquals(1, partition0.leader)
+    assertEquals(6, partition0.leaderEpoch)
+    assertEquals(List(1, 2), partition0.isr)
+
+    val partition1 = zkClient.getTopicPartitionState(new TopicPartition("test", 1)).get.leaderAndIsr
+    assertEquals(3, partition1.leader)
+    assertEquals(7, partition1.leaderEpoch)
+    assertEquals(List(3), partition1.isr)
+  }
+
+  @Test
+  def testCreateNewPartitions(): Unit = {
+    val migrationClient = new ZkMigrationClient(zkClient)
+    var migrationState = initialMigrationState
+    migrationState = migrationClient.getOrCreateMigrationRecoveryState(migrationState)
+    assertEquals(0, migrationState.migrationZkVersion())
+
+    val partitions = Map(
+      0 -> new PartitionRegistration(Array(0, 1, 2), Array(0, 1, 2), Array(), Array(), 0, LeaderRecoveryState.RECOVERED, 0, -1),
+      1 -> new PartitionRegistration(Array(1, 2, 3), Array(1, 2, 3), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 0, -1)
+    ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
+    migrationState = migrationClient.createTopic("test", Uuid.randomUuid(), partitions, migrationState)
+    assertEquals(1, migrationState.migrationZkVersion())
+
+    // Read back with Zk client
+    val partition0 = zkClient.getTopicPartitionState(new TopicPartition("test", 0)).get.leaderAndIsr
+    assertEquals(0, partition0.leader)
+    assertEquals(0, partition0.leaderEpoch)
+    assertEquals(List(0, 1, 2), partition0.isr)
+
+    val partition1 = zkClient.getTopicPartitionState(new TopicPartition("test", 1)).get.leaderAndIsr
+    assertEquals(1, partition1.leader)
+    assertEquals(0, partition1.leaderEpoch)
+    assertEquals(List(1, 2, 3), partition1.isr)
   }
 
   // Write Client Quotas using ZkMigrationClient and read them back using AdminZkClient
@@ -63,13 +148,13 @@ class ZkMigrationClientTest extends QuorumTestHarness {
   @Test
   def testWriteExistingClientQuotas(): Unit = {
     val migrationClient = new ZkMigrationClient(zkClient)
-    val adminZkClient = new AdminZkClient(zkClient)
     val props = new Properties()
     props.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, 100000L)
     adminZkClient.changeConfigs(ConfigType.User, "user1", props)
+    adminZkClient.changeConfigs(ConfigType.User, "user1/clients/clientA", props)
 
     var migrationState = initialMigrationState
-    migrationState = zkClient.getOrCreateMigrationState(migrationState)
+    migrationState = migrationClient.getOrCreateMigrationRecoveryState(migrationState)
     assertEquals(0, migrationState.migrationZkVersion())
 
     migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
@@ -103,7 +188,7 @@ class ZkMigrationClientTest extends QuorumTestHarness {
     val adminZkClient = new AdminZkClient(zkClient)
 
     var migrationState = initialMigrationState
-    migrationState = zkClient.getOrCreateMigrationState(migrationState)
+    migrationState = migrationClient.getOrCreateMigrationRecoveryState(migrationState)
     assertEquals(0, migrationState.migrationZkVersion())
     migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
       Map(ConfigType.User -> "user2"),

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -162,7 +162,7 @@ class ZkMigrationClientTest extends QuorumTestHarness {
   @Test
   def testWriteExistingClientQuotas(): Unit = {
     val props = new Properties()
-    props.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, 100000L)
+    props.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, "100000")
     adminZkClient.changeConfigs(ConfigType.User, "user1", props)
     adminZkClient.changeConfigs(ConfigType.User, "user1/clients/clientA", props)
 
@@ -338,8 +338,8 @@ class ZkMigrationClientTest extends QuorumTestHarness {
   @Test
   def testWriteExistingTopicConfigs(): Unit = {
     val props = new Properties()
-    props.put(TopicConfig.FLUSH_MS_CONFIG, 60000)
-    props.put(TopicConfig.RETENTION_MS_CONFIG, 300000)
+    props.put(TopicConfig.FLUSH_MS_CONFIG, "60000")
+    props.put(TopicConfig.RETENTION_MS_CONFIG, "300000")
     zkClient.setOrCreateEntityConfigs(ConfigType.Topic, "test", props)
 
     migrationState = migrationClient.writeConfigs(new ConfigResource(ConfigResource.Type.TOPIC, "test"),

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.zk
+
+import kafka.server.{ConfigType, QuorumTestHarness, ZkAdminManager}
+import org.apache.kafka.common.config.internals.QuotaConfigs
+import org.apache.kafka.common.quota.ClientQuotaEntity
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
+
+import java.util.Properties
+import scala.jdk.CollectionConverters._
+
+class ZkMigrationClientTest extends QuorumTestHarness {
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    super.setUp(testInfo)
+    zkClient.createControllerEpochRaw(1)
+
+   }
+
+  private def initialMigrationState: ZkMigrationLeadershipState = {
+    val (_, stat) = zkClient.getControllerEpoch.get
+    new ZkMigrationLeadershipState(3000, 42, 100, 42, Time.SYSTEM.milliseconds(), -1, stat.getVersion)
+  }
+
+  // Write Client Quotas using ZkMigrationClient and read them back using AdminZkClient
+  private def writeClientQuotaAndVerify(migrationClient: ZkMigrationClient,
+                                        adminZkClient: AdminZkClient,
+                                        migrationState: ZkMigrationLeadershipState,
+                                        entity: Map[String, String],
+                                        quotas: Map[String, Double],
+                                        zkEntityType: String,
+                                        zkEntityName: String): ZkMigrationLeadershipState = {
+    val nextMigrationState = migrationClient.updateClientQuotas(
+      new ClientQuotaEntity(entity.asJava),
+      quotas.asJava,
+      migrationState)
+    val newProps = ZkAdminManager.clientQuotaPropsToDoubleMap(
+      adminZkClient.fetchEntityConfig(zkEntityType, zkEntityName).asScala)
+    assertEquals(quotas, newProps)
+    nextMigrationState
+  }
+
+
+  @Test
+  def testWriteExistingClientQuotas(): Unit = {
+    val migrationClient = new ZkMigrationClient(zkClient)
+    val adminZkClient = new AdminZkClient(zkClient)
+    val props = new Properties()
+    props.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, 100000L)
+    adminZkClient.changeConfigs(ConfigType.User, "user1", props)
+
+    var migrationState = initialMigrationState
+    migrationState = zkClient.getOrCreateMigrationState(migrationState)
+    assertEquals(0, migrationState.migrationZkVersion())
+
+    migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
+      Map(ConfigType.User -> "user1"),
+      Map(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG -> 20000.0),
+      ConfigType.User, "user1")
+    assertEquals(1, migrationState.migrationZkVersion())
+
+    migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
+      Map(ConfigType.User -> "user1"),
+      Map(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG -> 10000.0),
+      ConfigType.User, "user1")
+    assertEquals(2, migrationState.migrationZkVersion())
+
+    migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
+      Map(ConfigType.User -> "user1"),
+      Map.empty,
+      ConfigType.User, "user1")
+    assertEquals(3, migrationState.migrationZkVersion())
+
+    migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
+      Map(ConfigType.User -> "user1"),
+      Map(QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG -> 100.0),
+      ConfigType.User, "user1")
+    assertEquals(4, migrationState.migrationZkVersion())
+  }
+
+  @Test
+  def testWriteNewClientQuotas(): Unit = {
+    val migrationClient = new ZkMigrationClient(zkClient)
+    val adminZkClient = new AdminZkClient(zkClient)
+
+    var migrationState = initialMigrationState
+    migrationState = zkClient.getOrCreateMigrationState(migrationState)
+    assertEquals(0, migrationState.migrationZkVersion())
+    migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
+      Map(ConfigType.User -> "user2"),
+      Map(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG -> 20000.0, QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG -> 100.0),
+      ConfigType.User, "user2")
+
+    assertEquals(1, migrationState.migrationZkVersion())
+
+    migrationState = writeClientQuotaAndVerify(migrationClient, adminZkClient, migrationState,
+      Map(ConfigType.User -> "user2", ConfigType.Client -> "clientA"),
+      Map(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG -> 10000.0, QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG -> 200.0),
+      ConfigType.User, "user2/clients/clientA")
+
+    assertEquals(2, migrationState.migrationZkVersion())
+  }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
@@ -62,7 +62,8 @@ public final class ClientQuotasImage {
         return entities.isEmpty();
     }
 
-    Map<ClientQuotaEntity, ClientQuotaImage> entities() {
+    // Visible for testing
+    public Map<ClientQuotaEntity, ClientQuotaImage> entities() {
         return entities;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
@@ -46,6 +46,17 @@ public interface MigrationClient {
      */
     ZkMigrationLeadershipState claimControllerLeadership(ZkMigrationLeadershipState state);
 
+    /**
+     * Release an existing claim on the cluster leadership in ZooKeeper. This involves deleting the /controller ZNode
+     * so that another controller can claim leadership.
+     *
+     * @param state The current migration leadership state.
+     * @return      An updated migration leadership state with controllerZkVersion = 1, or raise an exception if ZooKeeper
+     *
+     *
+     */
+    ZkMigrationLeadershipState releaseControllerLeadership(ZkMigrationLeadershipState state);
+
     ZkMigrationLeadershipState createTopic(String topicName, Uuid topicId, Map<Integer, PartitionRegistration> topicPartitions, ZkMigrationLeadershipState state);
 
     ZkMigrationLeadershipState updateTopicPartitions(Map<String, Map<Integer, PartitionRegistration>> topicPartitions, ZkMigrationLeadershipState state);

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.metadata.migration;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Methods for interacting with ZooKeeper during a KIP-866 migration. The migration leadership state is stored under
+ * a ZNode /migration. All write operations to ZK during the migration are performed as a multi-op transaction which
+ * also updates the state of /migration.
+ */
+public interface MigrationClient {
+    ZkMigrationLeadershipState getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState initialState);
+
+    ZkMigrationLeadershipState setMigrationRecoveryState(ZkMigrationLeadershipState state);
+
+    /**
+     * Attempt to claim controller leadership of the cluster in ZooKeeper. This involves overwriting the /controller
+     * and /controller_epoch ZNodes. The epoch given by {@code state} must be greater than the current epoch in ZooKeeper.
+     *
+     *
+     * @param state The current migration leadership state
+     * @return      An updated migration leadership state including the version of /controller_epoch ZNode, if the
+     *              leadership claim was successful. Otherwise, return the previous state unmodified.
+     */
+    ZkMigrationLeadershipState claimControllerLeadership(ZkMigrationLeadershipState state);
+
+    ZkMigrationLeadershipState createTopic(String topicName, Uuid topicId, Map<Integer, PartitionRegistration> topicPartitions, ZkMigrationLeadershipState state);
+
+    ZkMigrationLeadershipState updateTopicPartitions(Map<String, Map<Integer, PartitionRegistration>> topicPartitions, ZkMigrationLeadershipState state);
+
+    void readAllMetadata(Consumer<List<ApiMessageAndVersion>> batchConsumer, Consumer<Integer> brokerIdConsumer);
+
+    Set<Integer> readBrokerIds();
+
+    Set<Integer> readBrokerIdsFromTopicAssignments();
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
@@ -32,8 +32,21 @@ import java.util.function.Consumer;
  */
 public interface MigrationClient {
 
+    /**
+     * Read or initialize the ZK migration leader state in ZK. If the ZNode is absent, the given {@code initialState}
+     * will be written and subsequently returned with the zkVersion of the node. If the ZNode is present, it will be
+     * read and returned.
+     * @param initialState  An initial, emtpy, state to write to ZooKeeper for the migration state.
+     * @return  The existing migration state, or the initial state given.
+     */
     ZkMigrationLeadershipState getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState initialState);
 
+    /**
+     * Overwrite the migration state in ZK. This is done as a conditional update using
+     * {@link ZkMigrationLeadershipState#migrationZkVersion()}. If the conditional update fails, an exception is thrown.
+     * @param state The migration state to persist
+     * @return  The persisted migration state or an exception.
+     */
     ZkMigrationLeadershipState setMigrationRecoveryState(ZkMigrationLeadershipState state);
 
     /**
@@ -58,9 +71,17 @@ public interface MigrationClient {
      */
     ZkMigrationLeadershipState releaseControllerLeadership(ZkMigrationLeadershipState state);
 
-    ZkMigrationLeadershipState createTopic(String topicName, Uuid topicId, Map<Integer, PartitionRegistration> topicPartitions, ZkMigrationLeadershipState state);
+    ZkMigrationLeadershipState createTopic(
+        String topicName,
+        Uuid topicId,
+        Map<Integer, PartitionRegistration> topicPartitions,
+        ZkMigrationLeadershipState state
+    );
 
-    ZkMigrationLeadershipState updateTopicPartitions(Map<String, Map<Integer, PartitionRegistration>> topicPartitions, ZkMigrationLeadershipState state);
+    ZkMigrationLeadershipState updateTopicPartitions(
+        Map<String, Map<Integer, PartitionRegistration>> topicPartitions,
+        ZkMigrationLeadershipState state
+    );
 
     void readAllMetadata(Consumer<List<ApiMessageAndVersion>> batchConsumer, Consumer<Integer> brokerIdConsumer);
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
  * also updates the state of /migration.
  */
 public interface MigrationClient {
+
     ZkMigrationLeadershipState getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState initialState);
 
     ZkMigrationLeadershipState setMigrationRecoveryState(ZkMigrationLeadershipState state);

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/ZkMigrationLeadershipState.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/ZkMigrationLeadershipState.java
@@ -55,20 +55,20 @@ public class ZkMigrationLeadershipState {
 
     public ZkMigrationLeadershipState withMigrationZkVersion(int zkVersion) {
         return new ZkMigrationLeadershipState(
-                this.kraftControllerId, this.kraftControllerEpoch, this.kraftMetadataOffset,
-                this.kraftMetadataEpoch, this.lastUpdatedTimeMs, zkVersion, this.controllerZkVersion);
+            this.kraftControllerId, this.kraftControllerEpoch, this.kraftMetadataOffset,
+            this.kraftMetadataEpoch, this.lastUpdatedTimeMs, zkVersion, this.controllerZkVersion);
     }
 
     public ZkMigrationLeadershipState withControllerZkVersion(int zkVersion) {
         return new ZkMigrationLeadershipState(
-                this.kraftControllerId, this.kraftControllerEpoch, this.kraftMetadataOffset,
-                this.kraftMetadataEpoch, this.lastUpdatedTimeMs, this.migrationZkVersion, zkVersion);
+            this.kraftControllerId, this.kraftControllerEpoch, this.kraftMetadataOffset,
+            this.kraftMetadataEpoch, this.lastUpdatedTimeMs, this.migrationZkVersion, zkVersion);
     }
 
     public ZkMigrationLeadershipState withNewKRaftController(int controllerId, int controllerEpoch) {
         return new ZkMigrationLeadershipState(
-                controllerId, controllerEpoch, this.kraftMetadataOffset,
-                this.kraftMetadataEpoch, this.lastUpdatedTimeMs, this.migrationZkVersion, this.controllerZkVersion);
+            controllerId, controllerEpoch, this.kraftMetadataOffset,
+            this.kraftMetadataEpoch, this.lastUpdatedTimeMs, this.migrationZkVersion, this.controllerZkVersion);
     }
 
     public int kraftControllerId() {
@@ -121,15 +121,24 @@ public class ZkMigrationLeadershipState {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ZkMigrationLeadershipState that = (ZkMigrationLeadershipState) o;
-        return kraftControllerId == that.kraftControllerId && kraftControllerEpoch == that.kraftControllerEpoch
-            && kraftMetadataOffset == that.kraftMetadataOffset && kraftMetadataEpoch == that.kraftMetadataEpoch
-            && lastUpdatedTimeMs == that.lastUpdatedTimeMs && migrationZkVersion == that.migrationZkVersion
+        return kraftControllerId == that.kraftControllerId
+            && kraftControllerEpoch == that.kraftControllerEpoch
+            && kraftMetadataOffset == that.kraftMetadataOffset
+            && kraftMetadataEpoch == that.kraftMetadataEpoch
+            && lastUpdatedTimeMs == that.lastUpdatedTimeMs
+            && migrationZkVersion == that.migrationZkVersion
             && controllerZkVersion == that.controllerZkVersion;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kraftControllerId, kraftControllerEpoch, kraftMetadataOffset, kraftMetadataEpoch,
-            lastUpdatedTimeMs, migrationZkVersion, controllerZkVersion);
+        return Objects.hash(
+            kraftControllerId,
+            kraftControllerEpoch,
+            kraftMetadataOffset,
+            kraftMetadataEpoch,
+            lastUpdatedTimeMs,
+            migrationZkVersion,
+            controllerZkVersion);
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/ZkMigrationLeadershipState.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/ZkMigrationLeadershipState.java
@@ -53,10 +53,16 @@ public class ZkMigrationLeadershipState {
         this.controllerZkVersion = controllerZkVersion;
     }
 
-    public ZkMigrationLeadershipState withZkVersion(int zkVersion) {
+    public ZkMigrationLeadershipState withMigrationZkVersion(int zkVersion) {
         return new ZkMigrationLeadershipState(
                 this.kraftControllerId, this.kraftControllerEpoch, this.kraftMetadataOffset,
                 this.kraftMetadataEpoch, this.lastUpdatedTimeMs, zkVersion, this.controllerZkVersion);
+    }
+
+    public ZkMigrationLeadershipState withControllerZkVersion(int zkVersion) {
+        return new ZkMigrationLeadershipState(
+                this.kraftControllerId, this.kraftControllerEpoch, this.kraftMetadataOffset,
+                this.kraftMetadataEpoch, this.lastUpdatedTimeMs, this.migrationZkVersion, zkVersion);
     }
 
     public ZkMigrationLeadershipState withNewKRaftController(int controllerId, int controllerEpoch) {
@@ -100,14 +106,14 @@ public class ZkMigrationLeadershipState {
     @Override
     public String toString() {
         return "ZkMigrationLeadershipState{" +
-                "kraftControllerId=" + kraftControllerId +
-                ", kraftControllerEpoch=" + kraftControllerEpoch +
-                ", kraftMetadataOffset=" + kraftMetadataOffset +
-                ", kraftMetadataEpoch=" + kraftMetadataEpoch +
-                ", lastUpdatedTimeMs=" + lastUpdatedTimeMs +
-                ", migrationZkVersion=" + migrationZkVersion +
-                ", controllerZkVersion=" + controllerZkVersion +
-                '}';
+            "kraftControllerId=" + kraftControllerId +
+            ", kraftControllerEpoch=" + kraftControllerEpoch +
+            ", kraftMetadataOffset=" + kraftMetadataOffset +
+            ", kraftMetadataEpoch=" + kraftMetadataEpoch +
+            ", lastUpdatedTimeMs=" + lastUpdatedTimeMs +
+            ", migrationZkVersion=" + migrationZkVersion +
+            ", controllerZkVersion=" + controllerZkVersion +
+            '}';
     }
 
     @Override
@@ -115,11 +121,15 @@ public class ZkMigrationLeadershipState {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ZkMigrationLeadershipState that = (ZkMigrationLeadershipState) o;
-        return kraftControllerId == that.kraftControllerId && kraftControllerEpoch == that.kraftControllerEpoch && kraftMetadataOffset == that.kraftMetadataOffset && kraftMetadataEpoch == that.kraftMetadataEpoch && lastUpdatedTimeMs == that.lastUpdatedTimeMs && migrationZkVersion == that.migrationZkVersion && controllerZkVersion == that.controllerZkVersion;
+        return kraftControllerId == that.kraftControllerId && kraftControllerEpoch == that.kraftControllerEpoch
+            && kraftMetadataOffset == that.kraftMetadataOffset && kraftMetadataEpoch == that.kraftMetadataEpoch
+            && lastUpdatedTimeMs == that.lastUpdatedTimeMs && migrationZkVersion == that.migrationZkVersion
+            && controllerZkVersion == that.controllerZkVersion;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kraftControllerId, kraftControllerEpoch, kraftMetadataOffset, kraftMetadataEpoch, lastUpdatedTimeMs, migrationZkVersion, controllerZkVersion);
+        return Objects.hash(kraftControllerId, kraftControllerEpoch, kraftMetadataOffset, kraftMetadataEpoch,
+            lastUpdatedTimeMs, migrationZkVersion, controllerZkVersion);
     }
 }


### PR DESCRIPTION
This patch adds support for reading and writing ZooKeeper metadata during a [KIP-866](https://cwiki.apache.org/confluence/display/KAFKA/KIP-866+ZooKeeper+to+KRaft+Migration) migration. 

For reading metadata from ZK, code from KafkaZkClient and ZkData is reused to ensure we are decoding the JSON correctly.

For writing metadata, we create a special multi-op transaction that ensures only a single controller is writing to ZK. The transaction consists of three operations:

* CheckOp on `/controller_epoch`
* SetDataOp on `/migration` with zkVersion
* CreateOp/SetDataOp/DeleteOp (the actual operation being applied)

In the case of a batch of operations (such as topic creation), only the final MultiOp has a SetDataOp on `/migration` (the other requests use a CheckOp similar to `/controller_epoch`).
