### PR TITLE
MINOR: Update gradle to 8.0.2 and update several gradle plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,17 +31,17 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.44.0'
+  id 'com.github.ben-manes.versions' version '0.46.0'
   id 'idea'
   id 'java-library'
-  id 'org.owasp.dependencycheck' version '8.0.2'
+  id 'org.owasp.dependencycheck' version '8.1.2'
   id 'org.nosphere.apache.rat' version "0.8.0"
-  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.0"
+  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.8"
 
   id "com.github.spotbugs" version '5.0.13' apply false
-  id 'org.gradle.test-retry' version '1.5.1' apply false
+  id 'org.gradle.test-retry' version '1.5.2' apply false
   id 'org.scoverage' version '7.0.1' apply false
-  id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
+  id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -681,11 +681,8 @@ subprojects {
     }
 
     // Scalac 2.12 `-release` requires Java 9 or higher, but Scala 2.13 doesn't have that restriction
-    if (versions.baseScala == "2.13")
-      scalaCompileOptions.additionalParameters += ["-release:" + minJavaVersion] // Use `:` here to workaround Gradle bug (see https://github.com/gradle/gradle/issues/23962#issuecomment-1437348400)
-    else if (JavaVersion.current().isJava9Compatible())
-      scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)] // Don't use `:` here as it breaks compilation with Scala 2.12
-
+    if (versions.baseScala == "2.13" || JavaVersion.current().isJava9Compatible())
+      scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
 
     configure(scalaCompileOptions.forkOptions) {
       memoryMaximumSize = defaultMaxHeapSize

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,7 +62,7 @@ versions += [
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   dropwizardMetrics: "4.1.12.1",
-  gradle: "8.0.1",
+  gradle: "8.0.2",
   grgit: "4.1.1",
   httpclient: "4.5.13",
   easymock: "4.3",
@@ -124,7 +124,7 @@ versions += [
   spotbugs: "4.7.3",
   swaggerAnnotations: "2.2.0",
   swaggerJaxrs2: "2.2.0",
-  zinc: "1.7.2",
+  zinc: "1.8.0",
   zookeeper: "3.6.4",
   zstd: "1.5.2-1"
 ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha=948d1e4ccc2f6ae36cbfa087d827aaca51403acae5411e664a6000bb47946f22
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionSha=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -118,7 +118,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.0.1/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.0.2/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5


### PR DESCRIPTION
Also removed workaround from `build.gradle` that is no longer required after
the update to Gradle 8.0.2.

Related links:
 - zinc release notes:   https://github.com/sbt/zinc/releases/tag/v1.8.0
 - gradle release notes: https://github.com/gradle/gradle/releases/tag/v8.0.2
 - gradle diff:          https://github.com/gradle/gradle/compare/v8.0.1...v8.0.2

plugins version upgrade details:
 - 'com.github.ben-manes.versions'              0.44.0 -> 0.46.0
 - 'org.owasp.dependencycheck'                     8.0.2 -> 8.1.2
 - 'io.swagger.core.v3.swagger-gradle-plugin' 2.2.0 -> 2.2.8
 - 'org.gradle.test-retry'                                    1.5.1 -> 1.5.2
 - 'com.github.johnrengelman.shadow'           7.1.2 -> 8.1.0

FYI @ijuma 