### PR TITLE
KAFKA-14644: Process should crash after failure in Raft IO thread

### DIFF
--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -65,8 +65,7 @@ object KafkaRaftManager {
         client.poll()
       } catch {
         case t: Throwable =>
-          fatalFaultHandler.handleFault("Unexpected error in raft IO thread", t)
-          throw t
+          throw fatalFaultHandler.handleFault("Unexpected error in raft IO thread", t)
       }
     }
 

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -47,19 +47,27 @@ import org.apache.kafka.raft.RaftConfig.{AddressSpec, InetAddressSpec, NON_ROUTA
 import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, LeaderAndEpoch, RaftClient, RaftConfig, RaftRequest, ReplicatedLog}
 import org.apache.kafka.server.common.serialization.RecordSerde
 import org.apache.kafka.server.util.KafkaScheduler
+import org.apache.kafka.server.fault.FaultHandler
 
 import scala.jdk.CollectionConverters._
 
 object KafkaRaftManager {
   class RaftIoThread(
     client: KafkaRaftClient[_],
-    threadNamePrefix: String
+    threadNamePrefix: String,
+    fatalFaultHandler: FaultHandler
   ) extends ShutdownableThread(
     name = threadNamePrefix + "-io-thread",
     isInterruptible = false
   ) {
     override def doWork(): Unit = {
-      client.poll()
+      try {
+        client.poll()
+      } catch {
+        case t: Throwable =>
+          fatalFaultHandler.handleFault("Unexpected error in raft IO thread", t)
+          throw t
+      }
     }
 
     override def initiateShutdown(): Boolean = {
@@ -130,7 +138,8 @@ class KafkaRaftManager[T](
   time: Time,
   metrics: Metrics,
   threadNamePrefixOpt: Option[String],
-  val controllerQuorumVotersFuture: CompletableFuture[util.Map[Integer, AddressSpec]]
+  val controllerQuorumVotersFuture: CompletableFuture[util.Map[Integer, AddressSpec]],
+  fatalFaultHandler: FaultHandler
 ) extends RaftManager[T] with Logging {
 
   val apiVersions = new ApiVersions()
@@ -165,7 +174,7 @@ class KafkaRaftManager[T](
   private val expirationTimer = new SystemTimer("raft-expiration-executor")
   private val expirationService = new TimingWheelExpirationService(expirationTimer)
   override val client: KafkaRaftClient[T] = buildRaftClient()
-  private val raftIoThread = new RaftIoThread(client, threadNamePrefix)
+  private val raftIoThread = new RaftIoThread(client, threadNamePrefix, fatalFaultHandler)
 
   def startup(): Unit = {
     // Update the voter endpoints (if valid) with what's in RaftConfig

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -55,6 +55,7 @@ import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.server.common.MetadataVersion._
+import org.apache.kafka.server.fault.ProcessExitingFaultHandler
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.log.internals.LogDirFailureChannel
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
@@ -394,7 +395,8 @@ class KafkaServer(
             time,
             metrics,
             threadNamePrefix,
-            controllerQuorumVotersFuture
+            controllerQuorumVotersFuture,
+            fatalFaultHandler = new ProcessExitingFaultHandler()
           )
           val controllerNodes = RaftConfig.voterConnectionsToNodes(controllerQuorumVotersFuture.get()).asScala
           val quorumControllerNodeProvider = RaftControllerNodeProvider(raftManager, config, controllerNodes)

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -150,6 +150,12 @@ class SharedServer(
     }
   }
 
+  def raftManagerFaultHandler: FaultHandler = faultHandlerFactory.build(
+    name = "raft manager",
+    fatal = true,
+    action = () => {}
+  )
+
   /**
    * The fault handler to use when metadata loading fails.
    */
@@ -225,7 +231,9 @@ class SharedServer(
           time,
           metrics,
           threadNamePrefix,
-          controllerQuorumVotersFuture)
+          controllerQuorumVotersFuture,
+          raftManagerFaultHandler
+        )
         raftManager.startup()
 
         if (sharedServerConfig.processRoles.contains(ControllerRole)) {

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -19,7 +19,6 @@ package kafka.tools
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.concurrent.{CompletableFuture, CountDownLatch, LinkedBlockingDeque, TimeUnit}
-
 import joptsimple.OptionException
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.{KafkaRaftManager, RaftManager}
@@ -39,6 +38,7 @@ import org.apache.kafka.common.{TopicPartition, Uuid, protocol}
 import org.apache.kafka.raft.errors.NotLeaderException
 import org.apache.kafka.raft.{Batch, BatchReader, LeaderAndEpoch, RaftClient, RaftConfig}
 import org.apache.kafka.server.common.serialization.RecordSerde
+import org.apache.kafka.server.fault.ProcessExitingFaultHandler
 import org.apache.kafka.snapshot.SnapshotReader
 
 import scala.jdk.CollectionConverters._
@@ -91,6 +91,7 @@ class TestRaftServer(
       metrics,
       Some(threadNamePrefix),
       CompletableFuture.completedFuture(RaftConfig.parseVoterConnections(config.quorumVoters)),
+      new ProcessExitingFaultHandler()
     )
 
     workloadGenerator = new RaftWorkloadGenerator(

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -238,6 +238,7 @@ class RaftManagerTest {
     assertTrue(ioThread.isThreadFailed)
     assertFalse(ioThread.isRunning)
 
-    assertEquals(exception, faultHandler.firstException)
+    val caughtException = faultHandler.firstException.getCause
+    assertEquals(exception, caughtException)
   }
 }

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -200,7 +200,7 @@ class RaftManagerTest {
   @Test
   def testShutdownIoThread(): Unit = {
     val raftClient = mock(classOf[KafkaRaftClient[String]])
-    val faultHandler = mock(classOf[FaultHandler])
+    val faultHandler = new MockFaultHandler("RaftManagerTestFaultHandler")
     val ioThread = new RaftIoThread(raftClient, threadNamePrefix = "test-raft", faultHandler)
 
     when(raftClient.isRunning).thenReturn(true)
@@ -219,6 +219,7 @@ class RaftManagerTest {
     ioThread.run()
     assertFalse(ioThread.isRunning)
     assertTrue(ioThread.isShutdownComplete)
+    assertNull(faultHandler.firstException)
   }
 
   @Test


### PR DESCRIPTION
Unexpected errors caught in the Raft IO thread should cause the process to stop. This is similar to the handling of exceptions in the controller.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
