### PR TITLE
KAFKA-13602: Removing Multicasting partitioner for IQ

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -43,20 +43,10 @@ public class KeyQueryMetadata {
 
     private final int partition;
 
-    private final Set<Integer> partitions;
-
     public KeyQueryMetadata(final HostInfo activeHost, final Set<HostInfo> standbyHosts, final int partition) {
         this.activeHost = activeHost;
         this.standbyHosts = standbyHosts;
         this.partition = partition;
-        this.partitions = Collections.singleton(partition);
-    }
-
-    public KeyQueryMetadata(final HostInfo activeHost, final Set<HostInfo> standbyHosts, final Set<Integer> partitions) {
-        this.activeHost = activeHost;
-        this.standbyHosts = standbyHosts;
-        this.partition = partitions.size() == 1 ? partitions.iterator().next() : -1;
-        this.partitions = partitions;
     }
 
     /**
@@ -119,16 +109,6 @@ public class KeyQueryMetadata {
         return partition;
     }
 
-    /**
-     * Get the store partitions corresponding to the key.
-     * A Key can be on multiple partitions if it has been
-     * multicasted using StreamPartitioner#partitions method
-     * @return store partition number
-     */
-    public Set<Integer> partitions() {
-        return partitions;
-    }
-
     @Override
     public boolean equals(final Object obj) {
         if (!(obj instanceof KeyQueryMetadata)) {
@@ -137,8 +117,7 @@ public class KeyQueryMetadata {
         final KeyQueryMetadata keyQueryMetadata = (KeyQueryMetadata) obj;
         return Objects.equals(keyQueryMetadata.activeHost, activeHost)
             && Objects.equals(keyQueryMetadata.standbyHosts, standbyHosts)
-            && (Objects.equals(keyQueryMetadata.partition, partition)
-                || Objects.equals(keyQueryMetadata.partitions, partitions));
+            && Objects.equals(keyQueryMetadata.partition, partition);
     }
 
     @Override
@@ -147,7 +126,6 @@ public class KeyQueryMetadata {
                 "activeHost=" + activeHost +
                 ", standbyHosts=" + standbyHosts +
                 ", partition=" + partition +
-                ", partitions=" + partitions +
                 '}';
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -248,7 +248,7 @@ public class StreamsMetadataStateTest {
         metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
             cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
-        final KeyQueryMetadata expected = new KeyQueryMetadata(hostThree, mkSet(hostTwo), Collections.singleton(0));
+        final KeyQueryMetadata expected = new KeyQueryMetadata(hostThree, mkSet(hostTwo), 0);
         final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
                                                                     "the-key",
                                                                     Serdes.String().serializer());
@@ -263,30 +263,27 @@ public class StreamsMetadataStateTest {
         metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
             cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
-        final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, Collections.emptySet(), Collections.singleton(1));
+        final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, Collections.emptySet(), 1);
 
         final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
                 "the-key",
                 partitioner);
         assertEquals(expected, actual);
         assertEquals(1, actual.partition());
-        assertEquals(Collections.singleton(1), actual.partitions());
     }
 
     @Test
-    public void shouldGetInstanceWithKeyAndCustomMulticastingPartitioner() {
-        final TopicPartition tp4 = new TopicPartition("topic-three", 0);
-        final TopicPartition tp5 = new TopicPartition("topic-three", 1);
-        hostToActivePartitions.put(hostTwo, mkSet(tp4, tp5));
+    public void shouldFailWhenIqQueriedWithCustomPartitionerReturningMultiplePartitions() {
+        final TopicPartition tp4 = new TopicPartition("topic-three", 1);
+        hostToActivePartitions.put(hostTwo, mkSet(topic2P0, tp4));
 
-        final KeyQueryMetadata expected = new KeyQueryMetadata(hostThree, Collections.singleton(hostTwo), mkSet(0, 1));
+        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
+                cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
-        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
+
+        assertThrows(IllegalArgumentException.class, () -> metadataState.getKeyQueryMetadataForKey("table-three",
                 "the-key",
-                new MultiValuedPartitioner());
-        assertEquals(expected, actual);
-        assertEquals(-1, actual.partition());
-        assertEquals(mkSet(0, 1), actual.partitions());
+                new MultiValuedPartitioner()));
     }
 
     @Test
@@ -304,7 +301,7 @@ public class StreamsMetadataStateTest {
         metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions,
                 cluster.withPartitions(Collections.singletonMap(topic2P2, new PartitionInfo("topic-two", 2, null, null, null))));
 
-        final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, mkSet(hostOne), Collections.singleton(2));
+        final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, mkSet(hostOne), 2);
 
         final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("merged-table",  "the-key",
             (topic, key, value, numPartitions) -> 2);


### PR DESCRIPTION
Follow up PR for KIP-837. We don't want to allow multicasting for IQ. This PR imposes that restriction.