### PR TITLE
MINOR: the package of JmxTool is incorrect when running quota_test.py

### DIFF
--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -19,7 +19,7 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.util import wait_until
 
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
-from kafkatest.version import get_version, V_0_11_0_0, DEV_BRANCH
+from kafkatest.version import get_version, V_0_11_0_0, V_3_4_0, DEV_BRANCH
 
 class JmxMixin(object):
     """This mixin helps existing service subclasses start JmxTool on their worker nodes and collect jmx stats.
@@ -44,7 +44,7 @@ class JmxMixin(object):
         self.jmx_tool_err_log = os.path.join(root, "jmx_tool.err.log")
 
     def clean_node(self, node, idx=None):
-        node.account.kill_java_processes(self.jmx_class_name(), clean_shutdown=False,
+        node.account.kill_java_processes(self.jmx_class_name(self.jmxtool_version(node)), clean_shutdown=False,
                                          allow_fail=True)
         if idx is None:
             idx = self.idx(node)
@@ -68,13 +68,8 @@ class JmxMixin(object):
 
         wait_until(check_jmx_port_listening, timeout_sec=30, backoff_sec=.1,
                    err_msg="%s: Never saw JMX port for %s start listening" % (node.account, self))
-
-        # To correctly wait for requested JMX metrics to be added we need the --wait option for JmxTool. This option was
-        # not added until 0.11.0.1, so any earlier versions need to use JmxTool from a newer version.
-        use_jmxtool_version = get_version(node)
-        if use_jmxtool_version <= V_0_11_0_0:
-            use_jmxtool_version = DEV_BRANCH
-        cmd = "%s %s " % (self.path.script("kafka-run-class.sh", use_jmxtool_version), self.jmx_class_name())
+        use_jmxtool_version = self.jmxtool_version(node)
+        cmd = "%s %s " % (self.path.script("kafka-run-class.sh", use_jmxtool_version), self.jmx_class_name(use_jmxtool_version))
         cmd += "--reporting-interval %d --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:%d/jmxrmi" % (self.jmx_poll_ms, self.jmx_port)
         cmd += " --wait"
         for jmx_object_name in self.jmx_object_names:
@@ -140,8 +135,20 @@ class JmxMixin(object):
         for node in self.nodes:
             self.read_jmx_output(self.idx(node), node)
 
-    def jmx_class_name(self):
-        return "org.apache.kafka.tools.JmxTool"
+    def jmxtool_version(self, node):
+        # To correctly wait for requested JMX metrics to be added we need the --wait option for JmxTool. This option was
+        # not added until 0.11.0.1, so any earlier versions need to use JmxTool from a newer version.
+        version = get_version(node)
+        if version <= V_0_11_0_0:
+            return DEV_BRANCH
+        else:
+            return version
+
+    def jmx_class_name(self, version):
+        if version <= V_3_4_0:
+            return "kafka.tools.JmxTool"
+        else:
+            return "org.apache.kafka.tools.JmxTool"
 
 class JmxTool(JmxMixin, KafkaPathResolverMixin):
     """


### PR DESCRIPTION
related to #13136

`JmxTool` was moved from `kafka.tools.JmxTool` to `org.apache.kafka.tools.JmxTool`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
