### PR TITLE
MINOR: upgrade.from is revealed for Upgrade doc

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -1849,12 +1849,10 @@ only support 0.10.1.x or later brokers while 0.10.1.x brokers also support older
 
 <p><b>Note:</b> Bumping the protocol version and restarting can be done any time after the brokers were upgraded. It does not have to be immediately after.
 
-<!-- TODO: add when 0.10.1.2 is released
 <h5><a id="upgrade_1012_notable" href="#upgrade_1012_notable">Notable changes in 0.10.1.2</a></h5>
 <ul>
     <li> New configuration parameter <code>upgrade.from</code> added that allows rolling bounce upgrade from version 0.10.0.x </li>
 </ul>
--->
 
 <h5><a id="upgrade_10_1_breaking" href="#upgrade_10_1_breaking">Potential breaking changes in 0.10.1.0</a></h5>
 <ul>


### PR DESCRIPTION
Since 0.10.1.2 is long ago released, this config param should be revealed.

This PR doesn't touch codebase, so no necessary to test it.
