### PR TITLE
KAFKA-14745: Cache the ReplicationPolicy instance in MirrorConnectorC…

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -108,8 +108,11 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     public static final String OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT = SOURCE_CLUSTER_ALIAS_DEFAULT;
     public static final String OFFSET_SYNCS_TOPIC_LOCATION_DOC = "The location (source/target) of the offset-syncs topic.";
 
+    private final ReplicationPolicy replicationPolicy;
+
     protected MirrorConnectorConfig(ConfigDef configDef, Map<String, String> props) {
         super(configDef, props, true);
+        replicationPolicy = getConfiguredInstance(REPLICATION_POLICY_CLASS, ReplicationPolicy.class);
     }
 
     String connectorName() {
@@ -133,7 +136,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     ReplicationPolicy replicationPolicy() {
-        return getConfiguredInstance(REPLICATION_POLICY_CLASS, ReplicationPolicy.class);
+        return replicationPolicy;
     }
 
     Map<String, Object> sourceProducerConfig() {

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -171,10 +171,6 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
         }
     }
 
-    ReplicationPolicy replicationPolicy() {
-        return getConfiguredInstance(REPLICATION_POLICY_CLASS, ReplicationPolicy.class);
-    }
-
     int replicationFactor() {
         return getInt(REPLICATION_FACTOR);
     }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -29,6 +29,7 @@ import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class MirrorConnectorConfigTest {
 
@@ -181,6 +182,12 @@ public class MirrorConnectorConfigTest {
         Map<String, String> connectorProps = makeProps("metric.reporters", reporters);
         MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         assertEquals(2, config.metricsReporters().size());
+    }
+
+    @Test
+    public void testReplicationPolicy() {
+        MirrorConnectorConfig config = new TestMirrorConnectorConfig(makeProps());
+        assertSame(config.replicationPolicy(), config.replicationPolicy());
     }
 
 }


### PR DESCRIPTION
…onfig

Otherwise calls to `checkpointsTopic()`, whcih happen relatively frequently, keep creating new ReplicationPolicy instances. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
