### PR TITLE
KAFKA-14452: Make sticky assignors rack-aware if client rack is configured (KIP-881)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
@@ -101,13 +102,13 @@ public class CooperativeStickyAssignor extends AbstractStickyAssignor {
                 encodedGeneration = Optional.of(DEFAULT_GENERATION);
             }
         }
-        return new MemberData(subscription.ownedPartitions(), encodedGeneration);
+        return new MemberData(subscription.ownedPartitions(), encodedGeneration, subscription.rackId());
     }
 
     @Override
-    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
-                                                    Map<String, Subscription> subscriptions) {
-        Map<String, List<TopicPartition>> assignments = super.assign(partitionsPerTopic, subscriptions);
+    public Map<String, List<TopicPartition>> assignPartitions(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                                              Map<String, Subscription> subscriptions) {
+        Map<String, List<TopicPartition>> assignments = super.assignPartitions(partitionsPerTopic, subscriptions);
 
         Map<TopicPartition, String> partitionsTransferringOwnership = super.partitionsTransferringOwnership == null ?
             computePartitionsTransferringOwnership(subscriptions, assignments) :

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -220,7 +220,7 @@ public class StickyAssignor extends AbstractStickyAssignor {
         // since StickyAssignor is an eager rebalance protocol that will revoke all existing partitions before joining group
         ByteBuffer userData = subscription.userData();
         if (userData == null || !userData.hasRemaining()) {
-            return new MemberData(Collections.emptyList(), Optional.empty());
+            return new MemberData(Collections.emptyList(), Optional.empty(), subscription.rackId());
         }
         return deserializeTopicPartitionAssignment(userData);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -27,16 +28,26 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-
 import org.apache.kafka.clients.consumer.internals.Utils.PartitionComparator;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Sticky assignment implementation used by {@link org.apache.kafka.clients.consumer.StickyAssignor} and
+ * {@link org.apache.kafka.clients.consumer.CooperativeStickyAssignor}. Sticky assignors are rack-aware.
+ * If racks are specified for consumers, we attempt to match consumer racks with partition replica
+ * racks on a best-effort basis, prioritizing balanced assignment over rack alignment. Previously
+ * owned partitions may be reassigned to improve rack locality. We use rack-aware assignment if both
+ * consumer and partition racks are available and some partitions have replicas only on a subset of racks.
+ */
 public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
     private static final Logger log = LoggerFactory.getLogger(AbstractStickyAssignor.class);
 
@@ -61,33 +72,49 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
     public static final class MemberData {
         public final List<TopicPartition> partitions;
         public final Optional<Integer> generation;
-        public MemberData(List<TopicPartition> partitions, Optional<Integer> generation) {
+        public final Optional<String> rackId;
+        public MemberData(List<TopicPartition> partitions, Optional<Integer> generation, Optional<String> rackId) {
             this.partitions = partitions;
             this.generation = generation;
+            this.rackId = rackId;
+        }
+
+        public MemberData(List<TopicPartition> partitions, Optional<Integer> generation) {
+            this(partitions, generation, Optional.empty());
         }
     }
 
     abstract protected MemberData memberData(Subscription subscription);
 
     @Override
-    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
-                                                    Map<String, Subscription> subscriptions) {
+    public Map<String, List<TopicPartition>> assignPartitions(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                                              Map<String, Subscription> subscriptions) {
         Map<String, List<TopicPartition>> consumerToOwnedPartitions = new HashMap<>();
         Set<TopicPartition> partitionsWithMultiplePreviousOwners = new HashSet<>();
+
+        List<PartitionInfo> allPartitions = new ArrayList<>();
+        partitionsPerTopic.values().forEach(allPartitions::addAll);
+        RackInfo rackInfo =  new RackInfo(allPartitions, subscriptions);
+
         AbstractAssignmentBuilder assignmentBuilder;
         if (allSubscriptionsEqual(partitionsPerTopic.keySet(), subscriptions, consumerToOwnedPartitions, partitionsWithMultiplePreviousOwners)) {
             log.debug("Detected that all consumers were subscribed to same set of topics, invoking the "
                           + "optimized assignment algorithm");
             partitionsTransferringOwnership = new HashMap<>();
-            assignmentBuilder = new ConstrainedAssignmentBuilder(partitionsPerTopic, consumerToOwnedPartitions, partitionsWithMultiplePreviousOwners);
+            assignmentBuilder = new ConstrainedAssignmentBuilder(partitionsPerTopic, rackInfo, consumerToOwnedPartitions, partitionsWithMultiplePreviousOwners);
         } else {
             log.debug("Detected that not all consumers were subscribed to same set of topics, falling back to the "
                           + "general case assignment algorithm");
             // we must set this to null for the general case so the cooperative assignor knows to compute it from scratch
             partitionsTransferringOwnership = null;
-            assignmentBuilder = new GeneralAssignmentBuilder(partitionsPerTopic, subscriptions, consumerToOwnedPartitions);
+            assignmentBuilder = new GeneralAssignmentBuilder(partitionsPerTopic, rackInfo, consumerToOwnedPartitions, subscriptions);
         }
         return assignmentBuilder.build();
+    }
+
+    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+                                                    Map<String, Subscription> subscriptions) {
+        return assignPartitions(partitionInfosWithoutRacks(partitionsPerTopic), subscriptions);
     }
 
     /**
@@ -398,17 +425,107 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         }
     }
 
-    private static abstract class AbstractAssignmentBuilder {
+    private class RackInfo {
+        private final Map<String, String> consumerRacks;
+        private final Map<TopicPartition, Set<String>> partitionRacks;
+        private final Map<TopicPartition, Integer> numConsumersByPartition;
 
-        final Map<String, Integer> partitionsPerTopic;
+        public RackInfo(List<PartitionInfo> partitionInfos, Map<String, Subscription> subscriptions) {
+            List<Subscription> consumers = new ArrayList<>(subscriptions.values());
+
+            Map<String, List<String>> consumersByRack = new HashMap<>();
+            subscriptions.forEach((memberId, subscription) ->
+                    subscription.rackId().filter(r -> !r.isEmpty()).ifPresent(rackId -> put(consumersByRack, rackId, memberId)));
+
+            Map<String, List<TopicPartition>> partitionsByRack;
+            Map<TopicPartition, Set<String>> partitionRacks;
+            if (consumersByRack.isEmpty()) {
+                partitionsByRack = Collections.emptyMap();
+                partitionRacks = Collections.emptyMap();
+            } else {
+                partitionRacks = new HashMap<>(partitionInfos.size());
+                partitionsByRack = new HashMap<>();
+                partitionInfos.forEach(p -> {
+                    TopicPartition tp = new TopicPartition(p.topic(), p.partition());
+                    Set<String> racks = new HashSet<>(p.replicas().length);
+                    partitionRacks.put(tp, racks);
+                    Arrays.stream(p.replicas())
+                            .map(Node::rack)
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .forEach(rackId -> {
+                                put(partitionsByRack, rackId, tp);
+                                racks.add(rackId);
+                            });
+                });
+            }
+
+            if (useRackAwareAssignment(consumersByRack.keySet(), partitionsByRack.keySet(), partitionRacks)) {
+                this.consumerRacks = new HashMap<>(consumers.size());
+                consumersByRack.forEach((rack, rackConsumers) -> rackConsumers.forEach(c -> consumerRacks.put(c, rack)));
+                this.partitionRacks = partitionRacks;
+            } else {
+                this.consumerRacks = Collections.emptyMap();
+                this.partitionRacks = Collections.emptyMap();
+            }
+            numConsumersByPartition = partitionRacks.entrySet().stream()
+                    .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().stream()
+                        .map(r -> consumersByRack.getOrDefault(r, Collections.emptyList()).size())
+                        .reduce(0, Integer::sum)));
+        }
+
+        private boolean racksMismatch(String consumer, TopicPartition tp) {
+            String consumerRack = consumerRacks.get(consumer);
+            Set<String> replicaRacks = partitionRacks.get(tp);
+            return consumerRack != null && (replicaRacks == null || !replicaRacks.contains(consumerRack));
+        }
+
+        private List<TopicPartition> sortPartitionsByRackConsumers(List<TopicPartition> partitions) {
+            if (numConsumersByPartition.isEmpty())
+                return partitions;
+            // Return a sorted linked list of partitions to enable fast updates during rack-aware assignment
+            List<TopicPartition> sortedPartitions = new LinkedList<>(partitions);
+            sortedPartitions.sort(Comparator.comparing(tp -> numConsumersByPartition.getOrDefault(tp, 0)));
+            return sortedPartitions;
+        }
+
+        private int nextRackConsumer(TopicPartition tp, List<String> consumerList, int firstIndex) {
+            Set<String> racks = partitionRacks.get(tp);
+            if (racks == null || racks.isEmpty())
+                return -1;
+            for (int i = 0; i < consumerList.size(); i++) {
+                int index = (firstIndex + i) % consumerList.size();
+                String consumer = consumerList.get(index);
+                String consumerRack = consumerRacks.get(consumer);
+                if (consumerRack != null && racks.contains(consumerRack))
+                    return index;
+            }
+            return -1;
+        }
+
+        @Override
+        public String toString() {
+            return "RackInfo(" +
+                    "consumerRacks=" + consumerRacks +
+                    ", partitionRacks=" + partitionRacks +
+                    ")";
+        }
+    }
+
+    private abstract class AbstractAssignmentBuilder {
+
+        final Map<String, List<PartitionInfo>> partitionsPerTopic;
+        final RackInfo rackInfo;
         final Map<String, List<TopicPartition>> currentAssignment;
         final int totalPartitionsCount;
 
-        AbstractAssignmentBuilder(Map<String, Integer> partitionsPerTopic,
+        AbstractAssignmentBuilder(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                  RackInfo rackInfo,
                                   Map<String, List<TopicPartition>> currentAssignment) {
             this.partitionsPerTopic = partitionsPerTopic;
             this.currentAssignment = currentAssignment;
-            this.totalPartitionsCount = partitionsPerTopic.values().stream().reduce(0, Integer::sum);
+            this.rackInfo = rackInfo;
+            this.totalPartitionsCount = partitionsPerTopic.values().stream().map(List::size).reduce(0, Integer::sum);
         }
 
         /**
@@ -422,10 +539,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             List<TopicPartition> allPartitions = new ArrayList<>(totalPartitionsCount);
 
             for (String topic : sortedAllTopics) {
-                int partitionCount = partitionsPerTopic.get(topic);
-                for (int i = 0; i < partitionCount; ++i) {
-                    allPartitions.add(new TopicPartition(topic, i));
-                }
+                partitionsPerTopic.get(topic).forEach(p -> allPartitions.add(new TopicPartition(p.topic(), p.partition())));
             }
             return allPartitions;
         }
@@ -436,11 +550,15 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
      * The method includes the following steps:
      *
      * 1. Reassign previously owned partitions:
-     *   a. if owned less than minQuota partitions, just assign all owned partitions, and put the member into unfilled member list
+     *   a. if owned less than minQuota partitions, just assign all owned partitions, and put the member into unfilled member list.
      *   b. if owned maxQuota or more, and we're still under the number of expected max capacity members, assign maxQuota partitions
      *   c. if owned at least "minQuota" of partitions, assign minQuota partitions, and put the member into unfilled member list if
      *     we're still under the number of expected max capacity members
-     * 2. Fill remaining members up to the expected numbers of maxQuota partitions, otherwise, to minQuota partitions
+     *   If using rack-aware algorithm, only owned partitions with matching racks are allocated in this step.
+     * 2. Fill remaining members with rack matching up to the expected numbers of maxQuota partitions, otherwise, to minQuota partitions.
+     *    Partitions that cannot be aligned on racks within the quota are not assigned in this step. This step is only used if rack-aware.
+     * 3. Fill remaining members up to the expected numbers of maxQuota partitions, otherwise, to minQuota partitions.
+     *    For rack-aware algorithm, these are partitions that could not be aligned on racks within the balancing constraints.
      *
      */
     private class ConstrainedAssignmentBuilder extends AbstractAssignmentBuilder {
@@ -465,16 +583,18 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         /**
          * Constructs a constrained assignment builder.
          *
-         * @param partitionsPerTopic                   The number of partitions for each subscribed topic
+         * @param partitionsPerTopic                   The partitions for each subscribed topic
+         * @param rackInfo                             Rack information for consumers and racks
          * @param consumerToOwnedPartitions            Each consumer's previously owned and still-subscribed partitions
          * @param partitionsWithMultiplePreviousOwners The partitions being claimed in the previous assignment of multiple consumers
          */
-        ConstrainedAssignmentBuilder(Map<String, Integer> partitionsPerTopic,
+        ConstrainedAssignmentBuilder(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                     RackInfo rackInfo,
                                      Map<String, List<TopicPartition>> consumerToOwnedPartitions,
                                      Set<TopicPartition> partitionsWithMultiplePreviousOwners) {
-            super(partitionsPerTopic, consumerToOwnedPartitions);
-            this.partitionsWithMultiplePreviousOwners = partitionsWithMultiplePreviousOwners;
+            super(partitionsPerTopic, rackInfo, consumerToOwnedPartitions);
 
+            this.partitionsWithMultiplePreviousOwners = partitionsWithMultiplePreviousOwners;
             allRevokedPartitions = new HashSet<>();
             unfilledMembersWithUnderMinQuotaPartitions = new LinkedList<>();
             unfilledMembersWithExactlyMinQuotaPartitions = new LinkedList<>();
@@ -495,8 +615,8 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         @Override
         Map<String, List<TopicPartition>> build() {
             if (log.isDebugEnabled()) {
-                log.debug("Performing constrained assign with partitionsPerTopic: {}, currentAssignment: {}.",
-                        partitionsPerTopic, currentAssignment);
+                log.debug("Performing constrained assign with partitionsPerTopic: {}, currentAssignment: {} rackInfo {}.",
+                        partitionsPerTopic, currentAssignment, rackInfo);
             }
 
             assignOwnedPartitions();
@@ -510,7 +630,9 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
             Collections.sort(unfilledMembersWithUnderMinQuotaPartitions);
             Collections.sort(unfilledMembersWithExactlyMinQuotaPartitions);
+            unassignedPartitions = rackInfo.sortPartitionsByRackConsumers(unassignedPartitions);
 
+            assignRackAwareRoundRobin(unassignedPartitions);
             assignRoundRobin(unassignedPartitions);
             verifyUnfilledMembers();
 
@@ -519,13 +641,14 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             return assignment;
         }
 
-
         // Reassign previously owned partitions, up to the expected number of partitions per consumer
         private void assignOwnedPartitions() {
 
             for (Map.Entry<String, List<TopicPartition>> consumerEntry : currentAssignment.entrySet()) {
                 String consumer = consumerEntry.getKey();
-                List<TopicPartition> ownedPartitions = consumerEntry.getValue();
+                List<TopicPartition> ownedPartitions = consumerEntry.getValue().stream()
+                        .filter(tp -> !rackInfo.racksMismatch(consumer, tp))
+                        .collect(Collectors.toList());
 
                 List<TopicPartition> consumerAssignment = assignment.get(consumer);
 
@@ -571,6 +694,42 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                         unfilledMembersWithExactlyMinQuotaPartitions.add(consumer);
                     }
                 }
+            }
+        }
+
+        // Round-Robin filling within racks for remaining members up to the expected numbers of maxQuota,
+        // otherwise, to minQuota
+        private void assignRackAwareRoundRobin(List<TopicPartition> unassignedPartitions) {
+            int nextUnfilledConsumerIndex = 0;
+            Iterator<TopicPartition> unassignedIter = unassignedPartitions.iterator();
+            while (!rackInfo.consumerRacks.isEmpty() && unassignedIter.hasNext()) {
+                TopicPartition unassignedPartition = unassignedIter.next();
+                String consumer = null;
+                int nextIndex = rackInfo.nextRackConsumer(unassignedPartition, unfilledMembersWithUnderMinQuotaPartitions, nextUnfilledConsumerIndex);
+                if (nextIndex >= 0) {
+                    consumer = unfilledMembersWithUnderMinQuotaPartitions.get(nextIndex);
+                    int assignmentCount = assignment.get(consumer).size() + 1;
+                    if (assignmentCount >= minQuota) {
+                        unfilledMembersWithUnderMinQuotaPartitions.remove(consumer);
+                        if (assignmentCount < maxQuota)
+                            unfilledMembersWithExactlyMinQuotaPartitions.add(consumer);
+                    } else {
+                        nextIndex++;
+                    }
+                    nextUnfilledConsumerIndex = unfilledMembersWithUnderMinQuotaPartitions.isEmpty() ? 0 : nextIndex % unfilledMembersWithUnderMinQuotaPartitions.size();
+                } else if (!unfilledMembersWithExactlyMinQuotaPartitions.isEmpty()) {
+                    int firstIndex = rackInfo.nextRackConsumer(unassignedPartition, unfilledMembersWithExactlyMinQuotaPartitions, 0);
+                    if (firstIndex >= 0) {
+                        consumer = unfilledMembersWithExactlyMinQuotaPartitions.get(firstIndex);
+                        if (assignment.get(consumer).size() + 1 == maxQuota)
+                            unfilledMembersWithExactlyMinQuotaPartitions.remove(firstIndex);
+                    }
+                }
+                if (consumer == null)
+                    continue;
+
+                assignNewPartition(unassignedPartition, consumer);
+                unassignedIter.remove();
             }
         }
 
@@ -653,7 +812,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                                     "and no more partitions to be assigned", unfilledMember));
                         } else {
                             log.trace("skip over this unfilled member: [{}] because we've reached the expected number of " +
-                                    "members with more than the minQuota partitions, and this member already have minQuota partitions", unfilledMember);
+                                    "members with more than the minQuota partitions, and this member already has minQuota partitions", unfilledMember);
                         }
                     }
                 }
@@ -693,7 +852,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             TopicPartition nextAssignedPartition = sortedAssignedPartitionsIter.next();
 
             for (String topic : sortedAllTopics) {
-                int partitionCount = partitionsPerTopic.get(topic);
+                int partitionCount = partitionsPerTopic.get(topic).size();
                 for (int i = 0; i < partitionCount; i++) {
                     if (shouldAddDirectly || !(nextAssignedPartition.topic().equals(topic) && nextAssignedPartition.partition() == i)) {
                         unassignedPartitions.add(new TopicPartition(topic, i));
@@ -717,11 +876,17 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
      * This general assignment algorithm guarantees the assignment that is as balanced as possible.
      * This method includes the following steps:
      *
-     * 1. Preserving all the existing partition assignments
-     * 2. Removing all the partition assignments that have become invalid due to the change that triggers the reassignment
-     * 3. Assigning the unassigned partitions in a way that balances out the overall assignments of partitions to consumers
-     * 4. Further balancing out the resulting assignment by finding the partitions that can be reassigned
-     *    to another consumer towards an overall more balanced assignment.
+     * 1. Preserving all the existing partition assignments. If rack-aware algorithm is used, only assignments
+     *    within racks are preserved.
+     * 2. Removing all the partition assignments that have become invalid due to the change that triggers the reassignment.
+     *    Partition assignments with mismatched racks are also removed.
+     * 3. Assigning the unassigned partitions in a way that balances out the overall assignments of partitions to consumers.
+     *    while preserving rack-alignment. This step is used only for rack-aware assignment.
+     * 4. Assigning the remaining unassigned partitions in a way that balances out the overall assignments of partitions to consumers.
+     *    For rack-aware algorithm, these are partitions that could not be aligned on racks within the balancing constraints.
+     * 5. Further balancing out the resulting assignment by finding the partitions that can be reassigned
+     *    to another consumer towards an overall more balanced assignment. For rack-aware algorithm, attempt
+     *    to retain rack alignment if possible.
      *
      */
     private class GeneralAssignmentBuilder extends AbstractAssignmentBuilder {
@@ -741,14 +906,16 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         /**
          * Constructs a general assignment builder.
          *
-         * @param partitionsPerTopic         The number of partitions for each subscribed topic.
+         * @param partitionsPerTopic         The partitions for each subscribed topic.
          * @param subscriptions              Map from the member id to their respective topic subscription
          * @param currentAssignment          Each consumer's previously owned and still-subscribed partitions
+         * @param rackInfo                   Rack information for consumers and partitions
          */
-        GeneralAssignmentBuilder(Map<String, Integer> partitionsPerTopic,
-                                 Map<String, Subscription> subscriptions,
-                                 Map<String, List<TopicPartition>> currentAssignment) {
-            super(partitionsPerTopic, currentAssignment);
+        GeneralAssignmentBuilder(Map<String, List<PartitionInfo>> partitionsPerTopic,
+                                 RackInfo rackInfo,
+                                 Map<String, List<TopicPartition>> currentAssignment,
+                                 Map<String, Subscription> subscriptions) {
+            super(partitionsPerTopic, rackInfo, currentAssignment);
             this.subscriptions = subscriptions;
 
             topic2AllPotentialConsumers = new HashMap<>(partitionsPerTopic.keySet().size());
@@ -786,13 +953,12 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         @Override
         Map<String, List<TopicPartition>> build() {
             if (log.isDebugEnabled()) {
-                log.debug("performing general assign. partitionsPerTopic: {}, subscriptions: {}, currentAssignment: {}",
-                        partitionsPerTopic, subscriptions, currentAssignment);
+                log.debug("performing general assign. partitionsPerTopic: {}, subscriptions: {}, currentAssignment: {}, rackInfo: {}",
+                        partitionsPerTopic, subscriptions, currentAssignment, rackInfo);
             }
 
             Map<TopicPartition, ConsumerGenerationPair> prevAssignment = new HashMap<>();
             partitionMovements = new PartitionMovements();
-
             prepopulateCurrentAssignments(prevAssignment);
 
             // the partitions already assigned in current assignment
@@ -821,7 +987,8 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             List<TopicPartition> assignedPartitions = new ArrayList<>();
             for (Iterator<Entry<String, List<TopicPartition>>> it = currentAssignment.entrySet().iterator(); it.hasNext();) {
                 Map.Entry<String, List<TopicPartition>> entry = it.next();
-                Subscription consumerSubscription = subscriptions.get(entry.getKey());
+                String consumer = entry.getKey();
+                Subscription consumerSubscription = subscriptions.get(consumer);
                 if (consumerSubscription == null) {
                     // if a consumer that existed before (and had some partition assignments) is now removed, remove it from currentAssignment
                     for (TopicPartition topicPartition: entry.getValue())
@@ -835,7 +1002,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                             // if this topic partition of this consumer no longer exists, remove it from currentAssignment of the consumer
                             partitionIter.remove();
                             currentPartitionConsumer.remove(partition);
-                        } else if (!consumerSubscription.topics().contains(partition.topic())) {
+                        } else if (!consumerSubscription.topics().contains(partition.topic()) || rackInfo.racksMismatch(consumer, partition)) {
                             // because the consumer is no longer subscribed to its topic, remove it from currentAssignment of the consumer
                             partitionIter.remove();
                             revocationRequired = true;
@@ -950,7 +1117,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         /**
          * determine if the current assignment is a balanced one
          *
-         * @return  true if the given assignment is balanced; false otherwise
+         * @return true if the given assignment is balanced; false otherwise
          */
         private boolean isBalanced() {
             int min = currentAssignment.get(sortedCurrentSubscriptions.first()).size();
@@ -986,7 +1153,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
                 // otherwise make sure it cannot get any more
                 for (String topic: allSubscribedTopics) {
-                    int partitionCount = partitionsPerTopic.get(topic);
+                    int partitionCount = partitionsPerTopic.get(topic).size();
                     for (int i = 0; i < partitionCount; i++) {
                         TopicPartition topicPartition = new TopicPartition(topic, i);
                         if (!currentAssignment.get(consumer).contains(topicPartition)) {
@@ -1015,7 +1182,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
             if (allSubscribedTopics.size() == partitionsPerTopic.size()) {
                 maxAssignmentSize = totalPartitionsCount;
             } else {
-                maxAssignmentSize = allSubscribedTopics.stream().map(partitionsPerTopic::get).reduce(0, Integer::sum);
+                maxAssignmentSize = allSubscribedTopics.stream().map(partitionsPerTopic::get).map(List::size).reduce(0, Integer::sum);
             }
             return maxAssignmentSize;
         }
@@ -1047,28 +1214,36 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         /**
          * The assignment should improve the overall balance of the partition assignments to consumers.
          */
-        private void assignPartition(TopicPartition partition) {
+        private boolean maybeAssignPartition(TopicPartition partition, RackInfo rackInfo) {
             for (String consumer: sortedCurrentSubscriptions) {
-                if (consumer2AllPotentialTopics.get(consumer).contains(partition.topic())) {
+                if (consumer2AllPotentialTopics.get(consumer).contains(partition.topic()) && (rackInfo == null || !rackInfo.racksMismatch(consumer, partition))) {
                     sortedCurrentSubscriptions.remove(consumer);
                     currentAssignment.get(consumer).add(partition);
                     currentPartitionConsumer.put(partition, consumer);
                     sortedCurrentSubscriptions.add(consumer);
-                    break;
+                    return true;
                 }
             }
+            return false;
         }
 
-
-        // assign all unassigned partitions
-        private void assign(List<TopicPartition> unassignedPartitions) {
+        /**
+         * attempt to assign all unassigned partitions
+         *
+         * @param unassignedPartitions partitions that are still unassigned
+         * @param rackInfo             rack information used to match racks. If null, no rack-matching is performed
+         * @param removeAssigned       flag that indicates if assigned partitions should be removed from `unassignedPartitions`
+         */
+        private void maybeAssign(List<TopicPartition> unassignedPartitions, RackInfo rackInfo, boolean removeAssigned) {
             // assign all unassigned partitions
-            for (TopicPartition partition: unassignedPartitions) {
+            for (Iterator<TopicPartition> iter = unassignedPartitions.iterator(); iter.hasNext();) {
+                TopicPartition partition = iter.next();
                 // skip if there is no potential consumer for the topic
                 if (topic2AllPotentialConsumers.get(partition.topic()).isEmpty())
                     continue;
 
-                assignPartition(partition);
+                if (maybeAssignPartition(partition, rackInfo) && removeAssigned)
+                    iter.remove();
             }
         }
 
@@ -1100,19 +1275,25 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         }
 
         /**
-         * Balance the current assignment using the data structures created in the assign(...) method above.
+         * Balance the current assignment using the data structures created in the assignPartitions(...) method above.
          */
         private void balance(Map<TopicPartition, ConsumerGenerationPair> prevAssignment,
                              List<TopicPartition> unassignedPartitions) {
             boolean initializing = currentAssignment.get(sortedCurrentSubscriptions.last()).isEmpty();
 
-            assign(unassignedPartitions);
+            // First assign with rack matching and then assign any remaining without rack matching
+            List<TopicPartition> partitionsToAssign = unassignedPartitions;
+            if (!rackInfo.consumerRacks.isEmpty()) {
+                partitionsToAssign = new LinkedList<>(unassignedPartitions);
+                maybeAssign(partitionsToAssign, rackInfo, true);
+            }
+            maybeAssign(partitionsToAssign, null, false);
 
             // narrow down the reassignment scope to only those partitions that can actually be reassigned
             Set<TopicPartition> fixedPartitions = new HashSet<>();
             for (String topic: topic2AllPotentialConsumers.keySet())
                 if (!canTopicParticipateInReassignment(topic)) {
-                    for (int i = 0; i < partitionsPerTopic.get(topic); i++) {
+                    for (int i = 0; i < partitionsPerTopic.get(topic).size(); i++) {
                         fixedPartitions.add(new TopicPartition(topic, i));
                     }
                 }
@@ -1188,12 +1369,32 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                     }
 
                     // check if a better-suited consumer exist for the partition; if so, reassign it
-                    for (String otherConsumer: topic2AllPotentialConsumers.get(partition.topic())) {
-                        if (currentAssignment.get(consumer).size() > currentAssignment.get(otherConsumer).size() + 1) {
-                            reassignPartition(partition);
-                            reassignmentPerformed = true;
-                            modified = true;
-                            break;
+                    // Use consumer within rack if possible
+                    String consumerRack = rackInfo.consumerRacks.get(consumer);
+                    Set<String> partitionRacks = rackInfo.partitionRacks.get(partition);
+                    boolean foundRackConsumer = false;
+                    if (consumerRack != null && !partitionRacks.isEmpty() && partitionRacks.contains(consumerRack)) {
+                        for (String otherConsumer : topic2AllPotentialConsumers.get(partition.topic())) {
+                            String otherConsumerRack = rackInfo.consumerRacks.get(otherConsumer);
+                            if (otherConsumerRack == null || !partitionRacks.contains(otherConsumerRack))
+                                continue;
+                            if (currentAssignment.get(consumer).size() > currentAssignment.get(otherConsumer).size() + 1) {
+                                reassignPartition(partition);
+                                reassignmentPerformed = true;
+                                modified = true;
+                                foundRackConsumer = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!foundRackConsumer) {
+                        for (String otherConsumer : topic2AllPotentialConsumers.get(partition.topic())) {
+                            if (currentAssignment.get(consumer).size() > currentAssignment.get(otherConsumer).size() + 1) {
+                                reassignPartition(partition);
+                                reassignmentPerformed = true;
+                                modified = true;
+                                break;
+                            }
                         }
                     }
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -73,6 +73,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         public final List<TopicPartition> partitions;
         public final Optional<Integer> generation;
         public final Optional<String> rackId;
+
         public MemberData(List<TopicPartition> partitions, Optional<Integer> generation, Optional<String> rackId) {
             this.partitions = partitions;
             this.generation = generation;
@@ -727,11 +728,11 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                             unfilledMembersWithExactlyMinQuotaPartitions.remove(firstIndex);
                     }
                 }
-                if (consumer == null)
-                    continue;
 
-                assignNewPartition(unassignedPartition, consumer);
-                unassignedIter.remove();
+                if (consumer != null) {
+                    assignNewPartition(unassignedPartition, consumer);
+                    unassignedIter.remove();
+                }
             }
         }
 
@@ -1005,7 +1006,8 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                             partitionIter.remove();
                             currentPartitionConsumer.remove(partition);
                         } else if (!consumerSubscription.topics().contains(partition.topic()) || rackInfo.racksMismatch(consumer, partition)) {
-                            // because the consumer is no longer subscribed to its topic, remove it from currentAssignment of the consumer
+                            // if the consumer is no longer subscribed to its topic or if racks don't match for rack-aware assignment,
+                            // remove it from currentAssignment of the consumer
                             partitionIter.remove();
                             revocationRequired = true;
                         } else {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -94,7 +94,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
         List<PartitionInfo> allPartitions = new ArrayList<>();
         partitionsPerTopic.values().forEach(allPartitions::addAll);
-        RackInfo rackInfo =  new RackInfo(allPartitions, subscriptions);
+        RackInfo rackInfo = new RackInfo(allPartitions, subscriptions);
 
         AbstractAssignmentBuilder assignmentBuilder;
         if (allSubscriptionsEqual(partitionsPerTopic.keySet(), subscriptions, consumerToOwnedPartitions, partitionsWithMultiplePreviousOwners)) {
@@ -615,7 +615,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         @Override
         Map<String, List<TopicPartition>> build() {
             if (log.isDebugEnabled()) {
-                log.debug("Performing constrained assign with partitionsPerTopic: {}, currentAssignment: {} rackInfo {}.",
+                log.debug("Performing constrained assign with partitionsPerTopic: {}, currentAssignment: {}, rackInfo {}.",
                         partitionsPerTopic, currentAssignment, rackInfo);
             }
 
@@ -700,9 +700,11 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
         // Round-Robin filling within racks for remaining members up to the expected numbers of maxQuota,
         // otherwise, to minQuota
         private void assignRackAwareRoundRobin(List<TopicPartition> unassignedPartitions) {
+            if (rackInfo.consumerRacks.isEmpty())
+                return;
             int nextUnfilledConsumerIndex = 0;
             Iterator<TopicPartition> unassignedIter = unassignedPartitions.iterator();
-            while (!rackInfo.consumerRacks.isEmpty() && unassignedIter.hasNext()) {
+            while (unassignedIter.hasNext()) {
                 TopicPartition unassignedPartition = unassignedIter.next();
                 String consumer = null;
                 int nextIndex = rackInfo.nextRackConsumer(unassignedPartition, unfilledMembersWithUnderMinQuotaPartitions, nextUnfilledConsumerIndex);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -24,18 +24,31 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.StickyAssignor;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.RackConfig;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_RACK_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.TEST_NAME_WITH_CONSUMER_RACK;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.nullRacks;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.racks;
+import static org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignorTest.verifyRackAssignment;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -62,16 +75,21 @@ public abstract class AbstractStickyAssignorTest {
     protected String groupId = "group";
     protected int generationId = 1;
 
+    protected int numBrokerRacks;
+    protected boolean hasConsumerRack;
+    protected int replicationFactor = 2;
+    private int nextPartitionIndex;
+
     protected abstract AbstractStickyAssignor createAssignor();
 
     // simulate ConsumerProtocolSubscription V0 protocol
-    protected abstract Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId);
+    protected abstract Subscription buildSubscriptionV0(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex);
 
     // simulate ConsumerProtocolSubscription V1 protocol
-    protected abstract Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId);
+    protected abstract Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex);
 
     // simulate ConsumerProtocolSubscription V2 or above protocol
-    protected abstract Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generation);
+    protected abstract Subscription buildSubscriptionV2Above(List<String> topics, List<TopicPartition> partitions, int generation, int consumerIndex);
 
     protected abstract ByteBuffer generateUserData(List<String> topics, List<TopicPartition> partitions, int generation);
 
@@ -92,9 +110,9 @@ public abstract class AbstractStickyAssignorTest {
         List<TopicPartition> ownedPartitions = partitions(tp(topic1, 0), tp(topic2, 1));
         List<Subscription> subscriptions = new ArrayList<>();
         // add subscription in all ConsumerProtocolSubscription versions
-        subscriptions.add(buildSubscriptionV0(topics, ownedPartitions, generationId));
-        subscriptions.add(buildSubscriptionV1(topics, ownedPartitions, generationId));
-        subscriptions.add(buildSubscriptionV2Above(topics, ownedPartitions, generationId));
+        subscriptions.add(buildSubscriptionV0(topics, ownedPartitions, generationId, 0));
+        subscriptions.add(buildSubscriptionV1(topics, ownedPartitions, generationId, 1));
+        subscriptions.add(buildSubscriptionV2Above(topics, ownedPartitions, generationId, 2));
         for (Subscription subscription : subscriptions) {
             if (subscription != null) {
                 AbstractStickyAssignor.MemberData memberData = assignor.memberData(subscription);
@@ -104,12 +122,14 @@ public abstract class AbstractStickyAssignorTest {
         }
     }
 
-    @Test
-    public void testOneConsumerNoTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(Collections.emptyList()));
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testOneConsumerNoTopic(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        subscriptions = Collections.singletonMap(consumerId, subscription(Collections.emptyList(), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(assignment.get(consumerId).isEmpty());
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -118,13 +138,15 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOneConsumerNonexistentTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 0);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testOneConsumerNonexistentTopic(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, Collections.emptyList());
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(assignment.get(consumerId).isEmpty());
@@ -134,13 +156,15 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOneConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOneConsumerOneTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
@@ -148,21 +172,23 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOnlyAssignsPartitionsFromSubscribedTopics() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOnlyAssignsPartitionsFromSubscribedTopics(RackConfig rackConfig) {
         String otherTopic = "other";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 2));
         subscriptions = mkMap(
                 mkEntry(consumerId, buildSubscriptionV2Above(
                         topics(topic),
                         Arrays.asList(tp(topic, 0), tp(topic, 1), tp(otherTopic, 0), tp(otherTopic, 1)),
-                        generationId)
+                        generationId, 0)
                 )
         );
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumerId));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
@@ -170,14 +196,16 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOneConsumerMultipleTopics() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOneConsumerMultipleTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 1));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 2));
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic1, topic2), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerId));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
@@ -185,30 +213,34 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testTwoConsumersOneTopicOnePartition() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersOneTopicOnePartition(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 1));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testTwoConsumersOneTopicTwoPartitions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersOneTopicTwoPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 2));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 1)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -217,17 +249,19 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testMultipleConsumersMixedTopicSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMultipleConsumersMixedTopicSubscriptions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 2));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic1)));
-        subscriptions.put(consumer2, new Subscription(topics(topic1, topic2)));
-        subscriptions.put(consumer3, new Subscription(topics(topic1)));
+        subscriptions.put(consumer1, subscription(topics(topic1), 0));
+        subscriptions.put(consumer2, subscription(topics(topic1, topic2), 1));
+        subscriptions.put(consumer3, subscription(topics(topic1), 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic1, 1)), assignment.get(consumer3));
@@ -237,16 +271,18 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testTwoConsumersTwoTopicsSixPartitions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testTwoConsumersTwoTopicsSixPartitions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic1, topic2)));
-        subscriptions.put(consumer2, new Subscription(topics(topic1, topic2)));
+        subscriptions.put(consumer1, subscription(topics(topic1, topic2), 0));
+        subscriptions.put(consumer2, subscription(topics(topic1, topic2), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -258,20 +294,22 @@ public abstract class AbstractStickyAssignorTest {
     /**
      * This unit test is testing consumer owned minQuota partitions, and expected to have maxQuota partitions situation
      */
-    @Test
-    public void testConsumerOwningMinQuotaExpectedMaxQuota() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testConsumerOwningMinQuotaExpectedMaxQuota(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         List<String> subscribedTopics = topics(topic1, topic2);
 
         subscriptions.put(consumer1,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 1)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 1)), generationId, 0));
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 2)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 2)), generationId, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic2, 1), tp(topic2, 0)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 2)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -283,21 +321,23 @@ public abstract class AbstractStickyAssignorTest {
     /**
      * This unit test is testing consumers owned maxQuota partitions are more than numExpectedMaxCapacityMembers situation
      */
-    @Test
-    public void testMaxQuotaConsumerMoreThanNumExpectedMaxCapacityMembers() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
-        partitionsPerTopic.put(topic2, 2);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMaxQuotaConsumerMoreThanNumExpectedMaxCapacityMembers(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 2));
 
         List<String> subscribedTopics = topics(topic1, topic2);
 
         subscriptions.put(consumer1,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 0)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0), tp(topic2, 0)), generationId, 0));
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 1)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1), tp(topic2, 1)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singletonMap(tp(topic2, 0), consumer3), assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -311,21 +351,23 @@ public abstract class AbstractStickyAssignorTest {
     /**
      * This unit test is testing all consumers owned less than minQuota partitions situation
      */
-    @Test
-    public void testAllConsumersAreUnderMinQuota() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 2);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersAreUnderMinQuota(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 2));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         List<String> subscribedTopics = topics(topic1, topic2);
 
         subscriptions.put(consumer1,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0)), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 0)), generationId, 0));
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId));
+            buildSubscriptionV2Above(subscribedTopics, partitions(tp(topic1, 1)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(subscribedTopics, Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -336,21 +378,23 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testAddRemoveConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAddRemoveConsumerOneTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumer1));
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(isFullyBalanced(assignment));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId, 1));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(Collections.singletonMap(tp(topic, 2), consumer2), assignor.partitionsTransferringOwnership);
 
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -359,8 +403,8 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
 
         subscriptions.remove(consumer1);
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), assignment.get(consumer2), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), assignment.get(consumer2), generationId, 1));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 2), tp(topic, 1), tp(topic, 0))),
             new HashSet<>(assignment.get(consumer2)));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -369,17 +413,19 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testAddRemoveTwoConsumersTwoTopics() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAddRemoveTwoConsumersTwoTopics(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         List<String> allTopics = topics(topic1, topic2);
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 4);
-        subscriptions.put(consumer1, new Subscription(allTopics));
-        subscriptions.put(consumer2, new Subscription(allTopics));
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 4));
+        subscriptions.put(consumer1, subscription(allTopics, 0));
+        subscriptions.put(consumer2, subscription(allTopics, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1), tp(topic2, 3)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -388,11 +434,11 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
 
         // add 2 consumers
-        subscriptions.put(consumer1, buildSubscriptionV2Above(allTopics, assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, assignment.get(consumer2), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId));
-        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer1, buildSubscriptionV2Above(allTopics, assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(allTopics, assignment.get(consumer2), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId, 2));
+        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, Collections.emptyList(), generationId, 3));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         Map<TopicPartition, String> expectedPartitionsTransferringOwnership = new HashMap<>();
         expectedPartitionsTransferringOwnership.put(tp(topic2, 1), consumer3);
@@ -410,9 +456,9 @@ public abstract class AbstractStickyAssignorTest {
         // remove 2 consumers
         subscriptions.remove(consumer1);
         subscriptions.remove(consumer2);
-        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, assignment.get(consumer3), generationId));
-        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, assignment.get(consumer4), generationId));
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        subscriptions.put(consumer3, buildSubscriptionV2Above(allTopics, assignment.get(consumer3), generationId, 2));
+        subscriptions.put(consumer4, buildSubscriptionV2Above(allTopics, assignment.get(consumer4), generationId, 3));
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic2, 1), tp(topic2, 3), tp(topic1, 0), tp(topic2, 0)), assignment.get(consumer3));
         assertEquals(partitions(tp(topic2, 2), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer4));
 
@@ -441,33 +487,39 @@ public abstract class AbstractStickyAssignorTest {
      *  - consumer3: topic1-1, topic5-0
      *  - consumer4: topic4-0, topic5-1
      */
-    @Test
-    public void testPoorRoundRobinAssignmentScenario() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i <= 5; i++)
-            partitionsPerTopic.put(String.format("topic%d", i), (i % 2) + 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testPoorRoundRobinAssignmentScenario(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            String topicName = String.format("topic%d", i);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, (i % 2) + 1));
+        }
 
         subscriptions.put("consumer1",
-            new Subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5")));
+            subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5"), 0));
         subscriptions.put("consumer2",
-            new Subscription(topics("topic1", "topic3", "topic5")));
+            subscription(topics("topic1", "topic3", "topic5"), 1));
         subscriptions.put("consumer3",
-            new Subscription(topics("topic1", "topic3", "topic5")));
+            subscription(topics("topic1", "topic3", "topic5"), 2));
         subscriptions.put("consumer4",
-            new Subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5")));
+            subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5"), 3));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test
-    public void testAddRemoveTopicTwoConsumers() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumer1, new Subscription(topics(topic)));
-        subscriptions.put(consumer2, new Subscription(topics(topic)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAddRemoveTopicTwoConsumers(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumer1, subscription(topics(topic), 0));
+        subscriptions.put(consumer2, subscription(topics(topic), 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         assertTrue(isFullyBalanced(assignment));
@@ -478,11 +530,11 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue((consumer1Assignment1.size() == 1 && consumer2Assignment1.size() == 2) ||
             (consumer1Assignment1.size() == 2 && consumer2Assignment1.size() == 1));
 
-        partitionsPerTopic.put(topic2, 3);
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer2), generationId));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), assignment.get(consumer2), generationId, 1));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -495,10 +547,10 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(consumer2assignment.containsAll(consumer2Assignment1));
 
         partitionsPerTopic.remove(topic);
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer1), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer2), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer1), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic2), assignment.get(consumer2), generationId, 1));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         // verify balance
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
@@ -512,246 +564,275 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(consumer2assignment.containsAll(consumer2Assignment3));
     }
 
-    @Test
-    public void testReassignmentAfterOneConsumerLeaves() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 20; i++)
-            partitionsPerTopic.put(getTopicName(i, 20), i);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testReassignmentAfterOneConsumerLeaves(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 20; i++) {
+            String topicName = getTopicName(i, 20);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, i));
+        }
 
         for (int i = 1; i < 20; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = 1; j <= i; j++)
                 topics.add(getTopicName(j, 20));
-            subscriptions.put(getConsumerName(i, 20), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, 20), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < 20; i++) {
             String consumer = getConsumerName(i, 20);
             subscriptions.put(consumer,
-                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId));
+                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId, i));
         }
         subscriptions.remove("consumer10");
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(assignor.isSticky());
     }
 
 
-    @Test
-    public void testReassignmentAfterOneConsumerAdded() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put("topic", 20);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testReassignmentAfterOneConsumerAdded(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put("topic", partitionInfos("topic", 20));
 
         for (int i = 1; i < 10; i++)
             subscriptions.put(getConsumerName(i, 10),
-                new Subscription(topics("topic")));
+                subscription(topics("topic"), i));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         // add a new consumer
-        subscriptions.put(getConsumerName(10, 10), new Subscription(topics("topic")));
+        subscriptions.put(getConsumerName(10, 10), subscription(topics("topic"), 10));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test
-    public void testSameSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 15; i++)
-            partitionsPerTopic.put(getTopicName(i, 15), i);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testSameSubscriptions(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 15; i++) {
+            String topicName = getTopicName(i, 15);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, i));
+        }
 
         for (int i = 1; i < 9; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = 1; j <= partitionsPerTopic.size(); j++)
                 topics.add(getTopicName(j, 15));
-            subscriptions.put(getConsumerName(i, 9), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, 9), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < 9; i++) {
             String consumer = getConsumerName(i, 9);
             subscriptions.put(consumer,
-                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId));
+                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId, i));
         }
         subscriptions.remove(getConsumerName(5, 9));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
     @Timeout(30)
-    @Test
-    public void testLargeAssignmentAndGroupWithUniformSubscription() {
-        // 1 million partitions!
-        int topicCount = 500;
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testLargeAssignmentAndGroupWithUniformSubscription(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        // 1 million partitions for non-rack-aware! For rack-aware, use smaller number of partitions to reduce test run time.
+        int topicCount = hasConsumerRack ? 50 : 500;
         int partitionCount = 2_000;
         int consumerCount = 2_000;
 
         List<String> topics = new ArrayList<>();
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (int i = 0; i < topicCount; i++) {
             String topicName = getTopicName(i, topicCount);
             topics.add(topicName);
-            partitionsPerTopic.put(topicName, partitionCount);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, partitionCount));
         }
 
         for (int i = 0; i < consumerCount; i++) {
-            subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, consumerCount), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         for (int i = 1; i < consumerCount; i++) {
             String consumer = getConsumerName(i, consumerCount);
-            subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId));
+            subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId, i));
         }
 
-        assignor.assign(partitionsPerTopic, subscriptions);
+        assignor.assignPartitions(partitionsPerTopic, subscriptions);
     }
 
     @Timeout(90)
-    @Test
-    public void testLargeAssignmentAndGroupWithNonEqualSubscription() {
-        // 1 million partitions!
-        int topicCount = 500;
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testLargeAssignmentAndGroupWithNonEqualSubscription(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
+        // 1 million partitions for non-rack-aware! For rack-aware, use smaller number of partitions to reduce test run time.
+        int topicCount = hasConsumerRack ? 50 : 500;
         int partitionCount = 2_000;
         int consumerCount = 2_000;
 
         List<String> topics = new ArrayList<>();
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (int i = 0; i < topicCount; i++) {
             String topicName = getTopicName(i, topicCount);
             topics.add(topicName);
-            partitionsPerTopic.put(topicName, partitionCount);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, partitionCount));
         }
         for (int i = 0; i < consumerCount; i++) {
             if (i == consumerCount - 1) {
-                subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics.subList(0, 1)));
+                subscriptions.put(getConsumerName(i, consumerCount), subscription(topics.subList(0, 1), i));
             } else {
-                subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics));
+                subscriptions.put(getConsumerName(i, consumerCount), subscription(topics, i));
             }
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
 
         for (int i = 1; i < consumerCount; i++) {
             String consumer = getConsumerName(i, consumerCount);
             if (i == consumerCount - 1) {
-                subscriptions.put(consumer, buildSubscriptionV2Above(topics.subList(0, 1), assignment.get(consumer), generationId));
+                subscriptions.put(consumer, buildSubscriptionV2Above(topics.subList(0, 1), assignment.get(consumer), generationId, i));
             } else {
-                subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId));
+                subscriptions.put(consumer, buildSubscriptionV2Above(topics, assignment.get(consumer), generationId, i));
             }
         }
 
-        assignor.assign(partitionsPerTopic, subscriptions);
+        assignor.assignPartitions(partitionsPerTopic, subscriptions);
     }
 
-    @Test
-    public void testLargeAssignmentWithMultipleConsumersLeavingAndRandomSubscription() {
+    @Timeout(60)
+    @ParameterizedTest(name = TEST_NAME_WITH_CONSUMER_RACK)
+    @ValueSource(booleans = {false, true})
+    public void testLargeAssignmentWithMultipleConsumersLeavingAndRandomSubscription(boolean hasConsumerRack) {
+        initializeRacks(hasConsumerRack ? RackConfig.BROKER_AND_CONSUMER_RACK : RackConfig.NO_CONSUMER_RACK);
         Random rand = new Random();
         int topicCount = 40;
         int consumerCount = 200;
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 0; i < topicCount; i++)
-            partitionsPerTopic.put(getTopicName(i, topicCount), rand.nextInt(10) + 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 0; i < topicCount; i++) {
+            String topicName = getTopicName(i, topicCount);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, rand.nextInt(10) + 1));
+        }
 
         for (int i = 0; i < consumerCount; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = 0; j < rand.nextInt(20); j++)
                 topics.add(getTopicName(rand.nextInt(topicCount), topicCount));
-            subscriptions.put(getConsumerName(i, consumerCount), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, consumerCount), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         for (int i = 1; i < consumerCount; i++) {
             String consumer = getConsumerName(i, consumerCount);
             subscriptions.put(consumer,
-                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId));
+                buildSubscriptionV2Above(subscriptions.get(consumer).topics(), assignment.get(consumer), generationId, i));
         }
         for (int i = 0; i < 50; ++i) {
             String c = getConsumerName(rand.nextInt(consumerCount), consumerCount);
             subscriptions.remove(c);
         }
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(assignor.isSticky());
     }
 
-    @Test
-    public void testNewSubscription() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 5; i++)
-            partitionsPerTopic.put(getTopicName(i, 5), 1);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testNewSubscription(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 5; i++) {
+            String topicName = getTopicName(i, 5);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, 1));
+        }
 
         for (int i = 0; i < 3; i++) {
             List<String> topics = new ArrayList<>();
             for (int j = i; j <= 3 * i - 2; j++)
                 topics.add(getTopicName(j, 5));
-            subscriptions.put(getConsumerName(i, 3), new Subscription(topics));
+            subscriptions.put(getConsumerName(i, 3), subscription(topics, i));
         }
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
         subscriptions.get(getConsumerName(0, 3)).topics().add(getTopicName(1, 5));
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         assertTrue(assignor.isSticky());
     }
 
-    @Test
-    public void testMoveExistingAssignments() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testMoveExistingAssignments(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         String topic4 = "topic4";
         String topic5 = "topic5";
         String topic6 = "topic6";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i <= 6; i++)
-            partitionsPerTopic.put(String.format("topic%d", i), 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i <= 6; i++) {
+            String topicName = String.format("topic%d", i);
+            partitionsPerTopic.put(topicName, partitionInfos(topicName, 1));
+        }
 
         subscriptions.put(consumer1,
             buildSubscriptionV2Above(topics(topic1, topic2),
-                partitions(tp(topic1, 0)), generationId));
+                partitions(tp(topic1, 0)), generationId, 0));
         subscriptions.put(consumer2,
             buildSubscriptionV2Above(topics(topic1, topic2, topic3, topic4),
-                partitions(tp(topic2, 0), tp(topic3, 0)), generationId));
+                partitions(tp(topic2, 0), tp(topic3, 0)), generationId, 1));
         subscriptions.put(consumer3,
             buildSubscriptionV2Above(topics(topic2, topic3, topic4, topic5, topic6),
-                partitions(tp(topic4, 0), tp(topic5, 0), tp(topic6, 0)), generationId));
+                partitions(tp(topic4, 0), tp(topic5, 0), tp(topic6, 0)), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertNull(assignor.partitionsTransferringOwnership);
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test
-    public void testStickiness() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testStickiness(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 3));
 
-        subscriptions.put(consumer1, new Subscription(topics(topic1)));
-        subscriptions.put(consumer2, new Subscription(topics(topic1)));
-        subscriptions.put(consumer3, new Subscription(topics(topic1)));
-        subscriptions.put(consumer4, new Subscription(topics(topic1)));
+        subscriptions.put(consumer1, subscription(topics(topic1), 0));
+        subscriptions.put(consumer2, subscription(topics(topic1), 1));
+        subscriptions.put(consumer3, subscription(topics(topic1), 2));
+        subscriptions.put(consumer4, subscription(topics(topic1), 3));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
         Map<String, TopicPartition> partitionsAssigned = new HashMap<>();
@@ -769,14 +850,14 @@ public abstract class AbstractStickyAssignorTest {
         // removing the potential group leader
         subscriptions.remove(consumer1);
         subscriptions.put(consumer2,
-            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer2), generationId));
+            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer2), generationId, 1));
         subscriptions.put(consumer3,
-            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer3), generationId));
+            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer3), generationId, 2));
         subscriptions.put(consumer4,
-            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer4), generationId));
+            buildSubscriptionV2Above(topics(topic1), assignment.get(consumer4), generationId, 3));
 
 
-        assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
@@ -790,28 +871,32 @@ public abstract class AbstractStickyAssignorTest {
         }
     }
 
-    @Test
-    public void testAssignmentUpdatedForDeletedTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic3, 100);
-        subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2, topic3)));
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAssignmentUpdatedForDeletedTopic(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, partitionInfos(topic1, 1));
+        partitionsPerTopic.put(topic3, partitionInfos(topic3, 100));
+        subscriptions = Collections.singletonMap(consumerId, subscription(topics(topic1, topic2, topic3), 0));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
         assertEquals(assignment.values().stream().mapToInt(List::size).sum(), 1 + 100);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testNoExceptionThrownWhenOnlySubscribedTopicDeleted() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        subscriptions.put(consumerId, new Subscription(topics(topic)));
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testNoExceptionThrownWhenOnlySubscribedTopicDeleted(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        subscriptions.put(consumerId, subscription(topics(topic), 0));
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
-        subscriptions.put(consumerId, buildSubscriptionV2Above(topics(topic), assignment.get(consumerId), generationId));
+        subscriptions.put(consumerId, buildSubscriptionV2Above(topics(topic), assignment.get(consumerId), generationId, 0));
 
         assignment = assignor.assign(Collections.emptyMap(), subscriptions);
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -819,8 +904,10 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(assignment.get(consumerId).isEmpty());
     }
 
-    @Test
-    public void testReassignmentWithRandomSubscriptionsAndChanges() {
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testReassignmentWithRandomSubscriptionsAndChanges(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
         final int minNumConsumers = 20;
         final int maxNumConsumers = 40;
         final int minNumTopics = 10;
@@ -831,47 +918,50 @@ public abstract class AbstractStickyAssignorTest {
 
             ArrayList<String> topics = new ArrayList<>();
 
-            Map<String, Integer> partitionsPerTopic = new HashMap<>();
+            Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
             for (int i = 0; i < numTopics; ++i) {
-                topics.add(getTopicName(i, maxNumTopics));
-                partitionsPerTopic.put(getTopicName(i, maxNumTopics), i + 1);
+                String topicName = getTopicName(i, maxNumTopics);
+                topics.add(topicName);
+                partitionsPerTopic.put(topicName, partitionInfos(topicName, i + 1));
             }
 
             int numConsumers = minNumConsumers + new Random().nextInt(maxNumConsumers - minNumConsumers);
 
             for (int i = 0; i < numConsumers; ++i) {
                 List<String> sub = Utils.sorted(getRandomSublist(topics));
-                subscriptions.put(getConsumerName(i, maxNumConsumers), new Subscription(sub));
+                subscriptions.put(getConsumerName(i, maxNumConsumers), subscription(sub, i));
             }
 
             assignor = createAssignor();
 
-            Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+            Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
             verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
 
             subscriptions.clear();
             for (int i = 0; i < numConsumers; ++i) {
                 List<String> sub = Utils.sorted(getRandomSublist(topics));
                 String consumer = getConsumerName(i, maxNumConsumers);
-                subscriptions.put(consumer, buildSubscriptionV2Above(sub, assignment.get(consumer), generationId));
+                subscriptions.put(consumer, buildSubscriptionV2Above(sub, assignment.get(consumer), generationId, i));
             }
 
-            assignment = assignor.assign(partitionsPerTopic, subscriptions);
+            assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
             verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
             assertTrue(assignor.isSticky());
         }
     }
 
-    @Test
-    public void testAllConsumersReachExpectedQuotaAndAreConsideredFilled() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 4);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testAllConsumersReachExpectedQuotaAndAreConsideredFilled(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 4));
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), Collections.emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(partitions(tp(topic, 0), tp(topic, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 3)), assignment.get(consumer3));
@@ -881,18 +971,20 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOwnedPartitionsAreInvalidatedForConsumerWithStaleGeneration() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOwnedPartitionsAreInvalidatedForConsumerWithStaleGeneration(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         int currentGeneration = 10;
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration - 1));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration - 1, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1))), new HashSet<>(assignment.get(consumer1)));
         assertEquals(new HashSet<>(partitions(tp(topic, 1), tp(topic2, 0), tp(topic2, 2))), new HashSet<>(assignment.get(consumer2)));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -901,18 +993,20 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testOwnedPartitionsAreInvalidatedForConsumerWithNoGeneration() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(topic2, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testOwnedPartitionsAreInvalidatedForConsumerWithNoGeneration(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
+        partitionsPerTopic.put(topic2, partitionInfos(topic2, 3));
 
         int currentGeneration = 10;
 
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), DEFAULT_GENERATION));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), currentGeneration, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic, topic2), partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1)), DEFAULT_GENERATION, 1));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         assertEquals(new HashSet<>(partitions(tp(topic, 0), tp(topic, 2), tp(topic2, 1))), new HashSet<>(assignment.get(consumer1)));
         assertEquals(new HashSet<>(partitions(tp(topic, 1), tp(topic2, 0), tp(topic2, 2))), new HashSet<>(assignment.get(consumer2)));
         assertTrue(assignor.partitionsTransferringOwnership.isEmpty());
@@ -921,17 +1015,19 @@ public abstract class AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
-    @Test
-    public void testPartitionsTransferringOwnershipIncludeThePartitionClaimedByMultipleConsumersInSameGeneration() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+    @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
+    @EnumSource(RackConfig.class)
+    public void testPartitionsTransferringOwnershipIncludeThePartitionClaimedByMultipleConsumersInSameGeneration(RackConfig rackConfig) {
+        initializeRacks(rackConfig);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, partitionInfos(topic, 3));
 
         // partition topic-0 is owned by multiple consumer
-        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId));
-        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId));
-        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId));
+        subscriptions.put(consumer1, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 1)), generationId, 0));
+        subscriptions.put(consumer2, buildSubscriptionV2Above(topics(topic), partitions(tp(topic, 0), tp(topic, 2)), generationId, 1));
+        subscriptions.put(consumer3, buildSubscriptionV2Above(topics(topic), emptyList(), generationId, 2));
 
-        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        Map<String, List<TopicPartition>> assignment = assignor.assignPartitions(partitionsPerTopic, subscriptions);
         // we should include the partitions claimed by multiple consumers in partitionsTransferringOwnership
         assertEquals(Collections.singletonMap(tp(topic, 0), consumer3), assignor.partitionsTransferringOwnership);
 
@@ -940,6 +1036,139 @@ public abstract class AbstractStickyAssignorTest {
         assertEquals(partitions(tp(topic, 2)), assignment.get(consumer2));
         assertEquals(partitions(tp(topic, 0)), assignment.get(consumer3));
         assertTrue(isFullyBalanced(assignment));
+    }
+
+    @Test
+    public void testRackAwareAssignmentWithUniformSubscription() {
+        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 7), mkEntry("t3", 2));
+        List<String> allTopics = asList("t1", "t2", "t3");
+        List<List<String>> consumerTopics = asList(allTopics, allTopics, allTopics);
+        List<String> nonRackAwareAssignment = asList(
+                "t1-0, t1-3, t2-0, t2-3, t2-6",
+                "t1-1, t1-4, t2-1, t2-4, t3-0",
+                "t1-2, t1-5, t2-2, t2-5, t3-1"
+        );
+        verifyUniformSubscription(assignor, topics, 3, nullRacks(3), racks(3), consumerTopics, nonRackAwareAssignment, -1);
+        verifyUniformSubscription(assignor, topics, 3, racks(3), nullRacks(3), consumerTopics, nonRackAwareAssignment, -1);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyUniformSubscription(assignor, topics, 3, racks(3), racks(3), consumerTopics, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyUniformSubscription(assignor, topics, 4, racks(4), racks(3), consumerTopics, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+        verifyUniformSubscription(assignor, topics, 3, racks(3), racks(3), consumerTopics, nonRackAwareAssignment, 0);
+        verifyUniformSubscription(assignor, topics, 3, racks(3), asList("d", "e", "f"), consumerTopics, nonRackAwareAssignment, -1);
+        verifyUniformSubscription(assignor, topics, 3, racks(3), asList(null, "e", "f"), consumerTopics, nonRackAwareAssignment, -1);
+
+        // Verify assignment is rack-aligned for lower replication factor where brokers have a subset of partitions
+        List<String> assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        verifyUniformSubscription(assignor, topics, 1, racks(3), racks(3), consumerTopics, assignment, 0);
+        assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        verifyUniformSubscription(assignor, topics, 2, racks(3), racks(3), consumerTopics, assignment, 0);
+
+        // One consumer on a rack with no partitions. We allocate with misaligned rack to this consumer to maintain balance.
+        assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        verifyUniformSubscription(assignor, topics, 3, racks(2), racks(3), consumerTopics, assignment, 5);
+
+        // Verify that rack-awareness is improved if already owned partitions are misaligned
+        assignment = asList("t1-0, t1-3, t2-0, t2-3, t2-6", "t1-1, t1-4, t2-1, t2-4, t3-0", "t1-2, t1-5, t2-2, t2-5, t3-1");
+        List<String> owned = asList("t1-0, t1-1, t1-2, t1-3, t1-4", "t1-5, t2-0, t2-1, t2-2, t2-3", "t2-4, t2-5, t2-6, t3-0, t3-1");
+        verifyRackAssignment(assignor, topics, 1, racks(3), racks(3), consumerTopics, owned, assignment, 0);
+
+        // Verify that stickiness is retained when racks match
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, assignment, assignment, 0);
+    }
+
+    private void verifyUniformSubscription(AbstractStickyAssignor assignor,
+                                           Map<String, Integer> numPartitionsPerTopic,
+                                           int replicationFactor,
+                                           List<String> brokerRacks,
+                                           List<String> consumerRacks,
+                                           List<List<String>> consumerTopics,
+                                           List<String> expectedAssignments,
+                                           int numPartitionsWithRackMismatch) {
+        verifyRackAssignment(assignor, numPartitionsPerTopic, replicationFactor, brokerRacks, consumerRacks,
+                consumerTopics, null, expectedAssignments, numPartitionsWithRackMismatch);
+        verifyRackAssignment(assignor, numPartitionsPerTopic, replicationFactor, brokerRacks, consumerRacks,
+                consumerTopics, expectedAssignments, expectedAssignments, numPartitionsWithRackMismatch);
+    }
+
+    @Test
+    public void testRackAwareAssignmentWithNonEqualSubscription() {
+        Map<String, Integer> topics = mkMap(mkEntry("t1", 6), mkEntry("t2", 7), mkEntry("t3", 2));
+        List<String> allTopics = asList("t1", "t2", "t3");
+        List<List<String>> consumerTopics = asList(allTopics, allTopics, asList("t1", "t3"));
+        List<String> nonRackAwareAssignment = asList(
+                "t1-5, t2-0, t2-2, t2-4, t2-6",
+                "t1-3, t2-1, t2-3, t2-5, t3-0",
+                "t1-0, t1-1, t1-2, t1-4, t3-1"
+        );
+        verifyNonEqualSubscription(assignor, topics, 3, nullRacks(3), racks(3), consumerTopics, nonRackAwareAssignment, -1);
+        verifyNonEqualSubscription(assignor, topics, 3, racks(3), nullRacks(3), consumerTopics, nonRackAwareAssignment, -1);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyNonEqualSubscription(assignor, topics, 3, racks(3), racks(3), consumerTopics, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+        verifyNonEqualSubscription(assignor, topics, 4, racks(4), racks(3), consumerTopics, nonRackAwareAssignment, 0);
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+        verifyNonEqualSubscription(assignor, topics, 3, racks(3), racks(3), consumerTopics, nonRackAwareAssignment, 0);
+        verifyNonEqualSubscription(assignor, topics, 3, racks(3), asList("d", "e", "f"), consumerTopics, nonRackAwareAssignment, -1);
+        verifyNonEqualSubscription(assignor, topics, 3, racks(3), asList(null, "e", "f"), consumerTopics, nonRackAwareAssignment, -1);
+
+        // Verify assignment is rack-aligned for lower replication factor where brokers have a subset of partitions
+        // Rack-alignment is best-effort, misalignments can occur when number of rack choices is low.
+        List<String> assignment = asList("t1-3, t2-0, t2-2, t2-3, t2-6", "t1-4, t2-1, t2-4, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-5, t3-1");
+        verifyNonEqualSubscription(assignor, topics, 1, racks(3), racks(3), consumerTopics, assignment, 4);
+        assignment = asList("t1-3, t2-0, t2-2, t2-5, t2-6", "t1-0, t2-1, t2-3, t2-4, t3-0", "t1-1, t1-2, t1-4, t1-5, t3-1");
+        verifyNonEqualSubscription(assignor, topics, 2, racks(3), racks(3), consumerTopics, assignment, 0);
+
+        // One consumer on a rack with no partitions. We allocate with misaligned rack to this consumer to maintain balance.
+        verifyNonEqualSubscription(assignor, topics, 3, racks(2), racks(3), consumerTopics,
+                asList("t1-5, t2-0, t2-2, t2-4, t2-6", "t1-3, t2-1, t2-3, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-4, t3-1"), 5);
+
+        // Verify that rack-awareness is improved if already owned partitions are misaligned.
+        // Rack alignment is attempted, but not guaranteed.
+        List<String> owned = asList("t1-0, t1-1, t1-2, t1-3, t1-4", "t1-5, t2-0, t2-1, t2-2, t2-3", "t2-4, t2-5, t2-6, t3-0, t3-1");
+        if (assignor instanceof StickyAssignor) {
+            assignment = asList("t1-3, t2-0, t2-2, t2-3, t2-6", "t1-4, t2-1, t2-4, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-5, t3-1");
+            verifyRackAssignment(assignor, topics, 1, racks(3), racks(3), consumerTopics, owned, assignment, 4);
+        } else {
+            List<String> intermediate = asList("t1-3", "t2-1", "t3-1");
+            verifyRackAssignment(assignor, topics, 1, racks(3), racks(3), consumerTopics, owned, intermediate, 0);
+            assignment = asList("t1-3, t2-0, t2-2, t2-3, t2-6", "t1-4, t2-1, t2-4, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-5, t3-1");
+            verifyRackAssignment(assignor, topics, 1, racks(3), racks(3), consumerTopics, intermediate, assignment, 4);
+        }
+
+        // Verify that result is same as non-rack-aware assignment if all racks match
+        if (assignor instanceof StickyAssignor) {
+            assignment = asList("t1-5, t2-0, t2-2, t2-4, t2-6", "t1-3, t2-1, t2-3, t2-5, t3-0", "t1-0, t1-1, t1-2, t1-4, t3-1");
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+            verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, owned, assignment, 0);
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+            verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, owned, assignment, 0);
+        } else {
+            assignment = asList("t1-2, t1-3, t1-4, t2-4, t2-5", "t2-0, t2-1, t2-2, t2-3, t2-6", "t1-0, t1-1, t1-5, t3-0, t3-1");
+            List<String> intermediate = asList("t1-2, t1-3, t1-4", "t2-0, t2-1, t2-2, t2-3", "t3-0, t3-1");
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, false);
+            verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, owned, intermediate, 0);
+            verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, intermediate, assignment, 0);
+            AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
+            verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, owned, intermediate, 0);
+            verifyRackAssignment(assignor, topics, 3, racks(3), racks(3), consumerTopics, intermediate, assignment, 0);
+        }
+    }
+
+    private void verifyNonEqualSubscription(AbstractStickyAssignor assignor,
+                                            Map<String, Integer> numPartitionsPerTopic,
+                                            int replicationFactor,
+                                            List<String> brokerRacks,
+                                            List<String> consumerRacks,
+                                            List<List<String>> consumerTopics,
+                                            List<String> expectedAssignments,
+                                            int numPartitionsWithRackMismatch) {
+        verifyRackAssignment(assignor, numPartitionsPerTopic, replicationFactor, brokerRacks,
+                consumerRacks, consumerTopics, null, expectedAssignments, numPartitionsWithRackMismatch);
+        verifyRackAssignment(assignor, numPartitionsPerTopic, replicationFactor, brokerRacks,
+                consumerRacks, consumerTopics, expectedAssignments, expectedAssignments, numPartitionsWithRackMismatch);
     }
 
     private String getTopicName(int i, int maxNum) {
@@ -975,6 +1204,15 @@ public abstract class AbstractStickyAssignorTest {
 
     protected static TopicPartition tp(String topic, int partition) {
         return new TopicPartition(topic, partition);
+    }
+
+    protected Optional<String> consumerRackId(int consumerIndex) {
+        int numRacks = numBrokerRacks > 0 ? numBrokerRacks : AbstractPartitionAssignorTest.ALL_RACKS.length;
+        return Optional.ofNullable(hasConsumerRack ? AbstractPartitionAssignorTest.ALL_RACKS[consumerIndex % numRacks] : null);
+    }
+
+    protected Subscription subscription(List<String> topics, int consumerIndex) {
+        return new Subscription(topics, null, Collections.emptyList(), DEFAULT_GENERATION, consumerRackId(consumerIndex));
     }
 
     protected static boolean isFullyBalanced(Map<String, List<TopicPartition>> assignment) {
@@ -1017,7 +1255,7 @@ public abstract class AbstractStickyAssignorTest {
      */
     protected void verifyValidityAndBalance(Map<String, Subscription> subscriptions,
                                             Map<String, List<TopicPartition>> assignments,
-                                            Map<String, Integer> partitionsPerTopic) {
+                                            Map<String, List<PartitionInfo>> partitionsPerTopic) {
         int size = subscriptions.size();
         assert size == assignments.size();
 
@@ -1068,7 +1306,22 @@ public abstract class AbstractStickyAssignorTest {
         }
     }
 
+
     protected AbstractStickyAssignor.MemberData memberData(Subscription subscription) {
         return assignor.memberData(subscription);
+    }
+
+    protected List<PartitionInfo> partitionInfos(String topic, int numberOfPartitions) {
+        int nextIndex = nextPartitionIndex;
+        nextPartitionIndex += 1;
+        return AbstractPartitionAssignorTest.partitionInfos(topic, numberOfPartitions,
+                replicationFactor, numBrokerRacks, nextIndex);
+    }
+
+    protected void initializeRacks(RackConfig rackConfig) {
+        this.replicationFactor = 3;
+        this.numBrokerRacks = rackConfig != RackConfig.NO_BROKER_RACK ? 3 : 0;
+        this.hasConsumerRack = rackConfig != RackConfig.NO_CONSUMER_RACK;
+        AbstractPartitionAssignorTest.preferRackAwareLogic(assignor, true);
     }
 }


### PR DESCRIPTION
Best-effort rack alignment for sticky assignors when both consumer racks and partition racks are available with the protocol changes introduced in KIP-881. Rack-aware assignment is enabled by configuring client.rack for consumers. The assignment builders attempt to align on racks on a best-effort basis, but prioritize balanced assignment over rack alignment.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
