### PR TITLE
KAFKA-14719: Fix a return code during broker is bootstrapping

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -286,7 +286,9 @@ class DefaultAutoTopicCreationManager(
       val validationError: Option[Errors] = if (!isValidTopicName(topic)) {
         Some(Errors.INVALID_TOPIC_EXCEPTION)
       } else if (!inflightTopics.add(topic)) {
-        Some(Errors.UNKNOWN_TOPIC_OR_PARTITION)
+        assert (inflightTopics.contains(topic))
+        trace("topic: %s is in inflightTopics, it will be created later".format(topic))
+        Some(Errors.REPLICA_NOT_AVAILABLE)
       } else {
         None
       }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1176,6 +1176,14 @@ class KafkaApis(val requestChannel: RequestChannel,
     errorUnavailableEndpoints: Boolean,
     errorUnavailableListeners: Boolean
   ): Seq[MetadataResponseTopic] = {
+    // TODO(duyuqi)
+    // At my experiments, I find some of topics is not in metadataCache, but
+    // why metadataCache has no some topics?
+    // KafkaServer has started and topics what created before should be persistent to
+    // zookeeper or other meta storage, and when restart KafkaServer, it should be reloaded,
+    // but why metadataCache has no some topics?
+    // If metadataCache is not integrity, I think KafkaServer should not provide the service
+    // until metadataCache has constructed.
     val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
       errorUnavailableEndpoints, errorUnavailableListeners)
 


### PR DESCRIPTION
I am not sure whether this patch is reasonable,.Maybe the return code is by design?
We can talk about this at https://issues.apache.org/jira/browse/KAFKA-14719.

If I am correct, I will continue this patch. I need your help.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
