### PR TITLE
MINOR: Fix testPreferredReplicaAsLeaderWhenSameRackFollowerIsOutOfIsr

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1323,6 +1323,17 @@ class ReplicaManagerTest {
 
       replicaManager.becomeLeaderOrFollower(2, leaderAndIsrRequest, (_, _) => ())
 
+      appendRecords(replicaManager, tp0, TestUtils.singletonRecords(s"message".getBytes)).onFire { response =>
+        assertEquals(Errors.NONE, response.error)
+      }
+      // fetch as follower to advance the high watermark
+      fetchPartitionAsFollower(
+        replicaManager,
+        new TopicIdPartition(topicId, new TopicPartition(topic, 0)),
+        new PartitionData(Uuid.ZERO_UUID, 0, 0, 100000, Optional.empty()),
+        replicaId = 1
+      )
+
       val metadata = new DefaultClientMetadata("rack-b", "client-id",
         InetAddress.getByName("localhost"), KafkaPrincipal.ANONYMOUS, "default")
 
@@ -1337,7 +1348,7 @@ class ReplicaManagerTest {
       assertTrue(consumerResult.hasFired)
 
       // PartitionView passed to ReplicaSelector should not contain the follower as it's not in the ISR
-      val expectedReplicaViews = Set(new DefaultReplicaView(leaderNode, 0, 0))
+      val expectedReplicaViews = Set(new DefaultReplicaView(leaderNode, 1, 0))
       val partitionView = replicaManager.replicaSelectorOpt.get
         .asInstanceOf[MockReplicaSelector].getPartitionViewArgument
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1326,7 +1326,7 @@ class ReplicaManagerTest {
       appendRecords(replicaManager, tp0, TestUtils.singletonRecords(s"message".getBytes)).onFire { response =>
         assertEquals(Errors.NONE, response.error)
       }
-      // fetch as follower to advance the high watermark
+      // Fetch as follower to initialise the log end offset of the replica
       fetchPartitionAsFollower(
         replicaManager,
         new TopicIdPartition(topicId, new TopicPartition(topic, 0)),


### PR DESCRIPTION
Even if the follower is the ISR, the follower will be excluded because the logEndOffset (-1) is less than the fetchOffset (0)
```
if (partition.inSyncReplicaIds.contains(replica.brokerId) &&
                replicaState.logEndOffset >= fetchOffset &&
                replicaState.logStartOffset <= fetchOffset)
```
https://github.com/CalvinConfluent/kafka/blob/trunk/core/src/main/scala/kafka/server/ReplicaManager.scala#L1252

So the test needs to update its logEndOffset by appending one message.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
