### PR TITLE
MINOR: Replace ArrayBuffer with ListBuffer for better performance

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -484,10 +484,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
    * group does not know, because the information is not available yet or because the it has
    * failed to parse the Consumer Protocol, it returns true to be safe.
    */
-  def isSubscribedToTopic(topic: String): Boolean = subscribedTopics match {
-    case Some(topics) => topics.contains(topic)
-    case None => true
-  }
+  def isSubscribedToTopic(topic: String): Boolean = subscribedTopics.forall(topics => topics.contains(topic))
 
   /**
    * Collects the set of topics that the members are subscribed to when the Protocol Type is equal

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -321,14 +321,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
    *  Check if the cleaning for a partition is in a particular state. The caller is expected to hold lock while making the call.
    */
   private def isCleaningInState(topicPartition: TopicPartition, expectedState: LogCleaningState): Boolean = {
-    inProgress.get(topicPartition) match {
-      case None => false
-      case Some(state) =>
-        if (state == expectedState)
-          true
-        else
-          false
-    }
+    inProgress.get(topicPartition).contains(expectedState)
   }
 
   /**

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -156,7 +156,7 @@ object BrokerMetadataCheckpoint extends Logging {
     require(logDirs.nonEmpty, "Must have at least one log dir to read meta.properties")
 
     val brokerMetadataMap = mutable.HashMap[String, Properties]()
-    val offlineDirs = mutable.ArrayBuffer.empty[String]
+    val offlineDirs = mutable.ListBuffer.empty[String]
 
     for (logDir <- logDirs) {
       val brokerCheckpointFile = new File(logDir, "meta.properties")

--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -47,7 +47,7 @@ class ControllerConfigurationValidator extends ConfigurationValidator {
   private def validateTopicName(
     name: String
   ): Unit = {
-    if (name.isEmpty()) {
+    if (name.isEmpty) {
       throw new InvalidRequestException("Default topic resources are not allowed.")
     }
     Topic.validate(name)
@@ -56,7 +56,7 @@ class ControllerConfigurationValidator extends ConfigurationValidator {
   private def validateBrokerName(
     name: String
   ): Unit = {
-    if (!name.isEmpty()) {
+    if (name.nonEmpty) {
       val brokerId = try {
         Integer.valueOf(name)
       } catch {
@@ -95,12 +95,12 @@ class ControllerConfigurationValidator extends ConfigurationValidator {
       case TOPIC =>
         validateTopicName(resource.name())
         val properties = new Properties()
-        val nullTopicConfigs = new mutable.ArrayBuffer[String]()
+        val nullTopicConfigs = new mutable.ListBuffer[String]()
         config.entrySet().forEach(e => {
-          if (e.getValue() == null) {
-            nullTopicConfigs += e.getKey()
+          if (e.getValue == null) {
+            nullTopicConfigs += e.getKey
           } else {
-            properties.setProperty(e.getKey(), e.getValue())
+            properties.setProperty(e.getKey, e.getValue)
           }
         })
         if (nullTopicConfigs.nonEmpty) {

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -705,10 +705,7 @@ class FetchSessionCache(private val maxEntries: Int,
   }
 
   def remove(sessionId: Int): Option[FetchSession] = synchronized {
-    get(sessionId) match {
-      case None => None
-      case Some(session) => remove(session)
-    }
+    get(sessionId).flatMap(session => remove(session))
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -706,8 +706,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       forgottenTopics,
       topicNames)
 
-    val erroneous = mutable.ArrayBuffer[(TopicIdPartition, FetchResponseData.PartitionData)]()
-    val interesting = mutable.ArrayBuffer[(TopicIdPartition, FetchRequest.PartitionData)]()
+    val erroneous = mutable.ListBuffer[(TopicIdPartition, FetchResponseData.PartitionData)]()
+    val interesting = mutable.ListBuffer[(TopicIdPartition, FetchRequest.PartitionData)]()
     if (fetchRequest.isFromFollower) {
       // The follower must have ClusterAction on ClusterResource in order to fetch partition data.
       if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME)) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -726,7 +726,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     } else {
       // Regular Kafka consumers need READ permission on each partition they are fetching.
-      val partitionDatas = new mutable.ArrayBuffer[(TopicIdPartition, FetchRequest.PartitionData)]
+      val partitionDatas = new mutable.ListBuffer[(TopicIdPartition, FetchRequest.PartitionData)]
       fetchContext.foreachPartition { (topicIdPartition, partitionData) =>
         if (topicIdPartition.topic == null)
           erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.UNKNOWN_TOPIC_ID)
@@ -2289,7 +2289,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     var skippedMarkers = 0
     for (marker <- markers.asScala) {
       val producerId = marker.producerId
-      val partitionsWithCompatibleMessageFormat = new mutable.ArrayBuffer[TopicPartition]
+      val partitionsWithCompatibleMessageFormat = new mutable.ListBuffer[TopicPartition]
 
       val currentErrors = new ConcurrentHashMap[TopicPartition, Errors]()
       marker.partitions.forEach { partition =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1209,7 +1209,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     var limitBytes = params.maxBytes
-    val result = new mutable.ArrayBuffer[(TopicIdPartition, LogReadResult)]
+    val result = new mutable.ListBuffer[(TopicIdPartition, LogReadResult)]
     var minOneMessage = !params.hardMaxBytesLimit
     readPartitionInfo.foreach { case (tp, fetchInfo) =>
       val readResult = read(tp, fetchInfo, limitBytes, minOneMessage)
@@ -1512,10 +1512,7 @@ class ReplicaManager(val config: KafkaConfig,
    * @return true if the request topic id is consistent, false otherwise
    */
   private def hasConsistentTopicId(requestTopicIdOpt: Option[Uuid], logTopicIdOpt: Option[Uuid]): Boolean = {
-    requestTopicIdOpt match {
-      case None => true
-      case Some(requestTopicId) => logTopicIdOpt.isEmpty || logTopicIdOpt.contains(requestTopicId)
-    }
+    requestTopicIdOpt.forall(requestTopicId => logTopicIdOpt.isEmpty || logTopicIdOpt.contains(requestTopicId))
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1056,7 +1056,7 @@ class ReplicaManager(val config: KafkaConfig,
       responseCallback(fetchPartitionData)
     } else {
       // construct the fetch results from the read results
-      val fetchPartitionStatus = new mutable.ArrayBuffer[(TopicIdPartition, FetchPartitionStatus)]
+      val fetchPartitionStatus = new mutable.ListBuffer[(TopicIdPartition, FetchPartitionStatus)]
       fetchInfos.foreach { case (topicIdPartition, partitionData) =>
         logReadResultMap.get(topicIdPartition).foreach(logReadResult => {
           val logOffsetMetadata = logReadResult.info.fetchOffsetMetadata

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -192,7 +192,7 @@ class BrokerMetadataPublisher(
         }
         try {
           // Notify the group coordinator about deleted topics.
-          val deletedTopicPartitions = new mutable.ArrayBuffer[TopicPartition]()
+          val deletedTopicPartitions = new mutable.ListBuffer[TopicPartition]()
           topicsDelta.deletedTopicIds().forEach { id =>
             val topicImage = topicsDelta.image().getTopic(id)
             topicImage.partitions().keySet().forEach {

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -359,10 +359,7 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
     _currentImage.topics().topicsByName().containsKey(topicName)
 
   override def contains(tp: TopicPartition): Boolean = {
-    Option(_currentImage.topics().getTopic(tp.topic())) match {
-      case None => false
-      case Some(topic) => topic.partitions().containsKey(tp.partition())
-    }
+    Option(_currentImage.topics().getTopic(tp.topic())).exists(topic => topic.partitions().containsKey(tp.partition()))
   }
 
   def setImage(newImage: MetadataImage): Unit = _currentImage = newImage

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -361,7 +361,7 @@ class ZkMetadataCache(brokerId: Int, metadataVersion: MetadataVersion, brokerFea
         // is a bit faster than scala.collection.mutable.HashMap. When we drop support for Scala 2.10, we could
         // move to `AnyRefMap`, which has comparable performance.
         val nodes = new java.util.HashMap[ListenerName, Node]
-        val endPoints = new mutable.ArrayBuffer[EndPoint]
+        val endPoints = new mutable.ListBuffer[EndPoint]
         broker.endpoints.forEach { ep =>
           val listenerName = new ListenerName(ep.listener)
           endPoints += new EndPoint(ep.host, ep.port, listenerName, SecurityProtocol.forId(ep.securityProtocol))
@@ -384,7 +384,7 @@ class ZkMetadataCache(brokerId: Int, metadataVersion: MetadataVersion, brokerFea
       newZeroIds.foreach { case (zeroIdTopic, _) => topicIds.remove(zeroIdTopic) }
       topicIds ++= newTopicIds.toMap
 
-      val deletedPartitions = new mutable.ArrayBuffer[TopicPartition]
+      val deletedPartitions = new mutable.ListBuffer[TopicPartition]
       if (!updateMetadataRequest.partitionStates.iterator.hasNext) {
         metadataSnapshot = MetadataSnapshot(metadataSnapshot.partitionStates, topicIds.toMap, controllerIdOpt, aliveBrokers, aliveNodes)
       } else {

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -758,10 +758,7 @@ class KRaftClusterTest {
     image: ClusterImage,
     brokerId: Int
   ): Boolean = {
-    Option(image.brokers().get(brokerId)) match {
-      case None => false
-      case Some(registration) => !registration.fenced()
-    }
+    Option(image.brokers().get(brokerId)).exists(registration => !registration.fenced())
   }
 
   private def brokerIsAbsent(


### PR DESCRIPTION
`ListBuffer` should be preferred over `ArrayBuffer` in cases where:
1. No indexing is required.
2. The data structure is converted to Java's List from scala.

`ListBuffer` has a [guaranteed constant time performance](https://docs.scala-lang.org/overviews/collections-2.13/performance-characteristics.html) for append operations which makes it a lucrative data structure for  cases when we create a list and append multiple entries to it.

This PR modifies usage of `ArrayBuffer` to `ListBuffer` in latency sensitive code path. To prove the usefulness of this change, I am attaching a CPU profile for an [open messaging benchmark](https://openmessaging.cloud/docs/benchmarks/). Please note that the self-time of the `ReplicaManager.fetchMessages()` reduced after this changes (depicted by the empty space in top of the frame for `ReplicaManager.fetchMessages()`.

**Before this PR**
 
![Screenshot 2022-12-08 at 15 30 24](https://user-images.githubusercontent.com/71267/206517187-6ebbcad5-00b5-4706-a2b8-5c64dce71d9a.png)

**After this PR**
![Screenshot 2022-12-08 at 15 30 37](https://user-images.githubusercontent.com/71267/206517243-97938193-449d-4e46-9c32-fb9bc82c0469.png)


Note: This PR piggybacks some general scala cleanup regarding usage of Optionals.