### PR TITLE
KAFKA-14533: re-enable 'false' and disable the 'true' parameter of SmokeTestDriverIntegrationTest 

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -97,8 +97,8 @@ public class SmokeTestDriverIntegrationTest {
     private static Stream<Boolean> parameters() {
         return Stream.of(
             // TODO KAFKA-14533: debug and re-enable both parameters
-            Boolean.TRUE
-            //Boolean.FALSE
+            //Boolean.TRUE
+            Boolean.FALSE
           );
     }
 


### PR DESCRIPTION
I immediately saw a failure with `stateUpdaterEnabled = true` after disabling the `false` parameter, which suggests the problem actually does lie in the state updater itself and not the act of parametrization of the test. To verify this theory, and help stabilize the 3.4 release branch, let's try one more test by swapping out the `true` build in favor of the `false` one. If the `listOffsets` requests stop failing and causing this integration test to hit the global timeout as is currently happening at such a high rate, then we have pretty good evidence pointing at the state updater and should be able to debug things more easily from there.

After getting in a few builds to see whether the flakiness subsides, we should merge this PR to re-enable both parameters going forward: https://github.com/apache/kafka/pull/13155