### PR TITLE
KAFKA-14623: OAuth's HttpAccessTokenRetriever potentially leaks secrets in logging

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/HttpAccessTokenRetriever.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/HttpAccessTokenRetriever.java
@@ -242,8 +242,11 @@ public class HttpAccessTokenRetriever implements AccessTokenRetriever {
 
         // NOTE: the contents of the response should not be logged so that we don't leak any
         // sensitive data.
-        // TODO: is it OK to log the error response body and/or its formatted version?
         String responseBody = null;
+
+        // NOTE: It is OK to log the error response body and/or its formatted version as
+        // per the OAuth spec, it doesn't include sensitive information.
+        // See https://www.ietf.org/rfc/rfc6749.txt, section 5.2
         String errorResponseBody = null;
 
         try (InputStream is = con.getInputStream()) {
@@ -300,6 +303,8 @@ public class HttpAccessTokenRetriever implements AccessTokenRetriever {
     }
 
     static String formatErrorMessage(String errorResponseBody) {
+        // See https://www.ietf.org/rfc/rfc6749.txt, section 5.2 for the format
+        // of this error message.
         if (errorResponseBody == null || errorResponseBody.trim().equals("")) {
             return "{}";
         }


### PR DESCRIPTION
Removed logging of the HTTP response directly in all known cases to prevent potentially logging access tokens.

See [KAFKA-14623](https://issues.apache.org/jira/browse/KAFKA-14623).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
