### PR TITLE
MINOR: Parse file offset of Remote Index as Long type instead of Int type in RemoteIndexCache

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -133,7 +133,7 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
 
       // Create entries for each path if all the index files exist.
       val firstIndex = name.indexOf('_')
-      val offset = name.substring(0, firstIndex).toInt
+      val offset = name.substring(0, firstIndex).toLong
       val uuid = Uuid.fromString(name.substring(firstIndex + 1, name.lastIndexOf('_')))
 
       if(!entries.containsKey(uuid)) {


### PR DESCRIPTION
Parse the file offset of Remote Index as long type instead of Int type, otherwise overflow will occur.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
