### PR TITLE
KAFKA-14633: Reduce data copy & buffer allocation during decompression

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -24,8 +24,8 @@ import org.apache.kafka.common.compress.ZstdFactory;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.apache.kafka.common.utils.ChunkedBytesStream;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -66,14 +66,23 @@ public enum CompressionType {
         @Override
         public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
             try {
-                // Set output buffer (uncompressed) to 16 KB (none by default) and input buffer (compressed) to
-                // 8 KB (0.5 KB by default) to ensure reasonable performance in cases where the caller reads a small
-                // number of bytes (potentially a single byte)
-                return new BufferedInputStream(new GZIPInputStream(new ByteBufferInputStream(buffer), 8 * 1024),
-                        16 * 1024);
+                // Set input buffer (compressed) to 8 KB (GZIPInputStream uses 0.5 KB by default) to ensure reasonable
+                // performance in cases where the caller reads a small number of bytes (potentially a single byte).
+                //
+                // Size of output buffer (uncompressed) is provided by decompressionOutputSize.
+                //
+                // ChunkedBytesStream is used to wrap the GZIPInputStream because the default implementation of
+                // GZIPInputStream does not use an intermediate buffer for decompression in chunks.
+                return new ChunkedBytesStream(new GZIPInputStream(new ByteBufferInputStream(buffer), 8 * 1024), decompressionBufferSupplier, decompressionOutputSize(), false);
             } catch (Exception e) {
                 throw new KafkaException(e);
             }
+        }
+
+        @Override
+        public int decompressionOutputSize() {
+            // 16KB has been chosen based on legacy implementation introduced in https://github.com/apache/kafka/pull/6785
+            return 16 * 1024;
         }
     },
 
@@ -91,7 +100,17 @@ public enum CompressionType {
 
         @Override
         public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
-            return SnappyFactory.wrapForInput(buffer);
+            // SnappyInputStream uses default implementation of InputStream for skip. Default implementation of
+            // SnappyInputStream allocates a new skip buffer every time, hence, we prefer our own implementation.
+            return new ChunkedBytesStream(SnappyFactory.wrapForInput(buffer), decompressionBufferSupplier, decompressionOutputSize(), false);
+        }
+
+        @Override
+        public int decompressionOutputSize() {
+            // SnappyInputStream already uses an intermediate buffer internally. The size
+            // of this buffer is based on legacy implementation based on skipArray introduced in
+            // https://github.com/apache/kafka/pull/6785
+            return 2 * 1024; // 2KB
         }
     },
 
@@ -108,11 +127,20 @@ public enum CompressionType {
         @Override
         public InputStream wrapForInput(ByteBuffer inputBuffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
             try {
-                return new KafkaLZ4BlockInputStream(inputBuffer, decompressionBufferSupplier,
-                                                    messageVersion == RecordBatch.MAGIC_VALUE_V0);
+                return new ChunkedBytesStream(
+                    new KafkaLZ4BlockInputStream(inputBuffer, decompressionBufferSupplier, messageVersion == RecordBatch.MAGIC_VALUE_V0),
+                    decompressionBufferSupplier, decompressionOutputSize(), true);
             } catch (Throwable e) {
                 throw new KafkaException(e);
             }
+        }
+
+        @Override
+        public int decompressionOutputSize() {
+            // KafkaLZ4BlockInputStream uses an internal intermediate buffer to store decompressed data. The size
+            // of this buffer is based on legacy implementation based on skipArray introduced in
+            // https://github.com/apache/kafka/pull/6785
+            return 2 * 1024; // 2KB
         }
     },
 
@@ -124,8 +152,21 @@ public enum CompressionType {
 
         @Override
         public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
-            return ZstdFactory.wrapForInput(buffer, messageVersion, decompressionBufferSupplier);
+            return new ChunkedBytesStream(ZstdFactory.wrapForInput(buffer, messageVersion, decompressionBufferSupplier), decompressionBufferSupplier, decompressionOutputSize(), false);
         }
+
+        /**
+         * Size of intermediate buffer which contains uncompressed data.
+         * This size should be <= ZSTD_BLOCKSIZE_MAX
+         * see: https://github.com/facebook/zstd/blob/189653a9c10c9f4224a5413a6d6a69dd01d7c3bd/lib/zstd.h#L854
+         */
+        @Override
+        public int decompressionOutputSize() {
+            // 16KB has been chosen based on legacy implementation introduced in https://github.com/apache/kafka/pull/6785
+            return 16 * 1024;
+        }
+
+
     };
 
     public final int id;
@@ -140,7 +181,7 @@ public enum CompressionType {
 
     /**
      * Wrap bufferStream with an OutputStream that will compress data with this CompressionType.
-     *
+     * <p>
      * Note: Unlike {@link #wrapForInput}, {@link #wrapForOutput} cannot take {@link ByteBuffer}s directly.
      * Currently, {@link MemoryRecordsBuilder#writeDefaultBatchHeader()} and {@link MemoryRecordsBuilder#writeLegacyCompressedWrapperHeader()}
      * write to the underlying buffer in the given {@link ByteBufferOutputStream} after the compressed data has been written.
@@ -158,6 +199,13 @@ public enum CompressionType {
      *                                    performance impact.
      */
     public abstract InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier);
+
+    /**
+     * Recommended size of buffer for storing decompressed output.
+     */
+    public int decompressionOutputSize() {
+        throw new UnsupportedOperationException("Size of decompression buffer is not defined for this compression type=" + this.name);
+    }
 
     public static CompressionType forId(int id) {
         switch (id) {

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -20,13 +20,11 @@ import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.ByteUtils;
-import org.apache.kafka.common.utils.PrimitiveRef;
-import org.apache.kafka.common.utils.PrimitiveRef.IntRef;
 import org.apache.kafka.common.utils.Utils;
 
-import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -273,16 +271,19 @@ public class DefaultRecord implements Record {
         return result;
     }
 
-    public static DefaultRecord readFrom(DataInput input,
+    public static DefaultRecord readFrom(InputStream input,
                                          long baseOffset,
                                          long baseTimestamp,
                                          int baseSequence,
                                          Long logAppendTime) throws IOException {
         int sizeOfBodyInBytes = ByteUtils.readVarint(input);
         ByteBuffer recordBuffer = ByteBuffer.allocate(sizeOfBodyInBytes);
-        input.readFully(recordBuffer.array(), 0, sizeOfBodyInBytes);
-        int totalSizeInBytes = ByteUtils.sizeOfVarint(sizeOfBodyInBytes) + sizeOfBodyInBytes;
-        return readFrom(recordBuffer, totalSizeInBytes, sizeOfBodyInBytes, baseOffset, baseTimestamp,
+        int bytesRead = Utils.readFully(input, recordBuffer);
+        if (bytesRead != sizeOfBodyInBytes)
+            throw new InvalidRecordException("Invalid record size: expected " + sizeOfBodyInBytes +
+                " bytes in record payload, but the record payload reached EOF.");
+        recordBuffer.flip(); // prepare for reading
+        return readFrom(recordBuffer, sizeOfBodyInBytes, baseOffset, baseTimestamp,
                 baseSequence, logAppendTime);
     }
 
@@ -292,23 +293,20 @@ public class DefaultRecord implements Record {
                                          int baseSequence,
                                          Long logAppendTime) {
         int sizeOfBodyInBytes = ByteUtils.readVarint(buffer);
-        if (buffer.remaining() < sizeOfBodyInBytes)
-            throw new InvalidRecordException("Invalid record size: expected " + sizeOfBodyInBytes +
-                " bytes in record payload, but instead the buffer has only " + buffer.remaining() +
-                " remaining bytes.");
-
-        int totalSizeInBytes = ByteUtils.sizeOfVarint(sizeOfBodyInBytes) + sizeOfBodyInBytes;
-        return readFrom(buffer, totalSizeInBytes, sizeOfBodyInBytes, baseOffset, baseTimestamp,
-                baseSequence, logAppendTime);
+        return readFrom(buffer, sizeOfBodyInBytes, baseOffset, baseTimestamp,
+            baseSequence, logAppendTime);
     }
 
     private static DefaultRecord readFrom(ByteBuffer buffer,
-                                          int sizeInBytes,
                                           int sizeOfBodyInBytes,
                                           long baseOffset,
                                           long baseTimestamp,
                                           int baseSequence,
                                           Long logAppendTime) {
+        if (buffer.remaining() < sizeOfBodyInBytes)
+            throw new InvalidRecordException("Invalid record size: expected " + sizeOfBodyInBytes +
+                " bytes in record payload, but instead the buffer has only " + buffer.remaining() +
+                " remaining bytes.");
         try {
             int recordStart = buffer.position();
             byte attributes = buffer.get();
@@ -323,21 +321,13 @@ public class DefaultRecord implements Record {
                     DefaultRecordBatch.incrementSequence(baseSequence, offsetDelta) :
                     RecordBatch.NO_SEQUENCE;
 
-            ByteBuffer key = null;
+            // read key
             int keySize = ByteUtils.readVarint(buffer);
-            if (keySize >= 0) {
-                key = buffer.slice();
-                key.limit(keySize);
-                buffer.position(buffer.position() + keySize);
-            }
+            ByteBuffer key = Utils.readBytes(buffer, keySize);
 
-            ByteBuffer value = null;
+            // read value
             int valueSize = ByteUtils.readVarint(buffer);
-            if (valueSize >= 0) {
-                value = buffer.slice();
-                value.limit(valueSize);
-                buffer.position(buffer.position() + valueSize);
-            }
+            ByteBuffer value = Utils.readBytes(buffer, valueSize);
 
             int numHeaders = ByteUtils.readVarint(buffer);
             if (numHeaders < 0)
@@ -356,14 +346,14 @@ public class DefaultRecord implements Record {
                 throw new InvalidRecordException("Invalid record size: expected to read " + sizeOfBodyInBytes +
                         " bytes in record payload, but instead read " + (buffer.position() - recordStart));
 
-            return new DefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, key, value, headers);
+            int totalSizeInBytes = ByteUtils.sizeOfVarint(sizeOfBodyInBytes) + sizeOfBodyInBytes;
+            return new DefaultRecord(totalSizeInBytes, attributes, offset, timestamp, sequence, key, value, headers);
         } catch (BufferUnderflowException | IllegalArgumentException e) {
             throw new InvalidRecordException("Found invalid record structure", e);
         }
     }
 
-    public static PartialDefaultRecord readPartiallyFrom(DataInput input,
-                                                         byte[] skipArray,
+    public static PartialDefaultRecord readPartiallyFrom(InputStream input,
                                                          long baseOffset,
                                                          long baseTimestamp,
                                                          int baseSequence,
@@ -371,61 +361,51 @@ public class DefaultRecord implements Record {
         int sizeOfBodyInBytes = ByteUtils.readVarint(input);
         int totalSizeInBytes = ByteUtils.sizeOfVarint(sizeOfBodyInBytes) + sizeOfBodyInBytes;
 
-        return readPartiallyFrom(input, skipArray, totalSizeInBytes, sizeOfBodyInBytes, baseOffset, baseTimestamp,
+        return readPartiallyFrom(input, totalSizeInBytes, baseOffset, baseTimestamp,
             baseSequence, logAppendTime);
     }
 
-    private static PartialDefaultRecord readPartiallyFrom(DataInput input,
-                                                          byte[] skipArray,
+    private static PartialDefaultRecord readPartiallyFrom(InputStream input,
                                                           int sizeInBytes,
-                                                          int sizeOfBodyInBytes,
                                                           long baseOffset,
                                                           long baseTimestamp,
                                                           int baseSequence,
                                                           Long logAppendTime) throws IOException {
-        ByteBuffer skipBuffer = ByteBuffer.wrap(skipArray);
-        // set its limit to 0 to indicate no bytes readable yet
-        skipBuffer.limit(0);
-
         try {
-            // reading the attributes / timestamp / offset and key-size does not require
-            // any byte array allocation and therefore we can just read them straight-forwardly
-            IntRef bytesRemaining = PrimitiveRef.ofInt(sizeOfBodyInBytes);
-
-            byte attributes = readByte(skipBuffer, input, bytesRemaining);
-            long timestampDelta = readVarLong(skipBuffer, input, bytesRemaining);
+            byte attributes = (byte) input.read();
+            long timestampDelta = ByteUtils.readVarlong(input);
             long timestamp = baseTimestamp + timestampDelta;
             if (logAppendTime != null)
                 timestamp = logAppendTime;
 
-            int offsetDelta = readVarInt(skipBuffer, input, bytesRemaining);
+            int offsetDelta = ByteUtils.readVarint(input);
             long offset = baseOffset + offsetDelta;
             int sequence = baseSequence >= 0 ?
                 DefaultRecordBatch.incrementSequence(baseSequence, offsetDelta) :
                 RecordBatch.NO_SEQUENCE;
 
-            // first skip key
-            int keySize = skipLengthDelimitedField(skipBuffer, input, bytesRemaining);
+            // skip key
+            int keySize = ByteUtils.readVarint(input);
+            skipBytes(input, keySize);
 
-            // then skip value
-            int valueSize = skipLengthDelimitedField(skipBuffer, input, bytesRemaining);
+            // skip value
+            int valueSize = ByteUtils.readVarint(input);
+            skipBytes(input, valueSize);
 
-            // then skip header
-            int numHeaders = readVarInt(skipBuffer, input, bytesRemaining);
+            // skip header
+            int numHeaders = ByteUtils.readVarint(input);
             if (numHeaders < 0)
                 throw new InvalidRecordException("Found invalid number of record headers " + numHeaders);
             for (int i = 0; i < numHeaders; i++) {
-                int headerKeySize = skipLengthDelimitedField(skipBuffer, input, bytesRemaining);
+                int headerKeySize = ByteUtils.readVarint(input);
                 if (headerKeySize < 0)
                     throw new InvalidRecordException("Invalid negative header key size " + headerKeySize);
+                skipBytes(input, headerKeySize);
 
                 // headerValueSize
-                skipLengthDelimitedField(skipBuffer, input, bytesRemaining);
+                int headerValueSize = ByteUtils.readVarint(input);
+                skipBytes(input, headerValueSize);
             }
-
-            if (bytesRemaining.value > 0 || skipBuffer.remaining() > 0)
-                throw new InvalidRecordException("Invalid record size: expected to read " + sizeOfBodyInBytes +
-                    " bytes in record payload, but there are still bytes remaining");
 
             return new PartialDefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, keySize, valueSize);
         } catch (BufferUnderflowException | IllegalArgumentException e) {
@@ -433,87 +413,33 @@ public class DefaultRecord implements Record {
         }
     }
 
-    private static byte readByte(ByteBuffer buffer, DataInput input, IntRef bytesRemaining) throws IOException {
-        if (buffer.remaining() < 1 && bytesRemaining.value > 0) {
-            readMore(buffer, input, bytesRemaining);
-        }
 
-        return buffer.get();
-    }
+    /**
+     * Skips n bytes from the data input.
+     *
+     * No-op for case where bytesToSkip <= 0. This could occur for cases where field is expected to be null.
+     * @throws  InvalidRecordException if the number of bytes could not be skipped.
+     */
+    private static void skipBytes(InputStream in, int bytesToSkip) throws IOException {
+        if (bytesToSkip <= 0) return;
 
-    private static long readVarLong(ByteBuffer buffer, DataInput input, IntRef bytesRemaining) throws IOException {
-        if (buffer.remaining() < 10 && bytesRemaining.value > 0) {
-            readMore(buffer, input, bytesRemaining);
-        }
-
-        return ByteUtils.readVarlong(buffer);
-    }
-
-    private static int readVarInt(ByteBuffer buffer, DataInput input, IntRef bytesRemaining) throws IOException {
-        if (buffer.remaining() < 5 && bytesRemaining.value > 0) {
-            readMore(buffer, input, bytesRemaining);
-        }
-
-        return ByteUtils.readVarint(buffer);
-    }
-
-    private static int skipLengthDelimitedField(ByteBuffer buffer, DataInput input, IntRef bytesRemaining) throws IOException {
-        boolean needMore = false;
-        int sizeInBytes = -1;
-        int bytesToSkip = -1;
-
-        while (true) {
-            if (needMore) {
-                readMore(buffer, input, bytesRemaining);
-                needMore = false;
-            }
-
-            if (bytesToSkip < 0) {
-                if (buffer.remaining() < 5 && bytesRemaining.value > 0) {
-                    needMore = true;
-                } else {
-                    sizeInBytes = ByteUtils.readVarint(buffer);
-                    if (sizeInBytes <= 0)
-                        return sizeInBytes;
-                    else
-                        bytesToSkip = sizeInBytes;
-
+        // Starting JDK 12, this implementation could be replaced by InputStream#skipNBytes
+        while (bytesToSkip > 0) {
+            long ns = in.skip(bytesToSkip);
+            if (ns > 0 && ns <= bytesToSkip) {
+                // adjust number to skip
+                bytesToSkip -= ns;
+            } else if (ns == 0) { // no bytes skipped
+                // read one byte to check for EOS
+                if (in.read() == -1) {
+                    throw new InvalidRecordException("Reached end of input stream before skipping all bytes. " +
+                        "Remaining bytes:" + bytesToSkip);
                 }
-            } else {
-                if (bytesToSkip > buffer.remaining()) {
-                    bytesToSkip -= buffer.remaining();
-                    buffer.position(buffer.limit());
-                    needMore = true;
-                } else {
-                    buffer.position(buffer.position() + bytesToSkip);
-                    return sizeInBytes;
-                }
+                // one byte read so decrement number to skip
+                bytesToSkip--;
+            } else { // skipped negative or too many bytes
+                throw new IOException("Unable to skip exactly");
             }
-        }
-    }
-
-    private static void readMore(ByteBuffer buffer, DataInput input, IntRef bytesRemaining) throws IOException {
-        if (bytesRemaining.value > 0) {
-            byte[] array = buffer.array();
-
-            // first copy the remaining bytes to the beginning of the array;
-            // at most 4 bytes would be shifted here
-            int stepsToLeftShift = buffer.position();
-            int bytesToLeftShift = buffer.remaining();
-            for (int i = 0; i < bytesToLeftShift; i++) {
-                array[i] = array[i + stepsToLeftShift];
-            }
-
-            // then try to read more bytes to the remaining of the array
-            int bytesRead = Math.min(bytesRemaining.value, array.length - bytesToLeftShift);
-            input.readFully(array, bytesToLeftShift, bytesRead);
-            buffer.rewind();
-            // only those many bytes are readable
-            buffer.limit(bytesToLeftShift + bytesRead);
-
-            bytesRemaining.value -= bytesRead;
-        } else {
-            throw new InvalidRecordException("Invalid record size: expected to read more bytes in record payload");
         }
     }
 
@@ -524,17 +450,10 @@ public class DefaultRecord implements Record {
             if (headerKeySize < 0)
                 throw new InvalidRecordException("Invalid negative header key size " + headerKeySize);
 
-            ByteBuffer headerKeyBuffer = buffer.slice();
-            headerKeyBuffer.limit(headerKeySize);
-            buffer.position(buffer.position() + headerKeySize);
+            ByteBuffer headerKeyBuffer = Utils.readBytes(buffer, headerKeySize);
 
-            ByteBuffer headerValue = null;
             int headerValueSize = ByteUtils.readVarint(buffer);
-            if (headerValueSize >= 0) {
-                headerValue = buffer.slice();
-                headerValue.limit(headerValueSize);
-                buffer.position(buffer.position() + headerValueSize);
-            }
+            ByteBuffer headerValue = Utils.readBytes(buffer, headerValueSize);
 
             headers[i] = new RecordHeader(headerKeyBuffer, headerValue);
         }

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -415,10 +415,16 @@ public class DefaultRecord implements Record {
 
 
     /**
-     * Skips n bytes from the data input.
+     * Skips over and discards exactly {@code bytesToSkip} bytes from the input stream.
+     *
+     * We require a loop over {@link InputStream#skip(long)} because it is possible for InputStream to skip smaller
+     * number of bytes than expected (see javadoc for InputStream#skip).
      *
      * No-op for case where bytesToSkip <= 0. This could occur for cases where field is expected to be null.
-     * @throws  InvalidRecordException if the number of bytes could not be skipped.
+     * @throws InvalidRecordException if end of stream is encountered before we could skip required bytes.
+     * @throws IOException is an I/O error occurs while trying to skip from InputStream.
+     * 
+     * @see java.io.InputStream#skip(long)
      */
     private static void skipBytes(InputStream in, int bytesToSkip) throws IOException {
         if (bytesToSkip <= 0) return;

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -26,9 +26,8 @@ import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Crc32C;
 
-import java.io.DataInputStream;
-import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -133,8 +132,6 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
     private static final int CONTROL_FLAG_MASK = 0x20;
     private static final byte DELETE_HORIZON_FLAG_MASK = 0x40;
     private static final byte TIMESTAMP_TYPE_MASK = 0x08;
-
-    private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
     private final ByteBuffer buffer;
 
@@ -270,23 +267,20 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         return buffer.getInt(PARTITION_LEADER_EPOCH_OFFSET);
     }
 
-    public DataInputStream recordInputStream(BufferSupplier bufferSupplier) {
+    public InputStream recordInputStream(BufferSupplier bufferSupplier) {
         final ByteBuffer buffer = this.buffer.duplicate();
         buffer.position(RECORDS_OFFSET);
-        return new DataInputStream(compressionType().wrapForInput(buffer, magic(), bufferSupplier));
+        return compressionType().wrapForInput(buffer, magic(), bufferSupplier);
     }
 
     private CloseableIterator<Record> compressedIterator(BufferSupplier bufferSupplier, boolean skipKeyValue) {
-        final DataInputStream inputStream = recordInputStream(bufferSupplier);
+        final InputStream inputStream = recordInputStream(bufferSupplier);
 
         if (skipKeyValue) {
-            // this buffer is used to skip length delimited fields like key, value, headers
-            byte[] skipArray = new byte[MAX_SKIP_BUFFER_SIZE];
-
             return new StreamRecordIterator(inputStream) {
                 @Override
                 protected Record doReadRecord(long baseOffset, long baseTimestamp, int baseSequence, Long logAppendTime) throws IOException {
-                    return DefaultRecord.readPartiallyFrom(inputStream, skipArray, baseOffset, baseTimestamp, baseSequence, logAppendTime);
+                    return DefaultRecord.readPartiallyFrom(inputStream, baseOffset, baseTimestamp, baseSequence, logAppendTime);
                 }
             };
         } else {
@@ -569,7 +563,8 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         return sequence - decrement;
     }
 
-    private abstract class RecordIterator implements CloseableIterator<Record> {
+    // visible for testing
+    abstract class RecordIterator implements CloseableIterator<Record> {
         private final Long logAppendTime;
         private final long baseOffset;
         private final long baseTimestamp;
@@ -622,10 +617,11 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
     }
 
-    private abstract class StreamRecordIterator extends RecordIterator {
-        private final DataInputStream inputStream;
+    // visible for testing
+    abstract class StreamRecordIterator extends RecordIterator {
+        private final InputStream inputStream;
 
-        StreamRecordIterator(DataInputStream inputStream) {
+        StreamRecordIterator(InputStream inputStream) {
             super();
             this.inputStream = inputStream;
         }
@@ -636,8 +632,8 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         protected Record readNext(long baseOffset, long baseTimestamp, int baseSequence, Long logAppendTime) {
             try {
                 return doReadRecord(baseOffset, baseTimestamp, baseSequence, logAppendTime);
-            } catch (EOFException e) {
-                throw new InvalidRecordException("Incorrect declared batch size, premature EOF reached");
+            } catch (IllegalArgumentException e) {
+                throw new InvalidRecordException("Incorrect declared batch size, premature EOF reached", e);
             } catch (IOException e) {
                 throw new KafkaException("Failed to decompress record stream", e);
             }

--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteBufferInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteBufferInputStream.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
@@ -47,5 +48,10 @@ public final class ByteBufferInputStream extends InputStream {
         len = Math.min(len, buffer.remaining());
         buffer.get(bytes, off, len);
         return len;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return buffer.remaining();
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
@@ -196,28 +196,28 @@ public final class ByteUtils {
      * @return The integer read
      *
      * @throws IllegalArgumentException if variable-length value does not terminate after 5 bytes have been read
-     * @throws IOException              if {@link DataInput} throws {@link IOException}
-     * @throws EOFException             if {@link DataInput} throws {@link EOFException}
+     * @throws IOException              if {@link InputStream} throws {@link IOException}
+     * @throws EOFException             if {@link InputStream} throws {@link EOFException}
      */
-    static int readUnsignedVarint(DataInput in) throws IOException {
-        byte tmp = in.readByte();
+    static int readUnsignedVarint(InputStream in) throws IOException {
+        byte tmp = (byte) in.read();
         if (tmp >= 0) {
             return tmp;
         } else {
             int result = tmp & 127;
-            if ((tmp = in.readByte()) >= 0) {
+            if ((tmp = (byte) in.read()) >= 0) {
                 result |= tmp << 7;
             } else {
                 result |= (tmp & 127) << 7;
-                if ((tmp = in.readByte()) >= 0) {
+                if ((tmp = (byte) in.read()) >= 0) {
                     result |= tmp << 14;
                 } else {
                     result |= (tmp & 127) << 14;
-                    if ((tmp = in.readByte()) >= 0) {
+                    if ((tmp = (byte) in.read()) >= 0) {
                         result |= tmp << 21;
                     } else {
                         result |= (tmp & 127) << 21;
-                        result |= (tmp = in.readByte()) << 28;
+                        result |= (tmp = (byte) in.read()) << 28;
                         if (tmp < 0) {
                             throw illegalVarintException(result);
                         }
@@ -252,7 +252,7 @@ public final class ByteUtils {
      * @throws IllegalArgumentException if variable-length value does not terminate after 5 bytes have been read
      * @throws IOException              if {@link DataInput} throws {@link IOException}
      */
-    public static int readVarint(DataInput in) throws IOException {
+    public static int readVarint(InputStream in) throws IOException {
         int value = readUnsignedVarint(in);
         return (value >>> 1) ^ -(value & 1);
     }
@@ -267,11 +267,11 @@ public final class ByteUtils {
      * @throws IllegalArgumentException if variable-length value does not terminate after 10 bytes have been read
      * @throws IOException              if {@link DataInput} throws {@link IOException}
      */
-    public static long readVarlong(DataInput in) throws IOException {
+    public static long readVarlong(InputStream in) throws IOException {
         long value = 0L;
         int i = 0;
         long b;
-        while (((b = in.readByte()) & 0x80) != 0) {
+        while (((b = in.read()) & 0x80) != 0) {
             value |= (b & 0x7f) << i;
             i += 7;
             if (i > 63)

--- a/clients/src/main/java/org/apache/kafka/common/utils/ChunkedBytesStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ChunkedBytesStream.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.io.BufferedInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * ChunkedBytesStream is a copy of {@link ByteBufferInputStream} with the following differences:
+ * - Unlike {@link java.io.BufferedInputStream#skip(long)} this class could be configured to not push skip() to
+ * input stream. We may want to avoid pushing this to input stream because it's implementation maybe inefficient,
+ * e.g. the case of ZstdInputStream which allocates a new buffer from buffer pool, per skip call.
+ * - Unlike {@link java.io.BufferedInputStream}, which allocates an intermediate buffer, this uses a buffer supplier to
+ * create the intermediate buffer.
+ * <p>
+ * Note that:
+ * - this class is not thread safe and shouldn't be used in scenarios where multiple threads access this.
+ * - the implementation of this class is performance sensitive. Minor changes such as usage of ByteBuffer instead of byte[]
+ * can significantly impact performance, hence, proceed with caution.
+ */
+public class ChunkedBytesStream extends FilterInputStream {
+    /**
+     * Supplies the ByteBuffer which is used as intermediate buffer to store the chunk of output data.
+     */
+    private final BufferSupplier bufferSupplier;
+    /**
+     * Intermediate buffer to store the chunk of output data. The ChunkedBytesStream is considered closed if
+     * this buffer is null.
+     */
+    private byte[] intermediateBuf;
+    /**
+     * The index one greater than the index of the last valid byte in
+     * the buffer.
+     * This value is always in the range <code>0</code> through <code>intermediateBuf.length</code>;
+     * elements <code>intermediateBuf[0]</code>  through <code>intermediateBuf[count-1]
+     * </code>contain buffered input data obtained
+     * from the underlying  input stream.
+     */
+    protected int count = 0;
+    /**
+     * The current position in the buffer. This is the index of the next
+     * character to be read from the <code>buf</code> array.
+     * <p>
+     * This value is always in the range <code>0</code>
+     * through <code>count</code>. If it is less
+     * than <code>count</code>, then  <code>intermediateBuf[pos]</code>
+     * is the next byte to be supplied as input;
+     * if it is equal to <code>count</code>, then
+     * the  next <code>read</code> or <code>skip</code>
+     * operation will require more bytes to be
+     * read from the contained  input stream.
+     */
+    protected int pos = 0;
+    /**
+     * Reference for the intermediate buffer. This reference is only kept for releasing the buffer from the
+     * buffer supplier.
+     */
+    private final ByteBuffer intermediateBufRef;
+    /**
+     * Determines if the skip be pushed down
+     */
+    private final boolean pushSkipToSourceStream;
+
+    public ChunkedBytesStream(InputStream in, BufferSupplier bufferSupplier, int intermediateBufSize, boolean pushSkipToSourceStream) {
+        super(in);
+        this.bufferSupplier = bufferSupplier;
+        intermediateBufRef = bufferSupplier.get(intermediateBufSize);
+        if (!intermediateBufRef.hasArray() || (intermediateBufRef.arrayOffset() != 0)) {
+            throw new IllegalArgumentException("provided ByteBuffer lacks array or has non-zero arrayOffset");
+        }
+        intermediateBuf = intermediateBufRef.array();
+        this.pushSkipToSourceStream = pushSkipToSourceStream;
+    }
+
+    /**
+     * Check to make sure that buffer has not been nulled out due to
+     * close; if not return it;
+     */
+    private byte[] getBufIfOpen() throws IOException {
+        byte[] buffer = intermediateBuf;
+        if (buffer == null)
+            throw new IOException("Stream closed");
+        return buffer;
+    }
+
+    /**
+     * See
+     * the general contract of the <code>read</code>
+     * method of <code>InputStream</code>.
+     *
+     * @return the next byte of data, or <code>-1</code> if the end of the
+     * stream is reached.
+     * @throws IOException if this input stream has been closed by
+     *                     invoking its {@link #close()} method,
+     *                     or an I/O error occurs.
+     * @see BufferedInputStream#read()
+     */
+    @Override
+    public int read() throws IOException {
+        if (pos >= count) {
+            fill();
+            if (pos >= count)
+                return -1;
+        }
+
+        return getBufIfOpen()[pos++] & 0xff;
+    }
+
+    /**
+     * Check to make sure that underlying input stream has not been
+     * nulled out due to close; if not return it;
+     */
+    InputStream getInIfOpen() throws IOException {
+        InputStream input = in;
+        if (input == null)
+            throw new IOException("Stream closed");
+        return input;
+    }
+
+    /**
+     * Fills the intermediate buffer with more data. The amount of new data read is equal to the remaining empty space
+     * in the buffer. For optimal performance, read as much data as possible in this call.
+     * This method also assumes that all data has already been read in, hence pos > count.
+     */
+    int fill() throws IOException {
+        byte[] buffer = getBufIfOpen();
+        pos = 0;
+        count = pos;
+        int n = getInIfOpen().read(buffer, pos, buffer.length - pos);
+        if (n > 0)
+            count = n + pos;
+        return n;
+    }
+
+    @Override
+    public void close() throws IOException {
+        byte[] mybuf = intermediateBuf;
+        intermediateBuf = null;
+
+        InputStream input = in;
+        in = null;
+
+        if (mybuf != null)
+            bufferSupplier.release(intermediateBufRef);
+        if (input != null)
+            input.close();
+    }
+
+    /**
+     * Reads bytes from this byte-input stream into the specified byte array,
+     * starting at the given offset.
+     *
+     * <p> This method implements the general contract of the corresponding
+     * <code>{@link InputStream#read(byte[], int, int) read}</code> method of
+     * the <code>{@link InputStream}</code> class.  As an additional
+     * convenience, it attempts to read as many bytes as possible by repeatedly
+     * invoking the <code>read</code> method of the underlying stream.  This
+     * iterated <code>read</code> continues until one of the following
+     * conditions becomes true: <ul>
+     *
+     * <li> The specified number of bytes have been read,
+     *
+     * <li> The <code>read</code> method of the underlying stream returns
+     * <code>-1</code>, indicating end-of-file, or
+     *
+     * <li> The <code>available</code> method of the underlying stream
+     * returns zero, indicating that further input requests would block.
+     *
+     * </ul> If the first <code>read</code> on the underlying stream returns
+     * <code>-1</code> to indicate end-of-file then this method returns
+     * <code>-1</code>.  Otherwise this method returns the number of bytes
+     * actually read.
+     *
+     * <p> Subclasses of this class are encouraged, but not required, to
+     * attempt to read as many bytes as possible in the same fashion.
+     *
+     * @param b   destination buffer.
+     * @param off offset at which to start storing bytes.
+     * @param len maximum number of bytes to read.
+     * @return the number of bytes read, or <code>-1</code> if the end of
+     * the stream has been reached.
+     * @throws IOException if this input stream has been closed by
+     *                     invoking its {@link #close()} method,
+     *                     or an I/O error occurs.
+     * @see BufferedInputStream#read(byte[], int, int)
+     */
+    public int read(byte[] b, int off, int len) throws IOException {
+        getBufIfOpen(); // Check for closed stream
+        if ((off | len | (off + len) | (b.length - (off + len))) < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int n = 0;
+        for (; ; ) {
+            int nread = read1(b, off + n, len - n);
+            if (nread <= 0)
+                return (n == 0) ? nread : n;
+            n += nread;
+            if (n >= len)
+                return n;
+            // if not closed but no bytes available, return
+            InputStream input = in;
+            if (input != null && input.available() <= 0)
+                return n;
+        }
+    }
+
+    /**
+     * Read characters into a portion of an array, reading from the underlying
+     * stream at most once if necessary.
+     * <p>
+     * Note - Implementation copied from {@link BufferedInputStream}. Slight modification done to remove
+     * the mark position.
+     */
+    private int read1(byte[] b, int off, int len) throws IOException {
+        int avail = count - pos;
+        if (avail <= 0) {
+            /* If the requested length is at least as large as the buffer, and
+               if there is no mark/reset activity, do not bother to copy the
+               bytes into the local buffer.  In this way buffered streams will
+               cascade harmlessly. */
+            if (len >= getBufIfOpen().length) {
+                return getInIfOpen().read(b, off, len);
+            }
+            fill();
+            avail = count - pos;
+            if (avail <= 0) return -1;
+        }
+        int cnt = (avail < len) ? avail : len;
+        System.arraycopy(getBufIfOpen(), pos, b, off, cnt);
+        pos += cnt;
+        return cnt;
+    }
+
+    /**
+     * Skips over and discards exactly {@code n} bytes of data from this input stream.
+     * If {@code n} is zero, then no bytes are skipped.
+     * If {@code n} is negative, then no bytes are skipped.
+     * <p>
+     * This method blocks until the requested number of bytes has been skipped, end of file is reached, or an
+     * exception is thrown.
+     * <p> If end of stream is reached before the stream is at the desired position, then the bytes skipped till than pointed
+     * are returned.
+     * <p> If an I/O error occurs, then the input stream may be in an inconsistent state. It is strongly recommended that the
+     * stream be promptly closed if an I/O error occurs.
+     * <p>
+     * This method first skips and discards bytes in the intermediate buffer.
+     * After that, depending on the value of pushSkipToSourceStream, it either pushes down skippping of bytes to the
+     * sourceStream or it reads the data from input stream in chunks, copies the data into intermediate buffer
+     * and skips it.
+     * <p>
+     * Starting JDK 12, a new method was introduced in InputStream, skipNBytes which has a similar behaviour as
+     * this method.
+     *
+     * @param toSkip the number of bytes to be skipped.
+     * @return the actual number of bytes skipped which might be zero.
+     * @throws IOException if this input stream has been closed by invoking its {@link #close()} method,
+     *                     {@code in.skip(n)} throws an IOException, or an I/O error occurs.
+     */
+    @Override
+    public long skip(long toSkip) throws IOException {
+        getBufIfOpen(); // Check for closed stream
+        if (toSkip <= 0) {
+            return 0;
+        }
+
+        long remaining = toSkip;
+
+        // Skip bytes stored in intermediate buffer first
+        int avail = count - pos;
+        long bytesSkipped = (avail < remaining) ? avail : remaining;
+        pos += bytesSkipped;
+        remaining -= bytesSkipped;
+
+        while (remaining > 0) {
+            if (pushSkipToSourceStream) {
+                // Use sourceStream's skip() to skip the rest.
+                // conversion to int is acceptable because toSkip and remaining are int.
+                bytesSkipped = getInIfOpen().skip(remaining);
+                if (bytesSkipped == 0) {
+                    // read one byte to check for EOS
+                    if (read() == -1) {
+                        break;
+                    }
+                    // one byte read so decrement number to skip
+                    remaining--;
+                } else if (bytesSkipped > remaining || bytesSkipped < 0) { // skipped negative or too many bytes
+                    throw new IOException("Unable to skip exactly");
+                }
+            } else {
+                // skip from intermediate buffer, filling it first (if required)
+                if (pos >= count) {
+                    fill();
+                    // if we don't have data in intermediate buffer after fill, then stop skipping
+                    if (pos >= count)
+                        break;
+                }
+                avail = count - pos;
+                bytesSkipped = (avail < remaining) ? avail : remaining;
+                pos += bytesSkipped;
+            }
+            remaining -= bytesSkipped;
+        }
+        return toSkip - remaining;
+    }
+
+    // visible for testing
+    public InputStream sourceStream() {
+        return in;
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read (or
+     * skipped over) from this input stream without blocking by the next
+     * invocation of a method for this input stream. The next invocation might be
+     * the same thread or another thread.  A single read or skip of this
+     * many bytes will not block, but may read or skip fewer bytes.
+     * <p>
+     * This method returns the sum of the number of bytes remaining to be read in
+     * the buffer (<code>count&nbsp;- pos</code>) and the result of calling the
+     * {@link java.io.FilterInputStream#in in}.available().
+     *
+     * @return an estimate of the number of bytes that can be read (or skipped
+     * over) from this input stream without blocking.
+     * @throws IOException if this input stream has been closed by
+     *                     invoking its {@link #close()} method,
+     *                     or an I/O error occurs.
+     * @see BufferedInputStream#available()
+     */
+    @Override
+    public synchronized int available() throws IOException {
+        int n = count - pos;
+        int avail = getInIfOpen().available();
+        return n > (Integer.MAX_VALUE - avail)
+            ? Integer.MAX_VALUE
+            : n + avail;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.compress.KafkaLZ4BlockInputStream;
 import org.apache.kafka.common.compress.KafkaLZ4BlockOutputStream;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.apache.kafka.common.utils.ChunkedBytesStream;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -38,9 +39,8 @@ public class CompressionTypeTest {
 
         buffer.rewind();
 
-        KafkaLZ4BlockInputStream in = (KafkaLZ4BlockInputStream) CompressionType.LZ4.wrapForInput(
-                buffer, RecordBatch.MAGIC_VALUE_V0, BufferSupplier.NO_CACHING);
-        assertTrue(in.ignoreFlagDescriptorChecksum());
+        ChunkedBytesStream in = (ChunkedBytesStream) CompressionType.LZ4.wrapForInput(buffer, RecordBatch.MAGIC_VALUE_V0, BufferSupplier.NO_CACHING);
+        assertTrue(((KafkaLZ4BlockInputStream) in.sourceStream()).ignoreFlagDescriptorChecksum());
     }
 
     @Test
@@ -52,8 +52,7 @@ public class CompressionTypeTest {
 
         buffer.rewind();
 
-        KafkaLZ4BlockInputStream in = (KafkaLZ4BlockInputStream) CompressionType.LZ4.wrapForInput(
-                buffer, RecordBatch.MAGIC_VALUE_V1, BufferSupplier.create());
-        assertFalse(in.ignoreFlagDescriptorChecksum());
+        ChunkedBytesStream in = (ChunkedBytesStream) CompressionType.LZ4.wrapForInput(buffer, RecordBatch.MAGIC_VALUE_V1, BufferSupplier.create());
+        assertFalse(((KafkaLZ4BlockInputStream) in.sourceStream()).ignoreFlagDescriptorChecksum());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
@@ -17,26 +17,61 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.compress.ZstdFactory;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.ChunkedBytesStream;
 import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
 
 import static org.apache.kafka.common.record.DefaultRecordBatch.RECORDS_COUNT_OFFSET;
+import static org.apache.kafka.common.record.DefaultRecordBatch.RECORDS_OFFSET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DefaultRecordBatchTest {
+    private static final Random RANDOM;
+
+    static {
+        try {
+            RANDOM = SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @Test
     public void testWriteEmptyHeader() {
@@ -354,10 +389,11 @@ public class DefaultRecordBatchTest {
         assertEquals(marker, EndTransactionMarker.deserialize(commitRecord));
     }
 
-    @Test
-    public void testStreamingIteratorConsistency() {
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class)
+    public void testStreamingIteratorConsistency(CompressionType compressionType) {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
-                CompressionType.GZIP, TimestampType.CREATE_TIME,
+                compressionType, TimestampType.CREATE_TIME,
                 new SimpleRecord(1L, "a".getBytes(), "1".getBytes()),
                 new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
@@ -367,30 +403,162 @@ public class DefaultRecordBatchTest {
         }
     }
 
-    @Test
-    public void testSkipKeyValueIteratorCorrectness() {
-        Header[] headers = {new RecordHeader("k1", "v1".getBytes()), new RecordHeader("k2", "v2".getBytes())};
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class)
+    public void testSkipKeyValueIteratorCorrectness(CompressionType compressionType) throws NoSuchAlgorithmException {
+        Header[] headers = {new RecordHeader("k1", "v1".getBytes()), new RecordHeader("k2", null)};
+        byte[] largeRecordValue = new byte[200 * 1024]; // 200KB
+        RANDOM.nextBytes(largeRecordValue);
 
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
-            CompressionType.LZ4, TimestampType.CREATE_TIME,
+            compressionType, TimestampType.CREATE_TIME,
+            // one sample with small value size
             new SimpleRecord(1L, "a".getBytes(), "1".getBytes()),
-            new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
-            new SimpleRecord(3L, "c".getBytes(), "3".getBytes()),
-            new SimpleRecord(1000L, "abc".getBytes(), "0".getBytes()),
+            // one sample with null value
+            new SimpleRecord(2L, "b".getBytes(), null),
+            // one sample with null key
+            new SimpleRecord(3L, null, "3".getBytes()),
+            // one sample with null key and null value
+            new SimpleRecord(4L, null, (byte[]) null),
+            // one sample with large value size
+            new SimpleRecord(1000L, "abc".getBytes(), largeRecordValue),
+            // one sample with headers, one of the header has null value
             new SimpleRecord(9999L, "abc".getBytes(), "0".getBytes(), headers)
             );
+
         DefaultRecordBatch batch = new DefaultRecordBatch(records.buffer());
-        try (CloseableIterator<Record> streamingIterator = batch.skipKeyValueIterator(BufferSupplier.NO_CACHING)) {
-            assertEquals(Arrays.asList(
-                new PartialDefaultRecord(9, (byte) 0, 0L, 1L, -1, 1, 1),
-                new PartialDefaultRecord(9, (byte) 0, 1L, 2L, -1, 1, 1),
-                new PartialDefaultRecord(9, (byte) 0, 2L, 3L, -1, 1, 1),
-                new PartialDefaultRecord(12, (byte) 0, 3L, 1000L, -1, 3, 1),
-                new PartialDefaultRecord(25, (byte) 0, 4L, 9999L, -1, 3, 1)
-                ),
-                Utils.toList(streamingIterator)
-            );
+
+        try (BufferSupplier bufferSupplier = BufferSupplier.create();
+             CloseableIterator<Record> skipKeyValueIterator = batch.skipKeyValueIterator(bufferSupplier)) {
+
+            if (CompressionType.NONE == compressionType) {
+                // assert that for uncompressed data stream record iterator is not used
+                assertTrue(skipKeyValueIterator instanceof DefaultRecordBatch.RecordIterator);
+                // superficial validation for correctness. Deep validation is already performed in other tests
+                assertEquals(Utils.toList(records.records()).size(), Utils.toList(skipKeyValueIterator).size());
+            } else {
+                // assert that a streaming iterator is used for compressed records
+                assertTrue(skipKeyValueIterator instanceof DefaultRecordBatch.StreamRecordIterator);
+                // assert correctness for compressed records
+                assertIterableEquals(Arrays.asList(
+                        new PartialDefaultRecord(9, (byte) 0, 0L, 1L, -1, 1, 1),
+                        new PartialDefaultRecord(8, (byte) 0, 1L, 2L, -1, 1, -1),
+                        new PartialDefaultRecord(8, (byte) 0, 2L, 3L, -1, -1, 1),
+                        new PartialDefaultRecord(7, (byte) 0, 3L, 4L, -1, -1, -1),
+                        new PartialDefaultRecord(15 + largeRecordValue.length, (byte) 0, 4L, 1000L, -1, 3, largeRecordValue.length),
+                        new PartialDefaultRecord(23, (byte) 0, 5L, 9999L, -1, 3, 1)
+                    ), Utils.toList(skipKeyValueIterator));
+            }
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testBufferReuseInSkipKeyValueIterator(CompressionType compressionType, int expectedNumBufferAllocations, byte[] recordValue) {
+        MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
+            compressionType, TimestampType.CREATE_TIME,
+            new SimpleRecord(1000L, "a".getBytes(), "0".getBytes()),
+            new SimpleRecord(9999L, "b".getBytes(), recordValue)
+        );
+
+        DefaultRecordBatch batch = new DefaultRecordBatch(records.buffer());
+
+        try (BufferSupplier bufferSupplier = spy(BufferSupplier.create());
+             CloseableIterator<Record> streamingIterator = batch.skipKeyValueIterator(bufferSupplier)) {
+
+            // Consume through the iterator
+            Utils.toList(streamingIterator);
+
+            // Close the iterator to release any buffers
+            streamingIterator.close();
+
+            // assert number of buffer allocations
+            verify(bufferSupplier, times(expectedNumBufferAllocations)).get(anyInt());
+            verify(bufferSupplier, times(expectedNumBufferAllocations)).release(any(ByteBuffer.class));
+        }
+    }
+    private static Stream<Arguments> testBufferReuseInSkipKeyValueIterator() throws NoSuchAlgorithmException {
+        byte[] smallRecordValue = "1".getBytes();
+        byte[] largeRecordValue = new byte[512 * 1024]; // 512KB
+        RANDOM.nextBytes(largeRecordValue);
+
+        return Stream.of(
+            /*
+             * 1 allocation per batch (i.e. per iterator instance) for buffer holding uncompressed data
+             * = 1 buffer allocations
+             */
+            Arguments.of(CompressionType.GZIP, 1, smallRecordValue),
+            Arguments.of(CompressionType.GZIP, 1, largeRecordValue),
+            Arguments.of(CompressionType.SNAPPY, 1, smallRecordValue),
+            Arguments.of(CompressionType.SNAPPY, 1, largeRecordValue),
+            /*
+             * 1 allocation per batch (i.e. per iterator instance) for buffer holding compressed data
+             * 1 allocation per batch (i.e. per iterator instance) for buffer holding uncompressed data
+             * = 2 buffer allocations
+             */
+            Arguments.of(CompressionType.LZ4, 2, smallRecordValue),
+            Arguments.of(CompressionType.LZ4, 2, largeRecordValue),
+            Arguments.of(CompressionType.ZSTD, 2, smallRecordValue),
+            Arguments.of(CompressionType.ZSTD, 2, largeRecordValue)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testZstdJniForSkipKeyValueIterator(int expectedJniCalls, byte[] recordValue) throws IOException {
+        MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
+            CompressionType.ZSTD, TimestampType.CREATE_TIME,
+            new SimpleRecord(9L, "hakuna-matata".getBytes(), recordValue)
+        );
+
+        // Buffer containing compressed data
+        final ByteBuffer compressedBuf = records.buffer();
+        // Create a RecordBatch object
+        final DefaultRecordBatch batch = spy(new DefaultRecordBatch(compressedBuf.duplicate()));
+        final CompressionType mockCompression = mock(CompressionType.ZSTD.getClass());
+        doReturn(mockCompression).when(batch).compressionType();
+
+        // Buffer containing compressed records to be used for creating zstd-jni stream
+        ByteBuffer recordsBuffer = compressedBuf.duplicate();
+        recordsBuffer.position(RECORDS_OFFSET);
+
+        try (final BufferSupplier bufferSupplier = BufferSupplier.create();
+             final InputStream zstdStream = spy(ZstdFactory.wrapForInput(recordsBuffer, batch.magic(), bufferSupplier));
+             final InputStream chunkedStream = new ChunkedBytesStream(zstdStream, bufferSupplier, 16 * 1024, false)) {
+
+            when(mockCompression.wrapForInput(any(ByteBuffer.class), anyByte(), any(BufferSupplier.class))).thenReturn(chunkedStream);
+
+            try (CloseableIterator<Record> streamingIterator = batch.skipKeyValueIterator(bufferSupplier)) {
+                assertNotNull(streamingIterator);
+                Utils.toList(streamingIterator);
+                // verify the number of read() calls to zstd JNI stream. Each read() call is a JNI call.
+                verify(zstdStream, times(expectedJniCalls)).read(any(byte[].class), anyInt(), anyInt());
+                // verify that we don't use the underlying skip() functionality. The underlying skip() allocates
+                // 1 buffer per skip call from he buffer pool whereas our implementation
+                verify(zstdStream, never()).skip(anyLong());
+            }
+        }
+    }
+
+    private static Stream<Arguments> testZstdJniForSkipKeyValueIterator() throws NoSuchAlgorithmException {
+        byte[] smallRecordValue = "1".getBytes();
+        byte[] largeRecordValue = new byte[40 * 1024]; // 40KB
+        RANDOM.nextBytes(largeRecordValue);
+
+        return Stream.of(
+            /*
+             * We expect exactly 2 read call to the JNI:
+             * 1 for fetching the full data (size < 16KB)
+             * 1 for detecting end of stream by trying to read more data
+             */
+            Arguments.of(2, smallRecordValue),
+            /*
+             * We expect exactly 4 read call to the JNI:
+             * 3 for fetching the full data (Math.ceil(40/16))
+             * 1 for detecting end of stream by trying to read more data
+             */
+            Arguments.of(4, largeRecordValue)
+        );
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
@@ -534,7 +534,8 @@ public class DefaultRecordBatchTest {
                 // verify the number of read() calls to zstd JNI stream. Each read() call is a JNI call.
                 verify(zstdStream, times(expectedJniCalls)).read(any(byte[].class), anyInt(), anyInt());
                 // verify that we don't use the underlying skip() functionality. The underlying skip() allocates
-                // 1 buffer per skip call from he buffer pool whereas our implementation
+                // 1 buffer per skip call from he buffer pool whereas our implementation does not perform any allocation
+                // during skip.
                 verify(zstdStream, never()).skip(anyLong());
             }
         }

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
@@ -22,12 +22,11 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.ByteUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -36,14 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DefaultRecordTest {
-
-    private byte[] skipArray;
-
-    @BeforeEach
-    public void setUp() {
-        skipArray = new byte[64];
-    }
-
     @Test
     public void testBasicSerde() throws IOException {
         Header[] headers = new Header[] {
@@ -108,6 +99,12 @@ public class DefaultRecordTest {
         ByteBuffer buffer = out.buffer();
         buffer.flip();
         buffer.put(14, (byte) 8);
+        // test for input stream input
+        try (ByteBufferInputStream inpStream = new ByteBufferInputStream(buffer.asReadOnlyBuffer())) {
+            assertThrows(InvalidRecordException.class,
+                () -> DefaultRecord.readFrom(inpStream, baseOffset, baseTimestamp, baseSequence, null));
+        }
+        // test for buffer input
         assertThrows(InvalidRecordException.class,
             () -> DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, null));
     }
@@ -140,7 +137,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidKeySize() {
+    public void testInvalidKeySize() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -156,12 +153,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidKeySizePartial() {
+    public void testInvalidKeySizePartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -177,13 +173,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidValueSize() {
+    public void testInvalidValueSize() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -200,12 +194,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidValueSizePartial() {
+    public void testInvalidValueSizePartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -222,13 +215,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidNumHeaders() {
+    public void testInvalidNumHeaders() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -245,8 +236,7 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
 
         ByteBuffer buf2 = ByteBuffer.allocate(sizeOfBodyInBytes + ByteUtils.sizeOfVarint(sizeOfBodyInBytes));
         ByteUtils.writeVarint(sizeOfBodyInBytes, buf2);
@@ -259,12 +249,11 @@ public class DefaultRecordTest {
         buf2.position(buf2.limit());
 
         buf2.flip();
-        assertThrows(InvalidRecordException.class,
-                () -> DefaultRecord.readFrom(buf2, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf2);
     }
 
     @Test
-    public void testInvalidNumHeadersPartial() {
+    public void testInvalidNumHeadersPartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -281,13 +270,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidHeaderKey() {
+    public void testInvalidHeaderKey() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -305,12 +292,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () ->  DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidHeaderKeyPartial() {
+    public void testInvalidHeaderKeyPartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -328,13 +315,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testNullHeaderKey() {
+    public void testNullHeaderKey() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -352,12 +337,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testNullHeaderKeyPartial() {
+    public void testNullHeaderKeyPartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -375,13 +360,35 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidHeaderValue() {
+    public void testInvalidHeaderValue() throws IOException {
+        byte attributes = 0;
+        long timestampDelta = 2;
+        int offsetDelta = 1;
+        int sizeOfBodyInBytes = 100;
+
+        ByteBuffer buf = ByteBuffer.allocate(sizeOfBodyInBytes + ByteUtils.sizeOfVarint(sizeOfBodyInBytes));
+        ByteUtils.writeVarint(sizeOfBodyInBytes, buf);
+        buf.put(attributes);
+        ByteUtils.writeVarlong(timestampDelta, buf);
+        ByteUtils.writeVarint(offsetDelta, buf);
+        ByteUtils.writeVarint(-1, buf); // null key
+        ByteUtils.writeVarint(-1, buf); // null value
+        ByteUtils.writeVarint(1, buf);
+        ByteUtils.writeVarint(1, buf);
+        buf.put((byte) 1);
+        ByteUtils.writeVarint(105, buf); // header value too long
+        buf.position(buf.limit());
+        buf.flip();
+
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
+    }
+
+    @Test
+    public void testInvalidHeaderValuePartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -401,51 +408,22 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidHeaderValuePartial() {
-        byte attributes = 0;
-        long timestampDelta = 2;
-        int offsetDelta = 1;
-        int sizeOfBodyInBytes = 100;
-
-        ByteBuffer buf = ByteBuffer.allocate(sizeOfBodyInBytes + ByteUtils.sizeOfVarint(sizeOfBodyInBytes));
-        ByteUtils.writeVarint(sizeOfBodyInBytes, buf);
-        buf.put(attributes);
-        ByteUtils.writeVarlong(timestampDelta, buf);
-        ByteUtils.writeVarint(offsetDelta, buf);
-        ByteUtils.writeVarint(-1, buf); // null key
-        ByteUtils.writeVarint(-1, buf); // null value
-        ByteUtils.writeVarint(1, buf);
-        ByteUtils.writeVarint(1, buf);
-        buf.put((byte) 1);
-        ByteUtils.writeVarint(105, buf); // header value too long
-        buf.position(buf.limit());
-
-        buf.flip();
-        DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
-    }
-
-    @Test
-    public void testUnderflowReadingTimestamp() {
+    public void testUnderflowReadingTimestamp() throws IOException {
         byte attributes = 0;
         int sizeOfBodyInBytes = 1;
         ByteBuffer buf = ByteBuffer.allocate(sizeOfBodyInBytes + ByteUtils.sizeOfVarint(sizeOfBodyInBytes));
         ByteUtils.writeVarint(sizeOfBodyInBytes, buf);
         buf.put(attributes);
-
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testUnderflowReadingVarlong() {
+    public void testUnderflowReadingVarlong() throws IOException {
         byte attributes = 0;
         int sizeOfBodyInBytes = 2; // one byte for attributes, one byte for partial timestamp
         ByteBuffer buf = ByteBuffer.allocate(sizeOfBodyInBytes + ByteUtils.sizeOfVarint(sizeOfBodyInBytes) + 1);
@@ -453,14 +431,12 @@ public class DefaultRecordTest {
         buf.put(attributes);
         ByteUtils.writeVarlong(156, buf); // needs 2 bytes to represent
         buf.position(buf.limit() - 1);
-
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
-    public void testInvalidVarlong() {
+    public void testInvalidVarlong() throws IOException {
         byte attributes = 0;
         int sizeOfBodyInBytes = 11; // one byte for attributes, 10 bytes for max timestamp
         ByteBuffer buf = ByteBuffer.allocate(sizeOfBodyInBytes + ByteUtils.sizeOfVarint(sizeOfBodyInBytes) + 1);
@@ -472,8 +448,8 @@ public class DefaultRecordTest {
         buf.put(recordStartPosition + 10, Byte.MIN_VALUE); // use an invalid final byte
 
         buf.flip();
-        assertThrows(InvalidRecordException.class,
-            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
     }
 
     @Test
@@ -490,18 +466,44 @@ public class DefaultRecordTest {
         ByteBuffer buffer = out.buffer();
         buffer.flip();
 
+        // test for input stream input
+        try (ByteBufferInputStream inpStream = new ByteBufferInputStream(buffer.asReadOnlyBuffer())) {
+            DefaultRecord record = DefaultRecord.readFrom(inpStream, baseOffset, baseTimestamp, RecordBatch.NO_SEQUENCE, null);
+            assertNotNull(record);
+            assertEquals(RecordBatch.NO_SEQUENCE, record.sequence());
+        }
+
+        // test for buffer input
         DefaultRecord record = DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, RecordBatch.NO_SEQUENCE, null);
         assertNotNull(record);
         assertEquals(RecordBatch.NO_SEQUENCE, record.sequence());
     }
 
     @Test
-    public void testInvalidSizeOfBodyInBytes() {
+    public void testInvalidSizeOfBodyInBytes() throws IOException {
         int sizeOfBodyInBytes = 10;
         ByteBuffer buf = ByteBuffer.allocate(5);
         ByteUtils.writeVarint(sizeOfBodyInBytes, buf);
-
         buf.flip();
+
+        // test for input stream input
+        assertDecodingRecordFromBufferThrowsInvalidRecordException(buf);
+    }
+
+    private static void assertPartiallyDecodingRecordsFromBufferThrowsInvalidRecordException(ByteBuffer buf) throws IOException {
+        try (InputStream inputStream = new ByteBufferInputStream(buf)) {
+            assertThrows(InvalidRecordException.class,
+                () -> DefaultRecord.readPartiallyFrom(inputStream, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        }
+    }
+
+    private static void assertDecodingRecordFromBufferThrowsInvalidRecordException(ByteBuffer buf) throws IOException {
+        // test for input stream input
+        try (ByteBufferInputStream inpStream = new ByteBufferInputStream(buf.asReadOnlyBuffer())) {
+            assertThrows(InvalidRecordException.class,
+                () -> DefaultRecord.readFrom(inpStream, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
+        }
+        // test for buffer input
         assertThrows(InvalidRecordException.class,
             () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -428,7 +429,7 @@ public class ByteUtilsTest {
         ByteUtils.writeUnsignedVarint(value, out);
         buf.flip();
         assertArrayEquals(expectedEncoding, Utils.toArray(buf));
-        DataInputStream in = new DataInputStream(new ByteBufferInputStream(buf));
+        InputStream in = new ByteBufferInputStream(buf);
         assertEquals(value, ByteUtils.readUnsignedVarint(in));
     }
 
@@ -444,7 +445,7 @@ public class ByteUtilsTest {
         ByteUtils.writeVarint(value, out);
         buf.flip();
         assertArrayEquals(expectedEncoding, Utils.toArray(buf));
-        DataInputStream in = new DataInputStream(new ByteBufferInputStream(buf));
+        InputStream in = new ByteBufferInputStream(buf);
         assertEquals(value, ByteUtils.readVarint(in));
     }
 
@@ -460,7 +461,7 @@ public class ByteUtilsTest {
         ByteUtils.writeVarlong(value, out);
         buf.flip();
         assertArrayEquals(expectedEncoding, Utils.toArray(buf));
-        DataInputStream in = new DataInputStream(new ByteBufferInputStream(buf));
+        InputStream in = new ByteBufferInputStream(buf);
         assertEquals(value, ByteUtils.readVarlong(in));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ChunkedBytesStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ChunkedBytesStreamTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.spy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
+
+public class ChunkedBytesStreamTest {
+    private static final Random RANDOM = new Random(1337);
+    private final BufferSupplier supplier = BufferSupplier.NO_CACHING;
+
+    @Test
+    public void testEofErrorForMethodReadFully() throws IOException {
+        ByteBuffer input = ByteBuffer.allocate(8);
+        int lengthGreaterThanInput = input.capacity() + 1;
+        byte[] got = new byte[lengthGreaterThanInput];
+        try (InputStream is = new ChunkedBytesStream(new ByteBufferInputStream(input), supplier, 10, false)) {
+            assertEquals(8, is.read(got, 0, got.length), "Should return 8 signifying end of input");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSourceBytebuffersForTest")
+    public void testCorrectnessForMethodReadFully(ByteBuffer input) throws IOException {
+        byte[] got = new byte[input.array().length];
+        try (InputStream is = new ChunkedBytesStream(new ByteBufferInputStream(input), supplier, 10, false)) {
+            // perform a 2 pass read. this tests the scenarios where one pass may lead to partially consumed
+            // intermediate buffer
+            int toRead = RANDOM.nextInt(got.length);
+            is.read(got, 0, toRead);
+            is.read(got, toRead, got.length - toRead);
+        }
+        assertArrayEquals(input.array(), got);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSourceBytebuffersForTest")
+    public void testCorrectnessForMethodReadByte(ByteBuffer input) throws IOException {
+        byte[] got = new byte[input.array().length];
+        try (InputStream is = new ChunkedBytesStream(new ByteBufferInputStream(input), supplier, 10, false)) {
+            int i = 0;
+            while (i < got.length) {
+                got[i++] = (byte) is.read();
+            }
+        }
+        assertArrayEquals(input.array(), got);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSourceBytebuffersForTest")
+    public void testCorrectnessForMethodRead(ByteBuffer inputBuf) throws IOException {
+        int[] inputArr = new int[inputBuf.capacity()];
+        for (int i = 0; i < inputArr.length; i++) {
+            inputArr[i] = Byte.toUnsignedInt(inputBuf.get());
+        }
+        int[] got = new int[inputArr.length];
+        inputBuf.rewind();
+        try (InputStream is = new ChunkedBytesStream(new ByteBufferInputStream(inputBuf), supplier, 10, false)) {
+            int i = 0;
+            while (i < got.length) {
+                got[i++] = is.read();
+            }
+        }
+        assertArrayEquals(inputArr, got);
+    }
+
+    @Test
+    public void testEndOfFileForMethodRead() throws IOException {
+        ByteBuffer inputBuf = ByteBuffer.allocate(2);
+        int lengthGreaterThanInput = inputBuf.capacity() + 1;
+
+        try (InputStream is = new ChunkedBytesStream(new ByteBufferInputStream(inputBuf), supplier, 10, false)) {
+            int cnt = 0;
+            while (cnt++ < lengthGreaterThanInput) {
+                int res = is.read();
+                if (cnt > inputBuf.capacity())
+                    assertEquals(-1, res, "end of file for read should be -1");
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEndOfSourceForMethodSkip(boolean pushSkipToSourceStream) throws IOException {
+        ByteBuffer inputBuf = ByteBuffer.allocate(16);
+        RANDOM.nextBytes(inputBuf.array());
+        inputBuf.rewind();
+
+        final InputStream sourcestream = spy(new ByteBufferInputStream(inputBuf));
+        try (InputStream is = new ChunkedBytesStream(sourcestream, supplier, 10, pushSkipToSourceStream)) {
+            long res = is.skip(inputBuf.capacity() + 1);
+            assertEquals(inputBuf.capacity(), res);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource({"provideSourceSkipValuesForTest"})
+    public void testCorrectnessForMethodSkip(int bytesToPreRead, ByteBuffer inputBuf, int numBytesToSkip, boolean pushSkipToSourceStream) throws IOException {
+        int expectedInpLeftAfterSkip = inputBuf.remaining() - bytesToPreRead - numBytesToSkip;
+        int expectedSkippedBytes = Math.min(inputBuf.remaining() - bytesToPreRead, numBytesToSkip);
+
+        try (InputStream is = new ChunkedBytesStream(new ByteBufferInputStream(inputBuf.duplicate()), supplier, 10, pushSkipToSourceStream)) {
+            int cnt = 0;
+            while (cnt++ < bytesToPreRead) {
+                int r = is.read();
+                assertNotEquals(-1, r, "Unexpected end of data.");
+            }
+
+            long res = is.skip(numBytesToSkip);
+            assertEquals(expectedSkippedBytes, res);
+
+            // verify that we are able to read rest of the input
+            cnt = 0;
+            while (cnt++ < expectedInpLeftAfterSkip) {
+                int readRes = is.read();
+                assertNotEquals(-1, readRes, "Unexpected end of data.");
+            }
+        }
+    }
+
+    private static List<Arguments> provideSourceSkipValuesForTest() {
+        ByteBuffer bufGreaterThanIntermediateBuf = ByteBuffer.allocate(16);
+        RANDOM.nextBytes(bufGreaterThanIntermediateBuf.array());
+        bufGreaterThanIntermediateBuf.position(bufGreaterThanIntermediateBuf.capacity());
+        bufGreaterThanIntermediateBuf.flip();
+
+        ByteBuffer bufMuchGreaterThanIntermediateBuf = ByteBuffer.allocate(100);
+        RANDOM.nextBytes(bufMuchGreaterThanIntermediateBuf.array());
+        bufMuchGreaterThanIntermediateBuf.position(bufMuchGreaterThanIntermediateBuf.capacity());
+        bufMuchGreaterThanIntermediateBuf.flip();
+
+        ByteBuffer emptyBuffer = ByteBuffer.allocate(2);
+
+        ByteBuffer oneByteBuf = ByteBuffer.allocate(1).put((byte) 1);
+        oneByteBuf.flip();
+
+        List<List<Object>> testInputs = Arrays.asList(
+            // empty source byte array
+            Arrays.asList(0, emptyBuffer, 0),
+            Arrays.asList(0, emptyBuffer, 1),
+            Arrays.asList(1, emptyBuffer, 1),
+            Arrays.asList(1, emptyBuffer, 0),
+            // byte source array with 1 byte
+            Arrays.asList(0, oneByteBuf, 0),
+            Arrays.asList(0, oneByteBuf, 1),
+            Arrays.asList(1, oneByteBuf, 0),
+            Arrays.asList(1, oneByteBuf, 1),
+            // byte source array with full read from intermediate buf
+            Arrays.asList(0, bufGreaterThanIntermediateBuf.duplicate(), bufGreaterThanIntermediateBuf.capacity()),
+            Arrays.asList(bufGreaterThanIntermediateBuf.capacity(), bufGreaterThanIntermediateBuf.duplicate(), 0),
+            Arrays.asList(2, bufGreaterThanIntermediateBuf.duplicate(), 10),
+            Arrays.asList(2, bufGreaterThanIntermediateBuf.duplicate(), 8)
+        );
+
+        Boolean[] tailArgs = new Boolean[]{true, false};
+        List<Arguments> finalArguments = new ArrayList<>(2 * testInputs.size());
+        for (List<Object> args : testInputs) {
+            for (Boolean aBoolean : tailArgs) {
+                List<Object> expandedArgs = new ArrayList<>(args);
+                expandedArgs.add(aBoolean);
+                finalArguments.add(Arguments.of(expandedArgs.toArray()));
+            }
+        }
+        return finalArguments;
+    }
+
+    private static Stream<Arguments> provideSourceBytebuffersForTest() {
+        ByteBuffer bufGreaterThanIntermediateBuf = ByteBuffer.allocate(16);
+        RANDOM.nextBytes(bufGreaterThanIntermediateBuf.array());
+        bufGreaterThanIntermediateBuf.position(bufGreaterThanIntermediateBuf.capacity());
+
+        ByteBuffer bufMuchGreaterThanIntermediateBuf = ByteBuffer.allocate(100);
+        RANDOM.nextBytes(bufMuchGreaterThanIntermediateBuf.array());
+        bufMuchGreaterThanIntermediateBuf.position(bufMuchGreaterThanIntermediateBuf.capacity());
+
+        return Stream.of(
+            // empty byte array
+            Arguments.of(ByteBuffer.allocate(2)),
+            // byte array with 1 byte
+            Arguments.of(ByteBuffer.allocate(1).put((byte) 1).flip()),
+            // byte array with size < intermediate buffer
+            Arguments.of(ByteBuffer.allocate(8).put("12345678".getBytes()).flip()),
+            // byte array with size > intermediate buffer
+            Arguments.of(bufGreaterThanIntermediateBuf.flip()),
+            // byte array with size >> intermediate buffer
+            Arguments.of(bufMuchGreaterThanIntermediateBuf.flip())
+        );
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/BaseRecordBatchBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/BaseRecordBatchBenchmark.java
@@ -32,6 +32,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -101,6 +102,12 @@ public abstract class BaseRecordBatchBenchmark {
             int size = random.nextInt(maxBatchSize) + 1;
             batchBuffers[i] = createBatch(size);
         }
+    }
+
+    @TearDown
+    public void cleanUp() {
+        if (requestLocal != null)
+            requestLocal.close();
     }
 
     private static Header[] createHeaders() {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
@@ -247,14 +247,14 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
     }
 
     private <U> U readRecord(
-        InputStream bytesStream,
+        InputStream stream,
         int totalBatchSize,
         BiFunction<Optional<ByteBuffer>, Optional<ByteBuffer>, U> decoder
     ) {
         // Read size of body in bytes
         int size;
         try {
-            size = ByteUtils.readVarint(bytesStream);
+            size = ByteUtils.readVarint(stream);
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to read record size", e);
         }
@@ -272,7 +272,7 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
         buf.limit(size - 1);
 
         try {
-            int bytesRead = bytesStream.read(buf.array(), 0, size);
+            int bytesRead = stream.read(buf.array(), 0, size);
             if (bytesRead != size) {
                 throw new RuntimeException("Unable to read " + size + " bytes, only read " + bytesRead);
             }


### PR DESCRIPTION
This covers two JIRAs https://issues.apache.org/jira/browse/KAFKA-14632 and https://issues.apache.org/jira/browse/KAFKA-14633 

## Background 
![Screenshot 2023-01-19 at 18 27 45](https://user-images.githubusercontent.com/71267/213521204-bb3228ed-7d21-4e07-a520-697ea6fcc0ed.png)
Currently, we use 2 intermediate buffers while handling decompressed data (one of size 2KB and another of size 16KB). These buffers are (de)allocated once per batch. The decompressed data is first copied to a 16KB buffer and then again copied in chunks to a 2KB buffer.

The impact of this was observed in a flamegraph analysis for a compressed workload where we observed that 75% of CPU during `appendAsLeader()` is taken up by `ValidateMessagesAndAssignOffsets`.

![Screenshot 2023-01-20 at 10 41 08](https://user-images.githubusercontent.com/71267/213664252-389eaf3d-b8aa-465b-b010-db1024663d6f.png)


## Change
With this PR:
1. Introduced `ChunkedDataInputStream`. This is a customized implementation of `BufferedInputStream` and the javadoc for these classes mention why a custom stream was required.
2. We are removing the number of intermediate buffers from 2 to 1. This reduces 1 point of data copy.  This is achieved by getting rid of `BufferedInputStream` and replacing with `ChunkedDataInputStream`.
3. We are using thread local buffer pool for both the buffers involved in the process of decompression. 

After the change, the above buffer allocation looks as follows:
![Screenshot 2023-04-26 at 11 45 11](https://user-images.githubusercontent.com/71267/234538028-8055db23-098b-4963-9d66-8de357b21a1a.png)



## Results
After this change, 

1. For broker side decompression: JMH benchmark `RecordBatchIterationBenchmark` demonstrates 20-70% improvement in throughput (see results for `RecordBatchIterationBenchmark.measureSkipIteratorForVariableBatchSize`). 
2. For consumer side decompression: JMH benchmark `RecordBatchIterationBenchmark` a mix bag of single digit regression for some compression type to 10-50% improvement for Zstd (see results for `RecordBatchIterationBenchmark.measureStreamingIteratorForVariableBatchSize`). 

The reason that we don't see equivalent gains in consumer is because it copies all uncompressed data in a single buffer and then reads off it. We have not reduced any buffer allocation for consumer scenario(since we have only removed the "skiparray" used by skipIterator). There are potential opportunities to improve consumer side decompression but we will address that in a separate PR.

Details results from JMH benchmark for `RecordBatchIterationBenchmark` are available here: 
[benchmark-jira.xlsx](https://issues.apache.org/jira/secure/attachment/13057619/benchmark-jira%20%285%29.xlsx)

**Before & after object allocation captured in flamegraph**
Please observe how in the after flamegraph, the contribution of allocation by validateMessagesAndAssignOffsets and decreased drastically from 39% to 5%.
Before: (html available [here](https://issues.apache.org/jira/secure/attachment/13057480/flamegraph-trunk-heapalloc-before.html))
![Screenshot 2023-04-26 at 11 47 27](https://user-images.githubusercontent.com/71267/234538593-7fa52523-7272-424c-a714-853528302d8c.png)

After: (html available [here](https://issues.apache.org/jira/secure/attachment/13057479/flamegraph-pr-heapalloc-after.html))
![Screenshot 2023-04-26 at 11 47 46](https://user-images.githubusercontent.com/71267/234538652-d186d81e-25a6-4e18-8c60-8e0c55421ff2.png)
**Before & after CPU usage captured in flamegraph**
Please observe ~2% CPU reduction in the before and after flamegraph.

Before: (html available [here](https://issues.apache.org/jira/secure/attachment/13057621/decompression-opt-cpu-before.html))
![Screenshot 2023-04-26 at 21 47 43](https://user-images.githubusercontent.com/71267/234686389-b8667dcf-00e4-4225-b936-355b2d913cb4.png)
After: (html available [here](https://issues.apache.org/jira/secure/attachment/13057620/decompression-opt-cpu-after.html))
![Screenshot 2023-04-26 at 21 47 28](https://user-images.githubusercontent.com/71267/234686422-8f343d89-4dd0-4901-87cb-7e7cd180c142.png)


## Testing
- Sanity testing using the existing unit test to ensure that we don't impact correctness.
- Added unit tests for new classes and increased the test coverage of existing classes.
- JMH benchmarks for all compression types to ensure that we did not regress other compression types.

