### PR TITLE
MINOR: fix fault handling in ControllerServer and KafkaServer

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -312,7 +312,7 @@ class ControllerServer(
     } catch {
       case e: Throwable =>
         maybeChangeStatus(STARTING, STARTED)
-        sharedServer.controllerStartupFault.handleFault("caught exception", e)
+        sharedServer.controllerStartupFaultHandler.handleFault("caught exception", e)
         shutdown()
         throw e
     }

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -312,7 +312,7 @@ class ControllerServer(
     } catch {
       case e: Throwable =>
         maybeChangeStatus(STARTING, STARTED)
-        fatal("Fatal error during controller startup. Prepare to shutdown", e)
+        sharedServer.controllerStartupFault.handleFault("caught exception", e)
         shutdown()
         throw e
     }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -55,7 +55,7 @@ import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.server.common.MetadataVersion._
-import org.apache.kafka.server.fault.ProcessTerminatingFaultHandler
+import org.apache.kafka.server.fault.LoggingFaultHandler
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.util.KafkaScheduler
@@ -396,7 +396,7 @@ class KafkaServer(
             metrics,
             threadNamePrefix,
             controllerQuorumVotersFuture,
-            fatalFaultHandler = new ProcessTerminatingFaultHandler.Builder().build()
+            fatalFaultHandler = new LoggingFaultHandler("raftManager", () => shutdown())
           )
           val controllerNodes = RaftConfig.voterConnectionsToNodes(controllerQuorumVotersFuture.get()).asScala
           val quorumControllerNodeProvider = RaftControllerNodeProvider(raftManager, config, controllerNodes)

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -171,6 +171,17 @@ class SharedServer(
     })
 
   /**
+   * The fault handler to use when ControllerServer.startup throws an exception.
+   */
+  def controllerStartupFault: FaultHandler = faultHandlerFactory.build(
+    name = "controller startup",
+    fatal = true,
+    action = () => SharedServer.this.synchronized {
+      if (controllerMetrics != null) controllerMetrics.incrementMetadataErrorCount()
+      snapshotsDiabledReason.compareAndSet(null, "controller startup fault")
+    })
+
+  /**
    * The fault handler to use when the initial broker metadata load fails.
    */
   def initialBrokerMetadataLoadFaultHandler: FaultHandler = faultHandlerFactory.build(

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -173,7 +173,7 @@ class SharedServer(
   /**
    * The fault handler to use when ControllerServer.startup throws an exception.
    */
-  def controllerStartupFault: FaultHandler = faultHandlerFactory.build(
+  def controllerStartupFaultHandler: FaultHandler = faultHandlerFactory.build(
     name = "controller startup",
     fatal = true,
     action = () => SharedServer.this.synchronized {

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -962,6 +962,7 @@ class KRaftClusterTest {
       cluster.format()
       val exception = assertThrows(classOf[ExecutionException], () => cluster.startup())
       assertEquals("java.lang.IllegalStateException: test authorizer exception", exception.getMessage)
+      cluster.fatalFaultHandler().setIgnore(true)
     } finally {
       cluster.close()
     }


### PR DESCRIPTION
This PR has two fixes for fault handling. One makes fault handling more strict on the controller; the other makes it a bit less strict on the (ZK-based) broker.

In ControllerServer, invoke a fatal fault handler in the catch block of the ControllerServer.startup() function. This will protect us from cases where unwinding startup would otherwise encounter a deadlock, or be too slow.  This is the same reason why we made controller fault handlers call halt() instead of exit() in KAFKA-14693.  In a sense, this JIRA is a continuation of that fix since it turns some cases that would previously have been handled by calling shutdown() into cases where we invoke a fault handler which will call halt() directly.

In KafkaServer,  when we are in migration-from-zk mode and we create a RaftManager, it should have a fault handler which simply calls shutdown() on the broker rather than invoking
ProcessTerminatingFaultHandler. This fixes the bug where we could invoke the process terminating fault handler from junit tests.