### PR TITLE
MINOR: Implement toString method for TopicAssignment and PartitionAssignment

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 public class PartitionAssignment {
     private final List<Integer> replicas;
 
-    public PartitionAssignment(final List<Integer> replicas) {
+    public PartitionAssignment(List<Integer> replicas) {
         this.replicas = Collections.unmodifiableList(new ArrayList<>(replicas));
     }
 
@@ -52,5 +52,12 @@ public class PartitionAssignment {
     @Override
     public int hashCode() {
         return Objects.hash(replicas);
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionAssignment" +
+            "(replicas=" + replicas +
+            ")";
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/TopicAssignment.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 public class TopicAssignment {
     private final List<PartitionAssignment> assignments;
 
-    public TopicAssignment(final List<PartitionAssignment> assignments) {
+    public TopicAssignment(List<PartitionAssignment> assignments) {
         this.assignments = Collections.unmodifiableList(new ArrayList<>(assignments));
     }
 
@@ -51,5 +51,12 @@ public class TopicAssignment {
     @Override
     public int hashCode() {
         return Objects.hash(assignments);
+    }
+
+    @Override
+    public String toString() {
+        return "TopicAssignment" +
+            "(assignments=" + assignments +
+            ")";
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
@@ -57,4 +57,11 @@ public class PartitionAssignmentTest {
             }
         }
     }
+
+    @Test
+    public void testToString() {
+        List<Integer> replicas = Arrays.asList(0, 1, 2);
+        PartitionAssignment partitionAssignment = new PartitionAssignment(replicas);
+        assertEquals("PartitionAssignment(replicas=[0, 1, 2])", partitionAssignment.toString());
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
@@ -33,7 +33,7 @@ public class TopicAssignmentTest {
         List<Integer> replicasP1 = Arrays.asList(1, 2, 0);
         List<PartitionAssignment> partitionAssignments = Arrays.asList(
             new PartitionAssignment(replicasP0),
-             new PartitionAssignment(replicasP1)
+            new PartitionAssignment(replicasP1)
         );
         assertEquals(partitionAssignments, new TopicAssignment(partitionAssignments).assignments());
     }
@@ -53,7 +53,7 @@ public class TopicAssignmentTest {
                     new PartitionAssignment(
                         Arrays.asList(1, 2, 0)
                     )
-                 )
+                )
             )
         );
 
@@ -69,5 +69,15 @@ public class TopicAssignmentTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testToString() {
+        List<Integer> replicas = Arrays.asList(0, 1, 2);
+        List<PartitionAssignment> partitionAssignments = Arrays.asList(
+            new PartitionAssignment(replicas)
+        );
+        TopicAssignment topicAssignment = new TopicAssignment(partitionAssignments);
+        assertEquals("TopicAssignment(assignments=[PartitionAssignment(replicas=[0, 1, 2])])", topicAssignment.toString());
     }
 }


### PR DESCRIPTION
### Details
Implements `toString` method for classes `TopicAssignment` and` PartitionAssignment`. This probably should have been done as part of https://github.com/apache/kafka/pull/12892, but adding it in now. 

I also removed the `final` keyword from the constructor arguments as that doesn't seem to be what we normally do in Kafka. So removing them for consistency. 

### Testing
Added a couple unit tests and also ran `./gradlew metadata:test --tests org.apache.kafka.metadata.placement.PartitionAssignmentTest` and `./gradlew metadata:test --tests org.apache.kafka.metadata.placement.TopicAssignmentTest`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
