### PR TITLE
KAFKA-14708: Use Java thread instead of kafka library for example purpose

### DIFF
--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -16,7 +16,6 @@
  */
 package kafka.examples;
 
-import kafka.utils.ShutdownableThread;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -28,11 +27,12 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
-public class Consumer extends ShutdownableThread {
+public class Consumer extends Thread {
     private final KafkaConsumer<Integer, String> consumer;
     private final String topic;
     private final String groupId;
     private final int numMessageToConsume;
+    private volatile boolean isRunning;
     private int messageRemaining;
     private final CountDownLatch latch;
 
@@ -42,7 +42,7 @@ public class Consumer extends ShutdownableThread {
                     final boolean readCommitted,
                     final int numMessageToConsume,
                     final CountDownLatch latch) {
-        super("KafkaConsumerExample", false);
+        super("KafkaConsumerExample");
         this.groupId = groupId;
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaProperties.KAFKA_SERVER_URL + ":" + KafkaProperties.KAFKA_SERVER_PORT);
@@ -63,6 +63,7 @@ public class Consumer extends ShutdownableThread {
         this.numMessageToConsume = numMessageToConsume;
         this.messageRemaining = numMessageToConsume;
         this.latch = latch;
+        this.isRunning = true;
     }
 
     KafkaConsumer<Integer, String> get() {
@@ -70,6 +71,17 @@ public class Consumer extends ShutdownableThread {
     }
 
     @Override
+    public void run() {
+        try {
+            do {
+                doWork();
+            } while (isRunning && messageRemaining > 0);
+            System.out.println(groupId + " finished reading " + numMessageToConsume + " messages");
+        } catch (Exception ignored) {
+        } finally {
+            shutdown();
+        }
+    }
     public void doWork() {
         consumer.subscribe(Collections.singletonList(this.topic));
         ConsumerRecords<Integer, String> records = consumer.poll(Duration.ofSeconds(1));
@@ -77,19 +89,10 @@ public class Consumer extends ShutdownableThread {
             System.out.println(groupId + " received message : from partition " + record.partition() + ", (" + record.key() + ", " + record.value() + ") at offset " + record.offset());
         }
         messageRemaining -= records.count();
-        if (messageRemaining <= 0) {
-            System.out.println(groupId + " finished reading " + numMessageToConsume + " messages");
-            latch.countDown();
-        }
     }
 
-    @Override
-    public String name() {
-        return null;
-    }
-
-    @Override
-    public boolean isInterruptible() {
-        return false;
+    public void shutdown() {
+        latch.countDown();
+        this.isRunning = false;
     }
 }

--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -75,9 +75,10 @@ public class Consumer extends Thread {
         try {
             do {
                 doWork();
-            } while (isRunning && messageRemaining > 0);
+            } while (messageRemaining > 0);
             System.out.println(groupId + " finished reading " + numMessageToConsume + " messages");
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            System.out.println("Unexpected termination, exception thrown:" + e);
         } finally {
             shutdown();
         }
@@ -93,6 +94,5 @@ public class Consumer extends Thread {
 
     public void shutdown() {
         latch.countDown();
-        this.isRunning = false;
     }
 }

--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -32,7 +32,6 @@ public class Consumer extends Thread {
     private final String topic;
     private final String groupId;
     private final int numMessageToConsume;
-    private volatile boolean isRunning;
     private int messageRemaining;
     private final CountDownLatch latch;
 
@@ -63,7 +62,6 @@ public class Consumer extends Thread {
         this.numMessageToConsume = numMessageToConsume;
         this.messageRemaining = numMessageToConsume;
         this.latch = latch;
-        this.isRunning = true;
     }
 
     KafkaConsumer<Integer, String> get() {


### PR DESCRIPTION
The purpose was mentioned in Jira:

Remove "kafka.examples.Consumer" dependency on ShutdownableThread. "examples" module should be dependent only on public APIs but not to be dependent upon server common/internal components. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
