### PR TITLE
MINOR: Replace String literal with existing String variable

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/DefaultPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/DefaultPartitionerTest.java
@@ -46,7 +46,7 @@ public class DefaultPartitionerTest {
         final Partitioner partitioner = new DefaultPartitioner();
         final Cluster cluster = new Cluster("clusterId", asList(NODES), PARTITIONS,
             Collections.emptySet(), Collections.emptySet());
-        int partition = partitioner.partition("test",  null, KEY_BYTES, null, null, cluster);
-        assertEquals(partition, partitioner.partition("test", null, KEY_BYTES, null, null, cluster), "Same key should yield same partition");
+        int partition = partitioner.partition(TOPIC,  null, KEY_BYTES, null, null, cluster);
+        assertEquals(partition, partitioner.partition(TOPIC, null, KEY_BYTES, null, null, cluster), "Same key should yield same partition");
     }
 }


### PR DESCRIPTION
It is minor change.
I found out that String literal is used even though there is existing static String variable.
So, I replaced literal with variable.

Thank you :)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
