### PR TITLE
KAFKA-14295 FetchMessageConversionsPerSec meter not recorded

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkSend.java
@@ -31,6 +31,10 @@ public class NetworkSend implements Send {
         return destinationId;
     }
 
+    public Send send() {
+        return send;
+    }
+
     @Override
     public boolean completed() {
         return send.completed();

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -49,7 +49,7 @@ import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetFor
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.{EpochEndOffset, OffsetForLeaderTopicResult, OffsetForLeaderTopicResultCollection}
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.metrics.Metrics
-import org.apache.kafka.common.network.{ListenerName, Send}
+import org.apache.kafka.common.network.{ListenerName, NetworkSend, Send}
 import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
@@ -893,6 +893,8 @@ class KafkaApis(val requestChannel: RequestChannel,
             send.recordConversionStats.asScala.toMap.foreach {
               case (tp, stats) => updateRecordConversionStats(request, tp, stats)
             }
+          case send: NetworkSend =>
+            updateConversionStats(send.send())
           case _ =>
         }
       }

--- a/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
@@ -157,7 +157,7 @@ class FetchRequestDownConversionConfigTest extends BaseRequestTest {
    * Tests that "message.downconversion.enable" has no effect on fetch requests from replicas.
    */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("kraft"))
+  @ValueSource(strings = Array("zk", "kraft"))
   def testV1FetchFromReplica(quorum: String): Unit = {
     testV1Fetch(isFollowerFetch = true)
   }

--- a/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
@@ -223,7 +223,8 @@ class FetchRequestDownConversionConfigTest extends BaseRequestTest {
       assertEquals(Errors.UNSUPPORTED_VERSION, error(partitionWithDownConversionDisabled))
     }
     TestUtils.waitUntilTrue(() => TestUtils.metersCount(BrokerTopicStats.FetchMessageConversionsPerSec) > initialFetchMessageConversionsPerSec,
-    s"init: $initialFetchMessageConversionsPerSec final: ${TestUtils.metersCount(BrokerTopicStats.FetchMessageConversionsPerSec)}", 3000)
+      s"The `FetchMessageConversionsPerSec` metric count is not incremented after 5 seconds. " +
+      s"init: $initialFetchMessageConversionsPerSec final: ${TestUtils.metersCount(BrokerTopicStats.FetchMessageConversionsPerSec)}", 5000)
   }
 
   private def sendFetch(

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -2097,6 +2097,12 @@ object TestUtils extends Logging {
       .count
   }
 
+  def metersCount(metricName: String): Long = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .filter { case (k, _) => k.getMBeanName.endsWith(metricName)}
+      .values.map(_.asInstanceOf[Meter].count()).sum
+  }
+
   def clearYammerMetrics(): Unit = {
     for (metricName <- KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala)
       KafkaYammerMetrics.defaultRegistry.removeMetric(metricName)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-14295

The broker topic metric FetchMessageConversionsPerSec doesn't get recorded on a fetch message conversion.
The bug is that we pass in a callback that expects a MultiRecordsSend in KafkaApis:
```scala
def updateConversionStats(send: Send): Unit = {
  send match {
    case send: MultiRecordsSend if send.recordConversionStats != null =>
      send.recordConversionStats.asScala.toMap.foreach {
        case (tp, stats) => updateRecordConversionStats(request, tp, stats)
      }
    case _ =>
  }
} 
```
But we call this callback with a NetworkSend in the SocketServer:
```scala
selector.completedSends.forEach { send =>
  try {
    val response = inflightResponses.remove(send.destinationId).getOrElse {
      throw new IllegalStateException(s"Send for ${send.destinationId} completed, but not in `inflightResponses`")
    }
    updateRequestMetrics(response)

    // Invoke send completion callback
    response.onComplete.foreach(onComplete => onComplete(send))
```
Note that Selector.completedSends returns a collection of NetworkSend



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
