### PR TITLE
MINOR: Rename IBP_3_4_IV1 as added for KIP-405 to IBP_3_5_IV0

### DIFF
--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -117,6 +117,6 @@ public class ClusterTestExtensionsTest {
 
     @ClusterTest
     public void testDefaults(ClusterConfig config) {
-        Assertions.assertEquals(MetadataVersion.IBP_3_4_IV1, config.metadataVersion());
+        Assertions.assertEquals(MetadataVersion.IBP_3_5_IV0, config.metadataVersion());
     }
 }

--- a/core/src/test/java/kafka/test/annotation/ClusterTest.java
+++ b/core/src/test/java/kafka/test/annotation/ClusterTest.java
@@ -41,6 +41,6 @@ public @interface ClusterTest {
     String name() default "";
     SecurityProtocol securityProtocol() default SecurityProtocol.PLAINTEXT;
     String listener() default "";
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_4_IV1;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_5_IV0;
     ClusterConfigProperty[] serverProperties() default {};
 }

--- a/core/src/test/scala/integration/kafka/server/MetadataVersionIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MetadataVersionIntegrationTest.scala
@@ -47,7 +47,7 @@ class MetadataVersionIntegrationTest {
     assertEquals(ff.maxVersionLevel(), clusterInstance.config().metadataVersion().featureLevel())
 
     // Update to new version
-    val updateVersion = MetadataVersion.IBP_3_4_IV1.featureLevel.shortValue
+    val updateVersion = MetadataVersion.IBP_3_5_IV0.featureLevel.shortValue
     val updateResult = admin.updateFeatures(
       Map("metadata.version" -> new FeatureUpdate(updateVersion, UpgradeType.UPGRADE)).asJava, new UpdateFeaturesOptions())
     updateResult.all().get()

--- a/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
@@ -84,7 +84,7 @@ class FeatureCommandTest extends IntegrationTestHarness {
         Array("--bootstrap-server", bootstrapServers(), "describe"), env.out))
       assertEquals(String.format(
         "Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-          "SupportedMaxVersion: 3.4-IV1\tFinalizedVersionLevel: 3.3-IV1\t"),
+          "SupportedMaxVersion: 3.5-IV0\tFinalizedVersionLevel: 3.3-IV1\t"),
             env.outputWithoutEpoch())
     }
   }
@@ -173,7 +173,7 @@ class FeatureCommandUnitTest {
 
   @Test
   def testMetadataVersionsToString(): Unit = {
-    assertEquals("3.3-IV0, 3.3-IV1, 3.3-IV2, 3.3-IV3, 3.4-IV0, 3.4-IV1",
+    assertEquals("3.3-IV0, 3.3-IV1, 3.3-IV2, 3.3-IV3, 3.4-IV0, 3.5-IV0",
       FeatureCommand.metadataVersionsToString(IBP_3_3_IV0, IBP_3_5_IV0))
   }
 

--- a/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.clients.admin.FeatureUpdate.UpgradeType.{SAFE_DOWNGRADE,
 import org.apache.kafka.clients.admin.MockAdminClient
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.common.MetadataVersion
-import org.apache.kafka.server.common.MetadataVersion.{IBP_3_3_IV0, IBP_3_3_IV1, IBP_3_3_IV2, IBP_3_3_IV3, IBP_3_4_IV1}
+import org.apache.kafka.server.common.MetadataVersion.{IBP_3_3_IV0, IBP_3_3_IV1, IBP_3_3_IV2, IBP_3_3_IV3, IBP_3_5_IV0}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -174,7 +174,7 @@ class FeatureCommandUnitTest {
   @Test
   def testMetadataVersionsToString(): Unit = {
     assertEquals("3.3-IV0, 3.3-IV1, 3.3-IV2, 3.3-IV3, 3.4-IV0, 3.4-IV1",
-      FeatureCommand.metadataVersionsToString(IBP_3_3_IV0, IBP_3_4_IV1))
+      FeatureCommand.metadataVersionsToString(IBP_3_3_IV0, IBP_3_5_IV0))
   }
 
   @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -164,7 +164,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_4_IV1)).
+                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_5_IV0)).
                 setBrokerId(0).
                 setClusterId(logEnv.clusterId())).get();
             testConfigurationOperations(controlEnv.activeController());
@@ -205,7 +205,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_4_IV1)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_5_IV0)).
                     setBrokerId(0).
                     setClusterId(logEnv.clusterId())).get();
             testDelayedConfigurationOperations(logEnv, controlEnv.activeController());
@@ -536,7 +536,7 @@ public class QuorumControllerTest {
                     setBrokerId(0).
                     setClusterId(active.clusterId()).
                     setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_4_IV1)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_5_IV0)).
                     setListeners(listeners));
             assertEquals(2L, reply.get().epoch());
             CreateTopicsRequestData createTopicsRequestData =
@@ -957,7 +957,7 @@ public class QuorumControllerTest {
                     .setBrokerId(brokerId)
                     .setRack(null)
                     .setClusterId(controller.clusterId())
-                    .setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_4_IV1))
+                    .setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_5_IV0))
                     .setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB" + brokerId))
                     .setListeners(
                         new ListenerCollection(

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -168,7 +168,7 @@ public enum MetadataVersion {
     IBP_3_4_IV0(8, "3.4", "IV0", true),
 
     // Support for tiered storage (KIP-405)
-    IBP_3_4_IV1(9, "3.4", "IV1", true);
+    IBP_3_5_IV0(9, "3.5", "IV0", false);
 
     // NOTE: update the default version in @ClusterTest annotation to point to the latest version
     public static final String FEATURE_NAME = "metadata.version";
@@ -288,7 +288,7 @@ public enum MetadataVersion {
     }
 
     public short fetchRequestVersion() {
-        if (this.isAtLeast(IBP_3_4_IV1)) {
+        if (this.isAtLeast(IBP_3_5_IV0)) {
             return 14;
         } else if (this.isAtLeast(IBP_3_1_IV0)) {
             return 13;
@@ -332,7 +332,7 @@ public enum MetadataVersion {
     }
 
     public short listOffsetRequestVersion() {
-        if (this.isAtLeast(IBP_3_4_IV1)) {
+        if (this.isAtLeast(IBP_3_5_IV0)) {
             return 8;
         } else if (this.isAtLeast(IBP_3_0_IV1)) {
             return 7;

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -156,7 +156,8 @@ class MetadataVersionTest {
         assertEquals(IBP_3_3_IV3, MetadataVersion.fromVersionString("3.3-IV3"));
 
         assertEquals(IBP_3_4_IV0, MetadataVersion.fromVersionString("3.4-IV0"));
-        assertEquals(IBP_3_4_IV1, MetadataVersion.fromVersionString("3.4-IV1"));
+
+        assertEquals(IBP_3_5_IV0, MetadataVersion.fromVersionString("3.5-IV0"));
     }
 
     @Test
@@ -205,7 +206,7 @@ class MetadataVersionTest {
         assertEquals("3.3", IBP_3_3_IV2.shortVersion());
         assertEquals("3.3", IBP_3_3_IV3.shortVersion());
         assertEquals("3.4", IBP_3_4_IV0.shortVersion());
-        assertEquals("3.4", IBP_3_4_IV1.shortVersion());
+        assertEquals("3.5", IBP_3_5_IV0.shortVersion());
     }
 
     @Test
@@ -243,7 +244,7 @@ class MetadataVersionTest {
         assertEquals("3.3-IV2", IBP_3_3_IV2.version());
         assertEquals("3.3-IV3", IBP_3_3_IV3.version());
         assertEquals("3.4-IV0", IBP_3_4_IV0.version());
-        assertEquals("3.4-IV1", IBP_3_4_IV1.version());
+        assertEquals("3.5-IV0", IBP_3_5_IV0.version());
     }
 
     @Test


### PR DESCRIPTION
https://github.com/apache/kafka/pull/11390/ will be released as part of AK 3.5 but it added the MetadataVersion `IBP_3_4_IV1`.  It should have been `IBP_3_5_IV0`.  This change causes no incompatibility because this feature is not yet released.

Also, `didMetadataChange` is adjusted to `false` because the KRaft metadata log records are unaffected.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
