### PR TITLE
MINOR: Remove unnecessary asCollection causing eager dependency resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2735,7 +2735,7 @@ project(':connect:runtime') {
   task genConnectOpenAPIDocs(type: io.swagger.v3.plugins.gradle.tasks.ResolveTask, dependsOn: setVersionInOpenAPISpec) {
     classpath = sourceSets.main.runtimeClasspath
 
-    buildClasspath = classpath + configurations.swagger.asCollection()
+    buildClasspath = classpath + configurations.swagger
     outputFileName = 'connect_rest'
     outputFormat = 'YAML'
     prettyPrint = 'TRUE'


### PR DESCRIPTION
The call to `asCollection()` causes several configurations to be resolved eagerly, and potentially unnecessarily. Dropping `asCollection()` ensures the configurations are only resolved when they are needed.

Before: https://scans.gradle.com/s/ivl2vfw2sq252/performance/dependency-resolution#dependency-resolution-configuration-user-initiated
After: https://scans.gradle.com/s/uxkjpjvylz6qw/performance/dependency-resolution#dependency-resolution-configuration-user-initiated

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
