### PR TITLE
MINOR Fixed doc generation for LogConfig class in genTopicConfigDocs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1046,7 +1046,7 @@ project(':core') {
 
   task genTopicConfigDocs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'kafka.log.LogConfig'
+    mainClass = 'org.apache.kafka.server.log.internals.LogConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "topic_config.html").newOutputStream()
   }


### PR DESCRIPTION
MINOR Fixed doc generation for LogConfig class in genTopicConfigDocs.

This was a regression caused by https://github.com/apache/kafka/pull/13049

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
