### PR TITLE
MINOR: Remove accidental unnecessary code in src

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncClient.java
@@ -58,10 +58,6 @@ public abstract class AsyncClient<T1, Req extends AbstractRequest, Resp extends 
                 }
             }
 
-            @Override
-            public void onFailure(RuntimeException e, RequestFuture<T2> future1) {
-                future1.raise(e);
-            }
         });
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -59,11 +59,6 @@ public class TaggedFields extends DocumentedType {
         this.fields = fields;
     }
 
-    @Override
-    public boolean isNullable() {
-        return false;
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public void write(ByteBuffer buffer, Object o) {

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractLegacyRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractLegacyRecordBatch.java
@@ -471,11 +471,6 @@ public abstract class AbstractLegacyRecordBatch extends AbstractRecordBatch impl
         }
 
         @Override
-        public OptionalLong deleteHorizonMs() {
-            return OptionalLong.empty();
-        }
-
-        @Override
         public LegacyRecord outerRecord() {
             return record;
         }

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -708,11 +708,6 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         }
 
         @Override
-        public long checksum() {
-            return loadBatchHeader().checksum();
-        }
-
-        @Override
         public Integer countOrNull() {
             return loadBatchHeader().countOrNull();
         }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
@@ -53,10 +53,6 @@ public class DefaultConfigPropertyFilter implements ConfigPropertyFilter {
         useDefaultsFrom = config.useDefaultsFrom();
     }
 
-    @Override
-    public void close() {
-    }
-
     private boolean excluded(String prop) {
         return excludePattern != null && excludePattern.matcher(prop).matches();
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultGroupFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultGroupFilter.java
@@ -48,10 +48,6 @@ public class DefaultGroupFilter implements GroupFilter {
         excludePattern = config.excludePattern();
     }
 
-    @Override
-    public void close() {
-    }
-
     private boolean included(String group) {
         return includePattern != null && includePattern.matcher(group).matches();
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultTopicFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultTopicFilter.java
@@ -47,10 +47,6 @@ public class DefaultTopicFilter implements TopicFilter {
         excludePattern = config.excludePattern();
     }
 
-    @Override
-    public void close() {
-    }
-
     private boolean included(String topic) {
         return includePattern != null && includePattern.matcher(topic).matches();
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConfig.java
@@ -41,10 +41,6 @@ public class MirrorHeartbeatConfig extends MirrorConnectorConfig {
         super(CONNECTOR_CONFIG_DEF, props);
     }
 
-    String connectorName() {
-        return getString(ConnectorConfig.NAME_CONFIG);
-    }
-
     String heartbeatsTopic() {
         return replicationPolicy().heartbeatsTopic();
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConfig.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 import java.time.Duration;
 import java.util.Map;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -125,10 +125,6 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
         super(configDef, props);
     }
 
-    String connectorName() {
-        return getString(ConnectorConfig.NAME_CONFIG);
-    }
-
     Map<String, String> taskConfigForTopicPartitions(List<TopicPartition> topicPartitions, int taskIndex) {
         Map<String, String> props = originalsStrings();
         String topicPartitionsString = topicPartitions.stream()

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.ConfigUtils;
-import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 import java.time.Duration;
 import java.util.List;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -88,10 +88,6 @@ public class MirrorSourceConnectorTest {
                 return true;
             }
 
-            @Override
-            public boolean shouldReplicateSourceDefault(String prop) {
-                return false;
-            }
         };
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
@@ -55,6 +55,16 @@ public class InternalSinkRecord extends SinkRecord {
             valueSchema, value, kafkaOffset(), timestamp, timestampType(), headers());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
     /**
     * Return the original consumer record that this sink record represents.
     *

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
@@ -55,21 +55,6 @@ public class InternalSinkRecord extends SinkRecord {
             valueSchema, value, kafkaOffset(), timestamp, timestampType(), headers());
     }
 
-    @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return super.toString();
-    }
-
     /**
     * Return the original consumer record that this sink record represents.
     *

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
@@ -117,10 +117,6 @@ public class SourceConnectorConfig extends ConnectorConfig {
             super(plugins, configDef, props);
         }
 
-        @Override
-        public Object get(String key) {
-            return super.get(key);
-        }
     }
 
     private final TransactionBoundary transactionBoundary;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -677,11 +677,6 @@ class WorkerSinkTask extends WorkerTask {
     }
 
     @Override
-    protected void recordCommitFailure(long duration, Throwable error) {
-        super.recordCommitFailure(duration, error);
-    }
-
-    @Override
     protected void recordCommitSuccess(long duration) {
         super.recordCommitSuccess(duration);
         sinkTaskMetricsGroup.recordOffsetCommitSuccess();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/MockSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/MockSinkTask.java
@@ -69,11 +69,6 @@ public class MockSinkTask extends SinkTask {
     }
 
     @Override
-    public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-
-    }
-
-    @Override
     public void stop() {
 
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/MockSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/MockSinkTask.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.connect.tools;
 
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;


### PR DESCRIPTION
I ran IntelliJ IDEA's Code Inspection and corrected occurrences of the following:
* https://www.jetbrains.com/help/idea/list-of-java-inspections.html#inheritance-issues (method is identical to its super method)
* https://www.jetbrains.com/help/idea/list-of-java-inspections.html#imports (unused import)

It is safe to remove said methods because they are already defined upward in the hierarchy chain.

