### PR TITLE
MINOR: Fix PluginInfoTest for Connect

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/PluginInfoTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/PluginInfoTest.java
@@ -19,17 +19,19 @@ package org.apache.kafka.connect.runtime.rest.entities;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.junit.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PluginInfoTest {
 
     @Test
     public void testNoVersionFilter() {
         PluginInfo.NoVersionFilter filter = new PluginInfo.NoVersionFilter();
-        assertNotEquals("1.0", filter);
-        assertNotEquals(filter, new Object());
-        assertNotEquals(null, filter);
-        assertEquals(DelegatingClassLoader.UNDEFINED_VERSION, filter);
+        // We intentionally refrain from using assertEquals and assertNotEquals
+        // here to ensure that the filter's equals() method is used
+        assertFalse(filter.equals("1.0"));
+        assertFalse(filter.equals(new Object()));
+        assertFalse(filter.equals(null));
+        assertTrue(filter.equals(DelegatingClassLoader.UNDEFINED_VERSION));
     }
 }


### PR DESCRIPTION
The refactorings in https://github.com/apache/kafka/pull/13219 are largely very helpful; however, the changes to the `PluginInfoTest` suite have caused it to begin failing.

This PR reverts the changes to that test suite and adds a note on why we use `assertTrue(foo.equals(bar))` instead of `assertEquals(foo, bar)`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
