### PR TITLE
KAFKA-14491: [1/N] Add segment value format for RocksDB versioned store

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
@@ -55,6 +55,12 @@ import java.util.List;
  * to the timestamp of the single tombstone record version. To avoid the redundancy of serializing
  * the same timestamp twice, it is only serialized once and stored as the first timestamp of the
  * segment, which happens to be {@code next_timestamp}.)
+ * <p>
+ * After an "empty" segment has formed, it's possible that the segment will continue to be empty
+ * even as newer records are added. (For example, if additional puts happen with later timestamps
+ * such that those puts only affect later segments, then the earlier empty segment will remain
+ * empty.) As a result, when deserializing segments, callers should always check whether or not
+ * they are empty.
  */
 final class RocksDBVersionedStoreSegmentValueFormatter {
     private static final int TIMESTAMP_SIZE = 8;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
@@ -297,7 +297,7 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
                     currValueSize = unpackedReversedTimestampAndValueSizes.get(currIndex).valueSize;
                     cumValueSize = cumulativeValueSizes.get(currIndex);
                 } else {
-                    int timestampSegmentIndex = 2 * TIMESTAMP_SIZE + currIndex * (TIMESTAMP_SIZE + VALUE_SIZE);
+                    final int timestampSegmentIndex = 2 * TIMESTAMP_SIZE + currIndex * (TIMESTAMP_SIZE + VALUE_SIZE);
                     currTimestamp = ByteBuffer.wrap(segmentValue).getLong(timestampSegmentIndex);
                     currValueSize = ByteBuffer.wrap(segmentValue).getInt(timestampSegmentIndex + TIMESTAMP_SIZE);
                     cumValueSize += Math.max(currValueSize, 0);
@@ -311,8 +311,8 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
                     // found result
                     if (includeValue) {
                         if (currValueSize >= 0) {
-                            byte[] value = new byte[currValueSize];
-                            int valueSegmentIndex = segmentValue.length - cumValueSize;
+                            final byte[] value = new byte[currValueSize];
+                            final int valueSegmentIndex = segmentValue.length - cumValueSize;
                             System.arraycopy(segmentValue, valueSegmentIndex, value, 0, currValueSize);
                             return new SegmentSearchResult(currIndex, currTimestamp, currNextTimestamp, value);
                         } else {
@@ -371,7 +371,7 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
             if (isEmpty) {
                 initializeWithRecord(value, timestamp, nextTimestamp);
             } else {
-                int lastIndex = find(minTimestamp, false).index;
+                final int lastIndex = find(minTimestamp, false).index;
                 insertHelper(timestamp, value, lastIndex + 1);
             }
         }
@@ -390,12 +390,12 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
             final boolean needsMinTsUpdate = isLastIndex(index - 1);
             truncateDeserHelpersToIndex(index - 1);
             unpackedReversedTimestampAndValueSizes.add(new TimestampAndValueSize(timestamp, value.valueSize()));
-            int prevCumValueSize = deserIndex == -1 ? 0 : cumulativeValueSizes.get(deserIndex);
+            final int prevCumValueSize = deserIndex == -1 ? 0 : cumulativeValueSizes.get(deserIndex);
             cumulativeValueSizes.add(prevCumValueSize + value.value().length);
             deserIndex++;
 
             // update serialization and other props
-            int segmentTimestampIndex = 2 * TIMESTAMP_SIZE + index * (TIMESTAMP_SIZE + VALUE_SIZE);
+            final int segmentTimestampIndex = 2 * TIMESTAMP_SIZE + index * (TIMESTAMP_SIZE + VALUE_SIZE);
             segmentValue = ByteBuffer.allocate(segmentValue.length + TIMESTAMP_SIZE + VALUE_SIZE + value.value().length)
                 .put(segmentValue, 0, segmentTimestampIndex)
                 .putLong(timestamp)
@@ -418,8 +418,8 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
             }
             final ValueAndValueSize value = new ValueAndValueSize(valueOrNull);
 
-            int oldValueSize = Math.max(unpackedReversedTimestampAndValueSizes.get(index).valueSize, 0);
-            int oldCumValueSize = cumulativeValueSizes.get(index);
+            final int oldValueSize = Math.max(unpackedReversedTimestampAndValueSizes.get(index).valueSize, 0);
+            final int oldCumValueSize = cumulativeValueSizes.get(index);
 
             final boolean needsMinTsUpdate = isLastIndex(index);
             unpackedReversedTimestampAndValueSizes.set(index, new TimestampAndValueSize(timestamp, value.valueSize()));
@@ -427,7 +427,7 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
             truncateDeserHelpersToIndex(index);
 
             // update serialization and other props
-            int segmentTimestampIndex = 2 * TIMESTAMP_SIZE + index * (TIMESTAMP_SIZE + VALUE_SIZE);
+            final int segmentTimestampIndex = 2 * TIMESTAMP_SIZE + index * (TIMESTAMP_SIZE + VALUE_SIZE);
             segmentValue = ByteBuffer.allocate(segmentValue.length - oldValueSize + value.value().length)
                 .put(segmentValue, 0, segmentTimestampIndex)
                 .putLong(timestamp)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper utility for managing the bytes layout of the value stored in segments of the {@link RocksDBVersionedStore}.
+ * The value format is:
+ * <pre>
+ *     <next_timestamp> + <min_timestamp> + <list of <timestamp, value_size>, reverse-sorted by timestamp> + <list of values, forward-sorted by timestamp>
+ * </pre>
+ * Negative {@code value_size} is used to indicate that the value stored is a tombstone, in order to
+ * distinguish from empty array which has {@code value_size} of zero. In practice, {@code value_size}
+ * is always set to -1 for the tombstone case, though this need not be true in general.
+ */
+final class RocksDBVersionedStoreSegmentValueFormatter {
+    private static final int TIMESTAMP_SIZE = 8;
+    private static final int VALUE_SIZE = 4;
+
+    /**
+     * @return the validTo timestamp of the latest record in the provided segment
+     */
+    static long getNextTimestamp(final byte[] segmentValue) {
+        return ByteBuffer.wrap(segmentValue).getLong(0);
+    }
+
+    /**
+     * Returns whether the provided segment is "empty." An empty segment is one that
+     * contains only a single tombstone with no validTo timestamp specified. In this case,
+     * the serialized segment contains only the timestamp of the tombstone (stored as the segment's
+     * {@code nextTimestamp}) and nothing else.
+     * <p>
+     * This can happen if, e.g., the only record inserted for a particular key is
+     * a tombstone. In this case, the tombstone must be stored in a segment
+     * (as the latest value store does not store tombstones), but also has no validTo
+     * timestamp associated with it.
+     *
+     * @return whether the segment is "empty"
+     */
+    static boolean isEmpty(final byte[] segmentValue) {
+        return segmentValue.length <= TIMESTAMP_SIZE;
+    }
+
+    /**
+     * Requires that the segment is not empty. Caller is responsible for verifying that this
+     * is the case before calling this method.
+     *
+     * @return the timestamp of the earliest record in the provided segment.
+     */
+    static long getMinTimestamp(final byte[] segmentValue) {
+        return ByteBuffer.wrap(segmentValue).getLong(TIMESTAMP_SIZE);
+    }
+
+    /**
+     * @return the deserialized segment value
+     */
+    static SegmentValue deserialize(final byte[] segmentValue) {
+        return new PartiallyDeserializedSegmentValue(segmentValue);
+    }
+
+    /**
+     * Creates a new segment value that contains the provided record.
+     *
+     * @param value the record value
+     * @param validFrom the record's timestamp
+     * @param validTo the record's validTo timestamp
+     * @return the newly created segment value
+     */
+    static SegmentValue newSegmentValueWithRecord(
+        final byte[] value, final long validFrom, final long validTo) {
+        return new PartiallyDeserializedSegmentValue(value, validFrom, validTo);
+    }
+
+    /**
+     * Creates a new empty segment value.
+     *
+     * @param timestamp the timestamp of the tombstone for this empty segment value
+     * @return the newly created segment value
+     */
+    static SegmentValue newSegmentValueWithTombstone(final long timestamp) {
+        return new PartiallyDeserializedSegmentValue(timestamp);
+    }
+
+    interface SegmentValue {
+
+        /**
+         * @return whether the segment is empty. See
+         * {@link RocksDBVersionedStoreSegmentValueFormatter#isEmpty(byte[])} for details.
+         */
+        boolean isEmpty();
+
+        /**
+         * Finds the latest record in this segment with timestamp not exceeding the provided
+         * timestamp bound. This method requires that the provided timestamp bound exists in
+         * this segment, i.e., the segment is not empty, and the provided timestamp bound is
+         * at least minTimestamp and is smaller than nextTimestamp.
+         *
+         * @param timestamp the timestamp to find
+         * @param includeValue whether the value of the found record should be returned with the result
+         * @return the record that is found
+         * @throws IllegalArgumentException if the segment is empty, or if the provided timestamp
+         *         is not contained within this segment
+         */
+        SegmentSearchResult find(long timestamp, boolean includeValue);
+
+        /**
+         * Inserts the provided record into the segment as the latest record in the segment.
+         * This operation is allowed even if the segment is empty.
+         * <p>
+         * It is the caller's responsibility to enough that this action is desirable. In the event
+         * that the new record's timestamp is smaller than the current {@code nextTimestamp} of the
+         * segment, the operation will still be performed, and the segment's existing contents will
+         * be truncated to ensure consistency of timestamps within the segment. This truncation
+         * behavior helps reconcile inconsistencies between different segments, or between a segment
+         * and the latest value store, of a {@link RocksDBVersionedStore} instance.
+         *
+         * @param validFrom the timestamp of the record to insert
+         * @param validTo the validTo timestamp of the record to insert
+         * @param value the value of the record to insert
+         */
+        void insertAsLatest(long validFrom, long validTo, byte[] value);
+
+        /**
+         * Inserts the provided record into the segment as the earliest record in the segment.
+         * This operation is allowed even if the segment is empty. It is the caller's responsibility
+         * to ensure that this action is valid, i.e., that record's timestamp is smaller than the
+         * current {@code minTimestamp} of the segment, or the segment is empty.
+         *
+         * @param timestamp the timestamp of the record to insert
+         * @param value the value of the record to insert
+         */
+        void insertAsEarliest(long timestamp, byte[] value);
+
+        /**
+         * Inserts the provided record into the segment at the provided index. This operation
+         * requires that the segment is not empty, and that {@link SegmentValue#find(long, boolean)}
+         * has already been called in order to deserialize the relevant index (to insert into
+         * index n requires that index n-1 has already been deserialized).
+         * <p>
+         * It is the caller's responsibility to ensure that this action makes sense, i.e., that the
+         * insertion index is correct for the timestamp of the record being inserted.
+         *
+         * @param timestamp the timestamp of the record to insert
+         * @param value the value of the record to insert
+         * @param index the index that the newly inserted record should occupy
+         * @throws IllegalArgumentException if the segment is empty, if the provided index is out of
+         *         bounds, or if {@code find()} has not been called to deserialize the relevant index.
+         */
+        void insert(long timestamp, byte[] value, int index);
+
+        /**
+         * Updates the record at the provided index with the provided value and timestamp. This
+         * operation requires that the segment is not empty, and that {@link SegmentValue#find(long, boolean)}
+         * has already been called in order to deserialize the relevant index (i.e., the one being
+         * updated).
+         * <p>
+         * It is the caller's responsibility to ensure that this action makes sense, i.e., that the
+         * updated timestamp does not violate timestamp order within the segment.
+         *
+         * @param timestamp the updated record timestamp
+         * @param value the updated record value
+         * @param index the index of the record to update
+         */
+        void updateRecord(long timestamp, byte[] value, int index);
+
+        /**
+         * @return the bytes serialization for this segment value
+         */
+        byte[] serialize();
+
+        class SegmentSearchResult {
+            private final int index;
+            private final long validFrom;
+            private final long validTo;
+            private final byte[] value;
+            private final boolean includesValue;
+
+            SegmentSearchResult(final int index, final long validFrom, final long validTo,
+                                final byte[] value) {
+                this.index = index;
+                this.validFrom = validFrom;
+                this.validTo = validTo;
+                this.value = value;
+                this.includesValue = true;
+            }
+
+            SegmentSearchResult(final int index, final long validFrom, final long validTo) {
+                this.index = index;
+                this.validFrom = validFrom;
+                this.validTo = validTo;
+                this.value = null;
+                this.includesValue = false;
+            }
+
+            int index() {
+                return index;
+            }
+
+            long validFrom() {
+                return validFrom;
+            }
+
+            long validTo() {
+                return validTo;
+            }
+
+            byte[] value() {
+                return value;
+            }
+
+            /**
+             * @return whether the return value from {@link SegmentSearchResult#value()} is meaningful,
+             *         or if is is null because the return value was not requested
+             */
+            boolean includesValue() {
+                return includesValue;
+            }
+        }
+    }
+
+    private static class PartiallyDeserializedSegmentValue implements SegmentValue {
+        private byte[] segmentValue;
+        private long nextTimestamp;
+        private long minTimestamp;
+        private boolean isEmpty;
+
+        private int deserIndex = -1; // index up through which this segment has been deserialized (inclusive)
+        private List<TimestampAndValueSize> unpackedReversedTimestampAndValueSizes;
+        private List<Integer> cumulativeValueSizes; // ordered same as timestamp and value sizes (reverse time-sorted)
+
+        private PartiallyDeserializedSegmentValue(final byte[] segmentValue) {
+            this.segmentValue = segmentValue;
+            this.nextTimestamp =
+                RocksDBVersionedStoreSegmentValueFormatter.getNextTimestamp(segmentValue);
+            this.isEmpty = RocksDBVersionedStoreSegmentValueFormatter.isEmpty(segmentValue);
+            if (!isEmpty) {
+                this.minTimestamp =
+                    RocksDBVersionedStoreSegmentValueFormatter.getMinTimestamp(segmentValue);
+            }
+            resetDeserHelpers();
+        }
+
+        private PartiallyDeserializedSegmentValue(
+            final byte[] valueOrNull, final long validFrom, final long validTo) {
+            initializeWithRecord(new ValueAndValueSize(valueOrNull), validFrom, validTo);
+        }
+
+        private PartiallyDeserializedSegmentValue(final long timestamp) {
+            this.nextTimestamp = timestamp;
+            this.segmentValue = ByteBuffer.allocate(TIMESTAMP_SIZE).putLong(nextTimestamp).array();
+            this.isEmpty = true;
+            resetDeserHelpers();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return isEmpty;
+        }
+
+        @Override
+        public SegmentSearchResult find(final long timestamp, final boolean includeValue) {
+            if (isEmpty) {
+                throw new IllegalArgumentException("Cannot find on empty segment value.");
+            }
+            if (timestamp < minTimestamp) {
+                throw new IllegalArgumentException("Timestamp is too small to be found in this segment.");
+            }
+            if (timestamp >= nextTimestamp) {
+                throw new IllegalArgumentException("Timestamp is too large to be found in this segment.");
+            }
+
+            long currNextTimestamp = nextTimestamp;
+            long currTimestamp = -1L; // choose an invalid timestamp. if this is valid, this needs to be re-worked
+            int currValueSize;
+            int currIndex = 0;
+            int cumValueSize = 0;
+            while (currTimestamp != minTimestamp) {
+                if (currIndex <= deserIndex) {
+                    currTimestamp = unpackedReversedTimestampAndValueSizes.get(currIndex).timestamp;
+                    currValueSize = unpackedReversedTimestampAndValueSizes.get(currIndex).valueSize;
+                    cumValueSize = cumulativeValueSizes.get(currIndex);
+                } else {
+                    int timestampSegmentIndex = 2 * TIMESTAMP_SIZE + currIndex * (TIMESTAMP_SIZE + VALUE_SIZE);
+                    currTimestamp = ByteBuffer.wrap(segmentValue).getLong(timestampSegmentIndex);
+                    currValueSize = ByteBuffer.wrap(segmentValue).getInt(timestampSegmentIndex + TIMESTAMP_SIZE);
+                    cumValueSize += Math.max(currValueSize, 0);
+
+                    deserIndex = currIndex;
+                    unpackedReversedTimestampAndValueSizes.add(new TimestampAndValueSize(currTimestamp, currValueSize));
+                    cumulativeValueSizes.add(cumValueSize);
+                }
+
+                if (currTimestamp <= timestamp) {
+                    // found result
+                    if (includeValue) {
+                        if (currValueSize >= 0) {
+                            byte[] value = new byte[currValueSize];
+                            int valueSegmentIndex = segmentValue.length - cumValueSize;
+                            System.arraycopy(segmentValue, valueSegmentIndex, value, 0, currValueSize);
+                            return new SegmentSearchResult(currIndex, currTimestamp, currNextTimestamp, value);
+                        } else {
+                            return new SegmentSearchResult(currIndex, currTimestamp, currNextTimestamp, null);
+                        }
+                    } else {
+                        return new SegmentSearchResult(currIndex, currTimestamp, currNextTimestamp);
+                    }
+                }
+
+                // prep for next iteration
+                currNextTimestamp = currTimestamp;
+                currIndex++;
+            }
+
+            throw new IllegalStateException("Search in segment expected to find result but did not.");
+        }
+
+        @Override
+        public void insertAsLatest(final long validFrom, final long validTo, final byte[] valueOrNull) {
+            final ValueAndValueSize value = new ValueAndValueSize(valueOrNull);
+
+            if (nextTimestamp > validFrom) {
+                // detected inconsistency edge case where older segment has [a,b) while newer store
+                // has [a,c), due to [b,c) having failed to write to newer store.
+                // remove entries from this store until the overlap is resolved.
+                // TODO: will be implemented in a follow-up PR
+                throw new UnsupportedOperationException("case not yet implemented");
+            }
+
+            if (nextTimestamp != validFrom) {
+                // move nextTimestamp into list as tombstone and add new record on top
+                if (isEmpty) {
+                    initializeWithRecord(new ValueAndValueSize(null), nextTimestamp, validFrom);
+                } else {
+                    insert(nextTimestamp, null, 0);
+                }
+                insertHelper(validFrom, value, 0);
+            } else {
+                // nextTimestamp is moved into segment automatically as record is added on top
+                if (isEmpty) {
+                    initializeWithRecord(value, validFrom, validTo);
+                } else {
+                    insertHelper(validFrom, value, 0);
+                }
+            }
+            // update nextTimestamp
+            nextTimestamp = validTo;
+            ByteBuffer.wrap(segmentValue, 0, TIMESTAMP_SIZE).putLong(nextTimestamp);
+        }
+
+        @Override
+        public void insertAsEarliest(final long timestamp, final byte[] valueOrNull) {
+            final ValueAndValueSize value = new ValueAndValueSize(valueOrNull);
+
+            if (isEmpty) {
+                initializeWithRecord(value, timestamp, nextTimestamp);
+            } else {
+                int lastIndex = find(minTimestamp, false).index;
+                insertHelper(timestamp, value, lastIndex + 1);
+            }
+        }
+
+        @Override
+        public void insert(final long timestamp, final byte[] valueOrNull, final int index) {
+            final ValueAndValueSize value = new ValueAndValueSize(valueOrNull);
+            insertHelper(timestamp, value, index);
+        }
+
+        private void insertHelper(final long timestamp, final ValueAndValueSize value, final int index) {
+            if (isEmpty || index > deserIndex + 1 || index < 0) {
+                throw new IllegalArgumentException("Must invoke find() to deserialize record before insert() at specific index.");
+            }
+
+            final boolean needsMinTsUpdate = isLastIndex(index - 1);
+            truncateDeserHelpersToIndex(index - 1);
+            unpackedReversedTimestampAndValueSizes.add(new TimestampAndValueSize(timestamp, value.valueSize()));
+            int prevCumValueSize = deserIndex == -1 ? 0 : cumulativeValueSizes.get(deserIndex);
+            cumulativeValueSizes.add(prevCumValueSize + value.value().length);
+            deserIndex++;
+
+            // update serialization and other props
+            int segmentTimestampIndex = 2 * TIMESTAMP_SIZE + index * (TIMESTAMP_SIZE + VALUE_SIZE);
+            segmentValue = ByteBuffer.allocate(segmentValue.length + TIMESTAMP_SIZE + VALUE_SIZE + value.value().length)
+                .put(segmentValue, 0, segmentTimestampIndex)
+                .putLong(timestamp)
+                .putInt(value.valueSize())
+                .put(segmentValue, segmentTimestampIndex, segmentValue.length - segmentTimestampIndex - prevCumValueSize)
+                .put(value.value())
+                .put(segmentValue, segmentValue.length - prevCumValueSize, prevCumValueSize)
+                .array();
+
+            if (needsMinTsUpdate) {
+                minTimestamp = timestamp;
+                ByteBuffer.wrap(segmentValue, TIMESTAMP_SIZE, TIMESTAMP_SIZE).putLong(TIMESTAMP_SIZE, minTimestamp);
+            }
+        }
+
+        @Override
+        public void updateRecord(final long timestamp, final byte[] valueOrNull, final int index) {
+            if (index > deserIndex || index < 0) {
+                throw new IllegalArgumentException("Must invoke find() to deserialize record before updateRecord().");
+            }
+            final ValueAndValueSize value = new ValueAndValueSize(valueOrNull);
+
+            int oldValueSize = Math.max(unpackedReversedTimestampAndValueSizes.get(index).valueSize, 0);
+            int oldCumValueSize = cumulativeValueSizes.get(index);
+
+            final boolean needsMinTsUpdate = isLastIndex(index);
+            unpackedReversedTimestampAndValueSizes.set(index, new TimestampAndValueSize(timestamp, value.valueSize()));
+            cumulativeValueSizes.set(index, oldCumValueSize - oldValueSize + value.value().length);
+            truncateDeserHelpersToIndex(index);
+
+            // update serialization and other props
+            int segmentTimestampIndex = 2 * TIMESTAMP_SIZE + index * (TIMESTAMP_SIZE + VALUE_SIZE);
+            segmentValue = ByteBuffer.allocate(segmentValue.length - oldValueSize + value.value().length)
+                .put(segmentValue, 0, segmentTimestampIndex)
+                .putLong(timestamp)
+                .putInt(value.valueSize())
+                .put(segmentValue, segmentTimestampIndex + TIMESTAMP_SIZE + VALUE_SIZE, segmentValue.length - (segmentTimestampIndex + TIMESTAMP_SIZE + VALUE_SIZE) - oldCumValueSize)
+                .put(value.value())
+                .put(segmentValue, segmentValue.length - oldCumValueSize + oldValueSize, oldCumValueSize - oldValueSize)
+                .array();
+
+            if (needsMinTsUpdate) {
+                minTimestamp = timestamp;
+                ByteBuffer.wrap(segmentValue, TIMESTAMP_SIZE, TIMESTAMP_SIZE).putLong(TIMESTAMP_SIZE, minTimestamp);
+            }
+        }
+
+        @Override
+        public byte[] serialize() {
+            return segmentValue;
+        }
+
+        private void initializeWithRecord(final ValueAndValueSize value, final long validFrom, final long validTo) {
+            this.nextTimestamp = validTo;
+            this.minTimestamp = validFrom;
+            this.segmentValue = ByteBuffer.allocate(TIMESTAMP_SIZE * 3 + VALUE_SIZE + value.value().length)
+                .putLong(nextTimestamp)
+                .putLong(minTimestamp)
+                .putLong(validFrom)
+                .putInt(value.valueSize())
+                .put(value.value())
+                .array();
+            this.isEmpty = false;
+            resetDeserHelpers();
+        }
+
+        private void resetDeserHelpers() {
+            deserIndex = -1;
+            unpackedReversedTimestampAndValueSizes = new ArrayList<>();
+            cumulativeValueSizes = new ArrayList<>();
+        }
+
+        private void truncateDeserHelpersToIndex(final int index) {
+            deserIndex = index;
+            unpackedReversedTimestampAndValueSizes.subList(index + 1, unpackedReversedTimestampAndValueSizes.size()).clear();
+            cumulativeValueSizes.subList(index + 1, cumulativeValueSizes.size()).clear();
+        }
+
+        private boolean isLastIndex(final int index) {
+            if (deserIndex == -1
+                || unpackedReversedTimestampAndValueSizes.get(deserIndex).timestamp != minTimestamp) {
+                return false;
+            }
+            return index == deserIndex;
+        }
+
+        private static class TimestampAndValueSize {
+            final long timestamp;
+            final int valueSize;
+
+            TimestampAndValueSize(final long timestamp, final int valueSize) {
+                this.timestamp = timestamp;
+                this.valueSize = valueSize;
+            }
+        }
+
+        /**
+         * Helper class to assist in storing tombstones within segment values. Tombstones are stored
+         * with {@code value_size} as a negative value, in order to disambiguate between tombstones
+         * and empty bytes, as both have {@code value} as an empty array.
+         */
+        private static class ValueAndValueSize {
+            private final byte[] valueToStore;
+            private final int valueSizeToStore;
+
+            ValueAndValueSize(final byte[] valueOrNull) {
+                if (valueOrNull == null) {
+                    valueToStore = new byte[0];
+                    valueSizeToStore = -1;
+                } else {
+                    valueToStore = valueOrNull;
+                    valueSizeToStore = valueToStore.length;
+                }
+            }
+
+            byte[] value() {
+                return valueToStore;
+            }
+
+            int valueSize() {
+                return valueSizeToStore;
+            }
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
@@ -183,7 +183,6 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
 
             final SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
 
-            assertThat(result.includesValue(), equalTo(true));
             assertThat(result.index(), equalTo(entry.getValue()));
             assertThat(result.value(), equalTo(expectedRecord.value));
             assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
@@ -97,7 +97,7 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
         // test inserting at each possible index
         for (int insertIdx = 0; insertIdx <= testCase.records.size(); insertIdx++) {
             // build record to insert
-            long newRecordTimestamp;
+            final long newRecordTimestamp;
             if (insertIdx == 0) {
                 newRecordTimestamp = testCase.records.get(0).timestamp + 1;
                 if (newRecordTimestamp == testCase.nextTimestamp) {
@@ -111,9 +111,9 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
                     continue;
                 }
             }
-            TestRecord newRecord = new TestRecord("new".getBytes(), newRecordTimestamp);
+            final TestRecord newRecord = new TestRecord("new".getBytes(), newRecordTimestamp);
 
-            SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+            final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
 
             // insert() first requires a call to find()
             if (insertIdx > 0) {
@@ -122,7 +122,7 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
             segmentValue.insert(newRecord.timestamp, newRecord.value, insertIdx);
 
             // create expected results
-            List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
+            final List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
             expectedRecords.add(insertIdx, newRecord);
 
             verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
@@ -143,16 +143,16 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
                     updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp;
                 }
             }
-            TestRecord updatedRecord = new TestRecord("updated".getBytes(), updatedRecordTimestamp);
+            final TestRecord updatedRecord = new TestRecord("updated".getBytes(), updatedRecordTimestamp);
 
-            SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+            final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
 
             // updateRecord() first requires a call to find()
             segmentValue.find(testCase.records.get(updateIdx).timestamp, false);
             segmentValue.updateRecord(updatedRecord.timestamp, updatedRecord.value, updateIdx);
 
             // create expected results
-            List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
+            final List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
             expectedRecords.remove(updateIdx);
             expectedRecords.add(updateIdx, updatedRecord);
 
@@ -177,11 +177,11 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
         }
 
         // verify results
-        for (Map.Entry<Long, Integer> entry : expectedRecordIndices.entrySet()) {
-            TestRecord expectedRecord = testCase.records.get(entry.getValue());
-            long expectedValidTo = entry.getValue() == 0 ? testCase.nextTimestamp : testCase.records.get(entry.getValue() - 1).timestamp;
+        for (final Map.Entry<Long, Integer> entry : expectedRecordIndices.entrySet()) {
+            final TestRecord expectedRecord = testCase.records.get(entry.getValue());
+            final long expectedValidTo = entry.getValue() == 0 ? testCase.nextTimestamp : testCase.records.get(entry.getValue() - 1).timestamp;
 
-            SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
+            final SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
 
             assertThat(result.includesValue(), equalTo(true));
             assertThat(result.index(), equalTo(entry.getValue()));
@@ -223,15 +223,15 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
         verifySegmentContents(segmentValue, testCase);
     }
 
-    private static SegmentValue buildSegmentWithInsertLatest(TestCase testCase) {
+    private static SegmentValue buildSegmentWithInsertLatest(final TestCase testCase) {
         if (testCase.records.size() == 0) {
             return RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithTombstone(testCase.nextTimestamp);
         }
 
         SegmentValue segmentValue = null;
         for (int recordIdx = testCase.records.size() - 1; recordIdx >= 0; recordIdx--) {
-            TestRecord record = testCase.records.get(recordIdx);
-            long validTo = recordIdx == 0 ? testCase.nextTimestamp : testCase.records.get(recordIdx - 1).timestamp;
+            final TestRecord record = testCase.records.get(recordIdx);
+            final long validTo = recordIdx == 0 ? testCase.nextTimestamp : testCase.records.get(recordIdx - 1).timestamp;
 
             if (segmentValue == null) {
                 // initialize
@@ -248,22 +248,22 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
         return segmentValue;
     }
 
-    private static SegmentValue buildSegmentWithInsertEarliest(TestCase testCase) {
+    private static SegmentValue buildSegmentWithInsertEarliest(final TestCase testCase) {
         final SegmentValue segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithTombstone(testCase.nextTimestamp);
         for (int recordIdx = 0; recordIdx < testCase.records.size(); recordIdx++) {
-            TestRecord record = testCase.records.get(recordIdx);
+            final TestRecord record = testCase.records.get(recordIdx);
             segmentValue.insertAsEarliest(record.timestamp, record.value);
         }
         return segmentValue;
     }
 
-    private static void verifySegmentContents(SegmentValue segmentValue, TestCase expectedRecords) {
+    private static void verifySegmentContents(final SegmentValue segmentValue, final TestCase expectedRecords) {
         // verify expected records
         for (int recordIdx = 0; recordIdx < expectedRecords.records.size(); recordIdx++) {
-            TestRecord expectedRecord = expectedRecords.records.get(recordIdx);
-            long expectedValidTo = recordIdx == 0 ? expectedRecords.nextTimestamp : expectedRecords.records.get(recordIdx - 1).timestamp;
+            final TestRecord expectedRecord = expectedRecords.records.get(recordIdx);
+            final long expectedValidTo = recordIdx == 0 ? expectedRecords.nextTimestamp : expectedRecords.records.get(recordIdx - 1).timestamp;
 
-            SegmentSearchResult result = segmentValue.find(expectedRecord.timestamp, true);
+            final SegmentSearchResult result = segmentValue.find(expectedRecord.timestamp, true);
 
             assertThat(result.index(), equalTo(recordIdx));
             assertThat(result.value(), equalTo(expectedRecord.value));
@@ -281,7 +281,7 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
         final byte[] value;
         final long timestamp;
 
-        TestRecord(byte[] value, long timestamp) {
+        TestRecord(final byte[] value, final long timestamp) {
             this.value = value;
             this.timestamp = timestamp;
         }
@@ -292,11 +292,11 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
         final long nextTimestamp;
         final String name;
 
-        TestCase(String name, long nextTimestamp, TestRecord... records) {
+        TestCase(final String name, final long nextTimestamp, final TestRecord... records) {
             this(name, nextTimestamp, Arrays.asList(records));
         }
 
-        TestCase(String name, long nextTimestamp, List<TestRecord> records) {
+        TestCase(final String name, final long nextTimestamp, final List<TestRecord> records) {
             this.records = records;
             this.nextTimestamp = nextTimestamp;
             this.name = name;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.streams.state.internals.RocksDBVersionedStoreSegmentValueFormatter.SegmentValue;
+import org.apache.kafka.streams.state.internals.RocksDBVersionedStoreSegmentValueFormatter.SegmentValue.SegmentSearchResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class RocksDBVersionedStoreSegmentValueFormatterTest {
+
+    private static final List<TestCase> TEST_CASES = new ArrayList<>();
+    static {
+        // test cases are expected to have timestamps in strictly decreasing order
+        TEST_CASES.add(new TestCase("empty", 10));
+        TEST_CASES.add(new TestCase("single record", 10, new TestRecord("foo".getBytes(), 1)));
+        TEST_CASES.add(new TestCase("multiple records", 10, new TestRecord("foo".getBytes(), 8), new TestRecord("bar".getBytes(), 3), new TestRecord("baz".getBytes(), 0)));
+        TEST_CASES.add(new TestCase("single tombstone", 10, new TestRecord(null, 1)));
+        TEST_CASES.add(new TestCase("multiple tombstone", 10, new TestRecord(null, 4), new TestRecord(null, 1)));
+        TEST_CASES.add(new TestCase("tombstones and records (r, t, r)", 10, new TestRecord("foo".getBytes(), 5), new TestRecord(null, 2), new TestRecord("bar".getBytes(), 1)));
+        TEST_CASES.add(new TestCase("tombstones and records (t, r, t)", 10, new TestRecord(null, 5), new TestRecord("foo".getBytes(), 2), new TestRecord(null, 1)));
+        TEST_CASES.add(new TestCase("tombstones and records (r, r, t, t)", 10, new TestRecord("foo".getBytes(), 6), new TestRecord("bar".getBytes(), 5), new TestRecord(null, 2), new TestRecord(null, 1)));
+        TEST_CASES.add(new TestCase("tombstones and records (t, t, r, r)", 10, new TestRecord(null, 7), new TestRecord(null, 6), new TestRecord("foo".getBytes(), 2), new TestRecord("bar".getBytes(), 1)));
+        TEST_CASES.add(new TestCase("record with empty bytes", 10, new TestRecord(new byte[0], 1)));
+        TEST_CASES.add(new TestCase("records with empty bytes (r, e)", 10, new TestRecord("foo".getBytes(), 4), new TestRecord(new byte[0], 1)));
+        TEST_CASES.add(new TestCase("records with empty bytes (e, e, r)", 10, new TestRecord(new byte[0], 8), new TestRecord(new byte[0], 2), new TestRecord("foo".getBytes(), 1)));
+    }
+
+    private final TestCase testCase;
+
+    public RocksDBVersionedStoreSegmentValueFormatterTest(final TestCase testCase) {
+        this.testCase = testCase;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<TestCase> data() {
+        return TEST_CASES;
+    }
+
+    @Test
+    public void shouldSerializeAndDeserialize() {
+        final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+        final byte[] serialized = segmentValue.serialize();
+        final SegmentValue deserialized = RocksDBVersionedStoreSegmentValueFormatter.deserialize(serialized);
+
+        verifySegmentContents(deserialized, testCase);
+    }
+
+    @Test
+    public void shouldBuildWithInsertLatest() {
+        final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+        verifySegmentContents(segmentValue, testCase);
+    }
+
+    @Test
+    public void shouldBuildWithInsertEarliest() {
+        final SegmentValue segmentValue = buildSegmentWithInsertEarliest(testCase);
+
+        verifySegmentContents(segmentValue, testCase);
+    }
+
+    @Test
+    public void shouldInsertAtIndex() {
+        if (testCase.records.size() == 0) {
+            // cannot insert into empty segment
+            return;
+        }
+
+        // test inserting at each possible index
+        for (int insertIdx = 0; insertIdx <= testCase.records.size(); insertIdx++) {
+            // build record to insert
+            long newRecordTimestamp;
+            if (insertIdx == 0) {
+                newRecordTimestamp = testCase.records.get(0).timestamp + 1;
+                if (newRecordTimestamp == testCase.nextTimestamp) {
+                    // cannot insert because no timestamp exists between last record and nextTimestamp
+                    continue;
+                }
+            } else {
+                newRecordTimestamp = testCase.records.get(insertIdx - 1).timestamp - 1;
+                if (newRecordTimestamp < 0 || (insertIdx < testCase.records.size() && newRecordTimestamp == testCase.records.get(insertIdx).timestamp)) {
+                    // cannot insert because timestamps of existing records are adjacent
+                    continue;
+                }
+            }
+            TestRecord newRecord = new TestRecord("new".getBytes(), newRecordTimestamp);
+
+            SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+            // insert() first requires a call to find()
+            if (insertIdx > 0) {
+                segmentValue.find(testCase.records.get(insertIdx - 1).timestamp, false);
+            }
+            segmentValue.insert(newRecord.timestamp, newRecord.value, insertIdx);
+
+            // create expected results
+            List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
+            expectedRecords.add(insertIdx, newRecord);
+
+            verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
+        }
+    }
+
+    @Test
+    public void shouldUpdateAtIndex() {
+        // test updating at each possible index
+        for (int updateIdx = 0; updateIdx < testCase.records.size(); updateIdx++) {
+            // build updated record
+            long updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp - 1;
+            if (updatedRecordTimestamp < 0 || (updateIdx < testCase.records.size() - 1 && updatedRecordTimestamp == testCase.records.get(updateIdx + 1).timestamp)) {
+                // found timestamp conflict. try again
+                updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp + 1;
+                if (updateIdx > 0 && updatedRecordTimestamp == testCase.records.get(updateIdx - 1).timestamp) {
+                    // found timestamp conflict. use original timestamp
+                    updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp;
+                }
+            }
+            TestRecord updatedRecord = new TestRecord("updated".getBytes(), updatedRecordTimestamp);
+
+            SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+            // updateRecord() first requires a call to find()
+            segmentValue.find(testCase.records.get(updateIdx).timestamp, false);
+            segmentValue.updateRecord(updatedRecord.timestamp, updatedRecord.value, updateIdx);
+
+            // create expected results
+            List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
+            expectedRecords.remove(updateIdx);
+            expectedRecords.add(updateIdx, updatedRecord);
+
+            verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
+        }
+    }
+
+    @Test
+    public void shouldFindByTimestamp() {
+        final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+        // build expected mapping from timestamp -> record
+        final Map<Long, Integer> expectedRecordIndices = new HashMap<>();
+        for (int recordIdx = testCase.records.size() - 1; recordIdx >= 0; recordIdx--) {
+            if (recordIdx < testCase.records.size() - 1) {
+                expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp - 1, recordIdx + 1);
+            }
+            if (recordIdx > 0) {
+                expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp + 1, recordIdx);
+            }
+            expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp, recordIdx);
+        }
+
+        // verify results
+        for (Map.Entry<Long, Integer> entry : expectedRecordIndices.entrySet()) {
+            TestRecord expectedRecord = testCase.records.get(entry.getValue());
+            long expectedValidTo = entry.getValue() == 0 ? testCase.nextTimestamp : testCase.records.get(entry.getValue() - 1).timestamp;
+
+            SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
+
+            assertThat(result.includesValue(), equalTo(true));
+            assertThat(result.index(), equalTo(entry.getValue()));
+            assertThat(result.value(), equalTo(expectedRecord.value));
+            assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));
+            assertThat(result.validTo(), equalTo(expectedValidTo));
+        }
+
+        // verify exception when timestamp is out of range
+        final long minTimestamp = testCase.records.size() == 0 ? testCase.nextTimestamp : testCase.records.get(testCase.records.size() - 1).timestamp;
+        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.nextTimestamp, false));
+        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.nextTimestamp + 1, false));
+        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(minTimestamp - 1, false));
+    }
+
+    @Test
+    public void shouldGetTimestamps() {
+        final byte[] segmentValue = buildSegmentWithInsertLatest(testCase).serialize();
+        final boolean isEmpty = testCase.records.isEmpty();
+
+        assertThat(RocksDBVersionedStoreSegmentValueFormatter.isEmpty(segmentValue), equalTo(isEmpty));
+        assertThat(RocksDBVersionedStoreSegmentValueFormatter.getNextTimestamp(segmentValue), equalTo(testCase.nextTimestamp));
+        if (!isEmpty) {
+            assertThat(RocksDBVersionedStoreSegmentValueFormatter.getMinTimestamp(segmentValue), equalTo(testCase.records.get(testCase.records.size() - 1).timestamp));
+        }
+    }
+
+    @Test
+    public void shouldCreateNewWithRecord() {
+        if (testCase.records.size() != 1) {
+            return;
+        }
+
+        final SegmentValue segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithRecord(
+            testCase.records.get(0).value,
+            testCase.records.get(0).timestamp,
+            testCase.nextTimestamp);
+
+        verifySegmentContents(segmentValue, testCase);
+    }
+
+    private static SegmentValue buildSegmentWithInsertLatest(TestCase testCase) {
+        if (testCase.records.size() == 0) {
+            return RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithTombstone(testCase.nextTimestamp);
+        }
+
+        SegmentValue segmentValue = null;
+        for (int recordIdx = testCase.records.size() - 1; recordIdx >= 0; recordIdx--) {
+            TestRecord record = testCase.records.get(recordIdx);
+            long validTo = recordIdx == 0 ? testCase.nextTimestamp : testCase.records.get(recordIdx - 1).timestamp;
+
+            if (segmentValue == null) {
+                // initialize
+                if (testCase.records.size() > 1 && record.value == null) {
+                    segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithTombstone(record.timestamp);
+                } else {
+                    segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithRecord(record.value, record.timestamp, validTo);
+                }
+            } else {
+                // insert latest
+                segmentValue.insertAsLatest(record.timestamp, validTo, record.value);
+            }
+        }
+        return segmentValue;
+    }
+
+    private static SegmentValue buildSegmentWithInsertEarliest(TestCase testCase) {
+        final SegmentValue segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithTombstone(testCase.nextTimestamp);
+        for (int recordIdx = 0; recordIdx < testCase.records.size(); recordIdx++) {
+            TestRecord record = testCase.records.get(recordIdx);
+            segmentValue.insertAsEarliest(record.timestamp, record.value);
+        }
+        return segmentValue;
+    }
+
+    private static void verifySegmentContents(SegmentValue segmentValue, TestCase expectedRecords) {
+        // verify expected records
+        for (int recordIdx = 0; recordIdx < expectedRecords.records.size(); recordIdx++) {
+            TestRecord expectedRecord = expectedRecords.records.get(recordIdx);
+            long expectedValidTo = recordIdx == 0 ? expectedRecords.nextTimestamp : expectedRecords.records.get(recordIdx - 1).timestamp;
+
+            SegmentSearchResult result = segmentValue.find(expectedRecord.timestamp, true);
+
+            assertThat(result.index(), equalTo(recordIdx));
+            assertThat(result.value(), equalTo(expectedRecord.value));
+            assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));
+            assertThat(result.validTo(), equalTo(expectedValidTo));
+        }
+
+        // verify expected exceptions to from timestamp out-of-bounds
+        final long minTimestamp = expectedRecords.records.size() == 0 ? expectedRecords.nextTimestamp : expectedRecords.records.get(expectedRecords.records.size() - 1).timestamp;
+        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(expectedRecords.nextTimestamp, false));
+        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(minTimestamp - 1, false));
+    }
+
+    private static class TestRecord {
+        final byte[] value;
+        final long timestamp;
+
+        TestRecord(byte[] value, long timestamp) {
+            this.value = value;
+            this.timestamp = timestamp;
+        }
+    }
+
+    private static class TestCase {
+        final List<TestRecord> records;
+        final long nextTimestamp;
+        final String name;
+
+        TestCase(String name, long nextTimestamp, TestRecord... records) {
+            this(name, nextTimestamp, Arrays.asList(records));
+        }
+
+        TestCase(String name, long nextTimestamp, List<TestRecord> records) {
+            this.records = records;
+            this.nextTimestamp = nextTimestamp;
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
[KIP-889](https://cwiki.apache.org/confluence/display/KAFKA/KIP-889%3A+Versioned+State+Stores) proposed the introduction of versioned key-value stores, as well as a RocksDB-based implementation. The RocksDB implementation will consist of a "latest value store" for storing the latest record version associated with each key, in addition to multiple "segment stores" to store older record versions. Within a segment store, multiple record versions for the same key will be combined into a single bytes array "value" associated with the key and stored to RocksDB. 

This PR introduces the utility class that will be used to manage the value format of these segment stores, i.e., how multiple record versions for the same key will be combined into a single bytes array "value." Follow-up PRs will introduce the versioned store implementation itself (which calls heavily upon this utility class).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
