### PR TITLE
KAFKA-13881: Add Storage package info

### DIFF
--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/package-info.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 /**
- * Provides an pluggable API for defining remote storage and retrieval of Kafka log segments.
+ * Provides a pluggable API for defining remote storage and retrieval of Kafka log segments.
  */
 package org.apache.kafka.server.log.remote.storage;

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/package-info.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides an pluggable API for defining remote storage and retrieval of Kafka log segments.
+ */
+package org.apache.kafka.server.log.remote.storage;


### PR DESCRIPTION
This module exposes a single package as public API that needs a package description.

Similar to #12895.

Signed-off-by: Greg Harris <greg.harris@aiven.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
