### PR TITLE
KAFKA-14468: Implement CommitRequestManager to manage the commit and autocommit requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class CommitRequestManager implements RequestManager {
+    private final Queue<StagedCommit> stagedCommits;
+    // TODO: We will need to refactor the subscriptionState
+    private final SubscriptionState subscriptionState;
+    private final Logger log;
+    private final Optional<AutoCommitState> autoCommitState;
+    private final CoordinatorRequestManager coordinatorRequestManager;
+    private final GroupStateManager groupState;
+
+    public CommitRequestManager(
+            final Time time,
+            final LogContext logContext,
+            final SubscriptionState subscriptionState,
+            final ConsumerConfig config,
+            final CoordinatorRequestManager coordinatorRequestManager,
+            final GroupStateManager groupState) {
+        this.log = logContext.logger(getClass());
+        this.stagedCommits = new LinkedList<>();
+        if (config.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)) {
+            final long autoCommitInterval =
+                    Integer.toUnsignedLong(config.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG));
+            this.autoCommitState = Optional.of(new AutoCommitState(time, autoCommitInterval));
+        } else {
+            this.autoCommitState = Optional.empty();
+        }
+        this.coordinatorRequestManager = coordinatorRequestManager;
+        this.groupState = groupState;
+        this.subscriptionState = subscriptionState;
+    }
+
+    // Visible for testing
+    CommitRequestManager(
+            final LogContext logContext,
+            final SubscriptionState subscriptionState,
+            final CoordinatorRequestManager coordinatorRequestManager,
+            final GroupStateManager groupState,
+            final AutoCommitState autoCommitState) {
+        this.log = logContext.logger(getClass());
+        this.subscriptionState = subscriptionState;
+        this.coordinatorRequestManager = coordinatorRequestManager;
+        this.groupState = groupState;
+        this.autoCommitState = Optional.ofNullable(autoCommitState);
+        this.stagedCommits = new LinkedList<>();
+    }
+
+    /**
+     * Poll for the commit request if there's any. The function will also try to autocommit, if enabled.
+     *
+     * @param currentTimeMs
+     * @return
+     */
+    @Override
+    public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
+        if (coordinatorRequestManager == null) {
+            return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, new ArrayList<>());
+        }
+
+        maybeAutoCommit(currentTimeMs);
+
+        if (stagedCommits.isEmpty()) {
+            return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, new ArrayList<>());
+        }
+
+        List<NetworkClientDelegate.UnsentRequest> unsentCommitRequests =
+                stagedCommits.stream().map(StagedCommit::toUnsentRequest).collect(Collectors.toList());
+        return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.unmodifiableList(unsentCommitRequests));
+    }
+
+    public CompletableFuture<ClientResponse> add(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        StagedCommit commit = new StagedCommit(
+                offsets,
+                groupState.groupId,
+                groupState.groupInstanceId.orElse(null),
+                groupState.generation);
+        this.stagedCommits.add(commit);
+        return commit.future();
+    }
+
+    private void maybeAutoCommit(final long currentTimeMs) {
+        if (!autoCommitState.isPresent()) {
+            return;
+        }
+
+        AutoCommitState autocommit = autoCommitState.get();
+        if (!autocommit.canSendAutocommit(currentTimeMs)) {
+            return;
+        }
+
+        Map<TopicPartition, OffsetAndMetadata> allConsumedOffsets = subscriptionState.allConsumed();
+        log.debug("Auto-committing offsets {}", allConsumedOffsets);
+        this.add(allConsumedOffsets).whenComplete((response, throwable) -> {
+            if (throwable == null) {
+                log.debug("Completed asynchronous auto-commit of offsets {}", allConsumedOffsets);
+            }
+
+            if (throwable instanceof RetriableCommitFailedException) {
+                log.debug("Asynchronous auto-commit of offsets {} failed due to retriable error: {}", allConsumedOffsets,
+                        throwable);
+                autoCommitState.get().reset();
+            } else {
+                log.warn("Asynchronous auto-commit of offsets {} failed: {}", allConsumedOffsets,
+                        throwable.getMessage());
+            }
+        });
+        autocommit.reset();
+    }
+
+    public void clientPoll(final long currentTimeMs) {
+        this.autoCommitState.ifPresent(t -> t.ack(currentTimeMs));
+    }
+
+    private static class OffsetCommitRequestHandler extends NetworkClientDelegate.FutureCompletionHandler {
+        protected final Map<TopicPartition, OffsetAndMetadata> offsets;
+
+        public OffsetCommitRequestHandler(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+            this.offsets = offsets;
+        }
+    }
+
+    private class StagedCommit {
+        private final Map<TopicPartition, OffsetAndMetadata> offsets;
+        private final String groupId;
+        private final GroupStateManager.Generation generation;
+        private final String groupInstanceId;
+        private final NetworkClientDelegate.FutureCompletionHandler callback;
+
+        public StagedCommit(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                            final String groupId,
+                            final String groupInstanceId,
+                            final GroupStateManager.Generation generation) {
+            this.offsets = offsets;
+            // if no callback is provided, DefaultOffsetCommitCallback will be used.
+            this.callback = new NetworkClientDelegate.FutureCompletionHandler();
+            this.groupId = groupId;
+            this.generation = generation;
+            this.groupInstanceId = groupInstanceId;
+        }
+
+        public CompletableFuture<ClientResponse> future() {
+            return callback.future();
+        }
+
+        public NetworkClientDelegate.UnsentRequest toUnsentRequest() {
+            Map<String, OffsetCommitRequestData.OffsetCommitRequestTopic> requestTopicDataMap = new HashMap<>();
+            for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
+                TopicPartition topicPartition = entry.getKey();
+                OffsetAndMetadata offsetAndMetadata = entry.getValue();
+
+                OffsetCommitRequestData.OffsetCommitRequestTopic topic = requestTopicDataMap
+                        .getOrDefault(topicPartition.topic(),
+                                new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                                        .setName(topicPartition.topic())
+                        );
+
+                topic.partitions().add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                        .setPartitionIndex(topicPartition.partition())
+                        .setCommittedOffset(offsetAndMetadata.offset())
+                        .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                        .setCommittedMetadata(offsetAndMetadata.metadata())
+                );
+                requestTopicDataMap.put(topicPartition.topic(), topic);
+            }
+
+            OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(
+                    new OffsetCommitRequestData()
+                            .setGroupId(this.groupId)
+                            .setGenerationId(generation.generationId)
+                            .setMemberId(generation.memberId)
+                            .setGroupInstanceId(groupInstanceId)
+                            .setTopics(new ArrayList<>(requestTopicDataMap.values())));
+            return new NetworkClientDelegate.UnsentRequest(
+                    builder,
+                    coordinatorRequestManager.coordinator(),
+                    callback);
+        }
+    }
+
+    static class AutoCommitState {
+        private final Timer timer;
+        private final long autoCommitInterval;
+
+        public AutoCommitState(
+                final Time time,
+                final long autoCommitInterval) {
+            this.autoCommitInterval = autoCommitInterval;
+            this.timer = time.timer(autoCommitInterval);
+        }
+
+        public boolean canSendAutocommit(final long currentTimeMs) {
+            return this.timer.isExpired();
+        }
+
+        public void reset() {
+            this.timer.reset(autoCommitInterval);
+        }
+
+        public void ack(final long currentTimeMs) {
+            this.timer.update(currentTimeMs);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -144,6 +144,11 @@ public class CommitRequestManager implements RequestManager {
         this.autoCommitState.ifPresent(t -> t.ack(currentTimeMs));
     }
 
+    // Visible for testing
+    Queue<StagedCommit> stagedCommits() {
+        return this.stagedCommits;
+    }
+
     private class StagedCommit {
         private final Map<TopicPartition, OffsetAndMetadata> offsets;
         private final String groupId;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -61,7 +61,7 @@ public class DefaultBackgroundThread extends KafkaThread {
     private final ApplicationEventProcessor applicationEventProcessor;
     private final NetworkClientDelegate networkClientDelegate;
     private final ErrorEventHandler errorEventHandler;
-    private final GroupStateManager groupState;
+    private final GroupState groupState;
     private boolean running;
 
     private final Map<RequestManager.Type, Optional<RequestManager>> requestManagerRegistry;
@@ -76,7 +76,7 @@ public class DefaultBackgroundThread extends KafkaThread {
                             final ApplicationEventProcessor processor,
                             final ConsumerMetadata metadata,
                             final NetworkClientDelegate networkClient,
-                            final GroupStateManager groupState,
+                            final GroupState groupState,
                             final CoordinatorRequestManager coordinatorManager,
                             CommitRequestManager commitRequestManager) {
         super(BACKGROUND_THREAD_NAME, true);
@@ -120,7 +120,7 @@ public class DefaultBackgroundThread extends KafkaThread {
                     networkClient);
             this.running = true;
             this.errorEventHandler = new ErrorEventHandler(this.backgroundEventQueue);
-            this.groupState = new GroupStateManager(rebalanceConfig);
+            this.groupState = new GroupState(rebalanceConfig);
             this.requestManagerRegistry = Collections.unmodifiableMap(buildRequestManagerRegistry(logContext));
             this.applicationEventProcessor = new ApplicationEventProcessor(backgroundEventQueue, requestManagerRegistry);
         } catch (final Exception e) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -78,7 +78,7 @@ public class DefaultBackgroundThread extends KafkaThread {
                             final NetworkClientDelegate networkClient,
                             final GroupState groupState,
                             final CoordinatorRequestManager coordinatorManager,
-                            CommitRequestManager commitRequestManager) {
+                            final CommitRequestManager commitRequestManager) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
         this.running = true;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/GroupState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/GroupState.java
@@ -23,17 +23,17 @@ import org.apache.kafka.common.requests.OffsetCommitRequest;
 import java.util.Objects;
 import java.util.Optional;
 
-public class GroupStateManager {
+public class GroupState {
     public final String groupId;
     public final Optional<String> groupInstanceId;
     public Generation generation = Generation.NO_GENERATION;
 
-    public GroupStateManager(String groupId, Optional<String> groupInstanceId) {
+    public GroupState(String groupId, Optional<String> groupInstanceId) {
         this.groupId = groupId;
         this.groupInstanceId = groupInstanceId;
     }
 
-    public GroupStateManager(final GroupRebalanceConfig config) {
+    public GroupState(final GroupRebalanceConfig config) {
         this.groupId = config.groupId;
         this.groupInstanceId = config.groupInstanceId;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/GroupStateManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/GroupStateManager.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class GroupStateManager {
+    public final String groupId;
+    public final Optional<String> groupInstanceId;
+    public Generation generation = Generation.NO_GENERATION;
+
+    public GroupStateManager(String groupId, Optional<String> groupInstanceId) {
+        this.groupId = groupId;
+        this.groupInstanceId = groupInstanceId;
+    }
+
+    public GroupStateManager(final GroupRebalanceConfig config) {
+        this.groupId = config.groupId;
+        this.groupInstanceId = config.groupInstanceId;
+    }
+
+    protected static class Generation {
+        public static final Generation NO_GENERATION = new Generation(
+                OffsetCommitRequest.DEFAULT_GENERATION_ID,
+                JoinGroupRequest.UNKNOWN_MEMBER_ID,
+                null);
+
+        public final int generationId;
+        public final String memberId;
+        public final String protocolName;
+
+        public Generation(int generationId, String memberId, String protocolName) {
+            this.generationId = generationId;
+            this.memberId = memberId;
+            this.protocolName = protocolName;
+        }
+
+        /**
+         * @return true if this generation has a valid member id, false otherwise. A member might have an id before
+         * it becomes part of a group generation.
+         */
+        public boolean hasMemberId() {
+            return !memberId.isEmpty();
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final Generation that = (Generation) o;
+            return generationId == that.generationId &&
+                    Objects.equals(memberId, that.memberId) &&
+                    Objects.equals(protocolName, that.protocolName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(generationId, memberId, protocolName);
+        }
+
+        @Override
+        public String toString() {
+            return "Generation{" +
+                    "generationId=" + generationId +
+                    ", memberId='" + memberId + '\'' +
+                    ", protocol='" + protocolName + '\'' +
+                    '}';
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -201,9 +201,15 @@ public class NetworkClientDelegate implements AutoCloseable {
         private Timer timer;
 
         public UnsentRequest(
-            final AbstractRequest.Builder<?> requestBuilder,
-            final Optional<Node> node
-        ) {
+                final AbstractRequest.Builder<?> requestBuilder,
+                final Optional<Node> node) {
+            this(requestBuilder, node, new FutureCompletionHandler());
+        }
+
+        public UnsentRequest(
+                final AbstractRequest.Builder<?> requestBuilder,
+                final Optional<Node> node,
+                final FutureCompletionHandler handler) {
             Objects.requireNonNull(requestBuilder);
             this.requestBuilder = requestBuilder;
             this.node = node;
@@ -241,6 +247,10 @@ public class NetworkClientDelegate implements AutoCloseable {
 
         public void onFailure(final RuntimeException e) {
             future.completeExceptionally(e);
+        }
+
+        public CompletableFuture<ClientResponse> future() {
+            return future;
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -36,6 +36,6 @@ abstract public class ApplicationEvent {
         return type + " ApplicationEvent";
     }
     public enum Type {
-        NOOP, COMMIT,
+        NOOP, COMMIT, POLL,
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.NoopBackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.RequestManager;
@@ -25,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 
 public class ApplicationEventProcessor {
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
@@ -80,7 +78,7 @@ public class ApplicationEventProcessor {
         }
 
         CommitRequestManager manager = (CommitRequestManager) commitRequestManger.get();
-        CompletableFuture<ClientResponse> res = manager.add(event.offsets());
+        manager.add(event.offsets());
         return true;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -63,7 +63,7 @@ public class ApplicationEventProcessor {
     private boolean process(final PollApplicationEvent event) {
         Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
         if (!commitRequestManger.isPresent()) {
-            return false;
+            return true;
         }
 
         CommitRequestManager manager = (CommitRequestManager) commitRequestManger.get();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class CommitApplicationEvent extends ApplicationEvent {
+    final private CompletableFuture<Void> future;
+    final private Map<TopicPartition, OffsetAndMetadata> offsets;
+
+    public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        super(Type.COMMIT);
+        this.offsets = offsets;
+        Optional<Exception> exception = isValid(offsets);
+        if (exception.isPresent()) {
+            throw new RuntimeException(exception.get());
+        }
+        this.future = new CompletableFuture<>();
+    }
+
+    public CompletableFuture<Void> future() {
+        return future;
+    }
+
+    public Map<TopicPartition, OffsetAndMetadata> offsets() {
+        return offsets;
+    }
+
+    private Optional<Exception> isValid(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            OffsetAndMetadata offsetAndMetadata = entry.getValue();
+            if (offsetAndMetadata.offset() < 0) {
+                return Optional.of(new IllegalArgumentException("Invalid offset: " + offsetAndMetadata.offset()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        return getClass() + "_" + this.offsets;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -58,6 +58,7 @@ public class CommitApplicationEvent extends ApplicationEvent {
 
     @Override
     public String toString() {
-        return getClass() + "_" + this.offsets;
+        return "CommitApplicationEvent("
+                + "offsets=" + offsets + ")";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
@@ -14,18 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer.internals;
+package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+public class PollApplicationEvent extends ApplicationEvent {
+    public final long pollTimeMs;
 
-/**
- * {@code PollResult} consist of {@code UnsentRequest} if there are requests to send; otherwise, return the time till
- * the next poll event.
- */
-public interface RequestManager {
-    PollResult poll(long currentTimeMs);
-
-    enum Type {
-        COORDINATOR, COMMIT
+    protected PollApplicationEvent(final long currentTimeMs) {
+        super(Type.POLL);
+        this.pollTimeMs = currentTimeMs;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CommitRequestManagerTest {
+    private SubscriptionState subscriptionState;
+    private GroupStateManager groupStateManager;
+    private LogContext logContext;
+    private MockTime time;
+    private CoordinatorRequestManager coordinatorRequestManager;
+    private Properties props;
+
+    @BeforeEach
+    public void setup() {
+        this.logContext = new LogContext();
+        this.time = new MockTime(0);
+        this.subscriptionState = mock(SubscriptionState.class);
+        this.coordinatorRequestManager = mock(CoordinatorRequestManager.class);
+        this.groupStateManager = new GroupStateManager("group-1", Optional.empty());
+
+        this.props = new Properties();
+        this.props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100);
+        this.props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    }
+
+    @Test
+    public void testPoll() {
+        CommitRequestManager commitRequestManger = create(false, 0);
+        NetworkClientDelegate.PollResult res = commitRequestManger.poll(time.milliseconds());
+        assertEquals(0, res.unsentRequests.size());
+        assertEquals(Long.MAX_VALUE, res.timeUntilNextPollMs);
+
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("t1", 0), new OffsetAndMetadata(0));
+        commitRequestManger.add(offsets);
+        res = commitRequestManger.poll(time.milliseconds());
+        assertEquals(1, res.unsentRequests.size());
+    }
+
+    @Test
+    public void testPollAndAutocommit() {
+        CommitRequestManager commitRequestManger = create(true, 100);
+        NetworkClientDelegate.PollResult res = commitRequestManger.poll(time.milliseconds());
+        assertEquals(0, res.unsentRequests.size());
+        assertEquals(Long.MAX_VALUE, res.timeUntilNextPollMs);
+
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("t1", 0), new OffsetAndMetadata(0));
+        commitRequestManger.clientPoll(time.milliseconds());
+        when(subscriptionState.allConsumed()).thenReturn(offsets);
+        time.sleep(100);
+        commitRequestManger.clientPoll(time.milliseconds());
+        res = commitRequestManger.poll(time.milliseconds());
+        assertEquals(1, res.unsentRequests.size());
+    }
+
+    private CommitRequestManager create(final boolean autoCommitEnabled, final long autoCommitInterval) {
+        return new CommitRequestManager(
+                this.time,
+                this.logContext,
+                this.subscriptionState,
+                new ConsumerConfig(props),
+                this.coordinatorRequestManager,
+                this.groupStateManager);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,6 +108,15 @@ public class CommitRequestManagerTest {
         commitRequestManger.clientPoll(time.milliseconds());
         res = commitRequestManger.poll(time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
+    }
+
+    @Test
+    public void testEnsureStagedCommitsPurgedAfterPoll() {
+        CommitRequestManager commitRequestManger = create(true, 100);
+        commitRequestManger.add(new HashMap<>());
+        assertEquals(1, commitRequestManger.stagedCommits().size());
+        NetworkClientDelegate.PollResult res = commitRequestManger.poll(time.milliseconds());
+        assertTrue(commitRequestManger.stagedCommits().isEmpty());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -73,7 +73,7 @@ public class CommitRequestManagerTest {
     }
 
     @Test
-    public void testPollAndAutocommit() {
+    public void testPollAndAutoCommit() {
         CommitRequestManager commitRequestManger = create(true, 100);
         NetworkClientDelegate.PollResult res = commitRequestManger.poll(time.milliseconds());
         assertEquals(0, res.unsentRequests.size());
@@ -87,6 +87,14 @@ public class CommitRequestManagerTest {
         commitRequestManger.clientPoll(time.milliseconds());
         res = commitRequestManger.poll(time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
+    }
+
+    @Test
+    public void testAutoCommitFuture() {
+        CommitRequestManager commitRequestManger = create(true, 100);
+        commitRequestManger.sendAutoCommit(new HashMap<>()).complete(null);
+        commitRequestManger.sendAutoCommit(new HashMap<>()).completeExceptionally(new RuntimeException("mock " +
+                "exception"));
     }
 
     private CommitRequestManager create(final boolean autoCommitEnabled, final long autoCommitInterval) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
@@ -50,7 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultBackgroundThreadTest {
-    private static final long REFRESH_BACK_OFF_MS = 100;
+    private static final long RETRY_BACKOFF_MS = 100;
     private final Properties properties = new Properties();
     private MockTime time;
     private ConsumerMetadata metadata;
@@ -61,6 +62,8 @@ public class DefaultBackgroundThreadTest {
     private CoordinatorRequestManager coordinatorManager;
     private ErrorEventHandler errorEventHandler;
     private int requestTimeoutMs = 500;
+    private GroupStateManager groupState;
+    private CommitRequestManager commitManager;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -73,6 +76,16 @@ public class DefaultBackgroundThreadTest {
         this.processor = mock(ApplicationEventProcessor.class);
         this.coordinatorManager = mock(CoordinatorRequestManager.class);
         this.errorEventHandler = mock(ErrorEventHandler.class);
+        GroupRebalanceConfig rebalanceConfig = new GroupRebalanceConfig(
+                100,
+                100,
+                100,
+                "group_id",
+                Optional.empty(),
+                100,
+                true);
+        this.groupState = new GroupStateManager(rebalanceConfig);
+        this.commitManager = mock(CommitRequestManager.class);
     }
 
     @Test
@@ -87,7 +100,8 @@ public class DefaultBackgroundThreadTest {
     public void testApplicationEvent() {
         this.applicationEventsQueue = new LinkedBlockingQueue<>();
         this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollResult());
+        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new NoopApplicationEvent("noop event");
         this.applicationEventsQueue.add(e);
@@ -99,9 +113,11 @@ public class DefaultBackgroundThreadTest {
     @Test
     void testFindCoordinator() {
         DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        when(this.coordinatorManager.poll(time.milliseconds())).thenReturn(mockPollResult());
+        when(this.coordinatorManager.poll(time.milliseconds())).thenReturn(mockPollCoordinatorResult());
+        when(this.commitManager.poll(time.milliseconds())).thenReturn(mockPollCommitResult());
         backgroundThread.runOnce();
         Mockito.verify(coordinatorManager, times(1)).poll(anyLong());
+        Mockito.verify(commitManager, times(1)).poll(anyLong());
         Mockito.verify(networkClient, times(1)).poll(anyLong(), anyLong());
         backgroundThread.close();
     }
@@ -138,7 +154,7 @@ public class DefaultBackgroundThreadTest {
     private DefaultBackgroundThread mockBackgroundThread() {
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(RETRY_BACKOFF_MS_CONFIG, REFRESH_BACK_OFF_MS);
+        properties.put(RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
 
         return new DefaultBackgroundThread(
                 this.time,
@@ -150,12 +166,20 @@ public class DefaultBackgroundThreadTest {
                 processor,
                 this.metadata,
                 this.networkClient,
-                this.coordinatorManager);
+                this.groupState,
+                this.coordinatorManager,
+                this.commitManager);
     }
 
-    private NetworkClientDelegate.PollResult mockPollResult() {
+    private NetworkClientDelegate.PollResult mockPollCoordinatorResult() {
         return new NetworkClientDelegate.PollResult(
-                0,
+                RETRY_BACKOFF_MS,
+                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+    }
+
+    private NetworkClientDelegate.PollResult mockPollCommitResult() {
+        return new NetworkClientDelegate.PollResult(
+                RETRY_BACKOFF_MS,
                 Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -113,11 +113,10 @@ public class DefaultBackgroundThreadTest {
     @Test
     void testFindCoordinator() {
         DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        when(this.coordinatorManager.poll(time.milliseconds())).thenReturn(mockPollCoordinatorResult());
-        when(this.commitManager.poll(time.milliseconds())).thenReturn(mockPollCommitResult());
+        when(this.coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(this.commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         backgroundThread.runOnce();
         Mockito.verify(coordinatorManager, times(1)).poll(anyLong());
-        Mockito.verify(commitManager, times(1)).poll(anyLong());
         Mockito.verify(networkClient, times(1)).poll(anyLong(), anyLong());
         backgroundThread.close();
     }
@@ -138,8 +137,8 @@ public class DefaultBackgroundThreadTest {
     }
 
     private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(
-        final Time time,
-        final long timeout
+            final Time time,
+            final long timeout
     ) {
         NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
                 new FindCoordinatorRequest.Builder(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -62,7 +62,7 @@ public class DefaultBackgroundThreadTest {
     private CoordinatorRequestManager coordinatorManager;
     private ErrorEventHandler errorEventHandler;
     private int requestTimeoutMs = 500;
-    private GroupStateManager groupState;
+    private GroupState groupState;
     private CommitRequestManager commitManager;
 
     @BeforeEach
@@ -84,7 +84,7 @@ public class DefaultBackgroundThreadTest {
                 Optional.empty(),
                 100,
                 true);
-        this.groupState = new GroupStateManager(rebalanceConfig);
+        this.groupState = new GroupState(rebalanceConfig);
         this.commitManager = mock(CommitRequestManager.class);
     }
 


### PR DESCRIPTION
This pull request introduces a CommitRequestManager to efficiently manage commit requests from clients and the autocommit state. The manager utilizes a "staged" commit queue to store commit requests made by clients. A background thread regularly polls the CommitRequestManager, which then checks the queue for any outstanding commit requests. When permitted, the CommitRequestManager generates a PollResult which contains a list of UnsentRequests that are subsequently processed by the NetworkClientDelegate. 

In addition, a RequestManagerRegistry has been implemented to hold all request managers, including the new CommitRequestManager and the CoordinatorRequestManager. The registry is regularly polled by a background thread in each event loop, ensuring that all request managers are kept up to date and able to handle incoming requests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
