### PR TITLE
KAFKA-13999: Add ProducerCount metrics (KIP-847)

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -357,6 +357,11 @@ class Partition(val topicPartition: TopicPartition,
 
   def isAddingReplica(replicaId: Int): Boolean = assignmentState.isAddingReplica(replicaId)
 
+  def producerIdCount: Int = log.map(_.producerIdCount).getOrElse(0)
+
+  // Visible for testing
+  def removeExpiredProducers(currentTimeMs: Long): Unit = log.foreach(_.removeExpiredProducers(currentTimeMs))
+
   def inSyncReplicaIds: Set[Int] = partitionState.isr
 
   def maybeAddListener(listener: PartitionListener): Boolean = {

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -470,11 +470,8 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   }
 
-  val producerExpireCheck = scheduler.schedule("PeriodicProducerExpirationCheck", () => {
-    lock synchronized {
-      producerStateManager.removeExpiredProducers(time.milliseconds)
-    }
-  }, producerIdExpirationCheckIntervalMs, producerIdExpirationCheckIntervalMs)
+  val producerExpireCheck = scheduler.schedule("PeriodicProducerExpirationCheck", () => removeExpiredProducers(time.milliseconds),
+    producerIdExpirationCheckIntervalMs, producerIdExpirationCheckIntervalMs)
 
   // Visible for testing
   def removeExpiredProducers(currentTimeMs: Long): Unit = {

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -476,6 +476,13 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     }
   }, producerIdExpirationCheckIntervalMs, producerIdExpirationCheckIntervalMs)
 
+  // Visible for testing
+  def removeExpiredProducers(currentTimeMs: Long): Unit = {
+    lock synchronized {
+      producerStateManager.removeExpiredProducers(currentTimeMs)
+    }
+  }
+
   // For compatibility, metrics are defined to be under `Log` class
   override def metricName(name: String, tags: scala.collection.Map[String, String]): MetricName = {
     val pkg = getClass.getPackage
@@ -562,6 +569,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   def hasLateTransaction(currentTimeMs: Long): Boolean = {
     producerStateManager.hasLateTransaction(currentTimeMs)
   }
+
+  @threadsafe
+  def producerIdCount: Int = producerStateManager.producerIdCount
 
   def activeProducers: Seq[DescribeProducersResponseData.ProducerState] = {
     lock synchronized {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -255,6 +255,7 @@ class ReplicaManager(val config: KafkaConfig,
   newGauge("AtMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isAtMinIsr))
   newGauge("ReassigningPartitions", () => reassigningPartitionsCount)
   newGauge("PartitionsWithLateTransactionsCount", () => lateTransactionsCount)
+  newGauge("ProducerIdCount", () => producerIdCount)
 
   def reassigningPartitionsCount: Int = leaderPartitionsIterator.count(_.isReassigning)
 
@@ -262,6 +263,8 @@ class ReplicaManager(val config: KafkaConfig,
     val currentTimeMs = time.milliseconds()
     leaderPartitionsIterator.count(_.hasLateTransaction(currentTimeMs))
   }
+
+  def producerIdCount: Int = onlinePartitionsIterator.map(_.producerIdCount).sum
 
   val isrExpandRate: Meter = newMeter("IsrExpandsPerSec", "expands", TimeUnit.SECONDS)
   val isrShrinkRate: Meter = newMeter("IsrShrinksPerSec", "shrinks", TimeUnit.SECONDS)
@@ -1926,6 +1929,7 @@ class ReplicaManager(val config: KafkaConfig,
     removeMetric("AtMinIsrPartitionCount")
     removeMetric("ReassigningPartitions")
     removeMetric("PartitionsWithLateTransactionsCount")
+    removeMetric("ProducerIdCount")
   }
 
   def beginControlledShutdown(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/BrokerMetricNamesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerMetricNamesTest.scala
@@ -48,6 +48,7 @@ class BrokerMetricNamesTest(cluster: ClusterInstance) {
       "LeaderCount", "PartitionCount", "OfflineReplicaCount", "UnderReplicatedPartitions",
       "UnderMinIsrPartitionCount", "AtMinIsrPartitionCount", "ReassigningPartitions",
       "IsrExpandsPerSec", "IsrShrinksPerSec", "FailedIsrUpdatesPerSec",
+      "ProducerIdCount",
     )
     expectedMetricNames.foreach { metricName =>
       assertEquals(1, metrics.keySet.asScala.count(_.getMBeanName == s"$expectedPrefix=$metricName"))

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1605,6 +1605,11 @@ $ bin/kafka-acls.sh \
         <td>0</td>
       </tr>
       <tr>
+        <td>Producer Id counts</td>
+        <td>kafka.server:type=ReplicaManager,name=ProducerIdCount</td>
+        <td>Count of all producer ids for each replica on the broker.</td>
+      </tr>
+      <tr>
         <td>Partition counts</td>
         <td>kafka.server:type=ReplicaManager,name=PartitionCount</td>
         <td>mostly even across brokers</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1607,7 +1607,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Producer Id counts</td>
         <td>kafka.server:type=ReplicaManager,name=ProducerIdCount</td>
-        <td>Count of all producer ids for each replica on the broker.</td>
+        <td>Count of all producer ids created by transactional and idempotent producers in each replica on the broker</td>
       </tr>
       <tr>
         <td>Partition counts</td>

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -122,7 +122,7 @@ public class ProducerStateManager {
     private volatile File logDir;
 
     // The same as producers.size, but for lock-free access.
-    private volatile int _producerIdCount = 0;
+    private volatile int producerIdCount = 0;
 
     // Keep track of the last timestamp from the oldest transaction. This is used
     // to detect (approximately) when a transaction has been left hanging on a partition.
@@ -166,22 +166,22 @@ public class ProducerStateManager {
     }
 
     public int producerIdCount() {
-        return _producerIdCount;
+        return producerIdCount;
     }
 
     private void addProducerId(long producerId, ProducerStateEntry entry) {
         producers.put(producerId, entry);
-        _producerIdCount = producers.size();
+        producerIdCount = producers.size();
     }
 
     private void removeProducerIds(List<Long> keys) {
         producers.keySet().removeAll(keys);
-        _producerIdCount = producers.size();
+        producerIdCount = producers.size();
     }
 
     private void clearProducerIds() {
         producers.clear();
-        _producerIdCount = 0;
+        producerIdCount = 0;
     }
 
     /**

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -121,6 +121,9 @@ public class ProducerStateManager {
 
     private volatile File logDir;
 
+    // The same as producers.size, but for lock-free access.
+    private volatile int _producerIdCount = 0;
+
     // Keep track of the last timestamp from the oldest transaction. This is used
     // to detect (approximately) when a transaction has been left hanging on a partition.
     // We make the field volatile so that it can be safely accessed without a lock.
@@ -160,6 +163,25 @@ public class ProducerStateManager {
         log.info("Reloading the producer state snapshots");
         truncateFullyAndStartAt(0L);
         snapshots = loadSnapshots();
+    }
+
+    public int producerIdCount() {
+        return _producerIdCount;
+    }
+
+    private void addProducerId(long producerId, ProducerStateEntry entry) {
+        producers.put(producerId, entry);
+        _producerIdCount = producers.size();
+    }
+
+    private void removeProducerIds(List<Long> keys) {
+        producers.keySet().removeAll(keys);
+        _producerIdCount = producers.size();
+    }
+
+    private void clearProducerIds() {
+        producers.clear();
+        _producerIdCount = 0;
     }
 
     /**
@@ -306,7 +328,7 @@ public class ProducerStateManager {
     // Visible for testing
     public void loadProducerEntry(ProducerStateEntry entry) {
         long producerId = entry.producerId();
-        producers.put(producerId, entry);
+        addProducerId(producerId, entry);
         entry.currentTxnFirstOffset().ifPresent(offset -> ongoingTxns.put(offset, new TxnMetadata(producerId, offset)));
     }
 
@@ -322,7 +344,7 @@ public class ProducerStateManager {
                 .filter(entry -> isProducerExpired(currentTimeMs, entry.getValue()))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
-        producers.keySet().removeAll(keys);
+        removeProducerIds(keys);
     }
 
     /**
@@ -342,7 +364,7 @@ public class ProducerStateManager {
         }
 
         if (logEndOffset != mapEndOffset()) {
-            producers.clear();
+            clearProducerIds();
             ongoingTxns.clear();
             updateOldestTxnTimestamp();
 
@@ -374,7 +396,7 @@ public class ProducerStateManager {
         if (currentEntry != null) {
             currentEntry.update(updatedEntry);
         } else {
-            producers.put(appendInfo.producerId(), updatedEntry);
+            addProducerId(appendInfo.producerId(), updatedEntry);
         }
 
         appendInfo.startedTransactions().forEach(txn -> ongoingTxns.put(txn.firstOffset.messageOffset, txn));
@@ -479,7 +501,7 @@ public class ProducerStateManager {
      * Truncate the producer id mapping and remove all snapshots. This resets the state of the mapping.
      */
     public void truncateFullyAndStartAt(long offset) throws IOException {
-        producers.clear();
+        clearProducerIds();
         ongoingTxns.clear();
         unreplicatedTxns.clear();
         for (SnapshotFile snapshotFile : snapshots.values()) {


### PR DESCRIPTION
This is the PR for the implementation of KIP-847: https://cwiki.apache.org/confluence/display/KAFKA/KIP-847%3A+Add+ProducerIdCount+metrics
Add ProducerIdCount metric at the broker level:
```
kafka.server:type=ReplicaManager,name=ProducerIdCount
```

Added unit tests below to ensure the metric reported the count correctly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
