### PR TITLE
MINOR: startup timeouts for KRaft integration tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Time.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Time.java
@@ -17,7 +17,10 @@
 package org.apache.kafka.common.utils;
 
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 /**
@@ -86,4 +89,30 @@ public interface Time {
         return timer(timeout.toMillis());
     }
 
+    /**
+     * Wait for a future to complete, or time out.
+     *
+     * @param future        The future to wait for.
+     * @param deadlineNs    The time in the future, in monotonic nanoseconds, to time out.
+     * @return              The result of the future.
+     * @param <T>           The type of the future.
+     */
+    default <T> T waitForFuture(
+        CompletableFuture<T> future,
+        long deadlineNs
+    ) throws TimeoutException, InterruptedException, ExecutionException  {
+        TimeoutException timeoutException = null;
+        while (true) {
+            long nowNs = nanoseconds();
+            if (deadlineNs <= nowNs) {
+                throw (timeoutException == null) ? new TimeoutException() : timeoutException;
+            }
+            long deltaNs = deadlineNs - nowNs;
+            try {
+                return future.get(deltaNs, TimeUnit.NANOSECONDS);
+            } catch (TimeoutException t) {
+                timeoutException = t;
+            }
+        }
+    }
 }

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -44,6 +44,7 @@ import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.ApiMessageAndVersion
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.policy.{AlterConfigPolicy, CreateTopicPolicy}
+import org.apache.kafka.server.util.FutureUtils
 
 import java.util.OptionalLong
 import java.util.concurrent.locks.ReentrantLock
@@ -128,6 +129,8 @@ class ControllerServer(
 
   def startup(): Unit = {
     if (!maybeChangeStatus(SHUTDOWN, STARTING)) return
+    val startupDeadlineNs = FutureUtils.getDeadlineNsFromDelayMs(time.nanoseconds(),
+      config.controllerServerMaxStartupTimeMs)
     try {
       info("Starting controller")
       config.dynamicConfig.initialize(zkClientOpt = None)
@@ -192,7 +195,11 @@ class ControllerServer(
       alterConfigPolicy = Option(config.
         getConfiguredInstance(AlterConfigPolicyClassNameProp, classOf[AlterConfigPolicy]))
 
-      val controllerNodes = RaftConfig.voterConnectionsToNodes(sharedServer.controllerQuorumVotersFuture.get())
+      val voterConnections = FutureUtils.waitWithLogging(logger.underlying,
+        "controller quorum voters future",
+        sharedServer.controllerQuorumVotersFuture,
+        startupDeadlineNs, time)
+      val controllerNodes = RaftConfig.voterConnectionsToNodes(voterConnections)
       val quorumFeatures = QuorumFeatures.create(config.nodeId,
         sharedServer.raftManager.apiVersions,
         QuorumFeatures.defaultFeatureMap(),
@@ -291,13 +298,10 @@ class ControllerServer(
        * and KIP-801 for details.
        */
       socketServer.enableRequestProcessing(authorizerFutures)
+
       // Block here until all the authorizer futures are complete
-      try {
-        CompletableFuture.allOf(authorizerFutures.values.toSeq: _*).join()
-      } catch {
-        case t: Throwable => throw new RuntimeException("Received a fatal error while " +
-          "waiting for all of the authorizer futures to be completed.", t)
-      }
+      FutureUtils.waitWithLogging(logger.underlying, "all of the authorizer futures to be completed",
+        CompletableFuture.allOf(authorizerFutures.values.toSeq: _*), startupDeadlineNs, time)
     } catch {
       case e: Throwable =>
         maybeChangeStatus(STARTING, STARTED)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -89,6 +89,8 @@ object Defaults {
 
   /** KRaft mode configs */
   val EmptyNodeId: Int = -1
+  val BrokerServerMaxStartupTimeMs = Long.MaxValue
+  val ControllerServerMaxStartupTimeMs = Long.MaxValue
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""
@@ -376,6 +378,8 @@ object KafkaConfig {
   val MetadataMaxRetentionMillisProp = "metadata.max.retention.ms"
   val QuorumVotersProp = RaftConfig.QUORUM_VOTERS_CONFIG
   val MetadataMaxIdleIntervalMsProp = "metadata.max.idle.interval.ms"
+  val BrokerServerMaxStartupTimeMs = "broker.server.max.startup.time.ms"
+  val ControllerServerMaxStartupTimeMs = "controller.server.max.startup.time.ms"
 
   /** ZK to KRaft Migration configs */
   val MigrationEnabledProp = "zookeeper.metadata.migration.enable"
@@ -713,6 +717,10 @@ object KafkaConfig {
   val SaslMechanismControllerProtocolDoc = "SASL mechanism used for communication with controllers. Default is GSSAPI."
   val MetadataLogSegmentBytesDoc = "The maximum size of a single metadata log file."
   val MetadataLogSegmentMinBytesDoc = "Override the minimum size for a single metadata log file. This should be used for testing only."
+  val BrokerServerMaxStartupTimeMsDoc = "The maximum number of milliseconds we will wait for the BrokerServer to come up. " +
+  "By default there is no limit. This should be used for testing only."
+  val ControllerServerMaxStartupTimeMsDoc = "The maximum number of milliseconds we will wait for the ControllerServer to come up. " +
+  "By default there is no limit. This should be used for testing only."
 
   val MetadataLogSegmentMillisDoc = "The maximum time before a new metadata log file is rolled out (in milliseconds)."
   val MetadataMaxRetentionBytesDoc = "The maximum combined size of the metadata log and snapshots before deleting old " +
@@ -1086,7 +1094,7 @@ object KafkaConfig {
   val PasswordEncoderIterationsDoc =  "The iteration count used for encoding dynamically configured passwords."
 
   @nowarn("cat=deprecation")
-  private[server] val configDef = {
+  val configDef = {
     import ConfigDef.Importance._
     import ConfigDef.Range._
     import ConfigDef.Type._
@@ -1135,10 +1143,6 @@ object KafkaConfig {
        */
       .define(MetadataSnapshotMaxNewRecordBytesProp, LONG, Defaults.MetadataSnapshotMaxNewRecordBytes, atLeast(1), HIGH, MetadataSnapshotMaxNewRecordBytesDoc)
       .define(MetadataSnapshotMaxIntervalMsProp, LONG, Defaults.MetadataSnapshotMaxIntervalMs, atLeast(0), HIGH, MetadataSnapshotMaxIntervalMsDoc)
-
-      /*
-       * KRaft mode private configs. Note that these configs are defined as internal. We will make them public in the 3.0.0 release.
-       */
       .define(ProcessRolesProp, LIST, Collections.emptyList(), ValidList.in("broker", "controller"), HIGH, ProcessRolesDoc)
       .define(NodeIdProp, INT, Defaults.EmptyNodeId, null, HIGH, NodeIdDoc)
       .define(InitialBrokerRegistrationTimeoutMsProp, INT, Defaults.InitialBrokerRegistrationTimeoutMs, null, MEDIUM, InitialBrokerRegistrationTimeoutMsDoc)
@@ -1153,6 +1157,8 @@ object KafkaConfig {
       .define(MetadataMaxRetentionBytesProp, LONG, Defaults.MetadataMaxRetentionBytes, null, HIGH, MetadataMaxRetentionBytesDoc)
       .define(MetadataMaxRetentionMillisProp, LONG, LogConfig.DEFAULT_RETENTION_MS, null, HIGH, MetadataMaxRetentionMillisDoc)
       .define(MetadataMaxIdleIntervalMsProp, INT, Defaults.MetadataMaxIdleIntervalMs, atLeast(0), LOW, MetadataMaxIdleIntervalMsDoc)
+      .defineInternal(BrokerServerMaxStartupTimeMs, LONG, Defaults.BrokerServerMaxStartupTimeMs, atLeast(0), MEDIUM, BrokerServerMaxStartupTimeMsDoc)
+      .defineInternal(ControllerServerMaxStartupTimeMs, LONG, Defaults.ControllerServerMaxStartupTimeMs, atLeast(0),MEDIUM, ControllerServerMaxStartupTimeMsDoc)
       .define(MigrationEnabledProp, BOOLEAN, false, HIGH, "Enable ZK to KRaft migration")
 
       /************* Authorizer Configuration ***********/
@@ -1660,6 +1666,8 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   def metadataLogSegmentMillis = getLong(KafkaConfig.MetadataLogSegmentMillisProp)
   def metadataRetentionBytes = getLong(KafkaConfig.MetadataMaxRetentionBytesProp)
   def metadataRetentionMillis = getLong(KafkaConfig.MetadataMaxRetentionMillisProp)
+  val brokerServerMaxStartupTimeMs = getLong(KafkaConfig.BrokerServerMaxStartupTimeMs)
+  val controllerServerMaxStartupTimeMs = getLong(KafkaConfig.ControllerServerMaxStartupTimeMs)
 
   def numNetworkThreads = getInt(KafkaConfig.NumNetworkThreadsProp)
   def backgroundThreads = getInt(KafkaConfig.BackgroundThreadsProp)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -89,8 +89,7 @@ object Defaults {
 
   /** KRaft mode configs */
   val EmptyNodeId: Int = -1
-  val BrokerServerMaxStartupTimeMs = Long.MaxValue
-  val ControllerServerMaxStartupTimeMs = Long.MaxValue
+  val ServerMaxStartupTimeMs = Long.MaxValue
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""
@@ -378,8 +377,7 @@ object KafkaConfig {
   val MetadataMaxRetentionMillisProp = "metadata.max.retention.ms"
   val QuorumVotersProp = RaftConfig.QUORUM_VOTERS_CONFIG
   val MetadataMaxIdleIntervalMsProp = "metadata.max.idle.interval.ms"
-  val BrokerServerMaxStartupTimeMs = "broker.server.max.startup.time.ms"
-  val ControllerServerMaxStartupTimeMs = "controller.server.max.startup.time.ms"
+  val ServerMaxStartupTimeMsProp = "server.max.startup.time.ms"
 
   /** ZK to KRaft Migration configs */
   val MigrationEnabledProp = "zookeeper.metadata.migration.enable"
@@ -717,9 +715,7 @@ object KafkaConfig {
   val SaslMechanismControllerProtocolDoc = "SASL mechanism used for communication with controllers. Default is GSSAPI."
   val MetadataLogSegmentBytesDoc = "The maximum size of a single metadata log file."
   val MetadataLogSegmentMinBytesDoc = "Override the minimum size for a single metadata log file. This should be used for testing only."
-  val BrokerServerMaxStartupTimeMsDoc = "The maximum number of milliseconds we will wait for the BrokerServer to come up. " +
-  "By default there is no limit. This should be used for testing only."
-  val ControllerServerMaxStartupTimeMsDoc = "The maximum number of milliseconds we will wait for the ControllerServer to come up. " +
+  val ServerMaxStartupTimeMsDoc = "The maximum number of milliseconds we will wait for the server to come up. " +
   "By default there is no limit. This should be used for testing only."
 
   val MetadataLogSegmentMillisDoc = "The maximum time before a new metadata log file is rolled out (in milliseconds)."
@@ -1157,8 +1153,7 @@ object KafkaConfig {
       .define(MetadataMaxRetentionBytesProp, LONG, Defaults.MetadataMaxRetentionBytes, null, HIGH, MetadataMaxRetentionBytesDoc)
       .define(MetadataMaxRetentionMillisProp, LONG, LogConfig.DEFAULT_RETENTION_MS, null, HIGH, MetadataMaxRetentionMillisDoc)
       .define(MetadataMaxIdleIntervalMsProp, INT, Defaults.MetadataMaxIdleIntervalMs, atLeast(0), LOW, MetadataMaxIdleIntervalMsDoc)
-      .defineInternal(BrokerServerMaxStartupTimeMs, LONG, Defaults.BrokerServerMaxStartupTimeMs, atLeast(0), MEDIUM, BrokerServerMaxStartupTimeMsDoc)
-      .defineInternal(ControllerServerMaxStartupTimeMs, LONG, Defaults.ControllerServerMaxStartupTimeMs, atLeast(0),MEDIUM, ControllerServerMaxStartupTimeMsDoc)
+      .defineInternal(ServerMaxStartupTimeMsProp, LONG, Defaults.ServerMaxStartupTimeMs, atLeast(0), MEDIUM, ServerMaxStartupTimeMsDoc)
       .define(MigrationEnabledProp, BOOLEAN, false, HIGH, "Enable ZK to KRaft migration")
 
       /************* Authorizer Configuration ***********/
@@ -1666,8 +1661,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   def metadataLogSegmentMillis = getLong(KafkaConfig.MetadataLogSegmentMillisProp)
   def metadataRetentionBytes = getLong(KafkaConfig.MetadataMaxRetentionBytesProp)
   def metadataRetentionMillis = getLong(KafkaConfig.MetadataMaxRetentionMillisProp)
-  val brokerServerMaxStartupTimeMs = getLong(KafkaConfig.BrokerServerMaxStartupTimeMs)
-  val controllerServerMaxStartupTimeMs = getLong(KafkaConfig.ControllerServerMaxStartupTimeMs)
+  val serverMaxStartupTimeMs = getLong(KafkaConfig.ServerMaxStartupTimeMsProp)
 
   def numNetworkThreads = getInt(KafkaConfig.NumNetworkThreadsProp)
   def backgroundThreads = getInt(KafkaConfig.BackgroundThreadsProp)

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -155,6 +155,8 @@ public class KafkaClusterTestKit implements AutoCloseable {
             ControllerNode controllerNode = nodes.controllerNodes().get(node.id());
 
             Map<String, String> props = new HashMap<>(configProps);
+            props.put(KafkaConfig$.MODULE$.ServerMaxStartupTimeMsProp(),
+                    Long.toString(TimeUnit.MINUTES.toMillis(10)));
             props.put(KafkaConfig$.MODULE$.ProcessRolesProp(), roles(node.id()));
             props.put(KafkaConfig$.MODULE$.NodeIdProp(),
                     Integer.toString(node.id()));

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -295,8 +295,7 @@ abstract class QuorumTestHarness extends Logging {
       throw new RuntimeException("Only one KRaft controller is supported for now.")
     }
     val props = propsList(0)
-    props.setProperty(KafkaConfig.BrokerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
-    props.setProperty(KafkaConfig.ControllerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
+    props.setProperty(KafkaConfig.ServerMaxStartupTimeMsProp, TimeUnit.MINUTES.toMillis(10).toString)
     props.setProperty(KafkaConfig.ProcessRolesProp, "controller")
     if (props.getProperty(KafkaConfig.NodeIdProp) == null) {
       props.setProperty(KafkaConfig.NodeIdProp, "1000")

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayOutputStream, File, PrintStream}
 import java.net.InetSocketAddress
 import java.util
 import java.util.{Collections, Properties}
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{CompletableFuture, TimeUnit}
 import javax.security.auth.login.Configuration
 import kafka.tools.StorageTool
 import kafka.utils.{CoreUtils, Logging, TestInfoUtils, TestUtils}
@@ -295,6 +295,8 @@ abstract class QuorumTestHarness extends Logging {
       throw new RuntimeException("Only one KRaft controller is supported for now.")
     }
     val props = propsList(0)
+    props.setProperty(KafkaConfig.BrokerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
+    props.setProperty(KafkaConfig.ControllerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
     props.setProperty(KafkaConfig.ProcessRolesProp, "controller")
     if (props.getProperty(KafkaConfig.NodeIdProp) == null) {
       props.setProperty(KafkaConfig.NodeIdProp, "1000")

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -306,8 +306,7 @@ object TestUtils extends Logging {
 
     val props = new Properties
     if (zkConnect == null) {
-      props.setProperty(KafkaConfig.BrokerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
-      props.setProperty(KafkaConfig.ControllerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
+      props.setProperty(KafkaConfig.ServerMaxStartupTimeMsProp, TimeUnit.MINUTES.toMillis(10).toString)
       props.put(KafkaConfig.NodeIdProp, nodeId.toString)
       props.put(KafkaConfig.BrokerIdProp, nodeId.toString)
       props.put(KafkaConfig.AdvertisedListenersProp, listeners)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -306,6 +306,8 @@ object TestUtils extends Logging {
 
     val props = new Properties
     if (zkConnect == null) {
+      props.setProperty(KafkaConfig.BrokerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
+      props.setProperty(KafkaConfig.ControllerServerMaxStartupTimeMs, TimeUnit.MINUTES.toMillis(10).toString)
       props.put(KafkaConfig.NodeIdProp, nodeId.toString)
       props.put(KafkaConfig.BrokerIdProp, nodeId.toString)
       props.put(KafkaConfig.AdvertisedListenersProp, listeners)

--- a/server-common/src/main/java/org/apache/kafka/server/util/Deadline.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/Deadline.java
@@ -19,7 +19,6 @@ package org.apache.kafka.server.util;
 import org.apache.kafka.common.utils.Time;
 
 import java.math.BigInteger;
-import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -38,17 +37,10 @@ public class Deadline {
         long delay,
         TimeUnit timeUnit
     ) {
-        return fromDelay(time.nanoseconds(), delay, timeUnit);
-    }
-
-    public static Deadline fromDelay(
-        long nowNs,
-        long delay,
-        TimeUnit timeUnit
-    ) {
         if (delay < 0) {
             throw new RuntimeException("Negative delays are not allowed.");
         }
+        long nowNs = time.nanoseconds();
         BigInteger deadlineNs = BigInteger.valueOf(nowNs).
                 add(BigInteger.valueOf(timeUnit.toNanos(delay)));
         if (deadlineNs.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) >= 0) {

--- a/server-common/src/main/java/org/apache/kafka/server/util/Deadline.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/Deadline.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.common.utils.Time;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+
+public class Deadline {
+    private final long nanoseconds;
+
+    public static Deadline fromMonotonicNanoseconds(
+        long nanoseconds
+    ) {
+        return new Deadline(nanoseconds);
+    }
+
+    public static Deadline fromDelay(
+        Time time,
+        long delay,
+        TimeUnit timeUnit
+    ) {
+        return fromDelay(time.nanoseconds(), delay, timeUnit);
+    }
+
+    public static Deadline fromDelay(
+        long nowNs,
+        long delay,
+        TimeUnit timeUnit
+    ) {
+        if (delay < 0) {
+            throw new RuntimeException("Negative delays are not allowed.");
+        }
+        BigInteger deadlineNs = BigInteger.valueOf(nowNs).
+                add(BigInteger.valueOf(timeUnit.toNanos(delay)));
+        if (deadlineNs.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) >= 0) {
+            return new Deadline(Long.MAX_VALUE);
+        } else {
+            return new Deadline(deadlineNs.longValue());
+        }
+    }
+
+    private Deadline(long nanoseconds) {
+        this.nanoseconds = nanoseconds;
+    }
+
+    public long nanoseconds() {
+        return nanoseconds;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nanoseconds);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || !(o.getClass().equals(this.getClass()))) return false;
+        Deadline other = (Deadline) o;
+        return nanoseconds == other.nanoseconds;
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
@@ -27,37 +27,14 @@ import java.util.concurrent.TimeoutException;
 
 public class FutureUtils {
     /**
-     * Based on the current time and a delay, computes a monotonic deadline in the future.
-     *
-     * @param nowNs     The current time in monotonic nanoseconds.
-     * @param delayMs   The delay in milliseconds.
-     * @return          The monotonic deadline in the future. This value is capped at
-     *                  Long.MAX_VALUE.
-     */
-    public static long getDeadlineNsFromDelayMs(
-        long nowNs,
-        long delayMs
-    ) {
-        if (delayMs < 0) {
-            throw new RuntimeException("Negative delays are not allowed.");
-        }
-        BigInteger delayNs = BigInteger.valueOf(delayMs).multiply(BigInteger.valueOf(1_000_000));
-        BigInteger deadlineNs = BigInteger.valueOf(nowNs).add(delayNs);
-        if (deadlineNs.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) >= 0) {
-            return Long.MAX_VALUE;
-        } else {
-            return deadlineNs.longValue();
-        }
-    }
-
-    /**
      * Wait for a future until a specific time in the future, with copious logging.
      *
      * @param log           The slf4j object to use to log success and failure.
      * @param action        The action we are waiting for.
      * @param future        The future we are waiting for.
-     * @param deadlineNs    The deadline in the future we are waiting for.
+     * @param deadline      The deadline in the future we are waiting for.
      * @param time          The clock object.
+     *
      * @return              The result of the future.
      * @param <T>           The type of the future.
      *
@@ -68,12 +45,12 @@ public class FutureUtils {
         Logger log,
         String action,
         CompletableFuture<T> future,
-        long deadlineNs,
+        Deadline deadline,
         Time time
     ) throws Throwable {
         log.info("Waiting for {}", action);
         try {
-            T result = time.waitForFuture(future, deadlineNs);
+            T result = time.waitForFuture(future, deadline.nanoseconds());
             log.info("Finished waiting for {}", action);
             return result;
         } catch (TimeoutException t)  {

--- a/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.math.BigInteger;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+
+public class FutureUtils {
+    /**
+     * Based on the current time and a delay, computes a monotonic deadline in the future.
+     *
+     * @param nowNs     The current time in monotonic nanoseconds.
+     * @param delayMs   The delay in milliseconds.
+     * @return          The monotonic deadline in the future. This value is capped at
+     *                  Long.MAX_VALUE.
+     */
+    public static long getDeadlineNsFromDelayMs(
+        long nowNs,
+        long delayMs
+    ) {
+        if (delayMs < 0) {
+            throw new RuntimeException("Negative delays are not allowed.");
+        }
+        BigInteger delayNs = BigInteger.valueOf(delayMs).multiply(BigInteger.valueOf(1_000_000));
+        BigInteger deadlineNs = BigInteger.valueOf(nowNs).add(delayNs);
+        if (deadlineNs.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) >= 0) {
+            return Long.MAX_VALUE;
+        } else {
+            return deadlineNs.longValue();
+        }
+    }
+
+    /**
+     * Wait for a future until a specific time in the future, with copious logging.
+     *
+     * @param log           The slf4j object to use to log success and failure.
+     * @param action        The action we are waiting for.
+     * @param future        The future we are waiting for.
+     * @param deadlineNs    The deadline in the future we are waiting for.
+     * @param time          The clock object.
+     * @return              The result of the future.
+     * @param <T>           The type of the future.
+     *
+     * @throws java.util.concurrent.TimeoutException If the future times out.
+     * @throws Throwable If the future fails. Note: we unwrap ExecutionException here.
+     */
+    public static <T> T waitWithLogging(
+        Logger log,
+        String action,
+        CompletableFuture<T> future,
+        long deadlineNs,
+        Time time
+    ) throws Throwable {
+        log.info("Waiting for {}", action);
+        try {
+            T result = time.waitForFuture(future, deadlineNs);
+            log.info("Finished waiting for {}", action);
+            return result;
+        } catch (TimeoutException t)  {
+            log.error("Timed out while waiting for {}", action, t);
+            TimeoutException timeout = new TimeoutException("Timed out while waiting for " + action);
+            timeout.setStackTrace(t.getStackTrace());
+            throw timeout;
+        } catch (Throwable t)  {
+            if (t instanceof ExecutionException) {
+                ExecutionException executionException = (ExecutionException) t;
+                t = executionException.getCause();
+            }
+            log.error("Received a fatal error while waiting for {}", action, t);
+            throw new RuntimeException("Received a fatal error while waiting for " + action, t);
+        }
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
@@ -19,7 +19,6 @@ package org.apache.kafka.server.util;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 
-import java.math.BigInteger;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;

--- a/server-common/src/test/java/org/apache/kafka/server/util/DeadlineTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/DeadlineTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@Timeout(value = 120)
+public class DeadlineTest {
+    private static final Logger log = LoggerFactory.getLogger(FutureUtilsTest.class);
+
+    @Test
+    public void testOneMillisecondDeadline() {
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(1),
+                Deadline.fromDelay(0, 1, TimeUnit.MILLISECONDS).nanoseconds());
+    }
+
+    @Test
+    public void testOneMillisecondDeadlineWithBase() {
+        final long nowNs = 123456789L;
+        assertEquals(nowNs + TimeUnit.MILLISECONDS.toNanos(1),
+                Deadline.fromDelay(nowNs, 1, TimeUnit.MILLISECONDS).nanoseconds());
+    }
+
+    @Test
+    public void testNegativeDelayFails() {
+        assertEquals("Negative delays are not allowed.",
+            assertThrows(RuntimeException.class,
+                () -> Deadline.fromDelay(123456789L, -1L, TimeUnit.MILLISECONDS)).
+                    getMessage());
+    }
+
+    @Test
+    public void testMaximumDelay() {
+        assertEquals(Long.MAX_VALUE,
+                Deadline.fromDelay(123L, Long.MAX_VALUE, TimeUnit.HOURS).nanoseconds());
+        assertEquals(Long.MAX_VALUE,
+                Deadline.fromDelay(0, Long.MAX_VALUE / 2, TimeUnit.MILLISECONDS).nanoseconds());
+        assertEquals(Long.MAX_VALUE,
+                Deadline.fromDelay(Long.MAX_VALUE, Long.MAX_VALUE, TimeUnit.NANOSECONDS).nanoseconds());
+    }
+}

--- a/server-common/src/test/java/org/apache/kafka/server/util/DeadlineTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/DeadlineTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class DeadlineTest {
     private static final Logger log = LoggerFactory.getLogger(FutureUtilsTest.class);
 
-    private static Time monoTime(long monotonicTime){
+    private static Time monoTime(long monotonicTime) {
         return new MockTime(0, 0, monotonicTime);
     }
 

--- a/server-common/src/test/java/org/apache/kafka/server/util/FutureUtilsTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/FutureUtilsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@Timeout(value = 120)
+public class FutureUtilsTest {
+    private static final Logger log = LoggerFactory.getLogger(FutureUtilsTest.class);
+
+    @Test
+    public void testOneMillisecondDeadline() {
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(1), FutureUtils.getDeadlineNsFromDelayMs(0, 1));
+    }
+
+    @Test
+    public void testOneMillisecondDeadlineWithBase() {
+        final long nowNs = 123456789L;
+        assertEquals(nowNs + TimeUnit.MILLISECONDS.toNanos(1), FutureUtils.getDeadlineNsFromDelayMs(nowNs, 1));
+    }
+
+    @Test
+    public void testNegativeDelayFails() {
+        assertEquals("Negative delays are not allowed.",
+            assertThrows(RuntimeException.class,
+                () -> FutureUtils.getDeadlineNsFromDelayMs(123456789L, -1L)).
+                    getMessage());
+    }
+
+    @Test
+    public void testMaximumDelay() {
+        assertEquals(Long.MAX_VALUE, FutureUtils.getDeadlineNsFromDelayMs(123L, Long.MAX_VALUE));
+        assertEquals(Long.MAX_VALUE, FutureUtils.getDeadlineNsFromDelayMs(Long.MAX_VALUE / 2, Long.MAX_VALUE));
+        assertEquals(Long.MAX_VALUE, FutureUtils.getDeadlineNsFromDelayMs(Long.MAX_VALUE, Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testWaitWithLogging() throws Throwable {
+        ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(1);
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        executorService.schedule(() -> future.complete(123), 1000, TimeUnit.NANOSECONDS);
+        assertEquals(123, FutureUtils.waitWithLogging(log,
+            "the future to be completed",
+            future,
+            FutureUtils.getDeadlineNsFromDelayMs(Time.SYSTEM.nanoseconds(), 15000),
+            Time.SYSTEM));
+        executorService.shutdownNow();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWaitWithLoggingTimeout(boolean immediateTimeout) throws Throwable {
+        ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(1);
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        executorService.schedule(() -> future.complete(456), 10000, TimeUnit.MILLISECONDS);
+        assertThrows(TimeoutException.class, () -> {
+            FutureUtils.waitWithLogging(log,
+                "the future to be completed",
+                future,
+                immediateTimeout ?
+                    Time.SYSTEM.nanoseconds() - 10000 :
+                    Time.SYSTEM.nanoseconds() + 10000,
+                Time.SYSTEM);
+        });
+        executorService.shutdownNow();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void testWaitWithLoggingError() throws Throwable {
+        ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(1);
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        executorService.schedule(() -> {
+            future.completeExceptionally(new IllegalArgumentException("uh oh"));
+        }, 1, TimeUnit.NANOSECONDS);
+        assertEquals("Received a fatal error while waiting for the future to be completed",
+            assertThrows(RuntimeException.class, () -> {
+                FutureUtils.waitWithLogging(log,
+                        "the future to be completed",
+                        future,
+                        FutureUtils.getDeadlineNsFromDelayMs(Time.SYSTEM.nanoseconds(), 5000),
+                        Time.SYSTEM);
+            }).getMessage());
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+    }
+}


### PR DESCRIPTION
When running junit tests, it is not good to block forever on CompletableFuture objects.  When there are bugs, this can lead to junit tests hanging forever. Jenkins does not deal with this well -- it often brings down the whole multi-hour test run.  Therefore, when running integration tests in JUnit, set some reasonable time limits on broker and controller startup time.