### PR TITLE
KAFKA-14491: [7/N] Enforce strict grace period for versioned stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/VersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/VersionedKeyValueStore.java
@@ -30,6 +30,11 @@ import org.apache.kafka.streams.processor.StateStore;
  * to return accurate results for calls to {@link #get(Object, long)} where the provided timestamp
  * bound is within history retention of the current observed stream time. (Queries with timestamp
  * bound older than the specified history retention are considered invalid.)
+ * <p>
+ * The store's "history retention" also doubles as its "grace period," which determines how far
+ * back in time writes to the store will be accepted. A versioned store will not accept writes
+ * (inserts, updates, or deletions) if the timestamp associated with the write is older than the
+ * current observed stream time by more than the grace period.
  *
  * @param <K> The key type
  * @param <V> The value type
@@ -38,6 +43,10 @@ public interface VersionedKeyValueStore<K, V> extends StateStore {
 
     /**
      * Add a new record version associated with the specified key and timestamp.
+     * <p>
+     * If the timestamp associated with the new record version is older than the store's
+     * grace period (i.e., history retention) relative to the current observed stream time,
+     * then the record will not be added.
      *
      * @param key       The key
      * @param value     The value, it can be {@code null}. {@code null} is interpreted as a delete.
@@ -52,6 +61,10 @@ public interface VersionedKeyValueStore<K, V> extends StateStore {
      * <p>
      * This operation is semantically equivalent to {@link #get(Object, long) #get(key, timestamp)}
      * followed by {@link #put(Object, Object, long) #put(key, null, timestamp)}.
+     * <p>
+     * If the timestamp associated with this deletion is older than the store's grace period
+     * (i.e., history retention) relative to the current observed stream time, then the deletion
+     * will not be performed.
      *
      * @param key       The key
      * @param timestamp The timestamp for this delete

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -156,6 +156,7 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
     public VersionedRecord<byte[]> get(final Bytes key, final long asOfTimestamp) {
 
         if (asOfTimestamp < observedStreamTime - historyRetention) {
+            LOG.warn("Returning null for expired get.");
             // history retention has elapsed. return null for predictability, even if data
             // is still present in store.
             return null;


### PR DESCRIPTION
The RocksDB-based implementation for versioned key-value stores introduced in https://github.com/apache/kafka/pull/13188 has a well-defined "history retention" parameter which specifies how far back in time (relative to the current observed stream time) reads may take place, but there is no well-defined equivalent (aka "grace period") for how far back in time writes will be accepted. Instead, there is an implicit grace period whereby the store accepts all writes which affect valid reads. This doesn't quite work, though, because it requires infinite tombstone retention when the latest value for a particular key is a tombstone -- if the latest value for a key is a very old tombstone, we can’t expire it because if there’s an even older non-null put to store later, then without the tombstone we’ll accept this write as the latest value for the key, even though it isn't.

In light of this, this PR changes the versioned store semantics to define an explicit "grace period" property. ([KIP-889](https://cwiki.apache.org/confluence/display/KAFKA/KIP-889%3A+Versioned+State+Stores) has been updated accordingly.) For now, grace period will always be equal to the history retention, though in the future we can introduce a new KIP to expose options to configure grace period separately. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
