### PR TITLE
MINOR: some ZK migration code cleanups.

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/ClusterDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterDelta.java
@@ -31,8 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 
 /**
@@ -56,17 +54,6 @@ public final class ClusterDelta {
             return result.orElse(null);
         }
         return image.broker(nodeId);
-    }
-
-    public Set<Integer> liveZkBrokerIdChanges() {
-        return changedBrokers
-            .values()
-            .stream()
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .filter(registration -> registration.isMigratingZkBroker() && !registration.fenced())
-            .map(BrokerRegistration::id)
-            .collect(Collectors.toSet());
     }
 
     public void finishSnapshot() {

--- a/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
@@ -34,15 +34,9 @@ public final class ClusterImage {
     public static final ClusterImage EMPTY = new ClusterImage(Collections.emptyMap());
 
     private final Map<Integer, BrokerRegistration> brokers;
-    private final Map<Integer, BrokerRegistration> zkBrokers;
 
     public ClusterImage(Map<Integer, BrokerRegistration> brokers) {
         this.brokers = Collections.unmodifiableMap(brokers);
-        this.zkBrokers = Collections.unmodifiableMap(brokers
-            .entrySet()
-            .stream()
-            .filter(entry -> entry.getValue().isMigratingZkBroker())
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     public boolean isEmpty() {
@@ -53,20 +47,9 @@ public final class ClusterImage {
         return brokers;
     }
 
-    public Map<Integer, BrokerRegistration> zkBrokers() {
-        return Collections.unmodifiableMap(
-            brokers
-                .entrySet()
-                .stream()
-                .filter(x -> x.getValue().isMigratingZkBroker() && !x.getValue().fenced())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
-
     public BrokerRegistration broker(int nodeId) {
         return brokers.get(nodeId);
     }
-
-
 
     public boolean containsBroker(int brokerId) {
         return brokers.containsKey(brokerId);

--- a/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.image;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.image.writer.ImageWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
@@ -25,7 +24,6 @@ import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.util.TranslatedValueMapView;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -110,14 +108,6 @@ public final class TopicsImage {
      */
     public Map<Uuid, String> topicIdToNameView() {
         return new TranslatedValueMapView<>(topicsById, image -> image.name());
-    }
-
-    public Map<TopicPartition, PartitionRegistration> partitions() {
-        Map<TopicPartition, PartitionRegistration> partitions = new HashMap<>();
-        topicsById.values().forEach(topic -> {
-            topic.partitions().forEach((key, value) -> partitions.put(new TopicPartition(topic.name(), key), value));
-        });
-        return partitions;
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationDriverState.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationDriverState.java
@@ -18,6 +18,10 @@
 package org.apache.kafka.metadata.migration;
 
 /**
+ * This is the internal state of the KRaftMigrationDriver class on a particular controller node.
+ * Unlike the ZkMigrationState, which is persisted in the metadata log and image, this is soft
+ * state which is stored in memory only.
+ *
  *      UNINITIALIZED───────────────►INACTIVE◄────────────────DUAL_WRITE◄────────────────────────┐
  *            │                         ▲                                                        │
  *            │                         │                                                        │
@@ -34,7 +38,7 @@ package org.apache.kafka.metadata.migration;
  *            ▼                         │                         │                              │
  * BECOME_CONTROLLER───────────────────►└────────────────────►WAIT_FOR_BROKERS───────────────────┘
  */
-public enum MigrationState {
+public enum MigrationDriverState {
     UNINITIALIZED(false),                  // Initial state.
     INACTIVE(false),                       // State when not the active controller.
     WAIT_FOR_CONTROLLER_QUORUM(false),     // Ensure all the quorum nodes are ready for migration.
@@ -46,7 +50,7 @@ public enum MigrationState {
 
     private final boolean isActiveController;
 
-    MigrationState(boolean isActiveController) {
+    MigrationDriverState(boolean isActiveController) {
         this.isActiveController = isActiveController;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/ZkMigrationState.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/ZkMigrationState.java
@@ -19,32 +19,39 @@ package org.apache.kafka.metadata.migration;
 import java.util.Optional;
 
 /**
+ * The cluster-wide ZooKeeper migration state.
+ *
  * An enumeration of the possible states of the ZkMigrationState field in ZkMigrationStateRecord.
+ * This information is persisted in the metadata log and image.
  *
  * @see org.apache.kafka.common.metadata.ZkMigrationStateRecord
  */
 public enum ZkMigrationState {
     /**
-     * No migration has been started by the controller. The controller is in regular KRaft mode
+     * The cluster was created in KRaft mode. A cluster that was created in ZK mode can never attain
+     * this state; the endpoint of migration is POST_MIGRATION, instead.
      */
     NONE((byte) 0),
 
     /**
      * A KRaft controller has been elected with "zookeeper.metadata.migration.enable" set to "true".
-     * The controller is now awaiting the pre-conditions for starting the migration.
+     * The controller is now awaiting the preconditions for starting the migration to KRaft. In this
+     * state, the metadata log does not yet contain the cluster's data. There is a metadata quorum,
+     * but it is not doing anything useful yet.
      */
     PRE_MIGRATION((byte) 1),
 
     /**
-     * The ZK data has been migrated and the KRaft controller is now writing metadata to both ZK and the
-     * metadata log. The controller will remain in this state until all of the brokers have been restarted
-     * in KRaft mode
+     * The ZK data has been migrated, and the KRaft controller is now writing metadata to both ZK
+     * and the metadata log. The controller will remain in this state until all of the brokers have
+     * been restarted in KRaft mode.
      */
     MIGRATION((byte) 2),
 
     /**
-     * The migration has been fully completed. The cluster is running in KRaft mode. This state will persist
-     * indefinitely after the migration.
+     * The migration from ZK has been fully completed. The cluster is running in KRaft mode. This state
+     * will persist indefinitely after the migration. In operational terms, this is the same as the NONE
+     * state.
      */
     POST_MIGRATION((byte) 3);
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -280,7 +280,7 @@ public class KRaftMigrationDriverTest {
         driver.publishLogDelta(delta, image, new LogDeltaManifest(provenance,
             new LeaderAndEpoch(OptionalInt.of(3000), 1), 1, 100, 42));
 
-        TestUtils.waitForCondition(() -> driver.migrationState().get(1, TimeUnit.MINUTES).equals(MigrationState.DUAL_WRITE),
+        TestUtils.waitForCondition(() -> driver.migrationState().get(1, TimeUnit.MINUTES).equals(MigrationDriverState.DUAL_WRITE),
             "Waiting for KRaftMigrationDriver to enter DUAL_WRITE state");
 
         Assertions.assertEquals(1, metadataPropagator.images);


### PR DESCRIPTION
Some minor improvements to the JavaDoc for ZkMigrationState.

Rename MigrationState to MigrationDriverState to avoid confusion with ZkMigrationState.

Remove ClusterImage#zkBrokers. This costs O(num_brokers) time to calculate, but is only ever used when in migration state. It should just be calculated in the migration code. (Additionally, the function ClusterImage.zkBrokers() returns something other than ClusterImage#zkBrokers, which is confusing.)

Also remove ClusterDelta#liveZkBrokerIdChanges. This is only used in one place, and it's easy to calculate it there. In general we should avoid providing expensive accessors unless absolutely necessary. Expensive code should look expensive: if people want to iterate over all brokers, they can write a loop to do that rather than hiding it inside an accessor.