### PR TITLE
MINOR: use built-in "--rerun" to replace "-Prerun-tests"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew integrationTest
     
 ### Force re-running tests without code change ###
-    ./gradlew -Prerun-tests test
-    ./gradlew -Prerun-tests unitTest
-    ./gradlew -Prerun-tests integrationTest
+    ./gradlew test --rerun
+    ./gradlew unitTest --rerun
+    ./gradlew integrationTest --rerun
 
 ### Running a particular unit/integration test ###
     ./gradlew clients:test --tests RequestResponseTest
 
 ### Repeatedly running a particular unit/integration test ###
-    I=0; while ./gradlew clients:test -Prerun-tests --tests RequestResponseTest --fail-fast; do (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done
+    I=0; while ./gradlew clients:test --tests RequestResponseTest --rerun --fail-fast; do (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done
 
 ### Running a particular test method within a unit/integration test ###
     ./gradlew core:test --tests kafka.api.ProducerFailureHandlingTest.testCannotSendToInternalTopic

--- a/build.gradle
+++ b/build.gradle
@@ -437,11 +437,6 @@ subprojects {
       maxRetries = userMaxTestRetries
       maxFailures = userMaxTestRetryFailures
     }
-
-    // Allows devs to run tests in a loop to debug flaky tests. See README.
-    if (project.hasProperty("rerun-tests")) {
-      outputs.upToDateWhen { false }
-    }
   }
 
   task integrationTest(type: Test, dependsOn: compileJava) {
@@ -487,11 +482,6 @@ subprojects {
       maxRetries = userMaxTestRetries
       maxFailures = userMaxTestRetryFailures
     }
-
-    // Allows devs to run tests in a loop to debug flaky tests. See README.
-    if (project.hasProperty("rerun-tests")) {
-      outputs.upToDateWhen { false }
-    }
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {
@@ -534,11 +524,6 @@ subprojects {
     retry {
       maxRetries = userMaxTestRetries
       maxFailures = userMaxTestRetryFailures
-    }
-
-    // Allows devs to run tests in a loop to debug flaky tests. See README.
-    if (project.hasProperty("rerun-tests")) {
-      outputs.upToDateWhen { false }
     }
   }
 


### PR DESCRIPTION
related to https://github.com/apache/kafka/pull/13288#issuecomment-1455134690

#11926 added custom flag `-Prerun-tests` to re-run tests without recompilation. The function is duplicate to built-in flag `--rerun`. We don't need to have more custom tasks. The built-in task `--rerun` is good to test flaky test without recompilation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
