### PR TITLE
MINOR: KafkaConfig should not expose internal config when queried for non-internal values

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -579,7 +579,7 @@ object ConfigCommand extends Logging {
       .filter(entry => configSourceFilter match {
         case Some(configSource) => entry.source == configSource
         case None => true
-      }).toSeq
+      }).toSeq.sortBy(entry => entry.name())
   }
 
   private def describeQuotaConfigs(adminClient: Admin, entityTypes: List[String], entityNames: List[String]): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1516,7 +1516,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   override def values: util.Map[String, _] =
     if (this eq currentConfig) super.values else currentConfig.values
   override def nonInternalValues: util.Map[String, _] =
-    if (this eq currentConfig) super.nonInternalValues else currentConfig.values
+    if (this eq currentConfig) super.nonInternalValues else currentConfig.nonInternalValues
   override def originalsStrings: util.Map[String, String] =
     if (this eq currentConfig) super.originalsStrings else currentConfig.originalsStrings
   override def originalsWithPrefix(prefix: String): util.Map[String, AnyRef] =

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -588,6 +588,16 @@ class DynamicBrokerConfigTest {
     assertTrue(m.currentReporters.isEmpty)
   }
 
+  @Test
+  def testNonInternalValuesDoesNotExposeInternalConfigs(): Unit = {
+    val props = new Properties()
+    props.put(KafkaConfig.ZkConnectProp, "localhost:2181")
+    props.put(KafkaConfig.MetadataLogSegmentMinBytesProp, "1024")
+    val config = new KafkaConfig(props)
+    assertFalse(config.nonInternalValues.containsKey(KafkaConfig.MetadataLogSegmentMinBytesProp))
+    config.updateCurrentConfig(new KafkaConfig(props))
+    assertFalse(config.nonInternalValues.containsKey(KafkaConfig.MetadataLogSegmentMinBytesProp))
+  }
 }
 
 class TestDynamicThreadPool() extends BrokerReconfigurable {


### PR DESCRIPTION
Side fix: Print the topic/broker/broker-loggers configurations in alphabetical/sorted order. This will be useful when the user supplies the '--all' flag.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
