### PR TITLE
KAFKA-5238: BrokerTopicMetrics can be recreated after topic is deleted

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -879,7 +879,10 @@ class KafkaApis(val requestChannel: RequestChannel,
             // If the topic name was not known, we will have no bytes out.
             if (topicResponse.topic != null) {
               val tp = new TopicIdPartition(topicResponse.topicId, new TopicPartition(topicResponse.topic, data.partitionIndex))
-              brokerTopicStats.updateBytesOut(tp.topic, fetchRequest.isFromFollower, reassigningPartitions.contains(tp), FetchResponse.recordsSize(data))
+              // do not recreate the metrics if this was a DelayedFetch executed after a topic was deleted
+              if (data.errorCode != Errors.UNKNOWN_TOPIC_OR_PARTITION.code) {
+                brokerTopicStats.updateBytesOut(tp.topic, fetchRequest.isFromFollower, reassigningPartitions.contains(tp), FetchResponse.recordsSize(data))
+              }
             }
           }
         }


### PR DESCRIPTION
Do not recreate the BrokerTopicMetrics on creating the fetch response to a DelayedFetch request executed after a topic was deleted

Add a variant of MetricsTest.testBrokerTopicMetricsUnregisteredAfterDeletingTopic
where messages are consumed 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
