### PR TITLE
KAFKA-14491: [3/N] Add logical key value segments

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This "logical segment" is a segment which shares its underlying physical store with other
+ * logical segments. Each segment uses a unique, fixed-length key prefix derived from the
+ * segment ID when writing to the shared physical store. In other words, a logical segment
+ * stores a key into a shared physical store by prepending the key with a prefix (unique to
+ * the specific logical segment), and storing the combined key into the physical store.
+ */
+class LogicalKeyValueSegment implements Comparable<LogicalKeyValueSegment>, Segment {
+    private static final Logger log = LoggerFactory.getLogger(LogicalKeyValueSegment.class);
+
+    public final long id;
+    private final String name;
+    private final RocksDBStore physicalStore;
+    private final PrefixKeyFormatter prefixKeyFormatter;
+
+    final Set<KeyValueIterator<Bytes, byte[]>> openIterators = Collections.synchronizedSet(new HashSet<>());
+
+    LogicalKeyValueSegment(final long id,
+                           final String name,
+                           final RocksDBStore physicalStore) {
+        this.id = id;
+        this.name = name;
+        this.physicalStore = Objects.requireNonNull(physicalStore);
+
+        this.prefixKeyFormatter = new PrefixKeyFormatter(serializeLongToBytes(id));
+    }
+
+    @Override
+    public int compareTo(final LogicalKeyValueSegment segment) {
+        return Long.compare(id, segment.id);
+    }
+
+    @Override
+    public synchronized void destroy() {
+        final Bytes keyPrefix = prefixKeyFormatter.getPrefix();
+
+        // this deleteRange() call deletes all entries with the given prefix, because the
+        // deleteRange() implementation calls Bytes.increment() in order to make keyTo inclusive
+        physicalStore.deleteRange(keyPrefix, keyPrefix);
+    }
+
+    @Override
+    public synchronized void deleteRange(final Bytes keyFrom, final Bytes keyTo) {
+        physicalStore.deleteRange(
+            prefixKeyFormatter.addPrefix(keyFrom),
+            prefixKeyFormatter.addPrefix(keyTo));
+    }
+
+    @Override
+    public synchronized void put(final Bytes key, final byte[] value) {
+        physicalStore.put(
+            prefixKeyFormatter.addPrefix(key),
+            value);
+    }
+
+    @Override
+    public synchronized byte[] putIfAbsent(final Bytes key, final byte[] value) {
+        return physicalStore.putIfAbsent(
+            prefixKeyFormatter.addPrefix(key),
+            value);
+    }
+
+    @Override
+    public synchronized void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+        physicalStore.putAll(entries.stream()
+            .map(kv -> new KeyValue<>(
+                prefixKeyFormatter.addPrefix(kv.key),
+                kv.value))
+            .collect(Collectors.toList()));
+    }
+
+    @Override
+    public synchronized byte[] delete(final Bytes key) {
+        return physicalStore.delete(prefixKeyFormatter.addPrefix(key));
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Deprecated
+    @Override
+    public void init(final ProcessorContext context, final StateStore root) {
+        throw new UnsupportedOperationException("cannot initialize a logical segment");
+    }
+
+    @Override
+    public void flush() {
+        throw new UnsupportedOperationException("nothing to flush for logical segment");
+    }
+
+    @Override
+    public synchronized void close() {
+        // close open iterators
+        final HashSet<KeyValueIterator<Bytes, byte[]>> iterators;
+        synchronized (openIterators) {
+            iterators = new HashSet<>(openIterators);
+            openIterators.clear();
+        }
+        if (iterators.size() != 0) {
+            log.warn("Closing {} open iterators for store {}", iterators.size(), name);
+            for (final KeyValueIterator<Bytes, byte[]> iterator : iterators) {
+                iterator.close();
+            }
+        }
+    }
+
+    @Override
+    public boolean persistent() {
+        return true;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public synchronized byte[] get(final Bytes key) {
+        return physicalStore.get(prefixKeyFormatter.addPrefix(key));
+    }
+
+    @Override
+    public synchronized KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
+        final KeyValueIterator<Bytes, byte[]> iteratorWithKeyPrefixes = physicalStore.range(
+            prefixKeyFormatter.addPrefix(from),
+            prefixKeyFormatter.addPrefix(to),
+            openIterators);
+        return new StrippedPrefixKeyValueIteratorAdapter(
+            iteratorWithKeyPrefixes,
+            prefixKeyFormatter::removePrefix);
+    }
+
+    @Override
+    public synchronized KeyValueIterator<Bytes, byte[]> all() {
+        final KeyValueIterator<Bytes, byte[]> iteratorWithKeyPrefixes = physicalStore.prefixScan(
+            prefixKeyFormatter.getPrefix(),
+            new BytesSerializer(),
+            openIterators);
+        return new StrippedPrefixKeyValueIteratorAdapter(
+            iteratorWithKeyPrefixes,
+            prefixKeyFormatter::removePrefix);
+    }
+
+    @Override
+    public long approximateNumEntries() {
+        throw new UnsupportedOperationException("Cannot estimate num entries for logical segment");
+    }
+
+    @Override
+    public void addToBatch(final KeyValue<byte[], byte[]> record, final WriteBatch batch) throws RocksDBException {
+        physicalStore.addToBatch(
+            new KeyValue<>(
+                prefixKeyFormatter.addPrefix(record.key),
+                record.value),
+            batch);
+    }
+
+    @Override
+    public void write(final WriteBatch batch) throws RocksDBException {
+        // no key transformations here since they should've already been done as part
+        // of adding to the write batch
+        physicalStore.write(batch);
+    }
+
+    /**
+     * Manages translation between raw key and the key to be stored into the physical store.
+     * The key for the physical store is the raw key prepended with a fixed-length prefix.
+     */
+    private static class PrefixKeyFormatter {
+        private final byte[] prefix;
+
+        PrefixKeyFormatter(final byte[] prefix) {
+            this.prefix = prefix;
+        }
+
+        Bytes addPrefix(final Bytes key) {
+            return key == null ? null : Bytes.wrap(addPrefix(key.get()));
+        }
+
+        byte[] addPrefix(final byte[] key) {
+            final byte[] keyWithPrefix = new byte[prefix.length + key.length];
+            System.arraycopy(prefix, 0, keyWithPrefix, 0, prefix.length);
+            System.arraycopy(key, 0, keyWithPrefix, prefix.length, key.length);
+            return keyWithPrefix;
+        }
+
+        Bytes removePrefix(final Bytes keyWithPrefix) {
+            return Bytes.wrap(removePrefix(keyWithPrefix.get()));
+        }
+
+        private byte[] removePrefix(final byte[] keyWithPrefix) {
+            final int rawKeyLength = keyWithPrefix.length - prefix.length;
+            final byte[] rawKey = new byte[rawKeyLength];
+            System.arraycopy(keyWithPrefix, prefix.length, rawKey, 0, rawKeyLength);
+            return rawKey;
+        }
+
+        Bytes getPrefix() {
+            return Bytes.wrap(prefix);
+        }
+    }
+
+    /**
+     * Converts a {@link KeyValueIterator} which returns keys with prefixes to one which
+     * returns un-prefixed keys.
+     */
+    private static class StrippedPrefixKeyValueIteratorAdapter implements KeyValueIterator<Bytes, byte[]> {
+
+        private final KeyValueIterator<Bytes, byte[]> iteratorWithKeyPrefixes;
+        private final Function<Bytes, Bytes> prefixRemover;
+
+        StrippedPrefixKeyValueIteratorAdapter(final KeyValueIterator<Bytes, byte[]> iteratorWithKeyPrefixes,
+                                              final Function<Bytes, Bytes> prefixRemover) {
+            this.iteratorWithKeyPrefixes = iteratorWithKeyPrefixes;
+            this.prefixRemover = prefixRemover;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iteratorWithKeyPrefixes.hasNext();
+        }
+
+        @Override
+        public KeyValue<Bytes, byte[]> next() {
+            final KeyValue<Bytes, byte[]> next = iteratorWithKeyPrefixes.next();
+            return new KeyValue<>(prefixRemover.apply(next.key), next.value);
+        }
+
+        @Override
+        public Bytes peekNextKey() {
+            return prefixRemover.apply(iteratorWithKeyPrefixes.peekNextKey());
+        }
+
+        @Override
+        public void remove() {
+            iteratorWithKeyPrefixes.remove();
+        }
+
+        @Override
+        public void close() {
+            iteratorWithKeyPrefixes.close();
+        }
+    }
+
+    private static byte[] serializeLongToBytes(final long l) {
+        return ByteBuffer.allocate(Long.BYTES).putLong(l).array();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+
+public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSegment> {
+
+    private final RocksDBMetricsRecorder metricsRecorder;
+    private final RocksDBStore physicalStore;
+
+    LogicalKeyValueSegments(final String name,
+                            final String parentDir,
+                            final long retentionPeriod,
+                            final long segmentInterval,
+                            final RocksDBMetricsRecorder metricsRecorder) {
+        super(name, retentionPeriod, segmentInterval);
+        this.metricsRecorder = metricsRecorder;
+        this.physicalStore = new RocksDBStore(name, parentDir, metricsRecorder, false);
+    }
+
+    @Override
+    public LogicalKeyValueSegment getOrCreateSegment(final long segmentId,
+                                                     final ProcessorContext context) {
+        if (segments.containsKey(segmentId)) {
+            return segments.get(segmentId);
+        } else {
+            final LogicalKeyValueSegment newSegment = new LogicalKeyValueSegment(segmentId, segmentName(segmentId), physicalStore);
+
+            if (segments.put(segmentId, newSegment) != null) {
+                throw new IllegalStateException("LogicalKeyValueSegment already exists. Possible concurrent access.");
+            }
+
+            return newSegment;
+        }
+    }
+
+    @Override
+    public void openExisting(final ProcessorContext context, final long streamTime) {
+        metricsRecorder.init(ProcessorContextUtils.getMetricsImpl(context), context.taskId());
+        physicalStore.openDB(context.appConfigs(), context.stateDir());
+    }
+
+    @Override
+    public void flush() {
+        physicalStore.flush();
+    }
+
+    @Override
+    public void close() {
+        // close the logical segments first to close any open iterators
+        super.close();
+        physicalStore.close();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
@@ -122,7 +122,7 @@ public class LogicalKeyValueSegmentTest {
             serializeBytes("other")));
 
         segment1.putAll(segment1Records);
-        segment2.putAll(segment1Records);
+        segment2.putAll(segment2Records);
 
         assertEquals("v1", getAndDeserialize(segment1, "shared"));
         assertEquals("v2", getAndDeserialize(segment2, "shared"));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LogicalKeyValueSegmentTest {
+
+    private static final String STORE_NAME = "physical-rocks";
+    private static final String METRICS_SCOPE = "metrics-scope";
+    private static final String DB_FILE_DIR = "rocksdb";
+    private static final Serializer<String> STRING_SERIALIZER = new StringSerializer();
+    private static final Deserializer<String> STRING_DESERIALIZER = new StringDeserializer();
+
+    private RocksDBStore physicalStore;
+
+    private LogicalKeyValueSegment segment1;
+    private LogicalKeyValueSegment segment2;
+
+    @Before
+    public void setUp() {
+        physicalStore = new RocksDBStore(STORE_NAME, DB_FILE_DIR, new RocksDBMetricsRecorder(METRICS_SCOPE, STORE_NAME), false);
+        physicalStore.init((StateStoreContext) new InternalMockProcessorContext<>(
+            TestUtils.tempDirectory(),
+            Serdes.String(),
+            Serdes.String(),
+            new StreamsConfig(StreamsTestUtils.getStreamsConfig())
+        ), physicalStore);
+
+        segment1 = new LogicalKeyValueSegment(1, "segment-1", physicalStore);
+        segment2 = new LogicalKeyValueSegment(2, "segment-2", physicalStore);
+    }
+
+    @After
+    public void tearDown() {
+        segment1.close();
+        segment2.close();
+        physicalStore.close();
+    }
+
+    @Test
+    public void shouldPut() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("1", "a");
+        final KeyValue<String, String> kv1 = new KeyValue<>("2", "b");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+
+        assertEquals("a", getAndDeserialize(segment1, "1"));
+        assertEquals("b", getAndDeserialize(segment1, "2"));
+        assertEquals("a", getAndDeserialize(segment2, "1"));
+        assertEquals("b", getAndDeserialize(segment2, "2"));
+    }
+
+    @Test
+    public void shouldPutAll() {
+        final List<KeyValue<Bytes, byte[]>> entries = new ArrayList<>();
+        entries.add(new KeyValue<>(
+            new Bytes(STRING_SERIALIZER.serialize(null, "1")),
+            STRING_SERIALIZER.serialize(null, "a")));
+        entries.add(new KeyValue<>(
+            new Bytes(STRING_SERIALIZER.serialize(null, "2")),
+            STRING_SERIALIZER.serialize(null, "b")));
+        entries.add(new KeyValue<>(
+            new Bytes(STRING_SERIALIZER.serialize(null, "3")),
+            STRING_SERIALIZER.serialize(null, "c")));
+
+        segment1.putAll(entries);
+        segment2.putAll(entries);
+
+        assertEquals("a", getAndDeserialize(segment1, "1"));
+        assertEquals("b", getAndDeserialize(segment1, "2"));
+        assertEquals("c", getAndDeserialize(segment1, "3"));
+        assertEquals("a", getAndDeserialize(segment2, "1"));
+        assertEquals("b", getAndDeserialize(segment2, "2"));
+        assertEquals("c", getAndDeserialize(segment2, "3"));
+    }
+
+    @Test
+    public void shouldPutIfAbsent() {
+        final Bytes keyBytes = new Bytes(STRING_SERIALIZER.serialize(null, "one"));
+        final byte[] valueBytes = STRING_SERIALIZER.serialize(null, "A");
+        final byte[] valueBytesUpdate = STRING_SERIALIZER.serialize(null, "B");
+
+        segment1.putIfAbsent(keyBytes, valueBytes);
+        segment1.putIfAbsent(keyBytes, valueBytesUpdate);
+        segment2.putIfAbsent(keyBytes, valueBytesUpdate);
+
+        assertEquals("A", STRING_DESERIALIZER.deserialize(null, segment1.get(keyBytes)));
+        assertEquals("B", STRING_DESERIALIZER.deserialize(null, segment2.get(keyBytes)));
+    }
+
+    @Test
+    public void shouldDelete() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("1", "a");
+        final KeyValue<String, String> kv1 = new KeyValue<>("2", "b");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment1.delete(new Bytes(kv0.key.getBytes(UTF_8)));
+
+        assertNull(segment1.get(new Bytes(kv0.key.getBytes(UTF_8))));
+        assertEquals("b", getAndDeserialize(segment1, "2"));
+        assertEquals("a", getAndDeserialize(segment2, "1"));
+        assertEquals("b", getAndDeserialize(segment2, "2"));
+    }
+
+    @Test
+    public void shouldReturnValuesOnRange() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+        final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
+        final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv2.key.getBytes(UTF_8)), kv2.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kvOther.key.getBytes(UTF_8)), kvOther.value.getBytes(UTF_8));
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(kv0);
+        expectedContents.add(kv1);
+
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(null, new Bytes(STRING_SERIALIZER.serialize(null, "1")))) {
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnAll() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+        final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
+        final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv2.key.getBytes(UTF_8)), kv2.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kvOther.key.getBytes(UTF_8)), kvOther.value.getBytes(UTF_8));
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(kv0);
+        expectedContents.add(kv1);
+        expectedContents.add(kv2);
+
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.all()) {
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldDeleteRange() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+        final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
+        final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv2.key.getBytes(UTF_8)), kv2.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kvOther.key.getBytes(UTF_8)), kvOther.value.getBytes(UTF_8));
+        segment1.deleteRange(new Bytes(kv0.key.getBytes(UTF_8)), new Bytes(kv1.key.getBytes(UTF_8)));
+
+        assertNull(segment1.get(new Bytes(kv0.key.getBytes(UTF_8))));
+        assertNull(segment1.get(new Bytes(kv1.key.getBytes(UTF_8))));
+        assertEquals("two", getAndDeserialize(segment1, "2"));
+        assertEquals("other", getAndDeserialize(segment2, "1"));
+    }
+
+    @Test
+    public void shouldDestroy() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("1", "a");
+        final KeyValue<String, String> kv1 = new KeyValue<>("2", "b");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+
+        segment1.destroy();
+
+        assertEquals("a", getAndDeserialize(segment2, "1"));
+        assertEquals("b", getAndDeserialize(segment2, "2"));
+
+        segment1 = new LogicalKeyValueSegment(1, "segment-1", physicalStore);
+
+        assertNull(segment1.get(new Bytes(kv0.key.getBytes(UTF_8))));
+        assertNull(segment1.get(new Bytes(kv1.key.getBytes(UTF_8))));
+    }
+
+    @Test
+    public void shouldCloseOpenIteratorsWhenStoreClosed() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+
+        segment1.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment1.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv0.key.getBytes(UTF_8)), kv0.value.getBytes(UTF_8));
+        segment2.put(new Bytes(kv1.key.getBytes(UTF_8)), kv1.value.getBytes(UTF_8));
+
+        final KeyValueIterator<Bytes, byte[]> range1 = segment1.range(null, new Bytes(STRING_SERIALIZER.serialize(null, "1")));
+        final KeyValueIterator<Bytes, byte[]> all1 = segment1.all();
+        final KeyValueIterator<Bytes, byte[]> range2 = segment2.range(null, new Bytes(STRING_SERIALIZER.serialize(null, "1")));
+
+        assertTrue(range1.hasNext());
+        assertTrue(all1.hasNext());
+        assertTrue(range2.hasNext());
+
+        segment1.close();
+
+        assertThrows(InvalidStateStoreException.class, range1::hasNext);
+        assertThrows(InvalidStateStoreException.class, all1::hasNext);
+        assertTrue(range2.hasNext());
+    }
+
+    private static String getAndDeserialize(final LogicalKeyValueSegment segment, final String key) {
+        return STRING_DESERIALIZER.deserialize(null, segment.get(new Bytes(STRING_SERIALIZER.serialize(null, key))));
+    }
+
+    private static List<KeyValue<String, String>> getDeserializedList(final KeyValueIterator<Bytes, byte[]> iter) {
+        final List<KeyValue<Bytes, byte[]>> bytes = Utils.toList(iter);
+        return bytes.stream().map(kv -> new KeyValue<>(kv.key.toString(), STRING_DESERIALIZER.deserialize(null, kv.value))).collect(Collectors.toList());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
@@ -57,6 +57,7 @@ public class LogicalKeyValueSegmentTest {
 
     private LogicalKeyValueSegment segment1;
     private LogicalKeyValueSegment segment2;
+    private LogicalKeyValueSegment segment3;
 
     @Before
     public void setUp() {
@@ -70,12 +71,14 @@ public class LogicalKeyValueSegmentTest {
 
         segment1 = new LogicalKeyValueSegment(1, "segment-1", physicalStore);
         segment2 = new LogicalKeyValueSegment(2, "segment-2", physicalStore);
+        segment3 = new LogicalKeyValueSegment(3, "segment-3", physicalStore);
     }
 
     @After
     public void tearDown() {
         segment1.close();
         segment2.close();
+        segment3.close();
         physicalStore.close();
     }
 
@@ -157,13 +160,14 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
         final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
 
-        segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
-        segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment1.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
-        segment2.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment2.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment2.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        segment2.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment1.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment3.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
 
         // non-null bounds
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("1")), new Bytes(serializeBytes("2")))) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(new Bytes(serializeBytes("1")), new Bytes(serializeBytes("2")))) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv1);
             expectedContents.add(kv2);
@@ -171,7 +175,7 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null lower bound
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(null, new Bytes(serializeBytes("1")))) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(null, new Bytes(serializeBytes("1")))) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);
@@ -179,7 +183,7 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null upper bound
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(new Bytes(serializeBytes("0")), null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);
@@ -188,7 +192,7 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null upper and lower bounds
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(new Bytes(serializeBytes("0")), null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
@@ -65,7 +65,7 @@ public class LogicalKeyValueSegmentsTest {
             SEGMENT_INTERVAL,
             new RocksDBMetricsRecorder(METRICS_SCOPE, STORE_NAME)
         );
-        segments.openExisting(context, -1L);
+        segments.openExisting(context, 0L);
     }
 
     @After
@@ -83,9 +83,9 @@ public class LogicalKeyValueSegmentsTest {
 
     @Test
     public void shouldCreateSegments() {
-        final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(0, context, -1L);
-        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(1, context, -1L);
-        final LogicalKeyValueSegment segment3 = segments.getOrCreateSegmentIfLive(2, context, -1L);
+        final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(0, context, 0L);
+        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(1, context, SEGMENT_INTERVAL);
+        final LogicalKeyValueSegment segment3 = segments.getOrCreateSegmentIfLive(2, context, 2 * SEGMENT_INTERVAL);
 
         final File rocksdbDir = new File(new File(context.stateDir(), DB_FILE_DIR), STORE_NAME);
         assertTrue(rocksdbDir.isDirectory());
@@ -116,9 +116,13 @@ public class LogicalKeyValueSegmentsTest {
 
     @Test
     public void shouldGetSegmentForTimestamp() {
-        final LogicalKeyValueSegment segment = segments.getOrCreateSegmentIfLive(0, context, -1L);
-        segments.getOrCreateSegmentIfLive(1, context, -1L);
-        assertEquals(segment, segments.getSegmentForTimestamp(0L));
+        final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(0, context, 0L);
+        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(1, context, SEGMENT_INTERVAL);
+
+        assertEquals(segment1, segments.getSegmentForTimestamp(0L));
+        assertEquals(segment1, segments.getSegmentForTimestamp(SEGMENT_INTERVAL - 1));
+        assertEquals(segment2, segments.getSegmentForTimestamp(SEGMENT_INTERVAL));
+        assertEquals(segment2, segments.getSegmentForTimestamp(2 * SEGMENT_INTERVAL - 1));
     }
 
     @Test
@@ -155,7 +159,7 @@ public class LogicalKeyValueSegmentsTest {
 
     @Test
     public void shouldClearSegmentsOnClose() {
-        segments.getOrCreateSegmentIfLive(0, context, -1L);
+        segments.getOrCreateSegmentIfLive(0, context, 0L);
         segments.close();
         assertThat(segments.getSegmentForTimestamp(0), is(nullValue()));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockRecordCollector;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LogicalKeyValueSegmentsTest {
+
+    private static final long SEGMENT_INTERVAL = 100L;
+    private static final long RETENTION_PERIOD = 4 * SEGMENT_INTERVAL;
+    private static final String STORE_NAME = "logical-segments";
+    private static final String METRICS_SCOPE = "metrics-scope";
+    private static final String DB_FILE_DIR = "rocksdb";
+
+    private InternalMockProcessorContext context;
+
+    private LogicalKeyValueSegments segments;
+
+    @Before
+    public void setUp() {
+        context = new InternalMockProcessorContext<>(
+            TestUtils.tempDirectory(),
+            Serdes.String(),
+            Serdes.Long(),
+            new MockRecordCollector(),
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
+        );
+        segments = new LogicalKeyValueSegments(
+            STORE_NAME,
+            DB_FILE_DIR,
+            RETENTION_PERIOD,
+            SEGMENT_INTERVAL,
+            new RocksDBMetricsRecorder(METRICS_SCOPE, STORE_NAME)
+        );
+        segments.openExisting(context, -1L);
+    }
+
+    @After
+    public void tearDown() {
+        segments.close();
+    }
+
+    @Test
+    public void shouldGetSegmentIdsFromTimestamp() {
+        assertEquals(0, segments.segmentId(0));
+        assertEquals(1, segments.segmentId(SEGMENT_INTERVAL));
+        assertEquals(2, segments.segmentId(2 * SEGMENT_INTERVAL));
+        assertEquals(3, segments.segmentId(3 * SEGMENT_INTERVAL));
+    }
+
+    @Test
+    public void shouldCreateSegments() {
+        final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(1, context, -1L);
+        final LogicalKeyValueSegment segment3 = segments.getOrCreateSegmentIfLive(2, context, -1L);
+
+        final File rocksdbDir = new File(new File(context.stateDir(), DB_FILE_DIR), STORE_NAME);
+        assertTrue(rocksdbDir.isDirectory());
+
+        assertTrue(segment1.isOpen());
+        assertTrue(segment2.isOpen());
+        assertTrue(segment3.isOpen());
+    }
+
+    @Test
+    public void shouldNotCreateSegmentThatIsAlreadyExpired() {
+        final long streamTime = updateStreamTimeAndCreateSegment(7);
+        assertNull(segments.getOrCreateSegmentIfLive(0, context, streamTime));
+    }
+
+    @Test
+    public void shouldCleanupSegmentsThatHaveExpired() {
+        final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(0, context, 0);
+        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(0, context, SEGMENT_INTERVAL * 2L);
+        final LogicalKeyValueSegment segment3 = segments.getOrCreateSegmentIfLive(3, context, SEGMENT_INTERVAL * 3L);
+        final LogicalKeyValueSegment segment4 = segments.getOrCreateSegmentIfLive(7, context, SEGMENT_INTERVAL * 7L);
+
+        final List<LogicalKeyValueSegment> allSegments = segments.allSegments(true);
+        assertEquals(2, allSegments.size());
+        assertEquals(segment3, allSegments.get(0));
+        assertEquals(segment4, allSegments.get(1));
+    }
+
+    @Test
+    public void shouldGetSegmentForTimestamp() {
+        final LogicalKeyValueSegment segment = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        segments.getOrCreateSegmentIfLive(1, context, -1L);
+        assertEquals(segment, segments.getSegmentForTimestamp(0L));
+    }
+
+    @Test
+    public void shouldGetSegmentsWithinTimeRange() {
+        final long streamTime = updateStreamTimeAndCreateSegment(4);
+        segments.getOrCreateSegmentIfLive(0, context, streamTime);
+        segments.getOrCreateSegmentIfLive(2, context, streamTime);
+        segments.getOrCreateSegmentIfLive(1, context, streamTime); // intentionally out of order for test
+        segments.getOrCreateSegmentIfLive(3, context, streamTime);
+        segments.getOrCreateSegmentIfLive(4, context, streamTime);
+
+        final List<LogicalKeyValueSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
+        assertEquals(3, segments.size());
+        assertEquals(0, segments.get(0).id);
+        assertEquals(1, segments.get(1).id);
+        assertEquals(2, segments.get(2).id);
+    }
+
+    @Test
+    public void shouldGetSegmentsWithinBackwardTimeRange() {
+        final long streamTime = updateStreamTimeAndCreateSegment(4);
+        segments.getOrCreateSegmentIfLive(0, context, streamTime);
+        segments.getOrCreateSegmentIfLive(2, context, streamTime);
+        segments.getOrCreateSegmentIfLive(1, context, streamTime); // intentionally out of order for test
+        segments.getOrCreateSegmentIfLive(3, context, streamTime);
+        segments.getOrCreateSegmentIfLive(4, context, streamTime);
+
+        final List<LogicalKeyValueSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, false);
+        assertEquals(3, segments.size());
+        assertEquals(2, segments.get(0).id);
+        assertEquals(1, segments.get(1).id);
+        assertEquals(0, segments.get(2).id);
+    }
+
+    @Test
+    public void shouldClearSegmentsOnClose() {
+        segments.getOrCreateSegmentIfLive(0, context, -1L);
+        segments.close();
+        assertThat(segments.getSegmentForTimestamp(0), is(nullValue()));
+    }
+
+    private long updateStreamTimeAndCreateSegment(final int segment) {
+        final long streamTime = SEGMENT_INTERVAL * segment;
+        segments.getOrCreateSegmentIfLive(segment, context, streamTime);
+        return streamTime;
+    }
+}


### PR DESCRIPTION
Today's KeyValueSegments create a new RocksDB instance for each KeyValueSegment. This PR introduces an analogous LogicalKeyValueSegments implementation, with corresponding LogicalKeyValueSegment, which shares a single physical RocksDB instance across all "logical" segments. This will be used for the RocksDB versioned store implementation proposed in [KIP-889](https://cwiki.apache.org/confluence/display/KAFKA/KIP-889%3A+Versioned+State+Stores).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
