### PR TITLE
MINOR: No error with zero results state query

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
@@ -72,12 +72,12 @@ public class StateQueryResult<R> {
                 .filter(r -> r.getResult() != null)
                 .collect(Collectors.toList());
 
-        if (nonempty.size() != 1) {
+        if (nonempty.size() > 1) {
             throw new IllegalArgumentException(
                 "The query did not return exactly one partition result: " + partitionResults
             );
         } else {
-            return nonempty.get(0);
+            return nonempty.isEmpty() ? null : nonempty.get(0);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
@@ -1,0 +1,48 @@
+package org.apache.kafka.streams.query;
+
+import org.apache.kafka.streams.query.internals.SucceededQueryResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+
+class StateQueryResultTest {
+
+    StateQueryResult<String> stringStateQueryResult;
+    final QueryResult<String> noResultsFound = new SucceededQueryResult<>(null);
+    final QueryResult<String> validResult = new SucceededQueryResult<>("Foo");
+
+    @BeforeEach
+    public void setUp() {
+        stringStateQueryResult = new StateQueryResult<>();
+    }
+
+    @Test
+    @DisplayName("Zero query results shouldn't error")
+    void getOnlyPartitionResultNoResultsTest() {
+        stringStateQueryResult.addResult(0, noResultsFound);
+        final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
+        assertThat(result, nullValue());
+    }
+
+    @Test
+    @DisplayName("Valid query results still works")
+    void getOnlyPartitionResultWithSingleResultTest() {
+        stringStateQueryResult.addResult(0, validResult);
+        final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
+        assertThat(result.getResult(), is("Foo"));
+    }
+
+    @Test
+    @DisplayName("More than one query result throws IllegalArgumentException ")
+    void getOnlyPartitionResultMultipleResults() {
+        stringStateQueryResult.addResult(0, validResult);
+        stringStateQueryResult.addResult(1, validResult);
+        assertThrows(IllegalArgumentException.class, () ->stringStateQueryResult.getOnlyPartitionResult());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.streams.query;
 
 import org.apache.kafka.streams.query.internals.SucceededQueryResult;
@@ -43,6 +59,6 @@ class StateQueryResultTest {
     void getOnlyPartitionResultMultipleResults() {
         stringStateQueryResult.addResult(0, validResult);
         stringStateQueryResult.addResult(1, validResult);
-        assertThrows(IllegalArgumentException.class, () ->stringStateQueryResult.getOnlyPartitionResult());
+        assertThrows(IllegalArgumentException.class, () -> stringStateQueryResult.getOnlyPartitionResult());
     }
 }


### PR DESCRIPTION
This PR updates `StateQueryResult.getOnlyPartitionResult()` to not throw an `IllegaArgumentException` when there are 0 query results.

Added a test that will fail without this patch

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
