### PR TITLE
KAKFA-14733: Added a few missing checks for Kraft Authorizer and updated AclAuthorizerTest to run tests for both zk and kraft

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -139,6 +139,9 @@ public class AclControlManager {
                 throw new InvalidRequestException("Invalid permissionType " +
                     binding.entry().permissionType());
         }
+        if (binding.pattern().name() == null || binding.pattern().name().isEmpty()) {
+            throw new InvalidRequestException("Resource name should not be empty");
+        }
     }
 
     ControllerResult<List<AclDeleteResult>> deleteAcls(List<AclBindingFilter> filters) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -259,6 +259,9 @@ public class StandardAuthorizerData {
         AuthorizableRequestContext requestContext,
         Action action
     ) {
+        if (action.resourcePattern().patternType() != LITERAL) {
+            throw new IllegalArgumentException("Only literal resources are supported. Got: " + action.resourcePattern().patternType());
+        }
         KafkaPrincipal principal = baseKafkaPrincipal(requestContext);
         final MatchingRule rule;
 

--- a/metadata/src/test/java/org/apache/kafka/controller/MockAclControlManager.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockAclControlManager.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.metadata.AccessControlEntryRecord;
+import org.apache.kafka.common.metadata.RemoveAccessControlEntryRecord;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.metadata.authorizer.ClusterMetadataAuthorizer;
+import org.apache.kafka.server.authorizer.AclCreateResult;
+import org.apache.kafka.server.authorizer.AclDeleteResult;
+import org.apache.kafka.timeline.SnapshotRegistry;
+
+import java.util.List;
+import java.util.Optional;
+
+public class MockAclControlManager extends AclControlManager {
+  public MockAclControlManager(LogContext logContext,
+                        Optional<ClusterMetadataAuthorizer> authorizer) {
+    super(new SnapshotRegistry(logContext), authorizer);
+  }
+
+  public List<AclCreateResult> createAndReplayAcls(List<AclBinding> acls) {
+    ControllerResult<List<AclCreateResult>> createResults = createAcls(acls);
+    createResults.records().forEach(record -> replay((AccessControlEntryRecord) record.message(), Optional.empty()));
+    return createResults.response();
+  }
+
+  public List<AclDeleteResult> deleteAndReplayAcls(List<AclBindingFilter> filters) {
+    ControllerResult<List<AclDeleteResult>> deleteResults = deleteAcls(filters);
+    deleteResults.records().forEach(record -> replay((RemoveAccessControlEntryRecord) record.message(), Optional.empty()));
+    return deleteResults.response();
+  }
+
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/MockAclControlManager.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockAclControlManager.java
@@ -31,21 +31,20 @@ import java.util.List;
 import java.util.Optional;
 
 public class MockAclControlManager extends AclControlManager {
-  public MockAclControlManager(LogContext logContext,
-                        Optional<ClusterMetadataAuthorizer> authorizer) {
-    super(new SnapshotRegistry(logContext), authorizer);
-  }
+    public MockAclControlManager(LogContext logContext,
+                                 Optional<ClusterMetadataAuthorizer> authorizer) {
+        super(new SnapshotRegistry(logContext), authorizer);
+    }
 
-  public List<AclCreateResult> createAndReplayAcls(List<AclBinding> acls) {
-    ControllerResult<List<AclCreateResult>> createResults = createAcls(acls);
-    createResults.records().forEach(record -> replay((AccessControlEntryRecord) record.message(), Optional.empty()));
-    return createResults.response();
-  }
+    public List<AclCreateResult> createAndReplayAcls(List<AclBinding> acls) {
+        ControllerResult<List<AclCreateResult>> createResults = createAcls(acls);
+        createResults.records().forEach(record -> replay((AccessControlEntryRecord) record.message(), Optional.empty()));
+        return createResults.response();
+    }
 
-  public List<AclDeleteResult> deleteAndReplayAcls(List<AclBindingFilter> filters) {
-    ControllerResult<List<AclDeleteResult>> deleteResults = deleteAcls(filters);
-    deleteResults.records().forEach(record -> replay((RemoveAccessControlEntryRecord) record.message(), Optional.empty()));
-    return deleteResults.response();
-  }
-
+    public List<AclDeleteResult> deleteAndReplayAcls(List<AclBindingFilter> filters) {
+        ControllerResult<List<AclDeleteResult>> deleteResults = deleteAcls(filters);
+        deleteResults.records().forEach(record -> replay((RemoveAccessControlEntryRecord) record.message(), Optional.empty()));
+        return deleteResults.response();
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MockAclMutator.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MockAclMutator.java
@@ -29,34 +29,34 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 public class MockAclMutator implements AclMutator {
-  MockAclControlManager aclControlManager;
+    MockAclControlManager aclControlManager;
 
-  public MockAclMutator(StandardAuthorizer authorizer) {
-    aclControlManager = createAclControlManager(authorizer);
-  }
+    public MockAclMutator(StandardAuthorizer authorizer) {
+        aclControlManager = createAclControlManager(authorizer);
+    }
 
-  private MockAclControlManager createAclControlManager(StandardAuthorizer standardAuthorizer) {
-    LogContext logContext = new LogContext();
-    return new MockAclControlManager(logContext, Optional.of(standardAuthorizer));
-  }
+    private MockAclControlManager createAclControlManager(StandardAuthorizer standardAuthorizer) {
+        LogContext logContext = new LogContext();
+        return new MockAclControlManager(logContext, Optional.of(standardAuthorizer));
+    }
 
-  @Override
-  public CompletableFuture<List<AclCreateResult>> createAcls(
-      ControllerRequestContext context,
-      List<AclBinding> aclBindings
-  ) {
-    CompletableFuture<List<AclCreateResult>> future = new CompletableFuture<>();
-    future.complete(aclControlManager.createAndReplayAcls(aclBindings));
-    return future;
-  }
+    @Override
+    public CompletableFuture<List<AclCreateResult>> createAcls(
+        ControllerRequestContext context,
+        List<AclBinding> aclBindings
+    ) {
+        CompletableFuture<List<AclCreateResult>> future = new CompletableFuture<>();
+        future.complete(aclControlManager.createAndReplayAcls(aclBindings));
+        return future;
+    }
 
-  @Override
-  public CompletableFuture<List<AclDeleteResult>> deleteAcls(
-      ControllerRequestContext context,
-      List<AclBindingFilter> aclBindingFilters
-  ) {
-    CompletableFuture<List<AclDeleteResult>> future = new CompletableFuture<>();
-    future.complete(aclControlManager.deleteAndReplayAcls(aclBindingFilters));
-    return future;
-  }
+    @Override
+    public CompletableFuture<List<AclDeleteResult>> deleteAcls(
+        ControllerRequestContext context,
+        List<AclBindingFilter> aclBindingFilters
+    ) {
+        CompletableFuture<List<AclDeleteResult>> future = new CompletableFuture<>();
+        future.complete(aclControlManager.deleteAndReplayAcls(aclBindingFilters));
+        return future;
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MockAclMutator.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/MockAclMutator.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.controller.ControllerRequestContext;
+import org.apache.kafka.controller.MockAclControlManager;
+import org.apache.kafka.server.authorizer.AclCreateResult;
+import org.apache.kafka.server.authorizer.AclDeleteResult;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+public class MockAclMutator implements AclMutator {
+  MockAclControlManager aclControlManager;
+
+  public MockAclMutator(StandardAuthorizer authorizer) {
+    aclControlManager = createAclControlManager(authorizer);
+  }
+
+  private MockAclControlManager createAclControlManager(StandardAuthorizer standardAuthorizer) {
+    LogContext logContext = new LogContext();
+    return new MockAclControlManager(logContext, Optional.of(standardAuthorizer));
+  }
+
+  @Override
+  public CompletableFuture<List<AclCreateResult>> createAcls(
+      ControllerRequestContext context,
+      List<AclBinding> aclBindings
+  ) {
+    CompletableFuture<List<AclCreateResult>> future = new CompletableFuture<>();
+    future.complete(aclControlManager.createAndReplayAcls(aclBindings));
+    return future;
+  }
+
+  @Override
+  public CompletableFuture<List<AclDeleteResult>> deleteAcls(
+      ControllerRequestContext context,
+      List<AclBindingFilter> aclBindingFilters
+  ) {
+    CompletableFuture<List<AclDeleteResult>> future = new CompletableFuture<>();
+    future.complete(aclControlManager.deleteAndReplayAcls(aclBindingFilters));
+    return future;
+  }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -104,10 +104,10 @@ public class StandardAuthorizerTest {
         "127.0.0.1",
         9020);
 
-    static class AuthorizerTestServerInfo implements AuthorizerServerInfo {
+    public static class AuthorizerTestServerInfo implements AuthorizerServerInfo {
         private final Collection<Endpoint> endpoints;
 
-        AuthorizerTestServerInfo(Collection<Endpoint> endpoints) {
+        public AuthorizerTestServerInfo(Collection<Endpoint> endpoints) {
             assertFalse(endpoints.isEmpty());
             this.endpoints = endpoints;
         }


### PR DESCRIPTION
Added the following checks - 
* In StandardAuthorizerData.authorize() to fail if `patternType` other than `LITERAL` is passed.
* In AclControlManager.addAcl() to fail if Resource Name is null or empty.

Also, updated `AclAuthorizerTest` includes a lot of tests covering various scenarios that are missing in `StandardAuthorizerTest`. This PR changes the AclAuthorizerTest to run tests for both `zk` and `kraft` modes - 
* Rename AclAuthorizerTest -> AuthorizerTest
* Parameterize relevant tests to run for both modes

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
