### PR TITLE
MINOR: remove onChange call in stream assignor assign method

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -422,7 +422,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             if (minReceivedMetadataVersion >= 2) {
                 populatePartitionsByHostMaps(partitionsByHost, standbyPartitionsByHost, partitionsForTask, clientMetadataMap);
             }
-            streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, fullMetadata);
 
             // ---------------- Step Four ---------------- //
 


### PR DESCRIPTION
## Description
Remove unnecessary calls in assign method. From @ableegoldman : 
> That said, yes we can definitely remove the one that’s just in #assign — tbh it’s weird that it’s even there at all since this would only be called for the group leader anyways, so it can’t be that important for IQ. It’s probably only still there for historical reasons although I can’t even imagine what the original reason was

## Test
Existing tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
