### PR TITLE
MINOR: update RocksDBMetricsRecorder test to JUnit5 and fix memory leak

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -23,12 +23,12 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.RocksDBMetricContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
 import org.rocksdb.Cache;
 import org.rocksdb.HistogramData;
 import org.rocksdb.HistogramType;
@@ -52,7 +52,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class RocksDBMetricsRecorderTest {
     private final static String METRICS_SCOPE = "metrics-scope";
     private final static TaskId TASK_ID1 = new TaskId(0, 0);
@@ -98,16 +97,21 @@ public class RocksDBMetricsRecorderTest {
 
     private MockedStatic<RocksDBMetrics> dbMetrics;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         setUpMetricsMock();
         when(streamsMetrics.rocksDBMetricsRecordingTrigger()).thenReturn(recordingTrigger);
         recorder.init(streamsMetrics, TASK_ID1);
     }
 
-    @After
+    @AfterEach
     public void cleanUpMocks() {
         dbMetrics.close();
+    }
+
+    @AfterAll
+    public static void cleanUpMockito() {
+        Mockito.framework().clearInlineMocks();
     }
 
     @Test


### PR DESCRIPTION
The test was leaking memory via Mockito internals. Piggybacking an update to JUnit5.

### Test strategy

Ran the tests 10,000 times, and observed the memory consumption:

Before: 
![image](https://user-images.githubusercontent.com/1628637/222692563-fe8d9725-eca4-4143-915c-39e1fa2cacb0.png)

After:
![image](https://user-images.githubusercontent.com/1628637/222692684-3b17e3e9-4cd3-4e65-9567-73e9a9378b2f.png)

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
