### PR TITLE
MINOR: Check process role and set correct logdirs

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -179,7 +179,12 @@ object KafkaRaftServer {
    *         be consistent across all log dirs) and the offline directories
    */
   def initializeLogDirs(config: KafkaConfig): (MetaProperties, BootstrapMetadata, Seq[String]) = {
-    val logDirs = (config.logDirs.toSet + config.metadataLogDir).toSeq
+    val logDirs = if (config.processRoles.equals(Set(BrokerRole, ControllerRole)))
+      (config.logDirs.toSet + config.metadataLogDir).toSeq
+    else if (config.processRoles.equals(Set(ControllerRole)))
+      Seq(config.metadataLogDir)
+    else
+      config.logDirs
     val (rawMetaProperties, offlineDirs) = BrokerMetadataCheckpoint.
       getBrokerMetadataAndOfflineDirs(logDirs, ignoreMissing = false)
 


### PR DESCRIPTION
Currently a controller role will fail if no log.dirs are specified. This is caused by KafkaRaftServer as it merges the configs in log.dirs and metadata.log.dir. If the paths in log.dirs weren't initialized with storage-tool when the process fails. This is unwanted as controller only roles don't need log.dirs.

This fix attempts to fix that by not merging the two configs, only if the process has both broker and controller roles.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
