### PR TITLE
KAFKA-6793: Unused configuration logging appears to be noisy and unnecessary 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -377,7 +377,7 @@ public class AbstractConfig {
     }
 
     /**
-     * Log warnings for any unused configurations
+     * Debug level log for any unused configurations
      */
     public void logUnused() {
         Set<String> unusedkeys = unused();

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -377,12 +377,12 @@ public class AbstractConfig {
     }
 
     /**
-     * Debug level log for any unused configurations
+     * Info level log for any unused configurations
      */
     public void logUnused() {
         Set<String> unusedkeys = unused();
         if (!unusedkeys.isEmpty()) {
-            log.debug("These configurations '{}' were supplied but are not used yet.", unusedkeys);
+            log.info("These configurations '{}' were supplied but are not used yet.", unusedkeys);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -18,11 +18,11 @@ package org.apache.kafka.common.config;
 
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.provider.ConfigProvider;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.kafka.common.config.provider.ConfigProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -382,7 +382,7 @@ public class AbstractConfig {
     public void logUnused() {
         Set<String> unusedkeys = unused();
         if (!unusedkeys.isEmpty()) {
-            log.warn("These configurations '{}' were supplied but are not used yet.", unusedkeys);
+            log.debug("These configurations '{}' were supplied but are not used yet.", unusedkeys);
         }
     }
 


### PR DESCRIPTION
Reviving this old discussion, apparently the PR was closed so I reopened another one.

**Issue**: Recently we've encountered complaints about the warning being too noisy, therefore we want to reduce it to debug level.

The original PR was closed in : https://issues.apache.org/jira/browse/KAFKA-6793

**Questions**
Is this log useful at all? Should we just remove it?