### PR TITLE
KAFKA-14491: [14/N] Set changelog topic configs for versioned stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -279,9 +279,11 @@ public class InternalTopicManager {
                                        final InternalTopicConfig topicConfig,
                                        final Config brokerSideTopicConfig) {
         if (topicConfig instanceof UnwindowedUnversionedChangelogTopicConfig) {
-            validateCleanupPolicyForUnwindowedChangelogs(validationResult, topicConfig, brokerSideTopicConfig);
+            validateCleanupPolicyForUnwindowedUnversionedChangelogs(validationResult, topicConfig, brokerSideTopicConfig);
         } else if (topicConfig instanceof WindowedChangelogTopicConfig) {
             validateCleanupPolicyForWindowedChangelogs(validationResult, topicConfig, brokerSideTopicConfig);
+        } else if (topicConfig instanceof VersionedChangelogTopicConfig) {
+            validateCleanupPolicyForVersionedChangelogs(validationResult, topicConfig, brokerSideTopicConfig);
         } else if (topicConfig instanceof RepartitionTopicConfig) {
             validateCleanupPolicyForRepartitionTopic(validationResult, topicConfig, brokerSideTopicConfig);
         } else {
@@ -289,9 +291,9 @@ public class InternalTopicManager {
         }
     }
 
-    private void validateCleanupPolicyForUnwindowedChangelogs(final ValidationResult validationResult,
-                                                              final InternalTopicConfig topicConfig,
-                                                              final Config brokerSideTopicConfig) {
+    private void validateCleanupPolicyForUnwindowedUnversionedChangelogs(final ValidationResult validationResult,
+                                                                         final InternalTopicConfig topicConfig,
+                                                                         final Config brokerSideTopicConfig) {
         final String topicName = topicConfig.name();
         final String cleanupPolicy = getBrokerSideConfigValue(brokerSideTopicConfig, TopicConfig.CLEANUP_POLICY_CONFIG, topicName);
         if (cleanupPolicy.contains(TopicConfig.CLEANUP_POLICY_DELETE)) {
@@ -331,6 +333,35 @@ public class InternalTopicManager {
                         + topicName + " is set but it should be unset."
                 );
             }
+        }
+    }
+
+    private void validateCleanupPolicyForVersionedChangelogs(final ValidationResult validationResult,
+                                                             final InternalTopicConfig topicConfig,
+                                                             final Config brokerSideTopicConfig) {
+        final String topicName = topicConfig.name();
+        final String cleanupPolicy = getBrokerSideConfigValue(brokerSideTopicConfig, TopicConfig.CLEANUP_POLICY_CONFIG, topicName);
+
+        if (cleanupPolicy.contains(TopicConfig.CLEANUP_POLICY_DELETE)) {
+            validationResult.addMisconfiguration(
+                topicName,
+                "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic "
+                    + topicName + " should not contain \""
+                    + TopicConfig.CLEANUP_POLICY_DELETE + "\"."
+            );
+        }
+
+        final long brokerSideCompactionLagMs =
+            Long.parseLong(getBrokerSideConfigValue(brokerSideTopicConfig, TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, topicName));
+        final Map<String, String> streamsSideConfig =
+            topicConfig.getProperties(defaultTopicConfigs, windowChangeLogAdditionalRetention);
+        final long streamsSideCompactionLagMs = Long.parseLong(streamsSideConfig.get(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG));
+        if (brokerSideCompactionLagMs < streamsSideCompactionLagMs) {
+            validationResult.addMisconfiguration(
+                topicName,
+                "Min compaction lag (" + TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG + ") of existing internal topic "
+                    + topicName + " is " + brokerSideCompactionLagMs + " but should be " + streamsSideCompactionLagMs + " or larger."
+            );
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -278,7 +278,7 @@ public class InternalTopicManager {
     private void validateCleanupPolicy(final ValidationResult validationResult,
                                        final InternalTopicConfig topicConfig,
                                        final Config brokerSideTopicConfig) {
-        if (topicConfig instanceof UnwindowedChangelogTopicConfig) {
+        if (topicConfig instanceof UnwindowedUnversionedChangelogTopicConfig) {
             validateCleanupPolicyForUnwindowedChangelogs(validationResult, topicConfig, brokerSideTopicConfig);
         } else if (topicConfig instanceof WindowedChangelogTopicConfig) {
             validateCleanupPolicyForWindowedChangelogs(validationResult, topicConfig, brokerSideTopicConfig);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -36,6 +36,7 @@ import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -181,6 +182,14 @@ public class InternalTopologyBuilder {
             }
         }
 
+        private long historyRetention() {
+            if (builder instanceof VersionedKeyValueStoreBuilder) {
+                return ((VersionedKeyValueStoreBuilder<?, ?>) builder).historyRetention();
+            } else {
+                throw new IllegalStateException("historyRetention is not supported when not a versioned store");
+            }
+        }
+
         private Set<String> users() {
             return users;
         }
@@ -197,6 +206,10 @@ public class InternalTopologyBuilder {
             return builder instanceof WindowStoreBuilder
                 || builder instanceof TimestampedWindowStoreBuilder
                 || builder instanceof SessionStoreBuilder;
+        }
+
+        private boolean isVersionedStore() {
+            return builder instanceof VersionedKeyValueStoreBuilder;
         }
 
         // Apparently Java strips the generics from this method because we're using the raw type for builder,
@@ -1293,7 +1306,11 @@ public class InternalTopologyBuilder {
 
     private <S extends StateStore> InternalTopicConfig createChangelogTopicConfig(final StateStoreFactory<S> factory,
                                                                                   final String name) {
-        if (factory.isWindowStore()) {
+        if (factory.isVersionedStore()) {
+            final VersionedChangelogTopicConfig config = new VersionedChangelogTopicConfig(name, factory.logConfig());
+            config.setMinCompactionLagMs(factory.historyRetention());
+            return config;
+        } else if (factory.isWindowStore()) {
             final WindowedChangelogTopicConfig config = new WindowedChangelogTopicConfig(name, factory.logConfig());
             config.setRetentionMs(factory.retentionPeriod());
             return config;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1307,12 +1307,10 @@ public class InternalTopologyBuilder {
     private <S extends StateStore> InternalTopicConfig createChangelogTopicConfig(final StateStoreFactory<S> factory,
                                                                                   final String name) {
         if (factory.isVersionedStore()) {
-            final VersionedChangelogTopicConfig config = new VersionedChangelogTopicConfig(name, factory.logConfig());
-            config.setMinCompactionLagMs(factory.historyRetention());
+            final VersionedChangelogTopicConfig config = new VersionedChangelogTopicConfig(name, factory.logConfig(), factory.historyRetention());
             return config;
         } else if (factory.isWindowStore()) {
-            final WindowedChangelogTopicConfig config = new WindowedChangelogTopicConfig(name, factory.logConfig());
-            config.setRetentionMs(factory.retentionPeriod());
+            final WindowedChangelogTopicConfig config = new WindowedChangelogTopicConfig(name, factory.logConfig(), factory.retentionPeriod());
             return config;
         } else {
             return new UnwindowedUnversionedChangelogTopicConfig(name, factory.logConfig());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1315,7 +1315,7 @@ public class InternalTopologyBuilder {
             config.setRetentionMs(factory.retentionPeriod());
             return config;
         } else {
-            return new UnwindowedChangelogTopicConfig(name, factory.logConfig());
+            return new UnwindowedUnversionedChangelogTopicConfig(name, factory.logConfig());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/UnwindowedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/UnwindowedChangelogTopicConfig.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 /**
  * UnwindowedChangelogTopicConfig captures the properties required for configuring
- * the un-windowed store changelog topics.
+ * the un-windowed, un-versioned store changelog topics.
  */
 public class UnwindowedChangelogTopicConfig extends InternalTopicConfig {
     private static final Map<String, String> UNWINDOWED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/UnwindowedUnversionedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/UnwindowedUnversionedChangelogTopicConfig.java
@@ -24,10 +24,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * UnwindowedChangelogTopicConfig captures the properties required for configuring
+ * UnwindowedUnversionedChangelogTopicConfig captures the properties required for configuring
  * the un-windowed, un-versioned store changelog topics.
  */
-public class UnwindowedChangelogTopicConfig extends InternalTopicConfig {
+public class UnwindowedUnversionedChangelogTopicConfig extends InternalTopicConfig {
     private static final Map<String, String> UNWINDOWED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES;
     static {
         final Map<String, String> tempTopicDefaultOverrides = new HashMap<>(INTERNAL_TOPIC_DEFAULT_OVERRIDES);
@@ -35,7 +35,7 @@ public class UnwindowedChangelogTopicConfig extends InternalTopicConfig {
         UNWINDOWED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES = Collections.unmodifiableMap(tempTopicDefaultOverrides);
     }
 
-    UnwindowedChangelogTopicConfig(final String name, final Map<String, String> topicConfigs) {
+    UnwindowedUnversionedChangelogTopicConfig(final String name, final Map<String, String> topicConfigs) {
         super(name, topicConfigs);
     }
 
@@ -66,7 +66,7 @@ public class UnwindowedChangelogTopicConfig extends InternalTopicConfig {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final UnwindowedChangelogTopicConfig that = (UnwindowedChangelogTopicConfig) o;
+        final UnwindowedUnversionedChangelogTopicConfig that = (UnwindowedUnversionedChangelogTopicConfig) o;
         return Objects.equals(name, that.name) &&
                Objects.equals(topicConfigs, that.topicConfigs) &&
                Objects.equals(enforceNumberOfPartitions, that.enforceNumberOfPartitions);
@@ -79,7 +79,7 @@ public class UnwindowedChangelogTopicConfig extends InternalTopicConfig {
 
     @Override
     public String toString() {
-        return "UnwindowedChangelogTopicConfig(" +
+        return "UnwindowedUnversionedChangelogTopicConfig(" +
                 "name=" + name +
                 ", topicConfigs=" + topicConfigs +
                 ", enforceNumberOfPartitions=" + enforceNumberOfPartitions +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/VersionedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/VersionedChangelogTopicConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.config.TopicConfig;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * VersionedChangelogTopicConfig captures the properties required for configuring
+ * the versioned store changelog topics.
+ */
+public class VersionedChangelogTopicConfig extends InternalTopicConfig {
+    private static final Map<String, String> VERSIONED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES;
+    static {
+        final Map<String, String> tempTopicDefaultOverrides = new HashMap<>(INTERNAL_TOPIC_DEFAULT_OVERRIDES);
+        tempTopicDefaultOverrides.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
+        VERSIONED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES = Collections.unmodifiableMap(tempTopicDefaultOverrides);
+    }
+    private static final long VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS = 24 * 60 * 60 * 1000L;
+
+    private Long minCompactionLagMs;
+
+    VersionedChangelogTopicConfig(final String name, final Map<String, String> topicConfigs) {
+        super(name, topicConfigs);
+    }
+
+    /**
+     * Get the configured properties for this topic. If {@code minCompactionLagMs} is set then
+     * we add {@code VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS} to work out the
+     * desired min compaction lag for cleanup.policy=compact
+     *
+     * @param windowStoreAdditionalRetentionMs added to retention for window store changelog
+     *                                         topics to allow for clock drift etc. We do not reuse
+     *                                         this value for versioned store changelog topic
+     *                                         compaction lag as the user-facing config name is
+     *                                         window store specific.
+     * @return Properties to be used when creating the topic
+     */
+    @Override
+    public Map<String, String> getProperties(final Map<String, String> defaultProperties, final long windowStoreAdditionalRetentionMs) {
+        // internal topic config override rule: library overrides < global config overrides < per-topic config overrides
+        final Map<String, String> topicConfig = new HashMap<>(VERSIONED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES);
+
+        topicConfig.putAll(defaultProperties);
+
+        topicConfig.putAll(topicConfigs);
+
+        if (minCompactionLagMs != null) {
+            long compactionLagValue;
+            try {
+                compactionLagValue = Math.addExact(minCompactionLagMs, VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS);
+            } catch (final ArithmeticException swallow) {
+                compactionLagValue = Long.MAX_VALUE;
+            }
+            topicConfig.put(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagValue));
+        }
+
+        return topicConfig;
+    }
+
+    void setMinCompactionLagMs(final long minCompactionLagMs) {
+        if (!topicConfigs.containsKey(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG)) {
+            this.minCompactionLagMs = minCompactionLagMs;
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final VersionedChangelogTopicConfig that = (VersionedChangelogTopicConfig) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(topicConfigs, that.topicConfigs) &&
+            Objects.equals(minCompactionLagMs, that.minCompactionLagMs) &&
+            Objects.equals(enforceNumberOfPartitions, that.enforceNumberOfPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, topicConfigs, minCompactionLagMs, enforceNumberOfPartitions);
+    }
+
+    @Override
+    public String toString() {
+        return "VersionedChangelogTopicConfig(" +
+            "name=" + name +
+            ", topicConfigs=" + topicConfigs +
+            ", minCompactionLagMs=" + minCompactionLagMs +
+            ", enforceNumberOfPartitions=" + enforceNumberOfPartitions +
+            ")";
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/VersionedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/VersionedChangelogTopicConfig.java
@@ -46,8 +46,9 @@ public class VersionedChangelogTopicConfig extends InternalTopicConfig {
     }
 
     /**
-     * Get the configured properties for this topic. If {@code minCompactionLagMs} is set then
-     * we add {@code VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS} to work out the
+     * Get the configured properties for this topic. If no {@code minCompactionLagMs} is
+     * provided from the topic configs, then we add
+     * {@code VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS} to work out the
      * desired min compaction lag for cleanup.policy=compact
      *
      * @param windowStoreAdditionalRetentionMs added to retention for window store changelog

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/VersionedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/VersionedChangelogTopicConfig.java
@@ -36,10 +36,13 @@ public class VersionedChangelogTopicConfig extends InternalTopicConfig {
     }
     private static final long VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS = 24 * 60 * 60 * 1000L;
 
-    private Long minCompactionLagMs;
+    private final long minCompactionLagMs;
 
-    VersionedChangelogTopicConfig(final String name, final Map<String, String> topicConfigs) {
+    VersionedChangelogTopicConfig(final String name,
+                                  final Map<String, String> topicConfigs,
+                                  final long minCompactionLagMs) {
         super(name, topicConfigs);
+        this.minCompactionLagMs = minCompactionLagMs;
     }
 
     /**
@@ -63,7 +66,7 @@ public class VersionedChangelogTopicConfig extends InternalTopicConfig {
 
         topicConfig.putAll(topicConfigs);
 
-        if (minCompactionLagMs != null) {
+        if (!topicConfigs.containsKey(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG)) {
             long compactionLagValue;
             try {
                 compactionLagValue = Math.addExact(minCompactionLagMs, VERSIONED_STORE_CHANGE_LOG_ADDITIONAL_COMPACTION_LAG_MS);
@@ -74,12 +77,6 @@ public class VersionedChangelogTopicConfig extends InternalTopicConfig {
         }
 
         return topicConfig;
-    }
-
-    void setMinCompactionLagMs(final long minCompactionLagMs) {
-        if (!topicConfigs.containsKey(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG)) {
-            this.minCompactionLagMs = minCompactionLagMs;
-        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/WindowedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/WindowedChangelogTopicConfig.java
@@ -43,8 +43,9 @@ public class WindowedChangelogTopicConfig extends InternalTopicConfig {
     }
 
     /**
-     * Get the configured properties for this topic. If retentionMs is set then
-     * we add additionalRetentionMs to work out the desired retention when cleanup.policy=compact,delete
+     * Get the configured properties for this topic. If no retentionMs override is provided from
+     * the topic configs, then we add additionalRetentionMs to work out the desired retention
+     * when cleanup.policy=compact,delete
      *
      * @param additionalRetentionMs - added to retention to allow for clock drift etc
      * @return Properties to be used when creating the topic

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/WindowedChangelogTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/WindowedChangelogTopicConfig.java
@@ -35,10 +35,11 @@ public class WindowedChangelogTopicConfig extends InternalTopicConfig {
         WINDOWED_STORE_CHANGELOG_TOPIC_DEFAULT_OVERRIDES = Collections.unmodifiableMap(tempTopicDefaultOverrides);
     }
 
-    private Long retentionMs;
+    private final long retentionMs;
 
-    WindowedChangelogTopicConfig(final String name, final Map<String, String> topicConfigs) {
+    WindowedChangelogTopicConfig(final String name, final Map<String, String> topicConfigs, final long retentionMs) {
         super(name, topicConfigs);
+        this.retentionMs = retentionMs;
     }
 
     /**
@@ -57,7 +58,7 @@ public class WindowedChangelogTopicConfig extends InternalTopicConfig {
 
         topicConfig.putAll(topicConfigs);
 
-        if (retentionMs != null) {
+        if (!topicConfigs.containsKey(TopicConfig.RETENTION_MS_CONFIG)) {
             long retentionValue;
             try {
                 retentionValue = Math.addExact(retentionMs, additionalRetentionMs);
@@ -68,12 +69,6 @@ public class WindowedChangelogTopicConfig extends InternalTopicConfig {
         }
 
         return topicConfig;
-    }
-
-    void setRetentionMs(final long retentionMs) {
-        if (!topicConfigs.containsKey(TopicConfig.RETENTION_MS_CONFIG)) {
-            this.retentionMs = retentionMs;
-        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilder.java
@@ -71,6 +71,10 @@ public class VersionedKeyValueStoreBuilder<K, V>
         throw new IllegalStateException("Versioned stores do not support caching");
     }
 
+    public long historyRetention() {
+        return storeSupplier.historyRetentionMs();
+    }
+
     private VersionedBytesStore maybeWrapLogging(final VersionedBytesStore inner) {
         if (!enableLogging) {
             return inner;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -48,8 +48,8 @@ public class ChangelogTopicsTest {
     private static final Map<String, String> TOPIC_CONFIG = Collections.singletonMap("config1", "val1");
     private static final RepartitionTopicConfig REPARTITION_TOPIC_CONFIG =
         new RepartitionTopicConfig(REPARTITION_TOPIC_NAME, TOPIC_CONFIG);
-    private static final UnwindowedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG =
-        new UnwindowedChangelogTopicConfig(CHANGELOG_TOPIC_NAME1, TOPIC_CONFIG);
+    private static final UnwindowedUnversionedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG =
+        new UnwindowedUnversionedChangelogTopicConfig(CHANGELOG_TOPIC_NAME1, TOPIC_CONFIG);
 
     private static final TopicsInfo TOPICS_INFO1 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicConfigTest.java
@@ -54,7 +54,7 @@ public class InternalTopicConfigTest {
 
     @Test
     public void shouldSetCreateTimeByDefaultForUnwindowedChangelog() {
-        final UnwindowedChangelogTopicConfig topicConfig = new UnwindowedChangelogTopicConfig("name", Collections.emptyMap());
+        final UnwindowedUnversionedChangelogTopicConfig topicConfig = new UnwindowedUnversionedChangelogTopicConfig("name", Collections.emptyMap());
 
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
         assertEquals("CreateTime", properties.get(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG));
@@ -93,7 +93,7 @@ public class InternalTopicConfigTest {
         configs.put("retention.bytes", "10000");
         configs.put("message.timestamp.type", "LogAppendTime");
 
-        final UnwindowedChangelogTopicConfig topicConfig = new UnwindowedChangelogTopicConfig("name", configs);
+        final UnwindowedUnversionedChangelogTopicConfig topicConfig = new UnwindowedUnversionedChangelogTopicConfig("name", configs);
 
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
         assertEquals("1000", properties.get(TopicConfig.RETENTION_MS_CONFIG));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicConfigTest.java
@@ -46,15 +46,23 @@ public class InternalTopicConfigTest {
 
     @Test
     public void shouldSetCreateTimeByDefaultForWindowedChangelog() {
-        final WindowedChangelogTopicConfig topicConfig = new WindowedChangelogTopicConfig("name", Collections.emptyMap());
+        final WindowedChangelogTopicConfig topicConfig = new WindowedChangelogTopicConfig("name", Collections.emptyMap(), 10);
 
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
         assertEquals("CreateTime", properties.get(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG));
     }
 
     @Test
-    public void shouldSetCreateTimeByDefaultForUnwindowedChangelog() {
+    public void shouldSetCreateTimeByDefaultForUnwindowedUnversionedChangelog() {
         final UnwindowedUnversionedChangelogTopicConfig topicConfig = new UnwindowedUnversionedChangelogTopicConfig("name", Collections.emptyMap());
+
+        final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
+        assertEquals("CreateTime", properties.get(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG));
+    }
+
+    @Test
+    public void shouldSetCreateTimeByDefaultForVersionedChangelog() {
+        final VersionedChangelogTopicConfig topicConfig = new VersionedChangelogTopicConfig("name", Collections.emptyMap(), 12);
 
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
         assertEquals("CreateTime", properties.get(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG));
@@ -70,9 +78,14 @@ public class InternalTopicConfigTest {
 
     @Test
     public void shouldAugmentRetentionMsWithWindowedChangelog() {
-        final WindowedChangelogTopicConfig topicConfig = new WindowedChangelogTopicConfig("name", Collections.emptyMap());
-        topicConfig.setRetentionMs(10);
+        final WindowedChangelogTopicConfig topicConfig = new WindowedChangelogTopicConfig("name", Collections.emptyMap(), 10);
         assertEquals("30", topicConfig.getProperties(Collections.emptyMap(), 20).get(TopicConfig.RETENTION_MS_CONFIG));
+    }
+
+    @Test
+    public void shouldAugmentCompactionLagMsWithVersionedChangelog() {
+        final VersionedChangelogTopicConfig topicConfig = new VersionedChangelogTopicConfig("name", Collections.emptyMap(), 12);
+        assertEquals(Long.toString(12 + 24 * 60 * 60 * 1000L), topicConfig.getProperties(Collections.emptyMap(), 20).get(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG));
     }
 
     @Test
@@ -80,14 +93,25 @@ public class InternalTopicConfigTest {
         final Map<String, String> configs = new HashMap<>();
         configs.put("message.timestamp.type", "LogAppendTime");
 
-        final WindowedChangelogTopicConfig topicConfig = new WindowedChangelogTopicConfig("name", configs);
+        final WindowedChangelogTopicConfig topicConfig = new WindowedChangelogTopicConfig("name", configs, 10);
 
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
         assertEquals("LogAppendTime", properties.get(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG));
     }
 
     @Test
-    public void shouldUseSuppliedConfigsForUnwindowedChangelogConfig() {
+    public void shouldUseSuppliedConfigsForVersionedChangelogConfig() {
+        final Map<String, String> configs = new HashMap<>();
+        configs.put("message.timestamp.type", "LogAppendTime");
+
+        final VersionedChangelogTopicConfig topicConfig = new VersionedChangelogTopicConfig("name", configs, 12);
+
+        final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 0);
+        assertEquals("LogAppendTime", properties.get(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG));
+    }
+
+    @Test
+    public void shouldUseSuppliedConfigsForUnwindowedUnversionedChangelogConfig() {
         final Map<String, String> configs = new HashMap<>();
         configs.put("retention.ms", "1000");
         configs.put("retention.bytes", "10000");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -637,14 +637,17 @@ public class InternalTopicManagerTest {
         topicConfig.setNumberOfPartitions(1);
         final InternalTopicConfig topicConfig2 = new UnwindowedUnversionedChangelogTopicConfig(topic2, Collections.emptyMap());
         topicConfig2.setNumberOfPartitions(1);
-        final InternalTopicConfig topicConfig3 = new WindowedChangelogTopicConfig(topic3, Collections.emptyMap());
+        final InternalTopicConfig topicConfig3 = new WindowedChangelogTopicConfig(topic3, Collections.emptyMap(), 10);
         topicConfig3.setNumberOfPartitions(1);
+        final InternalTopicConfig topicConfig4 = new VersionedChangelogTopicConfig(topic4, Collections.emptyMap(), 12);
+        topicConfig4.setNumberOfPartitions(1);
 
         internalTopicManager.makeReady(Collections.singletonMap(topic1, topicConfig));
         internalTopicManager.makeReady(Collections.singletonMap(topic2, topicConfig2));
         internalTopicManager.makeReady(Collections.singletonMap(topic3, topicConfig3));
+        internalTopicManager.makeReady(Collections.singletonMap(topic4, topicConfig4));
 
-        assertEquals(mkSet(topic1, topic2, topic3), mockAdminClient.listTopics().names().get());
+        assertEquals(mkSet(topic1, topic2, topic3, topic4), mockAdminClient.listTopics().names().get());
         assertEquals(new TopicDescription(topic1, false, new ArrayList<TopicPartitionInfo>() {
             {
                 add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.emptyList()));
@@ -660,10 +663,16 @@ public class InternalTopicManagerTest {
                 add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.emptyList()));
             }
         }), mockAdminClient.describeTopics(Collections.singleton(topic3)).topicNameValues().get(topic3).get());
+        assertEquals(new TopicDescription(topic4, false, new ArrayList<TopicPartitionInfo>() {
+            {
+                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.emptyList()));
+            }
+        }), mockAdminClient.describeTopics(Collections.singleton(topic4)).topicNameValues().get(topic4).get());
 
         final ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topic1);
         final ConfigResource resource2 = new ConfigResource(ConfigResource.Type.TOPIC, topic2);
         final ConfigResource resource3 = new ConfigResource(ConfigResource.Type.TOPIC, topic3);
+        final ConfigResource resource4 = new ConfigResource(ConfigResource.Type.TOPIC, topic4);
 
         assertEquals(
             new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
@@ -676,6 +685,10 @@ public class InternalTopicManagerTest {
         assertEquals(
             new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE),
             mockAdminClient.describeConfigs(Collections.singleton(resource3)).values().get(resource3).get().get(TopicConfig.CLEANUP_POLICY_CONFIG)
+        );
+        assertEquals(
+            new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
+            mockAdminClient.describeConfigs(Collections.singleton(resource4)).values().get(resource4).get().get(TopicConfig.CLEANUP_POLICY_CONFIG)
         );
     }
 
@@ -1033,20 +1046,20 @@ public class InternalTopicManagerTest {
     }
 
     @Test
-    public void shouldReportMisconfigurationsOfCleanupPolicyForUnwindowedChangelogTopics() {
-        final Map<String, String> unwindowedChangelogConfigWithDeleteCleanupPolicy = unwindowedChangelogConfig();
-        unwindowedChangelogConfigWithDeleteCleanupPolicy.put(
+    public void shouldReportMisconfigurationsOfCleanupPolicyForUnwindowedUnversionedChangelogTopics() {
+        final Map<String, String> unwindowedUnversionedChangelogConfigWithDeleteCleanupPolicy = unwindowedUnversionedChangelogConfig();
+        unwindowedUnversionedChangelogConfigWithDeleteCleanupPolicy.put(
             TopicConfig.CLEANUP_POLICY_CONFIG,
             TopicConfig.CLEANUP_POLICY_DELETE
         );
-        setupTopicInMockAdminClient(topic1, unwindowedChangelogConfigWithDeleteCleanupPolicy);
-        final Map<String, String> unwindowedChangelogConfigWithDeleteCompactCleanupPolicy = unwindowedChangelogConfig();
-        unwindowedChangelogConfigWithDeleteCompactCleanupPolicy.put(
+        setupTopicInMockAdminClient(topic1, unwindowedUnversionedChangelogConfigWithDeleteCleanupPolicy);
+        final Map<String, String> unwindowedUnversionedChangelogConfigWithDeleteCompactCleanupPolicy = unwindowedUnversionedChangelogConfig();
+        unwindowedUnversionedChangelogConfigWithDeleteCompactCleanupPolicy.put(
             TopicConfig.CLEANUP_POLICY_CONFIG,
             TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE
         );
-        setupTopicInMockAdminClient(topic2, unwindowedChangelogConfigWithDeleteCompactCleanupPolicy);
-        setupTopicInMockAdminClient(topic3, unwindowedChangelogConfig());
+        setupTopicInMockAdminClient(topic2, unwindowedUnversionedChangelogConfigWithDeleteCompactCleanupPolicy);
+        setupTopicInMockAdminClient(topic3, unwindowedUnversionedChangelogConfig());
         final InternalTopicConfig internalTopicConfig1 = setupUnwindowedUnversionedChangelogTopicConfig(topic1, 1);
         final InternalTopicConfig internalTopicConfig2 = setupUnwindowedUnversionedChangelogTopicConfig(topic2, 1);
         final InternalTopicConfig internalTopicConfig3 = setupUnwindowedUnversionedChangelogTopicConfig(topic3, 1);
@@ -1132,6 +1145,57 @@ public class InternalTopicManagerTest {
         );
         assertThat(misconfigurationsForTopics, not(hasKey(topic1)));
         assertThat(misconfigurationsForTopics, not(hasKey(topic3)));
+    }
+
+    @Test
+    public void shouldReportMisconfigurationsOfCleanupPolicyForVersionedChangelogTopics() {
+        final long compactionLagMs = 1000;
+        final long shorterCompactionLagMs = 900;
+        setupTopicInMockAdminClient(topic1, versionedChangelogConfig(compactionLagMs));
+        setupTopicInMockAdminClient(topic2, versionedChangelogConfig(shorterCompactionLagMs));
+        final Map<String, String> versionedChangelogConfigCleanupPolicyDelete = versionedChangelogConfig(compactionLagMs);
+        versionedChangelogConfigCleanupPolicyDelete.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
+        setupTopicInMockAdminClient(topic3, versionedChangelogConfigCleanupPolicyDelete);
+        final Map<String, String> versionedChangelogConfigCleanupPolicyCompactAndDelete = versionedChangelogConfig(compactionLagMs);
+        versionedChangelogConfigCleanupPolicyCompactAndDelete.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT + TopicConfig.CLEANUP_POLICY_DELETE);
+        setupTopicInMockAdminClient(topic4, versionedChangelogConfigCleanupPolicyCompactAndDelete);
+        final InternalTopicConfig internalTopicConfig1 = setupVersionedChangelogTopicConfig(topic1, 1, compactionLagMs);
+        final InternalTopicConfig internalTopicConfig2 = setupVersionedChangelogTopicConfig(topic2, 1, compactionLagMs);
+        final InternalTopicConfig internalTopicConfig3 = setupVersionedChangelogTopicConfig(topic3, 1, compactionLagMs);
+        final InternalTopicConfig internalTopicConfig4 = setupVersionedChangelogTopicConfig(topic4, 1, compactionLagMs);
+
+        final ValidationResult validationResult = internalTopicManager.validate(mkMap(
+            mkEntry(topic1, internalTopicConfig1),
+            mkEntry(topic2, internalTopicConfig2),
+            mkEntry(topic3, internalTopicConfig3),
+            mkEntry(topic4, internalTopicConfig4)
+        ));
+
+        final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
+        assertThat(validationResult.missingTopics(), empty());
+        assertThat(misconfigurationsForTopics.size(), is(3));
+        assertThat(misconfigurationsForTopics, hasKey(topic2));
+        assertThat(misconfigurationsForTopics.get(topic2).size(), is(1));
+        assertThat(
+            misconfigurationsForTopics.get(topic2).get(0),
+            is("Min compaction lag (" + TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG + ") of existing internal topic " +
+                topic2 + " is " + shorterCompactionLagMs + " but should be " + compactionLagMs + " or larger.")
+        );
+        assertThat(misconfigurationsForTopics, hasKey(topic3));
+        assertThat(misconfigurationsForTopics.get(topic3).size(), is(1));
+        assertThat(
+            misconfigurationsForTopics.get(topic3).get(0),
+            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic3 + " should not contain \""
+                + TopicConfig.CLEANUP_POLICY_DELETE + "\".")
+        );
+        assertThat(misconfigurationsForTopics, hasKey(topic4));
+        assertThat(misconfigurationsForTopics.get(topic4).size(), is(1));
+        assertThat(
+            misconfigurationsForTopics.get(topic4).get(0),
+            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic4 + " should not contain \""
+                + TopicConfig.CLEANUP_POLICY_DELETE + "\".")
+        );
+        assertThat(misconfigurationsForTopics, not(hasKey(topic1)));
     }
 
     @Test
@@ -1493,10 +1557,10 @@ public class InternalTopicManagerTest {
     }
 
     @Test
-    public void shouldThrowWhenConfigDescriptionsDoNotCleanupPolicyForUnwindowedConfigDuringValidation() {
+    public void shouldThrowWhenConfigDescriptionsDoNotCleanupPolicyForUnwindowedUnversionedConfigDuringValidation() {
         shouldThrowWhenConfigDescriptionsDoNotContainConfigDuringValidation(
             setupUnwindowedUnversionedChangelogTopicConfig(topic1, 1),
-            configWithoutKey(unwindowedChangelogConfig(), TopicConfig.CLEANUP_POLICY_CONFIG)
+            configWithoutKey(unwindowedUnversionedChangelogConfig(), TopicConfig.CLEANUP_POLICY_CONFIG)
         );
     }
 
@@ -1668,7 +1732,7 @@ public class InternalTopicManagerTest {
         );
     }
 
-    private Map<String, String> unwindowedChangelogConfig() {
+    private Map<String, String> unwindowedUnversionedChangelogConfig() {
         return mkMap(
             mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
         );
@@ -1679,6 +1743,13 @@ public class InternalTopicManagerTest {
             mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE),
             mkEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs)),
             mkEntry(TopicConfig.RETENTION_BYTES_CONFIG, null)
+        );
+    }
+
+    private Map<String, String> versionedChangelogConfig(final long compactionLagMs) {
+        return mkMap(
+            mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
+            mkEntry(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagMs))
         );
     }
 
@@ -1704,7 +1775,20 @@ public class InternalTopicManagerTest {
                                                                   final long retentionMs) {
         final InternalTopicConfig internalTopicConfig = new WindowedChangelogTopicConfig(
             topicName,
-            mkMap(mkEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs)))
+            mkMap(mkEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMs))),
+            10
+        );
+        internalTopicConfig.setNumberOfPartitions(partitionCount);
+        return internalTopicConfig;
+    }
+
+    private InternalTopicConfig setupVersionedChangelogTopicConfig(final String topicName,
+                                                                   final int partitionCount,
+                                                                   final long compactionLagMs) {
+        final InternalTopicConfig internalTopicConfig = new VersionedChangelogTopicConfig(
+            topicName,
+            mkMap(mkEntry(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, String.valueOf(compactionLagMs))),
+            12
         );
         internalTopicConfig.setNumberOfPartitions(partitionCount);
         return internalTopicConfig;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -635,7 +635,7 @@ public class InternalTopicManagerTest {
     public void shouldCreateRequiredTopics() throws Exception {
         final InternalTopicConfig topicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
         topicConfig.setNumberOfPartitions(1);
-        final InternalTopicConfig topicConfig2 = new UnwindowedChangelogTopicConfig(topic2, Collections.emptyMap());
+        final InternalTopicConfig topicConfig2 = new UnwindowedUnversionedChangelogTopicConfig(topic2, Collections.emptyMap());
         topicConfig2.setNumberOfPartitions(1);
         final InternalTopicConfig topicConfig3 = new WindowedChangelogTopicConfig(topic3, Collections.emptyMap());
         topicConfig3.setNumberOfPartitions(1);
@@ -714,9 +714,9 @@ public class InternalTopicManagerTest {
         when(admin.describeTopics(Collections.singleton(topic2)))
             .thenAnswer(answer -> new MockDescribeTopicsResult(Collections.singletonMap(topic2, topicDescriptionSuccessFuture)));
 
-        final InternalTopicConfig topicConfig = new UnwindowedChangelogTopicConfig(topic1, Collections.emptyMap());
+        final InternalTopicConfig topicConfig = new UnwindowedUnversionedChangelogTopicConfig(topic1, Collections.emptyMap());
         topicConfig.setNumberOfPartitions(1);
-        final InternalTopicConfig topic2Config = new UnwindowedChangelogTopicConfig(topic2, Collections.emptyMap());
+        final InternalTopicConfig topic2Config = new UnwindowedUnversionedChangelogTopicConfig(topic2, Collections.emptyMap());
         topic2Config.setNumberOfPartitions(1);
         topicManager.makeReady(mkMap(
             mkEntry(topic1, topicConfig),
@@ -1047,9 +1047,9 @@ public class InternalTopicManagerTest {
         );
         setupTopicInMockAdminClient(topic2, unwindowedChangelogConfigWithDeleteCompactCleanupPolicy);
         setupTopicInMockAdminClient(topic3, unwindowedChangelogConfig());
-        final InternalTopicConfig internalTopicConfig1 = setupUnwindowedChangelogTopicConfig(topic1, 1);
-        final InternalTopicConfig internalTopicConfig2 = setupUnwindowedChangelogTopicConfig(topic2, 1);
-        final InternalTopicConfig internalTopicConfig3 = setupUnwindowedChangelogTopicConfig(topic3, 1);
+        final InternalTopicConfig internalTopicConfig1 = setupUnwindowedUnversionedChangelogTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupUnwindowedUnversionedChangelogTopicConfig(topic2, 1);
+        final InternalTopicConfig internalTopicConfig3 = setupUnwindowedUnversionedChangelogTopicConfig(topic3, 1);
 
         final ValidationResult validationResult = internalTopicManager.validate(mkMap(
             mkEntry(topic1, internalTopicConfig1),
@@ -1495,7 +1495,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldThrowWhenConfigDescriptionsDoNotCleanupPolicyForUnwindowedConfigDuringValidation() {
         shouldThrowWhenConfigDescriptionsDoNotContainConfigDuringValidation(
-            setupUnwindowedChangelogTopicConfig(topic1, 1),
+            setupUnwindowedUnversionedChangelogTopicConfig(topic1, 1),
             configWithoutKey(unwindowedChangelogConfig(), TopicConfig.CLEANUP_POLICY_CONFIG)
         );
     }
@@ -1691,10 +1691,10 @@ public class InternalTopicManagerTest {
         );
     }
 
-    private InternalTopicConfig setupUnwindowedChangelogTopicConfig(final String topicName,
-                                                                    final int partitionCount) {
+    private InternalTopicConfig setupUnwindowedUnversionedChangelogTopicConfig(final String topicName,
+                                                                               final int partitionCount) {
         final InternalTopicConfig internalTopicConfig =
-            new UnwindowedChangelogTopicConfig(topicName, Collections.emptyMap());
+            new UnwindowedUnversionedChangelogTopicConfig(topicName, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(partitionCount);
         return internalTopicConfig;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -640,15 +640,15 @@ public class InternalTopologyBuilderTest {
         expectedTopicGroups.put(SUBTOPOLOGY_0, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-1", "topic-1x", "topic-2"),
             Collections.emptyMap(),
-            Collections.singletonMap(store1, new UnwindowedChangelogTopicConfig(store1, Collections.emptyMap()))));
+            Collections.singletonMap(store1, new UnwindowedUnversionedChangelogTopicConfig(store1, Collections.emptyMap()))));
         expectedTopicGroups.put(SUBTOPOLOGY_1, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-3", "topic-4"),
             Collections.emptyMap(),
-            Collections.singletonMap(store2, new UnwindowedChangelogTopicConfig(store2, Collections.emptyMap()))));
+            Collections.singletonMap(store2, new UnwindowedUnversionedChangelogTopicConfig(store2, Collections.emptyMap()))));
         expectedTopicGroups.put(SUBTOPOLOGY_2, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-5"),
             Collections.emptyMap(),
-            Collections.singletonMap(store3, new UnwindowedChangelogTopicConfig(store3, Collections.emptyMap()))));
+            Collections.singletonMap(store3, new UnwindowedUnversionedChangelogTopicConfig(store3, Collections.emptyMap()))));
 
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);
@@ -943,7 +943,7 @@ public class InternalTopologyBuilderTest {
         assertEquals(2, properties.size());
         assertEquals(TopicConfig.CLEANUP_POLICY_COMPACT, properties.get(TopicConfig.CLEANUP_POLICY_CONFIG));
         assertEquals("appId-testStore-changelog", topicConfig.name());
-        assertTrue(topicConfig instanceof UnwindowedChangelogTopicConfig);
+        assertTrue(topicConfig instanceof UnwindowedUnversionedChangelogTopicConfig);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
@@ -36,6 +37,8 @@ import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.RocksDbVersionedKeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
 import org.apache.kafka.test.MockApiProcessor;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockKeyValueStoreBuilder;
@@ -901,7 +904,33 @@ public class InternalTopologyBuilderTest {
     }
 
     @Test
-    public void shouldAddInternalTopicConfigForNonWindowStores() {
+    public void shouldAddInternalTopicConfigForVersionedStores() {
+        builder.setApplicationId("appId");
+        builder.addSource(null, "source", null, null, null, "topic");
+        builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
+        builder.addStateStore(
+            new VersionedKeyValueStoreBuilder<>(
+                new RocksDbVersionedKeyValueBytesStoreSupplier("vstore", 60_000L),
+                Serdes.String(),
+                Serdes.String(),
+                new MockTime()
+            ),
+            "processor"
+        );
+        builder.buildTopology();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.subtopologyToTopicsInfo();
+        final InternalTopologyBuilder.TopicsInfo topicsInfo = topicGroups.values().iterator().next();
+        final InternalTopicConfig topicConfig = topicsInfo.stateChangelogTopics.get("appId-vstore-changelog");
+        final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 10000);
+        assertEquals(3, properties.size());
+        assertEquals(TopicConfig.CLEANUP_POLICY_COMPACT, properties.get(TopicConfig.CLEANUP_POLICY_CONFIG));
+        assertEquals(Long.toString(60_000L + 24 * 60 * 60 * 1000L), properties.get(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG));
+        assertEquals("appId-vstore-changelog", topicConfig.name());
+        assertTrue(topicConfig instanceof VersionedChangelogTopicConfig);
+    }
+
+    @Test
+    public void shouldAddInternalTopicConfigForNonWindowNonVersionedStores() {
         builder.setApplicationId("appId");
         builder.addSource(null, "source", null, null, null, "topic");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");


### PR DESCRIPTION
This PR sets the correct topic configs for changelog topics for versioned stores introduced in [KIP-889](https://cwiki.apache.org/confluence/display/KAFKA/KIP-889%3A+Versioned+State+Stores). Changelog topics for versioned stores differ from those for non-versioned stores only in that `min.compaction.lag.ms` needs to be set in order to prevent version history from being compacted prematurely. 

The value for `min.compaction.lag.ms` is equal to the store's history retention plus some buffer to account for the broker's use of wall-clock time in performing compactions. This buffer is analogous to the `windowstore.changelog.additional.retention.ms` value for window store changelog topic retention time, and uses the same default of 24 hours. In the future, we can propose a KIP to expose a config such as `versionedstore.changelog.additional.compaction.lag.ms` to allow users to tune this value.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
