### PR TITLE
MINOR: bump streams quickstart pom versions and add to list in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,9 @@ group=org.apache.kafka
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
+#  - streams/quickstart/pom.xml
+#  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+#  - streams/quickstart/java/pom.xml
 version=3.5.0-SNAPSHOT
 scalaVersion=2.13.10
 task=build

--- a/streams/quickstart/java/pom.xml
+++ b/streams/quickstart/java/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kafka</groupId>
         <artifactId>streams-quickstart</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>3.4.0-SNAPSHOT</kafka.version>
+        <kafka.version>3.5.0-SNAPSHOT</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
     </properties>
 

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 


### PR DESCRIPTION
The three pom files for the Streams quickstart also need to bump their versions after a branch cut. For some reason these are included (late) in the Release Process guide, but are missing from the list of what to update when bumping the version in `gradle.properties`. This commit adds the missing files to this list to help future RMs locate all the required version changes