### PR TITLE
KAFKA-14676: Include all SASL configs in login cache key to ensure clients in a JVM can use different OAuth configs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -99,14 +99,14 @@ public class LoginManager {
             LoginManager loginManager;
             Password jaasConfigValue = jaasContext.dynamicJaasConfig();
             if (jaasConfigValue != null) {
-                LoginMetadata<Password> loginMetadata = new LoginMetadata<>(jaasConfigValue, loginClass, loginCallbackClass);
+                LoginMetadata<Password> loginMetadata = new LoginMetadata<>(jaasConfigValue, loginClass, loginCallbackClass, configs);
                 loginManager = DYNAMIC_INSTANCES.get(loginMetadata);
                 if (loginManager == null) {
                     loginManager = new LoginManager(jaasContext, saslMechanism, configs, loginMetadata);
                     DYNAMIC_INSTANCES.put(loginMetadata, loginManager);
                 }
             } else {
-                LoginMetadata<String> loginMetadata = new LoginMetadata<>(jaasContext.name(), loginClass, loginCallbackClass);
+                LoginMetadata<String> loginMetadata = new LoginMetadata<>(jaasContext.name(), loginClass, loginCallbackClass, configs);
                 loginManager = STATIC_INSTANCES.get(loginMetadata);
                 if (loginManager == null) {
                     loginManager = new LoginManager(jaasContext, saslMechanism, configs, loginMetadata);
@@ -198,17 +198,23 @@ public class LoginManager {
         final T configInfo;
         final Class<? extends Login> loginClass;
         final Class<? extends AuthenticateCallbackHandler> loginCallbackClass;
+        final Map<String, Object> saslConfigs;
 
         LoginMetadata(T configInfo, Class<? extends Login> loginClass,
-                      Class<? extends AuthenticateCallbackHandler> loginCallbackClass) {
+                      Class<? extends AuthenticateCallbackHandler> loginCallbackClass,
+                      Map<String, ?> configs) {
             this.configInfo = configInfo;
             this.loginClass = loginClass;
             this.loginCallbackClass = loginCallbackClass;
+            this.saslConfigs = new HashMap<>();
+            configs.entrySet().stream()
+                    .filter(e -> e.getKey().startsWith("sasl."))
+                    .forEach(e -> saslConfigs.put(e.getKey(), e.getValue())); // value may be null
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(configInfo, loginClass, loginCallbackClass);
+            return Objects.hash(configInfo, loginClass, loginCallbackClass, saslConfigs);
         }
 
         @Override
@@ -219,7 +225,8 @@ public class LoginManager {
             LoginMetadata<?> loginMetadata = (LoginMetadata<?>) o;
             return Objects.equals(configInfo, loginMetadata.configInfo) &&
                    Objects.equals(loginClass, loginMetadata.loginClass) &&
-                   Objects.equals(loginCallbackClass, loginMetadata.loginCallbackClass);
+                   Objects.equals(loginCallbackClass, loginMetadata.loginCallbackClass) &&
+                   Objects.equals(saslConfigs, loginMetadata.saslConfigs);
         }
     }
 }


### PR DESCRIPTION
We currently cache login managers in static maps for both static JAAS config using system property and for JAAS config specified using Kafka config `sasl.jaas.config`. In addition to the JAAS config, the login manager callback handler is included in the key, but all other configs are ignored. This implementation is based on the assumption clients that require different logins (e.g. username/password) use different JAAS configs, because login properties are included in the JAAS config rather than as separate top-level configs. The OIDC support added in KIP-768 only allows configuration of token endpoint URL as a top-level config. This results in two clients in a JVM configured with different token endpoint URLs to incorrectly share a login.

This PR includes all SASL configs prefixed with `sasl.` to be included in the key so that logins are only shared if all the sasl configs are identical.

Two rejected approaches:
1) Only include `sasl.oauthbearer.token.endpoint.url` in the key. Rejected because there may be other configs in future for which we want different logins. It may also be useful to have a mechanism to force different logins when using custom configs, `sasl.` prefix would work in general.
2) Include all configs in the key. Kafka brokers create multiple inter-broker clients with different configs, e.g. client.id. We want brokers to create only one login, hence chose a subset based on the `sasl.` prefix.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
