### PR TITLE
KAFKA-14057: Support dynamic reconfiguration in KRaft remote controllers

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -77,10 +77,7 @@ class KafkaRaftServer(
   )
 
   private val broker: Option[BrokerServer] = if (config.processRoles.contains(BrokerRole)) {
-    Some(new BrokerServer(
-      sharedServer,
-      offlineDirs
-    ))
+    Some(new BrokerServer(sharedServer, offlineDirs))
   } else {
     None
   }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -211,7 +211,7 @@ class BrokerMetadataPublisher(
       }
 
       // Apply configuration deltas.
-      dynamicConfigPublisher.publish(delta, newImage)
+      dynamicConfigPublisher.publish(delta, newImage, null)
 
       // Apply client quotas delta.
       try {

--- a/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
@@ -22,6 +22,7 @@ import kafka.server.ConfigAdminManager.toLoggableProps
 import kafka.server.{ConfigEntityName, ConfigHandler, ConfigType, KafkaConfig}
 import kafka.utils.Logging
 import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, TOPIC}
+import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.fault.FaultHandler
 
@@ -31,10 +32,16 @@ class DynamicConfigPublisher(
   faultHandler: FaultHandler,
   dynamicConfigHandlers: Map[String, ConfigHandler],
   nodeType: String
-) extends Logging {
+) extends org.apache.kafka.image.publisher.MetadataPublisher with Logging {
   logIdent = s"[DynamicConfigPublisher nodeType=${nodeType} id=${conf.nodeId}] "
 
-  def publish(delta: MetadataDelta, newImage: MetadataImage): Unit = {
+  def name(): String = "DynamicConfigPublisher"
+
+  def publish(
+    delta: MetadataDelta,
+    newImage: MetadataImage,
+    manifest: LoaderManifest
+  ): Unit = {
     val deltaName = s"MetadataDelta up to ${newImage.highestOffsetAndEpoch().offset}"
     try {
       // Apply configuration deltas.

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -24,6 +24,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.common.acl.{AclBinding, AclBindingFilter}
+import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type
 import org.apache.kafka.common.message.DescribeClusterRequestData
@@ -31,7 +32,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors._
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter, ClientQuotaFilterComponent}
 import org.apache.kafka.common.requests.{ApiError, DescribeClusterRequest, DescribeClusterResponse}
-import org.apache.kafka.common.{Endpoint, TopicPartition, TopicPartitionInfo}
+import org.apache.kafka.common.{Endpoint, Reconfigurable, TopicPartition, TopicPartitionInfo}
 import org.apache.kafka.image.ClusterImage
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.authorizer._
@@ -39,12 +40,15 @@ import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{Tag, Test, Timeout}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.slf4j.LoggerFactory
 
 import java.io.File
 import java.nio.file.{FileSystems, Path}
+import java.util.concurrent.atomic.AtomicInteger
 import java.{lang, util}
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{CompletableFuture, CompletionStage}
 import java.util.{Arrays, Collections, Optional, OptionalLong, Properties}
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -966,6 +970,47 @@ class KRaftClusterTest {
       cluster.close()
     }
   }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testReconfigureControllerAuthorizer(combinedMode: Boolean): Unit = {
+    val cluster = new KafkaClusterTestKit.Builder(
+      new TestKitNodes.Builder().
+        setNumBrokerNodes(1).
+        setCoResident(combinedMode).
+        setNumControllerNodes(1).build()).
+        setConfigProp("authorizer.class.name", classOf[FakeConfigurableAuthorizer].getName).
+        build()
+
+    def assertFoobarValue(expected: Int): Unit = {
+      TestUtils.retry(60000) {
+        assertEquals(expected, cluster.controllers().values().iterator().next().
+          authorizer.get.asInstanceOf[FakeConfigurableAuthorizer].foobar.get())
+        assertEquals(expected, cluster.brokers().values().iterator().next().
+          authorizer.get.asInstanceOf[FakeConfigurableAuthorizer].foobar.get())
+      }
+    }
+
+    try {
+      cluster.format()
+      cluster.startup()
+      cluster.waitForReadyBrokers()
+      assertFoobarValue(0)
+      val admin = Admin.create(cluster.clientProperties())
+      try {
+        admin.incrementalAlterConfigs(
+          Collections.singletonMap(new ConfigResource(Type.BROKER, ""),
+            Collections.singletonList(new AlterConfigOp(
+              new ConfigEntry(FakeConfigurableAuthorizer.foobarConfigKey, "123"), OpType.SET)))).
+                all().get()
+      } finally {
+        admin.close()
+      }
+      assertFoobarValue(123)
+    } finally {
+      cluster.close()
+    }
+  }
 }
 
 class BadAuthorizer() extends Authorizer {
@@ -985,4 +1030,72 @@ class BadAuthorizer() extends Authorizer {
   override def createAcls(requestContext: AuthorizableRequestContext, aclBindings: util.List[AclBinding]): util.List[_ <: CompletionStage[AclCreateResult]] = ???
 
   override def deleteAcls(requestContext: AuthorizableRequestContext, aclBindingFilters: util.List[AclBindingFilter]): util.List[_ <: CompletionStage[AclDeleteResult]] = ???
+}
+
+object FakeConfigurableAuthorizer {
+  val foobarConfigKey = "fake.configurable.authorizer.foobar.config"
+
+  def fakeConfigurableAuthorizerConfigToInt(configs: util.Map[String, _]): Int = {
+    val result = configs.get(foobarConfigKey)
+    if (result == null) {
+      0
+    } else {
+      val resultString = result.toString().trim()
+      try {
+        Integer.valueOf(resultString)
+      } catch {
+        case e: NumberFormatException => throw new ConfigException(s"Bad value of ${foobarConfigKey}: ${resultString}")
+      }
+    }
+  }
+}
+
+class FakeConfigurableAuthorizer() extends Authorizer with Reconfigurable {
+  import FakeConfigurableAuthorizer._
+
+  val foobar = new AtomicInteger(0)
+
+  override def start(serverInfo: AuthorizerServerInfo): java.util.Map[Endpoint, _ <: CompletionStage[Void]] = {
+    serverInfo.endpoints().asScala.map(e => e -> {
+      val future = new CompletableFuture[Void]
+      future.complete(null)
+      future
+    }).toMap.asJava
+  }
+
+  override def reconfigurableConfigs(): java.util.Set[String] = Set(foobarConfigKey).asJava
+
+  override def validateReconfiguration(configs: util.Map[String, _]): Unit = {
+    fakeConfigurableAuthorizerConfigToInt(configs)
+  }
+
+  override def reconfigure(configs: util.Map[String, _]): Unit = {
+    foobar.set(fakeConfigurableAuthorizerConfigToInt(configs))
+  }
+
+  override def authorize(requestContext: AuthorizableRequestContext, actions: util.List[Action]): util.List[AuthorizationResult] = {
+    actions.asScala.map(_ => AuthorizationResult.ALLOWED).toList.asJava
+  }
+
+  override def acls(filter: AclBindingFilter): lang.Iterable[AclBinding] = List[AclBinding]().asJava
+
+  override def close(): Unit = {}
+
+  override def configure(configs: util.Map[String, _]): Unit = {
+    foobar.set(fakeConfigurableAuthorizerConfigToInt(configs))
+  }
+
+  override def createAcls(
+    requestContext: AuthorizableRequestContext,
+    aclBindings: util.List[AclBinding]
+  ): util.List[_ <: CompletionStage[AclCreateResult]] = {
+    Collections.emptyList()
+  }
+
+  override def deleteAcls(
+    requestContext: AuthorizableRequestContext,
+    aclBindingFilters: util.List[AclBindingFilter]
+  ): util.List[_ <: CompletionStage[AclDeleteResult]] = {
+    Collections.emptyList()
+  }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/loader/LoaderManifest.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/LoaderManifest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image.loader;
+
+import org.apache.kafka.image.MetadataProvenance;
+
+
+/**
+ * Contains information about what was loaded.
+ */
+public interface LoaderManifest {
+    /**
+     * Describes the type of manifest which this is.
+     */
+    LoaderManifestType type();
+
+    /**
+     * The highest offset and epoch included in the new image, inclusive.
+     */
+    MetadataProvenance provenance();
+}

--- a/metadata/src/main/java/org/apache/kafka/image/loader/LoaderManifestType.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/LoaderManifestType.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image.loader;
+
+
+/**
+ * Contains information about the type of a loader manifest.
+ */
+public enum LoaderManifestType {
+    LOG_DELTA,
+    SNAPSHOT;
+}

--- a/metadata/src/main/java/org/apache/kafka/image/loader/LogDeltaManifest.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/LogDeltaManifest.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * Contains information about a set of changes that were loaded from the metadata log.
  */
-public class LogDeltaManifest {
+public class LogDeltaManifest implements LoaderManifest {
     /**
      * The highest offset and epoch included in this delta, inclusive.
      */
@@ -66,7 +66,12 @@ public class LogDeltaManifest {
         this.numBytes = numBytes;
     }
 
+    @Override
+    public LoaderManifestType type() {
+        return LoaderManifestType.LOG_DELTA;
+    }
 
+    @Override
     public MetadataProvenance provenance() {
         return provenance;
     }

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -258,7 +258,8 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
             try {
                 log.info("Publishing initial snapshot at offset {} to {}",
                         image.highestOffsetAndEpoch().offset(), publisher.name());
-                publisher.publishSnapshot(delta, image, manifest);
+                publisher.publish(delta, image, manifest);
+                publisher.handleControllerChange(currentLeaderAndEpoch);
                 publishers.put(publisher.name(), publisher);
             } catch (Throwable e) {
                 faultHandler.handleFault("Unhandled error publishing the initial metadata " +
@@ -295,7 +296,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                 log.debug("Publishing new image with provenance {}.", image.provenance());
                 for (MetadataPublisher publisher : publishers.values()) {
                     try {
-                        publisher.publishLogDelta(delta, image, manifest);
+                        publisher.publish(delta, image, manifest);
                     } catch (Throwable e) {
                         faultHandler.handleFault("Unhandled error publishing the new metadata " +
                             "image ending at " + manifest.provenance().lastContainedOffset() +
@@ -392,7 +393,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                 log.debug("Publishing new snapshot image with provenance {}.", image.provenance());
                 for (MetadataPublisher publisher : publishers.values()) {
                     try {
-                        publisher.publishSnapshot(delta, image, manifest);
+                        publisher.publish(delta, image, manifest);
                     } catch (Throwable e) {
                         faultHandler.handleFault("Unhandled error publishing the new metadata " +
                                 "image from snapshot at offset " + reader.lastContainedLogOffset() +
@@ -449,6 +450,15 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
     public void handleLeaderChange(LeaderAndEpoch leaderAndEpoch) {
         eventQueue.append(() -> {
             currentLeaderAndEpoch = leaderAndEpoch;
+            for (MetadataPublisher publisher : publishers.values()) {
+                try {
+                    publisher.handleControllerChange(currentLeaderAndEpoch);
+                } catch (Throwable e) {
+                    faultHandler.handleFault("Unhandled error publishing the new leader " +
+                            "change to " + currentLeaderAndEpoch + " with publisher " +
+                            publisher.name(), e);
+                }
+            }
         });
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/loader/SnapshotManifest.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/SnapshotManifest.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * Contains information about a snapshot that was loaded.
  */
-public class SnapshotManifest {
+public class SnapshotManifest implements LoaderManifest {
     /**
      * The source of this snapshot.
      */
@@ -44,6 +44,12 @@ public class SnapshotManifest {
         this.elapsedNs = elapsedNs;
     }
 
+    @Override
+    public LoaderManifestType type() {
+        return LoaderManifestType.SNAPSHOT;
+    }
+
+    @Override
     public MetadataProvenance provenance() {
         return provenance;
     }

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/MetadataPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/MetadataPublisher.java
@@ -19,8 +19,8 @@ package org.apache.kafka.image.publisher;
 
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
-import org.apache.kafka.image.loader.LogDeltaManifest;
-import org.apache.kafka.image.loader.SnapshotManifest;
+import org.apache.kafka.image.loader.LoaderManifest;
+import org.apache.kafka.raft.LeaderAndEpoch;
 
 
 /**
@@ -40,33 +40,30 @@ public interface MetadataPublisher extends AutoCloseable {
     String name();
 
     /**
+     * Handle a change in the current controller.
+     *
+     * @param newLeaderAndEpoch The new quorum leader and epoch. The new leader will be
+     *                          OptionalInt.empty if there is currently no active controller.
+     */
+    default void handleControllerChange(LeaderAndEpoch newLeaderAndEpoch) { }
+
+    /**
      * Publish a new cluster metadata snapshot that we loaded.
      *
      * @param delta    The delta between the previous state and the new one.
      * @param newImage The complete new state.
-     * @param manifest The contents of what was published.
+     * @param manifest A manifest which describes the contents of what was published.
+     *                 If we loaded a snapshot, this will be a SnapshotManifest.
+     *                 If we loaded a log delta, this will be a LogDeltaManifest.
      */
-    void publishSnapshot(
+    void publish(
             MetadataDelta delta,
             MetadataImage newImage,
-            SnapshotManifest manifest
+            LoaderManifest manifest
     );
 
     /**
-     * Publish a change to the cluster metadata.
-     *
-     * @param delta    The delta between the previous state and the new one.
-     * @param newImage The complete new state.
-     * @param manifest The contents of what was published.
+     * Close this metadata publisher and free any associated resources.
      */
-    void publishLogDelta(
-            MetadataDelta delta,
-            MetadataImage newImage,
-            LogDeltaManifest manifest
-    );
-
-    /**
-     * Close this metadata publisher.
-     */
-    void close() throws Exception;
+    default void close() throws Exception { }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.image.loader.LoaderManifest;
 import org.apache.kafka.image.loader.LogDeltaManifest;
 import org.apache.kafka.image.loader.SnapshotManifest;
 import org.apache.kafka.queue.EventQueue;
@@ -200,7 +201,24 @@ public class SnapshotGenerator implements MetadataPublisher {
     }
 
     @Override
-    public void publishSnapshot(
+    public void publish(
+        MetadataDelta delta,
+        MetadataImage newImage,
+        LoaderManifest manifest
+    ) {
+        switch (manifest.type()) {
+            case LOG_DELTA:
+                publishLogDelta(delta, newImage, (LogDeltaManifest) manifest);
+                break;
+            case SNAPSHOT:
+                publishSnapshot(delta, newImage, (SnapshotManifest) manifest);
+                break;
+            default:
+                break;
+        }
+    }
+
+    void publishSnapshot(
         MetadataDelta delta,
         MetadataImage newImage,
         SnapshotManifest manifest
@@ -209,8 +227,7 @@ public class SnapshotGenerator implements MetadataPublisher {
         resetSnapshotCounters();
     }
 
-    @Override
-    public void publishLogDelta(
+    void publishLogDelta(
         MetadataDelta delta,
         MetadataImage newImage,
         LogDeltaManifest manifest

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
-import org.apache.kafka.image.loader.LogDeltaManifest;
-import org.apache.kafka.image.loader.SnapshotManifest;
+import org.apache.kafka.image.loader.LoaderManifest;
+import org.apache.kafka.image.loader.LoaderManifestType;
 import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.queue.EventQueue;
@@ -223,16 +223,21 @@ public class KRaftMigrationDriver implements MetadataPublisher {
     }
 
     @Override
-    public void publishSnapshot(MetadataDelta delta, MetadataImage newImage, SnapshotManifest manifest) {
-        enqueueMetadataChangeEvent(delta, newImage, manifest.provenance(), true, NO_OP_HANDLER);
+    public void handleControllerChange(LeaderAndEpoch newLeaderAndEpoch) {
+        eventQueue.append(new KRaftLeaderEvent(newLeaderAndEpoch));
     }
 
     @Override
-    public void publishLogDelta(MetadataDelta delta, MetadataImage newImage, LogDeltaManifest manifest) {
-        if (!leaderAndEpoch.equals(manifest.leaderAndEpoch())) {
-            eventQueue.append(new KRaftLeaderEvent(manifest.leaderAndEpoch()));
-        }
-        enqueueMetadataChangeEvent(delta, newImage, manifest.provenance(), false, NO_OP_HANDLER);
+    public void publish(
+        MetadataDelta delta,
+        MetadataImage newImage,
+        LoaderManifest manifest
+    ) {
+        enqueueMetadataChangeEvent(delta,
+                newImage,
+                manifest.provenance(),
+                manifest.type() == LoaderManifestType.SNAPSHOT,
+                NO_OP_HANDLER);
     }
 
     /**

--- a/metadata/src/test/java/org/apache/kafka/image/loader/MetadataLoaderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/loader/MetadataLoaderTest.java
@@ -92,25 +92,23 @@ public class MetadataLoaderTest {
         }
 
         @Override
-        public void publishSnapshot(
+        public void publish(
             MetadataDelta delta,
             MetadataImage newImage,
-            SnapshotManifest manifest
+            LoaderManifest manifest
         ) {
             latestDelta = delta;
             latestImage = newImage;
-            latestSnapshotManifest = manifest;
-        }
-
-        @Override
-        public void publishLogDelta(
-            MetadataDelta delta,
-            MetadataImage newImage,
-            LogDeltaManifest manifest
-        ) {
-            latestDelta = delta;
-            latestImage = newImage;
-            latestLogDeltaManifest = manifest;
+            switch (manifest.type()) {
+                case LOG_DELTA:
+                    latestLogDeltaManifest = (LogDeltaManifest) manifest;
+                    break;
+                case SNAPSHOT:
+                    latestSnapshotManifest = (SnapshotManifest) manifest;
+                    break;
+                default:
+                    throw new RuntimeException("Invalid manifest type " + manifest.type());
+            }
         }
 
         @Override

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -277,8 +277,9 @@ public class KRaftMigrationDriverTest {
         image = delta.apply(provenance);
 
         // Publish a delta with this node (3000) as the leader
-        driver.publishLogDelta(delta, image, new LogDeltaManifest(provenance,
-            new LeaderAndEpoch(OptionalInt.of(3000), 1), 1, 100, 42));
+        LeaderAndEpoch newLeader = new LeaderAndEpoch(OptionalInt.of(3000), 1);
+        driver.handleControllerChange(newLeader);
+        driver.publish(delta, image, new LogDeltaManifest(provenance, newLeader, 1, 100, 42));
 
         TestUtils.waitForCondition(() -> driver.migrationState().get(1, TimeUnit.MINUTES).equals(MigrationDriverState.DUAL_WRITE),
             "Waiting for KRaftMigrationDriver to enter DUAL_WRITE state");


### PR DESCRIPTION
This PR allows us to dynamically reconfigure the KRaft controller by setting either a cluster configuration (that is, a configuration that applies to all resource of type BROKER), or by configuring a combined broker/controller node.

As described in DynamicBrokerConfig#addReconfigurables(ControllerServer), we currently support reconfiguring Yammer metrics, metrics reporters, the socket server, and the Authorizer.  More dynamically reconfigurable Controller elements will be added later.

This PR refactors MetadataPublisher's interface a bit. There is now a handleControllerChange callback. This is something that some publishers might want (a good example is ZkMigrationClient). There is now only a single publish() function rather than a separate function for publishing snapshots and log deltas. Most publishers didn't want to do anything different in those two cases. The ones that do want to do something different for snapshots can always check the manifest type. The close function now has a default empty implementation, since most publishers didn't need to do anything there.

This PR fixes a bug where the KRaft broker's authorizer was not dynamically reconfigurable even if it had implemented Reconfigurable. The bug resulted from the fact that we called DynamicBrokerConfig.addReconfigurables prior to initializing BrokerServer.authorizer.