### PR TITLE
MINOR: ExponentialBackoff Javadoc improvements

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ExponentialBackoff.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ExponentialBackoff.java
@@ -20,12 +20,15 @@ package org.apache.kafka.common.utils;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * An utility class for keeping the parameters and providing the value of exponential
+ * A utility class for keeping the parameters and providing the value of exponential
  * retry backoff, exponential reconnect backoff, exponential timeout, etc.
+ * <p>
  * The formula is:
- * Backoff(attempts) = random(1 - jitter, 1 + jitter) * initialInterval * multiplier ^ attempts
- * If initialInterval is greater or equal than maxInterval, a constant backoff of will be provided
- * This class is thread-safe
+ * <pre>Backoff(attempts) = random(1 - jitter, 1 + jitter) * initialInterval * multiplier ^ attempts</pre>
+ * If {@code initialInterval} is greater than or equal to {@code maxInterval}, a constant backoff of
+ * {@code initialInterval} will be provided.
+ * <p>
+ * This class is thread-safe.
  */
 public class ExponentialBackoff {
     private final int multiplier;


### PR DESCRIPTION
- Rendered Javadoc before:
<img width="692" alt="Screenshot 2023-02-28 at 2 15 27 PM" src="https://user-images.githubusercontent.com/23502577/221804392-c203ea98-bc9b-43e1-83ff-817c70337945.png">


- Rendered Javadoc after:
<img width="687" alt="Screenshot 2023-02-28 at 2 29 51 PM" src="https://user-images.githubusercontent.com/23502577/221804410-b4934cef-f4ca-4908-96d6-73aa3fd8387a.png">

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
