### PR TITLE
KAFKA-14653: MirrorMakerConfig using raw properties instead of post-r…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -246,22 +246,13 @@ public class AbstractConfig {
      */
     public Map<String, String> originalsStrings() {
         Map<String, String> copy = new RecordingMap<>();
-        copyAsStrings(originals, copy);
-        return copy;
-    }
-
-    /**
-     * Ensures that all values of a map are strings, and copies them to another map.
-     * @param originals The map to validate.
-     * @param copy The target to copy to.
-     */
-    protected static void copyAsStrings(Map<String, ?> originals, Map<String, String> copy) {
         for (Map.Entry<String, ?> entry : originals.entrySet()) {
             if (!(entry.getValue() instanceof String))
                 throw new ClassCastException("Non-string value found in original settings for key " + entry.getKey() +
                         ": " + (entry.getValue() == null ? null : entry.getValue().getClass().getName()));
             copy.put(entry.getKey(), (String) entry.getValue());
         }
+        return copy;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -246,13 +246,22 @@ public class AbstractConfig {
      */
     public Map<String, String> originalsStrings() {
         Map<String, String> copy = new RecordingMap<>();
+        copyAsStrings(originals, copy);
+        return copy;
+    }
+
+    /**
+     * Ensures that all values of a map are strings, and copies them to another map.
+     * @param originals The map to validate.
+     * @param copy The target to copy to.
+     */
+    protected static void copyAsStrings(Map<String, ?> originals, Map<String, String> copy) {
         for (Map.Entry<String, ?> entry : originals.entrySet()) {
             if (!(entry.getValue() instanceof String))
                 throw new ClassCastException("Non-string value found in original settings for key " + entry.getKey() +
                         ": " + (entry.getValue() == null ? null : entry.getValue().getClass().getName()));
             copy.put(entry.getKey(), (String) entry.getValue());
         }
-        return copy;
     }
 
     /**

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -90,13 +90,11 @@ public class MirrorMakerConfig extends AbstractConfig {
 
     private final Map<String, String> rawProperties;
 
-    @SuppressWarnings("unchecked")
-    public MirrorMakerConfig(Map<?, ?> props) {
+    public MirrorMakerConfig(Map<String, String> props) {
         super(config(), props, true);
         plugins = new Plugins(originalsStrings());
 
-        rawProperties = new HashMap<>();
-        copyAsStrings((Map<String, ?>) props, rawProperties);
+        rawProperties = new HashMap<>(props);
     }
 
     public Set<String> clusters() {
@@ -145,7 +143,7 @@ public class MirrorMakerConfig extends AbstractConfig {
       */
     public MirrorClientConfig clientConfig(String cluster) {
         Map<String, String> props = new HashMap<>();
-        props.putAll(rawProperties);
+        props.putAll(originalsStrings());
         props.putAll(clusterProps(cluster));
         return new MirrorClientConfig(transform(props));
     }


### PR DESCRIPTION
…esolution properties.

MirrorMakerConfig extends AbstractConfig, which resolves config provider based references eagerly, construction time. Because of this, Connector configurations created by MirrorMaker2 always contain resolved property values, and never provider references. This can cause security, and host-specific configuration issues.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
