### PR TITLE
KAFKA-14482: Move LoadedLogOffsets to storage module

### DIFF
--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -27,14 +27,10 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.InvalidOffsetException
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.snapshot.Snapshots
-import org.apache.kafka.server.log.internals.{CorruptIndexException, LogConfig, LogDirFailureChannel, LogOffsetMetadata}
+import org.apache.kafka.server.log.internals.{CorruptIndexException, LoadedLogOffsets, LogConfig, LogDirFailureChannel, LogOffsetMetadata}
 
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 import scala.collection.{Set, mutable}
-
-case class LoadedLogOffsets(logStartOffset: Long,
-                            recoveryPoint: Long,
-                            nextOffsetMetadata: LogOffsetMetadata)
 
 object LogLoader extends Logging {
 
@@ -205,7 +201,7 @@ class LogLoader(
       reloadFromCleanShutdown = hadCleanShutdown,
       logIdent)
     val activeSegment = segments.lastSegment.get
-    LoadedLogOffsets(
+    new LoadedLogOffsets(
       newLogStartOffset,
       newRecoveryPoint,
       new LogOffsetMetadata(nextOffset, activeSegment.baseOffset, activeSegment.size))

--- a/storage/src/main/java/org/apache/kafka/server/log/internals/LoadedLogOffsets.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/internals/LoadedLogOffsets.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.internals;
+
+import java.util.Objects;
+
+public class LoadedLogOffsets {
+    public final long logStartOffset;
+    public final long recoveryPoint;
+    public final LogOffsetMetadata nextOffsetMetadata;
+
+    public LoadedLogOffsets(final long logStartOffset,
+                            final long recoveryPoint,
+                            final LogOffsetMetadata nextOffsetMetadata) {
+        this.logStartOffset = logStartOffset;
+        this.recoveryPoint = recoveryPoint;
+        this.nextOffsetMetadata = Objects.requireNonNull(nextOffsetMetadata, "nextOffsetMetadata should not be null");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final LoadedLogOffsets that = (LoadedLogOffsets) o;
+        return logStartOffset == that.logStartOffset
+                && recoveryPoint == that.recoveryPoint
+                && nextOffsetMetadata.equals(that.nextOffsetMetadata);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(logStartOffset);
+        result = 31 * result + Long.hashCode(recoveryPoint);
+        result = 31 * result + nextOffsetMetadata.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LoadedLogOffsets(" +
+                "logStartOffset=" + logStartOffset +
+                ", recoveryPoint=" + recoveryPoint +
+                ", nextOffsetMetadata=" + nextOffsetMetadata +
+                ')';
+    }
+}


### PR DESCRIPTION
This is a relatively independent change in the context of KAFKA-14482.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
