### PR TITLE
MINOR: fix warnings in Streams javadocs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
@@ -56,7 +56,7 @@ import static org.apache.kafka.streams.internals.StreamsConfigUtils.getTotalCach
  * Streams configs that apply at the topology level. The values in the {@link StreamsConfig} parameter of the
  * {@link org.apache.kafka.streams.KafkaStreams} or {@link KafkaStreamsNamedTopologyWrapper} constructors will
  * determine the defaults, which can then be overridden for specific topologies by passing them in when creating the
- * topology builders via the {@link org.apache.kafka.streams.StreamsBuilder()} method.
+ * topology builders via the {@link org.apache.kafka.streams.StreamsBuilder#StreamsBuilder(TopologyConfig)} StreamsBuilder(TopologyConfig)} method.
  */
 @SuppressWarnings("deprecation")
 public class TopologyConfig extends AbstractConfig {

--- a/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.streams;
 
 import org.apache.kafka.streams.processor.TopicNameExtractor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 
 import java.util.Set;
@@ -30,7 +32,7 @@ import java.util.regex.Pattern;
  * In contrast, two sub-topologies are not connected but can be linked to each other via topics, i.e., if one
  * sub-topology {@link Topology#addSink(String, String, String...) writes} into a topic and another sub-topology
  * {@link Topology#addSource(String, String...) reads} from the same topic.
- * Message {@link ProcessorContext#forward(Object, Object) forwards} using custom Processors and Transformers are not considered in the topology graph.
+ * Message {@link ProcessorContext#forward(Record, String)} forwards} using custom Processors and Transformers are not considered in the topology graph.
  * <p>
  * When {@link KafkaStreams#start()} is called, different sub-topologies will be constructed and executed as independent
  * {@link StreamTask tasks}.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -836,7 +836,7 @@ public interface KStream<K, V> {
 
     /**
      * Materialize this stream to a topic and creates a new {@code KStream} from the topic using default serializers,
-     * deserializers, and producer's {@link DefaultPartitioner}.
+     * deserializers, and producer's default partitioning strategy.
      * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
      * started).
      * <p>
@@ -876,7 +876,7 @@ public interface KStream<K, V> {
 
     /**
      * Materialize this stream to an auto-generated repartition topic and create a new {@code KStream}
-     * from the auto-generated topic using default serializers, deserializers, and producer's {@link DefaultPartitioner}.
+     * from the auto-generated topic using default serializers, deserializers, and producer's default partitioning strategy.
      * The number of partitions is determined based on the upstream topics partition numbers.
      * <p>
      * The created topic is considered as an internal topic and is meant to be used only by the current Kafka Streams instance.
@@ -910,7 +910,7 @@ public interface KStream<K, V> {
 
     /**
      * Materialize this stream to a topic using default serializers specified in the config and producer's
-     * {@link DefaultPartitioner}.
+     * default partitioning strategy.
      * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
      * started).
      *
@@ -931,7 +931,7 @@ public interface KStream<K, V> {
 
     /**
      * Dynamically materialize this stream to topics using default serializers specified in the config and producer's
-     * {@link DefaultPartitioner}.
+     * default partitioning strategy.
      * The topic names for each record to send to is dynamically determined based on the {@link TopicNameExtractor}.
      *
      * @param topicExtractor    the extractor to determine the name of the Kafka topic to write to for each record

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.internals.WindowedSerializer;
 import org.apache.kafka.streams.kstream.internals.WindowedStreamPartitioner;
 import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.internals.DefaultStreamPartitioner;
 
 import java.util.Objects;
 
@@ -74,7 +75,7 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * @param valueSerde    Serde to use for serializing the value
      * @param partitioner   the function used to determine how records are distributed among partitions of the topic,
      *                      if not specified and {@code keySerde} provides a {@link WindowedSerializer} for the key
-     *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultPartitioner}
+     *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultStreamPartitioner}
      *                      will be used
      * @param <K>           key type
      * @param <V>           value type
@@ -127,7 +128,7 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * Create a Produced instance with provided partitioner.
      * @param partitioner   the function used to determine how records are distributed among partitions of the topic,
      *                      if not specified and the key serde provides a {@link WindowedSerializer} for the key
-     *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultPartitioner} will be used
+     *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultStreamPartitioner} will be used
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with partitioner
@@ -141,7 +142,7 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * Produce records using the provided partitioner.
      * @param partitioner   the function used to determine how records are distributed among partitions of the topic,
      *                      if not specified and the key serde provides a {@link WindowedSerializer} for the key
-     *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultPartitioner} wil be used
+     *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultStreamPartitioner} wil be used
      * @return this
      */
     public Produced<K, V> withStreamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Repartitioned.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Repartitioned.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.internals.WindowedSerializer;
 import org.apache.kafka.streams.kstream.internals.WindowedStreamPartitioner;
 import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.internals.DefaultStreamPartitioner;
 
 /**
  * This class is used to provide the optional parameters for internal repartition topics.
@@ -92,7 +93,7 @@ public class Repartitioned<K, V> implements NamedOperation<Repartitioned<K, V>> 
      *
      * @param partitioner the function used to determine how records are distributed among partitions of the topic,
      *                    if not specified and the key serde provides a {@link WindowedSerializer} for the key
-     *                    {@link WindowedStreamPartitioner} will be used—otherwise {@link DefaultPartitioner} will be used
+     *                    {@link WindowedStreamPartitioner} will be used—otherwise {@link DefaultStreamPartitioner} will be used
      * @param <K>         key type
      * @param <V>         value type
      * @return A new {@code Repartitioned} instance configured with partitioner
@@ -161,7 +162,7 @@ public class Repartitioned<K, V> implements NamedOperation<Repartitioned<K, V>> 
      *
      * @param partitioner the function used to determine how records are distributed among partitions of the topic,
      *                    if not specified and the key serde provides a {@link WindowedSerializer} for the key
-     *                    {@link WindowedStreamPartitioner} will be used—otherwise {@link DefaultPartitioner} wil be used
+     *                    {@link WindowedStreamPartitioner} will be used—otherwise {@link DefaultStreamPartitioner} wil be used
      * @return a new {@code Repartitioned} instance configured with provided partitioner
      */
     public Repartitioned<K, V> withStreamPartitioner(final StreamPartitioner<K, V> partitioner) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 /**
  * Determine how records are distributed among the partitions in a Kafka topic. If not specified, the underlying producer's
- * {@link org.apache.kafka.clients.producer.internals.DefaultPartitioner} will be used to determine the partition.
+ * default partitioning strategy will be used to determine the partition.
  * <p>
  * Kafka topics are divided into one or more <i>partitions</i>. Since each partition must fit on the servers that host it, so
  * using multiple partitions allows the topic to scale beyond a size that will fit on a single machine. Partitions also enable you

--- a/streams/src/main/java/org/apache/kafka/streams/query/Position.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/Position.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * This class is threadsafe, although it is mutable. Readers are recommended to use {@link
  * Position#copy()} to avoid seeing mutations to the Position after they get the reference. For
  * examples, when a store executes a {@link org.apache.kafka.streams.processor.StateStore#query(Query,
- * PositionBound, boolean)} request and returns its current position via {@link
+ * PositionBound, QueryConfig)} request and returns its current position via {@link
  * QueryResult#setPosition(Position)}, it should pass a copy of its position instead of the mutable
  * reference.
  */

--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
@@ -104,14 +104,14 @@ public interface QueryResult<R> {
 
     /**
      * True iff the query was successfully executed. The response is available in {@link
-     * this#getResult()}.
+     * #getResult()}.
      */
     boolean isSuccess();
 
 
     /**
      * True iff the query execution failed. More information about the failure is available in
-     * {@link this#getFailureReason()} and {@link this#getFailureMessage()}.
+     * {@link #getFailureReason()} and {@link #getFailureMessage()}.
      */
     boolean isFailure();
 
@@ -146,7 +146,7 @@ public interface QueryResult<R> {
     /**
      * Returns the result of executing the query on one partition. The result type is determined by
      * the query. Note: queries may choose to return {@code null} for a successful query, so {@link
-     * this#isSuccess()} and {@link this#isFailure()} must be used to determine whether the query
+     * #isSuccess()} and {@link #isFailure()} must be used to determine whether the query
      * was successful of failed on this partition.
      *
      * @throws IllegalArgumentException if this is not a successful query.


### PR DESCRIPTION
While working on the 3.4 release I noticed we've built up an embarrassingly long list of warnings within the Streams javadocs. It's unavoidable for some links to break as the source code changes, but let's reset back to a good state before the list gets even longer