### PR TITLE
KAFKA-14605 Change the log level to info when logIfAllowed is set, warn when logIfDenied is set.

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -317,7 +317,7 @@ public class StandardAuthorizerData {
                 // In this case, log at debug level. If false, no access is actually granted, the result is used
                 // only to determine authorized operations. So log only at trace level.
                 if (action.logIfAllowed() && auditLog.isDebugEnabled()) {
-                    auditLog.debug(buildAuditMessage(principal, requestContext, action, rule));
+                    auditLog.info(buildAuditMessage(principal, requestContext, action, rule));
                 } else if (auditLog.isTraceEnabled()) {
                     auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
                 }
@@ -329,7 +329,7 @@ public class StandardAuthorizerData {
                 // authorized operations or a filter (e.g for regex subscriptions) to filter out authorized resources.
                 // In this case, log only at trace level.
                 if (action.logIfDenied()) {
-                    auditLog.info(buildAuditMessage(principal, requestContext, action, rule));
+                    auditLog.warn(buildAuditMessage(principal, requestContext, action, rule));
                 } else if (auditLog.isTraceEnabled()) {
                     auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
                 }


### PR DESCRIPTION
KAFKA-14605 StandardAuthorizer log at INFO level when logIfDenied is set(otherwise, we log at TRACE), but at debug level when logIfAllowed is set.
Since audit log is security log, it should be logged at default verbosity level, not debug or trace when logIfAllowed is set.
So I think, log at INFO when allow, and log at WARN when deny is better.

```java
    private void logAuditMessage(
        ...... ) {
        switch (rule.result()) {
            case ALLOWED:
                if (action.logIfAllowed() && auditLog.isDebugEnabled()) {
                    auditLog.debug(......); // info maybe better
                } else if (auditLog.isTraceEnabled()) {
                    auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
                }
                return;

            case DENIED:
                if (action.logIfDenied()) {
                    auditLog.info(......); // warn maybe better
                } else if (auditLog.isTraceEnabled()) {
                    auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
                }
        }
    }
```

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
