### PR TITLE
KAFKA-14417: Producer doesn't handle REQUEST_TIMED_OUT for InitProducerIdRequest, treats as fatal error -- Addressing the error server side

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -167,7 +167,7 @@ class RPCProducerIdManager(brokerId: Int,
       if (nextProducerId > currentProducerIdBlock.lastProducerId) {
         val block = nextProducerIdBlock.poll(maxWaitMs, TimeUnit.MILLISECONDS)
         if (block == null) {
-          throw Errors.REQUEST_TIMED_OUT.exception("Timed out waiting for next producer ID block")
+          throw Errors.COORDINATOR_LOAD_IN_PROGRESS.exception("Timed out waiting for next producer ID block")
         } else {
           block match {
             case Success(nextBlock) =>
@@ -236,7 +236,7 @@ class RPCProducerIdManager(brokerId: Int,
   private[transaction] def handleTimeout(): Unit = {
     warn("Timed out when requesting AllocateProducerIds from the controller.")
     requestInFlight.set(false)
-    nextProducerIdBlock.put(Failure(Errors.REQUEST_TIMED_OUT.exception))
+    nextProducerIdBlock.put(Failure(Errors.COORDINATOR_LOAD_IN_PROGRESS.exception))
     maybeRequestNextBlock()
   }
 }

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -167,6 +167,8 @@ class RPCProducerIdManager(brokerId: Int,
       if (nextProducerId > currentProducerIdBlock.lastProducerId) {
         val block = nextProducerIdBlock.poll(maxWaitMs, TimeUnit.MILLISECONDS)
         if (block == null) {
+          // Return COORDINATOR_LOAD_IN_PROGRESS rather than REQUEST_TIMED_OUT since older clients treat the error as fatal
+          // when it should be retriable like COORDINATOR_LOAD_IN_PROGRESS.
           throw Errors.COORDINATOR_LOAD_IN_PROGRESS.exception("Timed out waiting for next producer ID block")
         } else {
           block match {
@@ -236,7 +238,6 @@ class RPCProducerIdManager(brokerId: Int,
   private[transaction] def handleTimeout(): Unit = {
     warn("Timed out when requesting AllocateProducerIds from the controller.")
     requestInFlight.set(false)
-    nextProducerIdBlock.put(Failure(Errors.COORDINATOR_LOAD_IN_PROGRESS.exception))
     maybeRequestNextBlock()
   }
 }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -19,6 +19,7 @@ package kafka.coordinator.transaction
 import kafka.server.BrokerToControllerChannelManager
 import kafka.zk.{KafkaZkClient, ProducerIdBlockZNode}
 import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.errors.CoordinatorLoadInProgressException
 import org.apache.kafka.common.message.AllocateProducerIdsResponseData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.AllocateProducerIdsResponse
@@ -30,7 +31,6 @@ import org.junit.jupiter.params.provider.{EnumSource, ValueSource}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{mock, when}
-
 import java.util.stream.IntStream
 
 class ProducerIdManagerTest {
@@ -39,10 +39,13 @@ class ProducerIdManagerTest {
   val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
 
   // Mutable test implementation that lets us easily set the idStart and error
-  class MockProducerIdManager(val brokerId: Int, var idStart: Long, val idLen: Int, var error: Errors = Errors.NONE)
+  class MockProducerIdManager(val brokerId: Int, var idStart: Long, val idLen: Int, var error: Errors = Errors.NONE, timeout: Boolean = false)
     extends RPCProducerIdManager(brokerId, () => 1, brokerToController, 100) {
 
     override private[transaction] def sendRequest(): Unit = {
+      if (timeout)
+        return
+
       if (error == Errors.NONE) {
         handleAllocateProducerIdsResponse(new AllocateProducerIdsResponse(
           new AllocateProducerIdsResponseData().setProducerIdStart(idStart).setProducerIdLen(idLen)))
@@ -91,6 +94,17 @@ class ProducerIdManagerTest {
 
     assertEquals(pid2 + ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE, manager1.generateProducerId())
     assertEquals(pid2 + ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE * 2, manager2.generateProducerId())
+  }
+
+  @Test
+  def testRPCProducerIdManagerThrowsConcurrentTransactions(): Unit = {
+    val manager1 = new MockProducerIdManager(0, 0, 0, timeout = true)
+    val manager2 = new MockProducerIdManager(0, 0, 0)
+
+    assertThrows(classOf[CoordinatorLoadInProgressException], () => manager1.generateProducerId())
+
+    manager2.handleTimeout()
+    assertThrows(classOf[CoordinatorLoadInProgressException], () => manager2.generateProducerId())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -99,12 +99,7 @@ class ProducerIdManagerTest {
   @Test
   def testRPCProducerIdManagerThrowsConcurrentTransactions(): Unit = {
     val manager1 = new MockProducerIdManager(0, 0, 0, timeout = true)
-    val manager2 = new MockProducerIdManager(0, 0, 0)
-
     assertThrows(classOf[CoordinatorLoadInProgressException], () => manager1.generateProducerId())
-
-    manager2.handleTimeout()
-    assertThrows(classOf[CoordinatorLoadInProgressException], () => manager2.generateProducerId())
   }
 
   @Test


### PR DESCRIPTION
Older clients can not handle REQUEST_TIMED_OUT, so the error is changed to COORDINATOR_LOAD_IN_PROGRESS which is retriable and the desired behavior.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
