### PR TITLE
KAFKA-14601: Improve exception handling in KafkaEventQueue

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -306,7 +306,7 @@
     <suppress checks="(ParameterNumber|ClassDataAbstractionCoupling)"
               files="(QuorumController).java"/>
     <suppress checks="CyclomaticComplexity"
-              files="(ClientQuotasImage|MetadataDelta|QuorumController|ReplicationControlManager).java"/>
+              files="(ClientQuotasImage|KafkaEventQueue|MetadataDelta|QuorumController|ReplicationControlManager).java"/>
     <suppress checks="NPathComplexity"
               files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager|FeatureControlManager).java"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -180,7 +180,10 @@ class BrokerLifecycleManager(
   /**
    * The event queue.
    */
-  private[server] val eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix.getOrElse(""))
+  private[server] val eventQueue = new KafkaEventQueue(time,
+    logContext,
+    threadNamePrefix.getOrElse(""),
+    new ShutdownEvent())
 
   /**
    * Start the BrokerLifecycleManager.
@@ -239,7 +242,7 @@ class BrokerLifecycleManager(
    * Start shutting down the BrokerLifecycleManager, but do not block.
    */
   def beginShutdown(): Unit = {
-    eventQueue.beginShutdown("beginShutdown", new ShutdownEvent())
+    eventQueue.beginShutdown("beginShutdown");
   }
 
   /**
@@ -470,7 +473,7 @@ class BrokerLifecycleManager(
     override def run(): Unit = {
       if (!initialRegistrationSucceeded) {
         error("Shutting down because we were unable to register with the controller quorum.")
-        eventQueue.beginShutdown("registrationTimeout", new ShutdownEvent())
+        eventQueue.beginShutdown("registrationTimeout");
       }
     }
   }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataSnapshotter.scala
@@ -61,7 +61,7 @@ class BrokerMetadataSnapshotter(
   /**
    * The event queue which runs this listener.
    */
-  val eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix.getOrElse(""))
+  val eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix.getOrElse(""), new ShutdownEvent())
 
   override def maybeStartSnapshot(
     lastContainedLogTime: Long,
@@ -126,7 +126,7 @@ class BrokerMetadataSnapshotter(
   }
 
   def beginShutdown(): Unit = {
-    eventQueue.beginShutdown("beginShutdown", new ShutdownEvent())
+    eventQueue.beginShutdown("beginShutdown");
   }
 
   class ShutdownEvent() extends EventQueue.Event {

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -25,6 +25,7 @@ import org.apache.kafka.image.MetadataProvenance;
 import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.image.writer.ImageReWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
+import org.apache.kafka.queue.EventQueue;
 import org.apache.kafka.queue.KafkaEventQueue;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.BatchReader;
@@ -209,7 +210,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         this.uninitializedPublishers = new LinkedHashMap<>();
         this.publishers = new LinkedHashMap<>();
         this.image = MetadataImage.EMPTY;
-        this.eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix);
+        this.eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix, new ShutdownEvent());
     }
 
     private boolean stillNeedToCatchUp(long offset) {
@@ -537,9 +538,14 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
 
     @Override
     public void beginShutdown() {
-        eventQueue.beginShutdown("beginShutdown", () -> {
+        eventQueue.beginShutdown("beginShutdown");
+    }
+
+    class ShutdownEvent implements EventQueue.Event {
+        @Override
+        public void run() throws Exception {
             for (Iterator<MetadataPublisher> iter = uninitializedPublishers.values().iterator();
-                    iter.hasNext(); ) {
+                 iter.hasNext(); ) {
                 closePublisher(iter.next());
                 iter.remove();
             }
@@ -548,7 +554,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                 closePublisher(iter.next());
                 iter.remove();
             }
-        });
+        }
     }
 
     Time time() {

--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 
 import java.util.OptionalLong;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 
@@ -210,43 +209,14 @@ public interface EventQueue extends AutoCloseable {
                  Event event);
 
     /**
-     * Asynchronously shut down the event queue with no unnecessary delay.
-     * @see #beginShutdown(String, Event, long, TimeUnit)
-     *
-     * @param source                The source of the shutdown.
-     */
-    default void beginShutdown(String source) {
-        beginShutdown(source, new VoidEvent());
-    }
-
-    /**
-     * Asynchronously shut down the event queue with no unnecessary delay.
-     *
-     * @param source        The source of the shutdown.
-     * @param cleanupEvent  The mandatory event to invoke after all other events have
-     *                      been processed.
-     * @see #beginShutdown(String, Event, long, TimeUnit)
-     */
-    default void beginShutdown(String source, Event cleanupEvent) {
-        beginShutdown(source, cleanupEvent, 0, TimeUnit.SECONDS);
-    }
-
-    /**
      * Asynchronously shut down the event queue.
      *
-     * No new events will be accepted, and the timeout will be initiated
-     * for all existing events.
+     * No new events will be accepted, and the queue thread will exit after running the existing events.
+     * Deferred events will receive TimeoutExceptions.
      *
      * @param source        The source of the shutdown.
-     * @param cleanupEvent  The mandatory event to invoke after all other events have
-     *                      been processed.
-     * @param timeSpan      The amount of time to use for the timeout.
-     *                      Once the timeout elapses, any remaining queued
-     *                      events will get a
-     *                      {@link org.apache.kafka.common.errors.TimeoutException}.
-     * @param timeUnit      The time unit to use for the timeout.
      */
-    void beginShutdown(String source, Event cleanupEvent, long timeSpan, TimeUnit timeUnit);
+    void beginShutdown(String source);
 
     /**
      * @return The number of pending and running events. If this is 0, there is no running event and

--- a/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
+++ b/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import static java.util.concurrent.TimeUnit.HOURS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -165,7 +166,7 @@ public class KafkaEventQueueTest {
         queue.close();
     }
 
-    private final static long ONE_HOUR_NS = TimeUnit.NANOSECONDS.convert(1, TimeUnit.HOURS);
+    private final static long ONE_HOUR_NS = TimeUnit.NANOSECONDS.convert(1, HOURS);
 
     @Test
     public void testScheduleDeferredWithTagReplacement() throws Exception {
@@ -214,7 +215,7 @@ public class KafkaEventQueueTest {
         final AtomicInteger count = new AtomicInteger(0);
         CompletableFuture<Integer> future = new CompletableFuture<>();
         queue.scheduleDeferred("myDeferred",
-            __ -> OptionalLong.of(Time.SYSTEM.nanoseconds() + TimeUnit.HOURS.toNanos(1)),
+            __ -> OptionalLong.of(Time.SYSTEM.nanoseconds() + HOURS.toNanos(1)),
             new FutureEvent<>(future, () -> count.getAndAdd(1)));
         queue.beginShutdown("testShutdownBeforeDeferred");
         assertThrows(ExecutionException.class, () -> future.get());
@@ -257,7 +258,7 @@ public class KafkaEventQueueTest {
         future.complete(null);
         TestUtils.waitForCondition(() -> queue.isEmpty(), "Failed to see the queue become empty.");
         queue.scheduleDeferred("later",
-                __ -> OptionalLong.of(Time.SYSTEM.nanoseconds() + TimeUnit.HOURS.toNanos(1)),
+                __ -> OptionalLong.of(Time.SYSTEM.nanoseconds() + HOURS.toNanos(1)),
                 () -> { });
         assertFalse(queue.isEmpty());
         queue.scheduleDeferred("soon",
@@ -269,5 +270,146 @@ public class KafkaEventQueueTest {
         assertTrue(queue.isEmpty());
         queue.close();
         assertTrue(queue.isEmpty());
+    }
+
+    /**
+     * Test that we continue handling events after Event#handleException itself throws an exception.
+     */
+    @Test
+    public void testHandleExceptionThrowingAnException() throws Exception {
+        KafkaEventQueue queue = new KafkaEventQueue(Time.SYSTEM, new LogContext(),
+                "testHandleExceptionThrowingAnException");
+        CompletableFuture<Void> initialFuture = new CompletableFuture<>();
+        queue.append(() -> initialFuture.get());
+        AtomicInteger counter = new AtomicInteger(0);
+        queue.append(new EventQueue.Event() {
+            @Override
+            public void run() throws Exception {
+                counter.incrementAndGet();
+                throw new IllegalStateException("First exception");
+            }
+
+            @Override
+            public void handleException(Throwable e) {
+                if (e instanceof IllegalStateException) {
+                    counter.incrementAndGet();
+                    throw new RuntimeException("Second exception");
+                }
+            }
+        });
+        queue.append(() -> counter.incrementAndGet());
+        assertEquals(3, queue.size());
+        initialFuture.complete(null);
+        TestUtils.waitForCondition(() -> counter.get() == 3,
+                "Failed to see all events execute as planned.");
+        queue.close();
+    }
+
+    private static class InterruptableEvent implements EventQueue.Event {
+        private final CompletableFuture<Void> runFuture;
+        private final CompletableFuture<Thread> queueThread;
+        private final AtomicInteger numCallsToRun;
+        private final AtomicInteger numInterruptedExceptionsSeen;
+
+        InterruptableEvent(
+            CompletableFuture<Thread> queueThread,
+            AtomicInteger numCallsToRun,
+            AtomicInteger numInterruptedExceptionsSeen
+        ) {
+            this.runFuture = new CompletableFuture<>();
+            this.queueThread = queueThread;
+            this.numCallsToRun = numCallsToRun;
+            this.numInterruptedExceptionsSeen = numInterruptedExceptionsSeen;
+        }
+
+        @Override
+        public void run() throws Exception {
+            numCallsToRun.incrementAndGet();
+            queueThread.complete(Thread.currentThread());
+            runFuture.get();
+        }
+
+        @Override
+        public void handleException(Throwable e) {
+            if (e instanceof InterruptedException) {
+                numInterruptedExceptionsSeen.incrementAndGet();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Test
+    public void testInterruptedExceptionHandling() throws Exception {
+        KafkaEventQueue queue = new KafkaEventQueue(Time.SYSTEM, new LogContext(),
+                "testInterruptedExceptionHandling");
+        CompletableFuture<Thread> queueThread = new CompletableFuture<>();
+        AtomicInteger numCallsToRun = new AtomicInteger(0);
+        AtomicInteger numInterruptedExceptionsSeen = new AtomicInteger(0);
+        queue.append(new InterruptableEvent(queueThread, numCallsToRun, numInterruptedExceptionsSeen));
+        queue.append(new InterruptableEvent(queueThread, numCallsToRun, numInterruptedExceptionsSeen));
+        queue.append(new InterruptableEvent(queueThread, numCallsToRun, numInterruptedExceptionsSeen));
+        queue.append(new InterruptableEvent(queueThread, numCallsToRun, numInterruptedExceptionsSeen));
+        queueThread.get().interrupt();
+        TestUtils.retryOnExceptionWithTimeout(30000,
+                () -> assertEquals(1, numCallsToRun.get()));
+        TestUtils.retryOnExceptionWithTimeout(30000,
+                () -> assertEquals(3, numInterruptedExceptionsSeen.get()));
+        queue.close();
+    }
+
+    static class ExceptionTrapperEvent implements EventQueue.Event {
+        final CompletableFuture<Throwable> exception = new CompletableFuture<>();
+
+        @Override
+        public void run() throws Exception {
+            exception.complete(null);
+        }
+
+        @Override
+        public void handleException(Throwable e) {
+            exception.complete(e);
+        }
+    }
+
+    @Test
+    public void testInterruptedWithEmptyQueue() throws Exception {
+        CompletableFuture<Void> cleanupFuture = new CompletableFuture<>();
+        KafkaEventQueue queue = new KafkaEventQueue(Time.SYSTEM, new LogContext(),
+                "testInterruptedWithEmptyQueue", () -> cleanupFuture.complete(null));
+        CompletableFuture<Thread> queueThread = new CompletableFuture<>();
+        queue.append(() -> queueThread.complete(Thread.currentThread()));
+        TestUtils.retryOnExceptionWithTimeout(30000, () -> assertEquals(0, queue.size()));
+        queueThread.get().interrupt();
+        cleanupFuture.get();
+        ExceptionTrapperEvent ieTrapper = new ExceptionTrapperEvent();
+        queue.append(ieTrapper);
+        assertEquals(InterruptedException.class, ieTrapper.exception.get().getClass());
+        queue.close();
+        ExceptionTrapperEvent reTrapper = new ExceptionTrapperEvent();
+        queue.append(reTrapper);
+        assertEquals(RejectedExecutionException.class, reTrapper.exception.get().getClass());
+    }
+
+    @Test
+    public void testInterruptedWithDeferredEvents() throws Exception {
+        CompletableFuture<Void> cleanupFuture = new CompletableFuture<>();
+        KafkaEventQueue queue = new KafkaEventQueue(Time.SYSTEM, new LogContext(),
+                "testInterruptedWithDeferredEvents", () -> cleanupFuture.complete(null));
+        CompletableFuture<Thread> queueThread = new CompletableFuture<>();
+        queue.append(() -> queueThread.complete(Thread.currentThread()));
+        ExceptionTrapperEvent ieTrapper1 = new ExceptionTrapperEvent();
+        ExceptionTrapperEvent ieTrapper2 = new ExceptionTrapperEvent();
+        queue.scheduleDeferred("ie2",
+                __ -> OptionalLong.of(Time.SYSTEM.nanoseconds() + HOURS.toNanos(2)),
+                ieTrapper2);
+        queue.scheduleDeferred("ie1",
+                __ -> OptionalLong.of(Time.SYSTEM.nanoseconds() + HOURS.toNanos(1)),
+                ieTrapper1);
+        TestUtils.retryOnExceptionWithTimeout(30000, () -> assertEquals(2, queue.size()));
+        queueThread.get().interrupt();
+        cleanupFuture.get();
+        assertEquals(InterruptedException.class, ieTrapper1.exception.get().getClass());
+        assertEquals(InterruptedException.class, ieTrapper2.exception.get().getClass());
+        queue.close();
     }
 }

--- a/server-common/src/test/resources/test/log4j.properties
+++ b/server-common/src/test/resources/test/log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.kafka=INFO


### PR DESCRIPTION
If KafkaEventQueue gets an InterruptedException while waiting for a condition variable, it
currently exits immediately. Instead, it should complete the remaining events exceptionally and
then execute the cleanup event. This will allow us to finish any necessary cleanup steps.

In order to do this, we require the cleanup event to be provided when the queue is contructed,
rather than when it's being shut down.

Also, handle cases where Event#handleException itself throws an exception.

Remove timed shutdown from the event queue code since nobody was using it, and it adds complexity.

Add server-common/src/test/resources/test/log4j.properties since this gradle module somehow avoided
having a test log4j.properties up to this point.