### PR TITLE
KAFKA-6586: Refactor ConnectDistributed and ConnectStandalone to re-use shared logic

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.cli;
+
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.WorkerInfo;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.util.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * Connect initialization common logic that can be leveraged by concrete implementations of command line utilities
+ *
+ * @param <T> the type of {@link WorkerConfig} to be used
+ */
+public abstract class AbstractConnectCli<T extends WorkerConfig> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractConnectCli.class);
+    private final Time time = Time.SYSTEM;
+
+    /**
+     * @param config an instance of {@link WorkerConfig}
+     */
+    protected abstract Herder createHerder(T config, String workerId, Plugins plugins,
+                                           ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
+                                           RestServer restServer, RestClient restClient);
+
+    protected abstract T createConfig(Map<String, String> workerProps);
+
+    /**
+     * @param workerProps the worker properties map
+     * @param connectorPropsFiles zero or more connector property files for connectors that are to be created after
+     *                            Connect is successfully started
+     * @return a started instance of {@link Connect}
+     */
+    public Connect startConnect(Map<String, String> workerProps, String... connectorPropsFiles) {
+        log.info("Kafka Connect worker initializing ...");
+        long initStart = time.hiResClockMs();
+
+        WorkerInfo initInfo = new WorkerInfo();
+        initInfo.logAll();
+
+        log.info("Scanning for plugin classes. This might take a moment ...");
+        Plugins plugins = new Plugins(workerProps);
+        plugins.compareAndSwapWithDelegatingLoader();
+        T config = createConfig(workerProps);
+        log.debug("Kafka cluster ID: {}", config.kafkaClusterId());
+
+        RestClient restClient = new RestClient(config);
+
+        RestServer restServer = new RestServer(config, restClient);
+        restServer.initializeServer();
+
+        URI advertisedUrl = restServer.advertisedUrl();
+        String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+
+        ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy = plugins.newPlugin(
+                config.getString(WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG),
+                config, ConnectorClientConfigOverridePolicy.class);
+
+        Herder herder = createHerder(config, workerId, plugins, connectorClientConfigOverridePolicy, restServer, restClient);
+
+        final Connect connect = new Connect(herder, restServer);
+        log.info("Kafka Connect worker initialization took {}ms", time.hiResClockMs() - initStart);
+        try {
+            connect.start();
+        } catch (Exception e) {
+            log.error("Failed to start Connect", e);
+            connect.stop();
+            Exit.exit(3);
+        }
+
+        try {
+            for (final String connectorPropsFile : connectorPropsFiles) {
+                Map<String, String> connectorProps = Utils.propsToStringMap(Utils.loadProps(connectorPropsFile));
+                FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>((error, info) -> {
+                    if (error != null)
+                        log.error("Failed to create connector for {}", connectorPropsFile);
+                    else
+                        log.info("Created connector {}", info.result().name());
+                });
+                herder.putConnectorConfig(
+                        connectorProps.get(ConnectorConfig.NAME_CONFIG),
+                        connectorProps, false, cb);
+                cb.get();
+            }
+        } catch (Throwable t) {
+            log.error("Stopping after connector error", t);
+            connect.stop();
+            Exit.exit(3);
+        }
+
+        return connect;
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
@@ -21,19 +21,18 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.runtime.Connect;
-import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.WorkerInfo;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.RestServer;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
-import org.apache.kafka.connect.util.FutureCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -44,7 +43,32 @@ import java.util.Map;
 public abstract class AbstractConnectCli<T extends WorkerConfig> {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractConnectCli.class);
+    private final String[] args;
     private final Time time = Time.SYSTEM;
+
+    /**
+     *
+     * @param args the CLI arguments to be processed. Note that if one or more arguments are passed, the first argument is
+     *             assumed to be the Connect worker properties file and is processed in {@link #run()}. The remaining arguments
+     *             can be handled in {@link #processExtraArgs(Herder, String[])}
+     */
+    protected AbstractConnectCli(String... args) {
+        this.args = args;
+    }
+
+    protected abstract String usage();
+
+    /**
+     * The first CLI argument is assumed to be the Connect worker properties file and is processed by default. This method
+     * can be overridden if there are more arguments that need to be processed.
+     *
+     * @param herder the {@link Herder} instance that can be used to perform operations on the Connect cluster
+     * @param extraArgs the extra CLI arguments that need to be processed
+     * @throws Throwable if there's an error encountered while processing the extra CLI arguments; this causes {@link Connect}
+     *                   to be stopped.
+     */
+    protected void processExtraArgs(Herder herder, String[] extraArgs) throws Throwable {
+    }
 
     protected abstract Herder createHerder(T config, String workerId, Plugins plugins,
                                            ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
@@ -53,12 +77,38 @@ public abstract class AbstractConnectCli<T extends WorkerConfig> {
     protected abstract T createConfig(Map<String, String> workerProps);
 
     /**
-     * @param workerProps the worker properties map
-     * @param connectorPropsFiles zero or more connector property files for connectors that are to be created after
-     *                            Connect is successfully started
+     *  Validate {@link #args}, process worker properties from the first CLI argument, and start {@link Connect}
+     */
+    public void run() {
+        if (args.length < 1 || Arrays.asList(args).contains("--help")) {
+            log.info("Usage: {}", usage());
+            Exit.exit(1);
+        }
+
+        try {
+            String workerPropsFile = args[0];
+            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
+                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.emptyMap();
+            String[] extraArgs = Arrays.copyOfRange(args, 1, args.length);
+            Connect connect = startConnect(workerProps, extraArgs);
+
+            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
+            connect.awaitStop();
+
+        } catch (Throwable t) {
+            log.error("Stopping due to error", t);
+            Exit.exit(2);
+        }
+    }
+
+    /**
+     * Initialize and start an instance of {@link Connect}
+     *
+     * @param workerProps the worker properties map used to initialize the {@link WorkerConfig}
+     * @param extraArgs any additional CLI arguments that may need to be processed via {@link #processExtraArgs(Herder, String[])}
      * @return a started instance of {@link Connect}
      */
-    public Connect startConnect(Map<String, String> workerProps, String... connectorPropsFiles) {
+    public Connect startConnect(Map<String, String> workerProps, String... extraArgs) {
         log.info("Kafka Connect worker initializing ...");
         long initStart = time.hiResClockMs();
 
@@ -96,21 +146,9 @@ public abstract class AbstractConnectCli<T extends WorkerConfig> {
         }
 
         try {
-            for (final String connectorPropsFile : connectorPropsFiles) {
-                Map<String, String> connectorProps = Utils.propsToStringMap(Utils.loadProps(connectorPropsFile));
-                FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>((error, info) -> {
-                    if (error != null)
-                        log.error("Failed to create connector for {}", connectorPropsFile);
-                    else
-                        log.info("Created connector {}", info.result().name());
-                });
-                herder.putConnectorConfig(
-                        connectorProps.get(ConnectorConfig.NAME_CONFIG),
-                        connectorProps, false, cb);
-                cb.get();
-            }
+            processExtraArgs(herder, extraArgs);
         } catch (Throwable t) {
-            log.error("Stopping after connector error", t);
+            log.error("Stopping Connect due to an error while processing CLI arguments", t);
             connect.stop();
             Exit.exit(3);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/AbstractConnectCli.java
@@ -37,7 +37,7 @@ import java.net.URI;
 import java.util.Map;
 
 /**
- * Connect initialization common logic that can be leveraged by concrete implementations of command line utilities
+ * Common initialization logic for Kafka Connect, intended for use by command line utilities
  *
  * @param <T> the type of {@link WorkerConfig} to be used
  */
@@ -46,9 +46,6 @@ public abstract class AbstractConnectCli<T extends WorkerConfig> {
     private static final Logger log = LoggerFactory.getLogger(AbstractConnectCli.class);
     private final Time time = Time.SYSTEM;
 
-    /**
-     * @param config an instance of {@link WorkerConfig}
-     */
     protected abstract Herder createHerder(T config, String workerId, Plugins plugins,
                                            ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
                                            RestServer restServer, RestClient restClient);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -16,11 +16,8 @@
  */
 package org.apache.kafka.connect.cli;
 
-import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
-import org.apache.kafka.connect.runtime.Connect;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
@@ -40,8 +37,6 @@ import org.apache.kafka.connect.util.SharedTopicAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,6 +53,15 @@ import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
  */
 public class ConnectDistributed extends AbstractConnectCli<DistributedConfig> {
     private static final Logger log = LoggerFactory.getLogger(ConnectDistributed.class);
+
+    public ConnectDistributed(String... args) {
+        super(args);
+    }
+
+    @Override
+    protected String usage() {
+        return "ConnectDistributed worker.properties";
+    }
 
     @Override
     protected Herder createHerder(DistributedConfig config, String workerId, Plugins plugins,
@@ -102,25 +106,7 @@ public class ConnectDistributed extends AbstractConnectCli<DistributedConfig> {
     }
 
     public static void main(String[] args) {
-
-        if (args.length < 1 || Arrays.asList(args).contains("--help")) {
-            log.info("Usage: ConnectDistributed worker.properties");
-            Exit.exit(1);
-        }
-
-        try {
-            String workerPropsFile = args[0];
-            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
-                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.emptyMap();
-            ConnectDistributed connectDistributed = new ConnectDistributed();
-            Connect connect = connectDistributed.startConnect(workerProps);
-
-            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
-            connect.awaitStop();
-
-        } catch (Throwable t) {
-            log.error("Stopping due to error", t);
-            Exit.exit(2);
-        }
+        ConnectDistributed connectDistributed = new ConnectDistributed(args);
+        connectDistributed.run();
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.Worker;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
-import org.apache.kafka.connect.runtime.WorkerInfo;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
@@ -41,7 +40,6 @@ import org.apache.kafka.connect.util.SharedTopicAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,65 +49,23 @@ import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 
 /**
  * <p>
- * Command line utility that runs Kafka Connect in distributed mode. In this mode, the process joints a group of other workers
- * and work is distributed among them. This is useful for running Connect as a service, where connectors can be
- * submitted to the cluster to be automatically executed in a scalable, distributed fashion. This also allows you to
- * easily scale out horizontally, elastically adding or removing capacity simply by starting or stopping worker
- * instances.
+ * Command line utility that runs Kafka Connect in distributed mode. In this mode, the process joins a group of other
+ * workers and work (connectors and tasks) is distributed among them. This is useful for running Connect as a service,
+ * where connectors can be submitted to the cluster to be automatically executed in a scalable, distributed fashion.
+ * This also allows you to easily scale out horizontally, elastically adding or removing capacity simply by starting or
+ * stopping worker instances.
  * </p>
  */
-public class ConnectDistributed {
+public class ConnectDistributed extends AbstractConnectCli<DistributedConfig> {
     private static final Logger log = LoggerFactory.getLogger(ConnectDistributed.class);
 
-    private final Time time = Time.SYSTEM;
-    private final long initStart = time.hiResClockMs();
-
-    public static void main(String[] args) {
-
-        if (args.length < 1 || Arrays.asList(args).contains("--help")) {
-            log.info("Usage: ConnectDistributed worker.properties");
-            Exit.exit(1);
-        }
-
-        try {
-            WorkerInfo initInfo = new WorkerInfo();
-            initInfo.logAll();
-
-            String workerPropsFile = args[0];
-            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
-                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.emptyMap();
-
-            ConnectDistributed connectDistributed = new ConnectDistributed();
-            Connect connect = connectDistributed.startConnect(workerProps);
-
-            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
-            connect.awaitStop();
-
-        } catch (Throwable t) {
-            log.error("Stopping due to error", t);
-            Exit.exit(2);
-        }
-    }
-
-    public Connect startConnect(Map<String, String> workerProps) {
-        log.info("Scanning for plugin classes. This might take a moment ...");
-        Plugins plugins = new Plugins(workerProps);
-        plugins.compareAndSwapWithDelegatingLoader();
-        DistributedConfig config = new DistributedConfig(workerProps);
+    @Override
+    protected Herder createHerder(DistributedConfig config, String workerId, Plugins plugins,
+                                  ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
+                                  RestServer restServer, RestClient restClient) {
 
         String kafkaClusterId = config.kafkaClusterId();
-        log.debug("Kafka cluster ID: {}", kafkaClusterId);
-
-        RestClient restClient = new RestClient(config);
-
-        RestServer rest = new RestServer(config, restClient);
-        rest.initializeServer();
-
-        URI advertisedUrl = rest.advertisedUrl();
-        String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
-
         String clientIdBase = ConnectUtils.clientIdBase(config);
-
         // Create the admin client to be shared by all backing stores.
         Map<String, Object> adminProps = new HashMap<>(config.originals());
         ConnectUtils.addMetricsContextProperties(adminProps, config, kafkaClusterId);
@@ -119,15 +75,11 @@ public class ConnectDistributed {
         KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin, () -> clientIdBase);
         offsetBackingStore.configure(config);
 
-        ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy = plugins.newPlugin(
-                config.getString(WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG),
-                config, ConnectorClientConfigOverridePolicy.class);
-
-        Worker worker = new Worker(workerId, time, plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
+        Worker worker = new Worker(workerId, Time.SYSTEM, plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
         WorkerConfigTransformer configTransformer = worker.configTransformer();
 
         Converter internalValueConverter = worker.getInternalValueConverter();
-        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter, sharedAdmin, clientIdBase);
+        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(Time.SYSTEM, internalValueConverter, sharedAdmin, clientIdBase);
         statusBackingStore.configure(config);
 
         ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(
@@ -139,21 +91,36 @@ public class ConnectDistributed {
 
         // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
         // herder is stopped. This is easier than having to track and own the lifecycle ourselves.
-        DistributedHerder herder = new DistributedHerder(config, time, worker,
+        return new DistributedHerder(config, Time.SYSTEM, worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl.toString(), restClient, connectorClientConfigOverridePolicy, sharedAdmin);
-
-        final Connect connect = new Connect(herder, rest);
-        log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);
-        try {
-            connect.start();
-        } catch (Exception e) {
-            log.error("Failed to start Connect", e);
-            connect.stop();
-            Exit.exit(3);
-        }
-
-        return connect;
+                restServer.advertisedUrl().toString(), restClient, connectorClientConfigOverridePolicy, sharedAdmin);
     }
 
+    @Override
+    protected DistributedConfig createConfig(Map<String, String> workerProps) {
+        return new DistributedConfig(workerProps);
+    }
+
+    public static void main(String[] args) {
+
+        if (args.length < 1 || Arrays.asList(args).contains("--help")) {
+            log.info("Usage: ConnectDistributed worker.properties");
+            Exit.exit(1);
+        }
+
+        try {
+            String workerPropsFile = args[0];
+            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
+                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.emptyMap();
+            ConnectDistributed connectDistributed = new ConnectDistributed();
+            Connect connect = connectDistributed.startConnect(workerProps);
+
+            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
+            connect.awaitStop();
+
+        } catch (Throwable t) {
+            log.error("Stopping due to error", t);
+            Exit.exit(2);
+        }
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -78,7 +78,7 @@ public class ConnectStandalone extends AbstractConnectCli<StandaloneConfig> {
                 cb.get();
             }
         } catch (Throwable t) {
-            log.error("Stopping Connect due to an error while attempting to create a connector", t);
+            log.error("Stopping after connector error", t);
             connect.stop();
             Exit.exit(3);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -16,25 +16,24 @@
  */
 package org.apache.kafka.connect.cli;
 
-import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
-import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
 import org.apache.kafka.connect.storage.FileOffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetBackingStore;
+import org.apache.kafka.connect.util.FutureCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -46,6 +45,32 @@ import java.util.Map;
  */
 public class ConnectStandalone extends AbstractConnectCli<StandaloneConfig> {
     private static final Logger log = LoggerFactory.getLogger(ConnectStandalone.class);
+
+    protected ConnectStandalone(String... args) {
+        super(args);
+    }
+
+    @Override
+    protected String usage() {
+        return "ConnectStandalone worker.properties [connector1.properties connector2.properties ...]";
+    }
+
+    @Override
+    protected void processExtraArgs(Herder herder, String[] extraArgs) throws Throwable {
+        for (final String connectorPropsFile : extraArgs) {
+            Map<String, String> connectorProps = Utils.propsToStringMap(Utils.loadProps(connectorPropsFile));
+            FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>((error, info) -> {
+                if (error != null)
+                    log.error("Failed to create connector for {}", connectorPropsFile);
+                else
+                    log.info("Created connector {}", info.result().name());
+            });
+            herder.putConnectorConfig(
+                    connectorProps.get(ConnectorConfig.NAME_CONFIG),
+                    connectorProps, false, cb);
+            cb.get();
+        }
+    }
 
     @Override
     protected Herder createHerder(StandaloneConfig config, String workerId, Plugins plugins,
@@ -67,25 +92,7 @@ public class ConnectStandalone extends AbstractConnectCli<StandaloneConfig> {
     }
 
     public static void main(String[] args) {
-
-        if (args.length < 1 || Arrays.asList(args).contains("--help")) {
-            log.info("Usage: ConnectStandalone worker.properties [connector1.properties connector2.properties ...]");
-            Exit.exit(1);
-        }
-
-        try {
-            String workerPropsFile = args[0];
-            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
-                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.emptyMap();
-            ConnectStandalone connectStandalone = new ConnectStandalone();
-            Connect connect = connectStandalone.startConnect(workerProps, Arrays.copyOfRange(args, 1, args.length));
-
-            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
-            connect.awaitStop();
-
-        } catch (Throwable t) {
-            log.error("Stopping due to error", t);
-            Exit.exit(2);
-        }
+        ConnectStandalone connectStandalone = new ConnectStandalone(args);
+        connectStandalone.run();
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -39,8 +39,12 @@ import java.util.Map;
 /**
  * <p>
  * Command line utility that runs Kafka Connect as a standalone process. In this mode, work (connectors and tasks) is not
- * distributed. Instead, all the normal Connect machinery works within a single process. This is useful for for development
- * and testing Kafka Connect on a local machine.
+ * distributed. Instead, all the normal Connect machinery works within a single process. This is useful for ad hoc,
+ * small, or experimental jobs.
+ * </p>
+ * <p>
+ * Connector and task configs are stored in memory and are not persistent. However, connector offset data is persistent
+ * since it uses file storage (configurable via {@link StandaloneConfig#OFFSET_STORAGE_FILE_FILENAME_CONFIG})
  * </p>
  */
 public class ConnectStandalone extends AbstractConnectCli<StandaloneConfig> {


### PR DESCRIPTION
From the [JIRA ticket](https://issues.apache.org/jira/browse/KAFKA-6586):
> The main methods in ConnectDistributed and ConnectStandalone have a lot of duplication, and it'd be good to refactor to centralize the logic. We can pull most of this logic into an abstract class that ConnectStandalone and ConnectDistributed both extend. At a glance, the differences between the two are different config and Herder implementations and some different initialization logic.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
