### PR TITLE
Re-using callbackHandler for refreshing Kerberos TGT when keytab is not used

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/AbstractLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/AbstractLogin.java
@@ -71,6 +71,10 @@ public abstract class AbstractLogin implements Login {
         return contextName;
     }
 
+    protected AuthenticateCallbackHandler loginCallbackHandler() {
+        return loginCallbackHandler;
+    }
+
     protected Configuration configuration() {
         return configuration;
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -57,7 +57,6 @@ public class KerberosLogin extends AbstractLogin {
     private boolean isUsingTicketCache;
 
     private String principal;
-    private AuthenticateCallbackHandler callbackHandler;
 
     // LoginThread will sleep until 80% of time from last refresh to
     // ticket's expiry has been reached, at which time it will wake
@@ -91,7 +90,6 @@ public class KerberosLogin extends AbstractLogin {
         this.minTimeBeforeRelogin = (Long) configs.get(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN);
         this.kinitCmd = (String) configs.get(SaslConfigs.SASL_KERBEROS_KINIT_CMD);
         this.serviceName = getServiceName(configs, contextName, configuration);
-        this.callbackHandler = callbackHandler;
     }
 
     /**
@@ -371,7 +369,7 @@ public class KerberosLogin extends AbstractLogin {
             }
             //login and also update the subject field of this instance to
             //have the new credentials (pass it to the LoginContext constructor)
-            loginContext = new LoginContext(contextName(), subject, callbackHandler, configuration());
+            loginContext = new LoginContext(contextName(), subject, loginCallbackHandler(), configuration());
             log.info("Initiating re-login for {}", principal);
             login(loginContext);
         }
@@ -387,6 +385,16 @@ public class KerberosLogin extends AbstractLogin {
         loginContext.logout();
     }
 
+    // Visibility to override for testing
+    protected AuthenticateCallbackHandler loginCallbackHandler() {
+        return super.loginCallbackHandler();
+    }    
+
+    // Visibility to override for testing
+    protected LoginContext loginContext() {
+        return loginContext;
+    }    
+    
     private long currentElapsedTime() {
         return time.hiResClockMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -57,6 +57,7 @@ public class KerberosLogin extends AbstractLogin {
     private boolean isUsingTicketCache;
 
     private String principal;
+    private AuthenticateCallbackHandler callbackHandler;
 
     // LoginThread will sleep until 80% of time from last refresh to
     // ticket's expiry has been reached, at which time it will wake
@@ -90,6 +91,7 @@ public class KerberosLogin extends AbstractLogin {
         this.minTimeBeforeRelogin = (Long) configs.get(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN);
         this.kinitCmd = (String) configs.get(SaslConfigs.SASL_KERBEROS_KINIT_CMD);
         this.serviceName = getServiceName(configs, contextName, configuration);
+        this.callbackHandler = callbackHandler;
     }
 
     /**
@@ -369,7 +371,7 @@ public class KerberosLogin extends AbstractLogin {
             }
             //login and also update the subject field of this instance to
             //have the new credentials (pass it to the LoginContext constructor)
-            loginContext = new LoginContext(contextName(), subject, null, configuration());
+            loginContext = new LoginContext(contextName(), subject, callbackHandler, configuration());
             log.info("Initiating re-login for {}", principal);
             login(loginContext);
         }

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -57,7 +57,6 @@ public class KerberosLogin extends AbstractLogin {
     private boolean isUsingTicketCache;
 
     private String principal;
-    private AuthenticateCallbackHandler callbackHandler;
 
     // LoginThread will sleep until 80% of time from last refresh to
     // ticket's expiry has been reached, at which time it will wake
@@ -91,7 +90,6 @@ public class KerberosLogin extends AbstractLogin {
         this.minTimeBeforeRelogin = (Long) configs.get(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN);
         this.kinitCmd = (String) configs.get(SaslConfigs.SASL_KERBEROS_KINIT_CMD);
         this.serviceName = getServiceName(configs, contextName, configuration);
-        this.callbackHandler = callbackHandler;
     }
 
     /**
@@ -371,7 +369,7 @@ public class KerberosLogin extends AbstractLogin {
             }
             //login and also update the subject field of this instance to
             //have the new credentials (pass it to the LoginContext constructor)
-            loginContext = new LoginContext(contextName(), subject, callbackHandler, configuration());
+            loginContext = new LoginContext(contextName(), subject, loginCallbackHandler(), configuration());
             log.info("Initiating re-login for {}", principal);
             login(loginContext);
         }
@@ -386,7 +384,7 @@ public class KerberosLogin extends AbstractLogin {
     protected void logout() throws LoginException {
         loginContext.logout();
     }
-
+    
     private long currentElapsedTime() {
         return time.hiResClockMs();
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.kerberos;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.junit.jupiter.api.Test;
+
+public class KerberosLoginTest {
+	/*
+	 * KerberosLogin class should reuse the same callbackHandler for reLogin() as was used for login().
+	 */
+    @Test
+    public void testReuseCallbackDuringRelogin() throws Exception {
+    	KerberosLogin kl = new KerberosLogin();
+    	
+    	HashMap<String, Object> configs = new HashMap<>();
+    	configs.put(SaslConfigs.SASL_KERBEROS_SERVICE_NAME,"test");
+    	configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR,0.5);
+    	configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER,0.5);
+    	configs.put(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN,100l);
+    	
+    	Configuration configuration = new TestConfiguration();
+    	AuthenticateCallbackHandler callbackHandler = new TestAuthenticateCallbackHandler();
+    	
+    	kl.configure(configs, "dummy", configuration, callbackHandler);
+    	
+    	assertSame(callbackHandler,kl.loginCallbackHandler());
+    	
+    	setFieldViaReflection(kl,"isKrbTicket",true);
+    	setFieldViaReflection(kl,"loginContext",new TestLoginContext("dummy"));
+    	
+    	LoginContext lctxBeforeRelogin = (LoginContext) getFieldViaReflection(kl,"loginContext");
+    	
+    	try {
+    		kl.reLogin();
+    	} catch( Exception ex ) {
+    		// as expected -- all modules ignored
+    		// but the new login context should have been created with the callbackHandler at this point already
+    	}
+    	
+    	// login context must change
+    	LoginContext lctxAfterRelogin = (LoginContext) getFieldViaReflection(kl,"loginContext");
+    	assertNotSame(lctxAfterRelogin, lctxBeforeRelogin);
+    	
+    	// but the callbackHandler should be the same
+    	CallbackHandler ch = (CallbackHandler) getFieldViaReflection(lctxAfterRelogin,"callbackHandler");
+    	assertSame(callbackHandler,ch);
+    }
+
+	private void setFieldViaReflection(Object kl, String name, Object val) throws Exception {
+		Class clz = kl.getClass();
+		
+		Field field = clz.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(kl, val);
+	}
+	
+	private Object getFieldViaReflection(Object kl, String name) throws Exception {
+		Class clz = kl.getClass();
+		
+		Field field = clz.getDeclaredField(name);
+		field.setAccessible(true);
+		return field.get(kl);
+	}
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.kerberos;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.junit.jupiter.api.Test;
+
+public class KerberosLoginTest {
+	/*
+	 * KerberosLogin class should reuse the same callbackHandler for reLogin() as was used for login().
+	 */
+    @Test
+    public void testReuseCallbackDuringRelogin() throws Exception {
+    	KerberosLogin kl = new KerberosLogin();
+    	
+    	HashMap<String, Object> configs = new HashMap<>();
+    	configs.put(SaslConfigs.SASL_KERBEROS_SERVICE_NAME,"test");
+    	configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR,0.5);
+    	configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER,0.5);
+    	configs.put(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN,100l);
+    	
+    	Configuration configuration = new TestConfiguration();
+    	AuthenticateCallbackHandler callbackHandler = new TestAuthenticateCallbackHandler();
+    	
+    	kl.configure(configs, "dummy", configuration, callbackHandler);
+    	
+    	AuthenticateCallbackHandler storedCallbackHandler = (AuthenticateCallbackHandler) getFieldViaReflection(kl,"loginCallbackHandler");
+    	assertSame(callbackHandler,storedCallbackHandler);
+    	
+    	setFieldViaReflection(kl,"isKrbTicket",true);
+    	setFieldViaReflection(kl,"loginContext",new TestLoginContext("dummy"));
+    	
+    	LoginContext lctxBeforeRelogin = (LoginContext) getFieldViaReflection(kl,"loginContext");
+    	
+    	try {
+    		kl.reLogin();
+    	} catch( Exception ex ) {
+    		// as expected -- all modules ignored
+    		// but the new login context should have been created with the callbackHandler at this point already
+    	}
+    	
+    	// login context must change
+    	LoginContext lctxAfterRelogin = (LoginContext) getFieldViaReflection(kl,"loginContext");
+    	assertNotSame(lctxAfterRelogin, lctxBeforeRelogin);
+    	
+    	// but the callbackHandler should be the same
+    	CallbackHandler ch = (CallbackHandler) getFieldViaReflection(lctxAfterRelogin,"callbackHandler");
+    	assertSame(callbackHandler,ch);
+    }
+
+	private void setFieldViaReflection(Object kl, String name, Object val) throws Exception {
+		Class clz = kl.getClass();
+		
+		Field field = clz.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(kl, val);
+	}
+	
+	private Object getFieldViaReflection(Object kl, String name) throws Exception {
+		Class clz = kl.getClass();
+		
+		Field field = null;
+		while(field == null && clz != null) {
+			try {
+				field = clz.getDeclaredField(name);
+			} catch(NoSuchFieldException ex) {
+				clz = clz.getSuperclass();
+			}
+		}
+		
+		field.setAccessible(true);
+		return field.get(kl);
+	}
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
@@ -31,11 +31,11 @@ import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.junit.jupiter.api.Test;
 
 public class KerberosLoginTest {
-	/*
-	 * KerberosLogin class should reuse the same callbackHandler for reLogin() as
-	 * was used for login().
-	 */
-	@Test
+    /*
+     * KerberosLogin class should reuse the same callbackHandler for reLogin() as
+     * was used for login().
+     */
+    @Test
     public void testReuseCallbackDuringRelogin() throws Exception {
         KerberosLogin kl = new KerberosLogin();
 
@@ -60,7 +60,7 @@ public class KerberosLoginTest {
 
         try {
             kl.reLogin();
-		} catch (Exception ex) {
+        } catch (Exception ex) {
             // as expected -- all modules ignored
             // but the new login context should have been created with the callbackHandler
             // at this point already
@@ -81,7 +81,7 @@ public class KerberosLoginTest {
         Field field = clz.getDeclaredField(name);
         field.setAccessible(true);
         field.set(kl, val);
-	}
+    }
 
     private Object getFieldViaReflection(Object kl, String name) throws Exception {
         Class clz = kl.getClass();

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosLoginTest.java
@@ -32,68 +32,70 @@ import org.junit.jupiter.api.Test;
 
 public class KerberosLoginTest {
 	/*
-	 * KerberosLogin class should reuse the same callbackHandler for reLogin() as was used for login().
+	 * KerberosLogin class should reuse the same callbackHandler for reLogin() as
+	 * was used for login().
 	 */
-    @Test
+	@Test
     public void testReuseCallbackDuringRelogin() throws Exception {
-    	KerberosLogin kl = new KerberosLogin();
-    	
-    	HashMap<String, Object> configs = new HashMap<>();
-    	configs.put(SaslConfigs.SASL_KERBEROS_SERVICE_NAME,"test");
-    	configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR,0.5);
-    	configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER,0.5);
-    	configs.put(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN,100l);
-    	
-    	Configuration configuration = new TestConfiguration();
-    	AuthenticateCallbackHandler callbackHandler = new TestAuthenticateCallbackHandler();
-    	
-    	kl.configure(configs, "dummy", configuration, callbackHandler);
-    	
-    	AuthenticateCallbackHandler storedCallbackHandler = (AuthenticateCallbackHandler) getFieldViaReflection(kl,"loginCallbackHandler");
-    	assertSame(callbackHandler,storedCallbackHandler);
-    	
-    	setFieldViaReflection(kl,"isKrbTicket",true);
-    	setFieldViaReflection(kl,"loginContext",new TestLoginContext("dummy"));
-    	
-    	LoginContext lctxBeforeRelogin = (LoginContext) getFieldViaReflection(kl,"loginContext");
-    	
-    	try {
-    		kl.reLogin();
-    	} catch( Exception ex ) {
-    		// as expected -- all modules ignored
-    		// but the new login context should have been created with the callbackHandler at this point already
-    	}
-    	
-    	// login context must change
-    	LoginContext lctxAfterRelogin = (LoginContext) getFieldViaReflection(kl,"loginContext");
-    	assertNotSame(lctxAfterRelogin, lctxBeforeRelogin);
-    	
-    	// but the callbackHandler should be the same
-    	CallbackHandler ch = (CallbackHandler) getFieldViaReflection(lctxAfterRelogin,"callbackHandler");
-    	assertSame(callbackHandler,ch);
+        KerberosLogin kl = new KerberosLogin();
+
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put(SaslConfigs.SASL_KERBEROS_SERVICE_NAME, "test");
+        configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, 0.5);
+        configs.put(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER, 0.5);
+        configs.put(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN, 100L);
+
+        Configuration configuration = new TestConfiguration();
+        AuthenticateCallbackHandler callbackHandler = new TestAuthenticateCallbackHandler();
+
+        kl.configure(configs, "dummy", configuration, callbackHandler);
+
+        AuthenticateCallbackHandler storedCallbackHandler = (AuthenticateCallbackHandler) getFieldViaReflection(kl, "loginCallbackHandler");
+        assertSame(callbackHandler, storedCallbackHandler);
+
+        setFieldViaReflection(kl, "isKrbTicket", true);
+        setFieldViaReflection(kl, "loginContext", new TestLoginContext("dummy"));
+
+        LoginContext lctxBeforeRelogin = (LoginContext) getFieldViaReflection(kl, "loginContext");
+
+        try {
+            kl.reLogin();
+		} catch (Exception ex) {
+            // as expected -- all modules ignored
+            // but the new login context should have been created with the callbackHandler
+            // at this point already
+        }
+
+        // login context must change
+        LoginContext lctxAfterRelogin = (LoginContext) getFieldViaReflection(kl, "loginContext");
+        assertNotSame(lctxAfterRelogin, lctxBeforeRelogin);
+
+        // but the callbackHandler should be the same
+        CallbackHandler ch = (CallbackHandler) getFieldViaReflection(lctxAfterRelogin, "callbackHandler");
+        assertSame(callbackHandler, ch);
     }
 
-	private void setFieldViaReflection(Object kl, String name, Object val) throws Exception {
-		Class clz = kl.getClass();
-		
-		Field field = clz.getDeclaredField(name);
-		field.setAccessible(true);
-		field.set(kl, val);
+    private void setFieldViaReflection(Object kl, String name, Object val) throws Exception {
+        Class clz = kl.getClass();
+
+        Field field = clz.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(kl, val);
 	}
-	
-	private Object getFieldViaReflection(Object kl, String name) throws Exception {
-		Class clz = kl.getClass();
-		
-		Field field = null;
-		while(field == null && clz != null) {
-			try {
-				field = clz.getDeclaredField(name);
-			} catch(NoSuchFieldException ex) {
-				clz = clz.getSuperclass();
-			}
-		}
-		
-		field.setAccessible(true);
-		return field.get(kl);
-	}
+
+    private Object getFieldViaReflection(Object kl, String name) throws Exception {
+        Class clz = kl.getClass();
+
+        Field field = null;
+        while (field == null && clz != null) {
+            try {
+                field = clz.getDeclaredField(name);
+            } catch (NoSuchFieldException ex) {
+                clz = clz.getSuperclass();
+            }
+        }
+
+        field.setAccessible(true);
+        return field.get(kl);
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestAuthenticateCallbackHandler.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestAuthenticateCallbackHandler.java
@@ -1,0 +1,26 @@
+package org.apache.kafka.common.security.kerberos;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+
+public class TestAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
+	@Override
+	public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+	}
+
+	@Override
+	public void configure(Map<String, ?> configs, String saslMechanism,
+			List<AppConfigurationEntry> jaasConfigEntries) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestAuthenticateCallbackHandler.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestAuthenticateCallbackHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.security.kerberos;
 
 import java.io.IOException;
@@ -11,16 +27,15 @@ import javax.security.auth.login.AppConfigurationEntry;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 
 public class TestAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
-	@Override
-	public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-	}
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+    }
 
-	@Override
-	public void configure(Map<String, ?> configs, String saslMechanism,
-			List<AppConfigurationEntry> jaasConfigEntries) {
-	}
+    @Override
+    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+    }
 
-	@Override
-	public void close() {
-	}
+    @Override
+    public void close() {
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestConfiguration.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestConfiguration.java
@@ -1,0 +1,11 @@
+package org.apache.kafka.common.security.kerberos;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
+public class TestConfiguration extends Configuration {
+	@Override
+	public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+		return new AppConfigurationEntry[] {};
+	}
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestConfiguration.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestConfiguration.java
@@ -1,11 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.security.kerberos;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
 public class TestConfiguration extends Configuration {
-	@Override
-	public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-		return new AppConfigurationEntry[] {};
-	}
+    @Override
+    public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        return new AppConfigurationEntry[] {};
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestLoginContext.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestLoginContext.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.security.kerberos;
 
 import javax.security.auth.login.AppConfigurationEntry;
@@ -6,15 +22,14 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
 public class TestLoginContext extends LoginContext {
-    private static Configuration EMPTY_WILDCARD_CONFIGURATION = new Configuration() {
+    private final static Configuration EMPTY_WILDCARD_CONFIGURATION = new Configuration() {
         @Override
         public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
             return new AppConfigurationEntry[0]; // match any name
         }
     };
 	
-	
-	public TestLoginContext(String name) throws LoginException {
-		super(name,null,null,EMPTY_WILDCARD_CONFIGURATION);
-	}
+    public TestLoginContext(String name) throws LoginException {
+        super(name, null, null, EMPTY_WILDCARD_CONFIGURATION);
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestLoginContext.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestLoginContext.java
@@ -28,7 +28,7 @@ public class TestLoginContext extends LoginContext {
             return new AppConfigurationEntry[0]; // match any name
         }
     };
-	
+
     public TestLoginContext(String name) throws LoginException {
         super(name, null, null, EMPTY_WILDCARD_CONFIGURATION);
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestLoginContext.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/TestLoginContext.java
@@ -1,0 +1,20 @@
+package org.apache.kafka.common.security.kerberos;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+public class TestLoginContext extends LoginContext {
+    private static Configuration EMPTY_WILDCARD_CONFIGURATION = new Configuration() {
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+            return new AppConfigurationEntry[0]; // match any name
+        }
+    };
+	
+	
+	public TestLoginContext(String name) throws LoginException {
+		super(name,null,null,EMPTY_WILDCARD_CONFIGURATION);
+	}
+}


### PR DESCRIPTION
When keytab file is not used, and the necessary configuration data are provided by the SASL callback handler, the Kerberos TGT renewal fails because the code is not re-using the configured CallbackHandler in the re-login sequence.

The error is:

```
javax.security.auth.login.LoginException: No CallbackHandler available to garner authentication information from the user
```

The change preserves the instance of the CallbackHandler that was used to login into Kerberos and passes it to the LoginContext when TGT needs to be renewed. 

The change is tested in DIT with live Kafka and AD KRB instances in our current project.