### PR TITLE
MINOR: Fix various memory leaks in tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplierTest.java
@@ -134,8 +134,6 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
                   .withValue(new Change<>(newValue, oldValue)),
             forwarded.get(0).record()
         );
-
-        stateStore.close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplierTest.java
@@ -50,6 +50,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
     private File stateDir;
     private MockInternalNewProcessorContext<CombinedKey<String, String>, Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> context;
+    private TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = null;
 
     private static final String FK = "fk1";
     private static final String PK1 = "pk1";
@@ -71,6 +72,9 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
 
     @After
     public void after() throws IOException {
+        if (stateStore != null) {
+            stateStore.close();
+        }
         Utils.delete(stateDir);
     }
 
@@ -88,7 +92,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
                         SubscriptionWrapper<String>,
                         CombinedKey<String, String>,
                         Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 
@@ -130,6 +134,8 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
                   .withValue(new Change<>(newValue, oldValue)),
             forwarded.get(0).record()
         );
+
+        stateStore.close();
     }
 
     @Test
@@ -140,10 +146,9 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
-
         final SubscriptionWrapper<String> oldWrapper = new SubscriptionWrapper<>(
             new long[]{1L, 2L},
             Instruction.DELETE_KEY_AND_PROPAGATE,
@@ -192,7 +197,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 
@@ -244,7 +249,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 
@@ -296,7 +301,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 
@@ -348,7 +353,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 
@@ -400,7 +405,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 
@@ -452,7 +457,7 @@ public class SubscriptionStoreReceiveProcessorSupplierTest {
             SubscriptionWrapper<String>,
             CombinedKey<String, String>,
             Change<ValueAndTimestamp<SubscriptionWrapper<String>>>> processor = supplier.get();
-        final TimestampedKeyValueStore<Bytes, SubscriptionWrapper<String>> stateStore = storeBuilder.build();
+        stateStore = storeBuilder.build();
         context.addStateStore(stateStore);
         stateStore.init((StateStoreContext) context, stateStore);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -480,6 +480,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         assertEquals(2, writeBatchMap.size());
         for (final WriteBatch batch : writeBatchMap.values()) {
             assertEquals(1, batch.count());
+            batch.close();
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/BlockBasedTableConfigWithAccessibleCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/BlockBasedTableConfigWithAccessibleCacheTest.java
@@ -44,11 +44,12 @@ public class BlockBasedTableConfigWithAccessibleCacheTest {
     public void shouldSetBlockCacheAndMakeItAccessible() {
         final BlockBasedTableConfigWithAccessibleCache configWithAccessibleCache =
             new BlockBasedTableConfigWithAccessibleCache();
-        final Cache blockCache = new LRUCache(1024);
+        try (final Cache blockCache = new LRUCache(1024)) {
 
-        final BlockBasedTableConfig updatedConfig = configWithAccessibleCache.setBlockCache(blockCache);
+            final BlockBasedTableConfig updatedConfig = configWithAccessibleCache.setBlockCache(blockCache);
 
-        assertThat(updatedConfig, sameInstance(configWithAccessibleCache));
-        assertThat(configWithAccessibleCache.blockCache(), sameInstance(blockCache));
+            assertThat(updatedConfig, sameInstance(configWithAccessibleCache));
+            assertThat(configWithAccessibleCache.blockCache(), sameInstance(blockCache));
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.resetToNice;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -149,9 +150,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
                 matchesPattern("Unexpected method call DBOptions\\." + method.getName() + "((.*\n*)*):"));
         } finally {
-            reset(mockedDbOptions);
-            mockedDbOptions.close();
-            replay(mockedDbOptions);
+            resetToNice(mockedDbOptions);
             optionsFacadeDbOptions.close();
         }
     }
@@ -259,9 +258,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
                 matchesPattern("Unexpected method call ColumnFamilyOptions\\." + method.getName() +  "(.*)"));
         } finally {
-            reset(mockedColumnFamilyOptions);
-            mockedColumnFamilyOptions.close();
-            replay(mockedColumnFamilyOptions);
+            resetToNice(mockedColumnFamilyOptions);
             optionsFacadeColumnFamilyOptions.close();
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -360,7 +360,6 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
 
                 walOptions.forEach(option -> assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option))));
             }
-
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -148,6 +148,11 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             assertThat(undeclaredMockMethodCall.getCause(), instanceOf(AssertionError.class));
             assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
                 matchesPattern("Unexpected method call DBOptions\\." + method.getName() + "((.*\n*)*):"));
+        } finally {
+            reset(mockedDbOptions);
+            mockedDbOptions.close();
+            replay(mockedDbOptions);
+            optionsFacadeDbOptions.close();
         }
     }
 
@@ -253,6 +258,11 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             assertThat(undeclaredMockMethodCall.getCause(), instanceOf(AssertionError.class));
             assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
                 matchesPattern("Unexpected method call ColumnFamilyOptions\\." + method.getName() +  "(.*)"));
+        } finally {
+            reset(mockedColumnFamilyOptions);
+            mockedColumnFamilyOptions.close();
+            replay(mockedColumnFamilyOptions);
+            optionsFacadeColumnFamilyOptions.close();
         }
     }
 
@@ -333,23 +343,23 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class)) {
 
-            final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter adapter
-                = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), new ColumnFamilyOptions());
-
-            for (final Method method : RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class.getDeclaredMethods()) {
-                if (walRelatedMethods.contains(method.getName())) {
-                    method.invoke(adapter, getDBOptionsParameters(method.getParameterTypes()));
+            try (RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter adapter =
+                     new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), new ColumnFamilyOptions())) {
+                for (final Method method : RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class.getDeclaredMethods()) {
+                    if (walRelatedMethods.contains(method.getName())) {
+                        method.invoke(adapter, getDBOptionsParameters(method.getParameterTypes()));
+                    }
                 }
+
+                final List<String> walOptions = Arrays.asList("walDir", "walFilter", "walRecoveryMode", "walBytesPerSync", "walSizeLimitMB", "manualWalFlush", "maxTotalWalSize", "walTtlSeconds");
+
+                final Set<String> logMessages = appender.getEvents().stream()
+                    .filter(e -> e.getLevel().equals("WARN"))
+                    .map(LogCaptureAppender.Event::getMessage)
+                    .collect(Collectors.toSet());
+
+                walOptions.forEach(option -> assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option))));
             }
-
-            final List<String> walOptions = Arrays.asList("walDir", "walFilter", "walRecoveryMode", "walBytesPerSync", "walSizeLimitMB", "manualWalFlush", "maxTotalWalSize", "walTtlSeconds");
-
-            final Set<String> logMessages = appender.getEvents().stream()
-                .filter(e -> e.getLevel().equals("WARN"))
-                .map(LogCaptureAppender.Event::getMessage)
-                .collect(Collectors.toSet());
-
-            walOptions.forEach(option -> assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option))));
 
         }
     }


### PR DESCRIPTION
Various tests in the streams park were leaking native memory.

Most tests were fixed by closing the corresponding rocksdb resource.

I tested that the corresponding leak is gone by using a previous rocksdb
release with finalizers and checking if the finalizers would be called at some
point. 
