### PR TITLE
KAFKA-14491: [17/N] Refactor segments cleanup logic

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
@@ -79,16 +79,12 @@ abstract class AbstractSegments<S extends Segment> implements Segments<S> {
         final long minLiveTimestamp = streamTime - retentionPeriod;
         final long minLiveSegment = segmentId(minLiveTimestamp);
 
-        final S toReturn;
         if (segmentId >= minLiveSegment) {
             // The segment is live. get it, ensure it's open, and return it.
-            toReturn = getOrCreateSegment(segmentId, context);
+            return getOrCreateSegment(segmentId, context);
         } else {
-            toReturn = null;
+            return null;
         }
-
-        cleanupEarlierThan(minLiveSegment);
-        return toReturn;
     }
 
     @Override
@@ -113,8 +109,7 @@ abstract class AbstractSegments<S extends Segment> implements Segments<S> {
             // ignore
         }
 
-        final long minLiveSegment = segmentId(streamTime - retentionPeriod);
-        cleanupEarlierThan(minLiveSegment);
+        cleanupExpiredSegments(streamTime);
     }
 
     @Override
@@ -172,7 +167,8 @@ abstract class AbstractSegments<S extends Segment> implements Segments<S> {
         segments.clear();
     }
 
-    private void cleanupEarlierThan(final long minLiveSegment) {
+    protected void cleanupExpiredSegments(final long streamTime) {
+        final long minLiveSegment = segmentId(streamTime - retentionPeriod);
         final Iterator<Map.Entry<Long, S>> toRemove =
             segments.headMap(minLiveSegment, false).entrySet().iterator();
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -54,6 +54,15 @@ class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
     }
 
     @Override
+    public KeyValueSegment getOrCreateSegmentIfLive(final long segmentId,
+                                                    final ProcessorContext context,
+                                                    final long streamTime) {
+        final KeyValueSegment segment = super.getOrCreateSegmentIfLive(segmentId, context, streamTime);
+        cleanupExpiredSegments(streamTime);
+        return segment;
+    }
+
+    @Override
     public void openExisting(final ProcessorContext context, final long streamTime) {
         metricsRecorder.init(ProcessorContextUtils.getMetricsImpl(context), context.taskId());
         super.openExisting(context, streamTime);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
@@ -58,6 +58,11 @@ public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSeg
     }
 
     @Override
+    public void cleanupExpiredSegments(final long streamTime) {
+        super.cleanupExpiredSegments(streamTime);
+    }
+
+    @Override
     public void flush() {
         physicalStore.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -480,6 +480,8 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
         final byte[] value,
         final long timestamp
     ) {
+        segmentStores.cleanupExpiredSegments(observedStreamTime);
+
         // track the smallest timestamp seen so far that is larger than insertion timestamp.
         // this timestamp determines, based on all segments searched so far, which segment the
         // new record should be inserted into.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
@@ -54,6 +54,15 @@ class TimestampedSegments extends AbstractSegments<TimestampedSegment> {
     }
 
     @Override
+    public TimestampedSegment getOrCreateSegmentIfLive(final long segmentId,
+                                                    final ProcessorContext context,
+                                                    final long streamTime) {
+        final TimestampedSegment segment = super.getOrCreateSegmentIfLive(segmentId, context, streamTime);
+        cleanupExpiredSegments(streamTime);
+        return segment;
+    }
+
+    @Override
     public void openExisting(final ProcessorContext context, final long streamTime) {
         metricsRecorder.init(ProcessorContextUtils.getMetricsImpl(context), context.taskId());
         super.openExisting(context, streamTime);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
@@ -108,6 +108,8 @@ public class LogicalKeyValueSegmentsTest {
         final LogicalKeyValueSegment segment3 = segments.getOrCreateSegmentIfLive(3, context, SEGMENT_INTERVAL * 3L);
         final LogicalKeyValueSegment segment4 = segments.getOrCreateSegmentIfLive(7, context, SEGMENT_INTERVAL * 7L);
 
+        segments.cleanupExpiredSegments(SEGMENT_INTERVAL * 7L);
+
         final List<LogicalKeyValueSegment> allSegments = segments.allSegments(true);
         assertEquals(2, allSegments.size());
         assertEquals(segment3, allSegments.get(0));


### PR DESCRIPTION
Prior to this PR, AbstractSegments automatically called the helper method to clean up expired segments as part of `getOrCreateSegmentIfLive()`. This works fine for windowed store implementations which call `getOrCreateSegmentIfLive()` exactly once per `put()` call, but is inefficient and difficult to reason about for the new RocksDBVersionedStore implementation (cf. https://github.com/apache/kafka/pull/13188) which makes potentially multiple calls to `getOrCreateSegmentIfLive()` for different segments for a single `put()` call. This PR addresses this by refactoring the call to clean up expired segments out of `getOrCreateSegmentIfLive()`, opting to have the different segments implementations specify when cleanup should occur instead. After this PR, RocksDBVersionedStore only cleans up expired segments once per call to `put()`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
