### PR TITLE
MINOR: improve error message in ClientUtils

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -55,8 +55,10 @@ public final class ClientUtils {
                 try {
                     String host = getHost(url);
                     Integer port = getPort(url);
-                    if (host == null || port == null)
-                        throw new ConfigException("Invalid url in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
+                    if (host == null) 
+                        throw new ConfigException("Invalid host in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
+                    if (port == null)
+                        throw new ConfigException("Invalid port in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
 
                     if (clientDnsLookup == ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY) {
                         InetAddress[] inetAddresses = InetAddress.getAllByName(host);


### PR DESCRIPTION
Minor, but it would have saved a little time debugging invalid urls that were being set for bootstrap.servers in our configuration. It wasn't immediately obvious that the issue was a missing port.