### PR TITLE
MINOR: Update LICENSE-binary based on the 3.4 dependencies

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -207,7 +207,7 @@ License Version 2.0:
 
 audience-annotations-0.5.0
 commons-cli-1.4
-commons-lang3-3.12.0
+commons-lang3-3.8.1
 jackson-annotations-2.13.4
 jackson-core-2.13.4
 jackson-databind-2.13.4.2
@@ -250,7 +250,7 @@ netty-transport-native-epoll-4.1.78.Final
 netty-transport-native-unix-common-4.1.78.Final
 plexus-utils-3.3.0
 reload4j-1.2.19
-rocksdbjni-6.29.4.1
+rocksdbjni-7.1.2
 scala-collection-compat_2.13-2.6.0
 scala-library-2.13.10
 scala-logging_2.13-3.9.4
@@ -284,6 +284,7 @@ see: licenses/eclipse-public-license-2.0
 
 jakarta.annotation-api-1.3.5
 jakarta.ws.rs-api-2.1.6
+javax.annotation-api-1.3.2
 javax.ws.rs-api-2.1.1
 hk2-api-2.6.1
 hk2-locator-2.6.1


### PR DESCRIPTION
No new licenses are needed, just two version changes in existing dependencies & one new dependency with existing license