### PR TITLE
KAFKA-14491: [16/N] Add recovery logic for store inconsistency due to failed write

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatter.java
@@ -521,6 +521,13 @@ final class RocksDBVersionedStoreSegmentValueFormatter {
             return unpackedReversedTimestampAndValueSizes.get(index).timestamp == minTimestamp;
         }
 
+        /**
+         * Delete all record versions newer than (or at) the provided timestamp, and also truncate
+         * any partial records which extend beyond the provided timestamp. In other words, when
+         * this method returns, nextTimestamp will be equal to the truncation timestamp.
+         *
+         * @param timestamp timestamp to truncate to
+         */
         private void truncateRecordsToTimestamp(final long timestamp) {
             if (timestamp <= minTimestamp) {
                 // all record versions in this segment will be truncated.

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
@@ -29,204 +29,276 @@ import java.util.Map;
 import org.apache.kafka.streams.state.internals.RocksDBVersionedStoreSegmentValueFormatter.SegmentValue;
 import org.apache.kafka.streams.state.internals.RocksDBVersionedStoreSegmentValueFormatter.SegmentValue.SegmentSearchResult;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class RocksDBVersionedStoreSegmentValueFormatterTest {
 
-    private static final List<TestCase> TEST_CASES = new ArrayList<>();
-    static {
-        // test cases are expected to have timestamps in strictly decreasing order (except for the degenerate case)
-        TEST_CASES.add(new TestCase("degenerate", 10, new TestRecord(null, 10)));
-        TEST_CASES.add(new TestCase("single record", 10, new TestRecord("foo".getBytes(), 1)));
-        TEST_CASES.add(new TestCase("multiple records", 10, new TestRecord("foo".getBytes(), 8), new TestRecord("bar".getBytes(), 3), new TestRecord("baz".getBytes(), 0)));
-        TEST_CASES.add(new TestCase("single tombstone", 10, new TestRecord(null, 1)));
-        TEST_CASES.add(new TestCase("multiple tombstone", 10, new TestRecord(null, 4), new TestRecord(null, 1)));
-        TEST_CASES.add(new TestCase("tombstones and records (r, t, r)", 10, new TestRecord("foo".getBytes(), 5), new TestRecord(null, 2), new TestRecord("bar".getBytes(), 1)));
-        TEST_CASES.add(new TestCase("tombstones and records (t, r, t)", 10, new TestRecord(null, 5), new TestRecord("foo".getBytes(), 2), new TestRecord(null, 1)));
-        TEST_CASES.add(new TestCase("tombstones and records (r, r, t, t)", 10, new TestRecord("foo".getBytes(), 6), new TestRecord("bar".getBytes(), 5), new TestRecord(null, 2), new TestRecord(null, 1)));
-        TEST_CASES.add(new TestCase("tombstones and records (t, t, r, r)", 10, new TestRecord(null, 7), new TestRecord(null, 6), new TestRecord("foo".getBytes(), 2), new TestRecord("bar".getBytes(), 1)));
-        TEST_CASES.add(new TestCase("record with empty bytes", 10, new TestRecord(new byte[0], 1)));
-        TEST_CASES.add(new TestCase("records with empty bytes (r, e)", 10, new TestRecord("foo".getBytes(), 4), new TestRecord(new byte[0], 1)));
-        TEST_CASES.add(new TestCase("records with empty bytes (e, e, r)", 10, new TestRecord(new byte[0], 8), new TestRecord(new byte[0], 2), new TestRecord("foo".getBytes(), 1)));
-    }
+    /**
+     * Non-exceptional scenarios which are expected to occur during regular store operation.
+     */
+    @RunWith(Parameterized.class)
+    public static class ExpectedCasesTest {
 
-    private final TestCase testCase;
+        private static final List<TestCase> TEST_CASES = new ArrayList<>();
 
-    public RocksDBVersionedStoreSegmentValueFormatterTest(final TestCase testCase) {
-        this.testCase = testCase;
-    }
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<TestCase> data() {
-        return TEST_CASES;
-    }
-
-    @Test
-    public void shouldSerializeAndDeserialize() {
-        final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
-
-        final byte[] serialized = segmentValue.serialize();
-        final SegmentValue deserialized = RocksDBVersionedStoreSegmentValueFormatter.deserialize(serialized);
-
-        verifySegmentContents(deserialized, testCase);
-    }
-
-    @Test
-    public void shouldBuildWithInsertLatest() {
-        final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
-
-        verifySegmentContents(segmentValue, testCase);
-    }
-
-    @Test
-    public void shouldBuildWithInsertEarliest() {
-        final SegmentValue segmentValue = buildSegmentWithInsertEarliest(testCase);
-
-        verifySegmentContents(segmentValue, testCase);
-    }
-
-    @Test
-    public void shouldInsertAtIndex() {
-        if (testCase.isDegenerate) {
-            // cannot insert into degenerate segment
-            return;
+        static {
+            // test cases are expected to have timestamps in strictly decreasing order (except for the degenerate case)
+            TEST_CASES.add(new TestCase("degenerate", 10, new TestRecord(null, 10)));
+            TEST_CASES.add(new TestCase("single record", 10, new TestRecord("foo".getBytes(), 1)));
+            TEST_CASES.add(new TestCase("multiple records", 10, new TestRecord("foo".getBytes(), 8), new TestRecord("bar".getBytes(), 3), new TestRecord("baz".getBytes(), 0)));
+            TEST_CASES.add(new TestCase("single tombstone", 10, new TestRecord(null, 1)));
+            TEST_CASES.add(new TestCase("multiple tombstone", 10, new TestRecord(null, 4), new TestRecord(null, 1)));
+            TEST_CASES.add(new TestCase("tombstones and records (r, t, r)", 10, new TestRecord("foo".getBytes(), 5), new TestRecord(null, 2), new TestRecord("bar".getBytes(), 1)));
+            TEST_CASES.add(new TestCase("tombstones and records (t, r, t)", 10, new TestRecord(null, 5), new TestRecord("foo".getBytes(), 2), new TestRecord(null, 1)));
+            TEST_CASES.add(new TestCase("tombstones and records (r, r, t, t)", 10, new TestRecord("foo".getBytes(), 6), new TestRecord("bar".getBytes(), 5), new TestRecord(null, 2), new TestRecord(null, 1)));
+            TEST_CASES.add(new TestCase("tombstones and records (t, t, r, r)", 10, new TestRecord(null, 7), new TestRecord(null, 6), new TestRecord("foo".getBytes(), 2), new TestRecord("bar".getBytes(), 1)));
+            TEST_CASES.add(new TestCase("record with empty bytes", 10, new TestRecord(new byte[0], 1)));
+            TEST_CASES.add(new TestCase("records with empty bytes (r, e)", 10, new TestRecord("foo".getBytes(), 4), new TestRecord(new byte[0], 1)));
+            TEST_CASES.add(new TestCase("records with empty bytes (e, e, r)", 10, new TestRecord(new byte[0], 8), new TestRecord(new byte[0], 2), new TestRecord("foo".getBytes(), 1)));
         }
 
-        // test inserting at each possible index
-        for (int insertIdx = 0; insertIdx <= testCase.records.size() - 1; insertIdx++) {
-            // build record to insert
-            final long newRecordTimestamp;
-            if (insertIdx == 0) {
-                newRecordTimestamp = testCase.records.get(0).timestamp + 1;
-                if (newRecordTimestamp == testCase.nextTimestamp) {
-                    // cannot insert because no timestamp exists between last record and nextTimestamp
-                    continue;
-                }
-            } else {
-                newRecordTimestamp = testCase.records.get(insertIdx - 1).timestamp - 1;
-                if (newRecordTimestamp < 0 || (newRecordTimestamp == testCase.records.get(insertIdx).timestamp)) {
-                    // cannot insert because timestamps of existing records are adjacent
-                    continue;
-                }
+        private final TestCase testCase;
+
+        public ExpectedCasesTest(final TestCase testCase) {
+            this.testCase = testCase;
+        }
+
+        @Parameterized.Parameters(name = "{0}")
+        public static Collection<TestCase> data() {
+            return TEST_CASES;
+        }
+
+        @Test
+        public void shouldSerializeAndDeserialize() {
+            final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+            final byte[] serialized = segmentValue.serialize();
+            final SegmentValue deserialized = RocksDBVersionedStoreSegmentValueFormatter.deserialize(serialized);
+
+            verifySegmentContents(deserialized, testCase);
+        }
+
+        @Test
+        public void shouldBuildWithInsertLatest() {
+            final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+            verifySegmentContents(segmentValue, testCase);
+        }
+
+        @Test
+        public void shouldBuildWithInsertEarliest() {
+            final SegmentValue segmentValue = buildSegmentWithInsertEarliest(testCase);
+
+            verifySegmentContents(segmentValue, testCase);
+        }
+
+        @Test
+        public void shouldInsertAtIndex() {
+            if (testCase.isDegenerate) {
+                // cannot insert into degenerate segment
+                return;
             }
-            final TestRecord newRecord = new TestRecord("new".getBytes(), newRecordTimestamp);
+
+            // test inserting at each possible index
+            for (int insertIdx = 0; insertIdx <= testCase.records.size() - 1; insertIdx++) {
+                // build record to insert
+                final long newRecordTimestamp;
+                if (insertIdx == 0) {
+                    newRecordTimestamp = testCase.records.get(0).timestamp + 1;
+                    if (newRecordTimestamp == testCase.nextTimestamp) {
+                        // cannot insert because no timestamp exists between last record and nextTimestamp
+                        continue;
+                    }
+                } else {
+                    newRecordTimestamp = testCase.records.get(insertIdx - 1).timestamp - 1;
+                    if (newRecordTimestamp < 0 || (newRecordTimestamp == testCase.records.get(insertIdx).timestamp)) {
+                        // cannot insert because timestamps of existing records are adjacent
+                        continue;
+                    }
+                }
+                final TestRecord newRecord = new TestRecord("new".getBytes(), newRecordTimestamp);
+
+                final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+                // insert() first requires a call to find()
+                segmentValue.find(testCase.records.get(insertIdx).timestamp, false);
+
+                segmentValue.insert(newRecord.timestamp, newRecord.value, insertIdx);
+
+                // create expected results
+                final List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
+                expectedRecords.add(insertIdx, newRecord);
+
+                verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
+            }
+        }
+
+        @Test
+        public void shouldUpdateAtIndex() {
+            if (testCase.isDegenerate) {
+                // cannot update degenerate segment
+                return;
+            }
+
+            // test updating at each possible index
+            for (int updateIdx = 0; updateIdx < testCase.records.size(); updateIdx++) {
+                // build updated record
+                long updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp - 1;
+                if (updatedRecordTimestamp < 0 || (updateIdx < testCase.records.size() - 1 && updatedRecordTimestamp == testCase.records.get(updateIdx + 1).timestamp)) {
+                    // found timestamp conflict. try again
+                    updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp + 1;
+                    if (updateIdx > 0 && updatedRecordTimestamp == testCase.records.get(updateIdx - 1).timestamp) {
+                        // found timestamp conflict. use original timestamp
+                        updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp;
+                    }
+                }
+                final TestRecord updatedRecord = new TestRecord("updated".getBytes(), updatedRecordTimestamp);
+
+                final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+
+                // updateRecord() first requires a call to find()
+                segmentValue.find(testCase.records.get(updateIdx).timestamp, false);
+                segmentValue.updateRecord(updatedRecord.timestamp, updatedRecord.value, updateIdx);
+
+                // create expected results
+                final List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
+                expectedRecords.remove(updateIdx);
+                expectedRecords.add(updateIdx, updatedRecord);
+
+                verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
+            }
+        }
+
+        @Test
+        public void shouldFindByTimestamp() {
+            if (testCase.isDegenerate) {
+                // cannot find() on degenerate segment
+                return;
+            }
 
             final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
 
-            // insert() first requires a call to find()
-            segmentValue.find(testCase.records.get(insertIdx).timestamp, false);
+            // build expected mapping from timestamp -> record
+            final Map<Long, Integer> expectedRecordIndices = new HashMap<>();
+            // it's important that this for-loop iterates backwards through the record indices, so that
+            // when adjacent records have adjacent timestamps, then the record with the later timestamp
+            // (i.e., the earlier index) takes precedence
+            for (int recordIdx = testCase.records.size() - 1; recordIdx >= 0; recordIdx--) {
+                if (recordIdx < testCase.records.size() - 1) {
+                    expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp - 1, recordIdx + 1);
+                }
+                if (recordIdx > 0) {
+                    expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp + 1, recordIdx);
+                }
+                expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp, recordIdx);
+            }
 
-            segmentValue.insert(newRecord.timestamp, newRecord.value, insertIdx);
+            // verify results
+            for (final Map.Entry<Long, Integer> entry : expectedRecordIndices.entrySet()) {
+                final TestRecord expectedRecord = testCase.records.get(entry.getValue());
+                final long expectedValidTo = entry.getValue() == 0 ? testCase.nextTimestamp : testCase.records.get(entry.getValue() - 1).timestamp;
 
-            // create expected results
-            final List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
-            expectedRecords.add(insertIdx, newRecord);
+                final SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
 
-            verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
+                assertThat(result.index(), equalTo(entry.getValue()));
+                assertThat(result.value(), equalTo(expectedRecord.value));
+                assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));
+                assertThat(result.validTo(), equalTo(expectedValidTo));
+            }
+
+            // verify exception when timestamp is out of range
+            assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.nextTimestamp, false));
+            assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.nextTimestamp + 1, false));
+            assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.minTimestamp - 1, false));
+        }
+
+        @Test
+        public void shouldGetTimestamps() {
+            final byte[] segmentValue = buildSegmentWithInsertLatest(testCase).serialize();
+
+            assertThat(RocksDBVersionedStoreSegmentValueFormatter.getNextTimestamp(segmentValue), equalTo(testCase.nextTimestamp));
+            assertThat(RocksDBVersionedStoreSegmentValueFormatter.getMinTimestamp(segmentValue), equalTo(testCase.minTimestamp));
+        }
+
+        @Test
+        public void shouldCreateNewWithRecord() {
+            if (testCase.records.size() != 1) {
+                return;
+            }
+
+            final SegmentValue segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithRecord(
+                testCase.records.get(0).value,
+                testCase.records.get(0).timestamp,
+                testCase.nextTimestamp);
+
+            verifySegmentContents(segmentValue, testCase);
         }
     }
 
-    @Test
-    public void shouldUpdateAtIndex() {
-        if (testCase.isDegenerate) {
-            // cannot update degenerate segment
-            return;
+    /**
+     * These scenarios may only be hit in the event of an earlier exception, such as failure to
+     * write to a particular segment store of {@link RocksDBVersionedStore} resulting in an
+     * inconsistency among segments. These tests verify that the store is able to recover
+     * gracefully even if this happens.
+     */
+    @RunWith(Parameterized.class)
+    public static class ExceptionalCasesTest {
+
+        private static final long INSERT_VALID_FROM_TIMESTAMP = 10L;
+        private static final long INSERT_VALID_TO_TIMESTAMP = 13L;
+        private static final byte[] INSERT_VALUE = "new".getBytes();
+        private static final List<TestCase> TEST_CASES = new ArrayList<>();
+
+        static {
+            // test cases are expected to have timestamps in strictly decreasing order
+            TEST_CASES.add(new TestCase("truncate all, single record", 15, new TestRecord(null, 12)));
+            TEST_CASES.add(new TestCase("truncate all, single record, exact timestamp match", 15, new TestRecord(null, INSERT_VALID_FROM_TIMESTAMP)));
+            TEST_CASES.add(new TestCase("truncate all, multiple records", 15, new TestRecord(null, 12), new TestRecord("foo".getBytes(), 11)));
+            TEST_CASES.add(new TestCase("truncate all, multiple records, exact timestamp match", 15, new TestRecord(null, 12), new TestRecord("foo".getBytes(), 11), new TestRecord(null, INSERT_VALID_FROM_TIMESTAMP)));
+            TEST_CASES.add(new TestCase("partial truncation, single record", 15, new TestRecord(null, 8)));
+            TEST_CASES.add(new TestCase("partial truncation, multiple records", 15, new TestRecord("foo".getBytes(), 12), new TestRecord("bar".getBytes(), 8)));
+            TEST_CASES.add(new TestCase("partial truncation, on record boundary", 15, new TestRecord("foo".getBytes(), 12), new TestRecord("bar".getBytes(), INSERT_VALID_FROM_TIMESTAMP), new TestRecord("baz".getBytes(), 8)));
         }
 
-        // test updating at each possible index
-        for (int updateIdx = 0; updateIdx < testCase.records.size(); updateIdx++) {
-            // build updated record
-            long updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp - 1;
-            if (updatedRecordTimestamp < 0 || (updateIdx < testCase.records.size() - 1 && updatedRecordTimestamp == testCase.records.get(updateIdx + 1).timestamp)) {
-                // found timestamp conflict. try again
-                updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp + 1;
-                if (updateIdx > 0 && updatedRecordTimestamp == testCase.records.get(updateIdx - 1).timestamp) {
-                    // found timestamp conflict. use original timestamp
-                    updatedRecordTimestamp = testCase.records.get(updateIdx).timestamp;
-                }
-            }
-            final TestRecord updatedRecord = new TestRecord("updated".getBytes(), updatedRecordTimestamp);
+        private final TestCase testCase;
 
+        public ExceptionalCasesTest(final TestCase testCase) {
+            this.testCase = testCase;
+        }
+
+        @Parameterized.Parameters(name = "{0}")
+        public static Collection<TestCase> data() {
+            return TEST_CASES;
+        }
+
+        @Test
+        public void shouldRecoverFromStoreInconsistencyOnInsertLatest() {
             final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
 
-            // updateRecord() first requires a call to find()
-            segmentValue.find(testCase.records.get(updateIdx).timestamp, false);
-            segmentValue.updateRecord(updatedRecord.timestamp, updatedRecord.value, updateIdx);
+            segmentValue.insertAsLatest(INSERT_VALID_FROM_TIMESTAMP, INSERT_VALID_TO_TIMESTAMP, INSERT_VALUE);
 
-            // create expected results
-            final List<TestRecord> expectedRecords = new ArrayList<>(testCase.records);
-            expectedRecords.remove(updateIdx);
-            expectedRecords.add(updateIdx, updatedRecord);
-
-            verifySegmentContents(segmentValue, new TestCase("expected", testCase.nextTimestamp, expectedRecords));
-        }
-    }
-
-    @Test
-    public void shouldFindByTimestamp() {
-        if (testCase.isDegenerate) {
-            // cannot find() on degenerate segment
-            return;
+            final TestCase expectedRecords = buildExpectedRecordsForInsertLatest(testCase);
+            verifySegmentContents(segmentValue, expectedRecords);
         }
 
-        final SegmentValue segmentValue = buildSegmentWithInsertLatest(testCase);
+        private static TestCase buildExpectedRecordsForInsertLatest(final TestCase originalTestCase) {
+            final List<TestRecord> originalRecords = originalTestCase.records;
+            final List<TestRecord> newRecords = new ArrayList<>();
 
-        // build expected mapping from timestamp -> record
-        final Map<Long, Integer> expectedRecordIndices = new HashMap<>();
-        // it's important that this for-loop iterates backwards through the record indices, so that
-        // when adjacent records have adjacent timestamps, then the record with the later timestamp
-        // (i.e., the earlier index) takes precedence
-        for (int recordIdx = testCase.records.size() - 1; recordIdx >= 0; recordIdx--) {
-            if (recordIdx < testCase.records.size() - 1) {
-                expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp - 1, recordIdx + 1);
+            for (int i = originalRecords.size() - 1; i >= 0; i--) {
+                final TestRecord originalRecord = originalRecords.get(i);
+                if (originalRecord.timestamp < INSERT_VALID_FROM_TIMESTAMP) {
+                    newRecords.add(0, originalRecord);
+                } else {
+                    break;
+                }
             }
-            if (recordIdx > 0) {
-                expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp + 1, recordIdx);
-            }
-            expectedRecordIndices.put(testCase.records.get(recordIdx).timestamp, recordIdx);
+            newRecords.add(0, new TestRecord(INSERT_VALUE, INSERT_VALID_FROM_TIMESTAMP));
+            return new TestCase("expected", INSERT_VALID_TO_TIMESTAMP, newRecords);
         }
-
-        // verify results
-        for (final Map.Entry<Long, Integer> entry : expectedRecordIndices.entrySet()) {
-            final TestRecord expectedRecord = testCase.records.get(entry.getValue());
-            final long expectedValidTo = entry.getValue() == 0 ? testCase.nextTimestamp : testCase.records.get(entry.getValue() - 1).timestamp;
-
-            final SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
-
-            assertThat(result.index(), equalTo(entry.getValue()));
-            assertThat(result.value(), equalTo(expectedRecord.value));
-            assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));
-            assertThat(result.validTo(), equalTo(expectedValidTo));
-        }
-
-        // verify exception when timestamp is out of range
-        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.nextTimestamp, false));
-        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.nextTimestamp + 1, false));
-        assertThrows(IllegalArgumentException.class, () -> segmentValue.find(testCase.minTimestamp - 1, false));
-    }
-
-    @Test
-    public void shouldGetTimestamps() {
-        final byte[] segmentValue = buildSegmentWithInsertLatest(testCase).serialize();
-
-        assertThat(RocksDBVersionedStoreSegmentValueFormatter.getNextTimestamp(segmentValue), equalTo(testCase.nextTimestamp));
-        assertThat(RocksDBVersionedStoreSegmentValueFormatter.getMinTimestamp(segmentValue), equalTo(testCase.minTimestamp));
-    }
-
-    @Test
-    public void shouldCreateNewWithRecord() {
-        if (testCase.records.size() != 1) {
-            return;
-        }
-
-        final SegmentValue segmentValue = RocksDBVersionedStoreSegmentValueFormatter.newSegmentValueWithRecord(
-            testCase.records.get(0).value,
-            testCase.records.get(0).timestamp,
-            testCase.nextTimestamp);
-
-        verifySegmentContents(segmentValue, testCase);
     }
 
     private static SegmentValue buildSegmentWithInsertLatest(final TestCase testCase) {


### PR DESCRIPTION
The RocksDB-based implementation of versioned stores introduced in https://github.com/apache/kafka/pull/13188 consists of a "latest value store" and separate (logical) "segments stores." A single put operation may need to modify multiple (two) segments, or both a segment and the latest value store, which opens the possibility to store inconsistencies if the first write succeeds while the later one fails. When this happens, Streams will error out, but the store still needs to be able to recover upon restart. This PR adds the necessary repair logic into RocksDBVersionedStore to effectively undo the earlier failed write when a store inconsistency is encountered.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
