### PR TITLE
KAFKA-14535: Fix flaky EndToEndAuthorization tests which were sensitive to ACL change reordering

### DIFF
--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -502,6 +502,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     superuserAdminClient.deleteAcls(List(AclTopicWrite().toFilter).asJava).values
 
     brokers.foreach { s =>
+      TestUtils.waitAndVerifyAcls(TopicCreateAcl, s.dataPlaneRequestProcessor.authorizer.get, topicResource)
       TestUtils.waitAndVerifyAcls(GroupReadAcl, s.dataPlaneRequestProcessor.authorizer.get, groupResource)
     }
   }


### PR DESCRIPTION
The ACL change methods (create, delete) are eventually consistent across a Kafka cluster. As part of that, changes to the same resource made to different brokers may be reordered. In this test, a delete operation initiated in noConsumeWithoutDescribeAclSetup was being reordered to an unexpected time later in the test, causing an expected ACL to be missing.

To fix this, add a wait condition that asserts that the delete operations initiated in noConsumeWithoutDescribeAclSetup are completely applied before returning from the method.

Note: test failures were present for both the ZK and KRAFT iterations of the test, but the ZK iteration encountered it much more often, and was used to diagnose the reordering.

This is a typo in the original implementation of this method in https://github.com/apache/kafka/pull/1908/files#diff-c38532e2fcf5cce4cf30a824bc6bef9953c05d9472db51c3778a0286f6f01296R311 . And was made worse when the CREATE acl was added but never deleted: https://github.com/apache/kafka/pull/4795/files#diff-c38532e2fcf5cce4cf30a824bc6bef9953c05d9472db51c3778a0286f6f01296R293-R308 .
However, I don't think that this became flakey until https://github.com/apache/kafka/pull/12843 which replaced the AclCommand with the AdminClient, and removed the synchronization to wait for the ACL operation to resolve before proceeding with the test.

This does not require a change to the ACL mechanisms, as I believe the reordering is an expected part of the consistency algorithm, which includes a CAS operation to ZK. This is also not a security risk, as this only affects successful ACL change operations, and should not allow unsuccessful ACL change operations to insert invalid ACLs.

Signed-off-by: Greg Harris <greg.harris@aiven.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
