### PR TITLE
KAFKA-10199: Add task updater metrics, part 1

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -28,8 +28,10 @@ import java.util.Set;
 public interface ChangelogReader extends ChangelogRegister {
     /**
      * Restore all registered state stores by reading from their changelogs
+     *
+     * @return the total number of records restored in this call
      */
-    void restore(final Map<TaskId, Task> tasks);
+    long restore(final Map<TaskId, Task> tasks);
 
     /**
      * Transit to restore active changelogs mode

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -44,6 +44,12 @@ public interface ChangelogReader extends ChangelogRegister {
     void transitToUpdateStandby();
 
     /**
+     * @return true if the reader is in restoring active changelog mode;
+     *         false if the reader is in updating standby changelog mode
+     */
+    boolean isRestoringActive();
+
+    /**
      * @return the changelog partitions that have been completed restoring
      */
     Set<TopicPartition> completedChangelogs();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -467,11 +467,13 @@ public class DefaultStateUpdater implements StateUpdater {
                         elapsedMsSinceLastCommit, commitIntervalMs);
                 }
 
-                for (final Task task : updatingTasks.values()) {
-                    log.debug("Try to checkpoint current restoring progress for task {}", task.id());
-                    // do not enforce checkpointing during restoration if its position has not advanced much
-                    measureCheckpointLatency(() -> task.maybeCheckpoint(false));
-                }
+                measureCheckpointLatency(() -> {
+                    for (final Task task : updatingTasks.values()) {
+                        log.debug("Try to checkpoint current restoring progress for task {}", task.id());
+                        // do not enforce checkpointing during restoration if its position has not advanced much
+                        task.maybeCheckpoint(false);
+                    }
+                });
 
                 lastCommitMs = now;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.utils.LogContext;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -423,7 +423,7 @@ public class StoreChangelogReader implements ChangelogReader {
     // 2. if all changelogs have finished, return early;
     // 3. if there are any restoring changelogs, try to read from the restore consumer and process them.
     @Override
-    public void restore(final Map<TaskId, Task> tasks) {
+    public long restore(final Map<TaskId, Task> tasks) {
 
         // If we are updating only standby tasks, and are not using a separate thread, we should
         // use a non-blocking poll to unblock the processing as soon as possible.
@@ -435,9 +435,10 @@ public class StoreChangelogReader implements ChangelogReader {
             throw new IllegalStateException("Should not be in standby updating state if there are still un-completed active changelogs");
         }
 
+        long totalRestored = 0L;
         if (allChangelogsCompleted()) {
             log.debug("Finished restoring all changelogs {}", changelogs.keySet());
-            return;
+            return totalRestored;
         }
 
         final Set<TopicPartition> restoringChangelogs = restoringChangelogs();
@@ -479,12 +480,15 @@ public class StoreChangelogReader implements ChangelogReader {
                 //       small batches; this can be optimized in the future, e.g. wait longer for larger batches.
                 final TaskId taskId = changelogs.get(partition).stateManager.taskId();
                 try {
-                    if (restoreChangelog(changelogs.get(partition))) {
+                    final ChangelogMetadata changelogMetadata = changelogs.get(partition);
+                    int restored = restoreChangelog(changelogMetadata);
+                    if (restored > 0 || changelogMetadata.state().equals(ChangelogState.COMPLETED)) {
                         final Task task = tasks.get(taskId);
                         if (task != null) {
                             task.clearTaskTimeout();
                         }
                     }
+                    totalRestored += restored;
                 } catch (final TimeoutException timeoutException) {
                     tasks.get(taskId).maybeInitTaskTimeoutOrThrow(
                         time.milliseconds(),
@@ -497,6 +501,8 @@ public class StoreChangelogReader implements ChangelogReader {
 
             maybeLogRestorationProgress();
         }
+
+        return totalRestored;
     }
 
     private void pauseResumePartitions(final Map<TaskId, Task> tasks,
@@ -623,19 +629,17 @@ public class StoreChangelogReader implements ChangelogReader {
     /**
      * restore a changelog with its buffered records if there's any; for active changelogs also check if
      * it has completed the restoration and can transit to COMPLETED state and trigger restore callbacks
+     *
+     * @return number of records restored
      */
-    private boolean restoreChangelog(final ChangelogMetadata changelogMetadata) {
+    private int restoreChangelog(final ChangelogMetadata changelogMetadata) {
         final ProcessorStateManager stateManager = changelogMetadata.stateManager;
         final StateStoreMetadata storeMetadata = changelogMetadata.storeMetadata;
         final TopicPartition partition = storeMetadata.changelogPartition();
         final String storeName = storeMetadata.store().name();
         final int numRecords = changelogMetadata.bufferedLimitIndex;
 
-        boolean madeProgress = false;
-
         if (numRecords != 0) {
-            madeProgress = true;
-
             final List<ConsumerRecord<byte[], byte[]>> records = changelogMetadata.bufferedRecords.subList(0, numRecords);
             stateManager.restore(storeMetadata, records);
 
@@ -650,7 +654,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
             final Long currentOffset = storeMetadata.offset();
             log.trace("Restored {} records from changelog {} to store {}, end offset is {}, current offset is {}",
-                partition, storeName, numRecords, recordEndOffset(changelogMetadata.restoreEndOffset), currentOffset);
+                numRecords, partition, storeName, recordEndOffset(changelogMetadata.restoreEndOffset), currentOffset);
 
             changelogMetadata.bufferedLimitIndex = 0;
             changelogMetadata.totalRestored += numRecords;
@@ -667,8 +671,6 @@ public class StoreChangelogReader implements ChangelogReader {
 
         // we should check even if there's nothing restored, but do not check completed if we are processing standby tasks
         if (changelogMetadata.stateManager.taskType() == Task.TaskType.ACTIVE && hasRestoredToEnd(changelogMetadata)) {
-            madeProgress = true;
-
             log.info("Finished restoring changelog {} to store {} with a total number of {} records",
                 partition, storeName, changelogMetadata.totalRestored);
 
@@ -682,7 +684,7 @@ public class StoreChangelogReader implements ChangelogReader {
             }
         }
 
-        return madeProgress;
+        return numRecords;
     }
 
     private Set<Task> getTasksFromPartitions(final Map<TaskId, Task> tasks,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -330,6 +330,11 @@ public class StoreChangelogReader implements ChangelogReader {
         state = ChangelogReaderState.STANDBY_UPDATING;
     }
 
+    @Override
+    public boolean isRestoringActive() {
+        return state == ChangelogReaderState.ACTIVE_RESTORING;
+    }
+
     /**
      * Since it is shared for multiple tasks and hence multiple state managers, the registration would take its
      * corresponding state manager as well for restoring.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -404,7 +404,7 @@ public class StreamThread extends Thread {
             topologyMetadata,
             adminClient,
             stateDirectory,
-            maybeCreateAndStartStateUpdater(stateUpdaterEnabled, config, changelogReader, topologyMetadata, time, clientId, threadIdx)
+            maybeCreateAndStartStateUpdater(stateUpdaterEnabled, streamsMetrics, config, changelogReader, topologyMetadata, time, clientId, threadIdx)
         );
         referenceContainer.taskManager = taskManager;
 
@@ -448,6 +448,7 @@ public class StreamThread extends Thread {
     }
 
     private static StateUpdater maybeCreateAndStartStateUpdater(final boolean stateUpdaterEnabled,
+                                                                final StreamsMetricsImpl streamsMetrics,
                                                                 final StreamsConfig streamsConfig,
                                                                 final ChangelogReader changelogReader,
                                                                 final TopologyMetadata topologyMetadata,
@@ -456,7 +457,7 @@ public class StreamThread extends Thread {
                                                                 final int threadIdx) {
         if (stateUpdaterEnabled) {
             final String name = clientId + "-StateUpdater-" + threadIdx;
-            final StateUpdater stateUpdater = new DefaultStateUpdater(name, streamsConfig, changelogReader, topologyMetadata, time);
+            final StateUpdater stateUpdater = new DefaultStateUpdater(name, streamsMetrics.metricsRegistry(), streamsConfig, changelogReader, topologyMetadata, time);
             stateUpdater.start();
             return stateUpdater;
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1552,7 +1552,9 @@ public class TaskManager {
     /**
      * Returns tasks owned by the stream thread. With state updater disabled, these are all tasks. With
      * state updater enabled, this does not return any tasks currently owned by the state updater.
-     * @return
+     *
+     * TODO: after we complete switching to state updater, we could rename this function as allRunningTasks
+     *       to be differentiated from allTasks including running and restoring tasks
      */
     Map<TaskId, Task> allOwnedTasks() {
         // not bothering with an unmodifiable map, since the tasks themselves are mutable, but

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -146,6 +146,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String OPERATIONS = " operations";
     public static final String TOTAL_DESCRIPTION = "The total number of ";
     public static final String RATE_DESCRIPTION = "The average per-second number of ";
+    public static final String RATIO_DESCRIPTION = "The fraction of time the thread spent on ";
     public static final String AVG_LATENCY_DESCRIPTION = "The average latency of ";
     public static final String MAX_LATENCY_DESCRIPTION = "The maximum latency of ";
     public static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
@@ -175,6 +176,10 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public Version version() {
         return version;
+    }
+
+    public Metrics metricsRegistry() {
+        return metrics;
     }
 
     public RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -1572,62 +1572,62 @@ class DefaultStateUpdaterTest {
         final Map<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put("thread-id", "test-state-updater");
 
-        MetricName metricName = new MetricName("restoring-active-tasks",
-            "stream-state-metrics",
+        MetricName metricName = new MetricName("active-restoring-tasks",
+            "stream-state-updater-metrics",
             "The number of active tasks currently undergoing restoration",
             tagMap);
         verifyMetric(metrics, metricName, is(1.0));
 
-        metricName = new MetricName("restoring-standby-tasks",
-            "stream-state-metrics",
-            "The number of standby tasks currently undergoing restoration",
+        metricName = new MetricName("standby-updating-tasks",
+            "stream-state-updater-metrics",
+            "The number of standby tasks currently undergoing state update",
             tagMap);
         verifyMetric(metrics, metricName, is(1.0));
 
-        metricName = new MetricName("paused-active-tasks",
-            "stream-state-metrics",
+        metricName = new MetricName("active-paused-tasks",
+            "stream-state-updater-metrics",
             "The number of active tasks paused restoring",
             tagMap);
         verifyMetric(metrics, metricName, is(1.0));
 
-        metricName = new MetricName("paused-standby-tasks",
-            "stream-state-metrics",
-            "The number of standby tasks paused restoring",
+        metricName = new MetricName("standby-paused-tasks",
+            "stream-state-updater-metrics",
+            "The number of standby tasks paused state update",
             tagMap);
         verifyMetric(metrics, metricName, is(1.0));
 
         metricName = new MetricName("idle-ratio",
-            "stream-state-metrics",
+            "stream-state-updater-metrics",
             "The fraction of time the thread spent on being idle",
             tagMap);
         verifyMetric(metrics, metricName, not(0.0d));
 
-        metricName = new MetricName("restore-ratio",
-            "stream-state-metrics",
-            "The fraction of time the thread spent on restoring tasks",
+        metricName = new MetricName("active-restore-ratio",
+            "stream-state-updater-metrics",
+            "The fraction of time the thread spent on restoring active tasks",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        metricName = new MetricName("standby-update-ratio",
+            "stream-state-updater-metrics",
+            "The fraction of time the thread spent on updating standby tasks",
             tagMap);
         verifyMetric(metrics, metricName, not(0.0d));
 
         metricName = new MetricName("checkpoint-ratio",
-            "stream-state-metrics",
+            "stream-state-updater-metrics",
             "The fraction of time the thread spent on checkpointing tasks restored progress",
             tagMap);
         verifyMetric(metrics, metricName, not(0.0d));
 
-        metricName = new MetricName("restore-records-total",
-            "stream-state-metrics",
-            "The total number of records restored",
-            tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
-
         metricName = new MetricName("restore-records-rate",
-            "stream-state-metrics",
+            "stream-state-updater-metrics",
             "The average per-second number of records restored",
             tagMap);
         verifyMetric(metrics, metricName, not(0.0d));
 
         metricName = new MetricName("restore-call-rate",
-            "stream-state-metrics",
+            "stream-state-updater-metrics",
             "The average per-second number of restore calls triggered",
             tagMap);
         verifyMetric(metrics, metricName, not(0.0d));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -56,6 +56,7 @@ import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
 import static org.apache.kafka.test.StreamsTestUtils.TopologyMetadataBuilder.unnamedTopology;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1601,13 +1602,13 @@ class DefaultStateUpdaterTest {
             "stream-state-updater-metrics",
             "The fraction of time the thread spent on being idle",
             tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
+        verifyMetric(metrics, metricName, greaterThanOrEqualTo(0.0d));
 
         metricName = new MetricName("active-restore-ratio",
             "stream-state-updater-metrics",
             "The fraction of time the thread spent on restoring active tasks",
             tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
+        verifyMetric(metrics, metricName, greaterThanOrEqualTo(0.0d));
 
         metricName = new MetricName("standby-update-ratio",
             "stream-state-updater-metrics",
@@ -1619,7 +1620,7 @@ class DefaultStateUpdaterTest {
             "stream-state-updater-metrics",
             "The fraction of time the thread spent on checkpointing tasks restored progress",
             tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
+        verifyMetric(metrics, metricName, greaterThanOrEqualTo(0.0d));
 
         metricName = new MetricName("restore-records-rate",
             "stream-state-updater-metrics",

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
@@ -26,6 +28,7 @@ import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTasks;
 import org.apache.kafka.streams.processor.internals.Task.State;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -35,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -51,6 +55,9 @@ import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
 import static org.apache.kafka.test.StreamsTestUtils.TopologyMetadataBuilder.unnamedTopology;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -88,10 +95,12 @@ class DefaultStateUpdaterTest {
 
     // need an auto-tick timer to work for draining with timeout
     private final Time time = new MockTime(1L);
+    private final Metrics metrics = new Metrics(time);
     private final StreamsConfig config = new StreamsConfig(configProps(COMMIT_INTERVAL));
     private final ChangelogReader changelogReader = mock(ChangelogReader.class);
     private final TopologyMetadata topologyMetadata = unnamedTopology().build();
-    private DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, topologyMetadata, time);
+    private DefaultStateUpdater stateUpdater =
+        new DefaultStateUpdater("test-state-updater", metrics, config, changelogReader, topologyMetadata, time);
 
     @AfterEach
     public void tearDown() {
@@ -149,7 +158,7 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldRemoveUpdatingTasksOnShutdown() throws Exception {
         stateUpdater.shutdown(Duration.ofMillis(Long.MAX_VALUE));
-        stateUpdater = new DefaultStateUpdater("test-state-updater", new StreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, topologyMetadata, time);
+        stateUpdater = new DefaultStateUpdater("test-state-updater", metrics, new StreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, topologyMetadata, time);
         final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
@@ -643,7 +652,7 @@ class DefaultStateUpdaterTest {
             mkEntry(activeTask2.id(), activeTask2),
             mkEntry(standbyTask.id(), standbyTask)
         );
-        doThrow(taskCorruptedException).doNothing().when(changelogReader).restore(updatingTasks1);
+        doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks1);
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         stateUpdater.start();
 
@@ -670,7 +679,7 @@ class DefaultStateUpdaterTest {
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(mkSet(task1.id()));
         final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task1), taskCorruptedException);
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
-        doThrow(taskCorruptedException).doNothing().when(changelogReader).restore(updatingTasks);
+        doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks);
 
         stateUpdater.start();
         stateUpdater.add(task1);
@@ -828,7 +837,7 @@ class DefaultStateUpdaterTest {
             mkEntry(controlTask.id(), controlTask)
         );
         doThrow(streamsException)
-            .doNothing()
+            .doReturn(0L)
             .when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
 
@@ -970,7 +979,7 @@ class DefaultStateUpdaterTest {
             mkEntry(controlTask.id(), controlTask)
         );
         doThrow(streamsException)
-            .doNothing()
+            .doReturn(0L)
             .when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
 
@@ -1133,7 +1142,7 @@ class DefaultStateUpdaterTest {
                 mkEntry(controlTask.id(), controlTask)
         );
         doThrow(streamsException)
-                .doNothing()
+                .doReturn(0L)
                 .when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
 
@@ -1248,7 +1257,7 @@ class DefaultStateUpdaterTest {
             mkEntry(task2.id(), task2),
             mkEntry(task3.id(), task3)
         );
-        doNothing().doThrow(taskCorruptedException).doNothing().when(changelogReader).restore(updatingTasks);
+        doNothing().doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks);
         stateUpdater.start();
 
         stateUpdater.add(task1);
@@ -1362,7 +1371,7 @@ class DefaultStateUpdaterTest {
     public void shouldNotAutoCheckpointTasksIfIntervalNotElapsed() {
         // we need to use a non auto-ticking timer here to control how much time elapsed exactly
         final Time time = new MockTime();
-        final DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, topologyMetadata, time);
+        final DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", metrics, config, changelogReader, topologyMetadata, time);
         try {
             final StreamTask task1 = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
             final StreamTask task2 = statefulTask(TASK_0_2, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
@@ -1466,11 +1475,11 @@ class DefaultStateUpdaterTest {
             mkEntry(standbyTask1.id(), standbyTask1),
             mkEntry(standbyTask2.id(), standbyTask2)
         );
-        doNothing().doThrow(taskCorruptedException).doNothing().when(changelogReader).restore(updatingTasks1);
+        doNothing().doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks1);
         final Map<TaskId, Task> updatingTasks2 = mkMap(
             mkEntry(activeTask1.id(), activeTask1)
         );
-        doNothing().doThrow(streamsException).doNothing().when(changelogReader).restore(updatingTasks2);
+        doNothing().doThrow(streamsException).doReturn(0L).when(changelogReader).restore(updatingTasks2);
         stateUpdater.start();
         stateUpdater.add(standbyTask1);
         stateUpdater.add(activeTask1);
@@ -1524,6 +1533,118 @@ class DefaultStateUpdaterTest {
         verifyPausedTasks(activeTask, standbyTask);
 
         verifyGetTasks(mkSet(activeTask), mkSet(standbyTask));
+    }
+
+    @Test
+    public void shouldRecordMetrics() throws Exception {
+        final StreamTask activeTask1 = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final StreamTask activeTask2 = statefulTask(TASK_0_2, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
+        final StandbyTask standbyTask3 = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_1)).inState(State.RUNNING).build();
+        final StandbyTask standbyTask4 = standbyTask(TASK_1_1, mkSet(TOPIC_PARTITION_D_0)).inState(State.RUNNING).build();
+        final Map<TaskId, Task> tasks1234 = mkMap(
+            mkEntry(activeTask1.id(), activeTask1),
+            mkEntry(activeTask2.id(), activeTask2),
+            mkEntry(standbyTask3.id(), standbyTask3),
+            mkEntry(standbyTask4.id(), standbyTask4)
+        );
+        final Map<TaskId, Task> tasks134 = mkMap(
+            mkEntry(activeTask1.id(), activeTask1),
+            mkEntry(standbyTask3.id(), standbyTask3),
+            mkEntry(standbyTask4.id(), standbyTask4)
+        );
+        final Map<TaskId, Task> tasks13 = mkMap(
+            mkEntry(activeTask1.id(), activeTask1),
+            mkEntry(standbyTask3.id(), standbyTask3)
+        );
+
+        when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        when(changelogReader.restore(tasks1234)).thenReturn(1L);
+        when(changelogReader.restore(tasks134)).thenReturn(1L);
+        when(changelogReader.restore(tasks13)).thenReturn(1L);
+        stateUpdater.start();
+        stateUpdater.add(activeTask1);
+        stateUpdater.add(activeTask2);
+        stateUpdater.add(standbyTask3);
+        stateUpdater.add(standbyTask4);
+
+        verifyPausedTasks(activeTask2, standbyTask4);
+        assertThat(metrics.metrics().size(), is(11));
+
+        final Map<String, String> tagMap = new LinkedHashMap<>();
+        tagMap.put("thread-id", "state-updater");
+
+        MetricName metricName = new MetricName("restoring-active-tasks",
+            "stream-state-metrics",
+            "The number of active tasks currently undergoing restoration",
+            tagMap);
+        verifyMetric(metrics, metricName, is(1.0));
+
+        metricName = new MetricName("restoring-standby-tasks",
+            "stream-state-metrics",
+            "The number of active tasks currently undergoing restoration",
+            tagMap);
+        verifyMetric(metrics, metricName, is(1.0));
+
+        metricName = new MetricName("paused-active-tasks",
+            "stream-state-metrics",
+            "The number of active tasks paused restoring",
+            tagMap);
+        verifyMetric(metrics, metricName, is(1.0));
+
+        metricName = new MetricName("paused-standby-tasks",
+            "stream-state-metrics",
+            "The number of standby tasks paused restoring",
+            tagMap);
+        verifyMetric(metrics, metricName, is(1.0));
+
+        metricName = new MetricName("idle-ratio",
+            "stream-state-metrics",
+            "The fraction of time the thread spent on being idle",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        metricName = new MetricName("restore-ratio",
+            "stream-state-metrics",
+            "The fraction of time the thread spent on restoring tasks",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        metricName = new MetricName("checkpoint-ratio",
+            "stream-state-metrics",
+            "The fraction of time the thread spent on checkpointing tasks restored progress",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        metricName = new MetricName("restore-records-total",
+            "stream-state-metrics",
+            "The total number of records restored",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        metricName = new MetricName("restore-records-rate",
+            "stream-state-metrics",
+            "The average per-second number of records restored",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        metricName = new MetricName("restore-call-rate",
+            "stream-state-metrics",
+            "The average per-second number of restore calls triggered",
+            tagMap);
+        verifyMetric(metrics, metricName, not(0.0d));
+
+        stateUpdater.shutdown(Duration.ofMinutes(1));
+        assertThat(metrics.metrics().size(), is(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void verifyMetric(final Metrics metrics,
+                                         final MetricName metricName,
+                                         final Matcher<T> matcher) {
+        assertThat(metrics.metrics().get(metricName).metricName().description(), is(metricName.description()));
+        assertThat(metrics.metrics().get(metricName).metricName().tags(), is(metricName.tags()));
+        assertThat((T) metrics.metrics().get(metricName).metricValue(), matcher);
     }
 
     private void verifyGetTasks(final Set<StreamTask> expectedActiveTasks,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -1560,6 +1560,7 @@ class DefaultStateUpdaterTest {
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         when(changelogReader.restore(tasks1234)).thenReturn(1L);
         when(changelogReader.restore(tasks13)).thenReturn(1L);
+        when(changelogReader.isRestoringActive()).thenReturn(true);
         stateUpdater.start();
         stateUpdater.add(activeTask1);
         stateUpdater.add(activeTask2);
@@ -1612,7 +1613,7 @@ class DefaultStateUpdaterTest {
             "stream-state-updater-metrics",
             "The fraction of time the thread spent on updating standby tasks",
             tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
+        verifyMetric(metrics, metricName, is(0.0d));
 
         metricName = new MetricName("checkpoint-ratio",
             "stream-state-updater-metrics",

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
@@ -62,6 +62,11 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
+    public boolean isRestoringActive() {
+        return true;
+    }
+
+    @Override
     public Set<TopicPartition> completedChangelogs() {
         // assuming all restoring partitions are completed
         return restoringPartitions;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
@@ -46,8 +46,9 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
-    public void restore(final Map<TaskId, Task> tasks) {
+    public long restore(final Map<TaskId, Task> tasks) {
         // do nothing
+        return 0L;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1245,7 +1245,7 @@ public class StreamThreadTest {
 
         final ChangelogReader changelogReader = new MockChangelogReader() {
             @Override
-            public void restore(final Map<TaskId, Task> tasks) {
+            public long restore(final Map<TaskId, Task> tasks) {
                 consumer.addRecord(new ConsumerRecord<>(topic1, 1, 11, new byte[0], new byte[0]));
                 consumer.addRecord(new ConsumerRecord<>(topic1, 1, 12, new byte[1], new byte[0]));
 


### PR DESCRIPTION
0. Moved pausing-tasks logic out of the commit-interval loop to be on the top-level loop, similar to resuming tasks.
1. Added thread-level restoration metrics.
2. Related unit tests.


Should only be reviewed after #13025


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
