### PR TITLE
KAFKA-14680: `spotlessCheck` task is disabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,13 @@ plugins {
   id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.0"
 }
 
+gradle.taskGraph.whenReady {
+  taskGraph ->
+    if (taskGraph.hasTask(check)) {
+      spotlessScala.enabled = false
+    }
+}
+
 spotless {
   scala {
     target 'streams/**/*.scala'


### PR DESCRIPTION
**Note**: this solves build regression (after Gradle version was bumped from 7.6 to 8.0.1)

**Rationale**: see this comment made by @chia7712: https://github.com/apache/kafka/pull/13205#issuecomment-1444898374 

@chia7712 Feel free to test/review

FIY @ijuma 

Some resources used for this solution: 
- https://docs.gradle.org/8.0.1/userguide/more_about_tasks.html#sec:skipping_tasks
- https://stackoverflow.com/questions/33909943/exclude-tasks-from-the-task-that-my-task-depends-on
- https://stackoverflow.com/questions/35076540/can-gradle-task-dependencies-be-set-up-to-exclude-a-task 





