### PR TITLE
KAFKA-15685: added compatibility for MinGW

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -21,7 +21,7 @@ then
 fi
 
 # WINDOWS_OS_FORMAT == 1 if Cygwin or MinGW is detected, else 0.
-if [[ $(uname -a) =~ "CYGWIN" || $(uname -a) =~ "MINGW" ]]; then
+if [[ $(uname -a) =~ "CYGWIN" || $(uname -a) =~ "MINGW" || $(uname -a) =~ "MSYS" ]]; then
   WINDOWS_OS_FORMAT=1
 else
   WINDOWS_OS_FORMAT=0

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -20,11 +20,11 @@ then
   exit 1
 fi
 
-# CYGWIN == 1 if Cygwin is detected, else 0.
-if [[ $(uname -a) =~ "CYGWIN" ]]; then
-  CYGWIN=1
+# WINDOWS_OS_FORMAT == 1 if Cygwin or MinGW is detected, else 0.
+if [[ $(uname -a) =~ "CYGWIN" || $(uname -a) =~ "MINGW" ]]; then
+  WINDOWS_OS_FORMAT=1
 else
-  CYGWIN=0
+  WINDOWS_OS_FORMAT=0
 fi
 
 if [ -z "$INCLUDE_TEST_JARS" ]; then
@@ -229,7 +229,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   # Log to console. This is a tool.
   LOG4J_DIR="$base_dir/config/tools-log4j.properties"
   # If Cygwin is detected, LOG4J_DIR is converted to Windows format.
-  (( CYGWIN )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
+  (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
   KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_DIR}"
 else
   # create logs directory
@@ -239,7 +239,7 @@ else
 fi
 
 # If Cygwin is detected, LOG_DIR is converted to Windows format.
-(( CYGWIN )) && LOG_DIR=$(cygpath --path --mixed "${LOG_DIR}")
+(( WINDOWS_OS_FORMAT )) && LOG_DIR=$(cygpath --path --mixed "${LOG_DIR}")
 KAFKA_LOG4J_OPTS="-Dkafka.logs.dir=$LOG_DIR $KAFKA_LOG4J_OPTS"
 
 # Generic jvm settings you want to add
@@ -337,7 +337,7 @@ fi
 CLASSPATH=${CLASSPATH#:}
 
 # If Cygwin is detected, classpath is converted to Windows format.
-(( CYGWIN )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
+(( WINDOWS_OS_FORMAT )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -229,7 +229,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   # Log to console. This is a tool.
   LOG4J_DIR="$base_dir/config/tools-log4j.properties"
   # If Cygwin is detected, LOG4J_DIR is converted to Windows format.
-  (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
+  (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --windows "${LOG4J_DIR}")
   KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_DIR}"
 else
   # create logs directory
@@ -239,7 +239,7 @@ else
 fi
 
 # If Cygwin is detected, LOG_DIR is converted to Windows format.
-(( WINDOWS_OS_FORMAT )) && LOG_DIR=$(cygpath --path --mixed "${LOG_DIR}")
+(( WINDOWS_OS_FORMAT )) && LOG_DIR=$(cygpath --path --windows "${LOG_DIR}")
 KAFKA_LOG4J_OPTS="-Dkafka.logs.dir=$LOG_DIR $KAFKA_LOG4J_OPTS"
 
 # Generic jvm settings you want to add
@@ -337,7 +337,7 @@ fi
 CLASSPATH=${CLASSPATH#:}
 
 # If Cygwin is detected, classpath is converted to Windows format.
-(( WINDOWS_OS_FORMAT )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
+(( WINDOWS_OS_FORMAT )) && CLASSPATH=$(cygpath --path --windows "${CLASSPATH}")
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -23,6 +23,7 @@ fi
 # WINDOWS_OS_FORMAT == 1 if Cygwin or MinGW is detected, else 0.
 if [[ $(uname -a) =~ "CYGWIN" || $(uname -a) =~ "MINGW" || $(uname -a) =~ "MSYS" ]]; then
   WINDOWS_OS_FORMAT=1
+  export MSYS2_ARG_CONV_EXCL="-Xlog:gc*:file=;-Dlog4j.configuration=;$MSYS2_ARG_CONV_EXCL"
 else
   WINDOWS_OS_FORMAT=0
 fi
@@ -240,7 +241,7 @@ fi
 
 # If Cygwin is detected, LOG_DIR is converted to Windows format.
 (( WINDOWS_OS_FORMAT )) && LOG_DIR=$(cygpath --path --mixed "${LOG_DIR}")
-KAFKA_LOG4J_OPTS="-Dkafka.logs.dir=$LOG_DIR $KAFKA_LOG4J_OPTS"
+KAFKA_LOG4J_CMD_OPTS="-Dkafka.logs.dir=$LOG_DIR $KAFKA_LOG4J_OPTS"
 
 # Generic jvm settings you want to add
 if [ -z "$KAFKA_OPTS" ]; then
@@ -341,7 +342,7 @@ CLASSPATH=${CLASSPATH#:}
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
-  nohup "$JAVA" $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp "$CLASSPATH" $KAFKA_OPTS "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
+  nohup "$JAVA" $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_CMD_OPTS -cp "$CLASSPATH" $KAFKA_OPTS "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
 else
-  exec "$JAVA" $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp "$CLASSPATH" $KAFKA_OPTS "$@"
+  exec "$JAVA" $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_CMD_OPTS -cp "$CLASSPATH" $KAFKA_OPTS "$@"
 fi

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -229,7 +229,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   # Log to console. This is a tool.
   LOG4J_DIR="$base_dir/config/tools-log4j.properties"
   # If Cygwin is detected, LOG4J_DIR is converted to Windows format.
-  (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --windows "${LOG4J_DIR}")
+  (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
   KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_DIR}"
 else
   # create logs directory
@@ -239,7 +239,7 @@ else
 fi
 
 # If Cygwin is detected, LOG_DIR is converted to Windows format.
-(( WINDOWS_OS_FORMAT )) && LOG_DIR=$(cygpath --path --windows "${LOG_DIR}")
+(( WINDOWS_OS_FORMAT )) && LOG_DIR=$(cygpath --path --mixed "${LOG_DIR}")
 KAFKA_LOG4J_OPTS="-Dkafka.logs.dir=$LOG_DIR $KAFKA_LOG4J_OPTS"
 
 # Generic jvm settings you want to add
@@ -337,7 +337,7 @@ fi
 CLASSPATH=${CLASSPATH#:}
 
 # If Cygwin is detected, classpath is converted to Windows format.
-(( WINDOWS_OS_FORMAT )) && CLASSPATH=$(cygpath --path --windows "${CLASSPATH}")
+(( WINDOWS_OS_FORMAT )) && CLASSPATH=$(cygpath --path --mixed "${CLASSPATH}")
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then


### PR DESCRIPTION
kafka class runner is not working from MINGW/Git Bash on Windows:

```bash
rafal@rafal-laptok MINGW64 /c/rafal/git/configs (master)
$ "$KAFKA_DIR/bin/kafka-server-start.sh" server.properties
[0.004s][error][logging] Error opening log file '/c/rafal/tools/kafka_2.13-3.3.2/bin/../logs/kafkaServer-gc.log': No such file or directory
[0.004s][error][logging] Initialization of output 'file=/c/rafal/tools/kafka_2.13-3.3.2/bin/../logs/kafkaServer-gc.log' using options 'filecount=10,filesize=100M' failed.
Invalid -Xlog option '-Xlog:gc*:file=/c/rafal/tools/kafka_2.13-3.3.2/bin/../logs/kafkaServer-gc.log:time,tags:filecount=10,filesize=100M', see error log for details.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

however it works fine when using Cygwin. what i can see it has already logic for changing directory separators, so to fix this issue I just added extra condition for MINGW. it fixed issue on my pc.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
