### PR TITLE
MINOR: Use `LogConfig.validate` instead of `validateValues` in `KafkaMetadataLog`

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -565,7 +565,7 @@ object KafkaMetadataLog extends Logging {
     // Disable time and byte retention when deleting segments
     props.setProperty(LogConfig.RetentionMsProp, "-1")
     props.setProperty(LogConfig.RetentionBytesProp, "-1")
-    LogConfig.validateValues(props)
+    LogConfig.validate(props)
     val defaultLogConfig = LogConfig(props)
 
     if (config.logSegmentBytes < config.logSegmentMinBytes) {


### PR DESCRIPTION
`LogConfig.validateValues` may fail or incorrectly succeed if the properties don't include defaults.

During the conversion of `LogConfig` to Java (#13049), it became clear that the `asInstanceOf[Long]`
calls in `LogConfig.validateValues` were converting `null` to `0` when this method was invoked
from `KafkaMetadataLog`. This means that it would be possible for it to validate successfully
in cases where it should not.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
