### PR TITLE
MINOR: Clarify docs for Streams config max.warmup.replicas.

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -778,10 +778,21 @@ rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cl
           <span id="streams-developer-guide-max-warmup-replicas"></span><h4><a class="toc-backref" href="#id29">max.warmup.replicas</a><a class="headerlink" href="#max-warmup-replicas" title="Permalink to this headline"></a></h4>
           <blockquote>
             <div>
-              The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once for the purpose of keeping
-              the task available on one instance while it is warming up on another instance it has been reassigned to. Used to throttle how much extra broker
-              traffic and cluster state can be used for high availability. Increasing this will allow Streams to warm up more tasks at once, speeding up the time
-              for the reassigned warmups to restore sufficient state for them to be transitioned to active tasks. Must be at least 1.
+              <p>
+                The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once for the purpose of keeping
+                the task available on one instance while it is warming up on another instance it has been reassigned to. Used to throttle how much extra broker
+                traffic and cluster state can be used for high availability. Increasing this will allow Streams to warm up more tasks at once, speeding up the time
+                for the reassigned warmups to restore sufficient state for them to be transitioned to active tasks. Must be at least 1.
+              </p>
+              <p>
+                Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup replica can only be promoted to an active Task during
+                a rebalance (normally a Probing Rebalance, which occur at a frequency specified by the
+                <code class="docutils literal"><span class="pre">probing.rebalance.interval.ms</span></code> config). This means that the
+                maximum rate at which Stream Tasks can be migrated from over-burdened Streams Instances to fresher Streams Instances can be determined by
+                (<code class="docutils literal"><span class="pre">max.warmup.replicas</span></code> /
+                <code class="docutils literal"><span class="pre">probing.rebalance.interval.ms</span></code>). If it takes longer than the probing rebalance interval
+                for the data for a Task to be migrated, then that rate will be lower.
+              </p>
             </div>
           </blockquote>
         </div>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -785,7 +785,7 @@ rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cl
                 for the reassigned warmups to restore sufficient state for them to be transitioned to active tasks. Must be at least 1.
               </p>
               <p>
-                Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup task can only be promoted to an active task during
+                Note that one warmup replica corresponds to one <a href="https://kafka.apache.org/34/documentation/streams/architecture#streams_architecture_tasks">Stream Task</a>. Furthermore, note that each warmup task can only be promoted to an active task during
                 a rebalance (normally during a so-called probing rebalance, which occur at a frequency specified by the
                 <code class="docutils literal"><span class="pre">probing.rebalance.interval.ms</span></code> config). This means that the
                 maximum rate at which active tasks can be migrated from one Kafka Streams instance to another instance can be determined by

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -779,19 +779,18 @@ rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cl
           <blockquote>
             <div>
               <p>
-                The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once for the purpose of keeping
+                The maximum number of warmup replicas (extra standbys beyond the configured <code class="docutils literal"><span class="pre">num.standbys</span></code>) that can be assigned at once for the purpose of keeping
                 the task available on one instance while it is warming up on another instance it has been reassigned to. Used to throttle how much extra broker
                 traffic and cluster state can be used for high availability. Increasing this will allow Streams to warm up more tasks at once, speeding up the time
                 for the reassigned warmups to restore sufficient state for them to be transitioned to active tasks. Must be at least 1.
               </p>
               <p>
-                Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup replica can only be promoted to an active Task during
-                a rebalance (normally a Probing Rebalance, which occur at a frequency specified by the
+                Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup task can only be promoted to an active task during
+                a rebalance (normally during a so-called probing rebalance, which occur at a frequency specified by the
                 <code class="docutils literal"><span class="pre">probing.rebalance.interval.ms</span></code> config). This means that the
-                maximum rate at which Stream Tasks can be migrated from over-burdened Streams Instances to fresher Streams Instances can be determined by
+                maximum rate at which active tasks can be migrated from one Kafka Streams instance to another instance can be determined by
                 (<code class="docutils literal"><span class="pre">max.warmup.replicas</span></code> /
-                <code class="docutils literal"><span class="pre">probing.rebalance.interval.ms</span></code>). If it takes longer than the probing rebalance interval
-                for the data for a Task to be migrated, then that rate will be lower.
+                <code class="docutils literal"><span class="pre">probing.rebalance.interval.ms</span></code>).
               </p>
             </div>
           </blockquote>

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -579,7 +579,12 @@ public class StreamsConfig extends AbstractConfig {
     public static final String MAX_WARMUP_REPLICAS_CONFIG = "max.warmup.replicas";
     private static final String MAX_WARMUP_REPLICAS_DOC = "The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once for the purpose of keeping " +
                                                               " the task available on one instance while it is warming up on another instance it has been reassigned to. Used to throttle how much extra broker " +
-                                                              " traffic and cluster state can be used for high availability. Must be at least 1.";
+                                                              " traffic and cluster state can be used for high availability. Must be at least 1." +
+                                                              "Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup replica can only be promoted to an active Task " +
+                                                              "during a rebalance (normally a Probing Rebalance, which occur at a frequency specified by the `probing.rebalance.interval.ms` config). This means " +
+                                                              "that the maximum rate at which Stream Tasks can be migrated from over-burdened Streams Instances to fresher Streams Instances can be determined by " +
+                                                              "(`max.warmup.replicas` / `probing.rebalance.interval.ms`). If it takes longer than the probing rebalance interval for the data for a Task to be " +
+                                                              "migrated, then that rate will be lower.";
 
     /** {@code metadata.max.age.ms} */
     @SuppressWarnings("WeakerAccess")

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -580,11 +580,10 @@ public class StreamsConfig extends AbstractConfig {
     private static final String MAX_WARMUP_REPLICAS_DOC = "The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once for the purpose of keeping " +
                                                               " the task available on one instance while it is warming up on another instance it has been reassigned to. Used to throttle how much extra broker " +
                                                               " traffic and cluster state can be used for high availability. Must be at least 1." +
-                                                              "Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup replica can only be promoted to an active Task " +
-                                                              "during a rebalance (normally a Probing Rebalance, which occur at a frequency specified by the `probing.rebalance.interval.ms` config). This means " +
-                                                              "that the maximum rate at which Stream Tasks can be migrated from over-burdened Streams Instances to fresher Streams Instances can be determined by " +
-                                                              "(`max.warmup.replicas` / `probing.rebalance.interval.ms`). If it takes longer than the probing rebalance interval for the data for a Task to be " +
-                                                              "migrated, then that rate will be lower.";
+                                                              "Note that one warmup replica corresponds to one Stream Task. Furthermore, note that each warmup replica can only be promoted to an active task " +
+                                                              "during a rebalance (normally during a so-called probing rebalance, which occur at a frequency specified by the `probing.rebalance.interval.ms` config). This means " +
+                                                              "that the maximum rate at which active tasks can be migrated from one Kafka Streams Instance to another instance can be determined by " +
+                                                              "(`max.warmup.replicas` / `probing.rebalance.interval.ms`).";
 
     /** {@code metadata.max.age.ms} */
     @SuppressWarnings("WeakerAccess")


### PR DESCRIPTION
Documentation only—Minor clarification on how max.warmup.replicas works; specifically, that one "warmup replica" corresponds to a Task that is restoring its state. Also clarifies how max.warmup.replicas interacts with probing.rebalance.interval.ms.