### PR TITLE
MINOR: Update incorrect / misleading comment regarding rebalance exceptions in WorkerSinkTask

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -474,7 +474,7 @@ class WorkerSinkTask extends WorkerTask {
     private ConsumerRecords<byte[], byte[]> pollConsumer(long timeoutMs) {
         ConsumerRecords<byte[], byte[]> msgs = consumer.poll(Duration.ofMillis(timeoutMs));
 
-        // Exceptions raised from the task during a rebalance should be rethrown to stop the worker
+        // Exceptions raised from the task during a rebalance should be rethrown to stop the task and mark it as failed
         if (rebalanceException != null) {
             RuntimeException e = rebalanceException;
             rebalanceException = null;


### PR DESCRIPTION
- Handling of consumer rebalance related failures in sink tasks was added in https://github.com/apache/kafka/pull/767
- Exceptions thrown in the consumer rebalance listener are swallowed by the consumer; so the `WorkerSinkTask` stores exceptions arising from handling of assigned / revoked partitions and re-throws it in `WorkerSinkTask::pollConsumer` after the consumer poll returns.
- This exception is propagated up from `WorkerSinkTask::pollConsumer` <- `WorkerSinkTask::poll` <- `WorkerSinkTask::iteration` <- `WorkerSinkTask::execute` <- `WorkerTask::doRun` <- `WorkerTask::run` where it is finally handled by marking the task as failed - https://github.com/apache/kafka/blob/b8e606355b71528aa438e80ffeb3042d0d586998/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java#L259-L260
- Hence, the comment `Exceptions raised from the task during a rebalance should be rethrown to stop the worker` is inaccurate (the *worker* itself isn't stopped, the task is) and is being reworded.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
