### PR TITLE
KAFAK-14660: Fix divide-by-zero vulnerability

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -91,6 +91,10 @@ public class StickyTaskAssignor implements TaskAssignor {
 
     private void assignActive() {
         final int totalCapacity = sumCapacity(clients.values());
+        if (totalCapacity == 0) {
+            throw new IllegalStateException("`totalCapacity` should never be zero.");
+        }
+
         final int tasksPerThread = allTaskIds.size() / totalCapacity;
         final Set<TaskId> assigned = new HashSet<>();
 


### PR DESCRIPTION
This PR adds a safe-guard for divide-by-zero. While `totalCapacity` can never be zero, an explicit error message is desirable.