### PR TITLE
KAFKA-14645: Use plugin classloader when retrieving connector plugin config definitions

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -795,12 +795,18 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public List<ConfigKeyInfo> connectorPluginConfig(String pluginName) {
-        List<ConfigKeyInfo> results = new ArrayList<>();
-        ConfigDef configDefs;
+        Plugins p = plugins();
+        Class<?> pluginClass;
         try {
-            Plugins p = plugins();
+            pluginClass = p.pluginClass(pluginName);
+        } catch (ClassNotFoundException cnfe) {
+            throw new NotFoundException("Unknown plugin " + pluginName + ".");
+        }
+
+        try (LoaderSwap loaderSwap = p.withClassLoader(pluginClass.getClassLoader())) {
             Object plugin = p.newPlugin(pluginName);
             PluginType pluginType = PluginType.from(plugin.getClass());
+            ConfigDef configDefs;
             switch (pluginType) {
                 case SINK:
                 case SOURCE:
@@ -821,13 +827,14 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                 default:
                     throw new BadRequestException("Invalid plugin type " + pluginType + ". Valid types are sink, source, converter, header_converter, transformation, predicate.");
             }
-        } catch (ClassNotFoundException cnfe) {
-            throw new NotFoundException("Unknown plugin " + pluginName + ".");
+            List<ConfigKeyInfo> results = new ArrayList<>();
+            for (ConfigDef.ConfigKey configKey : configDefs.configKeys().values()) {
+                results.add(AbstractHerder.convertConfigKey(configKey));
+            }
+            return results;
+        } catch (ClassNotFoundException e) {
+            throw new ConnectException("Failed to load plugin class or one of its dependencies", e);
         }
-        for (ConfigDef.ConfigKey configKey : configDefs.configKeys().values()) {
-            results.add(AbstractHerder.convertConfigKey(configKey));
-        }
-        return results;
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -123,6 +123,10 @@ public class Plugins {
         );
     }
 
+    public Class<?> pluginClass(String classOrAlias) throws ClassNotFoundException {
+        return pluginClass(delegatingLoader, classOrAlias, Object.class);
+    }
+
     public static ClassLoader compareAndSwapLoaders(ClassLoader loader) {
         ClassLoader current = Thread.currentThread().getContextClassLoader();
         if (!current.equals(loader)) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -930,6 +930,7 @@ public class AbstractHerderTest {
 
         ConfigDef expectedConfig = pluginConfig.apply(newPluginInstance.get());
         assertEquals(expectedConfig.names().size(), configs.size());
+        // Make sure that we used the correct class loader when interacting with the plugin
         verify(plugins).withClassLoader(newPluginInstance.get().getClass().getClassLoader());
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -946,7 +946,7 @@ public class AbstractHerderTest {
     }
 
     @Test(expected = BadRequestException.class)
-    @SuppressWarnings({"rawTypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void testGetConnectorConfigDefWithInvalidPluginType() throws Exception {
         String connName = "AnotherPlugin";
         AbstractHerder herder = mock(AbstractHerder.class, withSettings()


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14645)

If we don't switch to the classloader of a plugin before loading or using its `ConfigDef`, then classloading bugs can appear for, e.g., properties with the `CLASS` type. See https://github.com/kcctl/kcctl/issues/266 for an instance of this kind of bug.

This PR adds a classloader swap in the part of the code base that's responsible for servicing requests to the `GET /connector-plugins/<type>/config` endpoint.

The existing monolithic unit test for this logic is broken out into dedicated individual unit tests for each kind of connector plugin; this is done to avoid having to reset expectations on the mocked `Plugins` object when verifying calls to `withClassLoader`, since in the unit testing environment the same classloader may be used for multiple different plugin types.