### PR TITLE
KAFKA-14556: make sure log cleaner throttler start time is correct

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -87,28 +87,28 @@ public class TaggedFields extends DocumentedType {
     @SuppressWarnings("unchecked")
     @Override
     public NavigableMap<Integer, Object> read(ByteBuffer buffer) {
-        int numTaggedFields = ByteUtils.readUnsignedVarint(buffer);
-        if (numTaggedFields == 0) {
-            return Collections.emptyNavigableMap();
-        }
-        NavigableMap<Integer, Object> objects = new TreeMap<>();
-        int prevTag = -1;
-        for (int i = 0; i < numTaggedFields; i++) {
-            int tag = ByteUtils.readUnsignedVarint(buffer);
-            if (tag <= prevTag) {
-                throw new RuntimeException("Invalid or out-of-order tag " + tag);
-            }
-            prevTag = tag;
-            int size = ByteUtils.readUnsignedVarint(buffer);
-            Field field = fields.get(tag);
-            if (field == null) {
-                byte[] bytes = new byte[size];
-                buffer.get(bytes);
-                objects.put(tag, new RawTaggedField(tag, bytes));
-            } else {
-                objects.put(tag, field.type.read(buffer));
-            }
-        }
+//         int numTaggedFields = ByteUtils.readUnsignedVarint(buffer);
+//         if (numTaggedFields == 0) {
+//             return Collections.emptyNavigableMap();
+//         }
+//         NavigableMap<Integer, Object> objects = new TreeMap<>();
+//         int prevTag = -1;
+//         for (int i = 0; i < numTaggedFields; i++) {
+//             int tag = ByteUtils.readUnsignedVarint(buffer);
+//             if (tag <= prevTag) {
+//                 throw new RuntimeException("Invalid or out-of-order tag " + tag);
+//             }
+//             prevTag = tag;
+//             int size = ByteUtils.readUnsignedVarint(buffer);
+//             Field field = fields.get(tag);
+//             if (field == null) {
+//                 byte[] bytes = new byte[size];
+//                 buffer.get(bytes);
+//                 objects.put(tag, new RawTaggedField(tag, bytes));
+//             } else {
+//                 objects.put(tag, field.type.read(buffer));
+//             }
+//         }
         throw new IllegalStateException("should not enter here!");
 //        return objects;
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -109,7 +109,8 @@ public class TaggedFields extends DocumentedType {
                 objects.put(tag, field.type.read(buffer));
             }
         }
-        return objects;
+        throw new IllegalStateException("should not enter here!");
+//        return objects;
     }
 
     @SuppressWarnings("unchecked")

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.protocol.types.Type.DocumentedType;
 import org.apache.kafka.common.utils.ByteUtils;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
+//import java.util.Collections;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -524,7 +524,7 @@ private[log] class Cleaner(val id: Int,
 
     val log = cleanable.log
     val stats = new CleanerStats()
-    throttler.initStartTimeNs(time.nanoseconds())
+    throttler.initStartTimeNs()
 
     // build the offset map
     info("Building offset map for %s...".format(cleanable.log.name))
@@ -1202,4 +1202,3 @@ private class AbortedTransactionMetadata(val abortedTxn: AbortedTxn) {
 
   override def toString: String = s"(txn: $abortedTxn, lastOffset: $lastObservedBatchOffset)"
 }
-

--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -29,7 +29,7 @@ import scala.math._
  * A class to measure and throttle the rate of some process. The throttler takes a desired rate-per-second
  * (the units of the process don't matter, it could be bytes or a count of some other thing), and will sleep for
  * an appropriate amount of time when {@link maybeThrottle(double)} is called to attain the desired rate.
- *
+ * 
  * @param desiredRatePerSec: The rate we want to hit in units/sec
  * @param checkIntervalMs: The interval at which to check our rate
  * @param throttleDown: Does throttling increase or decrease our rate?
@@ -53,6 +53,7 @@ class Throttler(@volatile var desiredRatePerSec: Double,
   private val msPerSec = TimeUnit.SECONDS.toMillis(1)
   private val nsPerSec = TimeUnit.SECONDS.toNanos(1)
 
+  // Before calling maybeThrottle(), remember to run initStartTimeNs() once to make sure the periodStartNs is correct
   def maybeThrottle(observed: Double): Unit = {
     val currentDesiredRatePerSec = desiredRatePerSec
 

--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -46,12 +46,7 @@ class Throttler(@volatile var desiredRatePerSec: Double,
                 time: Time = Time.SYSTEM) extends Logging with KafkaMetricsGroup {
 
   private val lock = new Object
-  private val logCleanerThrottlerMetricName = explicitMetricName(
-    "kafka.log",
-    "LogCleaner",
-    metricName,
-    Map.empty)
-  private val meter = newMeter(logCleanerThrottlerMetricName, units, TimeUnit.SECONDS)
+  private val meter = newMeter(metricName, units, TimeUnit.SECONDS)
   private val checkIntervalNs = TimeUnit.MILLISECONDS.toNanos(checkIntervalMs)
   private var periodStartNs: Long = 0
   private var observedSoFar: Double = 0.0
@@ -92,11 +87,11 @@ class Throttler(@volatile var desiredRatePerSec: Double,
   }
 
   // initial start time if it haven't been set. This method should be called when starting do disk IO works.
-  def initStartTimeNs(startTimeNs: Long): Unit = {
+  def initStartTimeNs(): Unit = {
     if (periodStartNs == 0) {
       lock synchronized {
         if (periodStartNs == 0) {
-          periodStartNs = startTimeNs
+          periodStartNs = time.nanoseconds()
         }
       }
     }

--- a/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
@@ -33,6 +33,7 @@ class ThrottlerTest {
                                   checkIntervalMs = throttleCheckIntervalMs,
                                   time = mockTime)
 
+    throttler.initStartTimeNs(mockTime.nanoseconds)
     // Observe desiredCountPerInterval at t1
     val t1 = mockTime.milliseconds()
     throttler.maybeThrottle(desiredCountPerInterval)
@@ -72,6 +73,7 @@ class ThrottlerTest {
       checkIntervalMs = throttleCheckIntervalMs,
       time = mockTime)
 
+    throttler.initStartTimeNs(mockTime.nanoseconds)
     // Observe desiredCountPerInterval at t1
     val t1 = mockTime.milliseconds()
     throttler.maybeThrottle(desiredCountPerInterval)

--- a/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
@@ -26,6 +26,7 @@ class ThrottlerTest {
   def testThrottleDesiredRate(): Unit = {
     val throttleCheckIntervalMs = 100
     val desiredCountPerSec = 1000.0
+    val longSleep = 10000
     val desiredCountPerInterval = desiredCountPerSec * throttleCheckIntervalMs / 1000.0
 
     val mockTime = new MockTime()
@@ -33,7 +34,10 @@ class ThrottlerTest {
                                   checkIntervalMs = throttleCheckIntervalMs,
                                   time = mockTime)
 
-    throttler.initStartTimeNs(mockTime.nanoseconds)
+    // Even if throttler started long time ago, as long as start time is initialized, everything should work well
+    mockTime.sleep(longSleep)
+
+    throttler.initStartTimeNs()
     // Observe desiredCountPerInterval at t1
     val t1 = mockTime.milliseconds()
     throttler.maybeThrottle(desiredCountPerInterval)
@@ -73,7 +77,7 @@ class ThrottlerTest {
       checkIntervalMs = throttleCheckIntervalMs,
       time = mockTime)
 
-    throttler.initStartTimeNs(mockTime.nanoseconds)
+    throttler.initStartTimeNs()
     // Observe desiredCountPerInterval at t1
     val t1 = mockTime.milliseconds()
     throttler.maybeThrottle(desiredCountPerInterval)


### PR DESCRIPTION
Log cleaner throttler will do throttling check very 300ms. The expected throttling work is like this:

disk IO operation for 300ms -> check if throttling is needed (sleep to slow down the IO) -> continue the disk IO operation -> check ...


But the 300ms interval start time is started when log cleaner created [here](https://github.com/jolshan/kafka/blob/trunk/core/src/main/scala/kafka/utils/Throttler.scala#L49). So, even if there's no logs needed to be cleaned, the interval time still elapses. When logs appeared and ready to be cleaned, the 300ms interval will exceed immediately and start to verify if throttling is needed, which is unexpected.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
