### PR TITLE
KAFKA-14707: Improve array size check

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.protocol.types;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.kafka.common.protocol.types.Type.DocumentedType;
 
 import java.nio.ByteBuffer;
@@ -72,10 +74,10 @@ public class ArrayOf extends DocumentedType {
         else if (size < 0)
             throw new SchemaException("Array size " + size + " cannot be negative");
 
-        Object[] objs = new Object[size];
+        List<Object> objs = new ArrayList<>();
         for (int i = 0; i < size; i++)
-            objs[i] = type.read(buffer);
-        return objs;
+            objs.add(type.read(buffer));
+        return objs.toArray();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
@@ -72,8 +72,6 @@ public class ArrayOf extends DocumentedType {
         else if (size < 0)
             throw new SchemaException("Array size " + size + " cannot be negative");
 
-        if (size > buffer.remaining())
-            throw new SchemaException("Error reading array of size " + size + ", only " + buffer.remaining() + " bytes available");
         Object[] objs = new Object[size];
         for (int i = 0; i < size; i++)
             objs[i] = type.read(buffer);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
@@ -77,8 +77,6 @@ public class CompactArrayOf extends DocumentedType {
             }
         }
         int size = n - 1;
-        if (size > buffer.remaining())
-            throw new SchemaException("Error reading array of size " + size + ", only " + buffer.remaining() + " bytes available");
         Object[] objs = new Object[size];
         for (int i = 0; i < size; i++)
             objs[i] = type.read(buffer);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.common.protocol.types;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.kafka.common.protocol.types.Type.DocumentedType;
 import org.apache.kafka.common.utils.ByteUtils;
 
@@ -79,10 +77,18 @@ public class CompactArrayOf extends DocumentedType {
             }
         }
         int size = n - 1;
-        List<Object> objs = new ArrayList<>();
-        for (int i = 0; i < size; i++)
-            objs.add(type.read(buffer));
-        return objs.toArray();
+
+        try {
+            Object[] objs = new Object[size];
+            for (int i = 0; i < size; i++)
+                objs[i] = type.read(buffer);
+            return objs;
+        } catch (OutOfMemoryError e) {
+            throw new SchemaException(e.getMessage() + ", size " + size);
+        } catch (Exception e) {
+            throw new SchemaException("Error reading array element of type " + type + ", remaining bytes " +
+                buffer.remaining() + " : " + (e.getMessage() == null ? e.getClass().getName() : e.getMessage()));
+        }
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/CompactArrayOf.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.protocol.types;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.kafka.common.protocol.types.Type.DocumentedType;
 import org.apache.kafka.common.utils.ByteUtils;
 
@@ -77,10 +79,10 @@ public class CompactArrayOf extends DocumentedType {
             }
         }
         int size = n - 1;
-        Object[] objs = new Object[size];
+        List<Object> objs = new ArrayList<>();
         for (int i = 0; i < size; i++)
-            objs[i] = type.read(buffer);
-        return objs;
+            objs.add(type.read(buffer));
+        return objs.toArray();
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.protocol.types;
 
+import java.nio.BufferUnderflowException;
 import org.apache.kafka.common.utils.ByteUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,7 +198,7 @@ public class ProtocolSerializationTest {
         try {
             type.read(invalidBuffer);
             fail("Array size not validated");
-        } catch (SchemaException e) {
+        } catch (BufferUnderflowException e) {
             // Expected exception
         }
     }
@@ -215,7 +216,7 @@ public class ProtocolSerializationTest {
         try {
             type.read(invalidBuffer);
             fail("Array size not validated");
-        } catch (SchemaException e) {
+        } catch (BufferUnderflowException e) {
             // Expected exception
         }
     }


### PR DESCRIPTION
```
if (size > buffer.remaining())
    throw new SchemaException("Error reading array of size " + size + ", only " + buffer.remaining() + " bytes available");
``` 
Array type has the above code snippet which checks if there are enough bytes in the buffer to read all the array elements. However, there is a unit mismatch because `size` is the number of elements in the array, not the number of bytes. Thus, even if the above check passes there still might be not enough bytes remaining in the buffer. It seems to be impossible to compute byte size of the array before reading the whole array because each element of the array might have a different size (for example, array of strings). I think array size check can be improved by explicitly checking for OOM & buffer read exceptions. I've also added a new unit test `testReadArrayWithIncorrectSize` which demonstrates the problem of the current implementation. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
