### PR TITLE
KAFKA-14396: De-flake memory tests with new TestUtils.restrictMemory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "unitTest integrationTest") {
+def doTest(env, target = "unitTest integrationTest memoryIsolationTest") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""

--- a/build.gradle
+++ b/build.gradle
@@ -421,6 +421,12 @@ subprojects {
     ])
   }
 
+  // Tests which need to execute in a throw-away JVM due to causing high memory pressure.
+  def memoryIsolated = [
+          "**/MemoryRecordsBuilderTest.*",
+          "**/GarbageCollectedMemoryPoolTest.*"
+  ]
+
   test {
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
@@ -436,7 +442,42 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
-    exclude testsToExclude
+    exclude testsToExclude + memoryIsolated
+
+    if (shouldUseJUnit5)
+      useJUnitPlatform()
+
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
+    }
+
+    // Allows devs to run tests in a loop to debug flaky tests. See README.
+    if (project.hasProperty("rerun-tests")) {
+      outputs.upToDateWhen { false }
+    }
+  }
+
+  task memoryIsolationTest(type: Test, dependsOn: compileJava) {
+    maxParallelForks = maxTestForks
+    ignoreFailures = userIgnoreFailures
+
+    maxHeapSize = defaultMaxHeapSize
+    // Discard the test JVM after each class to isolate them.
+    forkEvery 1
+    // Indicate to the memory-pressure utilities that they are safe to use.
+    // See clients/**/TestUtils.restrictMemory for details.
+    jvmArgs = defaultJvmArgs + ["-DmemoryIsolated=true"]
+
+    testLogging {
+      events = userTestLoggingEvents ?: testLoggingEvents
+      showStandardStreams = userShowStandardStreams ?: testShowStandardStreams
+      exceptionFormat = testExceptionFormat
+      displayGranularity = 0
+    }
+    logTestStdout.rehydrate(delegate, owner, this)()
+
+    include memoryIsolated
 
     if (shouldUseJUnit5)
       useJUnitPlatform()
@@ -469,7 +510,7 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
-    exclude testsToExclude
+    exclude testsToExclude + memoryIsolated
 
     if (shouldUseJUnit5) {
       if (project.name == 'streams') {

--- a/build.gradle
+++ b/build.gradle
@@ -424,7 +424,8 @@ subprojects {
   // Tests which need to execute in a throw-away JVM due to causing high memory pressure.
   def memoryIsolated = [
           "**/MemoryRecordsBuilderTest.*",
-          "**/GarbageCollectedMemoryPoolTest.*"
+          "**/GarbageCollectedMemoryPoolTest.*",
+          "**/ThreadCacheTest.*"
   ]
 
   test {
@@ -479,8 +480,25 @@ subprojects {
 
     include memoryIsolated
 
-    if (shouldUseJUnit5)
-      useJUnitPlatform()
+    if (shouldUseJUnit5) {
+      if (project.name == 'streams') {
+        useJUnitPlatform {
+          excludeTags "integration"
+          excludeTags "org.apache.kafka.test.IntegrationTest"
+          // Both engines are needed to run JUnit 4 tests alongside JUnit 5 tests.
+          // junit-vintage (JUnit 4) can be removed once the JUnit 4 migration is complete.
+          includeEngines "junit-vintage", "junit-jupiter"
+        }
+      } else {
+        useJUnitPlatform {
+          excludeTags "integration"
+        }
+      }
+    } else {
+      useJUnit {
+        excludeCategories 'org.apache.kafka.test.IntegrationTest'
+      }
+    }
 
     retry {
       maxRetries = userMaxTestRetries

--- a/build.gradle
+++ b/build.gradle
@@ -558,7 +558,7 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
-    exclude testsToExclude
+    exclude testsToExclude + memoryIsolated
 
     if (shouldUseJUnit5) {
       if (project.name == 'streams') {

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -637,6 +637,12 @@ public class TestUtils {
      * @throws IllegalStateException if the heap is too fragmented for contiguous data to be allocated
      */
     public static Utils.UncheckedCloseable restrictMemory(long allowedBytes, long toleranceBytes) {
+        if (System.getProperty("memoryIsolated") == null) {
+            throw new IllegalStateException(
+                    "This cannot be used in a shared JVM for risk of poisoning and lasting effects. " +
+                            "To to use this method, add the calling test class to the memoryIsolated list in build.gradle"
+            );
+        }
         // Reserve a single block for the caller before consuming the remaining memory in multiple allocations.
         // Discard the reservation before returning the memory handle to the caller.
         try (Utils.UncheckedCloseable ignored = reserve(allowedBytes)) {


### PR DESCRIPTION
Rather than relying on measuring Runtime::freeMemory() and calling System.gc(), tests which want to assert that there are no excessive allocations should execute in a restricted-memory environment.

In order to do this, add a new TestUtil method which intentionally consumes memory in a way that allows tests to assert that the code under test does not over-allocate or leak memory. This is a temporary effect on a single JVM, and is reverted as soon as the test code completes.

Apply this fix to MemoryRecordsBuilderTest::testBuffersDereferencedOnClose(), which now fails if the eponymous close() call is omitted.

Signed-off-by: Greg Harris <greg.harris@aiven.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
