### PR TITLE
[DO NOT MERGE] KAFKA-14533: re-enable the 'false' parameter of SmokeTestDriverIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -96,9 +96,8 @@ public class SmokeTestDriverIntegrationTest {
 
     private static Stream<Boolean> parameters() {
         return Stream.of(
-            // TODO KAFKA-14533: debug and re-enable both parameters
-            //Boolean.TRUE
-            Boolean.FALSE
+            Boolean.FALSE,
+            Boolean.TRUE
           );
     }
 


### PR DESCRIPTION
Doing the PR to re-enable the test build that I temporarily disabled in https://github.com/apache/kafka/pull/13147 in order to help with debugging and to stabilize the 3.4 release branch.

I'm still debugging this so we should not merge this PR just yet, but I wanted to at least open it now so it's not forgotten