### PR TITLE
Remove unused ZooKeeper log level configuration from `connect-log4j.properties`

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -38,5 +38,4 @@ connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
 log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
 
-log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR

--- a/tests/kafkatest/services/templates/connect_log4j.properties
+++ b/tests/kafkatest/services/templates/connect_log4j.properties
@@ -25,5 +25,4 @@ log4j.appender.FILE.Append=true
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n
 
-log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR


### PR DESCRIPTION
The `connect-log4j.properties` file configures the log level for the ZooKeeper logger. That seems unnecessary since Kafka Connect does not use ZooKeeper directly in any way. This PR removes it from the logging configuration file.