### PR TITLE
KAFKA-14711: kafaka-metadata-quorum.sh does not honor --command-confi…

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -411,6 +411,7 @@
     <allow pkg="org.apache.kafka.clients.admin" />
     <allow pkg="org.apache.kafka.clients.producer" />
     <allow pkg="org.apache.kafka.clients.consumer" />
+    <allow pkg="org.apache.kafka.test" />
     <allow pkg="com.fasterxml.jackson" />
     <allow pkg="org.jose4j" />
     <allow pkg="net.sourceforge.argparse4j" />

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1558,4 +1558,10 @@ public final class Utils {
         return result;
     }
 
+    public static File createTempFile(String contents) throws IOException {
+        File file = File.createTempFile("tmpfile", ".tmp");
+        file.deleteOnExit();
+        Files.write(file.toPath(), contents.getBytes());
+        return file;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1558,10 +1558,4 @@ public final class Utils {
         return result;
     }
 
-    public static File createTempFile(String contents) throws IOException {
-        File file = File.createTempFile("tmpfile", ".tmp");
-        file.deleteOnExit();
-        Files.write(file.toPath(), contents.getBytes());
-        return file;
-    }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -92,7 +92,7 @@ public class MetadataQuorumCommand {
                 if (!commandConfig.exists())
                     throw new TerseException("Properties file " + commandConfig.getPath() + " does not exists!");
 
-                Utils.loadProps(commandConfig.getPath());
+                props = Utils.loadProps(commandConfig.getPath());
             }
             props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, namespace.getString("bootstrap_server"));
             admin = Admin.create(props);

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.ToolsUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -86,14 +87,8 @@ public class MetadataQuorumCommand {
             Namespace namespace = parser.parseArgsOrFail(args);
             String command = namespace.getString("command");
 
-            File commandConfig = namespace.get("command_config");
-            Properties props = new Properties();
-            if (commandConfig != null) {
-                if (!commandConfig.exists())
-                    throw new TerseException("Properties file " + commandConfig.getPath() + " does not exists!");
-
-                props = Utils.loadProps(commandConfig.getPath());
-            }
+            File optionalCommandConfig = namespace.get("command_config");
+            final Properties props = getProperties(optionalCommandConfig);
             props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, namespace.getString("bootstrap_server"));
             admin = Admin.create(props);
 
@@ -113,6 +108,16 @@ public class MetadataQuorumCommand {
         } finally {
             if (admin != null)
                 admin.close();
+        }
+    }
+
+    private static Properties getProperties(File optionalCommandConfig) throws TerseException, IOException {
+        if (optionalCommandConfig == null) {
+            return new Properties();
+        } else {
+            if (!optionalCommandConfig.exists())
+                throw new TerseException("Properties file " + optionalCommandConfig.getPath() + " does not exists!");
+            return Utils.loadProps(optionalCommandConfig.getPath());
         }
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -146,7 +146,7 @@ class MetadataQuorumCommandTest {
     }
 
     @ClusterTests({
-            @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1)
+        @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1)
     })
     public void testCommandConfig() throws IOException {
         // specifying a --command-config containing properties that would prevent login must fail

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -24,7 +24,7 @@ import kafka.test.annotation.Type;
 import kafka.test.junit.ClusterTestExtensions;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -150,7 +150,7 @@ class MetadataQuorumCommandTest {
     })
     public void testCommandConfig() throws IOException {
         // specifying a --command-config containing properties that would prevent login must fail
-        File tmpfile = Utils.createTempFile(AdminClientConfig.SECURITY_PROTOCOL_CONFIG + "=SSL_PLAINTEXT");
+        File tmpfile = TestUtils.tempFile(AdminClientConfig.SECURITY_PROTOCOL_CONFIG + "=SSL_PLAINTEXT");
         assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),
                         "--command-config", tmpfile.getAbsolutePath(), "describe", "--status"));
     }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -22,10 +22,14 @@ import kafka.test.annotation.ClusterTestDefaults;
 import kafka.test.annotation.ClusterTests;
 import kafka.test.annotation.Type;
 import kafka.test.junit.ClusterTestExtensions;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
@@ -139,6 +143,16 @@ class MetadataQuorumCommandTest {
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication")
         );
         assertEquals("0", replicationOutput.split("\n")[1].split("\\s+")[2]);
+    }
+
+    @ClusterTests({
+            @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1)
+    })
+    public void testCommandConfig() throws IOException {
+        // specifying a --command-config containing properties that would prevent login must fail
+        File tmpfile = Utils.createTempFile(AdminClientConfig.SECURITY_PROTOCOL_CONFIG + "=SSL_PLAINTEXT");
+        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),
+                        "--command-config", tmpfile.getAbsolutePath(), "describe", "--status"));
     }
 
     @ClusterTest(clusterType = Type.ZK, brokers = 1)


### PR DESCRIPTION
…g option

https://github.com/apache/kafka/pull/12951 accidentally changed the behavior of the `kafaka-metadata-quorum.sh` CLI by making it silently ignore a `--command-config <filename>` properties file that exists. This was an undetected regression in the 3.4.0 release.  This patch fixes the issue such that any such specified file will be used.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
