### PR TITLE
KAFKA-14529: set inter.broker.protocol.version to pass broker registration

### DIFF
--- a/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
@@ -109,7 +109,9 @@ public class ZkClusterInvocationContext implements TestTemplateInvocationContext
                     @Override
                     public Properties serverConfig() {
                         Properties props = clusterConfig.serverProperties();
-                        props.put(KafkaConfig.InterBrokerProtocolVersionProp(), metadataVersion().version());
+                        if (!props.containsKey(KafkaConfig.InterBrokerProtocolVersionProp())) {
+                            props.put(KafkaConfig.InterBrokerProtocolVersionProp(), metadataVersion().version());
+                        }
                         return props;
                     }
 

--- a/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
@@ -18,7 +18,7 @@
 package kafka.server
 
 import kafka.test.ClusterInstance
-import kafka.test.annotation.{ClusterTest, Type}
+import kafka.test.annotation.{ClusterConfigProperty, ClusterTest, Type}
 import kafka.test.junit.ClusterTestExtensions
 import kafka.testkit.{KafkaClusterTestKit, TestKitNodes}
 import org.apache.kafka.common.Uuid
@@ -43,7 +43,9 @@ import scala.jdk.CollectionConverters._
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class KafkaServerKRaftRegistrationTest {
 
-  @ClusterTest(clusterType = Type.ZK, brokers = 3, metadataVersion = MetadataVersion.IBP_3_4_IV0)
+  @ClusterTest(clusterType = Type.ZK, brokers = 3, metadataVersion = MetadataVersion.IBP_3_4_IV0,
+    serverProperties = Array(new ClusterConfigProperty(key = "inter.broker.protocol.version", value = "3.4-IV0"))
+  )
   def testRegisterZkBrokerInKraft1(zkCluster: ClusterInstance): Unit = {
     val clusterId = zkCluster.clusterId()
 


### PR DESCRIPTION
We've introduced new metadata version 9 (IBP_3_4_IV1) for KIP-405, and it breaks the `KafkaServerKRaftRegistrationTest` unexpectedly. The error message is:
```
org.opentest4j.AssertionFailedError: Did not see 3 brokers within 30 seconds at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38) at org.junit.jupiter.api.Assertions.fail(Assertions.java:134) at kafka.server.KafkaServerKRaftRegistrationTest.testRegisterZkBrokerInKraft1(KafkaServerKRaftRegistrationTest.scala:78)
```

The reason is that in ZK migration mode, the ZK broker will use the IBP as supported version when broker registration as described [here](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaServer.scala#L406). In the test, we set the metadata version to `IBP_3_4_IV0`, but we didn't set the broker IBP to this version, which will default to the latest version. That's why it failed the tests because the broker registration keeps failing with `unsupportedVersion` error.

Fixed it by setting the broker IBP to the same version as `IBP_3_4_IV0`. We can also fix it by always setting the metadata version to the latest version though, I think what we want here is to make sure everything works fine in `IBP_3_4_IV0`.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
