### PR TITLE
KAFKA-10575: Add onRestoreSuspsnded to StateRestoreListener

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateRestoreListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateRestoreListener.java
@@ -41,8 +41,9 @@ import org.apache.kafka.common.TopicPartition;
  * class during state store registration.
  *
  * <p>
- * Also note that standby tasks restoration process are not monitored via this interface, since a standby task keep
- * getting data from the changelogs written by the active stream tasks and hence would not complete restoration at all.
+ * Also note that the update process of standby tasks is not monitored via this interface, since a standby task does
+ * note actually <it>restore</it> state, but keeps updating its state from the changelogs written by the active task
+ * which does not ever finish.
  *
  * <p>
  * Incremental updates are exposed so users can estimate how much progress has been made.
@@ -98,7 +99,7 @@ public interface StateRestoreListener {
      * If the migrated task is recycled or re-assigned back to the current host, another
      * {@link #onRestoreStart(TopicPartition, String, long, long)} would be called.
      *
-     * @param topicPartition the TopicPartition containing the values to restore
+     * @param topicPartition the {@link TopicPartition} containing the values to restore
      * @param storeName the name of the store just restored
      * @param totalRestored the total number of records restored for this TopicPartition before being paused
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateRestoreListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateRestoreListener.java
@@ -22,13 +22,16 @@ import org.apache.kafka.common.TopicPartition;
 /**
  * Class for listening to various states of the restoration process of a StateStore.
  *
+ * <p>
  * When calling {@link org.apache.kafka.streams.KafkaStreams#setGlobalStateRestoreListener(StateRestoreListener)}
  * the passed instance is expected to be stateless since the {@code StateRestoreListener} is shared
  * across all {@link org.apache.kafka.streams.processor.internals.StreamThread} instances.
  *
+ * <p>
  * Users desiring stateful operations will need to provide synchronization internally in
  * the {@code StateRestorerListener} implementation.
  *
+ * <p>
  * Note that this listener is only registered at the per-client level and users can base on the {@code storeName}
  * parameter to define specific monitoring for different {@link StateStore}s. There is another
  * {@link StateRestoreCallback} interface which is registered via the
@@ -37,6 +40,11 @@ import org.apache.kafka.common.TopicPartition;
  * These two interfaces serve different restoration purposes and users should not try to implement both of them in a single
  * class during state store registration.
  *
+ * <p>
+ * Also note that standby tasks restoration process are not monitored via this interface, since a standby task keep
+ * getting data from the changelogs written by the active stream tasks and hence would not complete restoration at all.
+ *
+ * <p>
  * Incremental updates are exposed so users can estimate how much progress has been made.
  */
 public interface StateRestoreListener {
@@ -85,4 +93,17 @@ public interface StateRestoreListener {
                       final String storeName,
                       final long totalRestored);
 
+    /**
+     * Method called when restoring the {@link StateStore} is suspended due to the task being migrated out of the host.
+     * If the migrated task is recycled or re-assigned back to the current host, another
+     * {@link #onRestoreStart(TopicPartition, String, long, long)} would be called.
+     *
+     * @param topicPartition the TopicPartition containing the values to restore
+     * @param storeName the name of the store just restored
+     * @param totalRestored the total number of records restored for this TopicPartition before being paused
+     */
+    default void onRestoreSuspended(final TopicPartition topicPartition,
+                                    final String storeName,
+                                    final long totalRestored) {
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockStateRestoreListener.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockStateRestoreListener.java
@@ -37,6 +37,7 @@ public class MockStateRestoreListener implements StateRestoreListener {
     public static final String RESTORE_START = "restore_start";
     public static final String RESTORE_BATCH = "restore_batch";
     public static final String RESTORE_END = "restore_end";
+    public static final String RESTORE_SUSPENDED = "restore_suspended";
 
     @Override
     public void onRestoreStart(final TopicPartition topicPartition,
@@ -66,6 +67,15 @@ public class MockStateRestoreListener implements StateRestoreListener {
                              final long totalRestored) {
         restoreTopicPartition = topicPartition;
         storeNameCalledStates.put(RESTORE_END, storeName);
+        totalNumRestored = totalRestored;
+    }
+
+    @Override
+    public void onRestoreSuspended(final TopicPartition topicPartition,
+                                   final String storeName,
+                                   final long totalRestored) {
+        restoreTopicPartition = topicPartition;
+        storeNameCalledStates.put(RESTORE_SUSPENDED, storeName);
         totalNumRestored = totalRestored;
     }
 


### PR DESCRIPTION
1. Add the new API (default impl is empty) to StateRestoreListener.
2. Update related unit tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
