### PR TITLE
Kafka 14128

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
@@ -160,7 +160,7 @@ public class KafkaFutureImpl<T> extends KafkaFuture<T> {
      * Waits if necessary for this future to complete, and then returns its result.
      */
     @Override
-    public T get() throws InterruptedException, ExecutionException {
+    public abstract T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         try {
             return completableFuture.get();
         } catch (ExecutionException e) {

--- a/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
@@ -160,7 +160,7 @@ public class KafkaFutureImpl<T> extends KafkaFuture<T> {
      * Waits if necessary for this future to complete, and then returns its result.
      */
     @Override
-    public abstract T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    public T get() throws InterruptedException, ExecutionException {
         try {
             return completableFuture.get();
         } catch (ExecutionException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -544,7 +544,7 @@ public class InternalTopicManager {
                 } else if (cause instanceof TimeoutException) {
                     tempUnknownTopics.add(topicName);
                     log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
-                            "Error message was: {}", topicName, retriableException.toString());
+                            "Error message was: {}", topicName, cause.toString());
                 } else {
                     log.error("Unexpected error during topic description for {}.\n" +
                         "Error message was: {}", topicName, cause.toString());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -469,7 +469,10 @@ public class InternalTopicManager {
                                                 topicName)
                                         );
                                     }
-                                } else {
+                                } else if (cause instanceof  TimeoutException) {
+                                    log.error("Creating topic {} timed out.\n" +
+                                            "Error message was: {}", topicName, retriableException.toString());
+                                }else {
                                     throw new StreamsException(
                                             String.format("Could not create topic %s.", topicName),
                                             cause

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -469,10 +469,7 @@ public class InternalTopicManager {
                                                 topicName)
                                         );
                                     }
-                                } else if (cause instanceof  TimeoutException) {
-                                    log.error("Creating topic {} timed out.\n" +
-                                            "Error message was: {}", topicName, retriableException.toString());
-                                }else {
+                                } else {
                                     throw new StreamsException(
                                             String.format("Could not create topic %s.", topicName),
                                             cause

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -469,6 +469,9 @@ public class InternalTopicManager {
                                                 topicName)
                                         );
                                     }
+                                } else if (cause instanceof TimeoutException) {
+                                    log.error("Creating topic {} timed out.\n" +
+                                            "Error message was: {}", topicName, cause.toString());
                                 } else {
                                     throw new StreamsException(
                                             String.format("Could not create topic %s.", topicName),
@@ -476,9 +479,6 @@ public class InternalTopicManager {
                                     );
                                 }
                             }
-                        } catch (final TimeoutException retriableException) {
-                            log.error("Creating topic {} timed out.\n" +
-                                    "Error message was: {}", topicName, retriableException.toString());
                         }
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -542,16 +542,14 @@ public class InternalTopicManager {
                     log.debug("The leader of topic {} is not available.\n" +
                         "Error message was: {}", topicName, cause.toString());
                 } else if (cause instanceof TimeoutException) {
-                    throw new RuntimeException();
+                    tempUnknownTopics.add(topicName);
+                    log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
+                            "Error message was: {}", topicName, retriableException.toString());
                 } else {
                     log.error("Unexpected error during topic description for {}.\n" +
                         "Error message was: {}", topicName, cause.toString());
                     throw new StreamsException(String.format("Could not create topic %s.", topicName), cause);
                 }
-            } catch (final TimeoutException retriableException) {
-                tempUnknownTopics.add(topicName);
-                log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
-                    "Error message was: {}", topicName, retriableException.toString());
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -541,6 +541,8 @@ public class InternalTopicManager {
                     tempUnknownTopics.add(topicName);
                     log.debug("The leader of topic {} is not available.\n" +
                         "Error message was: {}", topicName, cause.toString());
+                } else if (cause instanceof java.util.concurrent.TimeoutException) {
+                    throw new RuntimeException();
                 } else {
                     log.error("Unexpected error during topic description for {}.\n" +
                         "Error message was: {}", topicName, cause.toString());
@@ -550,8 +552,6 @@ public class InternalTopicManager {
                 tempUnknownTopics.add(topicName);
                 log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
                     "Error message was: {}", topicName, retriableException.toString());
-            } catch (final java.util.concurrent.TimeoutException e) {
-                throw new RuntimeException(e);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -57,11 +57,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.clients.admin.AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
+
 
 public class InternalTopicManager {
     private final static String BUG_ERROR_MESSAGE = "This indicates a bug. " +
@@ -524,7 +524,7 @@ public class InternalTopicManager {
         for (final Map.Entry<String, KafkaFuture<TopicDescription>> topicFuture : futures.entrySet()) {
             final String topicName = topicFuture.getKey();
             try {
-                final TopicDescription topicDescription = topicFuture.getValue().get(Long.parseLong(DEFAULT_API_TIMEOUT_MS_CONFIG), TimeUnit.MILLISECONDS);
+                final TopicDescription topicDescription = topicFuture.getValue().get();
                 existedTopicPartition.put(topicName, topicDescription.partitions().size());
             } catch (final InterruptedException fatalException) {
                 // this should not happen; if it ever happens it indicate a bug
@@ -541,7 +541,7 @@ public class InternalTopicManager {
                     tempUnknownTopics.add(topicName);
                     log.debug("The leader of topic {} is not available.\n" +
                         "Error message was: {}", topicName, cause.toString());
-                } else if (cause instanceof java.util.concurrent.TimeoutException) {
+                } else if (cause instanceof TimeoutException) {
                     throw new RuntimeException();
                 } else {
                     log.error("Unexpected error during topic description for {}.\n" +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -61,6 +61,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.clients.admin.AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
+
 public class InternalTopicManager {
     private final static String BUG_ERROR_MESSAGE = "This indicates a bug. " +
         "Please report at https://issues.apache.org/jira/projects/KAFKA/issues or to the dev-mailing list (https://kafka.apache.org/contact).";
@@ -522,7 +524,7 @@ public class InternalTopicManager {
         for (final Map.Entry<String, KafkaFuture<TopicDescription>> topicFuture : futures.entrySet()) {
             final String topicName = topicFuture.getKey();
             try {
-                final TopicDescription topicDescription = topicFuture.getValue().get(5000, TimeUnit.MILLISECONDS);
+                final TopicDescription topicDescription = topicFuture.getValue().get(Long.parseLong(DEFAULT_API_TIMEOUT_MS_CONFIG), TimeUnit.MILLISECONDS);
                 existedTopicPartition.put(topicName, topicDescription.partitions().size());
             } catch (final InterruptedException fatalException) {
                 // this should not happen; if it ever happens it indicate a bug
@@ -548,7 +550,7 @@ public class InternalTopicManager {
                 tempUnknownTopics.add(topicName);
                 log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
                     "Error message was: {}", topicName, retriableException.toString());
-            } catch (java.util.concurrent.TimeoutException e) {
+            } catch (final java.util.concurrent.TimeoutException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -59,6 +59,8 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -59,12 +59,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
-<<<<<<< HEAD
-=======
-import java.util.Arrays;
->>>>>>> ecd2b34666 (resolve conflict)
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -73,6 +67,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -61,6 +61,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Arrays;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+<<<<<<< HEAD
+=======
+import java.util.Arrays;
+>>>>>>> ecd2b34666 (resolve conflict)
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,6 +91,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class InternalTopicManagerTest {
@@ -307,7 +312,6 @@ public class InternalTopicManagerTest {
 
     @Test
     public void shouldThrowTimeoutExceptionIfGetNumPartitionsHasTopicDescriptionTimeout() {
-<<<<<<< HEAD
         mockAdminClient.timeoutNextRequest(1);
 
         final InternalTopicManager internalTopicManager =
@@ -321,24 +325,18 @@ public class InternalTopicManagerTest {
         } catch (final TimeoutException expected) {
             assertEquals(TimeoutException.class, expected.getCause().getClass());
         }
-=======
-        final MockTime time = new MockTime(
-                (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 15
-        );
-        final InternalTopicManager internalTopicManager =
-                new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
 
-        final TimeoutException exception = assertThrows(
-                TimeoutException.class,
-                () -> internalTopicManager.getNumPartitions(Collections.singleton("test_topic"), Collections.singleton("test_topic_2"))
-        );
+        mockAdminClient.timeoutNextRequest(1);
 
-        assertThat(
-                exception.getMessage(),
-                is("Describing topic test_topic (to get number of partitions) timed out.\n" +
-                        "Error message was: " + TimeoutException.class
-        ));
->>>>>>> a56b0ebc1b (add failing test)
+        try {
+            final Set<String> topic1set = new HashSet<String>(Arrays.asList(topic1));
+            final Set<String> topic2set = new HashSet<String>(Arrays.asList(topic2));
+
+            internalTopicManager.getNumPartitions(topic1set, topic2set);
+
+        } catch (final TimeoutException expected) {
+            assertEquals(TimeoutException.class, expected.getCause().getClass());
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -759,12 +759,10 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldExhaustRetriesOnTimeoutExceptionForMakeReady() {
         mockAdminClient.timeoutNextRequest(1);
-
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
         try {
             internalTopicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig));
-            fail("Should have thrown StreamsException.");
         } catch (final StreamsException expected) {
             assertEquals(TimeoutException.class, expected.getCause().getClass());
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -307,6 +307,7 @@ public class InternalTopicManagerTest {
 
     @Test
     public void shouldThrowTimeoutExceptionIfGetNumPartitionsHasTopicDescriptionTimeout() {
+<<<<<<< HEAD
         mockAdminClient.timeoutNextRequest(1);
 
         final InternalTopicManager internalTopicManager =
@@ -320,6 +321,24 @@ public class InternalTopicManagerTest {
         } catch (final TimeoutException expected) {
             assertEquals(TimeoutException.class, expected.getCause().getClass());
         }
+=======
+        final MockTime time = new MockTime(
+                (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 15
+        );
+        final InternalTopicManager internalTopicManager =
+                new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+
+        final TimeoutException exception = assertThrows(
+                TimeoutException.class,
+                () -> internalTopicManager.getNumPartitions(Collections.singleton("test_topic"), Collections.singleton("test_topic_2"))
+        );
+
+        assertThat(
+                exception.getMessage(),
+                is("Describing topic test_topic (to get number of partitions) timed out.\n" +
+                        "Error message was: " + TimeoutException.class
+        ));
+>>>>>>> a56b0ebc1b (add failing test)
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -305,6 +305,26 @@ public class InternalTopicManagerTest {
     }
 
     @Test
+    public void shouldThrowTimeoutExceptionIfGetNumPartitionsHasTopicDescriptionTimeout() {
+        final MockTime time = new MockTime(
+                (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 15
+        );
+        final InternalTopicManager internalTopicManager =
+                new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+
+        final TimeoutException exception = assertThrows(
+                TimeoutException.class,
+                () -> internalTopicManager.getNumPartitions(Collections.singleton("test_topic"), Collections.singleton("test_topic_2"))
+        );
+
+        assertThat(
+                exception.getMessage(),
+                is("Describing topic test_topic (to get number of partitions) timed out.\n" +
+                        "Error message was: " + TimeoutException.class
+        ));
+    }
+
+    @Test
     public void shouldThrowWhenCreateTopicsThrowsUnexpectedException() {
         final AdminClient admin = mock(AdminClient.class);
         final StreamsConfig streamsConfig = new StreamsConfig(config);


### PR DESCRIPTION
In response to [14128](https://issues.apache.org/jira/browse/KAFKA-14128). Addresses by moving final catch condition into an else block. 

Testing strategy: I'm attempting a unit test first.  I've cp'ed from the test above so I can use the MockTime and InternalTopicManager. Currently, when I run the test, it's throwing an error the top line of which is: 

```
expected org.apache.kafka.common.errors.TimeoutException to be thrown, but nothing was thrown
```

This is prior to the issue of figuring out the text of the error, which is my next step. 