### PR TITLE
KAFKA-14744; NPE while converting OffsetFetch from version < 8 to version >= 8

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -232,14 +232,22 @@ public class OffsetFetchRequest extends AbstractRequest {
             return data.groups();
         } else {
             OffsetFetchRequestData.OffsetFetchRequestGroup group =
-                new OffsetFetchRequestData.OffsetFetchRequestGroup().setGroupId(data.groupId());
+                new OffsetFetchRequestData.OffsetFetchRequestGroup()
+                    .setGroupId(data.groupId());
 
-            data.topics().forEach(topic -> {
-                group.topics().add(new OffsetFetchRequestTopics()
-                    .setName(topic.name())
-                    .setPartitionIndexes(topic.partitionIndexes())
-                );
-            });
+            if (data.topics() == null) {
+                // If topics is null, it means that all topic-partitions should
+                // be fetched hence we preserve it.
+                group.setTopics(null);
+            } else {
+                // Otherwise, topics are translated to the new structure.
+                data.topics().forEach(topic -> {
+                    group.topics().add(new OffsetFetchRequestTopics()
+                        .setName(topic.name())
+                        .setPartitionIndexes(topic.partitionIndexes())
+                    );
+                });
+            }
 
             return Collections.singletonList(group);
         }


### PR DESCRIPTION
While refactoring the OffsetFetch handling in KafkaApis, we introduced a NullPointerException (NPE). The NPE arises when the FetchOffset API is called with a client using a version older than version 8 and using null for the topics to signal that all topic-partition offsets must be returned. This means that this bug mainly impacts admin tools. The consumer does not use null.

This NPE is here: https://github.com/apache/kafka/commit/24a86423e9907b751d98fddc7196332feea2b48d#diff-0f2f19fd03e2fc5aa9618c607b432ea72e5aaa53866f07444269f38cb537f3feR237.

We missed this during the refactor because we had no tests in place to test this mode.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
