### PR TITLE
KAFKA-14491: [10/N] Add changelogging wrapper for versioned stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStore.java
@@ -36,7 +36,7 @@ public class ChangeLoggingVersionedKeyValueBytesStore extends ChangeLoggingKeyVa
     ChangeLoggingVersionedKeyValueBytesStore(final KeyValueStore<Bytes, byte[]> inner) {
         super(inner);
         if (!(inner instanceof VersionedBytesStore)) {
-            throw new IllegalStateException("inner store must be versioned");
+            throw new IllegalArgumentException("inner store must be versioned");
         }
         this.inner = (VersionedBytesStore) inner;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStore.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.VersionedBytesStore;
+
+/**
+ * A {@link VersionedBytesStore} wrapper for writing changelog records on calls to
+ * {@link VersionedBytesStore#put(Object, Object)} and {@link VersionedBytesStore#delete(Bytes, long)}.
+ */
+public class ChangeLoggingVersionedKeyValueBytesStore extends ChangeLoggingKeyValueBytesStore implements VersionedBytesStore {
+    private static final Deserializer<ValueAndTimestamp<byte[]>> VALUE_AND_TIMESTAMP_DESERIALIZER
+        = new NullableValueAndTimestampDeserializer<>(new ByteArrayDeserializer());
+
+    private final VersionedBytesStore inner;
+
+    ChangeLoggingVersionedKeyValueBytesStore(final KeyValueStore<Bytes, byte[]> inner) {
+        super(inner);
+        if (!(inner instanceof VersionedBytesStore)) {
+            throw new IllegalStateException("inner store must be versioned");
+        }
+        this.inner = (VersionedBytesStore) inner;
+    }
+
+    @Override
+    public byte[] get(final Bytes key, final long asOfTimestamp) {
+        return inner.get(key, asOfTimestamp);
+    }
+
+    @Override
+    public byte[] delete(final Bytes key, final long timestamp) {
+        final byte[] oldValue = inner.delete(key, timestamp);
+        log(key, ValueAndTimestamp.makeAllowNullable(null, timestamp));
+        return oldValue;
+    }
+
+    @Override
+    void log(final Bytes key, final byte[] rawValueAndTimestamp) {
+        final ValueAndTimestamp<byte[]> valueAndTimestamp
+            = VALUE_AND_TIMESTAMP_DESERIALIZER.deserialize(null, rawValueAndTimestamp);
+        log(key, valueAndTimestamp);
+    }
+
+    private void log(final Bytes key, final ValueAndTimestamp<byte[]> valueAndTimestamp) {
+        if (valueAndTimestamp == null) {
+            throw new IllegalStateException("Serialized bytes to put for versioned store cannot be null");
+        }
+        context.logChange(
+            name(),
+            key,
+            valueAndTimestamp.value(),
+            valueAndTimestamp.timestamp(),
+            wrapped().getPosition()
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStoreTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.VersionedBytesStore;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockRecordCollector;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@SuppressWarnings("rawtypes")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class ChangeLoggingVersionedKeyValueBytesStoreTest {
+
+    private static final Serializer<String> STRING_SERIALIZER = new StringSerializer();
+    private static final Serializer<ValueAndTimestamp<String>> VALUE_AND_TIMESTAMP_SERIALIZER
+        = new NullableValueAndTimestampSerializer<>(STRING_SERIALIZER);
+    private static final long HISTORY_RETENTION = 1000L;
+
+    private final MockRecordCollector collector = new MockRecordCollector();
+    private InternalMockProcessorContext context;
+    private VersionedBytesStore inner;
+    private ChangeLoggingVersionedKeyValueBytesStore store;
+
+    @Before
+    public void before() {
+        inner = (VersionedBytesStore) new RocksDbVersionedKeyValueBytesStoreSupplier("bytes_store", HISTORY_RETENTION).get();
+        store = new ChangeLoggingVersionedKeyValueBytesStore(inner);
+
+        context = mockContext();
+        context.setTime(0);
+        store.init((StateStoreContext) context, store);
+    }
+
+    private InternalMockProcessorContext mockContext() {
+        return new InternalMockProcessorContext<>(
+            TestUtils.tempDirectory(),
+            Serdes.String(),
+            Serdes.Long(),
+            collector,
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
+        );
+    }
+
+    @After
+    public void after() {
+        store.close();
+    }
+
+    @Test
+    public void shouldThrowIfInnerIsNotVersioned() {
+        assertThrows(IllegalStateException.class,
+            () -> new ChangeLoggingVersionedKeyValueBytesStore(new InMemoryKeyValueStore("kv")));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldDelegateDeprecatedInit() {
+        // recreate store with mock inner
+        store.close();
+        final VersionedBytesStore mockInner = mock(VersionedBytesStore.class);
+        store = new ChangeLoggingVersionedKeyValueBytesStore(mockInner);
+
+        store.init((ProcessorContext) context, store);
+
+        verify(mockInner).init((ProcessorContext) context, store);
+    }
+
+    @Test
+    public void shouldDelegateInit() {
+        // recreate store with mock inner
+        store.close();
+        final VersionedBytesStore mockInner = mock(VersionedBytesStore.class);
+        store = new ChangeLoggingVersionedKeyValueBytesStore(mockInner);
+
+        store.init((StateStoreContext) context, store);
+
+        verify(mockInner).init((StateStoreContext) context, store);
+    }
+
+    @Test
+    public void shouldPropagateAndLogOnPut() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        final String value = "foo";
+        final long timestamp = 10L;
+        final byte[] rawValueAndTimestamp = rawValueAndTimestamp(value, timestamp);
+
+        store.put(rawKey, rawValueAndTimestamp);
+
+        assertThat(inner.get(rawKey), equalTo(rawValueAndTimestamp));
+        assertThat(collector.collected().size(), equalTo(1));
+        assertThat(collector.collected().get(0).key(), equalTo(rawKey));
+        assertThat(collector.collected().get(0).value(), equalTo(rawBytes(value)));
+        assertThat(collector.collected().get(0).timestamp(), equalTo(timestamp));
+    }
+
+    @Test
+    public void shouldPropagateAndLogOnPutNull() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        final long timestamp = 10L;
+        final byte[] rawValueAndTimestamp = rawValueAndTimestamp(null, timestamp);
+        // put initial record to inner, so that later verification confirms that store.put() has an effect
+        final byte[] initialRawValueAndTimestamp = rawValueAndTimestamp("foo", timestamp - 1);
+        inner.put(rawKey, initialRawValueAndTimestamp);
+        assertThat(inner.get(rawKey), equalTo(initialRawValueAndTimestamp));
+
+        store.put(rawKey, rawValueAndTimestamp);
+
+        assertThat(inner.get(rawKey), nullValue());
+        assertThat(collector.collected().size(), equalTo(1));
+        assertThat(collector.collected().get(0).key(), equalTo(rawKey));
+        assertThat(collector.collected().get(0).value(), nullValue());
+        assertThat(collector.collected().get(0).timestamp(), equalTo(timestamp));
+    }
+
+    @Test
+    public void shouldPropagateAndLogOnDeleteWithTimestamp() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        final long timestamp = 10L;
+        // put initial record to inner, so that later verification confirms that store.put() has an effect
+        final byte[] initialRawValueAndTimestamp = rawValueAndTimestamp("foo", timestamp - 1);
+        inner.put(rawKey, initialRawValueAndTimestamp);
+        assertThat(inner.get(rawKey), equalTo(initialRawValueAndTimestamp));
+
+        store.delete(rawKey, timestamp);
+
+        assertThat(inner.get(rawKey), nullValue());
+        assertThat(collector.collected().size(), equalTo(1));
+        assertThat(collector.collected().get(0).key(), equalTo(rawKey));
+        assertThat(collector.collected().get(0).value(), nullValue());
+        assertThat(collector.collected().get(0).timestamp(), equalTo(timestamp));
+    }
+
+    @Test
+    public void shouldNotLogOnDeleteIfInnerStoreThrows() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        assertThrows(UnsupportedOperationException.class, () -> inner.delete(rawKey));
+
+        assertThrows(UnsupportedOperationException.class, () -> store.delete(rawKey));
+        assertThat(collector.collected().size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotLogOnPutAllIfInnerStoreThrows() {
+        final List<KeyValue<Bytes, byte[]>> entries = Collections.singletonList(KeyValue.pair(
+            Bytes.wrap(rawBytes("k")),
+            rawValueAndTimestamp("v", 12L)));
+        assertThrows(UnsupportedOperationException.class, () -> inner.putAll(entries));
+
+        assertThrows(UnsupportedOperationException.class, () -> store.putAll(entries));
+        assertThat(collector.collected().size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotLogOnPutIfAbsentIfInnerStoreThrows() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        final byte[] rawValue = rawBytes("v");
+        assertThrows(UnsupportedOperationException.class, () -> inner.putIfAbsent(rawKey, rawValue));
+
+        assertThrows(UnsupportedOperationException.class, () -> store.putIfAbsent(rawKey, rawValue));
+        assertThat(collector.collected().size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldDelegateGet() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        final byte[] rawValueAndTimestamp = rawValueAndTimestamp("v", 8L);
+        inner.put(rawKey, rawValueAndTimestamp);
+
+        assertThat(store.get(rawKey), equalTo(rawValueAndTimestamp));
+    }
+
+    @Test
+    public void shouldDelegateGetWithTimestamp() {
+        final Bytes rawKey = Bytes.wrap(rawBytes("k"));
+        final byte[] rawValueAndTimestamp = rawValueAndTimestamp("v", 8L);
+        inner.put(rawKey, rawValueAndTimestamp);
+
+        assertThat(store.get(rawKey, 10L), equalTo(rawValueAndTimestamp));
+    }
+
+    private static byte[] rawBytes(final String s) {
+        return STRING_SERIALIZER.serialize(null, s);
+    }
+
+    private static byte[] rawValueAndTimestamp(final String value, final long timestamp) {
+        return VALUE_AND_TIMESTAMP_SERIALIZER.serialize(null, ValueAndTimestamp.makeAllowNullable(value, timestamp));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStoreTest.java
@@ -87,7 +87,7 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
 
     @Test
     public void shouldThrowIfInnerIsNotVersioned() {
-        assertThrows(IllegalStateException.class,
+        assertThrows(IllegalArgumentException.class,
             () -> new ChangeLoggingVersionedKeyValueBytesStore(new InMemoryKeyValueStore("kv")));
     }
 
@@ -136,13 +136,13 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
     public void shouldPropagateAndLogOnPutNull() {
         final Bytes rawKey = Bytes.wrap(rawBytes("k"));
         final long timestamp = 10L;
-        final byte[] rawValueAndTimestamp = rawValueAndTimestamp(null, timestamp);
+        final byte[] rawTombstoneAndTimestamp = rawValueAndTimestamp(null, timestamp);
         // put initial record to inner, so that later verification confirms that store.put() has an effect
         final byte[] initialRawValueAndTimestamp = rawValueAndTimestamp("foo", timestamp - 1);
         inner.put(rawKey, initialRawValueAndTimestamp);
         assertThat(inner.get(rawKey), equalTo(initialRawValueAndTimestamp));
 
-        store.put(rawKey, rawValueAndTimestamp);
+        store.put(rawKey, rawTombstoneAndTimestamp);
 
         assertThat(inner.get(rawKey), nullValue());
         assertThat(collector.collected().size(), equalTo(1));


### PR DESCRIPTION
This PR introduces the changelogging layer for the new versioned key-value store introduced in [KIP-889](https://cwiki.apache.org/confluence/display/KAFKA/KIP-889%3A+Versioned+State+Stores). We choose to have the changelogging layer operate on `VersionedBytesStore` rather than `VersionedKeyValueStore` so that the outermost store layer (metered store, see https://github.com/apache/kafka/pull/13252 for more) can serialize to bytes once and then all inner stores operate only with bytes types. 

Changelog topic configs for versioned stores need to be slightly different than for non-versioned key-value stores. This change will be made in a follow-up PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
