### PR TITLE
MINOR: Don't throw if MirrorMaker topics already exist

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
@@ -130,6 +130,7 @@ final class MirrorUtils {
             Throwable cause = e.getCause();
             if (cause instanceof TopicExistsException) {
                 log.debug("Unable to create topic '{}' since it already exists.", topicName);
+                return;
             }
             if (cause instanceof UnsupportedVersionException) {
                 log.debug("Unable to create topic '{}' since the brokers do not support the CreateTopics API." +

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MirrorUtilsTest {
+
+    private static final String TOPIC = "topic";
+
+    private final Admin admin = mock(Admin.class);
+    private final CreateTopicsResult ctr = mock(CreateTopicsResult.class);
+    @SuppressWarnings("unchecked")
+    private final KafkaFuture<Void> future = mock(KafkaFuture.class);
+
+    @Test
+    public void testCreateCompactedTopic() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenReturn(null);
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+    }
+
+    @Test
+    public void testCreateCompactedTopicAlreadyExists() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenThrow(new ExecutionException(new TopicExistsException("topic exists")));
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+    }
+
+    @Test
+    public void testCreateCompactedTopicFails() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenThrow(new ExecutionException(new ClusterAuthorizationException("not authorized")));
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        try {
+            MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+            fail("Should have thrown");
+        } catch (ConnectException ce) {
+            assertTrue(ce.getCause() instanceof ExecutionException);
+            assertTrue(ce.getCause().getCause() instanceof ClusterAuthorizationException);
+        }
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
@@ -28,10 +28,11 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MirrorUtilsTest {
@@ -50,6 +51,10 @@ public class MirrorUtilsTest {
         when(ctr.values()).thenReturn(values);
         when(admin.createTopics(any(), any())).thenReturn(ctr);
         MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
     }
 
     @Test
@@ -59,6 +64,10 @@ public class MirrorUtilsTest {
         when(ctr.values()).thenReturn(values);
         when(admin.createTopics(any(), any())).thenReturn(ctr);
         MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
     }
 
     @Test
@@ -67,12 +76,12 @@ public class MirrorUtilsTest {
         when(future.get()).thenThrow(new ExecutionException(new ClusterAuthorizationException("not authorized")));
         when(ctr.values()).thenReturn(values);
         when(admin.createTopics(any(), any())).thenReturn(ctr);
-        try {
-            MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
-            fail("Should have thrown");
-        } catch (ConnectException ce) {
-            assertTrue(ce.getCause() instanceof ExecutionException);
-            assertTrue(ce.getCause().getCause() instanceof ClusterAuthorizationException);
-        }
+        Throwable ce = assertThrows(ConnectException.class, () -> MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin), "Should have exception thrown");
+
+        assertTrue(ce.getCause() instanceof ExecutionException);
+        assertTrue(ce.getCause().getCause() instanceof ClusterAuthorizationException);
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
     }
 }


### PR DESCRIPTION
Currently MirrorMaker throws a few exceptions at startup if its internal topics already exists.

For example:
```
Scheduler for MirrorHeartbeatConnector caught exception in scheduled task: creating internal topics (org.apache.kafka.connect.mirror.Scheduler:102)
org.apache.kafka.connect.errors.ConnectException: Error while attempting to create/find topic 'heartbeats'
	at org.apache.kafka.connect.mirror.MirrorUtils.createCompactedTopic(MirrorUtils.java:154)
	at org.apache.kafka.connect.mirror.MirrorUtils.createSinglePartitionCompactedTopic(MirrorUtils.java:160)
	at org.apache.kafka.connect.mirror.MirrorHeartbeatConnector.createInternalTopics(MirrorHeartbeatConnector.java:89)
	at org.apache.kafka.connect.mirror.Scheduler.run(Scheduler.java:93)
	at org.apache.kafka.connect.mirror.Scheduler.executeThread(Scheduler.java:112)
	at org.apache.kafka.connect.mirror.Scheduler.lambda$execute$2(Scheduler.java:63)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TopicExistsException: Topic 'heartbeats' already exists.
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:165)
	at org.apache.kafka.connect.mirror.MirrorUtils.createCompactedTopic(MirrorUtils.java:124)
	... 11 more
Caused by: org.apache.kafka.common.errors.TopicExistsException: Topic 'heartbeats' already exists.
```

This should not be treated as an error as it's expected to happen every time connectors are restarted.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
