### PR TITLE
KAFKA-14770: Allow dynamic keystore update for brokers if string representation of DN matches even if canonical DNs don't match

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -312,7 +312,13 @@ public class SslFactory implements Reconfigurable, Closeable {
             for (int i = 0; i < newEntries.size(); i++) {
                 CertificateEntries newEntry = newEntries.get(i);
                 CertificateEntries oldEntry = oldEntries.get(i);
-                if (!Objects.equals(newEntry.subjectPrincipal, oldEntry.subjectPrincipal)) {
+                Principal newPrincipal = newEntry.subjectPrincipal;
+                Principal oldPrincipal = oldEntry.subjectPrincipal;
+                // Compare principal objects to compare canonical names (e.g. to ignore leading/trailing whitespaces).
+                // Canonical names may differ if the tags of a field changes from one with a printable string representation
+                // to one without or vice-versa due to optional conversion to hex representation based on the tag. So we
+                // also compare Principal.getName which compares the RFC2253 name. If either matches, allow dynamic update.
+                if (!Objects.equals(newPrincipal, oldPrincipal) && !newPrincipal.getName().equalsIgnoreCase(oldPrincipal.getName())) {
                     throw new ConfigException(String.format("Keystore DistinguishedName does not match: " +
                         " existing={alias=%s, DN=%s}, new={alias=%s, DN=%s}",
                         oldEntry.alias, oldEntry.subjectPrincipal, newEntry.alias, newEntry.subjectPrincipal));


### PR DESCRIPTION
To avoid mistakes during dynamic broker config updates that could potentially affect clients, we restrict changes that can be performed dynamically without broker restart. For broker keystore updates, we require the DN to be the same for the old and new certificates since this could potentially contain host names used for host name verification by clients. DNs are compared using standard Java implementation of X500Principal.equals() which compares canonical names. If tags of fields change from one with a printable string representation and one without or vice-versa, canonical name check fails even if the actual name is the same since canonical representation converts to hex for some tags only. We can relax the verification to allow dynamic updates in this case by enabling dynamic update if either the canonical name or the RFC2253 string representation of the DN matches.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
