### PR TITLE
KAFKA-14731: Upgrade ZooKeeper to 3.6.4

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -263,8 +263,8 @@ swagger-core-2.2.0
 swagger-integration-2.2.0
 swagger-jaxrs2-2.2.0
 swagger-models-2.2.0
-zookeeper-3.6.3
-zookeeper-jute-3.6.3
+zookeeper-3.6.4
+zookeeper-jute-3.6.4
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -125,7 +125,7 @@ versions += [
   swaggerAnnotations: "2.2.0",
   swaggerJaxrs2: "2.2.0",
   zinc: "1.7.2",
-  zookeeper: "3.6.3",
+  zookeeper: "3.6.4",
   zstd: "1.5.2-1"
 ]
 libs += [


### PR DESCRIPTION
We have https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-14661 opened to upgrade ZooKeeper from 3.6.3 to 3.8.1, and that will likely be actioned in time for 3.5.0. But in the meantime, ZooKeeper 3.6.4 has been released, so we should take the patch version bump in trunk now and also apply the bump to the next patch releases of 3.0, 3.1, 3.2, 3.3, and 3.4.

ZooKeeper issues fixed in 3.6.4: https://issues.apache.org/jira/browse/ZOOKEEPER-4654?jql=project%20%3D%20ZOOKEEPER%20AND%20fixVersion%20%3D%203.6.4

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
