### PR TITLE
KAFKA-14529 Use the MetadataVersion from ClusterConfig in ZK ClusterTests

### DIFF
--- a/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
@@ -109,7 +109,7 @@ public class ZkClusterInvocationContext implements TestTemplateInvocationContext
                     @Override
                     public Properties serverConfig() {
                         Properties props = clusterConfig.serverProperties();
-                        props.put(KafkaConfig.InterBrokerProtocolVersionProp(), metadataVersion().version());
+                        props.put(KafkaConfig.InterBrokerProtocolVersionProp(), clusterConfig.metadataVersion().version());
                         return props;
                     }
 

--- a/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
@@ -44,7 +44,7 @@ import scala.jdk.CollectionConverters._
 class KafkaServerKRaftRegistrationTest {
 
   @ClusterTest(clusterType = Type.ZK, brokers = 3, metadataVersion = MetadataVersion.IBP_3_4_IV0)
-  def testRegisterZkBrokerInKraft1(zkCluster: ClusterInstance): Unit = {
+  def testRegisterZkBrokerInKraft(zkCluster: ClusterInstance): Unit = {
     val clusterId = zkCluster.clusterId()
 
     // Bootstrap the ZK cluster ID into KRaft


### PR DESCRIPTION
Rather than using the MetadataVersion specified in IntegrationTestHarness, we should be using the MetadataVersion specified in the `@ClusterTest` annotation. This patch fixes the ZK setup for cluster tests to read MetadataVersion from ClusterConfig (which is built using the annotations).

Thanks to @showuon for finding the root cause of this issue!