### PR TITLE
KAFKA-14558: Move/Rewrite LastRecord, TxnMetadata, BatchMetadata, ProducerStateEntry, and ProducerAppendInfo to the storage module

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -681,7 +681,7 @@ private[log] class Cleaner(val id: Int,
           // 3) The last entry in the log is a transaction marker. We retain this marker since it has the
           //    last producer epoch, which is needed to ensure fencing.
           lastRecordsOfActiveProducers.get(batch.producerId).exists { lastRecord =>
-            if(lastRecord.lastDataOffset.isPresent) {
+            if (lastRecord.lastDataOffset.isPresent) {
               batch.lastOffset == lastRecord.lastDataOffset.getAsLong
             } else {
               batch.isControlBatch && batch.producerEpoch == lastRecord.producerEpoch

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -174,8 +174,7 @@ class LogCleaner(initialConfig: CleanerConfig,
   }
 
   override def validateReconfiguration(newConfig: KafkaConfig): Unit = {
-    val newCleanerConfig = LogCleaner.cleanerConfig(newConfig)
-    val numThreads = newCleanerConfig.numThreads
+    val numThreads = LogCleaner.cleanerConfig(newConfig).numThreads
     val currentThreads = config.numThreads
     if (numThreads < 1)
       throw new ConfigException(s"Log cleaner threads should be at least 1")

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.utils.{BufferSupplier, Time, Utils}
 import org.apache.kafka.server.log.internals.{AbortedTxn, AppendOrigin, CompletedTxn, LazyIndex, LogConfig, LogOffsetMetadata, OffsetIndex, OffsetPosition, TimeIndex, TimestampOffset, TransactionIndex, TxnIndexSearchResult}
 
 import java.util.Optional
+import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
 import scala.math._
 
@@ -249,7 +250,7 @@ class LogSegment private[log] (val log: FileRecords,
     if (batch.hasProducerId) {
       val producerId = batch.producerId
       val appendInfo = producerStateManager.prepareUpdate(producerId, origin = AppendOrigin.REPLICATION)
-      val maybeCompletedTxn = appendInfo.append(batch, firstOffsetMetadataOpt = None)
+      val maybeCompletedTxn = appendInfo.append(batch, Optional.empty()).asScala
       producerStateManager.update(appendInfo)
       maybeCompletedTxn.foreach { completedTxn =>
         val lastStableOffset = producerStateManager.lastStableOffset(completedTxn)

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -101,12 +101,12 @@ object ProducerStateManager {
         val offsetDelta = producerEntryStruct.getInt(OffsetDeltaField)
         val coordinatorEpoch = producerEntryStruct.getInt(CoordinatorEpochField)
         val currentTxnFirstOffset = producerEntryStruct.getLong(CurrentTxnFirstOffsetField)
-        val lastAppendedDataBatches = new java.util.ArrayDeque[BatchMetadata]
+        val batchMetadata = new java.util.ArrayDeque[BatchMetadata]
         if (offset >= 0)
-          lastAppendedDataBatches.add(new BatchMetadata(seq, offset, offsetDelta, timestamp))
+          batchMetadata.add(new BatchMetadata(seq, offset, offsetDelta, timestamp))
 
         val currentTxnFirstOffsetValue = if (currentTxnFirstOffset >= 0) OptionalLong.of(currentTxnFirstOffset) else OptionalLong.empty()
-        new ProducerStateEntry(producerId, lastAppendedDataBatches, producerEpoch,
+        new ProducerStateEntry(producerId, batchMetadata, producerEpoch,
           coordinatorEpoch, timestamp, currentTxnFirstOffsetValue)
       }
     } catch {

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -101,11 +101,11 @@ object ProducerStateManager {
         val offsetDelta = producerEntryStruct.getInt(OffsetDeltaField)
         val coordinatorEpoch = producerEntryStruct.getInt(CoordinatorEpochField)
         val currentTxnFirstOffset = producerEntryStruct.getLong(CurrentTxnFirstOffsetField)
-        val lastAppendedDataBatches = new java.util.ArrayList[BatchMetadata]
+        val lastAppendedDataBatches = new java.util.ArrayDeque[BatchMetadata]
         if (offset >= 0)
           lastAppendedDataBatches.add(new BatchMetadata(seq, offset, offsetDelta, timestamp))
 
-        val currentTxnFirstOffsetValue:OptionalLong = if (currentTxnFirstOffset >= 0) OptionalLong.of(currentTxnFirstOffset) else OptionalLong.empty()
+        val currentTxnFirstOffsetValue = if (currentTxnFirstOffset >= 0) OptionalLong.of(currentTxnFirstOffset) else OptionalLong.empty()
         new ProducerStateEntry(producerId, lastAppendedDataBatches, producerEpoch,
           coordinatorEpoch, timestamp, currentTxnFirstOffsetValue)
       }
@@ -402,8 +402,8 @@ class ProducerStateManager(
    * Update the mapping with the given append information
    */
   def update(appendInfo: ProducerAppendInfo): Unit = {
-    if (appendInfo.producerId == RecordBatch.NO_PRODUCER_ID)
-      throw new IllegalArgumentException(s"Invalid producer id ${appendInfo.producerId} passed to update " +
+    if (appendInfo.producerId() == RecordBatch.NO_PRODUCER_ID)
+      throw new IllegalArgumentException(s"Invalid producer id ${appendInfo.producerId()} passed to update " +
         s"for partition $topicPartition")
 
     trace(s"Updated producer ${appendInfo.producerId} state to $appendInfo")

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -29,7 +29,7 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.{Files, NoSuchFileException, StandardOpenOption}
-import java.util.OptionalLong
+import java.util.{Optional, OptionalLong}
 import java.util.concurrent.ConcurrentSkipListMap
 import scala.collection.{immutable, mutable}
 import scala.jdk.CollectionConverters._
@@ -93,9 +93,11 @@ object ProducerStateManager {
         val offsetDelta = producerEntryStruct.getInt(OffsetDeltaField)
         val coordinatorEpoch = producerEntryStruct.getInt(CoordinatorEpochField)
         val currentTxnFirstOffset = producerEntryStruct.getLong(CurrentTxnFirstOffsetField)
-        val batchMetadata: BatchMetadata = if (offset >= 0) new BatchMetadata(seq, offset, offsetDelta, timestamp) else null
+        val batchMetadata =
+          if (offset >= 0) Optional.of(new BatchMetadata(seq, offset, offsetDelta, timestamp))
+          else Optional.empty[BatchMetadata]()
         val currentTxnFirstOffsetValue = if (currentTxnFirstOffset >= 0) OptionalLong.of(currentTxnFirstOffset) else OptionalLong.empty()
-        new ProducerStateEntry(producerId, batchMetadata, producerEpoch, coordinatorEpoch, timestamp, currentTxnFirstOffsetValue)
+        new ProducerStateEntry(producerId, producerEpoch, coordinatorEpoch, timestamp, currentTxnFirstOffsetValue, batchMetadata)
       }
     } catch {
       case e: SchemaException =>

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -93,11 +93,7 @@ object ProducerStateManager {
         val offsetDelta = producerEntryStruct.getInt(OffsetDeltaField)
         val coordinatorEpoch = producerEntryStruct.getInt(CoordinatorEpochField)
         val currentTxnFirstOffset = producerEntryStruct.getLong(CurrentTxnFirstOffsetField)
-        val batchMetadata: java.util.List[BatchMetadata] =
-          if (offset >= 0)
-            java.util.Collections.singletonList[BatchMetadata](new BatchMetadata(seq, offset, offsetDelta, timestamp))
-          else java.util.Collections.emptyList[BatchMetadata]()
-
+        val batchMetadata: BatchMetadata = if (offset >= 0) new BatchMetadata(seq, offset, offsetDelta, timestamp) else null
         val currentTxnFirstOffsetValue = if (currentTxnFirstOffset >= 0) OptionalLong.of(currentTxnFirstOffset) else OptionalLong.empty()
         new ProducerStateEntry(producerId, batchMetadata, producerEpoch, coordinatorEpoch, timestamp, currentTxnFirstOffsetValue)
       }

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -34,14 +34,6 @@ import java.util.concurrent.ConcurrentSkipListMap
 import scala.collection.{immutable, mutable}
 import scala.jdk.CollectionConverters._
 
-
-
-
-
-
-
-
-
 object ProducerStateManager {
   val LateTransactionBufferMs = 5 * 60 * 1000
 
@@ -101,13 +93,13 @@ object ProducerStateManager {
         val offsetDelta = producerEntryStruct.getInt(OffsetDeltaField)
         val coordinatorEpoch = producerEntryStruct.getInt(CoordinatorEpochField)
         val currentTxnFirstOffset = producerEntryStruct.getLong(CurrentTxnFirstOffsetField)
-        val batchMetadata = new java.util.ArrayDeque[BatchMetadata]
-        if (offset >= 0)
-          batchMetadata.add(new BatchMetadata(seq, offset, offsetDelta, timestamp))
+        val batchMetadata: java.util.List[BatchMetadata] =
+          if (offset >= 0)
+            java.util.Collections.singletonList[BatchMetadata](new BatchMetadata(seq, offset, offsetDelta, timestamp))
+          else java.util.Collections.emptyList[BatchMetadata]()
 
         val currentTxnFirstOffsetValue = if (currentTxnFirstOffset >= 0) OptionalLong.of(currentTxnFirstOffset) else OptionalLong.empty()
-        new ProducerStateEntry(producerId, batchMetadata, producerEpoch,
-          coordinatorEpoch, timestamp, currentTxnFirstOffsetValue)
+        new ProducerStateEntry(producerId, batchMetadata, producerEpoch, coordinatorEpoch, timestamp, currentTxnFirstOffsetValue)
       }
     } catch {
       case e: SchemaException =>

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -384,7 +384,7 @@ class ProducerStateManager(
   }
 
   def prepareUpdate(producerId: Long, origin: AppendOrigin): ProducerAppendInfo = {
-    val currentEntry = lastEntry(producerId).getOrElse(new ProducerStateEntry(producerId))
+    val currentEntry = lastEntry(producerId).getOrElse(ProducerStateEntry.empty(producerId))
     new ProducerAppendInfo(topicPartition, producerId, currentEntry, origin)
   }
 

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -21,7 +21,7 @@ import com.yammer.metrics.core.MetricName
 
 import java.io.{File, IOException}
 import java.nio.file.Files
-import java.util.Optional
+import java.util.{Optional, OptionalLong}
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, TimeUnit}
 import kafka.common.{OffsetsOutOfOrderException, UnexpectedAppendOffsetException}
 import kafka.log.remote.RemoteLogManager
@@ -42,14 +42,14 @@ import org.apache.kafka.common.utils.{PrimitiveRef, Time, Utils}
 import org.apache.kafka.common.{InvalidRecordException, KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.IBP_0_10_0_IV0
-import org.apache.kafka.server.log.internals.{AbortedTxn, AppendOrigin, CompletedTxn, LastRecord, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogValidator}
+import org.apache.kafka.server.log.internals.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, LastRecord, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogValidator}
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig
 import org.apache.kafka.server.record.BrokerCompressionType
 
 import scala.annotation.nowarn
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, immutable, mutable}
-import scala.compat.java8.OptionConverters.RichOptionalGeneric
+import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
 
 object LogAppendInfo {

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -42,7 +42,7 @@ import org.apache.kafka.common.utils.{PrimitiveRef, Time, Utils}
 import org.apache.kafka.common.{InvalidRecordException, KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.IBP_0_10_0_IV0
-import org.apache.kafka.server.log.internals.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, LastRecord, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogValidator}
+import org.apache.kafka.server.log.internals.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, LastRecord, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogValidator, ProducerAppendInfo}
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig
 import org.apache.kafka.server.record.BrokerCompressionType
 
@@ -686,7 +686,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   private[log] def lastRecordsOfActiveProducers: Map[Long, LastRecord] = lock synchronized {
     producerStateManager.activeProducers.map { case (producerId, producerIdEntry) =>
-      val lastDataOffset = if (producerIdEntry.lastDataOffset >= 0 ) Some(producerIdEntry.lastDataOffset) else None
+      val lastDataOffset =
+        if (producerIdEntry.lastDataOffset >= 0) OptionalLong.of(producerIdEntry.lastDataOffset)
+        else OptionalLong.empty()
       val lastRecord = new LastRecord(lastDataOffset, producerIdEntry.producerEpoch)
       producerId -> lastRecord
     }
@@ -1979,7 +1981,7 @@ object UnifiedLog extends Logging {
                               origin: AppendOrigin): Option[CompletedTxn] = {
     val producerId = batch.producerId
     val appendInfo = producers.getOrElseUpdate(producerId, producerStateManager.prepareUpdate(producerId, origin))
-    appendInfo.append(batch, firstOffsetMetadata)
+    appendInfo.append(batch, firstOffsetMetadata.asJava).asScala
   }
 
   /**

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -49,6 +49,7 @@ import org.apache.kafka.server.record.BrokerCompressionType
 import scala.annotation.nowarn
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, immutable, mutable}
+import scala.compat.java8.OptionConverters.RichOptionalGeneric
 import scala.jdk.CollectionConverters._
 
 object LogAppendInfo {
@@ -672,7 +673,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
           .setLastSequence(state.lastSeq)
           .setLastTimestamp(state.lastTimestamp)
           .setCoordinatorEpoch(state.coordinatorEpoch)
-          .setCurrentTxnStartOffset(state.currentTxnFirstOffset.getOrElse(-1L))
+          .setCurrentTxnStartOffset(state.currentTxnFirstOffset.orElse(-1L))
       }
     }.toSeq
   }
@@ -1083,7 +1084,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
         if (origin == AppendOrigin.CLIENT) {
           val maybeLastEntry = producerStateManager.lastEntry(batch.producerId)
 
-          maybeLastEntry.flatMap(_.findDuplicateBatch(batch)).foreach { duplicate =>
+          maybeLastEntry.flatMap(_.findDuplicateBatch(batch).asScala).foreach { duplicate =>
             return (updatedProducers, completedTxns.toList, Some(duplicate))
           }
         }

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -107,7 +107,7 @@ object DumpLogSegments {
         print(s"producerId: ${entry.producerId} producerEpoch: ${entry.producerEpoch} " +
           s"coordinatorEpoch: ${entry.coordinatorEpoch} currentTxnFirstOffset: ${entry.currentTxnFirstOffset} " +
           s"lastTimestamp: ${entry.lastTimestamp} ")
-        entry.batchMetadata.headOption.foreach { metadata =>
+        entry.batchMetadata.asScala.headOption.foreach { metadata =>
           print(s"firstSequence: ${metadata.firstSeq} lastSequence: ${metadata.lastSeq} " +
             s"lastOffset: ${metadata.lastOffset} offsetDelta: ${metadata.offsetDelta} timestamp: ${metadata.timestamp}")
         }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -358,7 +358,7 @@ class LogSegmentTest {
 
     // recover again, but this time assuming the transaction from pid2 began on a previous segment
     stateManager = newProducerStateManager()
-    val batchMetadata = new util.ArrayList[BatchMetadata]()
+    val batchMetadata = new util.ArrayDeque[BatchMetadata]()
     batchMetadata.add(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP))
     stateManager.loadProducerEntry(new ProducerStateEntry(pid2, batchMetadata, producerEpoch,0,
       RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -357,7 +357,7 @@ class LogSegmentTest {
 
     // recover again, but this time assuming the transaction from pid2 began on a previous segment
     stateManager = newProducerStateManager()
-    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP), producerEpoch, 0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
+    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, producerEpoch, 0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L), java.util.Optional.of(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP))))
     segment.recover(stateManager)
     assertEquals(108L, stateManager.mapEndOffset)
 

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -17,7 +17,6 @@
 package kafka.log
 
 import java.io.File
-import java.util
 import java.util.OptionalLong
 
 import kafka.server.checkpoints.LeaderEpochCheckpoint
@@ -358,10 +357,8 @@ class LogSegmentTest {
 
     // recover again, but this time assuming the transaction from pid2 began on a previous segment
     stateManager = newProducerStateManager()
-    val batchMetadata = new util.ArrayDeque[BatchMetadata]()
-    batchMetadata.add(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP))
-    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, batchMetadata, producerEpoch,0,
-      RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
+    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, java.util.Collections.singletonList(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP)),
+      producerEpoch, 0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
     segment.recover(stateManager)
     assertEquals(108L, stateManager.mapEndOffset)
 

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -357,8 +357,7 @@ class LogSegmentTest {
 
     // recover again, but this time assuming the transaction from pid2 began on a previous segment
     stateManager = newProducerStateManager()
-    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, java.util.Collections.singletonList(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP)),
-      producerEpoch, 0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
+    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP), producerEpoch, 0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
     segment.recover(stateManager)
     assertEquals(108L, stateManager.mapEndOffset)
 

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -358,9 +358,10 @@ class LogSegmentTest {
 
     // recover again, but this time assuming the transaction from pid2 began on a previous segment
     stateManager = newProducerStateManager()
-    stateManager.loadProducerEntry(new ProducerStateEntry(pid2,
-      util.Arrays.asList(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP)), producerEpoch,
-      0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
+    val batchMetadata = new util.ArrayList[BatchMetadata]()
+    batchMetadata.add(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP))
+    stateManager.loadProducerEntry(new ProducerStateEntry(pid2, batchMetadata, producerEpoch,0,
+      RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
     segment.recover(stateManager)
     assertEquals(108L, stateManager.mapEndOffset)
 

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -17,6 +17,9 @@
 package kafka.log
 
 import java.io.File
+import java.util
+import java.util.OptionalLong
+
 import kafka.server.checkpoints.LeaderEpochCheckpoint
 import kafka.server.epoch.{EpochEntry, LeaderEpochFileCache}
 import kafka.utils.TestUtils
@@ -25,7 +28,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.{MockTime, Time, Utils}
-import org.apache.kafka.server.log.internals.LogConfig
+import org.apache.kafka.server.log.internals.{BatchMetadata, LogConfig, ProducerStateEntry}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
@@ -356,8 +359,8 @@ class LogSegmentTest {
     // recover again, but this time assuming the transaction from pid2 began on a previous segment
     stateManager = newProducerStateManager()
     stateManager.loadProducerEntry(new ProducerStateEntry(pid2,
-      mutable.Queue[BatchMetadata](BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP)), producerEpoch,
-      0, RecordBatch.NO_TIMESTAMP, Some(75L)))
+      util.Arrays.asList(new BatchMetadata(10, 10L, 5, RecordBatch.NO_TIMESTAMP)), producerEpoch,
+      0, RecordBatch.NO_TIMESTAMP, OptionalLong.of(75L)))
     segment.recover(stateManager)
     assertEquals(108L, stateManager.mapEndOffset)
 

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.{MockTime, Utils}
-import org.apache.kafka.server.log.internals.{AppendOrigin, CompletedTxn, LogOffsetMetadata}
+import org.apache.kafka.server.log.internals.{AppendOrigin, CompletedTxn, LogOffsetMetadata, TxnMetadata}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.Mockito.{mock, when}
@@ -255,8 +255,8 @@ class ProducerStateManagerTest {
     appendData(30L, 31L, secondAppend)
 
     assertEquals(2, secondAppend.startedTransactions.size)
-    assertEquals(TxnMetadata(producerId, new LogOffsetMetadata(24L)), secondAppend.startedTransactions.head)
-    assertEquals(TxnMetadata(producerId, new LogOffsetMetadata(30L)), secondAppend.startedTransactions.last)
+    assertEquals(new TxnMetadata(producerId, new LogOffsetMetadata(24L)), secondAppend.startedTransactions.head)
+    assertEquals(new TxnMetadata(producerId, new LogOffsetMetadata(30L)), secondAppend.startedTransactions.last)
     stateManager.update(secondAppend)
     stateManager.completeTxn(firstCompletedTxn.get)
     stateManager.completeTxn(secondCompletedTxn.get)

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.{MockTime, Utils}
-import org.apache.kafka.server.log.internals.{AppendOrigin, CompletedTxn, LogOffsetMetadata, TxnMetadata}
+import org.apache.kafka.server.log.internals.{AppendOrigin, CompletedTxn, LogOffsetMetadata, ProducerStateEntry, TxnMetadata}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.Mockito.{mock, when}
@@ -196,7 +196,7 @@ class ProducerStateManagerTest {
     val producerEpoch = 0.toShort
     val offset = 992342L
     val seq = 0
-    val producerAppendInfo = new ProducerAppendInfo(partition, producerId, ProducerStateEntry.empty(producerId), AppendOrigin.CLIENT)
+    val producerAppendInfo = new ProducerAppendInfo(partition, producerId, new ProducerStateEntry(producerId), AppendOrigin.CLIENT)
 
     val firstOffsetMetadata = new LogOffsetMetadata(offset, 990000L, 234224)
     producerAppendInfo.appendDataBatch(producerEpoch, seq, seq, time.milliseconds(),
@@ -368,7 +368,7 @@ class ProducerStateManagerTest {
       val producerAppendInfo = new ProducerAppendInfo(
         partition,
         producerId,
-        ProducerStateEntry.empty(producerId),
+        new ProducerStateEntry(producerId),
         AppendOrigin.CLIENT
       )
       val firstOffsetMetadata = new LogOffsetMetadata(startOffset, segmentBaseOffset, 50 * relativeOffset)

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -200,7 +200,7 @@ class ProducerStateManagerTest {
     val producerEpoch = 0.toShort
     val offset = 992342L
     val seq = 0
-    val producerAppendInfo = new ProducerAppendInfo(partition, producerId, new ProducerStateEntry(producerId), AppendOrigin.CLIENT)
+    val producerAppendInfo = new ProducerAppendInfo(partition, producerId, ProducerStateEntry.empty(producerId), AppendOrigin.CLIENT)
 
     val firstOffsetMetadata = new LogOffsetMetadata(offset, 990000L, 234224)
     producerAppendInfo.appendDataBatch(producerEpoch, seq, seq, time.milliseconds(),
@@ -387,7 +387,7 @@ class ProducerStateManagerTest {
       val producerAppendInfo = new ProducerAppendInfo(
         partition,
         producerId,
-        new ProducerStateEntry(producerId),
+        ProducerStateEntry.empty(producerId),
         AppendOrigin.CLIENT
       )
       val firstOffsetMetadata = new LogOffsetMetadata(startOffset, segmentBaseOffset, 50 * relativeOffset)

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -271,14 +271,16 @@ class ProducerStateManagerTest {
   def assertTxnMetadataEquals(expected: java.util.List[TxnMetadata], actual: java.util.List[TxnMetadata]): Unit = {
     val expectedIter = expected.iterator()
     val actualIter = actual.iterator()
-    while(expectedIter.hasNext && actualIter.hasNext) {
+    assertEquals(expected.size(), actual.size())
+    while (expectedIter.hasNext && actualIter.hasNext) {
       assertTxnMetadataEquals(expectedIter.next(), actualIter.next())
     }
   }
 
-  def assertTxnMetadataEquals(expected: TxnMetadata, actual:TxnMetadata) : Unit = {
+  def assertTxnMetadataEquals(expected: TxnMetadata, actual: TxnMetadata): Unit = {
     assertEquals(expected.producerId, actual.producerId)
     assertEquals(expected.firstOffset, actual.firstOffset)
+    assertEquals(expected.lastOffset, actual.lastOffset)
   }
 
   @Test

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.internals;
+
+import org.apache.kafka.common.record.DefaultRecordBatch;
+
+import java.util.Objects;
+
+public class BatchMetadata {
+
+    public final int lastSeq;
+    public final long lastOffset;
+    public final int offsetDelta;
+    public final long timestamp;
+
+    public BatchMetadata(
+            int lastSeq,
+            long lastOffset,
+            int offsetDelta,
+            long timestamp) {
+        this.lastSeq = lastSeq;
+        this.lastOffset = lastOffset;
+        this.offsetDelta = offsetDelta;
+        this.timestamp = timestamp;
+    }
+
+    public int firstSeq() {
+        return DefaultRecordBatch.decrementSequence(lastSeq, offsetDelta);
+    }
+
+    public long firstOffset() {
+        return lastOffset - offsetDelta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BatchMetadata that = (BatchMetadata) o;
+        return lastSeq == that.lastSeq && lastOffset == that.lastOffset && offsetDelta == that.offsetDelta && timestamp == that.timestamp;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lastSeq, lastOffset, offsetDelta, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "BatchMetadata{" +
+                "lastSeq=" + lastSeq +
+                ", lastOffset=" + lastOffset +
+                ", offsetDelta=" + offsetDelta +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
@@ -18,8 +18,6 @@ package org.apache.kafka.server.log.internals;
 
 import org.apache.kafka.common.record.DefaultRecordBatch;
 
-import java.util.Objects;
-
 public class BatchMetadata {
 
     public final int lastSeq;
@@ -50,22 +48,31 @@ public class BatchMetadata {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         BatchMetadata that = (BatchMetadata) o;
-        return lastSeq == that.lastSeq && lastOffset == that.lastOffset && offsetDelta == that.offsetDelta && timestamp == that.timestamp;
+
+        if (lastSeq != that.lastSeq) return false;
+        if (lastOffset != that.lastOffset) return false;
+        if (offsetDelta != that.offsetDelta) return false;
+        return timestamp == that.timestamp;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(lastSeq, lastOffset, offsetDelta, timestamp);
+        int result = lastSeq;
+        result = 31 * result + (int) (lastOffset ^ (lastOffset >>> 32));
+        result = 31 * result + offsetDelta;
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
     }
 
     @Override
     public String toString() {
-        return "BatchMetadata{" +
+        return "BatchMetadata(" +
                 "lastSeq=" + lastSeq +
                 ", lastOffset=" + lastOffset +
                 ", offsetDelta=" + offsetDelta +
                 ", timestamp=" + timestamp +
-                '}';
+                ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
@@ -70,8 +70,8 @@ public class BatchMetadata {
     public String toString() {
         return "BatchMetadata(" +
                 "firstSeq=" + firstSeq() +
-                "lastSeq=" + lastSeq +
-                "firstOffset=" + firstOffset() +
+                ", lastSeq=" + lastSeq +
+                ", firstOffset=" + firstOffset() +
                 ", lastOffset=" + lastOffset +
                 ", timestamp=" + timestamp +
                 ')';

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/BatchMetadata.java
@@ -51,27 +51,28 @@ public class BatchMetadata {
 
         BatchMetadata that = (BatchMetadata) o;
 
-        if (lastSeq != that.lastSeq) return false;
-        if (lastOffset != that.lastOffset) return false;
-        if (offsetDelta != that.offsetDelta) return false;
-        return timestamp == that.timestamp;
+        return lastSeq == that.lastSeq &&
+                lastOffset == that.lastOffset &&
+                offsetDelta == that.offsetDelta &&
+                timestamp == that.timestamp;
     }
 
     @Override
     public int hashCode() {
         int result = lastSeq;
-        result = 31 * result + (int) (lastOffset ^ (lastOffset >>> 32));
+        result = 31 * result + Long.hashCode(lastOffset);
         result = 31 * result + offsetDelta;
-        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + Long.hashCode(timestamp);
         return result;
     }
 
     @Override
     public String toString() {
         return "BatchMetadata(" +
+                "firstSeq=" + firstSeq() +
                 "lastSeq=" + lastSeq +
+                "firstOffset=" + firstOffset() +
                 ", lastOffset=" + lastOffset +
-                ", offsetDelta=" + offsetDelta +
                 ", timestamp=" + timestamp +
                 ')';
     }

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.internals;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * The last written record for a given producer. The last data offset may be undefined
+ * if the only log entry for a producer is a transaction marker.
+ */
+public final class LastRecord {
+    public final OptionalLong lastDataOffset;
+    public final short producerEpoch;
+
+    public LastRecord(OptionalLong lastDataOffset, short producerEpoch) {
+        this.lastDataOffset = lastDataOffset;
+        this.producerEpoch = producerEpoch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LastRecord that = (LastRecord) o;
+        return producerEpoch == that.producerEpoch && Objects.equals(lastDataOffset, that.lastDataOffset);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lastDataOffset, producerEpoch);
+    }
+
+    @Override
+    public String toString() {
+        return "LastRecord{" +
+                "lastDataOffset=" + lastDataOffset +
+                ", producerEpoch=" + producerEpoch +
+                '}';
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
@@ -36,20 +36,25 @@ public final class LastRecord {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         LastRecord that = (LastRecord) o;
-        return producerEpoch == that.producerEpoch && Objects.equals(lastDataOffset, that.lastDataOffset);
+
+        if (producerEpoch != that.producerEpoch) return false;
+        return Objects.equals(lastDataOffset, that.lastDataOffset);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(lastDataOffset, producerEpoch);
+        int result = lastDataOffset != null ? lastDataOffset.hashCode() : 0;
+        result = 31 * result + (int) producerEpoch;
+        return result;
     }
 
     @Override
     public String toString() {
-        return "LastRecord{" +
+        return "LastRecord(" +
                 "lastDataOffset=" + lastDataOffset +
                 ", producerEpoch=" + producerEpoch +
-                '}';
+                ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
@@ -28,9 +28,9 @@ public final class LastRecord {
     public final short producerEpoch;
 
     public LastRecord(OptionalLong lastDataOffset, short producerEpoch) {
+        Objects.requireNonNull(lastDataOffset, "lastDataOffset must be non null");
         this.lastDataOffset = lastDataOffset;
         this.producerEpoch = producerEpoch;
-        Objects.requireNonNull(lastDataOffset, "lastDataOffset must be non null");
     }
 
     @Override
@@ -46,7 +46,7 @@ public final class LastRecord {
 
     @Override
     public int hashCode() {
-        return 31 * lastDataOffset.hashCode() + (int) producerEpoch;
+        return 31 * lastDataOffset.hashCode() + producerEpoch;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/LastRecord.java
@@ -30,6 +30,7 @@ public final class LastRecord {
     public LastRecord(OptionalLong lastDataOffset, short producerEpoch) {
         this.lastDataOffset = lastDataOffset;
         this.producerEpoch = producerEpoch;
+        Objects.requireNonNull(lastDataOffset, "lastDataOffset must be non null");
     }
 
     @Override
@@ -39,15 +40,13 @@ public final class LastRecord {
 
         LastRecord that = (LastRecord) o;
 
-        if (producerEpoch != that.producerEpoch) return false;
-        return Objects.equals(lastDataOffset, that.lastDataOffset);
+        return producerEpoch == that.producerEpoch &&
+                lastDataOffset.equals(that.lastDataOffset);
     }
 
     @Override
     public int hashCode() {
-        int result = lastDataOffset != null ? lastDataOffset.hashCode() : 0;
-        result = 31 * result + (int) producerEpoch;
-        return result;
+        return 31 * lastDataOffset.hashCode() + (int) producerEpoch;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerAppendInfo.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.TransactionCoordinatorFencedException;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.EndTransactionMarker;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * This class is used to validate the records appended by a given producer before they are written to the log.
+ * It is initialized with the producer's state after the last successful append, and transitively validates the
+ * sequence numbers and epochs of each new record. Additionally, this class accumulates transaction metadata
+ * as the incoming records are validated.
+ */
+public class ProducerAppendInfo {
+    private static final Logger log = LoggerFactory.getLogger(ProducerAppendInfo.class);
+    private final TopicPartition topicPartition;
+    public final long producerId;
+    private final ProducerStateEntry currentEntry;
+    private final AppendOrigin origin;
+
+    private final List<TxnMetadata> transactions = new ArrayList<>();
+    private final ProducerStateEntry updatedEntry;
+
+    /**
+     * @param topicPartition topic partition
+     * @param producerId     The id of the producer appending to the log
+     * @param currentEntry   The current entry associated with the producer id which contains metadata for a fixed number of
+     *                       the most recent appends made by the producer. Validation of the first incoming append will
+     *                       be made against the latest append in the current entry. New appends will replace older appends
+     *                       in the current entry so that the space overhead is constant.
+     * @param origin         Indicates the origin of the append which implies the extent of validation. For example, offset
+     *                       commits, which originate from the group coordinator, do not have sequence numbers and therefore
+     *                       only producer epoch validation is done. Appends which come through replication are not validated
+     *                       (we assume the validation has already been done) and appends from clients require full validation.
+     */
+    public ProducerAppendInfo(TopicPartition topicPartition,
+                              long producerId,
+                              ProducerStateEntry currentEntry,
+                              AppendOrigin origin) {
+        this.topicPartition = topicPartition;
+        this.producerId = producerId;
+        this.currentEntry = currentEntry;
+        this.origin = origin;
+
+        updatedEntry = new ProducerStateEntry(producerId, currentEntry.producerEpoch(),
+                currentEntry.coordinatorEpoch,
+                currentEntry.lastTimestamp,
+                currentEntry.currentTxnFirstOffset);
+    }
+
+    private void maybeValidateDataBatch(short producerEpoch, int firstSeq, long offset) {
+        checkProducerEpoch(producerEpoch, offset);
+        if (origin == AppendOrigin.CLIENT) {
+            checkSequence(producerEpoch, firstSeq, offset);
+        }
+    }
+
+    private void checkProducerEpoch(short producerEpoch, long offset) {
+        if (producerEpoch < updatedEntry.producerEpoch()) {
+            String message = String.format("Epoch of producer %d at offset %d in %s is %d, " +
+                    "which is smaller than the last seen epoch %d", producerId, offset, topicPartition, producerEpoch, updatedEntry.producerEpoch());
+
+            if (origin == AppendOrigin.REPLICATION) {
+                log.warn(message);
+            } else {
+                // Starting from 2.7, we replaced ProducerFenced error with InvalidProducerEpoch in the
+                // producer send response callback to differentiate from the former fatal exception,
+                // letting client abort the ongoing transaction and retry.
+                throw new InvalidProducerEpochException(message);
+            }
+        }
+    }
+
+    private void checkSequence(short producerEpoch, int appendFirstSeq, long offset) {
+        if (producerEpoch != updatedEntry.producerEpoch()) {
+            if (appendFirstSeq != 0) {
+                if (updatedEntry.producerEpoch() != RecordBatch.NO_PRODUCER_EPOCH) {
+                    throw new OutOfOrderSequenceException("Invalid sequence number for new epoch of producer " + producerId +
+                            "at offset " + offset + " in partition " + topicPartition + ": " + producerEpoch + " (request epoch), "
+                            + appendFirstSeq + " (seq. number), " + updatedEntry.producerEpoch() + " (current producer epoch)");
+                }
+            }
+        } else {
+            int currentLastSeq;
+            if (!updatedEntry.isEmpty())
+                currentLastSeq = updatedEntry.lastSeq();
+            else if (producerEpoch == currentEntry.producerEpoch())
+                currentLastSeq = currentEntry.lastSeq();
+            else
+                currentLastSeq = RecordBatch.NO_SEQUENCE;
+
+            // If there is no current producer epoch (possibly because all producer records have been deleted due to
+            // retention or the DeleteRecords API) accept writes with any sequence number
+            if (!(currentEntry.producerEpoch() == RecordBatch.NO_PRODUCER_EPOCH || inSequence(currentLastSeq, appendFirstSeq))) {
+                throw new OutOfOrderSequenceException("Out of order sequence number for producer " + producerId + " at " +
+                        "offset " + offset + " in partition " + topicPartition + ": " + appendFirstSeq +
+                        " (incoming seq. number), " + currentLastSeq + " (current end sequence number)");
+            }
+        }
+    }
+
+    private boolean inSequence(int lastSeq, int nextSeq) {
+        return nextSeq == lastSeq + 1L || (nextSeq == 0 && lastSeq == Integer.MAX_VALUE);
+    }
+
+    public Optional<CompletedTxn> append(RecordBatch batch, Optional<LogOffsetMetadata> firstOffsetMetadataOpt) {
+        if (batch.isControlBatch()) {
+            Iterator<Record> recordIterator = batch.iterator();
+            if (recordIterator.hasNext()) {
+                Record record = recordIterator.next();
+                EndTransactionMarker endTxnMarker = EndTransactionMarker.deserialize(record);
+                return appendEndTxnMarker(endTxnMarker, batch.producerEpoch(), batch.baseOffset(), record.timestamp());
+            } else {
+                // An empty control batch means the entire transaction has been cleaned from the log, so no need to append
+                return Optional.empty();
+            }
+        } else {
+            LogOffsetMetadata firstOffsetMetadata = firstOffsetMetadataOpt.orElse(new LogOffsetMetadata(batch.baseOffset()));
+            appendDataBatch(batch.producerEpoch(), batch.baseSequence(), batch.lastSequence(), batch.maxTimestamp(),
+                    firstOffsetMetadata, batch.lastOffset(), batch.isTransactional());
+            return Optional.empty();
+        }
+    }
+
+    public void appendDataBatch(short epoch,
+                                int firstSeq,
+                                int lastSeq,
+                                long lastTimestamp,
+                                LogOffsetMetadata firstOffsetMetadata,
+                                long lastOffset,
+                                boolean isTransactional) {
+        long firstOffset = firstOffsetMetadata.messageOffset;
+        maybeValidateDataBatch(epoch, firstSeq, firstOffset);
+        updatedEntry.addBatch(epoch, lastSeq, lastOffset, (int) (lastOffset - firstOffset), lastTimestamp);
+
+        OptionalLong currentTxnFirstOffset = updatedEntry.currentTxnFirstOffset;
+        if (currentTxnFirstOffset.isPresent()) {
+            if (!isTransactional)
+                // Received a non-transactional message while a transaction is active
+                throw new InvalidTxnStateException("Expected transactional write from producer " + producerId + " at " +
+                        "offset " + firstOffsetMetadata + " in partition " + topicPartition);
+        } else {
+            if (isTransactional) {
+                // Began a new transaction
+                updatedEntry.currentTxnFirstOffset = OptionalLong.of(firstOffset);
+                transactions.add(new TxnMetadata(producerId, firstOffsetMetadata));
+            }
+        }
+    }
+
+    private void checkCoordinatorEpoch(EndTransactionMarker endTxnMarker, long offset) {
+        if (updatedEntry.coordinatorEpoch > endTxnMarker.coordinatorEpoch()) {
+            if (origin == AppendOrigin.REPLICATION) {
+                log.info("Detected invalid coordinator epoch for producerId " + producerId + " at " +
+                        "offset " + offset + " in partition $topicPartition: " + endTxnMarker.coordinatorEpoch() +
+                        " is older than previously known coordinator epoch " + updatedEntry.coordinatorEpoch);
+            } else {
+                throw new TransactionCoordinatorFencedException("Invalid coordinator epoch for producerId " + producerId + " at " +
+                        "offset " + offset + " in partition " + topicPartition + ": " + endTxnMarker.coordinatorEpoch() +
+                        " (zombie), " + updatedEntry.coordinatorEpoch + " (current)");
+            }
+        }
+    }
+
+    public Optional<CompletedTxn> appendEndTxnMarker(
+            EndTransactionMarker endTxnMarker,
+            short producerEpoch,
+            long offset,
+            long timestamp) {
+        checkProducerEpoch(producerEpoch, offset);
+        checkCoordinatorEpoch(endTxnMarker, offset);
+
+        // Only emit the `CompletedTxn` for non-empty transactions. A transaction marker
+        // without any associated data will not have any impact on the last stable offset
+        // and would not need to be reflected in the transaction index.
+        Optional<CompletedTxn> completedTxn = updatedEntry.currentTxnFirstOffset.isPresent() ?
+                Optional.of(new CompletedTxn(producerId, updatedEntry.currentTxnFirstOffset.getAsLong(), offset,
+                        endTxnMarker.controlType() == ControlRecordType.ABORT))
+                : Optional.empty();
+
+        updatedEntry.maybeUpdateProducerEpoch(producerEpoch);
+        updatedEntry.currentTxnFirstOffset = OptionalLong.empty();
+        updatedEntry.coordinatorEpoch = endTxnMarker.coordinatorEpoch();
+        updatedEntry.lastTimestamp = timestamp;
+
+        return completedTxn;
+    }
+
+    public ProducerStateEntry toEntry() {
+        return updatedEntry;
+    }
+
+    public List<TxnMetadata> startedTransactions() {
+        return Collections.unmodifiableList(transactions);
+    }
+
+    @Override
+    public String toString() {
+        return "ProducerAppendInfo(" +
+                "topicPartition=" + topicPartition +
+                ", producerId=" + producerId +
+                ", currentEntry=" + currentEntry +
+                ", origin=" + origin +
+                ", transactions=" + transactions +
+                ", updatedEntry=" + updatedEntry +
+                ')';
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerAppendInfo.java
@@ -74,10 +74,8 @@ public class ProducerAppendInfo {
         this.currentEntry = currentEntry;
         this.origin = origin;
 
-        updatedEntry = new ProducerStateEntry(producerId, currentEntry.producerEpoch(),
-                currentEntry.coordinatorEpoch,
-                currentEntry.lastTimestamp,
-                currentEntry.currentTxnFirstOffset);
+        updatedEntry = new ProducerStateEntry(producerId, currentEntry.producerEpoch(), currentEntry.coordinatorEpoch, currentEntry.lastTimestamp, currentEntry.currentTxnFirstOffset, Optional.empty()
+        );
     }
 
     public long producerId() {
@@ -93,8 +91,8 @@ public class ProducerAppendInfo {
 
     private void checkProducerEpoch(short producerEpoch, long offset) {
         if (producerEpoch < updatedEntry.producerEpoch()) {
-            String message = String.format("Epoch of producer %d at offset %d in %s is %d, " +
-                    "which is smaller than the last seen epoch %d", producerId, offset, topicPartition, producerEpoch, updatedEntry.producerEpoch());
+            String message = "Epoch of producer " + producerId + " at offset " + offset + " in " + topicPartition +
+                    " is " + producerEpoch + ", " + "which is smaller than the last seen epoch " + updatedEntry.producerEpoch();
 
             if (origin == AppendOrigin.REPLICATION) {
                 log.warn(message);

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -22,7 +22,6 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
@@ -36,27 +35,27 @@ import java.util.stream.Stream;
 public class ProducerStateEntry {
     public static final int NUM_BATCHES_TO_RETAIN = 5;
     private final long producerId;
-    private final Deque<BatchMetadata> batchMetadata;
+    private final Deque<BatchMetadata> batchMetadata = new ArrayDeque<>();
     private short producerEpoch;
     public int coordinatorEpoch;
     public long lastTimestamp;
     public OptionalLong currentTxnFirstOffset;
 
     public ProducerStateEntry(long producerId) {
-        this(producerId, Collections.emptyList(), RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
+        this(producerId, null, RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
     }
 
     public ProducerStateEntry(long producerId, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
-        this(producerId, Collections.emptyList(), producerEpoch, coordinatorEpoch, lastTimestamp, currentTxnFirstOffset);
+        this(producerId, null, producerEpoch, coordinatorEpoch, lastTimestamp, currentTxnFirstOffset);
     }
 
-    public ProducerStateEntry(long producerId, List<BatchMetadata> batchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
+    public ProducerStateEntry(long producerId, BatchMetadata firstBatchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
         this.producerId = producerId;
-        this.batchMetadata = new ArrayDeque<>(batchMetadata);
         this.producerEpoch = producerEpoch;
         this.coordinatorEpoch = coordinatorEpoch;
         this.lastTimestamp = lastTimestamp;
         this.currentTxnFirstOffset = currentTxnFirstOffset;
+        if (firstBatchMetadata != null) batchMetadata.add(firstBatchMetadata);
     }
 
     public int firstSeq() {

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -34,12 +34,18 @@ import java.util.stream.Stream;
  */
 public class ProducerStateEntry {
     public static final int NUM_BATCHES_TO_RETAIN = 5;
-    private final long producerId;
-    private final Deque<BatchMetadata> batchMetadata = new ArrayDeque<>();
-    private short producerEpoch;
+
     public int coordinatorEpoch;
     public long lastTimestamp;
     public OptionalLong currentTxnFirstOffset;
+
+    private final long producerId;
+    private final Deque<BatchMetadata> batchMetadata = new ArrayDeque<>();
+    private short producerEpoch;
+
+    public static ProducerStateEntry empty(long producerId) {
+        return new ProducerStateEntry(producerId, RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty(), Optional.empty());
+    }
 
     public ProducerStateEntry(long producerId) {
         this(producerId, RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty(), Optional.empty());

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -27,13 +27,14 @@ import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 /**
- * The batchMetadata is ordered such that the batch with the lowest sequence is at the head of the queue while the
- * batch with the highest sequence is at the tail of the queue. We will retain at most {@link ProducerStateEntry#NUM_BATCHES_TO_RETAIN}
+ * This class represents the state of a specific producer-id.
+ * It contains batchMetadata queue which is ordered such that the batch with the lowest sequence is at the head of the
+ * queue while the batch with the highest sequence is at the tail of the queue. We will retain at most {@link ProducerStateEntry#NUM_BATCHES_TO_RETAIN}
  * elements in the queue. When the queue is at capacity, we remove the first element to make space for the incoming batch.
  */
 public class ProducerStateEntry {
     public static final int NUM_BATCHES_TO_RETAIN = 5;
-    public final long producerId;
+    private final long producerId;
     private final Deque<BatchMetadata> batchMetadata;
     private short producerEpoch;
     public int coordinatorEpoch;
@@ -127,6 +128,10 @@ public class ProducerStateEntry {
 
     public short producerEpoch() {
         return producerEpoch;
+    }
+
+    public long producerId() {
+        return producerId;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.internals;
+
+import org.apache.kafka.common.record.RecordBatch;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Stream;
+
+/**
+ * The batchMetadata is ordered such that the batch with the lowest sequence is at the head of the queue while the
+ * batch with the highest sequence is at the tail of the queue. We will retain at most {@link ProducerStateEntry#NumBatchesToRetain}
+ * elements in the queue. When the queue is at capacity, we remove the first element to make space for the incoming batch.
+ */
+public class ProducerStateEntry {
+    public static final int NumBatchesToRetain = 5;
+    public final long producerId;
+    private final List<BatchMetadata> batchMetadata;
+    public short producerEpoch;
+    public int coordinatorEpoch;
+    public long lastTimestamp;
+    public OptionalLong currentTxnFirstOffset;
+
+    public ProducerStateEntry(long producerId) {
+        this(producerId, Collections.emptyList(), RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
+    }
+
+    public ProducerStateEntry(long producerId, List<BatchMetadata> batchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
+        this.producerId = producerId;
+        this.batchMetadata = batchMetadata;
+        this.producerEpoch = producerEpoch;
+        this.coordinatorEpoch = coordinatorEpoch;
+        this.lastTimestamp = lastTimestamp;
+        this.currentTxnFirstOffset = currentTxnFirstOffset;
+    }
+
+    public int firstSeq() {
+        return isEmpty() ? RecordBatch.NO_SEQUENCE : batchMetadata.get(0).firstSeq();
+    }
+
+
+    public long firstDataOffset() {
+        return isEmpty() ? -1L : batchMetadata.get(0).firstOffset();
+    }
+
+    public int lastSeq() {
+        return isEmpty() ? RecordBatch.NO_SEQUENCE : batchMetadata.get(batchMetadata.size() - 1).lastSeq;
+    }
+
+    public long lastDataOffset() {
+        return isEmpty() ? -1L : batchMetadata.get(batchMetadata.size() - 1).lastOffset;
+    }
+
+    public int lastOffsetDelta() {
+        return isEmpty() ? 0 : batchMetadata.get(batchMetadata.size() - 1).offsetDelta;
+    }
+
+    public boolean isEmpty() {
+        return batchMetadata.isEmpty();
+    }
+
+    public void addBatch(short producerEpoch, int lastSeq, long lastOffset, int offsetDelta, long timestamp) {
+        maybeUpdateProducerEpoch(producerEpoch);
+        addBatchMetadata(new BatchMetadata(lastSeq, lastOffset, offsetDelta, timestamp));
+        this.lastTimestamp = timestamp;
+    }
+
+    public boolean maybeUpdateProducerEpoch(short producerEpoch) {
+        if (this.producerEpoch != producerEpoch) {
+            batchMetadata.clear();
+            this.producerEpoch = producerEpoch;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void addBatchMetadata(BatchMetadata batch) {
+        if (batchMetadata.size() == ProducerStateEntry.NumBatchesToRetain) batchMetadata.remove(0);
+        batchMetadata.add(batch);
+    }
+
+    public void update(ProducerStateEntry nextEntry) {
+        maybeUpdateProducerEpoch(nextEntry.producerEpoch);
+        while (!nextEntry.batchMetadata.isEmpty()) addBatchMetadata(nextEntry.batchMetadata.remove(0));
+        this.coordinatorEpoch = nextEntry.coordinatorEpoch;
+        this.currentTxnFirstOffset = nextEntry.currentTxnFirstOffset;
+        this.lastTimestamp = nextEntry.lastTimestamp;
+    }
+
+    public Optional<BatchMetadata> findDuplicateBatch(RecordBatch batch) {
+        if (batch.producerEpoch() != producerEpoch) return Optional.empty();
+        else return batchWithSequenceRange(batch.baseSequence(), batch.lastSequence());
+    }
+
+    // Return the batch metadata of the cached batch having the exact sequence range, if any.
+    Optional<BatchMetadata> batchWithSequenceRange(int firstSeq, int lastSeq) {
+        Stream<BatchMetadata> duplicate = batchMetadata.stream().filter(metadata -> firstSeq == metadata.firstSeq() && lastSeq == metadata.lastSeq);
+        return duplicate.findFirst();
+    }
+
+    public List<BatchMetadata> batchMetadata() {
+        return Collections.unmodifiableList(batchMetadata);
+    }
+
+    public short producerEpoch() {
+        return producerEpoch;
+    }
+
+    public int coordinatorEpoch() {
+        return coordinatorEpoch;
+    }
+
+    public long lastTimestamp() {
+        return lastTimestamp;
+    }
+
+    public OptionalLong currentTxnFirstOffset() {
+        return currentTxnFirstOffset;
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -42,20 +42,16 @@ public class ProducerStateEntry {
     public OptionalLong currentTxnFirstOffset;
 
     public ProducerStateEntry(long producerId) {
-        this(producerId, null, RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
+        this(producerId, RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty(), Optional.empty());
     }
 
-    public ProducerStateEntry(long producerId, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
-        this(producerId, null, producerEpoch, coordinatorEpoch, lastTimestamp, currentTxnFirstOffset);
-    }
-
-    public ProducerStateEntry(long producerId, BatchMetadata firstBatchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
+    public ProducerStateEntry(long producerId, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset, Optional<BatchMetadata> firstBatchMetadata) {
         this.producerId = producerId;
         this.producerEpoch = producerEpoch;
         this.coordinatorEpoch = coordinatorEpoch;
         this.lastTimestamp = lastTimestamp;
         this.currentTxnFirstOffset = currentTxnFirstOffset;
-        if (firstBatchMetadata != null) batchMetadata.add(firstBatchMetadata);
+        firstBatchMetadata.ifPresent(batchMetadata::add);
     }
 
     public int firstSeq() {

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -22,6 +22,7 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
@@ -42,16 +43,16 @@ public class ProducerStateEntry {
     public OptionalLong currentTxnFirstOffset;
 
     public ProducerStateEntry(long producerId) {
-        this(producerId, new ArrayDeque<>(), RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
+        this(producerId, Collections.emptyList(), RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
     }
 
     public ProducerStateEntry(long producerId, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
-        this(producerId, new ArrayDeque<>(), producerEpoch, coordinatorEpoch, lastTimestamp, currentTxnFirstOffset);
+        this(producerId, Collections.emptyList(), producerEpoch, coordinatorEpoch, lastTimestamp, currentTxnFirstOffset);
     }
 
-    public ProducerStateEntry(long producerId, Deque<BatchMetadata> batchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
+    public ProducerStateEntry(long producerId, List<BatchMetadata> batchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
         this.producerId = producerId;
-        this.batchMetadata = batchMetadata;
+        this.batchMetadata = new ArrayDeque<>(batchMetadata);
         this.producerEpoch = producerEpoch;
         this.coordinatorEpoch = coordinatorEpoch;
         this.lastTimestamp = lastTimestamp;

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/ProducerStateEntry.java
@@ -18,6 +18,7 @@ package org.apache.kafka.server.log.internals;
 
 import org.apache.kafka.common.record.RecordBatch;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -26,20 +27,24 @@ import java.util.stream.Stream;
 
 /**
  * The batchMetadata is ordered such that the batch with the lowest sequence is at the head of the queue while the
- * batch with the highest sequence is at the tail of the queue. We will retain at most {@link ProducerStateEntry#NumBatchesToRetain}
+ * batch with the highest sequence is at the tail of the queue. We will retain at most {@link ProducerStateEntry#NUM_BATCHES_TO_RETAIN}
  * elements in the queue. When the queue is at capacity, we remove the first element to make space for the incoming batch.
  */
 public class ProducerStateEntry {
-    public static final int NumBatchesToRetain = 5;
+    public static final int NUM_BATCHES_TO_RETAIN = 5;
     public final long producerId;
     private final List<BatchMetadata> batchMetadata;
-    public short producerEpoch;
+    private short producerEpoch;
     public int coordinatorEpoch;
     public long lastTimestamp;
     public OptionalLong currentTxnFirstOffset;
 
     public ProducerStateEntry(long producerId) {
-        this(producerId, Collections.emptyList(), RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
+        this(producerId, new ArrayList<>(), RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, OptionalLong.empty());
+    }
+
+    public ProducerStateEntry(long producerId, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
+        this(producerId, new ArrayList<>(), producerEpoch, coordinatorEpoch, lastTimestamp, currentTxnFirstOffset);
     }
 
     public ProducerStateEntry(long producerId, List<BatchMetadata> batchMetadata, short producerEpoch, int coordinatorEpoch, long lastTimestamp, OptionalLong currentTxnFirstOffset) {
@@ -93,7 +98,7 @@ public class ProducerStateEntry {
     }
 
     private void addBatchMetadata(BatchMetadata batch) {
-        if (batchMetadata.size() == ProducerStateEntry.NumBatchesToRetain) batchMetadata.remove(0);
+        if (batchMetadata.size() == ProducerStateEntry.NUM_BATCHES_TO_RETAIN) batchMetadata.remove(0);
         batchMetadata.add(batch);
     }
 
@@ -124,15 +129,15 @@ public class ProducerStateEntry {
         return producerEpoch;
     }
 
-    public int coordinatorEpoch() {
-        return coordinatorEpoch;
-    }
-
-    public long lastTimestamp() {
-        return lastTimestamp;
-    }
-
-    public OptionalLong currentTxnFirstOffset() {
-        return currentTxnFirstOffset;
+    @Override
+    public String toString() {
+        return "ProducerStateEntry(" +
+                "producerId=" + producerId +
+                ", batchMetadata=" + batchMetadata +
+                ", producerEpoch=" + producerEpoch +
+                ", coordinatorEpoch=" + coordinatorEpoch +
+                ", lastTimestamp=" + lastTimestamp +
+                ", currentTxnFirstOffset=" + currentTxnFirstOffset +
+                ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
@@ -30,6 +30,7 @@ public final class TxnMetadata {
         this.producerId = producerId;
         this.firstOffset = firstOffset;
         this.lastOffset = lastOffset;
+        Objects.requireNonNull(firstOffset, "firstOffset must be non null");
     }
     public TxnMetadata(long producerId, long firstOffset) {
         this(producerId, new LogOffsetMetadata(firstOffset));

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
@@ -43,21 +43,28 @@ public final class TxnMetadata {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         TxnMetadata that = (TxnMetadata) o;
-        return producerId == that.producerId && Objects.equals(firstOffset, that.firstOffset) && Objects.equals(lastOffset, that.lastOffset);
+
+        if (producerId != that.producerId) return false;
+        if (!Objects.equals(firstOffset, that.firstOffset)) return false;
+        return Objects.equals(lastOffset, that.lastOffset);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(producerId, firstOffset, lastOffset);
+        int result = (int) (producerId ^ (producerId >>> 32));
+        result = 31 * result + (firstOffset != null ? firstOffset.hashCode() : 0);
+        result = 31 * result + (lastOffset != null ? lastOffset.hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
-        return "TxnMetadata{" +
+        return "TxnMetadata(" +
                 "producerId=" + producerId +
                 ", firstOffset=" + firstOffset +
                 ", lastOffset=" + lastOffset +
-                '}';
+                ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
@@ -27,10 +27,10 @@ public final class TxnMetadata {
     public TxnMetadata(long producerId,
                        LogOffsetMetadata firstOffset,
                        OptionalLong lastOffset) {
+        Objects.requireNonNull(firstOffset, "firstOffset must be non null");
         this.producerId = producerId;
         this.firstOffset = firstOffset;
         this.lastOffset = lastOffset;
-        Objects.requireNonNull(firstOffset, "firstOffset must be non null");
     }
     public TxnMetadata(long producerId, long firstOffset) {
         this(producerId, new LogOffsetMetadata(firstOffset));
@@ -38,26 +38,6 @@ public final class TxnMetadata {
 
     public TxnMetadata(long producerId, LogOffsetMetadata firstOffset) {
         this(producerId, firstOffset, OptionalLong.empty());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        TxnMetadata that = (TxnMetadata) o;
-
-        if (producerId != that.producerId) return false;
-        if (!Objects.equals(firstOffset, that.firstOffset)) return false;
-        return Objects.equals(lastOffset, that.lastOffset);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = (int) (producerId ^ (producerId >>> 32));
-        result = 31 * result + (firstOffset != null ? firstOffset.hashCode() : 0);
-        result = 31 * result + (lastOffset != null ? lastOffset.hashCode() : 0);
-        return result;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/TxnMetadata.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.internals;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+public final class TxnMetadata {
+    public final long producerId;
+    public final LogOffsetMetadata firstOffset;
+    public OptionalLong lastOffset;
+
+    public TxnMetadata(long producerId,
+                       LogOffsetMetadata firstOffset,
+                       OptionalLong lastOffset) {
+        this.producerId = producerId;
+        this.firstOffset = firstOffset;
+        this.lastOffset = lastOffset;
+    }
+    public TxnMetadata(long producerId, long firstOffset) {
+        this(producerId, new LogOffsetMetadata(firstOffset));
+    }
+
+    public TxnMetadata(long producerId, LogOffsetMetadata firstOffset) {
+        this(producerId, firstOffset, OptionalLong.empty());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TxnMetadata that = (TxnMetadata) o;
+        return producerId == that.producerId && Objects.equals(firstOffset, that.firstOffset) && Objects.equals(lastOffset, that.lastOffset);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(producerId, firstOffset, lastOffset);
+    }
+
+    @Override
+    public String toString() {
+        return "TxnMetadata{" +
+                "producerId=" + producerId +
+                ", firstOffset=" + firstOffset +
+                ", lastOffset=" + lastOffset +
+                '}';
+    }
+}


### PR DESCRIPTION
For broader context on this change, you may want to look at KAFKA-14470: Move log layer to storage module.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
