### PR TITLE
MINOR: Move dynamic config logic to DynamicConfigPublisher

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -306,7 +306,7 @@
   </subpackage>
 
   <subpackage name="queue">
-      <allow pkg="org.apache.kafka.test" />
+    <allow pkg="org.apache.kafka.test" />
   </subpackage>
 
   <subpackage name="clients">

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -71,7 +71,7 @@ class BrokerServer(
   val initialOfflineDirs: Seq[String],
 ) extends KafkaBroker {
   val threadNamePrefix = sharedServer.threadNamePrefix
-  val config = new KafkaConfig(sharedServer.sharedServerConfig.props, false, None)
+  val config = sharedServer.brokerConfig
   val time = sharedServer.time
   def metrics = sharedServer.metrics
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -30,7 +30,7 @@ import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
 import kafka.security.CredentialProvider
 import kafka.server.KafkaRaftServer.ControllerRole
-import kafka.server.metadata.{BrokerMetadataListener, BrokerMetadataPublisher, BrokerMetadataSnapshotter, ClientQuotaMetadataManager, KRaftMetadataCache, SnapshotWriterBuilder}
+import kafka.server.metadata.{BrokerMetadataListener, BrokerMetadataPublisher, BrokerMetadataSnapshotter, ClientQuotaMetadataManager, DynamicConfigPublisher, KRaftMetadataCache, SnapshotWriterBuilder}
 import kafka.utils.{CoreUtils, KafkaScheduler}
 import org.apache.kafka.common.feature.SupportedVersionRange
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -39,7 +39,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
-import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time, Utils}
+import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.common.{ClusterResource, Endpoint}
 import org.apache.kafka.metadata.authorizer.ClusterMetadataAuthorizer
 import org.apache.kafka.metadata.{BrokerState, VersionRange}
@@ -71,7 +71,7 @@ class BrokerServer(
   val initialOfflineDirs: Seq[String],
 ) extends KafkaBroker {
   val threadNamePrefix = sharedServer.threadNamePrefix
-  val config = sharedServer.config
+  val config = new KafkaConfig(sharedServer.sharedServerConfig.props, false, None)
   val time = sharedServer.time
   def metrics = sharedServer.metrics
 
@@ -420,8 +420,13 @@ class BrokerServer(
         config.numIoThreads, s"${DataPlaneAcceptor.MetricPrefix}RequestHandlerAvgIdlePercent",
         DataPlaneAcceptor.ThreadPrefix)
 
-      // Block until we've caught up with the latest metadata from the controller quorum.
-      lifecycleManager.initialCatchUpFuture.get()
+      info("Waiting for broker metadata to catch up.")
+      try {
+        lifecycleManager.initialCatchUpFuture.get()
+      } catch {
+        case t: Throwable => throw new RuntimeException("Received a fatal error while " +
+          "waiting for the broker to catch up with the current cluster metadata.", t)
+      }
 
       // Apply the metadata log changes that we've accumulated.
       metadataPublisher = new BrokerMetadataPublisher(config,
@@ -431,7 +436,11 @@ class BrokerServer(
         groupCoordinator,
         transactionCoordinator,
         clientQuotaMetadataManager,
-        dynamicConfigHandlers.toMap,
+        new DynamicConfigPublisher(
+          config,
+          sharedServer.metadataPublishingFaultHandler,
+          dynamicConfigHandlers.toMap,
+        "broker"),
         authorizer,
         sharedServer.initialBrokerMetadataLoadFaultHandler,
         sharedServer.metadataPublishingFaultHandler)
@@ -567,9 +576,8 @@ class BrokerServer(
       isShuttingDown.set(false)
 
       CoreUtils.swallow(lifecycleManager.close(), this)
+      CoreUtils.swallow(config.dynamicConfig.clear(), this)
       sharedServer.stopForBroker()
-
-      CoreUtils.swallow(AppInfoParser.unregisterAppInfo(MetricsPrefix, config.nodeId.toString, metrics), this)
       info("shut down completed")
     } catch {
       case e: Throwable =>

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -59,7 +59,7 @@ class ControllerServer(
 
   import kafka.server.Server._
 
-  val config = new KafkaConfig(sharedServer.sharedServerConfig.props, false, None)
+  val config = sharedServer.controllerConfig
   val time = sharedServer.time
   def metrics = sharedServer.metrics
   val threadNamePrefix = sharedServer.threadNamePrefix.getOrElse("")

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -59,13 +59,11 @@ class ControllerServer(
 
   import kafka.server.Server._
 
-  val config = sharedServer.config
+  val config = new KafkaConfig(sharedServer.sharedServerConfig.props, false, None)
   val time = sharedServer.time
   def metrics = sharedServer.metrics
   val threadNamePrefix = sharedServer.threadNamePrefix.getOrElse("")
   def raftManager: KafkaRaftManager[ApiMessageAndVersion] = sharedServer.raftManager
-
-  config.dynamicConfig.initialize(zkClientOpt = None)
 
   val lock = new ReentrantLock()
   val awaitShutdownCond = lock.newCondition()
@@ -109,6 +107,7 @@ class ControllerServer(
     if (!maybeChangeStatus(SHUTDOWN, STARTING)) return
     try {
       info("Starting controller")
+      config.dynamicConfig.initialize(zkClientOpt = None)
 
       maybeChangeStatus(STARTING, STARTED)
       this.logIdent = new LogContext(s"[ControllerServer id=${config.nodeId}] ").logPrefix()
@@ -284,6 +283,7 @@ class ControllerServer(
       createTopicPolicy.foreach(policy => CoreUtils.swallow(policy.close(), this))
       alterConfigPolicy.foreach(policy => CoreUtils.swallow(policy.close(), this))
       socketServerFirstBoundPortFuture.completeExceptionally(new RuntimeException("shutting down"))
+      CoreUtils.swallow(config.dynamicConfig.clear(), this)
       sharedServer.stopForController()
     } catch {
       case e: Throwable =>

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -78,7 +78,7 @@ class StandardFaultHandlerFactory extends FaultHandlerFactory {
  * make debugging easier and reduce the chance of resource leaks.
  */
 class SharedServer(
-  val sharedServerConfig: KafkaConfig,
+  private val sharedServerConfig: KafkaConfig,
   val metaProps: MetaProperties,
   val time: Time,
   private val _metrics: Metrics,
@@ -91,6 +91,8 @@ class SharedServer(
   private var started = false
   private var usedByBroker: Boolean = false
   private var usedByController: Boolean = false
+  val brokerConfig = new KafkaConfig(sharedServerConfig.props, false, None)
+  val controllerConfig = new KafkaConfig(sharedServerConfig.props, false, None)
   @volatile var metrics: Metrics = _metrics
   @volatile var raftManager: KafkaRaftManager[ApiMessageAndVersion] = _
   @volatile var brokerMetrics: BrokerServerMetrics = _

--- a/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.metadata
+
+import java.util.Properties
+import kafka.server.ConfigAdminManager.toLoggableProps
+import kafka.server.{ConfigEntityName, ConfigHandler, ConfigType, KafkaConfig}
+import kafka.utils.Logging
+import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, TOPIC}
+import org.apache.kafka.image.{MetadataDelta, MetadataImage}
+import org.apache.kafka.server.fault.FaultHandler
+
+
+class DynamicConfigPublisher(
+  conf: KafkaConfig,
+  faultHandler: FaultHandler,
+  dynamicConfigHandlers: Map[String, ConfigHandler],
+  nodeType: String
+) extends Logging {
+  logIdent = s"[DynamicConfigPublisher nodeType=${nodeType} id=${conf.nodeId}] "
+
+  def publish(delta: MetadataDelta, newImage: MetadataImage): Unit = {
+    val deltaName = s"MetadataDelta up to ${newImage.highestOffsetAndEpoch().offset}"
+    try {
+      // Apply configuration deltas.
+      Option(delta.configsDelta()).foreach { configsDelta =>
+        configsDelta.changes().keySet().forEach { resource =>
+          val props = newImage.configs().configProperties(resource)
+          resource.`type`() match {
+            case TOPIC =>
+              dynamicConfigHandlers.get(ConfigType.Topic).foreach(topicConfigHandler =>
+                try {
+                  // Apply changes to a topic's dynamic configuration.
+                  info(s"Updating topic ${resource.name()} with new configuration : " +
+                    toLoggableProps(resource, props).mkString(","))
+                  topicConfigHandler.processConfigChanges(resource.name(), props)
+                } catch {
+                  case t: Throwable => faultHandler.handleFault("Error updating topic " +
+                    s"${resource.name()} with new configuration: ${toLoggableProps(resource, props).mkString(",")} " +
+                    s"in ${deltaName}", t)
+                }
+              )
+            case BROKER =>
+              dynamicConfigHandlers.get(ConfigType.Broker).foreach(nodeConfigHandler =>
+                if (resource.name().isEmpty) {
+                  try {
+                    // Apply changes to "cluster configs" (also known as default BROKER configs).
+                    // These are stored in KRaft with an empty name field.
+                    info("Updating cluster configuration : " +
+                      toLoggableProps(resource, props).mkString(","))
+                    nodeConfigHandler.processConfigChanges(ConfigEntityName.Default, props)
+                  } catch {
+                    case t: Throwable => faultHandler.handleFault("Error updating " +
+                      s"cluster with new configuration: ${toLoggableProps(resource, props).mkString(",")} " +
+                      s"in ${deltaName}", t)
+                  }
+                } else if (resource.name() == conf.nodeId.toString) {
+                  try {
+                    // Apply changes to this node's dynamic configuration.
+                    info(s"Updating node ${conf.nodeId} with new configuration : " +
+                      toLoggableProps(resource, props).mkString(","))
+                    nodeConfigHandler.processConfigChanges(resource.name(), props)
+                    // When applying a per node config (not a cluster config), we also
+                    // reload any associated file. For example, if the ssl.keystore is still
+                    // set to /tmp/foo, we still want to reload /tmp/foo in case its contents
+                    // have changed. This doesn't apply to topic configs or cluster configs.
+                    reloadUpdatedFilesWithoutConfigChange(props)
+                  } catch {
+                    case t: Throwable => faultHandler.handleFault("Error updating " +
+                      s"node with new configuration: ${toLoggableProps(resource, props).mkString(",")} " +
+                      s"in ${deltaName}", t)
+                  }
+                }
+              )
+            case _ => // nothing to do
+          }
+        }
+      }
+    } catch {
+      case t: Throwable => faultHandler.handleFault("Uncaught exception while " +
+        s"publishing dynamic configuration changes from ${deltaName}", t)
+    }
+  }
+
+  def reloadUpdatedFilesWithoutConfigChange(props: Properties): Unit = {
+    conf.dynamicConfig.reloadUpdatedFilesWithoutConfigChange(props)
+  }
+}


### PR DESCRIPTION
Split out the logic for applying dynamic configurations to a KafkaConfig object from BrokerMetadataPublisher into a new class, DynamicConfigPublisher. This will allow the ControllerServer to also run this code, in a follow-up change.

Create separate KafkaConfig objects in BrokerServer versus ControllerServer. This is necessary because the controller will apply configuration changes as soon as its raft client catches up to the high water mark, whereas the broker will wait for the active controller to acknowledge it has caught up in a heartbeat response. So when running in combined mode, we want two separate KafkaConfig objects that are changed at different times.

Minor changes: improve the error message when catching up broker metadata fails. Fix incorrect indentation in checkstyle/import-control.xml. Invoke AppInfoParser.unregisterAppInfo from SharedServer.stop so that it happens only when both the controller and broker have shut down.