### PR TITLE
KAFKA-14729: The kafakConsumer pollForFetches(timer) method takes up a lot of cpu due to the abnormal exit of the heartbeat thread

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -353,7 +353,8 @@ public abstract class AbstractCoordinator implements Closeable {
     protected synchronized long timeToNextHeartbeat(long now) {
         // if we have not joined the group or we are preparing rebalance,
         // we don't need to send heartbeats
-        if (state.hasNotJoinedGroup())
+        if (state.hasNotJoinedGroup() ||
+                (heartbeatThread != null && (heartbeatThread.hasFailed() || heartbeatThread.closed)))
             return Long.MAX_VALUE;
         return heartbeat.timeToNextHeartbeat(now);
     }
@@ -1531,6 +1532,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     this.failed.set(new RuntimeException(e));
             } finally {
                 log.debug("Heartbeat thread has closed");
+                this.closed = true;
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -352,11 +352,15 @@ public abstract class AbstractCoordinator implements Closeable {
 
     protected synchronized long timeToNextHeartbeat(long now) {
         // if we have not joined the group or we are preparing rebalance,
-        // or heartbeatThread has failed or heartbeatThread has been closed
         // we don't need to send heartbeats
-        if (state.hasNotJoinedGroup() ||
-                (heartbeatThread != null && (heartbeatThread.hasFailed() || heartbeatThread.closed)))
+        if (state.hasNotJoinedGroup())
             return Long.MAX_VALUE;
+        if (heartbeatThread != null) {
+            if (heartbeatThread.hasFailed()) {
+                // if an exception occurs in the heartbeat thread, raise it.
+                throw heartbeatThread.failureCause();
+            }
+        }
         return heartbeat.timeToNextHeartbeat(now);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -355,11 +355,9 @@ public abstract class AbstractCoordinator implements Closeable {
         // we don't need to send heartbeats
         if (state.hasNotJoinedGroup())
             return Long.MAX_VALUE;
-        if (heartbeatThread != null) {
-            if (heartbeatThread.hasFailed()) {
-                // if an exception occurs in the heartbeat thread, raise it.
-                throw heartbeatThread.failureCause();
-            }
+        if (heartbeatThread != null && heartbeatThread.hasFailed()) {
+            // if an exception occurs in the heartbeat thread, raise it.
+            throw heartbeatThread.failureCause();
         }
         return heartbeat.timeToNextHeartbeat(now);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -352,6 +352,7 @@ public abstract class AbstractCoordinator implements Closeable {
 
     protected synchronized long timeToNextHeartbeat(long now) {
         // if we have not joined the group or we are preparing rebalance,
+        // or heartbeatThread has failed or heartbeatThread has been closed
         // we don't need to send heartbeats
         if (state.hasNotJoinedGroup() ||
                 (heartbeatThread != null && (heartbeatThread.hasFailed() || heartbeatThread.closed)))

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -1207,17 +1207,21 @@ public class AbstractCoordinatorTest {
             return false;
         }, heartbeatResponse(Errors.UNKNOWN_SERVER_ERROR));
 
+        int times = 0;
         try {
             coordinator.ensureActiveGroup();
             mockTime.sleep(HEARTBEAT_INTERVAL_MS);
             long startMs = System.currentTimeMillis();
             while (System.currentTimeMillis() - startMs < 1000) {
                 Thread.sleep(10);
+                if (Long.MAX_VALUE == coordinator.timeToNextHeartbeat(0))
+                    times++;
                 coordinator.pollHeartbeat(mockTime.milliseconds());
             }
             fail("Expected pollHeartbeat to raise an error in 1 second");
         } catch (RuntimeException exception) {
             assertEquals(exception, e);
+            assertEquals(1, times);
         }
     }
 


### PR DESCRIPTION

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
