### PR TITLE
MINOR: Refactor task change logic to AbstractHerder, reuse for standalone mode.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -785,6 +785,23 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         return result;
     }
 
+    public boolean taskConfigsChanged(ClusterConfigState configState, String connName, List<Map<String, String>> taskProps) {
+        int currentNumTasks = configState.taskCount(connName);
+        if (taskProps.size() != currentNumTasks) {
+            log.debug("Connector {} task count changed from {} to {}", connName, currentNumTasks, taskProps.size());
+            return true;
+        } else {
+            for (int index = 0; index < currentNumTasks; index++) {
+                ConnectorTaskId taskId = new ConnectorTaskId(connName, index);
+                if (!taskProps.get(index).equals(configState.taskConfig(taskId))) {
+                    log.debug("Connector {} has change in generated task configurations", connName);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     // Visible for testing
     static Set<String> keysWithVariableValues(Map<String, String> rawConfig, Pattern pattern) {
         Set<String> keys = new HashSet<>();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -787,19 +787,25 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     public boolean taskConfigsChanged(ClusterConfigState configState, String connName, List<Map<String, String>> taskProps) {
         int currentNumTasks = configState.taskCount(connName);
+        boolean result = false;
         if (taskProps.size() != currentNumTasks) {
             log.debug("Connector {} task count changed from {} to {}", connName, currentNumTasks, taskProps.size());
-            return true;
+            result = true;
         } else {
             for (int index = 0; index < currentNumTasks; index++) {
                 ConnectorTaskId taskId = new ConnectorTaskId(connName, index);
                 if (!taskProps.get(index).equals(configState.taskConfig(taskId))) {
-                    log.debug("Connector {} has change in generated task configurations", connName);
-                    return true;
+                    log.debug("Connector {} has change in configuration for task {}-{}", connName, connName, index);
+                    result = true;
                 }
             }
         }
-        return false;
+        if (result) {
+            log.debug("Reconfiguring connector {}: writing new updated configurations for tasks", connName);
+        } else {
+            log.debug("Skipping reconfiguration of connector {} as generated configs appear unchanged", connName);
+        }
+        return result;
     }
 
     // Visible for testing

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1925,24 +1925,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
 
             final List<Map<String, String>> taskProps = worker.connectorTaskConfigs(connName, connConfig);
-            boolean changed = false;
-            int currentNumTasks = configState.taskCount(connName);
-            if (taskProps.size() != currentNumTasks) {
-                log.debug("Change in connector task count from {} to {}, writing updated task configurations", currentNumTasks, taskProps.size());
-                changed = true;
-            } else {
-                int index = 0;
-                for (Map<String, String> taskConfig : taskProps) {
-                    if (!taskConfig.equals(configState.taskConfig(new ConnectorTaskId(connName, index)))) {
-                        log.debug("Change in task configurations, writing updated task configurations");
-                        changed = true;
-                        break;
-                    }
-                    index++;
-                }
-            }
-            if (changed) {
+            if (taskConfigsChanged(configState, connName, taskProps)) {
                 List<Map<String, String>> rawTaskProps = reverseTransform(connName, configState, taskProps);
+                log.debug("Reconfiguring connector {}: writing new updated configurations for tasks", connName);
                 if (isLeader()) {
                     writeToConfigTopicAsLeader(() -> configBackingStore.putTaskConfigs(connName, rawTaskProps));
                     cb.onCompletion(null, null);
@@ -1981,6 +1966,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         }
                     });
                 }
+            } else {
+                log.debug("Skipping reconfiguration of connector {} as generated configs appear unchanged", connName);
             }
         } catch (Throwable t) {
             cb.onCompletion(t, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1927,7 +1927,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             final List<Map<String, String>> taskProps = worker.connectorTaskConfigs(connName, connConfig);
             if (taskConfigsChanged(configState, connName, taskProps)) {
                 List<Map<String, String>> rawTaskProps = reverseTransform(connName, configState, taskProps);
-                log.debug("Reconfiguring connector {}: writing new updated configurations for tasks", connName);
                 if (isLeader()) {
                     writeToConfigTopicAsLeader(() -> configBackingStore.putTaskConfigs(connName, rawTaskProps));
                     cb.onCompletion(null, null);
@@ -1966,8 +1965,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         }
                     });
                 }
-            } else {
-                log.debug("Skipping reconfiguration of connector {} as generated configs appear unchanged", connName);
             }
         } catch (Throwable t) {
             cb.onCompletion(t, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -427,9 +427,8 @@ public class StandaloneHerder extends AbstractHerder {
         }
 
         List<Map<String, String>> newTaskConfigs = recomputeTaskConfigs(connName);
-        List<Map<String, String>> oldTaskConfigs = configState.allTaskConfigs(connName);
 
-        if (!newTaskConfigs.equals(oldTaskConfigs)) {
+        if (taskConfigsChanged(configState, connName, newTaskConfigs)) {
             removeConnectorTasks(connName);
             List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
             configBackingStore.putTaskConfigs(connName, rawTaskConfigs);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * An immutable snapshot of the configuration state of connectors and tasks in a Kafka Connect cluster.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ClusterConfigState.java
@@ -189,28 +189,6 @@ public class ClusterConfigState {
     }
 
     /**
-     * Get all task configs for a connector. The configurations will have been transformed by
-     * {@link org.apache.kafka.common.config.ConfigTransformer} by having all variable
-     * references replaced with the current values from external instances of
-     * {@link ConfigProvider}, and may include secrets.
-     * @param connector name of the connector
-     * @return a list of task configurations
-     */
-    public List<Map<String, String>> allTaskConfigs(String connector) {
-        Map<Integer, Map<String, String>> taskConfigs = new TreeMap<>();
-        for (Map.Entry<ConnectorTaskId, Map<String, String>> taskConfigEntry : this.taskConfigs.entrySet()) {
-            if (taskConfigEntry.getKey().connector().equals(connector)) {
-                Map<String, String> configs = taskConfigEntry.getValue();
-                if (configTransformer != null) {
-                    configs = configTransformer.transform(connector, configs);
-                }
-                taskConfigs.put(taskConfigEntry.getKey().task(), configs);
-            }
-        }
-        return Collections.unmodifiableList(new ArrayList<>(taskConfigs.values()));
-    }
-
-    /**
      * Get the number of tasks for a given connector.
      * @param connectorName name of the connector to look up tasks for
      * @return the number of tasks

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -937,15 +937,14 @@ public class KafkaConfigBackingStoreTest {
         ClusterConfigState configState = configStorage.snapshot();
         assertEquals(TargetState.STARTED, configState.targetState(CONNECTOR_IDS.get(0)));
         assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_IDS.get(0)));
-        assertEquals(SAMPLE_CONFIGS.subList(0, 2), configState.allTaskConfigs(CONNECTOR_IDS.get(0)));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(new ConnectorTaskId(CONNECTOR_IDS.get(0),0)));
+        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(new ConnectorTaskId(CONNECTOR_IDS.get(0),1)));
         assertEquals(2, configState.taskCount(CONNECTOR_IDS.get(0)));
 
         configStorage.refresh(0, TimeUnit.SECONDS);
         configState = configStorage.snapshot();
         // Connector should now be removed from the snapshot
         assertFalse(configState.contains(CONNECTOR_IDS.get(0)));
-        // Task configs for the deleted connector should also be removed from the snapshot
-        assertEquals(Collections.emptyList(), configState.allTaskConfigs(CONNECTOR_IDS.get(0)));
         assertEquals(0, configState.taskCount(CONNECTOR_IDS.get(0)));
         // Ensure that the deleted connector's deferred task updates have been cleaned up
         // in order to prevent unbounded growth of the map

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -937,8 +937,8 @@ public class KafkaConfigBackingStoreTest {
         ClusterConfigState configState = configStorage.snapshot();
         assertEquals(TargetState.STARTED, configState.targetState(CONNECTOR_IDS.get(0)));
         assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_IDS.get(0)));
-        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(new ConnectorTaskId(CONNECTOR_IDS.get(0),0)));
-        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(new ConnectorTaskId(CONNECTOR_IDS.get(0),1)));
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.taskConfig(new ConnectorTaskId(CONNECTOR_IDS.get(0), 0)));
+        assertEquals(SAMPLE_CONFIGS.get(1), configState.taskConfig(new ConnectorTaskId(CONNECTOR_IDS.get(0), 1)));
         assertEquals(2, configState.taskCount(CONNECTOR_IDS.get(0)));
 
         configStorage.refresh(0, TimeUnit.SECONDS);


### PR DESCRIPTION
The condition to check for whether task configs has changed is duplicated in the Standalone and Distributed Herder classes.
This change refactors the implementation from DistributedHerder to cover the standalone, without changing the behavior.
Also alters the debug logs to include the connector name, and a log message to indicate when the logic has intentionally skipped writing the task configs to the backing topic.

This change will make fixes targeted at the task change logic also apply to the StandaloneHerder automatically, and prevent the divergence of the two code paths.
Additionally, this PR removes a ClusterConfigState method that was only in use by the StandaloneHerder.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
