### PR TITLE
KAFKA-13999: Add ProducerIdCount metric

### DIFF
--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -16,6 +16,7 @@
  */
 package kafka.log
 
+import kafka.metrics.KafkaMetricsGroup
 import kafka.server.{BrokerReconfigurable, KafkaConfig}
 import kafka.utils.{Logging, nonthreadsafe, threadsafe}
 import org.apache.kafka.common.TopicPartition
@@ -488,7 +489,7 @@ class ProducerStateManager(
   val maxTransactionTimeoutMs: Int,
   val producerStateManagerConfig: ProducerStateManagerConfig,
   val time: Time
-) extends Logging {
+) extends Logging with KafkaMetricsGroup {
   import ProducerStateManager._
   import java.util
 
@@ -501,6 +502,8 @@ class ProducerStateManager(
   private val producers = mutable.Map.empty[Long, ProducerStateEntry]
   private var lastMapOffset = 0L
   private var lastSnapOffset = 0L
+
+  newGauge("ProducerIdCount", () => producers.size)
 
   // Keep track of the last timestamp from the oldest transaction. This is used
   // to detect (approximately) when a transaction has been left hanging on a partition.


### PR DESCRIPTION
**Summary**
This PR provides an implementation of KIP-847 (https://cwiki.apache.org/confluence/display/KAFKA/KIP-847%3A+Add+ProducerIdCount+metrics). As far as I can tell, the original author @artemlivshits has not provided a pull request since the KIP was approved so I took the liberty of picking it up. Of course, if they provide a pull request I am happy to close this one.

I do not understand why the metric ought to be surfaced from `kafka.server:type=ReplicaManager,name=ProducerIdCount` when the information is stored in `ProducerStateManager`. I have thus taken the further liberty of surfacing the metric from `ProducerStateManager` directly under `kafka.log:type=ProducerStateManager,name=ProducerIdCount`. I am happy to revise this given the feedback or if this is accepted to update the KIP.

**Testing**
Grafana dashboard showing ProducerIdCount increasing when adding idempotent producers and decreasing whenever the the producer ids expire: https://g-576b9cd7b5.grafana-workspace.us-east-1.amazonaws.com/dashboard/snapshot/U5NfIDaMlm0VTIvmF4ZHJio7Kwuc1pTk

I do not know whether we carry out any unit/integration testing upon addition of new metrics, but if I am pointed to similar test cases I am happy to revise this PR.
