### PR TITLE
KAFKA-14728: Don't run 'spotlessScalaCheck' in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@
 def doValidation() {
   sh """
     ./retry_zinc ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+        checkstyleMain checkstyleTest spotbugsMain rat \
         --profile --continue -PxmlSpotBugsReport=true -PkeepAliveMode="session"
   """
 }


### PR DESCRIPTION
Blocks #13205.

Rationale:
- build works fine in trunk with Gradle 7.6 and spotless gradle plugin 6.13.0 for all currently used JDK versions (that is: JDK 8 / JDK 11 / JDK 17)
- however, recent spotless gradle plugin versions (6.14.+) support only JDK 11+ versions: https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#6140---2023-01-26
- given a fact that Kafka still needs to support JDK 8 builds (until Kafka version 4.0) it is reasonable to simply remove spotless checks out of Jenkinsfile (and re-introduce them when the time comes).

For even more details see GitHub discussion here: https://github.com/apache/kafka/pull/13205#issuecomment-1431575644