### PR TITLE
MINOR: add error reason when controller failed to handle events

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -432,8 +432,8 @@ public final class QuorumController implements Controller {
                                            OptionalLong startProcessingTimeNs,
                                            Throwable exception) {
         if (!startProcessingTimeNs.isPresent()) {
-            log.error("{}: unable to start processing because of {}.", name,
-                exception.getClass().getSimpleName());
+            log.error("{}: unable to start processing because of {}. Reason: {}", name,
+                exception.getClass().getSimpleName(), exception.getMessage());
             if (exception instanceof ApiException) {
                 return exception;
             } else {
@@ -444,8 +444,8 @@ public final class QuorumController implements Controller {
         long deltaNs = endProcessingTime - startProcessingTimeNs.getAsLong();
         long deltaUs = MICROSECONDS.convert(deltaNs, NANOSECONDS);
         if (exception instanceof ApiException) {
-            log.info("{}: failed with {} in {} us", name,
-                exception.getClass().getSimpleName(), deltaUs);
+            log.info("{}: failed with {} in {} us. Reason: {}", name,
+                exception.getClass().getSimpleName(), deltaUs, exception.getMessage());
             return exception;
         }
         if (isActiveController()) {


### PR DESCRIPTION
In KRaft, when controller failed to handle events, we'll log error and return back to brokers. But in some cases, we only log error class name, and return error class name back to brokers, which is un-useful for troubleshooting. Ex: When broker registration failed with unsupported version error, it showed:
```
2022-12-28T17:46:42.876+0800 [DEBUG] [TestEventLogger]     [2022-12-28 17:46:42,877] INFO [Controller 3000] registerBroker: failed with UnsupportedVersionException in 2888 us (org.apache.kafka.controller.QuorumController:447)

2022-12-28T17:46:42.877+0800 [DEBUG] [TestEventLogger]     [2022-12-28 17:46:42,878] INFO [BrokerLifecycleManager id=0] Unable to register broker 0 because the controller returned error UNSUPPORTED_VERSION (kafka.server.BrokerLifecycleManager:66)
```

Checking the logs, we still don't know which version it supports. 
After this PR, it will show:
```
2022-12-28T17:54:59.671+0800 [DEBUG] [TestEventLogger]     [2022-12-28 17:54:59,671] INFO [Controller 3000] registerBroker: failed with UnsupportedVersionException in 291 us. Reason: Unable to register because the broker does not support version 8 of metadata.version. It wants a version between 4 and 4, inclusive. (org.apache.kafka.controller.QuorumController:447)

2022-12-28T17:54:59.671+0800 [DEBUG] [TestEventLogger]     [2022-12-28 17:54:59,672] INFO [BrokerLifecycleManager id=0] Unable to register broker 0 because the controller returned error UNSUPPORTED_VERSION (kafka.server.BrokerLifecycleManager:66)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
