### PR TITLE
KAFKA-14768-KIP912: add new configure to reduce the max.block.ms safely

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -254,6 +254,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     private final Serializer<V> valueSerializer;
     private final ProducerConfig producerConfig;
     private final long maxBlockTimeMs;
+    private final boolean includeWaitTimeOnMetadataInMaxBlockTime;
+    private final long maxWaitTimeMsOnMetadata;
     private final boolean partitionerIgnoreKeys;
     private final ProducerInterceptors<K, V> interceptors;
     private final ApiVersions apiVersions;
@@ -408,6 +410,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             this.compressionType = CompressionType.forName(config.getString(ProducerConfig.COMPRESSION_TYPE_CONFIG));
 
             this.maxBlockTimeMs = config.getLong(ProducerConfig.MAX_BLOCK_MS_CONFIG);
+            this.includeWaitTimeOnMetadataInMaxBlockTime = config.getBoolean(ProducerConfig.INCLUDE_WAIT_TIME_ON_METADATA_IN_MAX_BLOCK_TIME_CONFIG);
+            this.maxWaitTimeMsOnMetadata = config.getLong(ProducerConfig.MAX_WAIT_TIME_MS_ON_METADATA_CONFIG);
             int deliveryTimeoutMs = configureDeliveryTimeout(config, log);
 
             this.apiVersions = new ApiVersions();
@@ -494,6 +498,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         this.totalMemorySize = config.getLong(ProducerConfig.BUFFER_MEMORY_CONFIG);
         this.compressionType = CompressionType.forName(config.getString(ProducerConfig.COMPRESSION_TYPE_CONFIG));
         this.maxBlockTimeMs = config.getLong(ProducerConfig.MAX_BLOCK_MS_CONFIG);
+        this.includeWaitTimeOnMetadataInMaxBlockTime = config.getBoolean(ProducerConfig.INCLUDE_WAIT_TIME_ON_METADATA_IN_MAX_BLOCK_TIME_CONFIG);
+        this.maxWaitTimeMsOnMetadata = config.getLong(ProducerConfig.MAX_WAIT_TIME_MS_ON_METADATA_CONFIG);
         this.partitionerIgnoreKeys = config.getBoolean(ProducerConfig.PARTITIONER_IGNORE_KEYS_CONFIG);
         this.apiVersions = new ApiVersions();
         this.transactionManager = transactionManager;
@@ -993,14 +999,14 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             long nowMs = time.milliseconds();
             ClusterAndWaitTime clusterAndWaitTime;
             try {
-                clusterAndWaitTime = waitOnMetadata(record.topic(), record.partition(), nowMs, maxBlockTimeMs);
+                clusterAndWaitTime = waitOnMetadata(record.topic(), record.partition(), nowMs, this.includeWaitTimeOnMetadataInMaxBlockTime ? maxBlockTimeMs : this.maxWaitTimeMsOnMetadata);
             } catch (KafkaException e) {
                 if (metadata.isClosed())
                     throw new KafkaException("Producer closed while send in progress", e);
                 throw e;
             }
             nowMs += clusterAndWaitTime.waitedOnMetadataMs;
-            long remainingWaitMs = Math.max(0, maxBlockTimeMs - clusterAndWaitTime.waitedOnMetadataMs);
+            long remainingWaitMs = Math.max(0, this.includeWaitTimeOnMetadataInMaxBlockTime ? maxBlockTimeMs - clusterAndWaitTime.waitedOnMetadataMs : maxBlockTimeMs);
             Cluster cluster = clusterAndWaitTime.cluster;
             byte[] serializedKey;
             try {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -192,11 +192,20 @@ public class ProducerConfig extends AbstractConfig {
     private static final String MAX_BLOCK_MS_DOC = "The configuration controls how long the <code>KafkaProducer</code>'s <code>send()</code>, <code>partitionsFor()</code>, "
                                                     + "<code>initTransactions()</code>, <code>sendOffsetsToTransaction()</code>, <code>commitTransaction()</code> "
                                                     + "and <code>abortTransaction()</code> methods will block. "
-                                                    + "For <code>send()</code> this timeout bounds the total time waiting for both metadata fetch and buffer allocation "
+                                                    + "For <code>send()</code> this timeout bounds the total time waiting for both metadata fetch if <code>max.block.ms.include.metadata</code> not false and buffer allocation "
                                                     + "(blocking in the user-supplied serializers or partitioner is not counted against this timeout). "
                                                     + "For <code>partitionsFor()</code> this timeout bounds the time spent waiting for metadata if it is unavailable. "
                                                     + "The transaction-related methods always block, but may timeout if "
                                                     + "the transaction coordinator could not be discovered or did not respond within the timeout.";
+    /** <code>max.block.metadata.ms</code> */
+    public static final String MAX_WAIT_TIME_MS_ON_METADATA_CONFIG = "max.block.metadata.ms";
+    private static final String MAX_WAIT_TIME_MS_ON_METADATA_DOC = "The configuration controls how long the <code>KafkaProducer</code>'s <code>send()</code>"
+                                                    + " waiting for metadata fetch ";
+
+    /** <code>max.block.ms.include.metadata</code> */
+    public static final String INCLUDE_WAIT_TIME_ON_METADATA_IN_MAX_BLOCK_TIME_CONFIG = "max.block.ms.include.metadata";
+    private static final String INCLUDE_WAIT_TIME_ON_METADATA_IN_MAX_BLOCK_TIME_DOC = "The configuration controls if the <code>KafkaProducer</code>'s <code>send()</code>"
+                                                    + " take time of waiting for metadata fetch as part of <code>max.block.ms</code>";
 
     /** <code>buffer.memory</code> */
     public static final String BUFFER_MEMORY_CONFIG = "buffer.memory";
@@ -379,6 +388,17 @@ public class ProducerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.MEDIUM,
                                         MAX_BLOCK_MS_DOC)
+                                .define(INCLUDE_WAIT_TIME_ON_METADATA_IN_MAX_BLOCK_TIME_CONFIG,
+                                        Type.BOOLEAN,
+                                        true,
+                                        Importance.LOW,
+                                        INCLUDE_WAIT_TIME_ON_METADATA_IN_MAX_BLOCK_TIME_DOC)
+                                .define(MAX_WAIT_TIME_MS_ON_METADATA_CONFIG,
+                                        Type.LONG,
+                                        60 * 1000,
+                                        atLeast(0),
+                                        Importance.LOW,
+                                        MAX_WAIT_TIME_MS_ON_METADATA_DOC)
                                 .define(REQUEST_TIMEOUT_MS_CONFIG,
                                         Type.INT,
                                         30 * 1000,


### PR DESCRIPTION
Hi Team:

https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-14768
refer to #13320 . it is another proposal to fix one of the issues.

In brief, It is draft one without unit test which adopt the proposal 2 which solve the issue 2 which I mentioned in the JIRA
(2) can't reduce the send message's block time to wanted value.

I created one KIP 
https://cwiki.apache.org/confluence/display/KAFKA/KIP-912%3A+Support+decreasing+send%27s+block+time+without+worrying+about+metadata%27s+fetch

Thanks for review. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
