### PR TITLE
KAFKA-14417: Producer doesn't handle REQUEST_TIMED_OUT for InitProducerIdRequest, treats as fatal error -- server-side

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -277,8 +277,7 @@ class BrokerServer(
       val producerIdManagerSupplier = () => ProducerIdManager.rpc(
         config.brokerId,
         brokerEpochSupplier = () => lifecycleManager.brokerEpoch,
-        clientToControllerChannelManager,
-        config.requestTimeoutMs
+        clientToControllerChannelManager
       )
 
       // Create transaction coordinator, but don't start it until we've started replica manager.

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -138,6 +138,7 @@ object BrokerToControllerChannelManager {
 trait BrokerToControllerChannelManager {
   def start(): Unit
   def shutdown(): Unit
+  def time(): Long
   def controllerApiVersions(): Option[NodeApiVersions]
   def sendRequest(
     request: AbstractRequest.Builder[_ <: AbstractRequest],
@@ -173,6 +174,10 @@ class BrokerToControllerChannelManagerImpl(
   def shutdown(): Unit = {
     requestThread.shutdown()
     info(s"Broker to controller channel manager for $channelName shutdown")
+  }
+
+  def time(): Long = {
+    time.milliseconds()
   }
 
   private[server] def newRequestThread = {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -357,8 +357,7 @@ class KafkaServer(
           ProducerIdManager.rpc(
             config.brokerId,
             brokerEpochSupplier = () => kafkaController.brokerEpoch,
-            clientToControllerChannelManager,
-            config.requestTimeoutMs
+            clientToControllerChannelManager
           )
         } else {
           ProducerIdManager.zk(config.brokerId, zkClient)

--- a/core/src/test/scala/unit/kafka/server/MockBrokerToControllerChannelManager.scala
+++ b/core/src/test/scala/unit/kafka/server/MockBrokerToControllerChannelManager.scala
@@ -37,6 +37,8 @@ class MockBrokerToControllerChannelManager(
 
   override def shutdown(): Unit = {}
 
+  override def time(): Long = time.milliseconds()
+
   override def sendRequest(
     request: AbstractRequest.Builder[_ <: AbstractRequest],
     callback: ControllerRequestCompletionHandler


### PR DESCRIPTION
To handle the server side, we will leave it to the client to timeout and retry forever (long max) for now. I've also configured the poll on the array blocking queue to this value.

In the future, I plan to propose a KIP that bumps the request version and allows the request to specify the retry timeout.

One thing to note, the brokerToControllerChannelManager passed in also has a timeout value. Eventually if we allow the request to specify the timeout, we will at least try until the brokerToControllerChannelManager's timeout.

Now, we retry on timeouts and the errors that retry sending the request. Added tests for these two cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
