### PR TITLE
KAFKA-14707: Handle possible read error in the Array type caused by insufficient remaining bytes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
@@ -72,8 +72,20 @@ public class ArrayOf extends DocumentedType {
         else if (size < 0)
             throw new SchemaException("Array size " + size + " cannot be negative");
 
-        if (size > buffer.remaining())
-            throw new SchemaException("Error reading array of size " + size + ", only " + buffer.remaining() + " bytes available");
+        int elementSize = 0;
+        if (size > 0 ) {
+            try {
+                int position = buffer.position();
+                Object obj = type.read(buffer);
+                buffer.position(position);
+                elementSize = type.sizeOf(obj);
+            } catch (Exception e) {
+                throw new SchemaException("Error reading first element of array: " +
+                    (e.getMessage() == null ? e.getClass().getName() : e.getMessage()));
+            }
+        }
+        if (size * elementSize > buffer.remaining())
+            throw new SchemaException("Error reading array of size " + size * elementSize + ", only " + buffer.remaining() + " bytes available");
         Object[] objs = new Object[size];
         for (int i = 0; i < size; i++)
             objs[i] = type.read(buffer);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
@@ -73,7 +73,7 @@ public class ArrayOf extends DocumentedType {
             throw new SchemaException("Array size " + size + " cannot be negative");
 
         int elementSize = 0;
-        if (size > 0 ) {
+        if (size > 0) {
             try {
                 int position = buffer.position();
                 Object obj = type.read(buffer);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
@@ -77,8 +77,20 @@ public class CompactArrayOf extends DocumentedType {
             }
         }
         int size = n - 1;
-        if (size > buffer.remaining())
-            throw new SchemaException("Error reading array of size " + size + ", only " + buffer.remaining() + " bytes available");
+        int elementSize = 0;
+        if (size > 0 ) {
+            try {
+                int position = buffer.position();
+                Object obj = type.read(buffer);
+                buffer.position(position);
+                elementSize = type.sizeOf(obj);
+            } catch (Exception e) {
+                throw new SchemaException("Error reading first element of array: " +
+                    (e.getMessage() == null ? e.getClass().getName() : e.getMessage()));
+            }
+        }
+        if (size * elementSize > buffer.remaining())
+            throw new SchemaException("Error reading array of size " + size * elementSize + ", only " + buffer.remaining() + " bytes available");
         Object[] objs = new Object[size];
         for (int i = 0; i < size; i++)
             objs[i] = type.read(buffer);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
@@ -78,7 +78,7 @@ public class CompactArrayOf extends DocumentedType {
         }
         int size = n - 1;
         int elementSize = 0;
-        if (size > 0 ) {
+        if (size > 0) {
             try {
                 int position = buffer.position();
                 Object obj = type.read(buffer);

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.protocol.types;
 
-import java.nio.Buffer;
 import org.apache.kafka.common.utils.ByteUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -454,7 +453,7 @@ public class ProtocolSerializationTest {
                 type.write(buffer, obj);
                 buffer.rewind();
                 type.read(buffer);
-                if (((Object []) obj).length > 0 ) {
+                if (((Object[]) obj).length > 0) {
                     try {
                         buffer.rewind();
                         buffer.limit(buffer.limit() - 1);


### PR DESCRIPTION
```
if (size > buffer.remaining())
    throw new SchemaException("Error reading array of size " + size + ", only " + buffer.remaining() + " bytes available");
``` 
Array type has the above code snippet which checks if there are enough bytes in the buffer to read all the array elements. However, there is a unit mismatch because `size` is the number of elements in the array, not the number of bytes. Thus, even if the above check passes there still might be not enough bytes remaining in the buffer. 

This PR handles this issue by first reading the first element and then computing the byte size of the array. I've added one unit test.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
