### PR TITLE
MINOR: Define a root project name in the Gradle settings file

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -59,3 +59,5 @@ include 'clients',
     'streams:upgrade-system-tests-33',
     'tools',
     'trogdor'
+
+rootProject.name = 'kafka'


### PR DESCRIPTION
It is a good practice to always define a root project name. However, this change is specifically being made to address a build caching miss as a result of not having the root project name defined.

The `aggregatedJavadoc` task takes in the root project name as an input. When executing the build from two uniquely named directories, we will see the second execution of `aggregatedJavadoc` will be re-executed due to computed build cache key being different.

Here are the steps to reproduce the issue:

1. Remove the contents of the Gradle local build cache with `rm -rf ~/.gradle/caches/build-cache-1`. WARNING: This is a destructive action, consider renaming the directory instead if you need to preserve the local build cache.
2. Clone and execute the project with `git clone --depth 1 git@github.com:apache/kafka.git first_build && (cd first_build && ./gradlew aggregatedJavadoc --build-cache)`.
3. Clone and execute the project again with `git clone --depth 1 git@github.com:apache/kafka.git second_build && (cd second_build && ./gradlew aggregatedJavadoc --build-cache --scan)`.
4. Agree to the Gradle Terms of Service when prompted to publish a Build Scan.
5. We can see on the Performance > Task execution screen that [a cacheable task](https://scans.gradle.com/s/7bnq7gb4ykmdk/timeline?cacheability=cacheable&hide-timeline&outcome=success,failed&sort=longest) has been executed. We can click the Cacheable link to find [the culprit](https://scans.gradle.com/s/7bnq7gb4ykmdk/timeline?cacheability=cacheable&hide-timeline&outcome=success,failed&sort=longest#lhlgorbepbsx4).

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
