### PR TITLE
KAFKA-14299: Avoid interrupted exceptions during clean shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -106,6 +106,7 @@ public class DefaultStateUpdater implements StateUpdater {
             } catch (final RuntimeException anyOtherException) {
                 handleRuntimeException(anyOtherException);
             } finally {
+                Thread.interrupted(); // Clear the interrupted flag.
                 removeAddedTasksFromInputQueue();
                 removeUpdatingAndPausedTasks();
                 shutdownGate.countDown();
@@ -443,8 +444,8 @@ public class DefaultStateUpdater implements StateUpdater {
     @Override
     public void shutdown(final Duration timeout) {
         if (stateUpdaterThread != null) {
-            stateUpdaterThread.isRunning.set(false);
             stateUpdaterThread.interrupt();
+            stateUpdaterThread.isRunning.set(false);
             try {
                 if (!shutdownGate.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
                     throw new StreamsException("State updater thread did not shutdown within the timeout");


### PR DESCRIPTION
The call to `interrupt` on the state updater thread during shutdown
could interrupt the thread while writing the checkpoint file. This can
cause a failure to write the checkpoint file and a misleading stack
trace in the logs.

I found no good way to test this in the unit tests.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
