### PR TITLE
MINOR: Add zk migration field to the ApiVersionsResponse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -84,6 +84,10 @@ public class ApiVersionsResponse extends AbstractResponse {
         return version >= 2;
     }
 
+    public short zkMigrationReady() {
+        return data.zkMigrationReady();
+    }
+
     public static ApiVersionsResponse parse(ByteBuffer buffer, short version) {
         // Fallback to version 0 for ApiVersions response. If a client sends an ApiVersionsRequest
         // using a version higher than that supported by the broker, a version 0 response is sent

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -84,7 +84,7 @@ public class ApiVersionsResponse extends AbstractResponse {
         return version >= 2;
     }
 
-    public short zkMigrationReady() {
+    public boolean zkMigrationReady() {
         return data.zkMigrationReady();
     }
 

--- a/clients/src/main/resources/common/message/ApiVersionsRequest.json
+++ b/clients/src/main/resources/common/message/ApiVersionsRequest.json
@@ -21,6 +21,9 @@
   // Versions 0 through 2 of ApiVersionsRequest are the same.
   //
   // Version 3 is the first flexible version and adds ClientSoftwareName and ClientSoftwareVersion.
+  //
+  // Version 4 adds zk to kraft migration field to the response used to determine if the controller
+  // is ready for migration.
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/ApiVersionsRequest.json
+++ b/clients/src/main/resources/common/message/ApiVersionsRequest.json
@@ -21,9 +21,6 @@
   // Versions 0 through 2 of ApiVersionsRequest are the same.
   //
   // Version 3 is the first flexible version and adds ClientSoftwareName and ClientSoftwareVersion.
-  //
-  // Version 4 adds zk to kraft migration field to the response used to determine if the controller
-  // is ready for migration.
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/ApiVersionsRequest.json
+++ b/clients/src/main/resources/common/message/ApiVersionsRequest.json
@@ -21,7 +21,7 @@
   // Versions 0 through 2 of ApiVersionsRequest are the same.
   //
   // Version 3 is the first flexible version and adds ClientSoftwareName and ClientSoftwareVersion.
-  "validVersions": "0-4",
+  "validVersions": "0-3",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ClientSoftwareName", "type": "string", "versions": "3+",

--- a/clients/src/main/resources/common/message/ApiVersionsRequest.json
+++ b/clients/src/main/resources/common/message/ApiVersionsRequest.json
@@ -21,7 +21,7 @@
   // Versions 0 through 2 of ApiVersionsRequest are the same.
   //
   // Version 3 is the first flexible version and adds ClientSoftwareName and ClientSoftwareVersion.
-  "validVersions": "0-3",
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ClientSoftwareName", "type": "string", "versions": "3+",

--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -70,7 +70,7 @@
           "about": "The cluster-wide finalized min version level for the feature."}
       ]
     },
-    { "name":  "ZkMigrationReady", "type": "bool", "versions": "4+", "taggedVersions": "4+",
+    { "name":  "ZkMigrationReady", "type": "bool", "versions": "3+", "taggedVersions": "3+",
       "tag": 3, "ignorable": true, "default": "false",
       "about": "Set by a KRaft controller if the required configurations for ZK migration are present" }
   ]

--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -25,12 +25,9 @@
   // not in the header. The length of the header must not change in order to guarantee the
   // backward compatibility.
   //
-  // Version 4 adds zk to kraft migration field to the response used to determine if the controller
-  // is ready for migration.
-  //
   // Starting from Apache Kafka 2.4 (KIP-511), ApiKeys field is populated with the supported
   // versions of the ApiVersionsRequest when an UNSUPPORTED_VERSION error is returned.
-  "validVersions": "0-4",
+  "validVersions": "0-3",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
@@ -73,7 +70,8 @@
           "about": "The cluster-wide finalized min version level for the feature."}
       ]
     },
-    { "name":  "ZkMigrationReady", "type": "int8", "versions": "4+", "taggedVersions": "4+", "tag": 3, "ignorable": true,
+    { "name":  "ZkMigrationReady", "type": "bool", "versions": "4+", "taggedVersions": "4+",
+      "tag": 3, "ignorable": true, "default": "false",
       "about": "Set by a KRaft controller if the required configurations for ZK migration are present" }
   ]
 }

--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -25,9 +25,12 @@
   // not in the header. The length of the header must not change in order to guarantee the
   // backward compatibility.
   //
+  // Version 4 adds zk to kraft migration field to the response used to determine if the controller
+  // is ready for migration.
+  //
   // Starting from Apache Kafka 2.4 (KIP-511), ApiKeys field is populated with the supported
   // versions of the ApiVersionsRequest when an UNSUPPORTED_VERSION error is returned.
-  "validVersions": "0-3",
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
@@ -69,6 +72,8 @@
         {"name":  "MinVersionLevel", "type": "int16", "versions":  "3+",
           "about": "The cluster-wide finalized min version level for the feature."}
       ]
-    }
+    },
+    { "name":  "ZkMigrationReady", "type": "int8", "versions": "4+", "taggedVersions": "4+", "tag": 3, "ignorable": true,
+      "about": "Set by a KRaft controller if the required configurations for ZK migration are present" }
   ]
 }


### PR DESCRIPTION
This field will be used by the KRaft controller to see if the quorum is ready to handle zk -> kraft migration.
