### PR TITLE
MINOR: Add missing unit tests for {Local|Remote}LeaderEndpoint classes

### DIFF
--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -22,6 +22,8 @@ import kafka.server.checkpoints.LazyOffsetCheckpoints
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.{Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
@@ -116,6 +118,46 @@ class LocalLeaderEndPointTest {
     replicaManager.logManager.getLog(topicPartition).foreach(log => log._localLogStartOffset = 3)
     assertEquals((0, 0L), endPoint.fetchEarliestOffset(topicPartition, currentLeaderEpoch = 7))
     assertEquals((4, 3L), endPoint.fetchEarliestLocalOffset(topicPartition, currentLeaderEpoch = 7))
+  }
+
+  @Test
+  def testFetchEpochEndOffsets(): Unit = {
+    appendRecords(replicaManager, topicPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+
+    var result = endPoint.fetchEpochEndOffsets(Map(
+      topicPartition -> new OffsetForLeaderPartition()
+        .setPartition(topicPartition.partition)
+        .setLeaderEpoch(0)))
+
+    var expected = Map(
+      topicPartition -> new EpochEndOffset()
+        .setPartition(topicPartition.partition)
+        .setErrorCode(Errors.NONE.code)
+        .setLeaderEpoch(0)
+        .setEndOffset(3L))
+
+    assertEquals(expected, result)
+
+    // Change leader epoch and end offset, and verify the behavior again.
+    val leaderAndIsrRequest = buildLeaderAndIsrRequest(leaderEpoch = 4)
+    replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest, (_, _) => ())
+    appendRecords(replicaManager, topicPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+
+    result = endPoint.fetchEpochEndOffsets(Map(
+      topicPartition -> new OffsetForLeaderPartition()
+        .setPartition(topicPartition.partition)
+        .setLeaderEpoch(4)))
+
+    expected = Map(
+      topicPartition -> new EpochEndOffset()
+        .setPartition(topicPartition.partition)
+        .setErrorCode(Errors.NONE.code)
+        .setLeaderEpoch(4)
+        .setEndOffset(6L))
+
+    assertEquals(expected, result)
   }
 
   private class CallbackResult[T] {

--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -158,6 +158,21 @@ class LocalLeaderEndPointTest {
         .setEndOffset(6L))
 
     assertEquals(expected, result)
+
+    // Check missing epoch
+    result = endPoint.fetchEpochEndOffsets(Map(
+      topicPartition -> new OffsetForLeaderPartition()
+        .setPartition(topicPartition.partition)
+        .setLeaderEpoch(5)))
+
+    expected = Map(
+      topicPartition -> new EpochEndOffset()
+        .setPartition(topicPartition.partition)
+        .setErrorCode(Errors.NONE.code)
+        .setLeaderEpoch(-1)
+        .setEndOffset(-1L))
+
+    assertEquals(expected, result)
   }
 
   private class CallbackResult[T] {

--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -159,7 +159,22 @@ class LocalLeaderEndPointTest {
 
     assertEquals(expected, result)
 
-    // Check missing epoch
+    // Check missing epoch: 3, we expect the API to return (leader_epoch=0, end_offset=3).
+    result = endPoint.fetchEpochEndOffsets(Map(
+      topicPartition -> new OffsetForLeaderPartition()
+        .setPartition(topicPartition.partition)
+        .setLeaderEpoch(3)))
+
+    expected = Map(
+      topicPartition -> new EpochEndOffset()
+        .setPartition(topicPartition.partition)
+        .setErrorCode(Errors.NONE.code)
+        .setLeaderEpoch(0)
+        .setEndOffset(3L))
+
+    assertEquals(expected, result)
+
+    // Check missing epoch: 5, we expect the API to return (leader_epoch=-1, end_offset=-1)
     result = endPoint.fetchEpochEndOffsets(Map(
       topicPartition -> new OffsetForLeaderPartition()
         .setPartition(topicPartition.partition)


### PR DESCRIPTION
I've added unit tests that were previously missing for the `LeaderEndpoint.fetchEpochEndOffsets()` public method.