### PR TITLE
MINOR: Small refactor in ApiVersionManager

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -632,7 +632,7 @@ public class KafkaAdminClientTest {
         if (error == Errors.NONE) {
             return ApiVersionsResponse.createApiVersionsResponse(
                 0,
-                ApiVersionsResponse.filterApis(RecordVersion.current(), ApiMessageType.ListenerType.ZK_BROKER),
+                ApiVersionsResponse.filterApis(ApiKeys.apisForListener(ApiMessageType.ListenerType.ZK_BROKER), RecordVersion.current()),
                 convertSupportedFeaturesMap(defaultFeatureMetadata().supportedFeatures()),
                 Collections.singletonMap("test_feature_1", (short) 2),
                 defaultFeatureMetadata().finalizedFeaturesEpoch().get()

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -99,7 +99,7 @@ public class ApiVersionsResponseTest {
         );
 
         ApiVersionCollection commonResponse = ApiVersionsResponse.intersectForwardableApis(
-            ApiMessageType.ListenerType.ZK_BROKER,
+            ApiKeys.apisForListener(ApiMessageType.ListenerType.ZK_BROKER),
             RecordVersion.current(),
             activeControllerApiVersions
         );

--- a/core/src/main/scala/kafka/server/ApiVersionManager.scala
+++ b/core/src/main/scala/kafka/server/ApiVersionManager.scala
@@ -43,6 +43,7 @@ object ApiVersionManager {
   ): ApiVersionManager = {
     new DefaultApiVersionManager(
       listenerType,
+      ApiKeys.apisForListener(listenerType).asScala,
       forwardingManager,
       supportedFeatures,
       metadataCache
@@ -69,6 +70,7 @@ class SimpleApiVersionManager(
 
 class DefaultApiVersionManager(
   val listenerType: ListenerType,
+  val enabledApis: collection.Set[ApiKeys],
   forwardingManager: Option[ForwardingManager],
   features: BrokerFeatures,
   metadataCache: MetadataCache
@@ -86,14 +88,7 @@ class DefaultApiVersionManager(
         finalizedFeatures.features.map(kv => (kv._1, kv._2.asInstanceOf[java.lang.Short])).asJava,
         finalizedFeatures.epoch,
         controllerApiVersions.orNull,
-        listenerType)
-  }
-
-  override def enabledApis: collection.Set[ApiKeys] = {
-    ApiKeys.apisForListener(listenerType).asScala
-  }
-
-  override def isApiEnabled(apiKey: ApiKeys): Boolean = {
-    apiKey.inScope(listenerType)
+        enabledApis.asJava
+    )
   }
 }

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -75,7 +75,7 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       ApiKeys.controllerApis()
     } else {
       ApiVersionsResponse.intersectForwardableApis(
-        ApiMessageType.ListenerType.BROKER,
+        ApiKeys.apisForListener(ApiMessageType.ListenerType.BROKER),
         RecordVersion.current,
         NodeApiVersions.create(ApiKeys.controllerApis().asScala.map(ApiVersionsResponse.toApiVersion).asJava).allSupportedApiVersions()
       )

--- a/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
@@ -38,6 +38,7 @@ class ApiVersionManagerTest {
   def testApiScope(apiScope: ListenerType): Unit = {
     val versionManager = new DefaultApiVersionManager(
       listenerType = apiScope,
+      enabledApis = ApiKeys.apisForListener(apiScope).asScala,
       forwardingManager = None,
       features = brokerFeatures,
       metadataCache = metadataCache
@@ -61,6 +62,7 @@ class ApiVersionManagerTest {
 
     val versionManager = new DefaultApiVersionManager(
       listenerType = ListenerType.ZK_BROKER,
+      enabledApis = ApiKeys.apisForListener(ListenerType.ZK_BROKER).asScala,
       forwardingManager = Some(forwardingManager),
       features = brokerFeatures,
       metadataCache = metadataCache
@@ -81,6 +83,7 @@ class ApiVersionManagerTest {
     for (forwardingManagerOpt <- Seq(Some(forwardingManager), None)) {
       val versionManager = new DefaultApiVersionManager(
         listenerType = ListenerType.BROKER,
+        enabledApis = ApiKeys.apisForListener(ListenerType.BROKER).asScala,
         forwardingManager = forwardingManagerOpt,
         features = brokerFeatures,
         metadataCache = metadataCache
@@ -102,6 +105,7 @@ class ApiVersionManagerTest {
 
     val versionManager = new DefaultApiVersionManager(
       listenerType = ListenerType.ZK_BROKER,
+      enabledApis = ApiKeys.apisForListener(ListenerType.ZK_BROKER).asScala,
       forwardingManager = Some(forwardingManager),
       features = brokerFeatures,
       metadataCache = metadataCache
@@ -120,6 +124,7 @@ class ApiVersionManagerTest {
   def testEnvelopeDisabledWhenForwardingManagerEmpty(): Unit = {
     val versionManager = new DefaultApiVersionManager(
       listenerType = ListenerType.ZK_BROKER,
+      enabledApis = ApiKeys.apisForListener(ListenerType.ZK_BROKER).asScala,
       forwardingManager = None,
       features = brokerFeatures,
       metadataCache = metadataCache


### PR DESCRIPTION
For KIP-848, I would like to check-in the new APIs but without exposing them while the KIP is in development. At first, my goal is to gate them by an internal configuration flag defined in KafkaConfig. Later one, this should be dynamic either based on MetadataVersion or another feature flag.

This patch is a small refactor in `ApiVersionManager` to allow filtering APIs. The basic idea is to filter them based on KafkaConfig [here](https://github.com/apache/kafka/compare/trunk...dajac:kafka:minor-refacor-apiversion-manager?expand=1#diff-b89d6d5e31fa117d2dfb7d242c5035c18556c783f58360ca3b42801100640090R44) so instead of letting the  `ApiVersionManager` determine the available APIs based on the listener type, we give it the allowed set. This is definitely not the end state that I want but is a first step towards it. It will at least allow me to get this APIs checked in safely. We can come back to the dynamic part of it a bit later.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
