### PR TITLE
MINOR: Move plugin path parsing from DelegatingClassLoader to PluginUtils

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -400,7 +400,7 @@ public class WorkerConfig extends AbstractConfig {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
     }
 
-    public static List<String> pluginLocations(Map<String, String> props) {
+    public static List<String> pluginPathElements(Map<String, String> props) {
         String locationList = props.get(WorkerConfig.PLUGIN_PATH_CONFIG);
         return locationList == null
                          ? new ArrayList<>()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
@@ -49,8 +48,6 @@ import static org.apache.kafka.connect.runtime.SourceConnectorConfig.TOPIC_CREAT
  */
 public class WorkerConfig extends AbstractConfig {
     private static final Logger log = LoggerFactory.getLogger(WorkerConfig.class);
-
-    private static final Pattern COMMA_WITH_WHITESPACE = Pattern.compile("\\s*,\\s*");
 
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
     public static final String BOOTSTRAP_SERVERS_DOC
@@ -400,11 +397,8 @@ public class WorkerConfig extends AbstractConfig {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
     }
 
-    public static List<String> pluginPathElements(Map<String, String> props) {
-        String locationList = props.get(WorkerConfig.PLUGIN_PATH_CONFIG);
-        return locationList == null
-                         ? new ArrayList<>()
-                         : Arrays.asList(COMMA_WITH_WHITESPACE.split(locationList.trim(), -1));
+    public static String pluginPath(Map<String, String> props) {
+        return props.get(WorkerConfig.PLUGIN_PATH_CONFIG);
     }
 
     public WorkerConfig(ConfigDef definition, Map<String, String> props) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -41,10 +41,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.Driver;
@@ -79,7 +77,6 @@ import java.util.stream.Collectors;
  */
 public class DelegatingClassLoader extends URLClassLoader {
     private static final Logger log = LoggerFactory.getLogger(DelegatingClassLoader.class);
-    private static final String CLASSPATH_NAME = "classpath";
     public static final String UNDEFINED_VERSION = "undefined";
 
     private final ConcurrentMap<String, SortedMap<PluginDesc<?>, ClassLoader>> pluginLoaders;
@@ -93,7 +90,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     private final SortedSet<PluginDesc<ConfigProvider>> configProviders;
     private final SortedSet<PluginDesc<ConnectRestExtension>> restExtensions;
     private final SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
-    private final List<String> pluginPaths;
+    private final List<Path> pluginLocations;
 
     private static final String MANIFEST_PREFIX = "META-INF/services/";
     private static final Class<?>[] SERVICE_LOADER_PLUGINS = new Class<?>[] {ConnectRestExtension.class, ConfigProvider.class};
@@ -109,9 +106,9 @@ public class DelegatingClassLoader extends URLClassLoader {
         ClassLoader.registerAsParallelCapable();
     }
 
-    public DelegatingClassLoader(List<String> pluginPaths, ClassLoader parent) {
+    public DelegatingClassLoader(List<Path> pluginLocations, ClassLoader parent) {
         super(new URL[0], parent);
-        this.pluginPaths = pluginPaths;
+        this.pluginLocations = pluginLocations;
         this.pluginLoaders = new ConcurrentHashMap<>();
         this.aliases = new ConcurrentHashMap<>();
         this.sinkConnectors = new TreeSet<>();
@@ -125,12 +122,12 @@ public class DelegatingClassLoader extends URLClassLoader {
         this.connectorClientConfigPolicies = new TreeSet<>();
     }
 
-    public DelegatingClassLoader(List<String> pluginPaths) {
+    public DelegatingClassLoader(List<Path> pluginLocations) {
         // Use as parent the classloader that loaded this class. In most cases this will be the
         // System classloader. But this choice here provides additional flexibility in managed
         // environments that control classloading differently (OSGi, Spring and others) and don't
         // depend on the System classloader to load Connect's classes.
-        this(pluginPaths, DelegatingClassLoader.class.getClassLoader());
+        this(pluginLocations, DelegatingClassLoader.class.getClassLoader());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -234,40 +231,21 @@ public class DelegatingClassLoader extends URLClassLoader {
     }
 
     protected void initLoaders() {
-        for (String configPath : pluginPaths) {
-            initPluginLoader(configPath);
+        for (Path pluginLocation : pluginLocations) {
+            try {
+                registerPlugin(pluginLocation);
+            } catch (InvalidPathException | MalformedURLException e) {
+                log.error("Invalid path in plugin path: {}. Ignoring.", pluginLocation, e);
+            } catch (IOException e) {
+                log.error("Could not get listing for plugin path: {}. Ignoring.", pluginLocation, e);
+            }
         }
         // Finally add parent/system loader.
-        initPluginLoader(CLASSPATH_NAME);
+        scanUrlsAndAddPlugins(
+                getParent(),
+                ClasspathHelper.forJavaClassPath().toArray(new URL[0])
+        );
         addAllAliases();
-    }
-
-    private void initPluginLoader(String path) {
-        try {
-            if (CLASSPATH_NAME.equals(path)) {
-                scanUrlsAndAddPlugins(
-                        getParent(),
-                        ClasspathHelper.forJavaClassPath().toArray(new URL[0])
-                );
-            } else {
-                Path pluginPath = Paths.get(path).toAbsolutePath();
-                // Update for exception handling
-                path = pluginPath.toString();
-                // Currently 'plugin.paths' property is a list of top-level directories
-                // containing plugins
-                if (Files.isDirectory(pluginPath)) {
-                    for (Path pluginLocation : PluginUtils.pluginLocations(pluginPath)) {
-                        registerPlugin(pluginLocation);
-                    }
-                } else if (PluginUtils.isArchive(pluginPath)) {
-                    registerPlugin(pluginPath);
-                }
-            }
-        } catch (InvalidPathException | MalformedURLException e) {
-            log.error("Invalid path in plugin path: {}. Ignoring.", path, e);
-        } catch (IOException e) {
-            log.error("Could not get listing for plugin path: {}. Ignoring.", path, e);
-        }
     }
 
     private void registerPlugin(Path pluginLocation)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -207,7 +208,7 @@ public class PluginUtils {
                 } else if (isArchive(pluginPathElement)) {
                     pluginLocations.add(pluginPathElement);
                 }
-            } catch (IOException e) {
+            } catch (InvalidPathException | IOException e) {
                 log.error("Could not get listing for plugin path: {}. Ignoring.", path, e);
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -61,8 +61,8 @@ public class Plugins {
 
     // VisibleForTesting
     Plugins(Map<String, String> props, ClassLoader parent) {
-        List<String> pluginPathElements = WorkerConfig.pluginPathElements(props);
-        List<Path> pluginLocations = PluginUtils.pluginLocations(pluginPathElements);
+        String pluginPath = WorkerConfig.pluginPath(props);
+        List<Path> pluginLocations = PluginUtils.pluginLocations(pluginPath);
         delegatingLoader = newDelegatingClassLoader(pluginLocations, parent);
         delegatingLoader.initLoaders();
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -36,6 +36,7 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -60,15 +61,16 @@ public class Plugins {
 
     // VisibleForTesting
     Plugins(Map<String, String> props, ClassLoader parent) {
-        List<String> pluginLocations = WorkerConfig.pluginLocations(props);
+        List<String> pluginPathElements = WorkerConfig.pluginPathElements(props);
+        List<Path> pluginLocations = PluginUtils.pluginLocations(pluginPathElements);
         delegatingLoader = newDelegatingClassLoader(pluginLocations, parent);
         delegatingLoader.initLoaders();
     }
 
     // VisibleForTesting
-    protected DelegatingClassLoader newDelegatingClassLoader(final List<String> paths, ClassLoader parent) {
+    protected DelegatingClassLoader newDelegatingClassLoader(final List<Path> pluginLocations, ClassLoader parent) {
         return AccessController.doPrivileged(
-                (PrivilegedAction<DelegatingClassLoader>) () -> new DelegatingClassLoader(paths, parent)
+                (PrivilegedAction<DelegatingClassLoader>) () -> new DelegatingClassLoader(pluginLocations, parent)
         );
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -21,7 +21,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -81,7 +80,7 @@ public class DelegatingClassLoaderTest {
         pluginDir.newFile("invalid.jar");
 
         DelegatingClassLoader classLoader = new DelegatingClassLoader(
-                Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
+                Collections.singletonList(pluginDir.getRoot().toPath().toAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
         );
         classLoader.initLoaders();
@@ -93,7 +92,7 @@ public class DelegatingClassLoaderTest {
         pluginDir.newFile("my-plugin/invalid.jar");
 
         DelegatingClassLoader classLoader = new DelegatingClassLoader(
-                Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
+                Collections.singletonList(pluginDir.getRoot().toPath().toAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
         );
         classLoader.initLoaders();
@@ -102,7 +101,7 @@ public class DelegatingClassLoaderTest {
     @Test
     public void testLoadingNoPlugins() {
         DelegatingClassLoader classLoader = new DelegatingClassLoader(
-                Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
+                Collections.singletonList(pluginDir.getRoot().toPath().toAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
         );
         classLoader.initLoaders();
@@ -113,7 +112,7 @@ public class DelegatingClassLoaderTest {
         pluginDir.newFolder("my-plugin");
 
         DelegatingClassLoader classLoader = new DelegatingClassLoader(
-                Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
+                Collections.singletonList(pluginDir.getRoot().toPath().toAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
         );
         classLoader.initLoaders();
@@ -126,13 +125,12 @@ public class DelegatingClassLoaderTest {
         pluginDir.newFile("my-plugin/invalid.jar");
         Path pluginPath = this.pluginDir.getRoot().toPath();
 
-        for (String sourceJar : TestPlugins.pluginPath()) {
-            Path source = new File(sourceJar).toPath();
+        for (Path source : TestPlugins.pluginPath()) {
             Files.copy(source, pluginPath.resolve(source.getFileName()));
         }
 
         DelegatingClassLoader classLoader = new DelegatingClassLoader(
-                Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
+                Collections.singletonList(pluginDir.getRoot().toPath().toAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
         );
         classLoader.initLoaders();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map.Entry;
@@ -74,7 +75,7 @@ public class PluginsTest {
         Map<String, String> pluginProps = new HashMap<>();
 
         // Set up the plugins with some test plugins to test isolation
-        pluginProps.put(WorkerConfig.PLUGIN_PATH_CONFIG, String.join(",", TestPlugins.pluginPath()));
+        pluginProps.put(WorkerConfig.PLUGIN_PATH_CONFIG, TestPlugins.pluginPathJoined());
         plugins = new Plugins(pluginProps);
         props = new HashMap<>(pluginProps);
         props.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
@@ -427,7 +428,7 @@ public class PluginsTest {
             TestPlugin parentResource, TestPlugin childResource, String className, String... expectedVersions) throws MalformedURLException {
         URL[] systemPath = TestPlugins.pluginPath(parentResource)
                 .stream()
-                .map(File::new)
+                .map(Path::toFile)
                 .map(File::toURI)
                 .map(uri -> {
                     try {
@@ -443,7 +444,7 @@ public class PluginsTest {
         // to simulate the situation where jars exist on both system classpath and plugin path.
         Map<String, String> pluginProps = Collections.singletonMap(
                 WorkerConfig.PLUGIN_PATH_CONFIG,
-                String.join(",", TestPlugins.pluginPath(childResource))
+                TestPlugins.pluginPathJoined(childResource)
         );
         plugins = new Plugins(pluginProps, parent);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/SynchronizationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/SynchronizationTest.java
@@ -24,6 +24,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -72,7 +73,7 @@ public class SynchronizationTest {
     public void setup() {
         Map<String, String> pluginProps = Collections.singletonMap(
             WorkerConfig.PLUGIN_PATH_CONFIG,
-            String.join(",", TestPlugins.pluginPath())
+            TestPlugins.pluginPathJoined()
         );
         threadPrefix = SynchronizationTest.class.getSimpleName()
             + "." + testName.getMethodName() + "-";
@@ -80,10 +81,10 @@ public class SynchronizationTest {
         pclBreakpoint = new Breakpoint<>();
         plugins = new Plugins(pluginProps) {
             @Override
-            protected DelegatingClassLoader newDelegatingClassLoader(List<String> paths, ClassLoader parent) {
+            protected DelegatingClassLoader newDelegatingClassLoader(List<Path> pluginLocations, ClassLoader parent) {
                 return AccessController.doPrivileged(
                     (PrivilegedAction<DelegatingClassLoader>) () ->
-                        new SynchronizedDelegatingClassLoader(paths, parent)
+                        new SynchronizedDelegatingClassLoader(pluginLocations, parent)
                 );
             }
         };
@@ -171,8 +172,8 @@ public class SynchronizationTest {
             ClassLoader.registerAsParallelCapable();
         }
 
-        public SynchronizedDelegatingClassLoader(List<String> pluginPaths, ClassLoader parent) {
-            super(pluginPaths, parent);
+        public SynchronizedDelegatingClassLoader(List<Path> pluginLocations, ClassLoader parent) {
+            super(pluginLocations, parent);
         }
 
         @Override


### PR DESCRIPTION
The logic for decomposing a `plugin.path` list into the component single-plugin locations is nontrivial, and currently implemented by the DelegatingClassLoader. Decoupling this logic from the DelegatingClassLoader will allow us to reuse these components in the KIP-898 connect-plugin-path.sh.

DelegatingClassLoader now takes a List<Path>, each corresponding exactly to one pluginLocation, which I'm currently trying to standardize as the name of the on-disk location which is assigned exactly one PluginClassLoader.

Conflicts with #13333 which also changes the type of PLUGIN_JARS.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
