### PR TITLE
MINOR: Make ByteUtilsBenchmark deterministic

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/util/ByteUtilsBenchmark.java
@@ -68,23 +68,35 @@ public class ByteUtilsBenchmark {
     }
 
     @Benchmark
-    public void testSizeOfUnsignedVarintNew(Blackhole bk) {
+    public void testSizeOfUnsignedVarintSimple(Blackhole bk) {
         for (int random_value : this.random_ints) {
-            bk.consume(ByteUtils.sizeOfUnsignedVarintNew(random_value));
+            int value = random_value;
+            int bytes = 1;
+            while ((value & 0xffffff80) != 0L) {
+                bytes += 1;
+                value >>>= 7;
+            }
+            bk.consume(bytes);
         }
     }
 
     @Benchmark
     public void testSizeOfVarlong(Blackhole bk) {
         for (long random_value : this.random_longs) {
-            bk.consume(ByteUtils.sizeOfUnsignedVarlong(random_value));
+            bk.consume(ByteUtils.sizeOfVarlong(random_value));
         }
     }
 
     @Benchmark
-    public void testSizeOfVarlongNew(Blackhole bk) {
+    public void testSizeOfVarlongSimple(Blackhole bk) {
         for (long random_value : this.random_longs) {
-            bk.consume(ByteUtils.sizeOfUnsignedVarlongNew(random_value));
+            long v = (random_value << 1) ^ (random_value >> 63);
+            int bytes = 1;
+            while ((v & 0xffffffffffffff80L) != 0L) {
+                bytes += 1;
+                v >>>= 7;
+            }
+            bk.consume(bytes);
         }
     }
 


### PR DESCRIPTION
# Motivation
The current implementation of the benchmark may produce different set of integers across benchmarks and hence, may not provide apples to apples comparison.

# Changes
1. With this change, we initialize random number generator with a fixed seed at the start of a benchmark. This ensures that for each benchmark, random number generator produces the same sequence of random values. Hence, the input data across benchmarks would be consistent providing a reliable apples to apples comparison.
2. We ensure that a new set of random numbers are generated per iteration, so that the bechmark calculation is performed over a diverse range of values

Sample result of a benchmark run:
```
Benchmark                                           Mode  Cnt     Score   Error  Units
ByteUtilsBenchmark.testSizeOfUnsignedVarint        thrpt   30  1302.193 ± 0.396  ops/s
ByteUtilsBenchmark.testSizeOfUnsignedVarintSimple  thrpt   30   328.678 ± 0.269  ops/s
ByteUtilsBenchmark.testSizeOfVarlong               thrpt   30   880.113 ± 0.676  ops/s
ByteUtilsBenchmark.testSizeOfVarlongSimple         thrpt   30   109.592 ± 0.071  ops/s
JMH benchmarks done
```