### PR TITLE
KAFKA-14694: RPCProducerIdManager should not wait on new block

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -3026,6 +3026,28 @@ public class SenderTest {
         verifyErrorMessage(produceResponse(tp0, 0L, Errors.INVALID_REQUEST, 0, -1, errorMessage), errorMessage);
     }
 
+    @Test
+    public void testSenderShouldRetryWithBackoffOnRetriableError() {
+        final long producerId = 343434L;
+        TransactionManager transactionManager = createTransactionManager();
+        setupWithTransactionState(transactionManager);
+        long start = time.milliseconds();
+
+        // first request is sent immediately
+        prepareAndReceiveInitProducerId(producerId, (short) -1, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        long request1 = time.milliseconds();
+        assertEquals(start, request1);
+
+        // backoff before sending second request
+        prepareAndReceiveInitProducerId(producerId, (short) -1, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        long request2 = time.milliseconds();
+        assertEquals(RETRY_BACKOFF_MS, request2 - request1);
+
+        // third request should also backoff
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertEquals(RETRY_BACKOFF_MS, time.milliseconds() - request2);
+    }
+
     private void verifyErrorMessage(ProduceResponse response, String expectedMessage) throws Exception {
         Future<RecordMetadata> future = appendToAccumulator(tp0, 0L, "key", "value");
         sender.runOnce(); // connect
@@ -3182,7 +3204,7 @@ public class SenderTest {
     }
 
     private TransactionManager createTransactionManager() {
-        return new TransactionManager(new LogContext(), null, 0, 100L, new ApiVersions());
+        return new TransactionManager(new LogContext(), null, 0, RETRY_BACKOFF_MS, new ApiVersions());
     }
     
     private void setupWithTransactionState(TransactionManager transactionManager) {

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -43,7 +43,7 @@ import scala.util.{Failure, Success, Try}
 object ProducerIdManager {
   // Once we reach this percentage of PIDs consumed from the current block, trigger a fetch of the next block
   val PidPrefetchThreshold = 0.90
-  val RetryBackoffMs = 100
+  val RetryBackoffMs = 50
 
   // Creates a ProducerIdGenerate that directly interfaces with ZooKeeper, IBP < 3.0-IV0
   def zk(brokerId: Int, zkClient: KafkaZkClient): ZkProducerIdManager = {

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -255,7 +255,7 @@ class RPCProducerIdManager(brokerId: Int,
       case Errors.BROKER_ID_NOT_REGISTERED =>
         warn("Our broker ID is not yet known by the controller, trying again.")
       case e: Errors =>
-        error(s"Had an unknown error from the controller: ${e.exception}")
+        error(s"Received an unexpected error code from the controller: $e")
     }
     shouldBackoff.set(!successfulResponse)
 

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -221,6 +221,7 @@ class RPCProducerIdManager(brokerId: Int,
         requestInFlight.compareAndSet(false, true) ) {
 
         sendRequest()
+        // Reset backoff after a successful send.
         backoffDeadlineMs.set(NoRetry)
       }
     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -115,8 +115,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     if (transactionalId == null) {
       // if the transactional id is null, then always blindly accept the request
       // and return a new producerId from the producerId manager
-      val result = producerIdManager.generateProducerId()
-      result match {
+      producerIdManager.generateProducerId() match {
         case Success(producerId) =>
           responseCallback(InitProducerIdResult(producerId, producerEpoch = 0, Errors.NONE))
         case Failure(exception) =>
@@ -132,8 +131,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     } else {
       val coordinatorEpochAndMetadata = txnManager.getTransactionState(transactionalId).flatMap {
         case None =>
-          val result = producerIdManager.generateProducerId()
-          result match {
+          producerIdManager.generateProducerId() match {
             case Success(producerId) =>
               val createdMetadata = new TransactionMetadata(transactionalId = transactionalId,
                 producerId = producerId,
@@ -145,6 +143,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 topicPartitions = collection.mutable.Set.empty[TopicPartition],
                 txnLastUpdateTimestamp = time.milliseconds())
               txnManager.putTransactionStateIfNotExists(createdMetadata)
+
             case Failure(exception) =>
               Left(Errors.forException(exception))
           }
@@ -244,8 +243,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
             if (txnMetadata.isProducerEpochExhausted &&
                 expectedProducerIdAndEpoch.forall(_.epoch == txnMetadata.producerEpoch)) {
 
-              val result = producerIdManager.generateProducerId()
-              result match {
+              producerIdManager.generateProducerId() match {
                 case Success(producerId) =>
                   Right(txnMetadata.prepareProducerIdRotation(producerId, transactionTimeoutMs, time.milliseconds(),
                     expectedProducerIdAndEpoch.isDefined))

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -292,6 +292,7 @@ class BrokerServer(
 
       val producerIdManagerSupplier = () => ProducerIdManager.rpc(
         config.brokerId,
+        time,
         brokerEpochSupplier = () => lifecycleManager.brokerEpoch,
         clientToControllerChannelManager
       )

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -293,8 +293,7 @@ class BrokerServer(
       val producerIdManagerSupplier = () => ProducerIdManager.rpc(
         config.brokerId,
         brokerEpochSupplier = () => lifecycleManager.brokerEpoch,
-        clientToControllerChannelManager,
-        config.requestTimeoutMs
+        clientToControllerChannelManager
       )
 
       // Create transaction coordinator, but don't start it until we've started replica manager.

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -461,8 +461,7 @@ class KafkaServer(
           ProducerIdManager.rpc(
             config.brokerId,
             brokerEpochSupplier = brokerEpochSupplier,
-            clientToControllerChannelManager,
-            config.requestTimeoutMs
+            clientToControllerChannelManager
           )
         } else {
           ProducerIdManager.zk(config.brokerId, zkClient)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -460,6 +460,7 @@ class KafkaServer(
         val producerIdManager = if (config.interBrokerProtocolVersion.isAllocateProducerIdsSupported) {
           ProducerIdManager.rpc(
             config.brokerId,
+            time,
             brokerEpochSupplier = brokerEpochSupplier,
             clientToControllerChannelManager
           )

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -72,7 +72,7 @@ class ProducerIdsIntegrationTest {
     clusterInstance.stop()
   }
 
-  @Disabled // TODO: Enable once producer id block size is configurable
+  @Disabled // TODO: Enable once producer id block size is configurable (KAFKA-15029)
   @ClusterTest(clusterType = Type.ZK, brokers = 1, autoStart = AutoStart.NO)
   def testMultipleAllocateProducerIdsRequest(clusterInstance: ClusterInstance): Unit = {
     clusterInstance.config().serverProperties().put(KafkaConfig.NumIoThreadsProp, "2")

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -24,14 +24,16 @@ import kafka.test.junit.ClusterTestExtensions
 import kafka.test.{ClusterConfig, ClusterInstance}
 import org.apache.kafka.common.message.InitProducerIdRequestData
 import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.{InitProducerIdRequest, InitProducerIdResponse}
 import org.apache.kafka.server.common.MetadataVersion
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{BeforeEach, Disabled, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util.stream.{Collectors, IntStream}
+import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
@@ -61,27 +63,59 @@ class ProducerIdsIntegrationTest {
     clusterInstance.stop()
   }
 
-  private def verifyUniqueIds(clusterInstance: ClusterInstance): Unit = {
-    // Request enough PIDs from each broker to ensure each broker generates two PID blocks
-    val ids = clusterInstance.brokerSocketServers().stream().flatMap( broker => {
-      IntStream.range(0, 1001).parallel().mapToObj( _ => nextProducerId(broker, clusterInstance.clientListener()))
-    }).collect(Collectors.toList[Long]).asScala.toSeq
+  @ClusterTest(clusterType = Type.ZK, brokers = 1, autoStart = AutoStart.NO)
+  @Timeout(20)
+  def testHandleAllocateProducerIdsSingleRequestHandlerThread(clusterInstance: ClusterInstance): Unit = {
+    clusterInstance.config().serverProperties().put(KafkaConfig.NumIoThreadsProp, "1")
+    clusterInstance.start()
+    verifyUniqueIds(clusterInstance)
+    clusterInstance.stop()
+  }
 
-    assertEquals(3003, ids.size, "Expected exactly 3003 IDs")
-    assertEquals(ids.size, ids.distinct.size, "Found duplicate producer IDs")
+  @Disabled // TODO: Enable once producer id block size is configurable
+  @ClusterTest(clusterType = Type.ZK, brokers = 1, autoStart = AutoStart.NO)
+  def testMultipleAllocateProducerIdsRequest(clusterInstance: ClusterInstance): Unit = {
+    clusterInstance.config().serverProperties().put(KafkaConfig.NumIoThreadsProp, "2")
+    clusterInstance.start()
+    verifyUniqueIds(clusterInstance)
+    clusterInstance.stop()
+  }
+
+  private def verifyUniqueIds(clusterInstance: ClusterInstance): Unit = {
+    // Request enough PIDs from each broker to ensure each broker generates two blocks
+    val ids = clusterInstance.brokerSocketServers().stream().flatMap( broker => {
+      IntStream.range(0, 1001).parallel().mapToObj( _ =>
+        nextProducerId(broker, clusterInstance.clientListener())
+      )}).collect(Collectors.toList[Long]).asScala.toSeq
+
+    val brokerCount = clusterInstance.brokerIds.size
+    val expectedTotalCount = 1001 * brokerCount
+    assertEquals(expectedTotalCount, ids.size, s"Expected exactly $expectedTotalCount IDs")
+    assertEquals(expectedTotalCount, ids.distinct.size, "Found duplicate producer IDs")
   }
 
   private def nextProducerId(broker: SocketServer, listener: ListenerName): Long = {
-    val data = new InitProducerIdRequestData()
-      .setProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
-      .setProducerId(RecordBatch.NO_PRODUCER_ID)
-      .setTransactionalId(null)
-      .setTransactionTimeoutMs(10)
-    val request = new InitProducerIdRequest.Builder(data).build()
+    // Generating producer ids may fail while waiting for the initial block and also
+    // when the current block is full and waiting for the prefetched block.
+    val deadline = 5.seconds.fromNow
+    var shouldRetry = true
+    var response: InitProducerIdResponse = null
+    while(shouldRetry && deadline.hasTimeLeft()) {
+      val data = new InitProducerIdRequestData()
+        .setProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+        .setProducerId(RecordBatch.NO_PRODUCER_ID)
+        .setTransactionalId(null)
+        .setTransactionTimeoutMs(10)
+      val request = new InitProducerIdRequest.Builder(data).build()
 
-    val response = IntegrationTestUtils.connectAndReceive[InitProducerIdResponse](request,
-      destination = broker,
-      listenerName = listener)
+      response = IntegrationTestUtils.connectAndReceive[InitProducerIdResponse](request,
+        destination = broker,
+        listenerName = listener)
+
+      shouldRetry = response.data.errorCode == Errors.COORDINATOR_LOAD_IN_PROGRESS.code
+    }
+    assertTrue(deadline.hasTimeLeft())
+    assertEquals(Errors.NONE.code, response.data.errorCode)
     response.data().producerId()
   }
 }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -175,7 +175,7 @@ class ProducerIdManagerTest {
         }
       }, 0)
     }
-    assertTrue(latch.await(15000, TimeUnit.MILLISECONDS))
+    assertTrue(latch.await(10000, TimeUnit.MILLISECONDS))
     requestHandlerThreadPool.shutdown()
 
     assertEquals(idBlockLen * 3, pidMap.size)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -175,7 +175,7 @@ class ProducerIdManagerTest {
         }
       }, 0)
     }
-    assertTrue(latch.await(10000, TimeUnit.MILLISECONDS))
+    assertTrue(latch.await(12000, TimeUnit.MILLISECONDS))
     requestHandlerThreadPool.shutdown()
 
     assertEquals(idBlockLen * 3, pidMap.size)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -18,14 +18,14 @@ package kafka.coordinator.transaction
 
 import kafka.coordinator.transaction.ProducerIdManager.RetryBackoffMs
 import kafka.server.BrokerToControllerChannelManager
-import kafka.utils.{MockTime, TestUtils}
+import kafka.utils.TestUtils
 import kafka.zk.{KafkaZkClient, ProducerIdBlockZNode}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException
 import org.apache.kafka.common.message.AllocateProducerIdsResponseData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.AllocateProducerIdsResponse
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{MockTime, Time}
 import org.apache.kafka.server.common.ProducerIdsBlock
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -80,12 +80,12 @@ class ProducerIdManagerTest {
       capturedFailure.set(nextProducerIdBlock.get == null)
     }
 
-    override private[transaction] def maybeRequestNextBlock(currentBlockCount: Long): Unit = {
+    override private[transaction] def maybeRequestNextBlock(): Unit = {
       if (error == Errors.NONE && !isErroneousBlock) {
-        super.maybeRequestNextBlock(currentBlockCount)
+        super.maybeRequestNextBlock()
       } else {
         if (remainingRetries > 0) {
-          super.maybeRequestNextBlock(currentBlockCount)
+          super.maybeRequestNextBlock()
           remainingRetries -= 1
         }
       }
@@ -179,9 +179,10 @@ class ProducerIdManagerTest {
     requestHandlerThreadPool.shutdown()
 
     assertEquals(idBlockLen * 3, pidMap.size)
-    for (pid <- pidMap.keys) {
-      assertEquals(1, pidMap.getOrElse(pid, 0))
-      assertTrue(pid < 4 * idBlockLen, s"Unexpected pid $pid; non-contiguous blocks generated")
+    pidMap.foreach { case (pid, count) =>
+      assertEquals(1, count)
+      assertTrue(pid < (3 * idBlockLen) + numThreads, s"Unexpected pid $pid; " +
+        s"non-contiguous blocks generated or did not fully exhaust blocks.")
     }
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -52,11 +52,11 @@ class ProducerIdManagerTest {
     val idLen: Int,
     var error: Errors = Errors.NONE,
     val isErroneousBlock: Boolean = false,
-    val time: Time = Time.SYSTEM
+    val time: Time = Time.SYSTEM,
+    var remainingRetries: Int = 1
   ) extends RPCProducerIdManager(brokerId, time, () => 1, brokerToController) {
 
     private val brokerToControllerRequestExecutor = Executors.newSingleThreadExecutor()
-    private var remainingRetries = 1
     val capturedFailure: AtomicBoolean = new AtomicBoolean(false)
 
     override private[transaction] def sendRequest(): Unit = {
@@ -216,7 +216,7 @@ class ProducerIdManagerTest {
   def testRetryBackoff(): Unit = {
     val time = new MockTime()
     val manager = new MockProducerIdManager(0, 0, 1,
-      error = Errors.UNKNOWN_SERVER_ERROR, time = time)
+      error = Errors.UNKNOWN_SERVER_ERROR, time = time, remainingRetries = 2)
 
     val nowMs = time.milliseconds
     verifyFailure(manager)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -17,6 +17,7 @@
 package kafka.coordinator.transaction
 
 import kafka.server.BrokerToControllerChannelManager
+import kafka.utils.TestUtils
 import kafka.zk.{KafkaZkClient, ProducerIdBlockZNode}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException
@@ -31,7 +32,11 @@ import org.junit.jupiter.params.provider.{EnumSource, ValueSource}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{mock, when}
-import java.util.stream.IntStream
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.mutable
+import scala.util.{Failure, Success}
 
 class ProducerIdManagerTest {
 
@@ -39,21 +44,35 @@ class ProducerIdManagerTest {
   val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
 
   // Mutable test implementation that lets us easily set the idStart and error
-  class MockProducerIdManager(val brokerId: Int, var idStart: Long, val idLen: Int, var error: Errors = Errors.NONE, timeout: Boolean = false)
-    extends RPCProducerIdManager(brokerId, () => 1, brokerToController, 100) {
+  class MockProducerIdManager(
+    val brokerId: Int,
+    var idStart: Long,
+    val idLen: Int,
+    var error: Errors = Errors.NONE,
+    var capturedFailure: AtomicReference[Throwable] = new AtomicReference[Throwable]()
+  ) extends RPCProducerIdManager(brokerId, () => 1, brokerToController) {
+
+    private val brokerToControllerRequestExecutor = Executors.newSingleThreadExecutor()
 
     override private[transaction] def sendRequest(): Unit = {
-      if (timeout)
-        return
 
-      if (error == Errors.NONE) {
-        handleAllocateProducerIdsResponse(new AllocateProducerIdsResponse(
-          new AllocateProducerIdsResponseData().setProducerIdStart(idStart).setProducerIdLen(idLen)))
-        idStart += idLen
-      } else {
-        handleAllocateProducerIdsResponse(new AllocateProducerIdsResponse(
-          new AllocateProducerIdsResponseData().setErrorCode(error.code)))
-      }
+      brokerToControllerRequestExecutor.submit(() => {
+        if (error == Errors.NONE) {
+          handleAllocateProducerIdsResponse(new AllocateProducerIdsResponse(
+            new AllocateProducerIdsResponseData().setProducerIdStart(idStart).setProducerIdLen(idLen)))
+          idStart += idLen
+        } else {
+          handleAllocateProducerIdsResponse(new AllocateProducerIdsResponse(
+            new AllocateProducerIdsResponseData().setErrorCode(error.code)))
+        }
+      }, 0)
+    }
+
+    override private[transaction] def handleAllocateProducerIdsResponse(response: AllocateProducerIdsResponse): Unit = {
+      brokerToControllerRequestExecutor.submit(() => {
+        super.handleAllocateProducerIdsResponse(response)
+        capturedFailure.set(nextProducerIdBlock.get.failed.get)
+      }, 0)
     }
   }
 
@@ -80,26 +99,20 @@ class ProducerIdManagerTest {
     val manager1 = new ZkProducerIdManager(0, zkClient)
     val manager2 = new ZkProducerIdManager(1, zkClient)
 
-    val pid1 = manager1.generateProducerId()
-    val pid2 = manager2.generateProducerId()
+    val pid1 = manager1.generateProducerId().get
+    val pid2 = manager2.generateProducerId().get
 
     assertEquals(0, pid1)
     assertEquals(ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE, pid2)
 
     for (i <- 1L until ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE)
-      assertEquals(pid1 + i, manager1.generateProducerId())
+      assertEquals(pid1 + i, manager1.generateProducerId().get)
 
     for (i <- 1L until ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE)
-      assertEquals(pid2 + i, manager2.generateProducerId())
+      assertEquals(pid2 + i, manager2.generateProducerId().get)
 
-    assertEquals(pid2 + ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE, manager1.generateProducerId())
-    assertEquals(pid2 + ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE * 2, manager2.generateProducerId())
-  }
-
-  @Test
-  def testRPCProducerIdManagerThrowsConcurrentTransactions(): Unit = {
-    val manager1 = new MockProducerIdManager(0, 0, 0, timeout = true)
-    assertThrows(classOf[CoordinatorLoadInProgressException], () => manager1.generateProducerId())
+    assertEquals(pid2 + ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE, manager1.generateProducerId().get)
+    assertEquals(pid2 + ProducerIdsBlock.PRODUCER_ID_BLOCK_SIZE * 2, manager2.generateProducerId().get)
   }
 
   @Test
@@ -113,12 +126,46 @@ class ProducerIdManagerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = Array(1, 2, 10))
-  def testContiguousIds(idBlockLen: Int): Unit = {
-    val manager = new MockProducerIdManager(0, 0, idBlockLen)
+  @ValueSource(ints = Array(1, 2, 10, 100))
+  def testConcurrentGeneratePidRequests(idBlockLen: Int): Unit = {
+    // Send concurrent generateProducerId requests. Ensure that the generated producer id is unique.
+    // For each block (total 3 blocks), only "idBlockLen" number of requests should go through.
+    // All other requests should fail immediately.
 
-    IntStream.range(0, idBlockLen * 3).forEach { i =>
-      assertEquals(i, manager.generateProducerId())
+    val numThreads = 5
+    val latch = new CountDownLatch(idBlockLen * 3)
+    val manager = new MockProducerIdManager(0, 0, idBlockLen)
+    val pidMap = mutable.Map[Long, Int]()
+    val requestHandlerThreadPool = Executors.newFixedThreadPool(numThreads)
+
+    for ( _ <- 0 until numThreads) {
+      requestHandlerThreadPool.submit(() => {
+        while(latch.getCount > 0) {
+          val result = manager.generateProducerId()
+          result match {
+            case Success(pid) =>
+              pidMap synchronized {
+                if (latch.getCount != 0) {
+                  val counter = pidMap.getOrElse(pid, 0)
+                  pidMap += pid -> (counter + 1)
+                  latch.countDown()
+                }
+              }
+
+            case Failure(exception) =>
+              assertEquals(classOf[CoordinatorLoadInProgressException], exception.getClass)
+          }
+          Thread.sleep(100)
+        }
+      }, 0)
+    }
+    assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+    requestHandlerThreadPool.shutdown()
+
+    assertEquals(idBlockLen * 3, pidMap.size)
+    for (pid <- pidMap.keys) {
+      assertEquals(1, pidMap.getOrElse(pid, 0))
+      assertTrue(pid < 4 * idBlockLen, s"Unexpected pid $pid; non-contiguous blocks generated")
     }
   }
 
@@ -126,25 +173,49 @@ class ProducerIdManagerTest {
   @EnumSource(value = classOf[Errors], names = Array("UNKNOWN_SERVER_ERROR", "INVALID_REQUEST"))
   def testUnrecoverableErrors(error: Errors): Unit = {
     val manager = new MockProducerIdManager(0, 0, 1)
-    assertEquals(0, manager.generateProducerId())
+
+    verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 0, 1), 0)
 
     manager.error = error
-    assertThrows(classOf[Throwable], () => manager.generateProducerId())
+    verifyFailure(manager, error.exception)
 
     manager.error = Errors.NONE
-    assertEquals(1, manager.generateProducerId())
+    assertEquals(classOf[CoordinatorLoadInProgressException], manager.generateProducerId().failed.get.getClass)
+    verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 1, 1), 1)
   }
 
   @Test
   def testInvalidRanges(): Unit = {
     var manager = new MockProducerIdManager(0, -1, 10)
-    assertThrows(classOf[KafkaException], () => manager.generateProducerId())
+    verifyFailure(manager, new KafkaException())
 
     manager = new MockProducerIdManager(0, 0, -1)
-    assertThrows(classOf[KafkaException], () => manager.generateProducerId())
+    verifyFailure(manager, new KafkaException())
 
     manager = new MockProducerIdManager(0, Long.MaxValue-1, 10)
-    assertThrows(classOf[KafkaException], () => manager.generateProducerId())
+    verifyFailure(manager, new KafkaException())
+  }
+
+  private def verifyFailure(manager: MockProducerIdManager, exception: Throwable): Unit = {
+    assertEquals(classOf[CoordinatorLoadInProgressException], manager.generateProducerId().failed.get.getClass)
+    TestUtils.waitUntilTrue(() => {
+      manager synchronized {
+        manager.capturedFailure.get != null
+      }
+    }, "expected exception but no exception was caught.")
+    assertEquals(exception.getClass, manager.capturedFailure.get.getClass)
+  }
+
+  private def verifyNewBlockAndProducerId(manager: MockProducerIdManager,
+                                          expectedBlock: ProducerIdsBlock,
+                                          expectedPid: Long): Unit = {
+
+    assertEquals(classOf[CoordinatorLoadInProgressException], manager.generateProducerId().failed.get.getClass)
+    TestUtils.waitUntilTrue(() => {
+      val nextBlock = manager.nextProducerIdBlock.get
+      nextBlock != null && nextBlock.get.equals(expectedBlock)
+    }, "failed to generate block")
+    assertEquals(expectedPid, manager.generateProducerId().get)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -43,6 +43,7 @@ import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, mutable}
+import scala.util.Success
 
 class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest[Transaction] {
   private val nTransactions = nThreads * 10
@@ -82,7 +83,11 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
 
     val pidGenerator: ProducerIdManager = mock(classOf[ProducerIdManager])
     when(pidGenerator.generateProducerId())
-      .thenAnswer(_ => if (bumpProducerId) producerId + 1 else producerId)
+      .thenAnswer(_ => if (bumpProducerId) {
+        Success(producerId + 1)
+      } else {
+        Success(producerId)
+      })
     val brokerNode = new Node(0, "host", 10)
     val metadataCache: MetadataCache = mock(classOf[MetadataCache])
     when(metadataCache.getPartitionLeaderEndpoint(

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -31,6 +31,7 @@ import org.mockito.Mockito.{mock, times, verify, when}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.Success
 
 class TransactionCoordinatorTest {
 
@@ -46,7 +47,7 @@ class TransactionCoordinatorTest {
   val brokerId = 0
   val coordinatorEpoch = 0
   private val transactionalId = "known"
-  private val producerId = 10
+  private val producerId = 10L
   private val producerEpoch: Short = 1
   private val txnTimeoutMs = 1
 
@@ -68,7 +69,7 @@ class TransactionCoordinatorTest {
   private def mockPidGenerator(): Unit = {
     when(pidGenerator.generateProducerId()).thenAnswer(_ => {
       nextPid += 1
-      nextPid - 1
+      Success(nextPid - 1)
     })
   }
 
@@ -856,7 +857,7 @@ class TransactionCoordinatorTest {
       (Short.MaxValue - 2).toShort, txnTimeoutMs, Empty, partitions, time.milliseconds, time.milliseconds)
 
     when(pidGenerator.generateProducerId())
-      .thenReturn(producerId + 1)
+      .thenReturn(Success(producerId + 1))
 
     when(transactionManager.validateTransactionTimeoutMs(anyInt()))
       .thenReturn(true)
@@ -897,7 +898,7 @@ class TransactionCoordinatorTest {
       (Short.MaxValue - 2).toShort, txnTimeoutMs, Empty, partitions, time.milliseconds, time.milliseconds)
 
     when(pidGenerator.generateProducerId())
-      .thenReturn(producerId + 1)
+      .thenReturn(Success(producerId + 1))
 
     when(transactionManager.validateTransactionTimeoutMs(anyInt()))
       .thenReturn(true)
@@ -1156,7 +1157,7 @@ class TransactionCoordinatorTest {
 
   private def validateIncrementEpochAndUpdateMetadata(state: TransactionState): Unit = {
     when(pidGenerator.generateProducerId())
-      .thenReturn(producerId)
+      .thenReturn(Success(producerId))
 
     when(transactionManager.validateTransactionTimeoutMs(anyInt()))
       .thenReturn(true)

--- a/server-common/src/main/java/org/apache/kafka/server/common/ProducerIdsBlock.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ProducerIdsBlock.java
@@ -18,6 +18,8 @@
 package org.apache.kafka.server.common;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Holds a range of Producer IDs used for Transactional and EOS producers.
@@ -32,11 +34,32 @@ public class ProducerIdsBlock {
     private final int assignedBrokerId;
     private final long firstProducerId;
     private final int blockSize;
+    private final AtomicLong producerIdCounter;
 
     public ProducerIdsBlock(int assignedBrokerId, long firstProducerId, int blockSize) {
         this.assignedBrokerId = assignedBrokerId;
         this.firstProducerId = firstProducerId;
         this.blockSize = blockSize;
+        producerIdCounter = new AtomicLong(firstProducerId);
+    }
+
+    /**
+     * Claim the next available producer id from the block.
+     * Returns an empty result if there are no more available producer ids in the block.
+     */
+    public Optional<Long> claimNextId() {
+        long nextId = producerIdCounter.getAndIncrement();
+        if (nextId > lastProducerId()) {
+            return Optional.empty();
+        }
+        return nextId > lastProducerId() ? Optional.empty() : Optional.of(nextId);
+    }
+
+    /**
+     * Returns whether all IDs are used
+     */
+    public boolean isExhausted() {
+        return producerIdCounter.get() == lastProducerId();
     }
 
     /**

--- a/server-common/src/main/java/org/apache/kafka/server/common/ProducerIdsBlock.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ProducerIdsBlock.java
@@ -56,13 +56,6 @@ public class ProducerIdsBlock {
     }
 
     /**
-     * Returns whether all IDs are used
-     */
-    public boolean isExhausted() {
-        return producerIdCounter.get() == lastProducerId();
-    }
-
-    /**
      * Get the ID of the broker that this block was assigned to.
      */
     public int assignedBrokerId() {

--- a/server-common/src/main/java/org/apache/kafka/server/common/ProducerIdsBlock.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ProducerIdsBlock.java
@@ -52,7 +52,7 @@ public class ProducerIdsBlock {
         if (nextId > lastProducerId()) {
             return Optional.empty();
         }
-        return nextId > lastProducerId() ? Optional.empty() : Optional.of(nextId);
+        return Optional.of(nextId);
     }
 
     /**


### PR DESCRIPTION
RPCProducerIdManager initiates an async request to the controller to grab a block of producer IDs and then blocks waiting for a response from the controller.

This is done in the request handler threads while holding a global lock. This means that if many producers are requesting producer IDs and the controller is slow to respond, many threads can get stuck waiting for the lock.

This patch aims to:
* resolve the deadlock scenario mentioned above by not waiting for a new block and returning an error immediately
* remove synchronization usages in RpcProducerIdManager.generateProducerId()
* handle errors returned from generateProducerId() so that KafkaApis does not log unexpected errors
* confirm producers backoff before retrying
* introduce backoff if manager fails to process AllocateProducerIdsResponse

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
