### PR TITLE
fix: replace an inefficient loop in kafka internals

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -179,17 +179,15 @@ public class DefaultRecord implements Record {
         if (key == null) {
             ByteUtils.writeVarint(-1, out);
         } else {
-            int keySize = key.remaining();
-            ByteUtils.writeVarint(keySize, out);
-            Utils.writeTo(out, key, keySize);
+            ByteUtils.writeVarint(key.remaining(), out);
+            Utils.writeTo(out, key);
         }
 
         if (value == null) {
             ByteUtils.writeVarint(-1, out);
         } else {
-            int valueSize = value.remaining();
-            ByteUtils.writeVarint(valueSize, out);
-            Utils.writeTo(out, value, valueSize);
+            ByteUtils.writeVarint(value.remaining(), out);
+            Utils.writeTo(out, value);
         }
 
         if (headers == null)

--- a/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
@@ -471,17 +471,15 @@ public final class LegacyRecord {
         if (key == null) {
             out.writeInt(-1);
         } else {
-            int size = key.remaining();
-            out.writeInt(size);
-            Utils.writeTo(out, key, size);
+            out.writeInt(key.remaining());
+            Utils.writeTo(out, key);
         }
         // write the value
         if (value == null) {
             out.writeInt(-1);
         } else {
-            int size = value.remaining();
-            out.writeInt(size);
-            Utils.writeTo(out, value, size);
+            out.writeInt(key.remaining());
+            Utils.writeTo(out, value);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1230,7 +1230,7 @@ public final class Utils {
         if (buffer.hasArray()) {
             out.write(buffer.array(), buffer.position() + buffer.arrayOffset(), length);
         } else {
-            Channels.newChannel(out).write(buffer);
+            Channels.newChannel(out).write(buffer.asReadOnlyBuffer());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1223,7 +1223,6 @@ public final class Utils {
      * in the buffer.
      * @param out The output to write to
      * @param buffer The buffer to write from
-     * @param length The number of bytes to write
      * @throws IOException For any errors writing to the output
      */
     public static void writeTo(DataOutputStream out, ByteBuffer buffer) throws IOException {

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.DataOutput;
+import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +40,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
@@ -1225,13 +1226,11 @@ public final class Utils {
      * @param length The number of bytes to write
      * @throws IOException For any errors writing to the output
      */
-    public static void writeTo(DataOutput out, ByteBuffer buffer, int length) throws IOException {
+    public static void writeTo(DataOutputStream out, ByteBuffer buffer, int length) throws IOException {
         if (buffer.hasArray()) {
             out.write(buffer.array(), buffer.position() + buffer.arrayOffset(), length);
         } else {
-            int pos = buffer.position();
-            for (int i = pos; i < length + pos; i++)
-                out.writeByte(buffer.get(i));
+            Channels.newChannel(out).write(buffer);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1226,9 +1226,9 @@ public final class Utils {
      * @param length The number of bytes to write
      * @throws IOException For any errors writing to the output
      */
-    public static void writeTo(DataOutputStream out, ByteBuffer buffer, int length) throws IOException {
+    public static void writeTo(DataOutputStream out, ByteBuffer buffer) throws IOException {
         if (buffer.hasArray()) {
-            out.write(buffer.array(), buffer.position() + buffer.arrayOffset(), length);
+            out.write(buffer.array(), buffer.position() + buffer.arrayOffset(), buffer.remaining());
         } else {
             Channels.newChannel(out).write(buffer.asReadOnlyBuffer());
         }

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -197,7 +197,7 @@ public class UtilsTest {
         int numBytes = source.remaining();
         int position = source.position();
         DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(dest));
-        Utils.writeTo(out, source, source.remaining());
+        Utils.writeTo(out, source);
         dest.flip();
         assertEquals(numBytes, dest.remaining());
         assertEquals(position, source.position());


### PR DESCRIPTION
Instead use Channels.newChannel to write in larger chunks