### PR TITLE
KAFKA-14371: Remove unused clusterId field from quorum-state file

### DIFF
--- a/raft/src/main/resources/common/message/QuorumStateData.json
+++ b/raft/src/main/resources/common/message/QuorumStateData.json
@@ -16,7 +16,8 @@
 {
   "type": "data",
   "name": "QuorumStateData",
-  "validVersions": "0",
+  // Version 1 removes clusterId field.
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {"name": "LeaderId", "type": "int32", "versions": "0+", "default": "-1"},

--- a/raft/src/main/resources/common/message/QuorumStateData.json
+++ b/raft/src/main/resources/common/message/QuorumStateData.json
@@ -19,7 +19,6 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    {"name": "ClusterId", "type": "string", "versions": "0+"},
     {"name": "LeaderId", "type": "int32", "versions": "0+", "default": "-1"},
     {"name": "LeaderEpoch", "type": "int32", "versions": "0+", "default": "-1"},
     {"name": "VotedId", "type": "int32", "versions": "0+", "default": "-1"},

--- a/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
@@ -106,12 +106,12 @@ public class FileBasedStateStoreTest {
         // We initialized a state from the metadata log
         assertTrue(stateFile.exists());
 
+
         String jsonString = "{\"clusterId\":\"abc\",\"leaderId\":0,\"leaderEpoch\":0,\"votedId\":-1,\"appliedOffset\":0,\"currentVoters\":[],\"data_version\":0}";
         writeToStateFile(stateFile, jsonString);
 
         // verify that we can read the state file that contains the removed "cluserId" field.
-        assertEquals(stateStore.readElectionState(), new ElectionState(0,
-                OptionalInt.of(0), OptionalInt.empty(), Collections.emptySet()));
+        assertEquals(ElectionState.withElectedLeader(0, 0, Collections.emptySet()), stateStore.readElectionState());
 
         stateStore.clear();
         assertFalse(stateFile.exists());

--- a/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FileBasedStateStoreTest.java
@@ -23,7 +23,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -106,12 +105,14 @@ public class FileBasedStateStoreTest {
         // We initialized a state from the metadata log
         assertTrue(stateFile.exists());
 
-
-        String jsonString = "{\"clusterId\":\"abc\",\"leaderId\":0,\"leaderEpoch\":0,\"votedId\":-1,\"appliedOffset\":0,\"currentVoters\":[],\"data_version\":0}";
+        final int epoch = 2;
+        final int leaderId = 1;
+        Set<Integer> voters = Utils.mkSet(leaderId);
+        String jsonString = "{\"clusterId\":\"abc\",\"leaderId\":" + leaderId + ",\"leaderEpoch\":" + epoch + ",\"votedId\":-1,\"appliedOffset\":0,\"currentVoters\":[],\"data_version\":0}";
         writeToStateFile(stateFile, jsonString);
 
         // verify that we can read the state file that contains the removed "cluserId" field.
-        assertEquals(ElectionState.withElectedLeader(0, 0, Collections.emptySet()), stateStore.readElectionState());
+        assertEquals(ElectionState.withElectedLeader(epoch, leaderId, voters), stateStore.readElectionState());
 
         stateStore.clear();
         assertFalse(stateFile.exists());


### PR DESCRIPTION
Remove clusterId field from the KRaft controller's quorum-state file `$LOG_DIR/__cluster_metadata-0/quorum-state`
Jira: [KAFKA-14371](https://issues.apache.org/jira/browse/KAFKA-14371)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
