### PR TITLE
Kafka 14565:  Interceptor Resource Leak

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -67,44 +67,43 @@ public class AbstractConfig {
      * Construct a configuration with a ConfigDef and the configuration properties, which can include properties
      * for zero or more {@link ConfigProvider} that will be used to resolve variables in configuration property
      * values.
-     *
+     * <p>
      * The originals is a name-value pair configuration properties and optional config provider configs. The
      * value of the configuration can be a variable as defined below or the actual value. This constructor will
      * first instantiate the ConfigProviders using the config provider configs, then it will find all the
      * variables in the values of the originals configurations, attempt to resolve the variables using the named
      * ConfigProviders, and then parse and validate the configurations.
-     *
+     * <p>
      * ConfigProvider configs can be passed either as configs in the originals map or in the separate
      * configProviderProps map. If config providers properties are passed in the configProviderProps any config
      * provider properties in originals map will be ignored. If ConfigProvider properties are not provided, the
      * constructor will skip the variable substitution step and will simply validate and parse the supplied
      * configuration.
-     *
+     * <p>
      * The "{@code config.providers}" configuration property and all configuration properties that begin with the
      * "{@code config.providers.}" prefix are reserved. The "{@code config.providers}" configuration property
      * specifies the names of the config providers, and properties that begin with the "{@code config.providers..}"
      * prefix correspond to the properties for that named provider. For example, the "{@code config.providers..class}"
      * property specifies the name of the {@link ConfigProvider} implementation class that should be used for
      * the provider.
-     *
+     * <p>
      * The keys for ConfigProvider configs in both originals and configProviderProps will start with the above
      * mentioned "{@code config.providers.}" prefix.
-     *
+     * <p>
      * Variables have the form "${providerName:[path:]key}", where "providerName" is the name of a ConfigProvider,
      * "path" is an optional string, and "key" is a required string. This variable is resolved by passing the "key"
      * and optional "path" to a ConfigProvider with the specified name, and the result from the ConfigProvider is
      * then used in place of the variable. Variables that cannot be resolved by the AbstractConfig constructor will
      * be left unchanged in the configuration.
      *
-     *
-     * @param definition the definition of the configurations; may not be null
-     * @param originals the configuration properties plus any optional config provider properties;
+     * @param definition          the definition of the configurations; may not be null
+     * @param originals           the configuration properties plus any optional config provider properties;
      * @param configProviderProps the map of properties of config providers which will be instantiated by
-     *        the constructor to resolve any variables in {@code originals}; may be null or empty
-     * @param doLog whether the configurations should be logged
+     *                            the constructor to resolve any variables in {@code originals}; may be null or empty
+     * @param doLog               whether the configurations should be logged
      */
     @SuppressWarnings("unchecked")
-    public AbstractConfig(ConfigDef definition, Map<?, ?> originals,  Map<String, ?> configProviderProps, boolean doLog) {
+    public AbstractConfig(ConfigDef definition, Map<?, ?> originals, Map<String, ?> configProviderProps, boolean doLog) {
         /* check that all the keys are really strings */
         for (Map.Entry<?, ?> entry : originals.entrySet())
             if (!(entry.getKey() instanceof String))
@@ -128,7 +127,7 @@ public class AbstractConfig {
      * that will be used to resolve variables in configuration property values.
      *
      * @param definition the definition of the configurations; may not be null
-     * @param originals the configuration properties plus any optional config provider properties; may not be null
+     * @param originals  the configuration properties plus any optional config provider properties; may not be null
      */
     public AbstractConfig(ConfigDef definition, Map<?, ?> originals) {
         this(definition, originals, Collections.emptyMap(), true);
@@ -140,8 +139,8 @@ public class AbstractConfig {
      * that will be used to resolve variables in configuration property values.
      *
      * @param definition the definition of the configurations; may not be null
-     * @param originals the configuration properties plus any optional config provider properties; may not be null
-     * @param doLog whether the configurations should be logged
+     * @param originals  the configuration properties plus any optional config provider properties; may not be null
+     * @param doLog      whether the configurations should be logged
      */
     public AbstractConfig(ConfigDef definition, Map<?, ?> originals, boolean doLog) {
         this(definition, originals, Collections.emptyMap(), doLog);
@@ -242,6 +241,7 @@ public class AbstractConfig {
 
     /**
      * Get all the original settings, ensuring that all values are of type String.
+     *
      * @return the original settings
      * @throws ClassCastException if any of the values are not strings
      */
@@ -270,7 +270,7 @@ public class AbstractConfig {
      * Gets all original settings with the given prefix.
      *
      * @param prefix the prefix to use as a filter
-     * @param strip strip the prefix before adding to the output if set true
+     * @param strip  strip the prefix before adding to the output if set true
      * @return a Map containing the settings with the prefix
      */
     public Map<String, Object> originalsWithPrefix(String prefix, boolean strip) {
@@ -289,7 +289,7 @@ public class AbstractConfig {
     /**
      * Put all keys that do not start with {@code prefix} and their parsed values in the result map and then
      * put all the remaining keys with the prefix stripped and their parsed values in the result map.
-     *
+     * <p>
      * This is useful if one wants to allow prefixed configs to override default ones.
      * <p>
      * Two forms of prefixes are supported:
@@ -324,7 +324,7 @@ public class AbstractConfig {
     /**
      * If at least one key with {@code prefix} exists, all prefixed values will be parsed and put into map.
      * If no value with {@code prefix} exists all unprefixed values will be returned.
-     *
+     * <p>
      * This is useful if one wants to allow prefixed configs to override default ones, but wants to use either
      * only prefixed configs or only regular configs, but not mix them.
      */
@@ -415,7 +415,7 @@ public class AbstractConfig {
      * Configurable configure it using the configuration.
      *
      * @param key The configuration key for the class
-     * @param t The interface the class should implement
+     * @param t   The interface the class should implement
      * @return A configured instance of the class
      */
     public <T> T getConfiguredInstance(String key, Class<T> t) {
@@ -426,8 +426,8 @@ public class AbstractConfig {
      * Get a configured instance of the give class specified by the given configuration key. If the object implements
      * Configurable configure it using the configuration.
      *
-     * @param key The configuration key for the class
-     * @param t The interface the class should implement
+     * @param key             The configuration key for the class
+     * @param t               The interface the class should implement
      * @param configOverrides override origin configs
      * @return A configured instance of the class
      */
@@ -441,8 +441,9 @@ public class AbstractConfig {
      * Get a list of configured instances of the given class specified by the given configuration key. The configuration
      * may specify either null or an empty string to indicate no configured instances. In both cases, this method
      * returns an empty list to indicate no configured instances.
+     *
      * @param key The configuration key for the class
-     * @param t The interface the class should implement
+     * @param t   The interface the class should implement
      * @return The list of configured instances
      */
     public <T> List<T> getConfiguredInstances(String key, Class<T> t) {
@@ -453,8 +454,9 @@ public class AbstractConfig {
      * Get a list of configured instances of the given class specified by the given configuration key. The configuration
      * may specify either null or an empty string to indicate no configured instances. In both cases, this method
      * returns an empty list to indicate no configured instances.
-     * @param key The configuration key for the class
-     * @param t The interface the class should implement
+     *
+     * @param key             The configuration key for the class
+     * @param t               The interface the class should implement
      * @param configOverrides Configuration overrides to use.
      * @return The list of configured instances
      */
@@ -466,8 +468,9 @@ public class AbstractConfig {
      * Get a list of configured instances of the given class specified by the given configuration key. The configuration
      * may specify either null or an empty string to indicate no configured instances. In both cases, this method
      * returns an empty list to indicate no configured instances.
-     * @param classNames The list of class names of the instances to create
-     * @param t The interface the class should implement
+     *
+     * @param classNames      The list of class names of the instances to create
+     * @param t               The interface the class should implement
      * @param configOverrides Configuration overrides to use.
      * @return The list of configured instances
      */
@@ -485,11 +488,17 @@ public class AbstractConfig {
             }
         } catch (Exception e) {
             for (Object object : objects) {
-                if (object instanceof Closeable) {
+                if (object instanceof AutoCloseable) {
+                    try {
+                        ((AutoCloseable) object).close();
+                    } catch (Exception ex) {
+                        log.error(String.format("Close exception on %s", object.getClass().getName()), ex);
+                    }
+                } else if (object instanceof Closeable) {
                     try {
                         ((Closeable) object).close();
                     } catch (Exception ex) {
-                        log.error("Close failed.", ex);
+                        log.error(String.format("Close exception on %s", object.getClass().getName()), ex);
                     }
                 }
             }
@@ -498,7 +507,7 @@ public class AbstractConfig {
         return objects;
     }
 
-    private Map<String, String> extractPotentialVariables(Map<?, ?>  configMap) {
+    private Map<String, String> extractPotentialVariables(Map<?, ?> configMap) {
         // Variables are tuples of the form "${providerName:[path:]key}". From the configMap we extract the subset of configs with string
         // values as potential variables.
         Map<String, String> configMapAsString = new HashMap<>();
@@ -513,12 +522,13 @@ public class AbstractConfig {
     /**
      * Instantiates given list of config providers and fetches the actual values of config variables from the config providers.
      * returns a map of config key and resolved values.
+     *
      * @param configProviderProps The map of config provider configs
-     * @param originals The map of raw configs.
+     * @param originals           The map of raw configs.
      * @return map of resolved config variable.
      */
     @SuppressWarnings("unchecked")
-    private  Map<String, ?> resolveConfigVariables(Map<String, ?> configProviderProps, Map<String, Object> originals) {
+    private Map<String, ?> resolveConfigVariables(Map<String, ?> configProviderProps, Map<String, Object> originals) {
         Map<String, String> providerConfigString;
         Map<String, ?> configProperties;
         Map<String, Object> resolvedOriginals = new HashMap<>();
@@ -564,7 +574,8 @@ public class AbstractConfig {
      * config.providers.{name}.class : The Java class name for a provider.
      * config.providers.{name}.param.{param-name} : A parameter to be passed to the above Java class on initialization.
      * returns a map of config provider name and its instance.
-     * @param indirectConfigs The map of potential variable configs
+     *
+     * @param indirectConfigs          The map of potential variable configs
      * @param providerConfigProperties The map of config provider configs
      * @return map map of config provider name and its instance.
      */
@@ -577,7 +588,7 @@ public class AbstractConfig {
 
         Map<String, String> providerMap = new HashMap<>();
 
-        for (String provider: configProviders.split(",")) {
+        for (String provider : configProviders.split(",")) {
             String providerClass = providerClassProperty(provider);
             if (indirectConfigs.containsKey(providerClass))
                 providerMap.put(provider, indirectConfigs.get(providerClass));

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.kafka.common.config.provider.ConfigProvider;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -488,19 +487,7 @@ public class AbstractConfig {
             }
         } catch (Exception e) {
             for (Object object : objects) {
-                if (object instanceof AutoCloseable) {
-                    try {
-                        ((AutoCloseable) object).close();
-                    } catch (Exception ex) {
-                        log.error(String.format("Close exception on %s", object.getClass().getName()), ex);
-                    }
-                } else if (object instanceof Closeable) {
-                    try {
-                        ((Closeable) object).close();
-                    } catch (Exception ex) {
-                        log.error(String.format("Close exception on %s", object.getClass().getName()), ex);
-                    }
-                }
+                Utils.closeQuietly((AutoCloseable) object, "AutoCloseable object constructed and configured during failed call to getConfiguredInstances");
             }
             throw e;
         }

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -389,27 +389,27 @@ public class AbstractConfig {
     private <T> T getConfiguredInstance(Object klass, Class<T> t, Map<String, Object> configPairs) {
         if (klass == null)
             return null;
-
-        Object o;
-        if (klass instanceof String) {
-            try {
-                o = Utils.newInstance((String) klass, t);
-            } catch (ClassNotFoundException e) {
-                throw new KafkaException("Class " + klass + " cannot be found", e);
-            }
-        } else if (klass instanceof Class<?>) {
-            o = Utils.newInstance((Class<?>) klass);
-        } else
-            throw new KafkaException("Unexpected element of type " + klass.getClass().getName() + ", expected String or Class");
-        if (!t.isInstance(o))
-            throw new KafkaException(klass + " is not an instance of " + t.getName());
-        if (o instanceof Configurable)
-            try {
+        Object o = null;
+        try {
+            if (klass instanceof String) {
+                try {
+                    o = Utils.newInstance((String) klass, t);
+                } catch (ClassNotFoundException e) {
+                    throw new KafkaException("Class " + klass + " cannot be found", e);
+                }
+            } else if (klass instanceof Class<?>) {
+                o = Utils.newInstance((Class<?>) klass);
+            } else
+                throw new KafkaException("Unexpected element of type " + klass.getClass().getName() + ", expected String or Class");
+            if (!t.isInstance(o))
+                throw new KafkaException(klass + " is not an instance of " + t.getName());
+            if (o instanceof Configurable)
                 ((Configurable) o).configure(configPairs);
-            } catch (Exception e) {
-                maybeClose(o, "AutoCloseable object constructed and configured during failed call to getConfiguredInstance");
-                throw e;
-            }
+        } catch (Exception e) {
+            maybeClose(o, "AutoCloseable object constructed and configured during failed call to getConfiguredInstance");
+            throw e;
+        }
+
 
         return t.cast(o);
     }

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -401,19 +401,15 @@ public class AbstractConfig {
             o = Utils.newInstance((Class<?>) klass);
         } else
             throw new KafkaException("Unexpected element of type " + klass.getClass().getName() + ", expected String or Class");
-
         try {
             if (!t.isInstance(o))
                 throw new KafkaException(klass + " is not an instance of " + t.getName());
-
             if (o instanceof Configurable)
                 ((Configurable) o).configure(configPairs);
-
         } catch (Exception e) {
             maybeClose(o, "AutoCloseable object constructed and configured during failed call to getConfiguredInstance");
             throw e;
         }
-
         return t.cast(o);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -389,27 +389,30 @@ public class AbstractConfig {
     private <T> T getConfiguredInstance(Object klass, Class<T> t, Map<String, Object> configPairs) {
         if (klass == null)
             return null;
-        Object o = null;
+        Object o;
+
+        if (klass instanceof String) {
+            try {
+                o = Utils.newInstance((String) klass, t);
+            } catch (ClassNotFoundException e) {
+                throw new KafkaException("Class " + klass + " cannot be found", e);
+            }
+        } else if (klass instanceof Class<?>) {
+            o = Utils.newInstance((Class<?>) klass);
+        } else
+            throw new KafkaException("Unexpected element of type " + klass.getClass().getName() + ", expected String or Class");
+
         try {
-            if (klass instanceof String) {
-                try {
-                    o = Utils.newInstance((String) klass, t);
-                } catch (ClassNotFoundException e) {
-                    throw new KafkaException("Class " + klass + " cannot be found", e);
-                }
-            } else if (klass instanceof Class<?>) {
-                o = Utils.newInstance((Class<?>) klass);
-            } else
-                throw new KafkaException("Unexpected element of type " + klass.getClass().getName() + ", expected String or Class");
             if (!t.isInstance(o))
                 throw new KafkaException(klass + " is not an instance of " + t.getName());
+
             if (o instanceof Configurable)
                 ((Configurable) o).configure(configPairs);
+
         } catch (Exception e) {
             maybeClose(o, "AutoCloseable object constructed and configured during failed call to getConfiguredInstance");
             throw e;
         }
-
 
         return t.cast(o);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -169,7 +169,6 @@ public class KafkaConsumerTest {
     private final int defaultApiTimeoutMs = 60000;
     private final int requestTimeoutMs = defaultApiTimeoutMs / 2;
     private final int heartbeatIntervalMs = 1000;
-    private final int targetInterceptor = 3;
 
     // Set auto commit interval lower than heartbeat so we don't need to deal with
     // a concurrent heartbeat request
@@ -507,12 +506,14 @@ public class KafkaConsumerTest {
 
     @Test
     public void testInterceptorConstructorConfigurationWithExceptionShouldCloseRemainingInstances() {
+        final int targetInterceptor = 3;
+
         try {
             Properties props = new Properties();
             props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-            props.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockConsumerInterceptor, "
-                    + "org.apache.kafka.test.MockConsumerInterceptor, "
-                    + "org.apache.kafka.test.MockConsumerInterceptor");
+            props.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,  MockConsumerInterceptor.class.getName() + ", "
+                    + MockConsumerInterceptor.class.getName() + ", "
+                    + MockConsumerInterceptor.class.getName());
 
             MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(targetInterceptor);
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -514,7 +514,7 @@ public class KafkaConsumerTest {
                     + "org.apache.kafka.test.MockConsumerInterceptor, "
                     + "org.apache.kafka.test.MockConsumerInterceptor");
 
-            MockConsumerInterceptor.setThrowConfigExceptionThreshold(onSelectedInterceptor);
+            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(onSelectedInterceptor);
 
             assertThrows(KafkaException.class, () -> {
                 new KafkaConsumer<>(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -169,7 +169,7 @@ public class KafkaConsumerTest {
     private final int defaultApiTimeoutMs = 60000;
     private final int requestTimeoutMs = defaultApiTimeoutMs / 2;
     private final int heartbeatIntervalMs = 1000;
-    private final int onSelectedInterceptor = 3;
+    private final int targetInterceptor = 3;
 
     // Set auto commit interval lower than heartbeat so we don't need to deal with
     // a concurrent heartbeat request
@@ -514,7 +514,7 @@ public class KafkaConsumerTest {
                     + "org.apache.kafka.test.MockConsumerInterceptor, "
                     + "org.apache.kafka.test.MockConsumerInterceptor");
 
-            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(onSelectedInterceptor);
+            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(targetInterceptor);
 
             assertThrows(KafkaException.class, () -> {
                 new KafkaConsumer<>(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -523,7 +523,7 @@ public class KafkaConsumerTest {
             });
 
             assertEquals(3, MockConsumerInterceptor.CONFIG_COUNT.get());
-            assertEquals(2, MockConsumerInterceptor.CLOSE_COUNT.get());
+            assertEquals(3, MockConsumerInterceptor.CLOSE_COUNT.get());
 
         } finally {
             MockConsumerInterceptor.resetCounters();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -137,7 +137,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KafkaProducerTest {
-    private final int targetInterceptor = 3;
     private final String topic = "topic";
     private final Collection<Node> nodes = Collections.singletonList(NODE);
     private final Cluster emptyCluster = new Cluster(
@@ -572,12 +571,13 @@ public class KafkaProducerTest {
     }
     @Test
     public void testInterceptorConstructorConfigurationWithExceptionShouldCloseRemainingInstances() {
+        final int targetInterceptor = 3;
         try {
             Properties props = new Properties();
             props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-            props.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockProducerInterceptor, "
-                    + "org.apache.kafka.test.MockProducerInterceptor, "
-                    + "org.apache.kafka.test.MockProducerInterceptor");
+            props.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
+                    +  org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
+                    +  org.apache.kafka.test.MockProducerInterceptor.class.getName());
             props.setProperty(MockProducerInterceptor.APPEND_STRING_PROP, "something");
 
             MockProducerInterceptor.setThrowOnConfigExceptionThreshold(targetInterceptor);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -137,7 +137,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KafkaProducerTest {
-    private final int onSelectedInterceptor = 3;
+    private final int targetInterceptor = 3;
     private final String topic = "topic";
     private final Collection<Node> nodes = Collections.singletonList(NODE);
     private final Cluster emptyCluster = new Cluster(
@@ -580,7 +580,7 @@ public class KafkaProducerTest {
                     + "org.apache.kafka.test.MockProducerInterceptor");
             props.setProperty(MockProducerInterceptor.APPEND_STRING_PROP, "something");
 
-            MockProducerInterceptor.setThrowOnConfigExceptionThreshold(onSelectedInterceptor);
+            MockProducerInterceptor.setThrowOnConfigExceptionThreshold(targetInterceptor);
 
             assertThrows(KafkaException.class, () -> {
                 new KafkaProducer<>(

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -588,7 +588,7 @@ public class KafkaProducerTest {
             });
 
             assertEquals(3, MockProducerInterceptor.CONFIG_COUNT.get());
-            assertEquals(2, MockProducerInterceptor.CLOSE_COUNT.get());
+            assertEquals(3, MockProducerInterceptor.CLOSE_COUNT.get());
 
         } finally {
             MockProducerInterceptor.resetCounters();

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -278,7 +278,7 @@ public class AbstractConfigTest {
                     () -> testConfig.getConfiguredInstances(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, Object.class)
             );
             assertEquals(3, MockConsumerInterceptor.CONFIG_COUNT.get());
-            assertEquals(2, MockConsumerInterceptor.CLOSE_COUNT.get());
+            assertEquals(3, MockConsumerInterceptor.CLOSE_COUNT.get());
         } finally {
             MockConsumerInterceptor.resetCounters();
         }

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -47,6 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractConfigTest {
 
+
+
     @Test
     public void testConfiguredInstances() {
         testValidInputs("");
@@ -56,12 +58,12 @@ public class AbstractConfigTest {
         testInvalidInputs("org.apache.kafka.clients.producer.unknown-metrics-reporter");
         testInvalidInputs("test1,test2");
         testInvalidInputs("org.apache.kafka.common.metrics.FakeMetricsReporter,");
-        testInvalidInputs(TestInterceptorConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockConsumerInterceptor, "
-                + "org.apache.kafka.test.MockConsumerInterceptor, "
-                + "org.apache.kafka.test.MockConsumerInterceptor",  org.apache.kafka.test.MockConsumerInterceptor.class);
-        testInvalidInputs(TestInterceptorConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockProducerInterceptor, "
-                + "org.apache.kafka.test.MockProducerInterceptor, "
-                + "org.apache.kafka.test.MockProducerInterceptor",  org.apache.kafka.test.MockProducerInterceptor.class);
+        testInvalidInputs(TestInterceptorConfig.INTERCEPTOR_CLASSES_CONFIG, TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR + ", "
+                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR + ", "
+                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR,  org.apache.kafka.test.MockConsumerInterceptor.class);
+        testInvalidInputs(TestInterceptorConfig.INTERCEPTOR_CLASSES_CONFIG, TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR + ", "
+                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR + ", "
+                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR,  org.apache.kafka.test.MockProducerInterceptor.class);
     }
 
     @Test
@@ -271,17 +273,17 @@ public class AbstractConfigTest {
         props.setProperty(TestInterceptorConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         props.setProperty(TestInterceptorConfig.CLIENT_ID_CONFIG, "fake client");
 
-        if (configurableClass.getName().equals("org.apache.kafka.test.MockProducerInterceptor")) {
+        if (configurableClass.getName().equals(TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR)) {
             props.setProperty(MockProducerInterceptor.APPEND_STRING_PROP, "something");
         }
         props.put(classesConfig, configValue);
         TestInterceptorConfig testInterceptorConfig = new TestInterceptorConfig(props);
 
         try {
-            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(testInterceptorConfig.getOnSelectedInterceptor());
+            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(testInterceptorConfig.getTargetInterceptor());
             testInterceptorConfig.getConfiguredInstances(classesConfig, configurableClass);
         } catch (KafkaException e) {
-            if (configurableClass.getName().equals("org.apache.kafka.test.MockConsumerInterceptor")) {
+            if (configurableClass.getName().equals(TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR)) {
                 assertEquals(3, MockConsumerInterceptor.CONFIG_COUNT.get());
                 assertEquals(2, MockConsumerInterceptor.CLOSE_COUNT.get());
             } else {
@@ -631,13 +633,15 @@ public class AbstractConfigTest {
     }
 
     private static class TestInterceptorConfig extends AbstractConfig {
-        private final int onSelectedInterceptor = 3;
+        private final int targetInterceptor = 3;
         private static final ConfigDef CONFIG;
         private static final String INTERCEPTOR_CLASSES_CONFIG_DOC = "A list of classes to use as interceptors.";
 
         public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
         public static final String CLIENT_ID_CONFIG = "client.id";
         public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
+        public static final String ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR = "org.apache.kafka.test.MockConsumerInterceptor";
+        public static final String ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR = "org.apache.kafka.test.MockProducerInterceptor";
 
         static {
             CONFIG = new ConfigDef().define(INTERCEPTOR_CLASSES_CONFIG,
@@ -650,8 +654,8 @@ public class AbstractConfigTest {
             super(CONFIG, props);
         }
 
-        public int getOnSelectedInterceptor() {
-            return onSelectedInterceptor;
+        public int getTargetInterceptor() {
+            return targetInterceptor;
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.config.provider.MockVaultConfigProvider;
 import org.apache.kafka.common.config.provider.MockFileConfigProvider;
 import org.apache.kafka.test.MockConsumerInterceptor;
-import org.apache.kafka.test.MockProducerInterceptor;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -47,8 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractConfigTest {
 
-
-
     @Test
     public void testConfiguredInstances() {
         testValidInputs("");
@@ -58,12 +55,6 @@ public class AbstractConfigTest {
         testInvalidInputs("org.apache.kafka.clients.producer.unknown-metrics-reporter");
         testInvalidInputs("test1,test2");
         testInvalidInputs("org.apache.kafka.common.metrics.FakeMetricsReporter,");
-        testInvalidInputs(TestInterceptorConfig.INTERCEPTOR_CLASSES_CONFIG, TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR + ", "
-                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR + ", "
-                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR,  org.apache.kafka.test.MockConsumerInterceptor.class);
-        testInvalidInputs(TestInterceptorConfig.INTERCEPTOR_CLASSES_CONFIG, TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR + ", "
-                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR + ", "
-                + TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR,  org.apache.kafka.test.MockProducerInterceptor.class);
     }
 
     @Test
@@ -268,31 +259,30 @@ public class AbstractConfigTest {
             // this is good
         }
     }
-    private <T> void testInvalidInputs(String classesConfig, String configValue, Class<T> configurableClass) {
-        Properties props = new Properties();
-        props.setProperty(TestInterceptorConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        props.setProperty(TestInterceptorConfig.CLIENT_ID_CONFIG, "fake client");
 
-        if (configurableClass.getName().equals(TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR)) {
-            props.setProperty(MockProducerInterceptor.APPEND_STRING_PROP, "something");
-        }
-        props.put(classesConfig, configValue);
-        TestInterceptorConfig testInterceptorConfig = new TestInterceptorConfig(props);
-
+    @Test
+    public void testConfiguredInstancesClosedOnFailure() {
+        final int targetInterceptor = 3;
         try {
-            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(testInterceptorConfig.getTargetInterceptor());
-            testInterceptorConfig.getConfiguredInstances(classesConfig, configurableClass);
-        } catch (KafkaException e) {
-            if (configurableClass.getName().equals(TestInterceptorConfig.ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR)) {
-                assertEquals(3, MockConsumerInterceptor.CONFIG_COUNT.get());
-                assertEquals(2, MockConsumerInterceptor.CLOSE_COUNT.get());
-            } else {
-                assertEquals(3, MockProducerInterceptor.CONFIG_COUNT.get());
-                assertEquals(2, MockProducerInterceptor.CLOSE_COUNT.get());
-            }
+            Map<String, String> props = new HashMap<>();
+            String threeConsumerInterceptors = MockConsumerInterceptor.class.getName() + ", "
+                    + MockConsumerInterceptor.class.getName() + ", "
+                    + MockConsumerInterceptor.class.getName();
+            props.put(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, threeConsumerInterceptors);
+            props.put("client.id", "test");
+            TestConfig testConfig = new TestConfig(props);
+
+            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(targetInterceptor);
+            assertThrows(
+                    Exception.class,
+                    () -> testConfig.getConfiguredInstances(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, Object.class)
+            );
+            assertEquals(3, MockConsumerInterceptor.CONFIG_COUNT.get());
+            assertEquals(2, MockConsumerInterceptor.CLOSE_COUNT.get());
+        } finally {
+            MockConsumerInterceptor.resetCounters();
         }
     }
-
     @Test
     public void testClassConfigs() {
         class RestrictedClassLoader extends ClassLoader {
@@ -629,33 +619,6 @@ public class AbstractConfigTest {
 
         public TestConfig(Map<?, ?> props) {
             super(CONFIG, props);
-        }
-    }
-
-    private static class TestInterceptorConfig extends AbstractConfig {
-        private final int targetInterceptor = 3;
-        private static final ConfigDef CONFIG;
-        private static final String INTERCEPTOR_CLASSES_CONFIG_DOC = "A list of classes to use as interceptors.";
-
-        public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
-        public static final String CLIENT_ID_CONFIG = "client.id";
-        public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
-        public static final String ORG_APACHE_KAFKA_TEST_MOCK_CONSUMER_INTERCEPTOR = "org.apache.kafka.test.MockConsumerInterceptor";
-        public static final String ORG_APACHE_KAFKA_TEST_MOCK_PRODUCER_INTERCEPTOR = "org.apache.kafka.test.MockProducerInterceptor";
-
-        static {
-            CONFIG = new ConfigDef().define(INTERCEPTOR_CLASSES_CONFIG,
-                    Type.LIST,
-                    "",
-                    Importance.LOW,
-                    INTERCEPTOR_CLASSES_CONFIG_DOC);
-        }
-        public TestInterceptorConfig(Map<?, ?> props) {
-            super(CONFIG, props);
-        }
-
-        public int getTargetInterceptor() {
-            return targetInterceptor;
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -268,15 +268,14 @@ public class AbstractConfigTest {
             String threeConsumerInterceptors = MockConsumerInterceptor.class.getName() + ", "
                     + MockConsumerInterceptor.class.getName() + ", "
                     + MockConsumerInterceptor.class.getName();
-            props.put(InterceptorTestConfig.INTERCEPTOR_CLASSES_CONFIG, threeConsumerInterceptors);
-            props.put(InterceptorTestConfig.CLIENT_ID_CONFIG, "test");
+            props.put(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, threeConsumerInterceptors);
+            props.put("client.id", "test");
+            TestConfig testConfig = new TestConfig(props);
 
-            InterceptorTestConfig interceptorTestConfig = new InterceptorTestConfig(props);
-            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(interceptorTestConfig.getTargetInterceptor());
-
+            MockConsumerInterceptor.setThrowOnConfigExceptionThreshold(3);
             assertThrows(
                     Exception.class,
-                    () -> interceptorTestConfig.getConfiguredInstances(InterceptorTestConfig.INTERCEPTOR_CLASSES_CONFIG, Object.class)
+                    () -> testConfig.getConfiguredInstances(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, Object.class)
             );
             assertEquals(3, MockConsumerInterceptor.CONFIG_COUNT.get());
             assertEquals(3, MockConsumerInterceptor.CLOSE_COUNT.get());
@@ -621,31 +620,6 @@ public class AbstractConfigTest {
 
         public TestConfig(Map<?, ?> props) {
             super(CONFIG, props);
-        }
-    }
-
-    private static class InterceptorTestConfig extends AbstractConfig {
-        private final int targetInterceptor = 3;
-        private static final ConfigDef CONFIG;
-        private static final String INTERCEPTOR_CLASSES_CONFIG_DOC = "A list of classes to use as interceptors.";
-
-        public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
-        public static final String CLIENT_ID_CONFIG = "client.id";
-        public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
-
-        static {
-            CONFIG = new ConfigDef().define(INTERCEPTOR_CLASSES_CONFIG,
-                    Type.LIST,
-                    Collections.emptyList(),
-                    Importance.LOW,
-                    INTERCEPTOR_CLASSES_CONFIG_DOC);
-        }
-        public InterceptorTestConfig(Map<?, ?> props) {
-            super(CONFIG, props);
-        }
-
-        public int getTargetInterceptor() {
-            return targetInterceptor;
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -636,7 +636,7 @@ public class AbstractConfigTest {
         static {
             CONFIG = new ConfigDef().define(INTERCEPTOR_CLASSES_CONFIG,
                     Type.LIST,
-                    "",
+                    Collections.emptyList(),
                     Importance.LOW,
                     INTERCEPTOR_CLASSES_CONFIG_DOC);
         }

--- a/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
@@ -41,6 +41,9 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
     public static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
     public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
     public static final AtomicInteger ON_COMMIT_COUNT = new AtomicInteger(0);
+    public static final AtomicInteger CONFIG_COUNT = new AtomicInteger(0);
+    public static final AtomicInteger THROW_CONFIG_EXCEPTION = new AtomicInteger(0);
+    public static final AtomicInteger THROW_CONFIG_EXCEPTION_THRESHOLD = new AtomicInteger(0);
     public static final AtomicReference<ClusterResource> CLUSTER_META = new AtomicReference<>();
     public static final ClusterResource NO_CLUSTER_ID = new ClusterResource("no_cluster_id");
     public static final AtomicReference<ClusterResource> CLUSTER_ID_BEFORE_ON_CONSUME = new AtomicReference<>(NO_CLUSTER_ID);
@@ -55,6 +58,11 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
         Object clientIdValue = configs.get(ConsumerConfig.CLIENT_ID_CONFIG);
         if (clientIdValue == null)
             throw new ConfigException("Mock consumer interceptor expects configuration " + ProducerConfig.CLIENT_ID_CONFIG);
+
+        CONFIG_COUNT.incrementAndGet();
+        if (CONFIG_COUNT.get() == THROW_CONFIG_EXCEPTION_THRESHOLD.get()) {
+            throw new ConfigException("Kafka producer creation failed. Failure may not have cleaned up listener thread resource.");
+        }
     }
 
     @Override
@@ -90,10 +98,16 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
         CLOSE_COUNT.incrementAndGet();
     }
 
+    public static void setThrowConfigExceptionThreshold(int value) {
+        THROW_CONFIG_EXCEPTION_THRESHOLD.set(value);
+    }
+
     public static void resetCounters() {
         INIT_COUNT.set(0);
         CLOSE_COUNT.set(0);
         ON_COMMIT_COUNT.set(0);
+        CONFIG_COUNT.set(0);
+        THROW_CONFIG_EXCEPTION.set(0);
         CLUSTER_META.set(null);
         CLUSTER_ID_BEFORE_ON_CONSUME.set(NO_CLUSTER_ID);
     }

--- a/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
@@ -43,7 +43,7 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
     public static final AtomicInteger ON_COMMIT_COUNT = new AtomicInteger(0);
     public static final AtomicInteger CONFIG_COUNT = new AtomicInteger(0);
     public static final AtomicInteger THROW_CONFIG_EXCEPTION = new AtomicInteger(0);
-    public static final AtomicInteger THROW_CONFIG_EXCEPTION_THRESHOLD = new AtomicInteger(0);
+    public static final AtomicInteger THROW_ON_CONFIG_EXCEPTION_THRESHOLD = new AtomicInteger(0);
     public static final AtomicReference<ClusterResource> CLUSTER_META = new AtomicReference<>();
     public static final ClusterResource NO_CLUSTER_ID = new ClusterResource("no_cluster_id");
     public static final AtomicReference<ClusterResource> CLUSTER_ID_BEFORE_ON_CONSUME = new AtomicReference<>(NO_CLUSTER_ID);
@@ -60,8 +60,8 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
             throw new ConfigException("Mock consumer interceptor expects configuration " + ProducerConfig.CLIENT_ID_CONFIG);
 
         CONFIG_COUNT.incrementAndGet();
-        if (CONFIG_COUNT.get() == THROW_CONFIG_EXCEPTION_THRESHOLD.get()) {
-            throw new ConfigException("Kafka producer creation failed. Failure may not have cleaned up listener thread resource.");
+        if (CONFIG_COUNT.get() == THROW_ON_CONFIG_EXCEPTION_THRESHOLD.get()) {
+            throw new ConfigException("Failed to instantiate interceptor. Reached configuration exception threshold.");
         }
     }
 
@@ -98,8 +98,8 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
         CLOSE_COUNT.incrementAndGet();
     }
 
-    public static void setThrowConfigExceptionThreshold(int value) {
-        THROW_CONFIG_EXCEPTION_THRESHOLD.set(value);
+    public static void setThrowOnConfigExceptionThreshold(int value) {
+        THROW_ON_CONFIG_EXCEPTION_THRESHOLD.set(value);
     }
 
     public static void resetCounters() {

--- a/clients/src/test/java/org/apache/kafka/test/MockProducerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockProducerInterceptor.java
@@ -32,6 +32,9 @@ public class MockProducerInterceptor implements ClusterResourceListener, Produce
     public static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
     public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
     public static final AtomicInteger ONSEND_COUNT = new AtomicInteger(0);
+    public static final AtomicInteger CONFIG_COUNT = new AtomicInteger(0);
+    public static final AtomicInteger THROW_CONFIG_EXCEPTION = new AtomicInteger(0);
+    public static final AtomicInteger THROW_ON_CONFIG_EXCEPTION_THRESHOLD = new AtomicInteger(0);
     public static final AtomicInteger ON_SUCCESS_COUNT = new AtomicInteger(0);
     public static final AtomicInteger ON_ERROR_COUNT = new AtomicInteger(0);
     public static final AtomicInteger ON_ERROR_WITH_METADATA_COUNT = new AtomicInteger(0);
@@ -59,6 +62,11 @@ public class MockProducerInterceptor implements ClusterResourceListener, Produce
         Object clientIdValue = configs.get(ProducerConfig.CLIENT_ID_CONFIG);
         if (clientIdValue == null)
             throw new ConfigException("Mock producer interceptor expects configuration " + ProducerConfig.CLIENT_ID_CONFIG);
+
+        CONFIG_COUNT.incrementAndGet();
+        if (CONFIG_COUNT.get() == THROW_ON_CONFIG_EXCEPTION_THRESHOLD.get()) {
+            throw new ConfigException("Failed to instantiate interceptor. Reached configuration exception threshold.");
+        }
     }
 
     @Override
@@ -89,10 +97,16 @@ public class MockProducerInterceptor implements ClusterResourceListener, Produce
         CLOSE_COUNT.incrementAndGet();
     }
 
+    public static void setThrowOnConfigExceptionThreshold(int value) {
+        THROW_ON_CONFIG_EXCEPTION_THRESHOLD.set(value);
+    }
+
     public static void resetCounters() {
         INIT_COUNT.set(0);
         CLOSE_COUNT.set(0);
         ONSEND_COUNT.set(0);
+        CONFIG_COUNT.set(0);
+        THROW_CONFIG_EXCEPTION.set(0);
         ON_SUCCESS_COUNT.set(0);
         ON_ERROR_COUNT.set(0);
         ON_ERROR_WITH_METADATA_COUNT.set(0);


### PR DESCRIPTION
Added try/catch within Abstract::getConfigInstances to capture interceptor configuration exceptions and enable clean up of resources used by previous created interceptor instances listed within the interceptor.classes property .

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
