### PR TITLE
MINOR: fix flaky integrations tests by using 60s default timeout for startup

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -121,24 +121,29 @@ public class ConsistencyVectorIntegrationTest {
         final KafkaStreams kafkaStreams2 = createKafkaStreams(builder, streamsConfiguration());
         final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams1, kafkaStreams2);
 
-        startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+        try {
+            startApplicationAndWaitUntilRunning(kafkaStreamsList);
 
-        produceValueRange(key, 0, batch1NumMessages);
+            produceValueRange(key, 0, batch1NumMessages);
 
-        // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+            // Assert that all messages in the first batch were processed in a timely manner
+            assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
 
-        final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
+            final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
 
-        // Assert that both active and standby have the same position bound
-        final StateQueryRequest<ValueAndTimestamp<Integer>> request =
-            StateQueryRequest
-                .inStore(TABLE_NAME)
-                .withQuery(KeyQuery.<Integer, ValueAndTimestamp<Integer>>withKey(key))
-                .withPositionBound(PositionBound.unbounded());
+            // Assert that both active and standby have the same position bound
+            final StateQueryRequest<ValueAndTimestamp<Integer>> request =
+                StateQueryRequest
+                    .inStore(TABLE_NAME)
+                    .withQuery(KeyQuery.<Integer, ValueAndTimestamp<Integer>>withKey(key))
+                    .withPositionBound(PositionBound.unbounded());
 
-        checkPosition(batch1NumMessages, request, kafkaStreams1);
-        checkPosition(batch1NumMessages, request, kafkaStreams2);
+            checkPosition(batch1NumMessages, request, kafkaStreams1);
+            checkPosition(batch1NumMessages, request, kafkaStreams2);
+        } finally {
+            kafkaStreams1.close();
+            kafkaStreams2.close();
+        }
     }
 
     private void checkPosition(final int batch1NumMessages,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -52,7 +52,6 @@ import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
@@ -114,7 +114,7 @@ public class EmitOnChangeIntegrationTest {
 
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
             kafkaStreams.setUncaughtExceptionHandler(exception -> StreamThreadExceptionResponse.REPLACE_THREAD);
-            StreamsTestUtils.startKafkaStreamsAndWaitForRunningState(kafkaStreams);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
 
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
                 inputTopic,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThr
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -504,7 +504,7 @@ public class EosIntegrationTest {
 
             waitForCondition(
                 () -> commitRequested.get() == 2, MAX_WAIT_TIME_MS,
-                "SteamsTasks did not request commit.");
+                "StreamsTasks did not request commit.");
 
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //
@@ -626,7 +626,7 @@ public class EosIntegrationTest {
 
             waitForCondition(
                 () -> commitRequested.get() == 2, MAX_WAIT_TIME_MS,
-                "SteamsTasks did not request commit.");
+                "StreamsTasks did not request commit.");
 
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //
@@ -761,7 +761,7 @@ public class EosIntegrationTest {
 
             waitForCondition(
                     () -> commitRequested.get() == 2, MAX_WAIT_TIME_MS,
-                    "SteamsTasks did not request commit.");
+                    "StreamsTasks did not request commit.");
 
             final List<KeyValue<Long, Long>> committedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, writtenData.size(), CONSUMER_GROUP_ID);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -87,9 +87,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
 import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
-import static org.apache.kafka.test.StreamsTestUtils.startKafkaStreamsAndWaitForRunningState;
 import static org.apache.kafka.test.TestUtils.consumerConfig;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -281,7 +281,7 @@ public class EosIntegrationTest {
             );
 
             try (final KafkaStreams streams = new KafkaStreams(builder.build(), config)) {
-                startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
+                startApplicationAndWaitUntilRunning(streams);
 
                 final List<KeyValue<Long, Long>> committedRecords = readResult(outputTopic, inputData.size(), CONSUMER_GROUP_ID);
                 checkResultPerKey(committedRecords, inputData, "The committed records do not match what expected");
@@ -339,7 +339,7 @@ public class EosIntegrationTest {
             properties);
 
         try (final KafkaStreams streams = new KafkaStreams(builder.build(), config)) {
-            startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
+            startApplicationAndWaitUntilRunning(streams);
 
             final List<KeyValue<Long, Long>> firstBurstOfData = prepareData(0L, 5L, 0L);
             final List<KeyValue<Long, Long>> secondBurstOfData = prepareData(5L, 8L, 0L);
@@ -380,7 +380,7 @@ public class EosIntegrationTest {
         // after fail over, we should read 40 committed records (even if 50 record got written)
 
         try (final KafkaStreams streams = getKafkaStreams("dummy", false, "appDir", 2, eosConfig, MAX_POLL_INTERVAL_MS)) {
-            startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
+            startApplicationAndWaitUntilRunning(streams);
 
             final List<KeyValue<Long, Long>> committedDataBeforeFailure = prepareData(0L, 10L, 0L, 1L);
             final List<KeyValue<Long, Long>> uncommittedDataBeforeFailure = prepareData(10L, 15L, 0L, 1L);
@@ -488,7 +488,7 @@ public class EosIntegrationTest {
         // We need more processing time under "with state" situation, so increasing the max.poll.interval.ms
         // to avoid unexpected rebalance during test, which will cause unexpected fail over triggered
         try (final KafkaStreams streams = getKafkaStreams("dummy", true, "appDir", 2, eosConfig, 3 * MAX_POLL_INTERVAL_MS)) {
-            startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
+            startApplicationAndWaitUntilRunning(streams);
 
             final List<KeyValue<Long, Long>> committedDataBeforeFailure = prepareData(0L, 10L, 0L, 1L);
             final List<KeyValue<Long, Long>> uncommittedDataBeforeFailure = prepareData(10L, 15L, 0L, 1L, 2L, 3L);
@@ -607,8 +607,8 @@ public class EosIntegrationTest {
             final KafkaStreams streams1 = getKafkaStreams("streams1", false, "appDir1", 1, eosConfig, MAX_POLL_INTERVAL_MS);
             final KafkaStreams streams2 = getKafkaStreams("streams2", false, "appDir2", 1, eosConfig, MAX_POLL_INTERVAL_MS)
         ) {
-            startKafkaStreamsAndWaitForRunningState(streams1, MAX_WAIT_TIME_MS);
-            startKafkaStreamsAndWaitForRunningState(streams2, MAX_WAIT_TIME_MS);
+            startApplicationAndWaitUntilRunning(streams1);
+            startApplicationAndWaitUntilRunning(streams2);
 
             final List<KeyValue<Long, Long>> committedDataBeforeStall = prepareData(0L, 10L, 0L, 1L);
             final List<KeyValue<Long, Long>> uncommittedDataBeforeStall = prepareData(10L, 15L, 0L, 1L);
@@ -757,7 +757,7 @@ public class EosIntegrationTest {
         try (final KafkaStreams streams = getKafkaStreams("streams", true, "appDir", 1, eosConfig, MAX_POLL_INTERVAL_MS)) {
             writeInputData(writtenData);
 
-            startKafkaStreamsAndWaitForRunningState(streams, MAX_WAIT_TIME_MS);
+            startApplicationAndWaitUntilRunning(streams);
 
             waitForCondition(
                     () -> commitRequested.get() == 2, MAX_WAIT_TIME_MS,
@@ -866,7 +866,7 @@ public class EosIntegrationTest {
                         this.context = context;
 
                         if (withState) {
-                            state = (KeyValueStore<Long, Long>) context.getStateStore(storeName);
+                            state = context.getStateStore(storeName);
                         }
                     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/InternalTopicIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/InternalTopicIntegrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import java.time.Duration;
 import kafka.utils.MockTime;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -52,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -62,7 +62,6 @@ import java.util.concurrent.TimeUnit;
 
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
-import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForCompletion;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -17,17 +17,6 @@
 
 package org.apache.kafka.streams.integration;
 
-import static java.time.Duration.ofSeconds;
-import static java.util.Arrays.asList;
-import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
-import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
-import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
-import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForApplicationState;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -71,6 +60,16 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.TestInfo;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.asList;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForApplicationState;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 @Timeout(600)
 @Tag("integration")
@@ -231,7 +230,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
             OUTPUT,
             expectedResult.size()));
 
-        assertEquals(expectedResult, result);
+        assertThat(expectedResult, equalTo(result));
     }
 
     private Properties getStreamsConfig(final String testName) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
 
 @Category({IntegrationTest.class})

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
@@ -162,7 +162,7 @@ public class KafkaStreamsCloseOptionsIntegrationTest {
 
         // RUN
         streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        IntegrationTestUtils.startApplicationAndWaitUntilRunning(singletonList(streams), Duration.ofSeconds(30));
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
 
         streams.close(new CloseOptions().leaveGroup(true).timeout(Duration.ofSeconds(30)));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -56,7 +56,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -285,7 +284,7 @@ public class LagFetchIntegrationTest {
                 "Should see empty lag map before streams is started.");
 
             // Get the instance to fully catch up and reach RUNNING state
-            startApplicationAndWaitUntilRunning(Collections.singletonList(streams), Duration.ofSeconds(60));
+            startApplicationAndWaitUntilRunning(streams);
             IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
                 consumerConfiguration,
                 outputTopicName,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -287,7 +287,7 @@ public class NamedTopologyIntegrationTest {
             Materialized.with(null, serdeScope.decorateSerde(Serdes.String(), props, false)));
 
         streams.start(asList(fkjBuilder.build(), countBuilder.build()));
-       IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         final String countTopicPrefix = TOPIC_PREFIX + "-" + countTopologyName;
         final String fkjTopicPrefix = TOPIC_PREFIX + "-" + fkjTopologyName;
@@ -359,7 +359,7 @@ public class NamedTopologyIntegrationTest {
             assertThat(streams.getTopologyByName(TOPOLOGY_1), is(Optional.empty()));
             streams.addNamedTopology(topology1Builder.build());
             streams.addNamedTopology(topology2Builder.build());
-           IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SINGLE_PARTITION_OUTPUT_STREAM, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -835,7 +835,7 @@ public class NamedTopologyIntegrationTest {
 
             streams.addNamedTopology(builder.build());
 
-           IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
                 DELAYED_INPUT_STREAM_2,
                 singletonList(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -286,7 +286,8 @@ public class NamedTopologyIntegrationTest {
             (value1, value2) -> String.valueOf(value1 + value2),
             Materialized.with(null, serdeScope.decorateSerde(Serdes.String(), props, false)));
 
-        streams.start(asList(fkjBuilder.build(), countBuilder.build()));
+        streams.addNamedTopology(fkjBuilder.build());
+        streams.addNamedTopology(countBuilder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         final String countTopicPrefix = TOPIC_PREFIX + "-" + countTopologyName;
@@ -314,7 +315,7 @@ public class NamedTopologyIntegrationTest {
             .groupByKey()
             .count(ROCKSDB_STORE)
             .toStream().to(OUTPUT_STREAM_1);
-        streams.start(topology1Builder.build());
+        streams.addNamedTopology(topology1Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         final List<KeyValue<String, Long>> results = waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3);
         assertThat(results, equalTo(COUNT_OUTPUT_DATA));
@@ -329,7 +330,9 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
-        streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
+        streams.addNamedTopology(topology1Builder.build());
+        streams.addNamedTopology(topology2Builder.build());
+        streams.addNamedTopology(topology3Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -397,7 +400,8 @@ public class NamedTopologyIntegrationTest {
             topology1Builder2.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(Materialized.as(topology1Store)).toStream().to(OUTPUT_STREAM_1);
             topology2Builder2.stream(SINGLE_PARTITION_INPUT_STREAM).groupByKey().count(Materialized.as(topology2Store)).toStream().to(SINGLE_PARTITION_OUTPUT_STREAM);
 
-            streams2.start(asList(topology1Builder2.build(), topology2Builder2.build()));
+            streams2.addNamedTopology(topology1Builder2.build());
+            streams2.addNamedTopology(topology2Builder2.build());
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
 
             verifyMetadataForTopology(
@@ -430,7 +434,7 @@ public class NamedTopologyIntegrationTest {
     @Test
     public void shouldAddNamedTopologyToRunningApplicationWithEmptyInitialTopology() throws Exception {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
-        streams.start();
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         streams.addNamedTopology(topology1Builder.build()).all().get();
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -440,7 +444,7 @@ public class NamedTopologyIntegrationTest {
     public void shouldAddNamedTopologyToRunningApplicationWithSingleInitialNamedTopology() throws Exception {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
-        streams.start(topology1Builder.build());
+        streams.addNamedTopology(topology1Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         streams.addNamedTopology(topology2Builder.build()).all().get();
 
@@ -453,7 +457,8 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
-        streams.start(asList(topology1Builder.build(), topology2Builder.build()));
+        streams.addNamedTopology(topology1Builder.build());
+        streams.addNamedTopology(topology2Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         streams.addNamedTopology(topology3Builder.build()).all().get();
@@ -472,8 +477,8 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         topology2Builder2.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
 
-        streams.start(topology1Builder.build());
-        streams2.start(topology1Builder2.build());
+        streams.addNamedTopology(topology1Builder.build());
+        streams2.addNamedTopology(topology1Builder2.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -492,8 +497,8 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
         topology1Builder2.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
 
-        streams.start(topology1Builder.build());
-        streams2.start(topology1Builder2.build());
+        streams.addNamedTopology(topology1Builder.build());
+        streams2.addNamedTopology(topology1Builder2.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -545,7 +550,8 @@ public class NamedTopologyIntegrationTest {
             topology2Builder.stream(DELAYED_INPUT_STREAM_2).map((k, v) -> {
                 throw new IllegalStateException("Should not process any records for removed topology-2");
             });
-            streams.start(asList(topology1Builder.build(), topology2Builder.build()));
+            streams.addNamedTopology(topology1Builder.build());
+            streams.addNamedTopology(topology2Builder.build());
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             streams.removeNamedTopology("topology-2").all().get();
@@ -569,7 +575,7 @@ public class NamedTopologyIntegrationTest {
             final KStream<String, Long> inputStream1 = topology1Builder.stream(INPUT_STREAM_1);
             inputStream1.groupByKey().count().toStream().to(COUNT_OUTPUT);
             inputStream1.groupByKey().reduce(Long::sum).toStream().to(SUM_OUTPUT);
-            streams.start(singletonList(topology1Builder.build()));
+            streams.addNamedTopology(topology1Builder.build());
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -599,7 +605,9 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(Pattern.compile(INPUT_STREAM_1)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
-        streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
+        streams.addNamedTopology(topology1Builder.build());
+        streams.addNamedTopology(topology2Builder.build());
+        streams.addNamedTopology(topology3Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -612,7 +620,9 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
-        streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
+        streams.addNamedTopology(topology1Builder.build());
+        streams.addNamedTopology(topology2Builder.build());
+        streams.addNamedTopology(topology3Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -628,7 +638,7 @@ public class NamedTopologyIntegrationTest {
             final KStream<String, Long> inputStream1 = topology1Builder.stream(INPUT_STREAM_1);
             inputStream1.groupByKey().count().toStream().to(COUNT_OUTPUT);
             inputStream1.groupByKey().reduce(Long::sum).toStream().to(SUM_OUTPUT);
-            streams.start();
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
             final NamedTopology namedTopology = topology1Builder.build();
             streams.addNamedTopology(namedTopology).all().get();
 
@@ -666,7 +676,7 @@ public class NamedTopologyIntegrationTest {
         final KStream<String, Long> inputStream1 = topology1Builder.stream(INPUT_STREAM_1);
         inputStream1.map(KeyValue::new).groupByKey().count().toStream().to(COUNT_OUTPUT);
         inputStream1.map(KeyValue::new).groupByKey().reduce(Long::sum).toStream().to(SUM_OUTPUT);
-        streams.start();
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         final NamedTopology namedTopology = topology1Builder.build();
         streams.addNamedTopology(namedTopology).all().get();
 
@@ -709,8 +719,9 @@ public class NamedTopologyIntegrationTest {
             streams.setUncaughtExceptionHandler(handler);
             streams2.setUncaughtExceptionHandler(handler);
 
-            streams.start(topology1Builder.build());
-            streams2.start(topology1Builder2.build());
+            streams.addNamedTopology(topology1Builder.build());
+            streams2.addNamedTopology(topology1Builder2.build());
+            
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
 
@@ -767,8 +778,8 @@ public class NamedTopologyIntegrationTest {
         streams.setUncaughtExceptionHandler(handler);
         streams2.setUncaughtExceptionHandler(handler);
 
-        streams.start(topology1Builder.build());
-        streams2.start(topology1Builder2.build());
+        streams.addNamedTopology(topology1Builder.build());
+        streams2.addNamedTopology(topology1Builder2.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
 
         retryOnExceptionWithTimeout(() -> {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -364,7 +364,7 @@ public class NamedTopologyIntegrationTest {
             assertThat(streams.getTopologyByName(TOPOLOGY_1), is(Optional.empty()));
             streams.addNamedTopology(topology1Builder.build());
             streams.addNamedTopology(topology2Builder.build());
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(singletonList(streams), Duration.ofSeconds(15));
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(singletonList(streams));
 
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SINGLE_PARTITION_OUTPUT_STREAM, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -840,10 +840,10 @@ public class NamedTopologyIntegrationTest {
 
             streams.addNamedTopology(builder.build());
 
-            StreamsTestUtils.startKafkaStreamsAndWaitForRunningState(streams);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
                 DELAYED_INPUT_STREAM_2,
-                Arrays.asList(
+                singletonList(
                     new KeyValue<>(1, "A")
                 ),
                 TestUtils.producerConfig(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -57,7 +57,6 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 import org.apache.kafka.streams.utils.UniqueTopicSerdeScope;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
 import java.util.Arrays;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -287,7 +287,7 @@ public class NamedTopologyIntegrationTest {
             Materialized.with(null, serdeScope.decorateSerde(Serdes.String(), props, false)));
 
         streams.start(asList(fkjBuilder.build(), countBuilder.build()));
-        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+       IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         final String countTopicPrefix = TOPIC_PREFIX + "-" + countTopologyName;
         final String fkjTopicPrefix = TOPIC_PREFIX + "-" + fkjTopologyName;
@@ -315,7 +315,7 @@ public class NamedTopologyIntegrationTest {
             .count(ROCKSDB_STORE)
             .toStream().to(OUTPUT_STREAM_1);
         streams.start(topology1Builder.build());
-         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         final List<KeyValue<String, Long>> results = waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3);
         assertThat(results, equalTo(COUNT_OUTPUT_DATA));
 
@@ -330,7 +330,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -359,7 +359,7 @@ public class NamedTopologyIntegrationTest {
             assertThat(streams.getTopologyByName(TOPOLOGY_1), is(Optional.empty()));
             streams.addNamedTopology(topology1Builder.build());
             streams.addNamedTopology(topology2Builder.build());
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+           IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SINGLE_PARTITION_OUTPUT_STREAM, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -441,7 +441,7 @@ public class NamedTopologyIntegrationTest {
         topology1Builder.stream(INPUT_STREAM_1).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_1);
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(IN_MEMORY_STORE).toStream().to(OUTPUT_STREAM_2);
         streams.start(topology1Builder.build());
-         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         streams.addNamedTopology(topology2Builder.build()).all().get();
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -454,7 +454,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(INPUT_STREAM_2).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(INPUT_STREAM_3).groupBy((k, v) -> k).count(ROCKSDB_STORE).toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build()));
-         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         streams.addNamedTopology(topology3Builder.build()).all().get();
 
@@ -546,7 +546,7 @@ public class NamedTopologyIntegrationTest {
                 throw new IllegalStateException("Should not process any records for removed topology-2");
             });
             streams.start(asList(topology1Builder.build(), topology2Builder.build()));
-             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             streams.removeNamedTopology("topology-2").all().get();
 
@@ -570,7 +570,7 @@ public class NamedTopologyIntegrationTest {
             inputStream1.groupByKey().count().toStream().to(COUNT_OUTPUT);
             inputStream1.groupByKey().reduce(Long::sum).toStream().to(SUM_OUTPUT);
             streams.start(singletonList(topology1Builder.build()));
-             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 3), equalTo(COUNT_OUTPUT_DATA));
             assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 3), equalTo(SUM_OUTPUT_DATA));
@@ -600,7 +600,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -613,7 +613,7 @@ public class NamedTopologyIntegrationTest {
         topology2Builder.stream(Pattern.compile(INPUT_STREAM_2)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_2);
         topology3Builder.stream(Pattern.compile(INPUT_STREAM_3)).groupBy((k, v) -> k).count().toStream().to(OUTPUT_STREAM_3);
         streams.start(asList(topology1Builder.build(), topology2Builder.build(), topology3Builder.build()));
-         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 3), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 3), equalTo(COUNT_OUTPUT_DATA));
@@ -835,7 +835,7 @@ public class NamedTopologyIntegrationTest {
 
             streams.addNamedTopology(builder.build());
 
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
+           IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
                 DELAYED_INPUT_STREAM_2,
                 singletonList(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -121,57 +121,62 @@ public class OptimizedKTableIntegrationTest {
         final KafkaStreams kafkaStreams2 = createKafkaStreams(builder, streamsConfiguration(testInfo));
         final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams1, kafkaStreams2);
 
-        startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+        try {
+            startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
 
-        produceValueRange(key, 0, batch1NumMessages);
+            produceValueRange(key, 0, batch1NumMessages);
 
-        // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+            // Assert that all messages in the first batch were processed in a timely manner
+            assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
 
-        final AtomicReference<ReadOnlyKeyValueStore<Integer, Integer>> newActiveStore = new AtomicReference<>(null);
-        TestUtils.retryOnExceptionWithTimeout(() -> {
-            final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams1, QueryableStoreTypes.keyValueStore());
-            final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
+            final AtomicReference<ReadOnlyKeyValueStore<Integer, Integer>> newActiveStore = new AtomicReference<>(null);
+            TestUtils.retryOnExceptionWithTimeout(() -> {
+                final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams1, QueryableStoreTypes.keyValueStore());
+                final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
-            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
 
-            try {
-                // Assert that the current value in store reflects all messages being processed
-                if ((keyQueryMetadata.activeHost().port() % 2) == 1) {
-                    assertThat(store1.get(key), is(equalTo(batch1NumMessages - 1)));
-                    kafkaStreams1.close();
-                    newActiveStore.set(store2);
-                } else {
-                    assertThat(store2.get(key), is(equalTo(batch1NumMessages - 1)));
-                    kafkaStreams2.close();
-                    newActiveStore.set(store1);
+                try {
+                    // Assert that the current value in store reflects all messages being processed
+                    if ((keyQueryMetadata.activeHost().port() % 2) == 1) {
+                        assertThat(store1.get(key), is(equalTo(batch1NumMessages - 1)));
+                        kafkaStreams1.close();
+                        newActiveStore.set(store2);
+                    } else {
+                        assertThat(store2.get(key), is(equalTo(batch1NumMessages - 1)));
+                        kafkaStreams2.close();
+                        newActiveStore.set(store1);
+                    }
+                } catch (final InvalidStateStoreException e) {
+                    LOG.warn("Detected an unexpected rebalance during test. Retrying if possible.", e);
+                    throw e;
+                } catch (final Throwable t) {
+                    LOG.error("Caught non-retriable exception in test. Exiting.", t);
+                    throw new NoRetryException(t);
                 }
-            } catch (final InvalidStateStoreException e) {
-                LOG.warn("Detected an unexpected rebalance during test. Retrying if possible.", e);
-                throw e;
-            } catch (final Throwable t) {
-                LOG.error("Caught non-retriable exception in test. Exiting.", t);
-                throw new NoRetryException(t);
-            }
-        });
+            });
 
-        // Wait for failover
-        TestUtils.retryOnExceptionWithTimeout(60 * 1000, 100, () -> {
-            // Assert that after failover we have recovered to the last store write
-            assertThat(newActiveStore.get().get(key), is(equalTo(batch1NumMessages - 1)));
-        });
+            // Wait for failover
+            TestUtils.retryOnExceptionWithTimeout(60 * 1000, 100, () -> {
+                // Assert that after failover we have recovered to the last store write
+                assertThat(newActiveStore.get().get(key), is(equalTo(batch1NumMessages - 1)));
+            });
 
-        final int totalNumMessages = batch1NumMessages + batch2NumMessages;
+            final int totalNumMessages = batch1NumMessages + batch2NumMessages;
 
-        produceValueRange(key, batch1NumMessages, totalNumMessages);
+            produceValueRange(key, batch1NumMessages, totalNumMessages);
 
-        // Assert that all messages in the second batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch2NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+            // Assert that all messages in the second batch were processed in a timely manner
+            assertThat(semaphore.tryAcquire(batch2NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
 
-        TestUtils.retryOnExceptionWithTimeout(60 * 1000, 100, () -> {
-            // Assert that the current value in store reflects all messages being processed
-            assertThat(newActiveStore.get().get(key), is(equalTo(totalNumMessages - 1)));
-        });
+            TestUtils.retryOnExceptionWithTimeout(60 * 1000, 100, () -> {
+                // Assert that the current value in store reflects all messages being processed
+                assertThat(newActiveStore.get().get(key), is(equalTo(totalNumMessages - 1)));
+            });
+        } finally {
+            kafkaStreams1.close();
+            kafkaStreams2.close();
+        }
     }
 
     private void produceValueRange(final int key, final int start, final int endExclusive) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
@@ -181,7 +181,7 @@ public class RangeQueryIntegrationTest {
         builder.table(inputStream, stateStoreConfig);
 
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), STREAMS_CONFIG)) {
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(Collections.singletonList(kafkaStreams), Duration.ofSeconds(60));
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
 
             writeInputData();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.streams.integration;
 
-import java.util.Collections;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -223,7 +223,7 @@ public class RegexSourceIntegrationTest {
             assertThat(topology.describe().subtopologies().size(), greaterThan(1));
             streams = new KafkaStreams(topology, streamsConfiguration);
 
-            startApplicationAndWaitUntilRunning(Collections.singletonList(streams), Duration.ofSeconds(30));
+            startApplicationAndWaitUntilRunning(streams);
 
             CLUSTER.createTopic(topic2);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
@@ -37,7 +37,6 @@ import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -64,6 +63,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -232,7 +233,7 @@ public class RocksDBMetricsIntegrationTest {
         kafkaStreams.cleanUp();
         produceRecords();
 
-        StreamsTestUtils.startKafkaStreamsAndWaitForRunningState(kafkaStreams, TIMEOUT);
+        startApplicationAndWaitUntilRunning(kafkaStreams);
 
         metricsVerifier.verify(kafkaStreams, "rocksdb-state-id");
         metricsVerifier.verify(kafkaStreams, "rocksdb-window-state-id");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -229,7 +229,7 @@ public class StandbyTaskEOSIntegrationTest {
         streamInstanceTwo = buildWithDeduplicationTopology(base + "-2");
 
         // start first instance and wait for processing
-        startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceOne), Duration.ofSeconds(30));
+        startApplicationAndWaitUntilRunning(streamInstanceOne);
         IntegrationTestUtils.waitUntilMinRecordsReceived(
             TestUtils.consumerConfig(
                 CLUSTER.bootstrapServers(),
@@ -241,7 +241,7 @@ public class StandbyTaskEOSIntegrationTest {
         );
 
         // start second instance and wait for standby replication
-        startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceTwo), Duration.ofSeconds(30));
+        startApplicationAndWaitUntilRunning(streamInstanceTwo);
         waitForCondition(
             () -> streamInstanceTwo.store(
                 StoreQueryParameters.fromNameAndType(
@@ -297,10 +297,7 @@ public class StandbyTaskEOSIntegrationTest {
 
         // "restart" first client and wait for standby recovery
         // (could actually also be active, but it does not matter as long as we enable "state stores"
-        startApplicationAndWaitUntilRunning(
-            Collections.singletonList(streamInstanceOneRecovery),
-            Duration.ofSeconds(30)
-        );
+        startApplicationAndWaitUntilRunning(streamInstanceOneRecovery);
         waitForCondition(
             () -> streamInstanceOneRecovery.store(
                 StoreQueryParameters.fromNameAndType(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -84,7 +84,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.anyOf;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Timeout(600)

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -78,6 +78,7 @@ import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -369,8 +370,8 @@ public class StoreQueryIntegrationTest {
 
         startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
 
-        assertTrue(kafkaStreams1.metadataForLocalThreads().size() > 1);
-        assertTrue(kafkaStreams2.metadataForLocalThreads().size() > 1);
+        assertThat(kafkaStreams1.metadataForLocalThreads().size(), greaterThan(1));
+        assertThat(kafkaStreams2.metadataForLocalThreads().size(), greaterThan(1));
 
         produceValueRange(key, 0, batch1NumMessages);
 
@@ -440,8 +441,8 @@ public class StoreQueryIntegrationTest {
         kafkaStreams2.start(builder2A.build());
         waitForApplicationState(kafkaStreamsList, State.RUNNING, Duration.ofSeconds(60));
 
-        assertTrue(kafkaStreams1.metadataForLocalThreads().size() > 1);
-        assertTrue(kafkaStreams2.metadataForLocalThreads().size() > 1);
+        assertThat(kafkaStreams1.metadataForLocalThreads().size(), greaterThan(1));
+        assertThat(kafkaStreams2.metadataForLocalThreads().size(), greaterThan(1));
 
         produceValueRange(key, 0, batch1NumMessages);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -53,7 +53,6 @@ import org.junit.rules.Timeout;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -75,7 +75,6 @@ public class TaskMetadataIntegrationTest {
     public static void closeCluster() {
         CLUSTER.stop();
     }
-    public static final Duration DEFAULT_DURATION = Duration.ofSeconds(30);
 
     @Rule
     public TestName testName = new TestName();
@@ -119,7 +118,7 @@ public class TaskMetadataIntegrationTest {
     @Test
     public void shouldReportCorrectCommittedOffsetInformation() {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(Collections.singletonList(kafkaStreams), DEFAULT_DURATION);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
             final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
             assertThat(taskMetadata.committedOffsets().size(), equalTo(1));
             final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);
@@ -145,7 +144,7 @@ public class TaskMetadataIntegrationTest {
     @Test
     public void shouldReportCorrectEndOffsetInformation() {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
-            IntegrationTestUtils.startApplicationAndWaitUntilRunning(Collections.singletonList(kafkaStreams), DEFAULT_DURATION);
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
             final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
             assertThat(taskMetadata.endOffsets().size(), equalTo(1));
             final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -72,7 +72,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -103,6 +103,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
+import static java.util.Collections.singletonList;
 
 /**
  * Utility functions to make integration testing more convenient.
@@ -960,6 +961,14 @@ public class IntegrationTestUtils {
         });
     }
 
+    public static void startApplicationAndWaitUntilRunning(final KafkaStreams streams) throws Exception {
+        startApplicationAndWaitUntilRunning(singletonList(streams));
+    }
+
+    public static void startApplicationAndWaitUntilRunning(final List<KafkaStreams> streamsList) throws Exception {
+        startApplicationAndWaitUntilRunning(streamsList, Duration.ofSeconds(DEFAULT_TIMEOUT));
+    }
+
     /**
      * Starts the given {@link KafkaStreams} instances and waits for all of them to reach the
      * {@link State#RUNNING} state at the same time. Note that states may change between the time
@@ -1099,7 +1108,7 @@ public class IntegrationTestUtils {
                                                final String applicationId) {
         try {
             final ConsumerGroupDescription groupDescription =
-                    adminClient.describeConsumerGroups(Collections.singletonList(applicationId))
+                    adminClient.describeConsumerGroups(singletonList(applicationId))
                             .describedGroups()
                             .get(applicationId)
                             .get();
@@ -1282,7 +1291,7 @@ public class IntegrationTestUtils {
                                                                  final long waitTime,
                                                                  final int maxMessages) {
         final List<ConsumerRecord<K, V>> consumerRecords;
-        consumer.subscribe(Collections.singletonList(topic));
+        consumer.subscribe(singletonList(topic));
         System.out.println("Got assignment:" + consumer.assignment());
         final int pollIntervalMs = 100;
         consumerRecords = new ArrayList<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -49,7 +49,7 @@ import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
-import static org.apache.kafka.test.StreamsTestUtils.TopologyMetadataBuilder.unamedTopology;
+import static org.apache.kafka.test.StreamsTestUtils.TopologyMetadataBuilder.unnamedTopology;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -90,7 +90,7 @@ class DefaultStateUpdaterTest {
     private final Time time = new MockTime(1L);
     private final StreamsConfig config = new StreamsConfig(configProps(COMMIT_INTERVAL));
     private final ChangelogReader changelogReader = mock(ChangelogReader.class);
-    private final TopologyMetadata topologyMetadata = unamedTopology().build();
+    private final TopologyMetadata topologyMetadata = unnamedTopology().build();
     private DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, topologyMetadata, time);
 
     @AfterEach

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -72,7 +72,7 @@ class DefaultStateUpdaterTest {
 
     private final static int COMMIT_INTERVAL = 100;
     private final static long CALL_TIMEOUT = 1000;
-    private final static long VERIFICATION_TIMEOUT = 15000;
+    private final static long VERIFICATION_TIMEOUT = 30000;
     private final static TopicPartition TOPIC_PARTITION_A_0 = new TopicPartition("topicA", 0);
     private final static TopicPartition TOPIC_PARTITION_A_1 = new TopicPartition("topicA", 1);
     private final static TopicPartition TOPIC_PARTITION_B_0 = new TopicPartition("topicB", 0);

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -47,12 +46,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
-import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -115,27 +111,6 @@ public final class StreamsTestUtils {
 
     public static Properties getStreamsConfig() {
         return getStreamsConfig(UUID.randomUUID().toString());
-    }
-
-    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams) throws InterruptedException {
-        startKafkaStreamsAndWaitForRunningState(kafkaStreams, DEFAULT_MAX_WAIT_MS);
-    }
-
-    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams,
-                                                               final long timeoutMs) throws InterruptedException {
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        kafkaStreams.setStateListener((newState, oldState) -> {
-            if (newState == KafkaStreams.State.RUNNING) {
-                countDownLatch.countDown();
-            }
-        });
-
-        kafkaStreams.start();
-        assertThat(
-            "KafkaStreams did not transit to RUNNING state within " + timeoutMs + " milli seconds.",
-            countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS),
-            equalTo(true)
-        );
     }
 
     public static <K, V> List<KeyValue<K, V>> toList(final Iterator<KeyValue<K, V>> iterator) {
@@ -345,7 +320,7 @@ public final class StreamsTestUtils {
             this.topologyMetadata = topologyMetadata;
         }
 
-        public static TopologyMetadataBuilder unamedTopology() {
+        public static TopologyMetadataBuilder unnamedTopology() {
             final TopologyMetadata topologyMetadata = mock(TopologyMetadata.class);
             when(topologyMetadata.isPaused(null)).thenReturn(false);
             return new TopologyMetadataBuilder(topologyMetadata);


### PR DESCRIPTION
The timeouts used for starting up Streams and waiting for the RUNNING state are all over the place across our integration tests, with some as low as 15s (which are unsurprisingly rather flaky). We use 60s as the default timeout for other APIs in the `IntegrationTestUtils` so we should do the same for `#startApplicationAndWaitUntilRunning`

I also noticed that we have several versions of that exact API in `StreamsTestUtils`, so I migrated everyone over to the `IntegrationTestUtils#startApplicationAndWaitUntilRunning` and added a few overloads for ease of use, including one for single KafkaStreams apps and one for using the default timeout