### PR TITLE
KAFKA-14540: Fix DataOutputStreamWritable#writeByteBuffer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/DataOutputStreamWritable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/DataOutputStreamWritable.java
@@ -99,7 +99,7 @@ public class DataOutputStreamWritable implements Writable, Closeable {
     public void writeByteBuffer(ByteBuffer buf) {
         try {
             if (buf.hasArray()) {
-                out.write(buf.array(), buf.arrayOffset(), buf.limit());
+                out.write(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
             } else {
                 byte[] bytes = Utils.toArray(buf);
                 out.write(bytes);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/DataOutputStreamWritable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/DataOutputStreamWritable.java
@@ -99,7 +99,7 @@ public class DataOutputStreamWritable implements Writable, Closeable {
     public void writeByteBuffer(ByteBuffer buf) {
         try {
             if (buf.hasArray()) {
-                out.write(buf.array(), buf.position(), buf.limit());
+                out.write(buf.array(), buf.arrayOffset(), buf.limit());
             } else {
                 byte[] bytes = Utils.toArray(buf);
                 out.write(bytes);

--- a/clients/src/test/java/org/apache/kafka/common/protocol/DataOutputStreamWritableTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/DataOutputStreamWritableTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.Test;
+
+public class DataOutputStreamWritableTest {
+    @Test
+    public void testWritingSlicedByteBuffer() {
+        ByteBuffer expectedBuffer = ByteBuffer.wrap(new byte[]{2, 3});
+        ByteBuffer originalBuffer = ByteBuffer.allocate(4);
+        for (int i = 0; i < originalBuffer.limit(); i++) {
+            originalBuffer.put(i, (byte) i);
+        }
+        // Move position forward to ensure slice is not whole buffer
+        originalBuffer.position(2);
+        ByteBuffer slicedBuffer = originalBuffer.slice();
+
+        ByteBuffer actualBuf = ByteBuffer.allocate(2);
+        Writable writable = new DataOutputStreamWritable(new DataOutputStream(new ByteBufferOutputStream(actualBuf)));
+
+        writable.writeByteBuffer(slicedBuffer);
+
+        assertEquals(2, actualBuf.position(), "Writing to the buffer moves the position forward");
+        assertEquals(expectedBuffer, actualBuf.position(0),
+                "Actual buffer should have expected elements");
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/DataOutputStreamWritableTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/DataOutputStreamWritableTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.protocol;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.DataOutputStream;
@@ -40,7 +41,7 @@ public class DataOutputStreamWritableTest {
         writable.writeByteBuffer(slicedBuffer);
 
         assertEquals(2, resultBuffer.position(), "Writing to the buffer moves the position forward");
-        assertEquals(expectedArray, resultBuffer.array(), "Result buffer should have expected elements");
+        assertArrayEquals(expectedArray, resultBuffer.array(), "Result buffer should have expected elements");
     }
 
     @Test
@@ -61,6 +62,6 @@ public class DataOutputStreamWritableTest {
         writable.writeByteBuffer(slicedBuffer);
 
         assertEquals(1, resultBuffer.position(), "Writing to the buffer moves the position forward");
-        assertEquals(expectedArray, resultBuffer.array(), "Result buffer should have expected elements");
+        assertArrayEquals(expectedArray, resultBuffer.array(), "Result buffer should have expected elements");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/DataOutputStreamWritableTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/DataOutputStreamWritableTest.java
@@ -26,22 +26,41 @@ import org.junit.jupiter.api.Test;
 public class DataOutputStreamWritableTest {
     @Test
     public void testWritingSlicedByteBuffer() {
-        ByteBuffer expectedBuffer = ByteBuffer.wrap(new byte[]{2, 3});
-        ByteBuffer originalBuffer = ByteBuffer.allocate(4);
-        for (int i = 0; i < originalBuffer.limit(); i++) {
-            originalBuffer.put(i, (byte) i);
-        }
-        // Move position forward to ensure slice is not whole buffer
-        originalBuffer.position(2);
-        ByteBuffer slicedBuffer = originalBuffer.slice();
+        byte[] expectedArray = new byte[]{2, 3, 0, 0};
+        ByteBuffer sourceBuffer = ByteBuffer.wrap(new byte[]{0, 1, 2, 3});
+        ByteBuffer resultBuffer = ByteBuffer.allocate(4);
 
-        ByteBuffer actualBuf = ByteBuffer.allocate(2);
-        Writable writable = new DataOutputStreamWritable(new DataOutputStream(new ByteBufferOutputStream(actualBuf)));
+        // Move position forward to ensure slice is not whole buffer
+        sourceBuffer.position(2);
+        ByteBuffer slicedBuffer = sourceBuffer.slice();
+
+        Writable writable = new DataOutputStreamWritable(
+                new DataOutputStream(new ByteBufferOutputStream(resultBuffer)));
 
         writable.writeByteBuffer(slicedBuffer);
 
-        assertEquals(2, actualBuf.position(), "Writing to the buffer moves the position forward");
-        assertEquals(expectedBuffer, actualBuf.position(0),
-                "Actual buffer should have expected elements");
+        assertEquals(2, resultBuffer.position(), "Writing to the buffer moves the position forward");
+        assertEquals(expectedArray, resultBuffer.array(), "Result buffer should have expected elements");
+    }
+
+    @Test
+    public void testWritingSlicedByteBufferWithNonZeroPosition() {
+        byte[] expectedArray = new byte[]{3, 0, 0, 0};
+        ByteBuffer originalBuffer = ByteBuffer.wrap(new byte[]{0, 1, 2, 3});
+        ByteBuffer resultBuffer = ByteBuffer.allocate(4);
+
+        // Move position forward to ensure slice is backed by heap buffer with non-zero offset
+        originalBuffer.position(2);
+        ByteBuffer slicedBuffer = originalBuffer.slice();
+        // Move the slice's position forward to ensure the writer starts reading at that position
+        slicedBuffer.position(1);
+
+        Writable writable = new DataOutputStreamWritable(
+                new DataOutputStream(new ByteBufferOutputStream(resultBuffer)));
+
+        writable.writeByteBuffer(slicedBuffer);
+
+        assertEquals(1, resultBuffer.position(), "Writing to the buffer moves the position forward");
+        assertEquals(expectedArray, resultBuffer.array(), "Result buffer should have expected elements");
     }
 }


### PR DESCRIPTION
When writing a `ByteBuffer` backed by a `HeapBuffer` to a `DataOutputStream`, it is necessary to pass in the offset and the position, not just the position. It is also necessary to pass the remain length, not the limit. The current code results in writing the wrong data to `DataOutputStream`. While the `DataOutputStreamWritable` is used in the project, I do not see any references that would utilize this code path, so this bug fix is relatively minor.

I added a new test to cover the exact bug. The test fails without this change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
