### PR TITLE
KAFKA-14491: [2/N] Refactor RocksDB store open iterator management

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ManagedKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ManagedKeyValueIterator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+/**
+ * A {@link KeyValueIterator} with life-cycle management.
+ */
+public interface ManagedKeyValueIterator<K, V> extends KeyValueIterator<K, V> {
+
+    /**
+     * Sets a close callback to be called when the iterator is closed.
+     */
+    void onClose(Runnable closeCallback);
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBRangeIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBRangeIterator.java
@@ -18,11 +18,9 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.rocksdb.RocksIterator;
 
 import java.util.Comparator;
-import java.util.Set;
 
 class RocksDBRangeIterator extends RocksDbIterator {
     // RocksDB's JNI interface does not expose getters/setters that allow the
@@ -35,12 +33,11 @@ class RocksDBRangeIterator extends RocksDbIterator {
 
     RocksDBRangeIterator(final String storeName,
                          final RocksIterator iter,
-                         final Set<KeyValueIterator<Bytes, byte[]>> openIterators,
                          final Bytes from,
                          final Bytes to,
                          final boolean forward,
                          final boolean toInclusive) {
-        super(storeName, iter, openIterators, forward);
+        super(storeName, iter, forward);
         this.forward = forward;
         this.toInclusive = toInclusive;
         if (forward) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -383,9 +383,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
 
         @Override
         public synchronized void close() {
-            if (closeCallback != null) {
-                closeCallback.run();
+            if (closeCallback == null) {
+                throw new IllegalStateException("RocksDBDualCFIterator expects close callback to be set immediately upon creation");
             }
+            closeCallback.run();
+
             iterNoTimestamp.close();
             iterWithTimestamp.close();
             open = false;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -192,7 +191,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
 
         @Override
-        public KeyValueIterator<Bytes, byte[]> range(final Bytes from,
+        public ManagedKeyValueIterator<Bytes, byte[]> range(final Bytes from,
                                                      final Bytes to,
                                                      final boolean forward) {
             return new RocksDBDualCFRangeIterator(
@@ -222,7 +221,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
 
         @Override
-        public KeyValueIterator<Bytes, byte[]> all(final boolean forward) {
+        public ManagedKeyValueIterator<Bytes, byte[]> all(final boolean forward) {
             final RocksIterator innerIterWithTimestamp = db.newIterator(newColumnFamily);
             final RocksIterator innerIterNoTimestamp = db.newIterator(oldColumnFamily);
             if (forward) {
@@ -236,7 +235,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
 
         @Override
-        public KeyValueIterator<Bytes, byte[]> prefixScan(final Bytes prefix) {
+        public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final Bytes prefix) {
             final Bytes to = Bytes.increment(prefix);
             return new RocksDBDualCFRangeIterator(
                 name,
@@ -282,7 +281,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
     }
 
     private class RocksDBDualCFIterator extends AbstractIterator<KeyValue<Bytes, byte[]>>
-        implements KeyValueIterator<Bytes, byte[]> {
+        implements ManagedKeyValueIterator<Bytes, byte[]> {
 
         // RocksDB's JNI interface does not expose getters/setters that allow the
         // comparator to be pluggable, and the default is lexicographic, so it's
@@ -299,6 +298,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         private byte[] nextWithTimestamp;
         private byte[] nextNoTimestamp;
         private KeyValue<Bytes, byte[]> next;
+        private Runnable closeCallback = null;
 
         RocksDBDualCFIterator(final String storeName,
                               final RocksIterator iterWithTimestamp,
@@ -383,7 +383,9 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
 
         @Override
         public synchronized void close() {
-            openIterators.remove(this);
+            if (closeCallback != null) {
+                closeCallback.run();
+            }
             iterNoTimestamp.close();
             iterWithTimestamp.close();
             open = false;
@@ -395,6 +397,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                 throw new NoSuchElementException();
             }
             return next.key;
+        }
+
+        @Override
+        public void onClose(final Runnable closeCallback) {
+            this.closeCallback = closeCallback;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
@@ -69,9 +69,11 @@ class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implemen
 
     @Override
     public synchronized void close() {
-        if (closeCallback != null) {
-            closeCallback.run();
+        if (closeCallback == null) {
+            throw new IllegalStateException("RocksDbIterator expects close callback to be set immediately upon creation");
         }
+        closeCallback.run();
+
         iter.close();
         open = false;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
@@ -20,31 +20,27 @@ import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.rocksdb.RocksIterator;
 
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.function.Consumer;
 
-class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implements KeyValueIterator<Bytes, byte[]> {
+class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implements ManagedKeyValueIterator<Bytes, byte[]> {
 
     private final String storeName;
     private final RocksIterator iter;
-    private final Set<KeyValueIterator<Bytes, byte[]>> openIterators;
     private final Consumer<RocksIterator> advanceIterator;
 
     private volatile boolean open = true;
 
     private KeyValue<Bytes, byte[]> next;
+    private Runnable closeCallback = null;
 
     RocksDbIterator(final String storeName,
                     final RocksIterator iter,
-                    final Set<KeyValueIterator<Bytes, byte[]>> openIterators,
                     final boolean forward) {
         this.storeName = storeName;
         this.iter = iter;
-        this.openIterators = openIterators;
         this.advanceIterator = forward ? RocksIterator::next : RocksIterator::prev;
     }
 
@@ -73,7 +69,9 @@ class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implemen
 
     @Override
     public synchronized void close() {
-        openIterators.remove(this);
+        if (closeCallback != null) {
+            closeCallback.run();
+        }
         iter.close();
         open = false;
     }
@@ -84,5 +82,10 @@ class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implemen
             throw new NoSuchElementException();
         }
         return next.key;
+    }
+
+    @Override
+    public synchronized void onClose(final Runnable closeCallback) {
+        this.closeCallback = closeCallback;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
@@ -393,6 +393,7 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
+        rocksDBRangeIterator.onClose(() -> {});
         rocksDBRangeIterator.close();
         verify(rocksIterator);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
@@ -393,7 +393,7 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
-        rocksDBRangeIterator.onClose(() -> {});
+        rocksDBRangeIterator.onClose(() -> { });
         rocksDBRangeIterator.close();
         verify(rocksIterator);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.Test;
 import org.rocksdb.RocksIterator;
 
-import java.util.Collections;
 import java.util.NoSuchElementException;
 
 import static org.easymock.EasyMock.mock;
@@ -67,7 +67,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key3Bytes,
             true,
@@ -103,7 +102,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key3Bytes,
             false,
@@ -142,7 +140,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             toBytes,
             true,
@@ -183,7 +180,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key4Bytes,
             false,
@@ -212,7 +208,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key2Bytes,
             true,
@@ -237,7 +232,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             fromBytes,
             toBytes,
             false,
@@ -265,7 +259,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key3Bytes,
             true,
@@ -299,7 +292,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key3Bytes,
             toBytes,
             false,
@@ -331,7 +323,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key3Bytes,
             true,
@@ -369,7 +360,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key3Bytes,
             toBytes,
             false,
@@ -398,7 +388,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key2Bytes,
             true,
@@ -406,6 +395,23 @@ public class RocksDBRangeIteratorTest {
         );
         rocksDBRangeIterator.close();
         verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldCallCloseCallbackOnClose() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
+            storeName,
+            rocksIterator,
+            key1Bytes,
+            key2Bytes,
+            true,
+            true
+        );
+        final AtomicBoolean callbackCalled = new AtomicBoolean(false);
+        rocksDBRangeIterator.onClose(() -> callbackCalled.set(true));
+        rocksDBRangeIterator.close();
+        assertThat(callbackCalled.get(), is(true));
     }
 
     @Test
@@ -425,7 +431,6 @@ public class RocksDBRangeIteratorTest {
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(
             storeName,
             rocksIterator,
-            Collections.emptySet(),
             key1Bytes,
             key2Bytes,
             true,


### PR DESCRIPTION
This PR refactors how the list of open iterators for RocksDB stores is managed. Prior to this PR, the `openIterators` list was passed into the constructor for the iterators themselves, allowing `RocksDbIterator.close()` to remove the iterator from the `openIterators` list. After this PR, the iterators themselves will not know about lists of open iterators. Instead, a generic close callback is exposed, and it's the responsibility of the store that creates a new iterator to set the callback on the iterator, to ensure that closing an iterator removes the iterator from the list of open iterators.

This refactor is desirable because it enables more flexible iterator lifecycle management. Building on top of this, RocksDBStore is updated with an option to allow the user (i.e., the caller of methods such as `range()` and `prefixScan()` which return iterators) to pass a custom `openIterators` list for the new iterator to be stored in. This will allow for a new Segments implementation where multiple Segments can share the same RocksDBStore instance, while having each Segment manage its own open iterators. (See https://github.com/apache/kafka/pull/13143 for more.)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
