### PR TITLE
MINOR: Remove duplicate empty string check

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/SimpleHeaderConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/SimpleHeaderConverter.java
@@ -58,9 +58,6 @@ public class SimpleHeaderConverter implements HeaderConverter {
         }
         try {
             String str = new String(value, UTF_8);
-            if (str.isEmpty()) {
-                return new SchemaAndValue(Schema.STRING_SCHEMA, str);
-            }
             return Values.parseString(str);
         } catch (NoSuchElementException e) {
             throw new DataException("Failed to deserialize value for header '" + headerKey + "' on topic '" + topic + "'", e);


### PR DESCRIPTION
`Values.parseString()` handles empty strings and returns the same `SchemaAndValue` [[0]](https://github.com/apache/kafka/blob/trunk/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java#L383-L389) so we don't need to do the check in `toConnectHeader()`. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
