### PR TITLE
Revert "KAFKA-14371: Remove unused clusterId field from quorum-state file"

### DIFF
--- a/raft/src/main/resources/common/message/QuorumStateData.json
+++ b/raft/src/main/resources/common/message/QuorumStateData.json
@@ -16,10 +16,10 @@
 {
   "type": "data",
   "name": "QuorumStateData",
-  // Version 1 removes clusterId field.
-  "validVersions": "0-1",
+  "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
+    {"name": "ClusterId", "type": "string", "versions": "0+"},
     {"name": "LeaderId", "type": "int32", "versions": "0+", "default": "-1"},
     {"name": "LeaderEpoch", "type": "int32", "versions": "0+", "default": "-1"},
     {"name": "VotedId", "type": "int32", "versions": "0+", "default": "-1"},


### PR DESCRIPTION
This reverts commit 0927049a617fa2937a211aab895f6590403130fb.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
