### PR TITLE
Minor: Decode the envelope requests for the request log

### DIFF
--- a/core/src/main/scala/kafka/server/EnvelopeUtils.scala
+++ b/core/src/main/scala/kafka/server/EnvelopeUtils.scala
@@ -106,7 +106,7 @@ object EnvelopeUtils {
     }
   }
 
-  private def parseForwardedRequestHeader(
+  def parseForwardedRequestHeader(
     buffer: ByteBuffer
   ): RequestHeader = {
     try {


### PR DESCRIPTION
When looking at the request log for anything forwarded to the controller, all we see is ENVELOPE and the base64 encoded bytes of the request body. 

This patch decodes the envelope request so it can be fully logged in the request log.

Here is a sample output before

> [2023-02-03 16:29:55,747] DEBUG Completed request:{"isForwarded":false,"requestHeader":{"requestApiKey":58,"requestApiVersion":0,"correlationId":6,"clientId":"1","requestApiKeyName":"ENVELOPE"},"request":{"requestData":"ACwAAQAAAAMADWFkbWluY2xpZW50LTIAAgIFdGVzdAMOc2VnbWVudC5ieXRlcwAHMjA0ODAwAAtzZWdtZW50Lm1zAQAAAAAA","requestPrincipal":"AAAFVXNlcgpBTk9OWU1PVVMAAA==","clientHostAddress":"fwAAAQ=="},"response":{"responseData":null,"errorCode":41},"connection":"127.0.0.1:51244-127.0.0.1:51264-1","totalTimeMs":0.362,"requestQueueTimeMs":0.096,"localTimeMs":0.12,"remoteTimeMs":0.0,"throttleTimeMs":0,"responseQueueTimeMs":0.051,"sendTimeMs":0.095,"securityProtocol":"PLAINTEXT","principal":"User:ANONYMOUS","listener":"EXTERNAL","clientInformation":{"softwareName":"apache-kafka-java","softwareVersion":"unknown"}} (kafka.request.logger:275)

and after:
> [2023-02-03 16:25:17,606] DEBUG Completed request:{"isForwarded":false,"requestHeader":{"requestApiKey":58,"requestApiVersion":0,"correlationId":0,"clientId":"0","requestApiKeyName":"ENVELOPE"},"request":{"envelopeRequestHeader":{"requestApiKey":44,"requestApiVersion":1,"correlationId":3,"clientId":"adminclient-2","requestApiKeyName":"INCREMENTAL_ALTER_CONFIGS"},"envelopeRequest":{"resources":[{"resourceType":2,"resourceName":"test","configs":[{"name":"segment.bytes","configOperation":0,"value":"204800"},{"name":"segment.ms","configOperation":1,"value":null}]}],"validateOnly":false}},"response":{"responseData":null,"errorCode":41},"connection":"127.0.0.1:50795-127.0.0.1:50813-0","totalTimeMs":4.067,"requestQueueTimeMs":1.86,"localTimeMs":1.927,"remoteTimeMs":0.0,"throttleTimeMs":0,"responseQueueTimeMs":0.096,"sendTimeMs":0.183,"securityProtocol":"PLAINTEXT","principal":"User:ANONYMOUS","listener":"EXTERNAL","clientInformation":{"softwareName":"apache-kafka-java","softwareVersion":"unknown"}} (kafka.request.logger:275)

This change slightly increases the logging overhead since it makes a copy of the request buffer and runs through the parsing logic. However, this seems like a reasonable tradeoff for better visibility.