### PR TITLE
MINOR Moved a few log segment util methods from LocalLog to LogFileUtils

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -32,14 +32,14 @@ import org.apache.kafka.common.requests.ListOffsetsRequest
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET
 import org.apache.kafka.common.utils.{PrimitiveRef, Time, Utils}
 import org.apache.kafka.common.{InvalidRecordException, KafkaException, TopicPartition, Uuid}
-import org.apache.kafka.server.common.{OffsetAndEpoch, MetadataVersion}
+import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.common.MetadataVersion.IBP_0_10_0_IV0
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.storage.internals.checkpoint.LeaderEpochCheckpointFile
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
-import org.apache.kafka.storage.internals.log.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, EpochEntry, FetchDataInfo, FetchIsolation, LastRecord, LogAppendInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetsListener, LogValidator, ProducerAppendInfo, ProducerStateManager, ProducerStateManagerConfig, RollParams}
+import org.apache.kafka.storage.internals.log.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, EpochEntry, FetchDataInfo, FetchIsolation, LastRecord, LogAppendInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata, LogOffsetsListener, LogValidator, ProducerAppendInfo, ProducerStateManager, ProducerStateManagerConfig, RollParams}
 
 import java.io.{File, IOException}
 import java.nio.file.Files
@@ -1835,7 +1835,7 @@ object UnifiedLog extends Logging {
       logOffsetsListener)
   }
 
-  def logFile(dir: File, offset: Long, suffix: String = ""): File = LocalLog.logFile(dir, offset, suffix)
+  def logFile(dir: File, offset: Long, suffix: String = ""): File = LogFileUtils.logFile(dir, offset, suffix)
 
   def logDeleteDirName(topicPartition: TopicPartition): String = LocalLog.logDeleteDirName(topicPartition)
 
@@ -1843,16 +1843,16 @@ object UnifiedLog extends Logging {
 
   def logDirName(topicPartition: TopicPartition): String = LocalLog.logDirName(topicPartition)
 
-  def offsetIndexFile(dir: File, offset: Long, suffix: String = ""): File = LocalLog.offsetIndexFile(dir, offset, suffix)
+  def offsetIndexFile(dir: File, offset: Long, suffix: String = ""): File = LogFileUtils.offsetIndexFile(dir, offset, suffix)
 
-  def timeIndexFile(dir: File, offset: Long, suffix: String = ""): File = LocalLog.timeIndexFile(dir, offset, suffix)
+  def timeIndexFile(dir: File, offset: Long, suffix: String = ""): File = LogFileUtils.timeIndexFile(dir, offset, suffix)
 
   def deleteFileIfExists(file: File, suffix: String = ""): Unit =
     Files.deleteIfExists(new File(file.getPath + suffix).toPath)
 
-  def transactionIndexFile(dir: File, offset: Long, suffix: String = ""): File = LocalLog.transactionIndexFile(dir, offset, suffix)
+  def transactionIndexFile(dir: File, offset: Long, suffix: String = ""): File = LogFileUtils.transactionIndexFile(dir, offset, suffix)
 
-  def offsetFromFile(file: File): Long = LocalLog.offsetFromFile(file)
+  def offsetFromFile(file: File): Long = LogFileUtils.offsetFromFile(file)
 
   def sizeInBytes(segments: Iterable[LogSegment]): Long = LogSegments.sizeInBytes(segments)
 

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1754,13 +1754,13 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 }
 
 object UnifiedLog extends Logging {
-  val LogFileSuffix = LocalLog.LogFileSuffix
+  val LogFileSuffix = LogFileUtils.LOG_FILE_SUFFIX
 
-  val IndexFileSuffix = LocalLog.IndexFileSuffix
+  val IndexFileSuffix = LogFileUtils.INDEX_FILE_SUFFIX
 
-  val TimeIndexFileSuffix = LocalLog.TimeIndexFileSuffix
+  val TimeIndexFileSuffix = LogFileUtils.TIME_INDEX_FILE_SUFFIX
 
-  val TxnIndexFileSuffix = LocalLog.TxnIndexFileSuffix
+  val TxnIndexFileSuffix = LogFileUtils.TXN_INDEX_FILE_SUFFIX
 
   val CleanedFileSuffix = LocalLog.CleanedFileSuffix
 

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, Record, SimpleRecord}
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.server.util.Scheduler
-import org.apache.kafka.storage.internals.log.{FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata}
+import org.apache.kafka.storage.internals.log.{FetchDataInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
@@ -612,14 +612,14 @@ class LocalLogTest {
   def testOffsetFromFile(): Unit = {
     val offset = 23423423L
 
-    val logFile = LocalLog.logFile(tmpDir, offset)
-    assertEquals(offset, LocalLog.offsetFromFile(logFile))
+    val logFile = LogFileUtils.logFile(tmpDir, offset)
+    assertEquals(offset, LogFileUtils.offsetFromFile(logFile))
 
-    val offsetIndexFile = LocalLog.offsetIndexFile(tmpDir, offset)
-    assertEquals(offset, LocalLog.offsetFromFile(offsetIndexFile))
+    val offsetIndexFile = LogFileUtils.offsetIndexFile(tmpDir, offset)
+    assertEquals(offset, LogFileUtils.offsetFromFile(offsetIndexFile))
 
-    val timeIndexFile = LocalLog.timeIndexFile(tmpDir, offset)
-    assertEquals(offset, LocalLog.offsetFromFile(timeIndexFile))
+    val timeIndexFile = LogFileUtils.timeIndexFile(tmpDir, offset)
+    assertEquals(offset, LogFileUtils.offsetFromFile(timeIndexFile))
   }
 
   @Test

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogFileUtils.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogFileUtils.java
@@ -93,7 +93,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct a log file name in the given dir with the given base offset and the given suffix
+     * Construct a log file name in the given dir with the given base offset.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -103,7 +103,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct a log file name in the given dir with the given base offset and the given suffix
+     * Construct a log file name in the given dir with the given base offset and the given suffix.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -114,7 +114,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct an index file name in the given dir using the given base offset and the given suffix
+     * Construct an index file name in the given dir using the given base offset.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -124,7 +124,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct an index file name in the given dir using the given base offset and the given suffix
+     * Construct an index file name in the given dir using the given base offset and the given suffix.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -135,7 +135,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct a time index file name in the given dir using the given base offset and the given suffix
+     * Construct a time index file name in the given dir using the given base offset.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -145,7 +145,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct a time index file name in the given dir using the given base offset and the given suffix
+     * Construct a time index file name in the given dir using the given base offset and the given suffix.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -156,7 +156,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct a transaction index file name in the given dir using the given base offset and the given suffix
+     * Construct a transaction index file name in the given dir using the given base offset.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -166,7 +166,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Construct a transaction index file name in the given dir using the given base offset and the given suffix
+     * Construct a transaction index file name in the given dir using the given base offset and the given suffix.
      *
      * @param dir    The directory in which the log will reside
      * @param offset The base offset of the log file
@@ -177,7 +177,7 @@ public final class LogFileUtils {
     }
 
     /**
-     * Returns the offset for the given file. The file name is of the form: {number}.{suffix}. This method extracts
+     * Returns the offset from the given file. The file name is of the form: {number}.{suffix}. This method extracts
      * the number from the given file's name.
      *
      * @param file file with the offset information as part of its name.

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogFileUtils.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogFileUtils.java
@@ -31,6 +31,26 @@ public final class LogFileUtils {
      */
     public static final String DELETED_FILE_SUFFIX = ".deleted";
 
+    /**
+     * Suffix of a log file
+     */
+    public static final String LOG_FILE_SUFFIX = ".log";
+
+    /**
+     * Suffix of an index file
+     */
+    public static final String INDEX_FILE_SUFFIX = ".index";
+
+    /**
+     * Suffix of a time index file
+     */
+    public static final String TIME_INDEX_FILE_SUFFIX = ".timeindex";
+
+    /**
+     * Suffix of an aborted txn index
+     */
+    public static final String TXN_INDEX_FILE_SUFFIX = ".txnindex";
+
     private LogFileUtils() {
     }
 
@@ -70,6 +90,101 @@ public final class LogFileUtils {
         nf.setMaximumFractionDigits(0);
         nf.setGroupingUsed(false);
         return nf.format(offset);
+    }
+
+    /**
+     * Construct a log file name in the given dir with the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     */
+    public static File logFile(File dir, long offset) {
+        return logFile(dir, offset, "");
+    }
+
+    /**
+     * Construct a log file name in the given dir with the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     * @param suffix The suffix to be appended to the file name (e.g. "", ".deleted", ".cleaned", ".swap", etc.)
+     */
+    public static File logFile(File dir, long offset, String suffix) {
+        return new File(dir, filenamePrefixFromOffset(offset) + LOG_FILE_SUFFIX + suffix);
+    }
+
+    /**
+     * Construct an index file name in the given dir using the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     */
+    public static File offsetIndexFile(File dir, long offset) {
+        return offsetIndexFile(dir, offset, "");
+    }
+
+    /**
+     * Construct an index file name in the given dir using the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     * @param suffix The suffix to be appended to the file name ("", ".deleted", ".cleaned", ".swap", etc.)
+     */
+    public static File offsetIndexFile(File dir, long offset, String suffix) {
+        return new File(dir, filenamePrefixFromOffset(offset) + INDEX_FILE_SUFFIX + suffix);
+    }
+
+    /**
+     * Construct a time index file name in the given dir using the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     */
+    public static File timeIndexFile(File dir, long offset) {
+        return timeIndexFile(dir, offset, "");
+    }
+
+    /**
+     * Construct a time index file name in the given dir using the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     * @param suffix The suffix to be appended to the file name ("", ".deleted", ".cleaned", ".swap", etc.)
+     */
+    public static File timeIndexFile(File dir, long offset, String suffix) {
+        return new File(dir, filenamePrefixFromOffset(offset) + TIME_INDEX_FILE_SUFFIX + suffix);
+    }
+
+    /**
+     * Construct a transaction index file name in the given dir using the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     */
+    public static File transactionIndexFile(File dir, long offset) {
+        return transactionIndexFile(dir, offset, "");
+    }
+
+    /**
+     * Construct a transaction index file name in the given dir using the given base offset and the given suffix
+     *
+     * @param dir    The directory in which the log will reside
+     * @param offset The base offset of the log file
+     * @param suffix The suffix to be appended to the file name ("", ".deleted", ".cleaned", ".swap", etc.)
+     */
+    public static File transactionIndexFile(File dir, long offset, String suffix) {
+        return new File(dir, filenamePrefixFromOffset(offset) + TXN_INDEX_FILE_SUFFIX + suffix);
+    }
+
+    /**
+     * Returns the offset for the given file. The file name is of the form: {number}.{suffix}. This method extracts
+     * the number from the given file's name.
+     *
+     * @param file file with the offset information as part of its name.
+     * @return offset of the given file
+     */
+    public static Long offsetFromFile(File file) {
+        return offsetFromFileName(file.getName());
     }
 
 }


### PR DESCRIPTION
MINOR Moved a few log segment util methods from LocalLog to LogFileUtils.

This is related to the changes required for [KAFKA-14481](https://issues.apache.org/jira/browse/KAFKA-14481)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
