### PR TITLE
KAFKA-14718: Fix flaky DedicatedMirrorIntegrationTest

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
 import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.KafkaOffsetBackingStore;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.storage.KafkaStatusBackingStore;
@@ -101,11 +102,12 @@ public class MirrorMaker {
 
     private static final long SHUTDOWN_TIMEOUT_SECONDS = 60L;
 
-    private static final List<Class<?>> CONNECTOR_CLASSES = Arrays.asList(
-        MirrorSourceConnector.class,
-        MirrorHeartbeatConnector.class,
-        MirrorCheckpointConnector.class);
- 
+    public static final List<Class<?>> CONNECTOR_CLASSES = Collections.unmodifiableList(
+        Arrays.asList(
+            MirrorSourceConnector.class,
+            MirrorHeartbeatConnector.class,
+            MirrorCheckpointConnector.class));
+
     private final Map<SourceAndTarget, Herder> herders = new HashMap<>();
     private CountDownLatch startLatch;
     private CountDownLatch stopLatch;
@@ -328,6 +330,11 @@ public class MirrorMaker {
                 MirrorMaker.this.stop();
             }
         }
+    }
+
+    public ConnectorStateInfo connectorStatus(SourceAndTarget sourceAndTarget, String connector) {
+        checkHerder(sourceAndTarget);
+        return herders.get(sourceAndTarget).connectorStatus(connector);
     }
 
     public static void main(String[] args) {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -17,12 +17,19 @@
 package org.apache.kafka.connect.mirror.integration;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.mirror.MirrorHeartbeatConnector;
 import org.apache.kafka.connect.mirror.MirrorMaker;
+import org.apache.kafka.connect.mirror.MirrorSourceConnector;
+import org.apache.kafka.connect.mirror.SourceAndTarget;
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.util.clusters.EmbeddedKafkaCluster;
+import org.apache.kafka.test.NoRetryException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -40,16 +47,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.connect.mirror.MirrorMaker.CONNECTOR_CLASSES;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 
 @Tag("integration")
 public class DedicatedMirrorIntegrationTest {
 
     private static final Logger log = LoggerFactory.getLogger(DedicatedMirrorIntegrationTest.class);
-
-    private static final int TOPIC_CREATION_TIMEOUT_MS = 120_000;
-    private static final int TOPIC_REPLICATION_TIMEOUT_MS = 120_000;
-
+    private static final int TOPIC_CREATION_TIMEOUT_MS = 30_000;
+    private static final int TOPIC_REPLICATION_TIMEOUT_MS = 30_000;
+    private static final long MM_START_UP_TIMEOUT_MS = 120_000;
     private Map<String, EmbeddedKafkaCluster> kafkaClusters;
     private Map<String, MirrorMaker> mirrorMakers;
 
@@ -63,8 +70,8 @@ public class DedicatedMirrorIntegrationTest {
     public void teardown() throws Throwable {
         AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
         mirrorMakers.forEach((name, mirrorMaker) ->
-            Utils.closeQuietly(mirrorMaker::stop, "MirrorMaker worker '" + name + "'", shutdownFailure)
-        );
+                Utils.closeQuietly(mirrorMaker::stop, "MirrorMaker worker '" + name + "'", shutdownFailure));
+        mirrorMakers.forEach((name, mirrorMaker) -> mirrorMaker.awaitStop());
         kafkaClusters.forEach((name, kafkaCluster) ->
             Utils.closeQuietly(kafkaCluster::stop, "Embedded Kafka cluster '" + name + "'", shutdownFailure)
         );
@@ -109,8 +116,7 @@ public class DedicatedMirrorIntegrationTest {
         clusterA.start();
         clusterB.start();
 
-        try (Admin adminA = clusterA.createAdminClient();
-             Admin adminB = clusterB.createAdminClient()) {
+        try (Admin adminB = clusterB.createAdminClient()) {
 
             // Cluster aliases
             final String a = "A";
@@ -142,15 +148,23 @@ public class DedicatedMirrorIntegrationTest {
                 }};
 
             // Bring up a single-node cluster
-            startMirrorMaker("single node", mmProps);
+            final MirrorMaker mm = startMirrorMaker("single node", mmProps);
+            final SourceAndTarget sourceAndTarget = new SourceAndTarget(a, b);
+            awaitMirrorMakerStart(mm, sourceAndTarget);
+
+            // wait for heartbeat connector to start a task
+            awaitConnectorTasksStart(mm, MirrorHeartbeatConnector.class, sourceAndTarget);
 
             final int numMessages = 10;
             String topic = testTopicPrefix + "1";
 
             // Create the topic on cluster A
-            createTopic(adminA, topic);
+            clusterA.createTopic(topic, 1);
             // and wait for MirrorMaker to create it on cluster B
             awaitTopicCreation(b, adminB, a + "." + topic);
+
+            // wait for source connector to start a task
+            awaitConnectorTasksStart(mm, MirrorSourceConnector.class, sourceAndTarget);
 
             // Write data to the topic on cluster A
             writeToTopic(clusterA, topic, numMessages);
@@ -176,9 +190,7 @@ public class DedicatedMirrorIntegrationTest {
         clusterA.start();
         clusterB.start();
 
-        try (Admin adminA = clusterA.createAdminClient();
-                Admin adminB = clusterB.createAdminClient()) {
-
+        try (Admin adminB = clusterB.createAdminClient()) {
             // Cluster aliases
             final String a = "A";
             // Use a convoluted cluster name to ensure URL encoding/decoding works
@@ -222,11 +234,18 @@ public class DedicatedMirrorIntegrationTest {
                     put("config.storage.replication.factor", "1");
                 }};
 
+            final SourceAndTarget sourceAndTarget = new SourceAndTarget(a, b);
             // Bring up a three-node cluster
             final int numNodes = 3;
             for (int i = 0; i < numNodes; i++) {
                 startMirrorMaker("node " + i, mmProps);
             }
+
+            // wait for mirror maker to start
+            awaitMirrorMakerStart(mirrorMakers.get("node 0"), sourceAndTarget);
+
+            // wait for heartbeat connector to start running
+            awaitConnectorTasksStart(mirrorMakers.get("node 0"), MirrorHeartbeatConnector.class, sourceAndTarget);
 
             // Create one topic per Kafka cluster per MirrorMaker node
             final int topicsPerCluster = numNodes;
@@ -235,9 +254,12 @@ public class DedicatedMirrorIntegrationTest {
                 String topic = testTopicPrefix + i;
 
                 // Create the topic on cluster A
-                createTopic(adminA, topic);
+                clusterA.createTopic(topic, 1);
                 // and wait for MirrorMaker to create it on cluster B
                 awaitTopicCreation(b, adminB, a + "." + topic);
+
+                // wait for source connector to start running
+                awaitConnectorTasksStart(mirrorMakers.get("node " + i), MirrorSourceConnector.class, sourceAndTarget);
 
                 // Write data to the topic on cluster A
                 writeToTopic(clusterA, topic, messagesPerTopic);
@@ -245,10 +267,6 @@ public class DedicatedMirrorIntegrationTest {
                 awaitTopicContent(clusterB, b, a + "." + topic, messagesPerTopic);
             }
         }
-    }
-
-    private void createTopic(Admin admin, String name) throws Exception {
-        admin.createTopics(Collections.singleton(new NewTopic(name, 1, (short) 1))).all().get();
     }
 
     private void awaitTopicCreation(String clusterName, Admin admin, String topic) throws Exception {
@@ -273,6 +291,29 @@ public class DedicatedMirrorIntegrationTest {
         }
     }
 
+    private void awaitMirrorMakerStart(final MirrorMaker mm, final SourceAndTarget sourceAndTarget) throws InterruptedException {
+        waitForCondition(() -> {
+            try {
+                return CONNECTOR_CLASSES.stream().allMatch(
+                    connectorClazz -> isConnectorRunningForMirrorMaker(connectorClazz, mm, sourceAndTarget));
+            } catch (Exception ex) {
+                log.error("Something unexpected occurred. Unable to check for startup status for mirror maker {}", mm, ex);
+                throw new NoRetryException(ex);
+            }
+        }, MM_START_UP_TIMEOUT_MS, "MirrorMaker instances did not transition to running in time");
+    }
+
+    private <T extends SourceConnector> void awaitConnectorTasksStart(final MirrorMaker mm, final Class<T> clazz, final SourceAndTarget sourceAndTarget) throws InterruptedException {
+        waitForCondition(() -> {
+            try {
+                return isTaskRunningForMirrorMakerConnector(clazz, mm, sourceAndTarget);
+            } catch (Exception ex) {
+                log.error("Something unexpected occurred. Unable to check for startup status of connector {} for mirror maker with source->target={}", clazz.getSimpleName(), sourceAndTarget, ex);
+                throw new NoRetryException(ex);
+            }
+        }, MM_START_UP_TIMEOUT_MS, "Tasks for connector " + clazz.getSimpleName() + " for MirrorMaker instances did not transition to running in time");
+    }
+
     private void awaitTopicContent(EmbeddedKafkaCluster cluster, String clusterName, String topic, int numMessages) throws Exception {
         try (Consumer<?, ?> consumer = cluster.createConsumer(Collections.singletonMap(AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
             consumer.subscribe(Collections.singleton(topic));
@@ -288,4 +329,40 @@ public class DedicatedMirrorIntegrationTest {
         }
     }
 
+    /**
+     * Validates that the underlying connector are running for the given MirrorMaker.
+     */
+    private boolean isConnectorRunningForMirrorMaker(final Class<?> connectorClazz, final MirrorMaker mm, final SourceAndTarget sourceAndTarget) {
+        final String connName = connectorClazz.getSimpleName();
+        try {
+            final ConnectorStateInfo connectorStatus = mm.connectorStatus(sourceAndTarget, connName);
+            if (connectorStatus.connector().state().equals(AbstractStatus.State.FAILED.toString())) {
+                throw new NoRetryException(new AssertionError(
+                    String.format("Connector %s is in FAILED state for MirrorMaker %s and source->target=%s",
+                            connectorClazz, mm, sourceAndTarget)));
+            }
+            // verify that connector state is set to running
+            return connectorStatus.connector().state().equals(AbstractStatus.State.RUNNING.toString());
+        } catch (NotFoundException nf) {
+            // Expected exception thrown by connectorStatus() when connect is not registered
+            return false;
+        }
+    }
+
+    /**
+     * Validates that the tasks are associated with the connector and they are running for the given MirrorMaker.
+     */
+    private <T extends SourceConnector> boolean isTaskRunningForMirrorMakerConnector(final Class<T> connectorClazz, final MirrorMaker mm, final SourceAndTarget sourceAndTarget) {
+        final String connName = connectorClazz.getSimpleName();
+        final ConnectorStateInfo connectorStatus = mm.connectorStatus(sourceAndTarget, connName);
+        return isConnectorRunningForMirrorMaker(connectorClazz, mm, sourceAndTarget)
+            // verify that at least one task exists
+            && !connectorStatus.tasks().isEmpty()
+            // verify that tasks are set to running
+            && connectorStatus.tasks().stream().allMatch(s -> {
+                if (s.state().equals(AbstractStatus.State.FAILED.toString()))
+                    throw new NoRetryException(new AssertionError(String.format("Task %s is in FAILED state", s)));
+                return s.state().equals(AbstractStatus.State.RUNNING.toString());
+            });
+    }
 }


### PR DESCRIPTION
# Motivation
The test suite `DedicatedMirrorIntegrationTest` fails in a flaky manner with the following error:
```
org.opentest4j.AssertionFailedError: Condition not met within timeout 30000. topic A.test-topic-0 was not created on cluster B- ._~:/?#[]@!$&'()*+;="<>%{}|\^`618 in time ==> expected: <true> but was: <false>
```
Root  cause of the failure is available in stdout:
```
[2023-02-17 18:56:32,308] INFO This node is a follower for A->B- ._~:/?#[]@!$&'()*+;="<>%{}|\^`618. Using existing connector configuration. (org.apache.kafka.connect.mirror.MirrorMaker:234)
[2023-02-17 18:56:42,567] INFO Kafka MirrorMaker stopping (org.apache.kafka.connect.mirror.MirrorMaker:202)
[2023-02-17 18:56:43,371] INFO Kafka MirrorMaker stopped. (org.apache.kafka.connect.mirror.MirrorMaker:213)
[2023-02-17 18:56:43,371] INFO Kafka MirrorMaker stopping (org.apache.kafka.connect.mirror.MirrorMaker:202)
[2023-02-17 18:56:44,376] INFO Kafka MirrorMaker stopped. (org.apache.kafka.connect.mirror.MirrorMaker:213)
[2023-02-17 18:56:44,377] INFO Kafka MirrorMaker stopping (org.apache.kafka.connect.mirror.MirrorMaker:202)
[2023-02-17 18:56:45,782] ERROR Failed to configure MirrorSourceConnector connector for A->B- ._~:/?#[]@!$&'()*+;="<>%{}|\^`618 (org.apache.kafka.connect.mirror.MirrorMaker:236)
org.apache.kafka.connect.errors.ConnectException: Worker is shutting down
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.halt(DistributedHerder.java:766)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.run(DistributedHerder.java:361)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
```

The test tries to assert topic replication on the second cluster but the mirror maker nodes themselves are unavailable. They are unavailable because the connectors fail to configure. Connectors fail to configure because the worker is already shutting down by the time they are ready to be configured.

# Change

This highlights a gap in MirrorMaker startup sequence where it does not wait for connectors to be configured by the herders before declaring itself as "started". This leads to a situation where MirrorMaker claims it has started but the herders are still in the process of configuring the connectors. During this time, mirror maker will not perform any replication.

With this change, we add a dependency on connector configuration for the MirrorMaker to declare itself as started.

# Rejected alternative
An alternative approach is to modify the test to wait for connectors to get configured on all 3 MM nodes before starting the actual test i.e. before making a call to create topic. But this alternative is artificially hiding the problems which users of MirrorMaker may also face.
