### PR TITLE
MINOR: fix authorizer reconfiguration in KRaft mode

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -312,9 +312,6 @@ class BrokerServer(
         config, Some(clientToControllerChannelManager), None, None,
         groupCoordinator, transactionCoordinator)
 
-      /* Add all reconfigurables for config change notification before starting the metadata listener */
-      config.dynamicConfig.addReconfigurables(this)
-
       dynamicConfigHandlers = Map[String, ConfigHandler](
         ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers, None),
         ConfigType.Broker -> new BrokerConfigHandler(config, quotaManagers))
@@ -460,6 +457,9 @@ class BrokerServer(
         credentialProvider,
         sharedServer.initialBrokerMetadataLoadFaultHandler,
         sharedServer.metadataPublishingFaultHandler)
+
+      // Add all reconfigurables for config change notification before installing the metadata publisher.
+      config.dynamicConfig.addReconfigurables(this)
 
       // Tell the metadata listener to start publishing its output, and wait for the first
       // publish operation to complete. This first operation will initialize logManager,


### PR DESCRIPTION
Fix a bug with authorizer reconfiguration in KRaft mode. The bug happened because we were invoking DynamicBrokerConfig.addReconfigurables before initializing BrokerServer.authorizer. Add a test of reconfiguring the Authorizer. Also, in testReconfigureControllerClientQuotas, test both combined and isolated mode.