### PR TITLE
KAFKA-14765: Support SCRAM for brokers at bootstrap

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramMechanism.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramMechanism.java
@@ -23,13 +23,15 @@ import java.util.Map;
 
 public enum ScramMechanism {
 
-    SCRAM_SHA_256("SHA-256", "HmacSHA256", 4096),
-    SCRAM_SHA_512("SHA-512", "HmacSHA512", 4096);
+    SCRAM_SHA_256((byte) 1, "SHA-256", "HmacSHA256", 4096, 16384),
+    SCRAM_SHA_512((byte) 2, "SHA-512", "HmacSHA512", 4096, 16384);
 
+    private final byte type;
     private final String mechanismName;
     private final String hashAlgorithm;
     private final String macAlgorithm;
     private final int minIterations;
+    private final int maxIterations;
 
     private static final Map<String, ScramMechanism> MECHANISMS_MAP;
 
@@ -40,11 +42,13 @@ public enum ScramMechanism {
         MECHANISMS_MAP = Collections.unmodifiableMap(map);
     }
 
-    ScramMechanism(String hashAlgorithm, String macAlgorithm, int minIterations) {
+    ScramMechanism(byte type, String hashAlgorithm, String macAlgorithm, int minIterations, int maxIterations) {
+        this.type = type;
         this.mechanismName = "SCRAM-" + hashAlgorithm;
         this.hashAlgorithm = hashAlgorithm;
-        this.macAlgorithm = macAlgorithm;
+        this.macAlgorithm  = macAlgorithm;
         this.minIterations = minIterations;
+        this.maxIterations = maxIterations;
     }
 
     public final String mechanismName() {
@@ -63,6 +67,10 @@ public enum ScramMechanism {
         return minIterations;
     }
 
+    public int maxIterations() {
+        return maxIterations;
+    }
+
     public static ScramMechanism forMechanismName(String mechanismName) {
         return MECHANISMS_MAP.get(mechanismName);
     }
@@ -73,5 +81,13 @@ public enum ScramMechanism {
 
     public static boolean isScram(String mechanismName) {
         return MECHANISMS_MAP.containsKey(mechanismName);
+    }
+
+    /**
+     *
+     * @return the type indicator for this SASL SCRAM mechanism
+     */
+    public byte type() {
+        return this.type;
     }
 }

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -22,15 +22,23 @@ import java.nio.file.{Files, Paths}
 import kafka.server.{BrokerMetadataCheckpoint, KafkaConfig, MetaProperties, RawMetaProperties}
 import kafka.utils.{Exit, Logging}
 import net.sourceforge.argparse4j.ArgumentParsers
-import net.sourceforge.argparse4j.impl.Arguments.{store, storeTrue}
+import net.sourceforge.argparse4j.impl.Arguments.{store, storeTrue, append}
 import net.sourceforge.argparse4j.inf.Namespace
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.bootstrap.{BootstrapDirectory, BootstrapMetadata}
-import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
+import org.apache.kafka.common.metadata.{NoOpRecord, FeatureLevelRecord}
+import org.apache.kafka.common.metadata.{UserScramCredentialRecord}
+import org.apache.kafka.common.security.scram.internals.ScramMechanism
+import org.apache.kafka.common.security.scram.internals.ScramFormatter
 
+import java.util
+import java.util.Base64
 import java.util.Optional
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+import scala.collection.mutable.ArrayBuffer
 
 object StorageTool extends Logging {
   def main(args: Array[String]): Unit = {
@@ -53,12 +61,22 @@ object StorageTool extends Logging {
             throw new TerseFailure(s"Must specify a valid KRaft metadata version of at least 3.0.")
           }
           val metaProperties = buildMetadataProperties(clusterId, config.get)
+          val metadataRecords : ArrayBuffer[ApiMessageAndVersion] = ArrayBuffer()
+          getUserScramCredentialRecords(namespace).foreach { 
+            if (!metadataVersion.isScramSupported()) {
+              throw new TerseFailure(s"SCRAM is only supported in metadataVersion IBP_3_5_IV0 or later.");
+            }
+            userScramCredentialRecords => for (record <- userScramCredentialRecords) {
+              metadataRecords.append(new ApiMessageAndVersion(record, 0.toShort))
+            }
+          }
           val ignoreFormatted = namespace.getBoolean("ignore_formatted")
           if (!configToSelfManagedMode(config.get)) {
             throw new TerseFailure("The kafka configuration file appears to be for " +
               "a legacy cluster. Formatting is only supported for clusters in KRaft mode.")
           }
-          Exit.exit(formatCommand(System.out, directories, metaProperties, metadataVersion, ignoreFormatted))
+          Exit.exit(formatCommand(System.out, directories, metaProperties, metadataVersion,
+                                  Some(metadataRecords), ignoreFormatted))
 
         case "random-uuid" =>
           System.out.println(Uuid.randomUuid)
@@ -76,9 +94,9 @@ object StorageTool extends Logging {
 
   def parseArguments(args: Array[String]): Namespace = {
     val parser = ArgumentParsers.
-      newArgumentParser("kafka-storage").
-      defaultHelp(true).
+      newArgumentParser("kafka-storage", /* defaultHelp */ true, /* prefixChars */ "-", /* fromFilePrefix */ "@").
       description("The Kafka storage tool.")
+
     val subparsers = parser.addSubparsers().dest("command")
 
     val infoParser = subparsers.addParser("info").
@@ -96,6 +114,9 @@ object StorageTool extends Logging {
       action(store()).
       required(true).
       help("The cluster ID to use.")
+    formatParser.addArgument("--add-scram", "-S").
+      action(append()).
+      help("Additional Bootstrap Metadata to add to the cluster.")
     formatParser.addArgument("--ignore-formatted", "-g").
       action(storeTrue())
     formatParser.addArgument("--release-version", "-r").
@@ -126,6 +147,108 @@ object StorageTool extends Logging {
     Option(namespace.getString("release_version"))
       .map(ver => MetadataVersion.fromVersionString(ver))
       .getOrElse(defaultValue)
+  }
+
+  def getUserScramCredentialRecord(mechanism: String,
+                                   config: String) : UserScramCredentialRecord = {
+    /*
+     * Remove  '[' amd ']'
+     * Split K->V pairs on ',' and no K or V should contain ','
+     * Split K and V on '=' but V could contain '=' if inside ""
+     * Create Map of K to V and replace all " in V
+     */
+    val argMap = config.substring(1, config.length - 1)
+                       .split(",")
+                       .map(_.split("=(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"))
+                       .map(args => args(0) -> args(1).replaceAll("\"", "")).toMap
+
+    val scramMechanism = ScramMechanism.forMechanismName(mechanism)
+
+    def getName(argMap: Map[String,String]) : String = {
+      if (!argMap.contains("name")) {
+        throw new TerseFailure(s"You must supply 'name' to add-scram")
+      }
+      argMap("name")
+    }
+
+    def getSalt(argMap: Map[String,String], scramMechanism : ScramMechanism) : Array[Byte] = {
+      if (argMap.contains("salt")) {
+        Base64.getDecoder.decode(argMap("salt"))
+      } else {
+        new ScramFormatter(scramMechanism).secureRandomBytes()
+      }
+    }
+
+    def getIterations(argMap: Map[String,String], scramMechanism : ScramMechanism) : Int = {
+      if (argMap.contains("salt")) {
+        val iterations = argMap("iterations").toInt
+        if (iterations < scramMechanism.minIterations()) {
+            throw new TerseFailure(s"The 'iterations' value must be >= ${scramMechanism.minIterations()} for add-scram")
+        }
+        if (iterations > scramMechanism.maxIterations()) {
+            throw new TerseFailure(s"The 'iterations' value must be <= ${scramMechanism.maxIterations()} for add-scram")
+        }
+        iterations
+      } else {
+        4096
+      }
+    }
+
+    def getSaltedPassword(argMap: Map[String,String],
+                          scramMechanism : ScramMechanism,
+                          salt : Array[Byte],
+                          iterations: Int) : Array[Byte] = {
+      if (argMap.contains("password")) {
+        if (argMap.contains("saltedpassword")) {
+            throw new TerseFailure(s"You must only supply one of 'password' or 'saltedpassword' to add-scram")
+        }
+        new ScramFormatter(scramMechanism).saltedPassword(argMap("password"), salt, iterations)
+      } else {
+        if (!argMap.contains("saltedpassword")) {
+            throw new TerseFailure(s"You must supply one of 'password' or 'saltedpassword' to add-scram")
+        }
+        if (!argMap.contains("salt")) {
+            throw new TerseFailure(s"You must supply 'salt' with 'saltedpassword' to add-scram")
+        }
+        Base64.getDecoder.decode(argMap("saltedpassword"))
+      }
+    }
+
+    val name = getName(argMap)
+    val salt = getSalt(argMap, scramMechanism)
+    val iterations = getIterations(argMap, scramMechanism)
+    val saltedPassword = getSaltedPassword(argMap, scramMechanism, salt, iterations)
+
+    val myrecord = new UserScramCredentialRecord()
+                         .setName(name)
+                         .setMechanism(scramMechanism.`type`)
+                         .setSalt(salt)
+                         .setIterations(iterations)
+                         .setSaltedPassword(saltedPassword)
+    myrecord
+  }
+
+  def getUserScramCredentialRecords(namespace: Namespace): Option[ArrayBuffer[UserScramCredentialRecord]] = {
+    if (namespace.getList("add_scram") != null) {
+      val listofAddConfig : List[String] = namespace.getList("add_scram").asScala.toList
+      val userScramCredentialRecords : ArrayBuffer[UserScramCredentialRecord] = ArrayBuffer()
+      for (singleAddConfig <- listofAddConfig) {
+        val singleAddConfigList = singleAddConfig.split("\\s+")
+
+        // The first subarg must be of the form key=value
+        val nameValueRecord = singleAddConfigList(0).split("=", 2)
+        nameValueRecord(0) match {
+          case "SCRAM-SHA-256" =>
+            userScramCredentialRecords.append(getUserScramCredentialRecord(nameValueRecord(0), nameValueRecord(1)))
+          case "SCRAM-SHA-512" =>
+            userScramCredentialRecords.append(getUserScramCredentialRecord(nameValueRecord(0), nameValueRecord(1)))
+          case _ => throw new TerseFailure(s"The add-scram mechanism ${nameValueRecord(0)} is not supported.")
+        }
+      }
+      Some(userScramCredentialRecords)
+    } else {
+      None
+    }
   }
 
   def infoCommand(stream: PrintStream, selfManagedMode: Boolean, directories: Seq[String]): Int = {
@@ -234,10 +357,23 @@ object StorageTool extends Logging {
                     directories: Seq[String],
                     metaProperties: MetaProperties,
                     metadataVersion: MetadataVersion,
+                    metadataOptionalArguments: Option[ArrayBuffer[ApiMessageAndVersion]],
                     ignoreFormatted: Boolean): Int = {
     if (directories.isEmpty) {
       throw new TerseFailure("No log directories found in the configuration.")
+    }:1
+
+    val metadataRecords = new util.ArrayList[ApiMessageAndVersion]
+    metadataRecords.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                        setName(MetadataVersion.FEATURE_NAME).
+                        setFeatureLevel(metadataVersion.featureLevel()), 0.toShort));
+
+    metadataOptionalArguments.foreach { metadataArguments =>
+      for (record <- metadataArguments) metadataRecords.add(record)
     }
+
+    metadataRecords.add(new ApiMessageAndVersion(new NoOpRecord(), 0.toShort));
+
     val unformattedDirectories = directories.filter(directory => {
       if (!Files.isDirectory(Paths.get(directory)) || !Files.exists(Paths.get(directory, "meta.properties"))) {
           true
@@ -262,7 +398,7 @@ object StorageTool extends Logging {
       val checkpoint = new BrokerMetadataCheckpoint(metaPropertiesPath.toFile)
       checkpoint.write(metaProperties.toProperties)
 
-      val bootstrapMetadata = BootstrapMetadata.fromVersion(metadataVersion, "format command")
+      val bootstrapMetadata = new BootstrapMetadata(metadataRecords, metadataVersion, "format command")
       val bootstrapDirectory = new BootstrapDirectory(directory, Optional.empty())
       bootstrapDirectory.writeBinaryFile(bootstrapMetadata)
 

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -397,6 +397,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                             JavaConverters.asScalaBuffer(Collections.singletonList(metadataLogDir)).toSeq(),
                             properties,
                             MetadataVersion.MINIMUM_BOOTSTRAP_VERSION,
+                            scala.Option.apply(null),
                             false);
                 } finally {
                     for (String line : stream.toString().split(String.format("%n"))) {

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -279,7 +279,7 @@ abstract class QuorumTestHarness extends Logging {
     var out: PrintStream = null
     try {
       out = new PrintStream(stream)
-      if (StorageTool.formatCommand(out, directories, metaProperties, metadataVersion, ignoreFormatted = false) != 0) {
+      if (StorageTool.formatCommand(out, directories, metaProperties, metadataVersion, None, ignoreFormatted = false) != 0) {
         throw new RuntimeException(stream.toString())
       }
       debug(s"Formatted storage directory(ies) ${directories}")

--- a/metadata/src/main/java/org/apache/kafka/metadata/bootstrap/BootstrapMetadata.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/bootstrap/BootstrapMetadata.java
@@ -73,7 +73,7 @@ public class BootstrapMetadata {
         return Optional.empty();
     }
 
-    BootstrapMetadata(
+    public BootstrapMetadata(
         List<ApiMessageAndVersion> records,
         MetadataVersion metadataVersion,
         String source


### PR DESCRIPTION
Implement KIP-900

Update kafka-storage to be able to add SCRAM records to the bootstrap metadata file at format time so that SCRAM is enabled at initial start of KRaft cluster.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
