### PR TITLE
KAFKA-14564: Upgrade netty to 4.1.86 to address CVEs

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -107,7 +107,7 @@ versions += [
   mavenArtifact: "3.8.4",
   metrics: "2.2.0",
   mockito: "4.6.1",
-  netty: "4.1.78.Final",
+  netty: "4.1.86.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
   reload4j: "1.2.19",


### PR DESCRIPTION
For [KAFKA-14564](https://issues.apache.org/jira/browse/KAFKA-14564): upgrade to Netty 4.1.86

Fixes the following:

* [CVE-2022-41881](https://nvd.nist.gov/vuln/detail/CVE-2022-41881)
* [CVE-2022-41915](https://nvd.nist.gov/vuln/detail/CVE-2022-41915)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
