### PR TITLE
MINOR: after reading BYTES type it's possible to access data beyond its size

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -689,10 +689,11 @@ public abstract class Type {
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
             int limit = buffer.limit();
-            buffer.limit(buffer.position() + size);
+            int newPosition = buffer.position() + size;
+            buffer.limit(newPosition);
             ByteBuffer val = buffer.slice();
             buffer.limit(limit);
-            buffer.position(buffer.position() + size);
+            buffer.position(newPosition);
             return val;
         }
 
@@ -741,10 +742,11 @@ public abstract class Type {
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
             int limit = buffer.limit();
-            buffer.limit(buffer.position() + size);
+            int newPosition = buffer.position() + size;
+            buffer.limit(newPosition);
             ByteBuffer val = buffer.slice();
             buffer.limit(limit);
-            buffer.position(buffer.position() + size);
+            buffer.position(newPosition);
             return val;
         }
 
@@ -804,10 +806,11 @@ public abstract class Type {
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
             int limit = buffer.limit();
-            buffer.limit(buffer.position() + size);
+            int newPosition = buffer.position() + size;
+            buffer.limit(newPosition);
             ByteBuffer val = buffer.slice();
             buffer.limit(limit);
-            buffer.position(buffer.position() + size);
+            buffer.position(newPosition);
             return val;
         }
 
@@ -871,10 +874,11 @@ public abstract class Type {
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
             int limit = buffer.limit();
-            buffer.limit(buffer.position() + size);
+            int newPosition = buffer.position() + size;
+            buffer.limit(newPosition);
             ByteBuffer val = buffer.slice();
             buffer.limit(limit);
-            buffer.position(buffer.position() + size);
+            buffer.position(newPosition);
             return val;
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -688,8 +688,10 @@ public abstract class Type {
             if (size > buffer.remaining())
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
+            int limit = buffer.limit();
+            buffer.limit(buffer.position() + size);
             ByteBuffer val = buffer.slice();
-            val.limit(size);
+            buffer.limit(limit);
             buffer.position(buffer.position() + size);
             return val;
         }
@@ -738,8 +740,10 @@ public abstract class Type {
             if (size > buffer.remaining())
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
+            int limit = buffer.limit();
+            buffer.limit(buffer.position() + size);
             ByteBuffer val = buffer.slice();
-            val.limit(size);
+            buffer.limit(limit);
             buffer.position(buffer.position() + size);
             return val;
         }
@@ -799,8 +803,10 @@ public abstract class Type {
             if (size > buffer.remaining())
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
+            int limit = buffer.limit();
+            buffer.limit(buffer.position() + size);
             ByteBuffer val = buffer.slice();
-            val.limit(size);
+            buffer.limit(limit);
             buffer.position(buffer.position() + size);
             return val;
         }
@@ -864,8 +870,10 @@ public abstract class Type {
             if (size > buffer.remaining())
                 throw new SchemaException("Error reading bytes of size " + size + ", only " + buffer.remaining() + " bytes available");
 
+            int limit = buffer.limit();
+            buffer.limit(buffer.position() + size);
             ByteBuffer val = buffer.slice();
-            val.limit(size);
+            buffer.limit(limit);
             buffer.position(buffer.position() + size);
             return val;
         }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -434,4 +434,21 @@ public class ProtocolSerializationTest {
         SchemaException e = assertThrows(SchemaException.class, () -> newSchema.read(buffer));
         assertTrue(e.getMessage().contains("Missing value for field 'field2' which has no default value"));
     }
+
+    @Test
+    public void testReadBytesBeyondItsSize() {
+        Type[] types = new Type[]{
+            Type.BYTES,
+            Type.COMPACT_BYTES,
+            Type.NULLABLE_BYTES,
+            Type.COMPACT_NULLABLE_BYTES
+        };
+        for (Type type : types) {
+            ByteBuffer buffer = ByteBuffer.allocate(20);
+            type.write(buffer, ByteBuffer.allocate(4));
+            buffer.rewind();
+            ByteBuffer bytes = (ByteBuffer) type.read(buffer);
+            assertThrows(IllegalArgumentException.class, () -> bytes.limit(bytes.limit() + 1));
+        }
+    }
 }


### PR DESCRIPTION
After reading data of type `BYTES`, `COMPACT_BYTES`, `NULLABLE_BYTES` or `COMPACT_NULLABLE_BYTES` returned `ByteBuffer` might have a capacity that is larger than its limit, thus these data types may access data that lies beyond its size by increasing limit of the returned `ByteBuffer`. I guess this is not very critical but I think it would be good to restrict increasing limit of the returned `ByteBuffer` by making its capacity strictly equal to its limit.  I think someone might unintentionally mishandle these data types and accidentally mess up data in the `ByteBuffer` from which they were read. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
