### PR TITLE
MINOR: Fix flaky tests in DefaultStateUpdaterTest

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -421,7 +421,7 @@ public class DefaultStateUpdater implements StateUpdater {
             if (task.isActive()) {
                 transitToUpdateStandbysIfOnlyStandbysLeft();
             }
-            log.debug((task.isActive() ? "Active" : "Standby")
+            log.info((task.isActive() ? "Active" : "Standby")
                 + " task " + task.id() + " was paused from the updating tasks and added to the paused tasks.");
         }
 
@@ -431,10 +431,10 @@ public class DefaultStateUpdater implements StateUpdater {
             pausedTasks.remove(taskId);
 
             if (task.isActive()) {
-                log.debug("Stateful active task " + task.id() + " was resumed to the updating tasks of the state updater");
+                log.info("Stateful active task " + task.id() + " was resumed to the updating tasks of the state updater");
                 changelogReader.enforceRestoreActive();
             } else {
-                log.debug("Standby task " + task.id() + " was resumed to the updating tasks of the state updater");
+                log.info("Standby task " + task.id() + " was resumed to the updating tasks of the state updater");
                 if (updatingTasks.size() == 1) {
                     changelogReader.transitToUpdateStandby();
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -201,11 +201,12 @@ class DefaultStateUpdaterTest {
     public void shouldRemovePausedAndUpdatingTasksOnShutdown() throws Exception {
         final StreamTask activeTask = statefulTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+
+        when(topologyMetadata.isPaused(standbyTask.id().topologyName())).thenReturn(false).thenReturn(true);
+
         stateUpdater.start();
         stateUpdater.add(activeTask);
         stateUpdater.add(standbyTask);
-        verifyUpdatingTasks(activeTask, standbyTask);
-        when(topologyMetadata.isPaused("B")).thenReturn(true);
         verifyPausedTasks(standbyTask);
         verifyUpdatingTasks(activeTask);
         verifyRemovedTasks();
@@ -879,12 +880,11 @@ class DefaultStateUpdaterTest {
         final StreamTask task1 = statefulTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StandbyTask task2 = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
 
+        when(topologyMetadata.isPaused(task1.id().topologyName())).thenReturn(false).thenReturn(true);
+
         stateUpdater.start();
         stateUpdater.add(task1);
         stateUpdater.add(task2);
-        verifyUpdatingTasks(task1, task2);
-
-        when(topologyMetadata.isPaused("A")).thenReturn(true);
 
         verifyPausedTasks(task1);
         verifyCheckpointTasks(true, task1);
@@ -901,14 +901,15 @@ class DefaultStateUpdaterTest {
         final StandbyTask task1 = standbyTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         final StandbyTask task2 = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
 
+        when(topologyMetadata.isPaused(task1.id().topologyName())).thenReturn(false).thenReturn(true);
+
         stateUpdater.start();
         stateUpdater.add(task1);
         stateUpdater.add(task2);
-        verifyUpdatingTasks(task1, task2);
-
-        when(topologyMetadata.isPaused("A")).thenReturn(true);
 
         verifyPausedTasks(task1);
+        verifyUpdatingTasks(task2);
+        verifyCheckpointTasks(true, task1);
         verify(changelogReader, times(1)).transitToUpdateStandby();
     }
 
@@ -1556,7 +1557,8 @@ class DefaultStateUpdaterTest {
             mkEntry(standbyTask3.id(), standbyTask3)
         );
 
-        when(topologyMetadata.isPaused("B")).thenReturn(true);
+        when(topologyMetadata.isPaused(activeTask2.id().topologyName())).thenReturn(true);
+        when(topologyMetadata.isPaused(standbyTask4.id().topologyName())).thenReturn(true);
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         when(changelogReader.restore(tasks1234)).thenReturn(1L);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -897,7 +897,7 @@ class DefaultStateUpdaterTest {
     }
 
     @Test
-    public void shouldPauseStandbyTaskAndNotTransitToUpdateStandbyAgain() throws Exception {
+    public void shouldPauseStandbyTaskAndNotTransitToRestoreActive() throws Exception {
         final StandbyTask task1 = standbyTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         final StandbyTask task2 = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
 
@@ -910,7 +910,7 @@ class DefaultStateUpdaterTest {
         verifyPausedTasks(task1);
         verifyUpdatingTasks(task2);
         verifyCheckpointTasks(true, task1);
-        verify(changelogReader, times(1)).transitToUpdateStandby();
+        verify(changelogReader, never()).enforceRestoreActive();
     }
 
     private void shouldPauseStatefulTask(final Task task) throws Exception {

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -52,7 +52,6 @@ import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -323,7 +322,7 @@ public final class StreamsTestUtils {
 
         public static TopologyMetadataBuilder unnamedTopology() {
             final TopologyMetadata topologyMetadata = mock(TopologyMetadata.class);
-            when(topologyMetadata.isPaused(any())).thenReturn(false);
+            when(topologyMetadata.isPaused(null)).thenReturn(false);
             return new TopologyMetadataBuilder(topologyMetadata);
         }
 


### PR DESCRIPTION
Found a few flaky tests while reviewing another PR. The root cause seems to be with changing the return behavior of `when` in mockito. Fixed those without using `reset` and also bumped a couple debug log lines to info since they could be very helpful in debugging.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
