### PR TITLE
MINOR: Small cleanups in refactored consumer implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -115,10 +115,12 @@ public class DefaultBackgroundThread extends KafkaThread {
             this.coordinatorManager = groupId == null ?
                     Optional.empty() :
                     Optional.of(new CoordinatorRequestManager(
-                            logContext,
-                            config,
-                            errorEventHandler,
-                            groupId));
+                        time,
+                        logContext,
+                        config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
+                        errorEventHandler,
+                        groupId
+                    ));
             this.applicationEventProcessor = new ApplicationEventProcessor(backgroundEventQueue);
         } catch (final Exception e) {
             close();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandler.java
@@ -28,7 +28,7 @@ public class ErrorEventHandler {
         this.backgroundEventQueue = backgroundEventQueue;
     }
 
-    public void handle(Exception e) {
+    public void handle(Throwable e) {
         backgroundEventQueue.add(new ErrorBackgroundEvent(e));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -98,7 +98,7 @@ public class NetworkClientDelegate implements AutoCloseable {
             if (unsent.timer.isExpired()) {
                 iterator.remove();
                 unsent.callback.onFailure(new TimeoutException(
-                    "Failed to send request after " + unsent.timer.timeoutMs() + " " + "ms."));
+                    "Failed to send request after " + unsent.timer.timeoutMs() + " ms."));
                 continue;
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A wrapper around the {@link org.apache.kafka.clients.NetworkClient} to handle network poll and send operations.
@@ -72,17 +73,16 @@ public class NetworkClientDelegate implements AutoCloseable {
      * @param currentTimeMs current time
      * @return a list of client response
      */
-    public List<ClientResponse> poll(final long timeoutMs, final long currentTimeMs) {
+    public void poll(final long timeoutMs, final long currentTimeMs) {
         trySend(currentTimeMs);
 
         long pollTimeoutMs = timeoutMs;
         if (!unsentRequests.isEmpty()) {
             pollTimeoutMs = Math.min(retryBackoffMs, pollTimeoutMs);
         }
-        List<ClientResponse> res = this.client.poll(pollTimeoutMs, currentTimeMs);
+
+        this.client.poll(pollTimeoutMs, currentTimeMs);
         checkDisconnects();
-        wakeup();
-        return res;
     }
 
     /**
@@ -97,8 +97,8 @@ public class NetworkClientDelegate implements AutoCloseable {
             unsent.timer.update(currentTimeMs);
             if (unsent.timer.isExpired()) {
                 iterator.remove();
-                unsent.callback.ifPresent(c -> c.onFailure(new TimeoutException(
-                        "Failed to send request after " + unsent.timer.timeoutMs() + " " + "ms.")));
+                unsent.callback.onFailure(new TimeoutException(
+                    "Failed to send request after " + unsent.timer.timeoutMs() + " " + "ms."));
                 continue;
             }
 
@@ -118,7 +118,7 @@ public class NetworkClientDelegate implements AutoCloseable {
             return false;
         }
         ClientRequest request = makeClientRequest(r, node, currentTimeMs);
-        if (!client.isReady(node, currentTimeMs)) {
+        if (!client.ready(node, currentTimeMs)) {
             // enqueue the request again if the node isn't ready yet. The request will be handled in the next iteration
             // of the event loop
             log.debug("Node is not ready, handle the request in the next event loop: node={}, request={}", node, r);
@@ -136,26 +136,31 @@ public class NetworkClientDelegate implements AutoCloseable {
             if (u.node.isPresent() && client.connectionFailed(u.node.get())) {
                 iter.remove();
                 AuthenticationException authenticationException = client.authenticationException(u.node.get());
-                u.callback.ifPresent(r -> r.onFailure(authenticationException));
+                u.callback.onFailure(authenticationException);
             }
         }
     }
 
-    private ClientRequest makeClientRequest(final UnsentRequest unsent, final Node node, final long currentTimeMs) {
+    private ClientRequest makeClientRequest(
+        final UnsentRequest unsent,
+        final Node node,
+        final long currentTimeMs
+    ) {
         return client.newClientRequest(
-                node.idString(),
-                unsent.abstractBuilder,
-                currentTimeMs,
-                true,
-                (int) unsent.timer.remainingMs(),
-                unsent.callback.orElse(new DefaultRequestFutureCompletionHandler()));
+            node.idString(),
+            unsent.requestBuilder,
+            currentTimeMs,
+            true,
+            (int) unsent.timer.remainingMs(),
+            unsent.callback
+        );
     }
 
     public Node leastLoadedNode() {
         return this.client.leastLoadedNode(time.milliseconds());
     }
 
-    public void add(final UnsentRequest r) {
+    public void send(final UnsentRequest r) {
         r.setTimer(this.time, this.requestTimeoutMs);
         unsentRequests.add(r);
     }
@@ -189,79 +194,67 @@ public class NetworkClientDelegate implements AutoCloseable {
             this.unsentRequests = Collections.unmodifiableList(unsentRequests);
         }
     }
-
     public static class UnsentRequest {
-        private final AbstractRequest.Builder abstractBuilder;
-        private final Optional<AbstractRequestFutureCompletionHandler> callback;
+        private final AbstractRequest.Builder<?> requestBuilder;
+        private final FutureCompletionHandler callback;
         private Optional<Node> node; // empty if random node can be choosen
         private Timer timer;
 
-        public UnsentRequest(final AbstractRequest.Builder abstractBuilder,
-                             final AbstractRequestFutureCompletionHandler callback) {
-            this(abstractBuilder, callback, null);
-        }
-
-        public UnsentRequest(final AbstractRequest.Builder abstractBuilder,
-                             final AbstractRequestFutureCompletionHandler callback,
-                             final Node node) {
-            Objects.requireNonNull(abstractBuilder);
-            this.abstractBuilder = abstractBuilder;
-            this.node = Optional.ofNullable(node);
-            this.callback = Optional.ofNullable(callback);
+        public UnsentRequest(
+            final AbstractRequest.Builder<?> requestBuilder,
+            final Optional<Node> node
+        ) {
+            Objects.requireNonNull(requestBuilder);
+            this.requestBuilder = requestBuilder;
+            this.node = node;
+            this.callback = new FutureCompletionHandler();
         }
 
         public void setTimer(final Time time, final long requestTimeoutMs) {
             this.timer = time.timer(requestTimeoutMs);
         }
 
-        public static UnsentRequest makeUnsentRequest(
-                final AbstractRequest.Builder<?> requestBuilder,
-                final AbstractRequestFutureCompletionHandler callback,
-                final Node node) {
-            return new UnsentRequest(requestBuilder, callback, node);
+        CompletableFuture<ClientResponse> future() {
+            return callback.future;
+        }
+
+        RequestCompletionHandler callback() {
+            return callback;
+        }
+
+        AbstractRequest.Builder<?> requestBuilder() {
+            return requestBuilder;
         }
 
         @Override
         public String toString() {
-            return abstractBuilder.toString();
+            return "UnsentRequest(builder=" + requestBuilder + ")";
         }
     }
 
-    public static class DefaultRequestFutureCompletionHandler extends AbstractRequestFutureCompletionHandler {
-        @Override
-        public void handleResponse(ClientResponse r, Exception t) {}
-    }
+    public static class FutureCompletionHandler implements RequestCompletionHandler {
+        private final CompletableFuture<ClientResponse> future;
 
-    public abstract static class AbstractRequestFutureCompletionHandler implements RequestCompletionHandler {
-        private final RequestFuture<ClientResponse> future;
-
-        AbstractRequestFutureCompletionHandler() {
-            this.future = new RequestFuture<>();
+        FutureCompletionHandler() {
+            this.future = new CompletableFuture<>();
         }
-
-        abstract public void handleResponse(ClientResponse r, Exception e);
 
         public void onFailure(final RuntimeException e) {
-            future.raise(e);
-            handleResponse(null, e);
+            future.completeExceptionally(e);
         }
 
         @Override
         public void onComplete(final ClientResponse response) {
-            fireCompletion(response);
-            handleResponse(response, null);
-        }
-
-        private void fireCompletion(final ClientResponse response) {
             if (response.authenticationException() != null) {
-                future.raise(response.authenticationException());
+                onFailure(response.authenticationException());
             } else if (response.wasDisconnected()) {
-                future.raise(DisconnectException.INSTANCE);
+                onFailure(DisconnectException.INSTANCE);
             } else if (response.versionMismatch() != null) {
-                future.raise(response.versionMismatch());
+                onFailure(response.versionMismatch());
             } else {
                 future.complete(response);
             }
         }
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
@@ -17,9 +17,9 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 public class ErrorBackgroundEvent extends BackgroundEvent {
-    private final Exception exception;
+    private final Throwable exception;
 
-    public ErrorBackgroundEvent(Exception e) {
+    public ErrorBackgroundEvent(Throwable e) {
         super(EventType.ERROR);
         exception = e;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -102,6 +102,10 @@ public class MockClient implements KafkaClient {
         this.metadataUpdater = metadataUpdater;
     }
 
+    public MockClient(Time time, List<Node> staticNodes) {
+        this(time, new StaticMetadataUpdater(staticNodes));
+    }
+
     public boolean isConnected(String idString) {
         return connectionState(idString).state == ConnectionState.State.CONNECTED;
     }
@@ -659,6 +663,19 @@ public class MockClient implements KafkaClient {
         public void update(Time time, MetadataUpdate update) {
             throw new UnsupportedOperationException();
         }
+    }
+
+    private static class StaticMetadataUpdater extends NoOpMetadataUpdater {
+        private final List<Node> nodes;
+        public StaticMetadataUpdater(List<Node> nodes) {
+            this.nodes = nodes;
+        }
+
+        @Override
+        public List<Node> fetchNodes() {
+            return nodes;
+        }
+
     }
 
     private static class DefaultMockMetadataUpdater implements MockMetadataUpdater {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -120,14 +121,16 @@ public class DefaultBackgroundThreadTest {
         assertEquals(10, backgroundThread.handlePollResult(failure));
     }
 
-    private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(final Time time,
-                                                                                   final long timeout) {
+    private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(
+        final Time time,
+        final long timeout
+    ) {
         NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
                 new FindCoordinatorRequest.Builder(
                         new FindCoordinatorRequestData()
                                 .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
                                 .setKey("foobar")),
-                null);
+            Optional.empty());
         req.setTimer(time, timeout);
         return req;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -16,157 +16,114 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetworkClientDelegateTest {
+    private static final int REQUEST_TIMEOUT_MS = 5000;
+    private static final String GROUP_ID = "group";
     private MockTime time;
-    private Properties properties;
-    private LogContext logContext;
-    private KafkaClient client;
-    private String groupId;
-    private SubscriptionState subscription;
-    private ConsumerMetadata metadata;
-    private Node node;
-    private int requestTimeoutMs = 500;
+    private MockClient client;
 
     @BeforeEach
     public void setup() {
         this.time = new MockTime(0);
-        this.properties = new Properties();
+        this.client = new MockClient(time, Collections.singletonList(mockNode()));
+    }
+
+    @Test
+    public void testSuccessfulResponse() throws Exception {
+        try (NetworkClientDelegate ncd = newNetworkClientDelegate()) {
+            NetworkClientDelegate.UnsentRequest unsentRequest = newUnsentFindCoordinatorRequest();
+            prepareFindCoordinatorResponse(Errors.NONE);
+
+            ncd.send(unsentRequest);
+            ncd.poll(0, time.milliseconds());
+
+            assertTrue(unsentRequest.future().isDone());
+            assertNotNull(unsentRequest.future().get());
+        }
+    }
+
+    @Test
+    public void testTimeoutBeforeSend() throws Exception {
+        try (NetworkClientDelegate ncd = newNetworkClientDelegate()) {
+            client.setUnreachable(mockNode(), REQUEST_TIMEOUT_MS);
+            NetworkClientDelegate.UnsentRequest unsentRequest = newUnsentFindCoordinatorRequest();
+            ncd.send(unsentRequest);
+            ncd.poll(0, time.milliseconds());
+            time.sleep(REQUEST_TIMEOUT_MS);
+            ncd.poll(0, time.milliseconds());
+            assertTrue(unsentRequest.future().isDone());
+            TestUtils.assertFutureThrows(unsentRequest.future(), TimeoutException.class);
+        }
+    }
+
+    @Test
+    public void testTimeoutAfterSend() throws Exception {
+        try (NetworkClientDelegate ncd = newNetworkClientDelegate()) {
+            NetworkClientDelegate.UnsentRequest unsentRequest = newUnsentFindCoordinatorRequest();
+            ncd.send(unsentRequest);
+            ncd.poll(0, time.milliseconds());
+            time.sleep(REQUEST_TIMEOUT_MS);
+            ncd.poll(0, time.milliseconds());
+            assertTrue(unsentRequest.future().isDone());
+            TestUtils.assertFutureThrows(unsentRequest.future(), DisconnectException.class);
+        }
+    }
+
+    public NetworkClientDelegate newNetworkClientDelegate() {
+        LogContext logContext = new LogContext();
+        Properties properties = new Properties();
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(RETRY_BACKOFF_MS_CONFIG, 100);
-        properties.put(REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
-        this.logContext = new LogContext();
-        this.client = mock(NetworkClient.class);
-        this.node = mockNode();
-        this.groupId = "group-1";
+        properties.put(GROUP_ID_CONFIG, GROUP_ID);
+        properties.put(REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
+        return new NetworkClientDelegate(this.time, new ConsumerConfig(properties), logContext, this.client);
     }
 
-    @Test
-    public void testPoll() {
-        NetworkClientDelegate ncd = mockNetworkClientDelegate();
-
-        // Successful case
-        NetworkClientDelegate.DefaultRequestFutureCompletionHandler callback = mock(NetworkClientDelegate.DefaultRequestFutureCompletionHandler.class);
-        NetworkClientDelegate.UnsentRequest r = mockUnsentFindCoordinatorRequest(callback);
-        ncd.add(r);
-        when(this.client.leastLoadedNode(time.milliseconds())).thenReturn(this.node);
-        when(this.client.isReady(this.node, time.milliseconds())).thenReturn(true);
-        ncd.poll(100, time.milliseconds());
-        verify(client, times(1)).send(any(), eq(time.milliseconds()));
-        verify(callback, never()).onFailure(any());
-
-        // Timeout case
-        NetworkClientDelegate.DefaultRequestFutureCompletionHandler callback2 = mock(NetworkClientDelegate.DefaultRequestFutureCompletionHandler.class);
-        NetworkClientDelegate.UnsentRequest r2 = mockUnsentFindCoordinatorRequest(callback2);
-        ncd.add(r2);
-        time.sleep(501);
-        when(this.client.leastLoadedNode(time.milliseconds())).thenReturn(this.node);
-        ncd.poll(100, time.milliseconds());
-        verify(client, never()).send(any(), eq(time.milliseconds()));
-        verify(callback2, times(1)).onFailure(any());
-
-        // Node found but not ready: first loop (the request should get re-enqueued into the unsentRequests
-        NetworkClientDelegate.DefaultRequestFutureCompletionHandler callback3 = mock(NetworkClientDelegate.DefaultRequestFutureCompletionHandler.class);
-        NetworkClientDelegate.UnsentRequest r3 = mockUnsentFindCoordinatorRequest(callback3);
-        ncd.add(r3);
-        when(this.client.leastLoadedNode(time.milliseconds())).thenReturn(this.node);
-        when(this.client.isReady(this.node, time.milliseconds())).thenReturn(false);
-        ncd.poll(100, time.milliseconds());
-        verify(client, never()).send(any(), eq(time.milliseconds()));
-        verify(callback3, never()).onFailure(any());
-
-        // The request expires in 500ms.
-        time.sleep(499);
-        when(this.client.leastLoadedNode(time.milliseconds())).thenReturn(this.node);
-        when(this.client.isReady(this.node, time.milliseconds())).thenReturn(true);
-        ncd.poll(100, time.milliseconds());
-        verify(client, times(1)).send(any(), eq(time.milliseconds()));
-        verify(callback3, never()).onFailure(any());
-    }
-
-    @Test
-    public void testUnableToFindBrokerAndTimeout() {
-        NetworkClientDelegate ncd = mockNetworkClientDelegate();
-
-        NetworkClientDelegate.DefaultRequestFutureCompletionHandler callback = mock(NetworkClientDelegate.DefaultRequestFutureCompletionHandler.class);
-        NetworkClientDelegate.UnsentRequest r = mockUnsentFindCoordinatorRequest(callback);
-        ncd.add(r);
-        final long timeoutMs = 100;
-        long totalTimeoutMs = 0;
-        while (totalTimeoutMs <= this.requestTimeoutMs) {
-            when(this.client.leastLoadedNode(time.milliseconds())).thenReturn(null);
-            ncd.poll(timeoutMs, time.milliseconds());
-            totalTimeoutMs += timeoutMs;
-            this.time.sleep(timeoutMs);
-        }
-        verify(client, times(6)).poll(eq(timeoutMs), anyLong());
-        verify(callback, times(1)).onFailure(isA(TimeoutException.class));
-    }
-
-    @Test
-    public void testNodeUnready() {
-        NetworkClientDelegate ncd = mockNetworkClientDelegate();
-
-        NetworkClientDelegate.DefaultRequestFutureCompletionHandler callback = mock(NetworkClientDelegate.DefaultRequestFutureCompletionHandler.class);
-        NetworkClientDelegate.UnsentRequest r = mockUnsentFindCoordinatorRequest(callback);
-        ncd.add(r);
-        final long timeoutMs = 100;
-        long totalTimeoutMs = 0;
-        while (totalTimeoutMs <= this.requestTimeoutMs) {
-            when(this.client.leastLoadedNode(time.milliseconds())).thenReturn(this.node);
-            when(this.client.isReady(this.node, time.milliseconds())).thenReturn(false);
-            ncd.poll(timeoutMs, time.milliseconds());
-            totalTimeoutMs += timeoutMs;
-            this.time.sleep(timeoutMs);
-        }
-        verify(client, times(6)).poll(eq(timeoutMs), anyLong());
-        verify(callback, times(1)).onFailure(isA(TimeoutException.class));
-    }
-
-    public NetworkClientDelegate mockNetworkClientDelegate() {
-        return new NetworkClientDelegate(this.time, new ConsumerConfig(this.properties), this.logContext, this.client);
-    }
-
-    public NetworkClientDelegate.UnsentRequest mockUnsentFindCoordinatorRequest(NetworkClientDelegate.AbstractRequestFutureCompletionHandler callback) {
-        Objects.requireNonNull(groupId);
+    public NetworkClientDelegate.UnsentRequest newUnsentFindCoordinatorRequest() {
+        Objects.requireNonNull(GROUP_ID);
         NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
-                new FindCoordinatorRequest.Builder(
-                        new FindCoordinatorRequestData()
-                                .setKey(this.groupId)
-                                .setKeyType(FindCoordinatorRequest.CoordinatorType.GROUP.id())),
-                callback);
-        req.setTimer(this.time, this.requestTimeoutMs);
+                new FindCoordinatorRequest.Builder(new FindCoordinatorRequestData()
+                    .setKey(GROUP_ID)
+                    .setKeyType(FindCoordinatorRequest.CoordinatorType.GROUP.id())
+                ),
+            Optional.empty()
+        );
+        req.setTimer(this.time, REQUEST_TIMEOUT_MS);
         return req;
+    }
+
+    public void prepareFindCoordinatorResponse(Errors error) {
+        FindCoordinatorResponse findCoordinatorResponse =
+            FindCoordinatorResponse.prepareResponse(error, GROUP_ID, mockNode());
+        client.prepareResponse(findCoordinatorResponse);
     }
 
     private Node mockNode() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestStateTest.java
@@ -32,11 +32,11 @@ public class RequestStateTest {
 
         // ensure not permitting consecutive requests
         assertTrue(state.canSendRequest(0));
-        state.updateLastSend(0);
+        state.onSendAttempt(0);
         assertFalse(state.canSendRequest(0));
-        state.updateLastFailedAttempt(35);
+        state.onFailedAttempt(35);
         assertTrue(state.canSendRequest(135));
-        state.updateLastFailedAttempt(140);
+        state.onFailedAttempt(140);
         assertFalse(state.canSendRequest(200));
         // exponential backoff
         assertTrue(state.canSendRequest(340));


### PR DESCRIPTION
This patch contains a few cleanups and fixes in the new refactored consumer logic:

- Use `CompletableFuture` instead of `RequestFuture` in `NetworkClientDelegate`. This is a much more extensible API and it avoids tying the new implementation to `ConsumerNetworkClient`.
- Fix call to `isReady` in `NetworkClientDelegate`. We need the call to `ready` to initiate the connection.
- Ensure backoff is enforced even after successful `FindCoordinator` requests. This avoids a tight loop while metadata is converging after a coordinator change.
- `RequestState` was incorrectly using the reconnect backoff as the retry backoff. In fact, we don't currently have a retry backoff max implemented in the consumer, so the use of `ExponentialBackoff` is unnecessary, but I've left it since we may add this with https://cwiki.apache.org/confluence/display/KAFKA/KIP-580%3A+Exponential+Backoff+for+Kafka+Clients. 
- Minor cleanups in test cases to avoid unused classes/fields.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
