### PR TITLE
KAFKA-13602: Remove unwanted logging in RecordCollectorImpl.java

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -159,7 +159,8 @@ public class RecordCollectorImpl implements RecordCollector {
                     final Set<Integer> multicastPartitions = maybeMulticastPartitions.get();
                     if (multicastPartitions.isEmpty()) {
                         // If a record is not to be sent to any partition, mark it as a dropped record.
-                        log.debug("Not sending the record with key {} , value {} to any partition", key, value);
+                        log.warn("Skipping record as partitioner returned empty partitions. "
+                                + "topic=[{}]", topic);
                         droppedRecordsSensor.record();
                     } else {
                         for (final int multicastPartition: multicastPartitions) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -227,7 +227,6 @@ public class RecordCollectorImpl implements RecordCollector {
 
             if (exception == null) {
                 final TopicPartition tp = new TopicPartition(metadata.topic(), metadata.partition());
-                log.info("Produced key:{}, value:{} successfully to tp:{}", key, value, tp);
                 if (metadata.offset() >= 0L) {
                     offsets.put(tp, metadata.offset());
                 } else {


### PR DESCRIPTION
There is unwanted logging introduced by https://github.com/apache/kafka/pull/12803 as pointed out in this comment: https://github.com/apache/kafka/pull/12803#discussion_r1046852940. This PR removes it.