### PR TITLE
chore: fix flaky DefaultStateUpdaterTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -52,6 +52,7 @@ import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -322,7 +323,7 @@ public final class StreamsTestUtils {
 
         public static TopologyMetadataBuilder unnamedTopology() {
             final TopologyMetadata topologyMetadata = mock(TopologyMetadata.class);
-            when(topologyMetadata.isPaused(null)).thenReturn(false);
+            when(topologyMetadata.isPaused(any())).thenReturn(false);
             return new TopologyMetadataBuilder(topologyMetadata);
         }
 


### PR DESCRIPTION
Mockito should not make named topologies paused by default.

