### PR TITLE
KIP-991 Add deletedConnector flag when stopping tasks

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/Task.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/Task.java
@@ -49,4 +49,17 @@ public interface Task {
      * Stop this task.
      */
     void stop();
+
+    /**
+     * Stop this task, while also indicating that the task is being stopped because the connector was
+     * deleted.
+     * <p>
+     * Tasks are not required to override this method, unless they need to perform additional cleanup
+     * actions in cases where the connector has been deleted.
+     *
+     * @param deletedConnector indicates if the connector has been deleted.
+     */
+    default void stop(boolean deletedConnector) {
+        stop();
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -311,7 +311,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
     @Override
     protected void close() {
         if (started) {
-            Utils.closeQuietly(task::stop, "source task");
+            Utils.closeQuietly(() -> task.stop(isDeletedConnector()), "source task");
         }
 
         closeProducer(Duration.ofSeconds(30));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -175,7 +175,7 @@ class WorkerSinkTask extends WorkerTask {
         // FIXME Kafka needs to add a timeout parameter here for us to properly obey the timeout
         // passed in
         try {
-            task.stop();
+            task.stop(isDeletedConnector());
         } catch (Throwable t) {
             log.warn("Could not stop task", t);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1947,8 +1947,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     private Callable<Void> getTaskStoppingCallable(final ConnectorTaskId taskId) {
+        return getTaskStoppingCallable(taskId, false);
+    }
+
+    private Callable<Void> getTaskStoppingCallable(final ConnectorTaskId taskId, boolean deletedConnector) {
         return () -> {
-            worker.stopAndAwaitTask(taskId);
+            worker.stopAndAwaitTask(taskId, deletedConnector);
             return null;
         };
     }
@@ -2565,7 +2569,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // this would avoid having to close a connection and then reopen it when the task is assigned back to this
                 // worker again.
                 for (final ConnectorTaskId taskId : tasks) {
-                    callables.add(getTaskStoppingCallable(taskId));
+                    callables.add(getTaskStoppingCallable(taskId, !configState.contains(taskId.connector())));
                 }
 
                 // The actual timeout for graceful task/connector stop is applied in worker's

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -243,7 +243,7 @@ public class ErrorHandlingTaskTest {
         // verify if invocation happened exactly 1 time
         verifyInitializeSink();
         verify(reporter).close();
-        verify(sinkTask).stop();
+        verify(sinkTask).stop(false);
         verify(consumer).close();
         verify(headerConverter).close();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -1157,7 +1157,7 @@ public class ExactlyOnceWorkerSourceTaskTest {
         verify(headerConverter).close();
 
         if (taskStarted) {
-            verify(sourceTask).stop();
+            verify(sourceTask).stop(false);
         }
 
         if (taskFailed) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -346,7 +346,7 @@ public class WorkerSinkTaskTest {
         // WorkerSinkTask::stop
         consumer.wakeup();
         PowerMock.expectLastCall();
-        sinkTask.stop();
+        sinkTask.stop(false);
         PowerMock.expectLastCall();
 
         EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -809,7 +809,7 @@ public class WorkerTest {
 
         // Called when we stop the worker
         verify(instantiatedTask).loader();
-        verify(instantiatedTask).stop();
+        verify(instantiatedTask).stop(false);
         verifyTaskConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG);
         verifyTaskConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG);
         verifyTaskHeaderConverter();
@@ -908,7 +908,7 @@ public class WorkerTest {
         WorkerSourceTask constructedMockTask = sourceTaskMockedConstruction.constructed().get(0);
         verify(constructedMockTask).initialize(taskConfig);
         verify(constructedMockTask).loader();
-        verify(constructedMockTask).stop();
+        verify(constructedMockTask).stop(false);
         verify(constructedMockTask).awaitStop(anyLong());
         verify(constructedMockTask).removeMetrics();
         verifyKafkaClusterId();
@@ -961,7 +961,7 @@ public class WorkerTest {
         verify(instantiatedTask).initialize(taskConfig);
 
         // Remove
-        verify(instantiatedTask).stop();
+        verify(instantiatedTask).stop(false);
         verify(instantiatedTask).awaitStop(anyLong());
         verify(instantiatedTask).removeMetrics();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -349,7 +349,7 @@ public class StandaloneHerderTest {
         taskConfigs.put("k", "v");
         EasyMock.expect(worker.connectorTaskConfigs(CONNECTOR_NAME, new SourceConnectorConfig(plugins, config, true))).andReturn(Collections.singletonList(taskConfigs));
 
-        worker.stopAndAwaitTasks(Collections.singletonList(taskId));
+        worker.stopAndAwaitTasks(Collections.singletonList(taskId), false);
         EasyMock.expectLastCall();
         statusBackingStore.put(new TaskStatus(new ConnectorTaskId(CONNECTOR_NAME, 0), AbstractStatus.State.DESTROYED, WORKER_ID, 0));
         EasyMock.expectLastCall();
@@ -1182,15 +1182,19 @@ public class StandaloneHerderTest {
     }
 
     private void expectStop() {
+        expectStop(false);
+    }
+
+    private void expectStop(boolean deletedConnector) {
         ConnectorTaskId task = new ConnectorTaskId(CONNECTOR_NAME, 0);
-        worker.stopAndAwaitTasks(singletonList(task));
+        worker.stopAndAwaitTasks(singletonList(task), deletedConnector);
         EasyMock.expectLastCall();
         worker.stopAndAwaitConnector(CONNECTOR_NAME);
         EasyMock.expectLastCall();
     }
 
     private void expectDestroy() {
-        expectStop();
+        expectStop(true);
     }
 
     private static Map<String, String> connectorConfig(SourceSink sourceSink) {


### PR DESCRIPTION
Companion PR for [KIP-901: Add flag connectorDeleted flag when stopping task](https://cwiki.apache.org/confluence/display/KAFKA/KIP-901%3A+Add+flag+connectorDeleted+flag+when+stopping+task)
This PR:

* Introduces a new `default void stop(boolean deletedConnector)` method to the `connect.connector.Task` interface, to indicate that a task is being stopped due to the connector being deleted.
* Patches the existing unit test, and introduces a new test case to validate the new logic

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
