### PR TITLE
KAFKA-14559: Fix JMX tool to handle the object names with wild cards and optional attributes

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/JmxToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/JmxToolTest.java
@@ -175,6 +175,140 @@ public class JmxToolTest {
     }
 
     @Test
+    public void testDomainNamePattern() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.serve?:*",
+            "--attributes", "FifteenMinuteRate,FiveMinuteRate",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    public void testDomainNamePatternWithNoAttributes() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.serve?:*",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    public void testPropertyListPattern() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=BrokerTopicMetrics,*",
+            "--attributes", "FifteenMinuteRate,FiveMinuteRate",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    public void testPropertyListPatternWithNoAttributes() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=BrokerTopicMetrics,*",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    public void testPropertyValuePattern() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=BrokerTopicMetrics,name=*InPerSec",
+            "--attributes", "FifteenMinuteRate,FiveMinuteRate",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    public void testPropertyValuePatternWithNoAttributes() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=BrokerTopicMetrics,name=*InPerSec",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    // Combination of property-list and property-value patterns
+    public void testPropertyPattern() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=*,*",
+            "--attributes", "FifteenMinuteRate,FiveMinuteRate",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
+    // Combination of property-list and property-value patterns
+    public void testPropertyPatternWithNoAttributes() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=*,*",
+            "--report-format", "csv",
+            "--one-time"
+        };
+        String out = executeAndGetOut(args);
+        assertNormalExit();
+
+        Map<String, String> csv = parseCsv(out);
+        assertEquals("1.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FifteenMinuteRate"));
+        assertEquals("3.0", csv.get("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec:FiveMinuteRate"));
+    }
+
+    @Test
     public void dateFormat() {
         String dateFormat = "yyyyMMdd-hh:mm:ss";
         String[] args = new String[]{


### PR DESCRIPTION
JMX tool doesn't handle the object names with wild cards. 

**Specific MBean name**
```
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec --attributes Count,FifteenMinuteRate 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec --object-name kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec --object-name kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec --attributes Count,FifteenMinuteRate

```
**Domain Pattern**
```
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.serve?:* 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.serve?:* --attributes Count,FifteenMinuteRate
```

```
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.*:* 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.*:* --attributes Count,FifteenMinuteRate
```

**Property List pattern**
```
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,* 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,* --attributes Count,FifteenMinuteRate

```
**Property Value pattern**
```
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,name=*InPerSec 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=BrokerTopicMetrics,name=*InPerSec --attributes Count,FifteenMinuteRate

```
**Property pattern: (combination of list & value patterns)** 
```
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=*,* 
❯ sh kafka-jmx.sh --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi --object-name kafka.server:type=*,* --attributes Count,FifteenMinuteRate

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
