### PR TITLE
MINOR; fix FetchFromFollowerIntegrationTest.testFetchFromFollowerWith…

### DIFF
--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -42,6 +42,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
   def overridingProps: Properties = {
     val props = new Properties
     props.put(KafkaConfig.NumPartitionsProp, numParts.toString)
+    props.put(KafkaConfig.OffsetsTopicReplicationFactorProp, numNodes.toString)
     props
   }
 


### PR DESCRIPTION
…Roll

The test was added with a fix to KAFKA-14379, the problem was that the replication factor for the offset topic was 1 and consumer group coordinator got unavailable when one of the brokers got shut down.

Ran the test from IntelliJ for 50 times, all passed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
