### PR TITLE
KAFKA-14513; Add broker side PartitionAssignor interface

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -340,6 +340,7 @@
 
   <subpackage name="coordinator">
     <subpackage name="group">
+      <allow pkg="org.apache.kafka.common.annotation" />
       <allow pkg="org.apache.kafka.common.message" />
       <allow pkg="org.apache.kafka.common.requests" />
     </subpackage>

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentMemberSpec.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentMemberSpec.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The assignment specification for a consumer group member.
+ */
+public class AssignmentMemberSpec {
+    /**
+     * The instance ID if provided.
+     */
+    final Optional<String> instanceId;
+
+    /**
+     * The rack ID if provided.
+     */
+    final Optional<String> rackId;
+
+    /**
+     * The topics that the member is subscribed to.
+     */
+    final Collection<String> subscribedTopics;
+
+    /**
+     * The current target partitions of the member.
+     */
+    final Collection<TopicPartition> targetPartitions;
+
+    public AssignmentMemberSpec(
+        Optional<String> instanceId,
+        Optional<String> rackId,
+        Collection<String> subscribedTopics,
+        Collection<TopicPartition> targetPartitions
+    ) {
+        Objects.requireNonNull(instanceId);
+        Objects.requireNonNull(rackId);
+        Objects.requireNonNull(subscribedTopics);
+        Objects.requireNonNull(targetPartitions);
+        this.instanceId = instanceId;
+        this.rackId = rackId;
+        this.subscribedTopics = subscribedTopics;
+        this.targetPartitions = targetPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AssignmentMemberSpec that = (AssignmentMemberSpec) o;
+
+        if (!instanceId.equals(that.instanceId)) return false;
+        if (!rackId.equals(that.rackId)) return false;
+        if (!subscribedTopics.equals(that.subscribedTopics)) return false;
+        return targetPartitions.equals(that.targetPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = instanceId.hashCode();
+        result = 31 * result + rackId.hashCode();
+        result = 31 * result + subscribedTopics.hashCode();
+        result = 31 * result + targetPartitions.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AssignmentMemberSpec(instanceId=" + instanceId +
+            ", rackId=" + rackId +
+            ", subscribedTopics=" + subscribedTopics +
+            ", targetPartitions=" + targetPartitions +
+            ')';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentSpec.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentSpec.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The assignment specification for a consumer group.
+ */
+public class AssignmentSpec {
+    /**
+     * The members keyed by member id.
+     */
+    final Map<String, AssignmentMemberSpec> members;
+
+    /**
+     * The topics' metadata keyed by topic id
+     */
+    final Map<Uuid, AssignmentTopicMetadata> topics;
+
+    public AssignmentSpec(
+        Map<String, AssignmentMemberSpec> members,
+        Map<Uuid, AssignmentTopicMetadata> topics
+    ) {
+        Objects.requireNonNull(members);
+        Objects.requireNonNull(topics);
+
+        this.members = members;
+        this.topics = topics;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AssignmentSpec that = (AssignmentSpec) o;
+
+        if (!members.equals(that.members)) return false;
+        return topics.equals(that.topics);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = members.hashCode();
+        result = 31 * result + topics.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AssignmentSpec(members=" + members +
+            ", topics=" + topics +
+            ')';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentSpec.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentSpec.java
@@ -41,7 +41,6 @@ public class AssignmentSpec {
     ) {
         Objects.requireNonNull(members);
         Objects.requireNonNull(topics);
-
         this.members = members;
         this.topics = topics;
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentTopicMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentTopicMetadata.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import java.util.Objects;
+
+/**
+ * Metadata of a topic.
+ */
+public class AssignmentTopicMetadata {
+    /**
+     * The topic name.
+     */
+    final String topicName;
+
+    /**
+     * The number of partitions.
+     */
+    final int numPartitions;
+
+    public AssignmentTopicMetadata(
+        String topicName,
+        int numPartitions
+    ) {
+        Objects.requireNonNull(topicName);
+        this.topicName = topicName;
+        this.numPartitions = numPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AssignmentTopicMetadata that = (AssignmentTopicMetadata) o;
+
+        if (numPartitions != that.numPartitions) return false;
+        return topicName.equals(that.topicName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = topicName.hashCode();
+        result = 31 * result + numPartitions;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AssignmentTopicMetadata(topicName=" + topicName +
+            ", numPartitions=" + numPartitions +
+            ')';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/GroupAssignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/GroupAssignment.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The partition assignment for a consumer group.
+ */
+public class GroupAssignment {
+    /**
+     * The member assignments keyed by member id.
+     */
+    final Map<String, MemberAssignment> members;
+
+    public GroupAssignment(
+        Map<String, MemberAssignment> members
+    ) {
+        Objects.requireNonNull(members);
+        this.members = members;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GroupAssignment that = (GroupAssignment) o;
+
+        return members.equals(that.members);
+    }
+
+    @Override
+    public int hashCode() {
+        return members.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "GroupAssignment(members=" + members + ')';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/MemberAssignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/MemberAssignment.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * The partition assignment for a consumer group member.
+ */
+public class MemberAssignment {
+    /**
+     * The target partitions assigned to this member.
+     */
+    final Collection<TopicPartition> targetPartitions;
+
+    public MemberAssignment(
+        Collection<TopicPartition> targetPartitions
+    ) {
+        Objects.requireNonNull(targetPartitions);
+        this.targetPartitions = targetPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MemberAssignment that = (MemberAssignment) o;
+
+        return targetPartitions.equals(that.targetPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return targetPartitions.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "MemberAssignment(targetPartitions=" + targetPartitions + ')';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/PartitionAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/PartitionAssignor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Server side partition assignor used by the GroupCoordinator.
+ *
+ * The interface is kept in an internal module until KIP-848 is fully
+ * implemented and ready to be released.
+ */
+@InterfaceStability.Unstable
+public interface PartitionAssignor {
+
+    /**
+     * Unique name for this assignor.
+     */
+    String name();
+
+    /**
+     * Perform the group assignment given the current members and
+     * topic metadata.
+     *
+     * @param assignmentSpec The assignment spec.
+     * @return The new assignment for the group.
+     */
+    GroupAssignment assign(AssignmentSpec assignmentSpec) throws PartitionAssignorException;
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/PartitionAssignorException.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/PartitionAssignorException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import org.apache.kafka.common.errors.ApiException;
+
+/**
+ * Exception thrown by {@link PartitionAssignor#assign(AssignmentSpec)}. The exception
+ * is only used internally.
+ */
+public class PartitionAssignorException extends ApiException {
+
+    public PartitionAssignorException(String message) {
+        super(message);
+    }
+
+    public PartitionAssignorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
This patch adds the broker side `PartitionAssignor` interface as detailed in KIP-848. The interfaces differs a bit from the KIP in the following ways:
* The POJOs are not defined within the interface because the interface is to heavy like this.
* The interface is kept in the `group-coordinator` module for now. We don't want to have it out there until KIP-848 is ready to be released. We will move it to its final destination later.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
