### PR TITLE
KAFKA-14797: Emit offset sync when offset translation lag would exceed max.offset.lag

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -305,7 +305,6 @@ public class MirrorSourceTask extends SourceTask {
     static class PartitionState {
         long previousUpstreamOffset = -1L;
         long previousDownstreamOffset = -1L;
-        long lastSyncUpstreamOffset = -1L;
         long lastSyncDownstreamOffset = -1L;
         long maxOffsetLag;
         boolean shouldSyncOffsets;
@@ -316,13 +315,14 @@ public class MirrorSourceTask extends SourceTask {
 
         // true if we should emit an offset sync
         boolean update(long upstreamOffset, long downstreamOffset) {
-            long upstreamStep = upstreamOffset - lastSyncUpstreamOffset;
-            long downstreamTargetOffset = lastSyncDownstreamOffset + upstreamStep;
+            // This value is what OffsetSyncStore::translateOffsets would compute for this offset given the last sync.
+            // Because this method is called at most once for each upstream offset, simplify upstreamStep to 1.
+            // TODO: share common implementation to enforce this relationship
+            long downstreamTargetOffset = lastSyncDownstreamOffset + 1;
             if (lastSyncDownstreamOffset == -1L
                     || downstreamOffset - downstreamTargetOffset >= maxOffsetLag
                     || upstreamOffset - previousUpstreamOffset != 1L
                     || downstreamOffset < previousDownstreamOffset) {
-                lastSyncUpstreamOffset = upstreamOffset;
                 lastSyncDownstreamOffset = downstreamOffset;
                 shouldSyncOffsets = true;
             }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -103,7 +103,7 @@ public class MirrorSourceTaskTest {
         partitionState.reset();
         assertFalse(partitionState.update(5, 154), "no sync");
         partitionState.reset();
-        assertFalse(partitionState.update(6, 203), "one past target offset");
+        assertFalse(partitionState.update(6, 203), "no sync");
         partitionState.reset();
         assertTrue(partitionState.update(7, 204), "one past target offset");
         partitionState.reset();

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -99,11 +99,13 @@ public class MirrorSourceTaskTest {
         partitionState.reset();
         assertFalse(partitionState.update(3, 152), "no sync");
         partitionState.reset();
-        assertFalse(partitionState.update(4, 153), "no sync");
+        assertTrue(partitionState.update(4, 153), "one past target offset");
         partitionState.reset();
         assertFalse(partitionState.update(5, 154), "no sync");
         partitionState.reset();
-        assertTrue(partitionState.update(6, 205), "one past target offset");
+        assertFalse(partitionState.update(6, 203), "one past target offset");
+        partitionState.reset();
+        assertTrue(partitionState.update(7, 204), "one past target offset");
         partitionState.reset();
         assertTrue(partitionState.update(2, 206), "upstream reset");
         partitionState.reset();

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -867,14 +867,9 @@ public class MirrorConnectorsIntegrationBaseTest {
     protected static void assertDownstreamRedeliveriesBoundedByMaxLag(Consumer<byte[], byte[]> targetConsumer) {
         ConsumerRecords<byte[], byte[]> records = targetConsumer.poll(CONSUMER_POLL_TIMEOUT_MS);
         // After a full sync, there should be at most offset.lag.max records per partition consumed by both upstream and downstream consumers.
-        Map<TopicPartition, Integer> perPartitionCount = new HashMap<>();
-        for (ConsumerRecord<byte[], byte[]> record : records) {
-            TopicPartition tp = new TopicPartition(record.topic(), record.partition());
-            int previous = perPartitionCount.getOrDefault(tp, 0);
-            perPartitionCount.put(tp, previous + 1);
-        }
-        for (Map.Entry<TopicPartition, Integer> entry : perPartitionCount.entrySet()) {
-            assertTrue(entry.getValue() < OFFSET_LAG_MAX,  "downstream consumer is re-reading more than " + OFFSET_LAG_MAX + " records from" + entry.getKey());
+        for (TopicPartition tp : records.partitions()) {
+            int count = records.records(tp).size();
+            assertTrue(count < OFFSET_LAG_MAX,  "downstream consumer is re-reading more than " + OFFSET_LAG_MAX + " records from" + tp);
         }
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -46,12 +46,12 @@ public class MirrorConnectorsIntegrationTransactionsTest extends MirrorConnector
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "embedded-kafka-0");
         startClusters(new HashMap<String, String>() {{
-            put("topics", "test-topic-.*, primary.test-topic-.*, backup.test-topic-.*");
-            put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".enabled", "true");
-            put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "true");
-            // This is not necessary for this test, but is not tested elsewhere.
-            put("offset.lag.max", "0");
-        }});
+                put("topics", "test-topic-.*, primary.test-topic-.*, backup.test-topic-.*");
+                put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".enabled", "true");
+                put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "true");
+                // This is not necessary for this test, but is not tested elsewhere.
+                put("offset.lag.max", "0");
+            }});
     }
 
     /**

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -49,8 +49,6 @@ public class MirrorConnectorsIntegrationTransactionsTest extends MirrorConnector
                 put("topics", "test-topic-.*, primary.test-topic-.*, backup.test-topic-.*");
                 put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".enabled", "true");
                 put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "true");
-                // This is not necessary for this test, but is not tested elsewhere.
-                put("offset.lag.max", "0");
             }});
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -45,11 +45,7 @@ public class MirrorConnectorsIntegrationTransactionsTest extends MirrorConnector
         backupBrokerProps.put("transaction.state.log.min.isr", "1");
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "embedded-kafka-0");
-        startClusters(new HashMap<String, String>() {{
-                put("topics", "test-topic-.*, primary.test-topic-.*, backup.test-topic-.*");
-                put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".enabled", "true");
-                put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "true");
-            }});
+        super.startClusters();
     }
 
     /**

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -45,7 +45,13 @@ public class MirrorConnectorsIntegrationTransactionsTest extends MirrorConnector
         backupBrokerProps.put("transaction.state.log.min.isr", "1");
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "embedded-kafka-0");
-        super.startClusters();
+        startClusters(new HashMap<String, String>() {{
+            put("topics", "test-topic-.*, primary.test-topic-.*, backup.test-topic-.*");
+            put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".enabled", "true");
+            put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "true");
+            // This is not necessary for this test, but is not tested elsewhere.
+            put("offset.lag.max", "0");
+        }});
     }
 
     /**


### PR DESCRIPTION
This fixes a regression in KAFKA-12468 #13178 and must accompany that patch in all releases.

In KAFKA-12468, the OffsetCheckpointTask was changed to use a more conservative method of translating offsets, in order to avoid translating offsets incorrectly. That method requires more offset syncs to be emitted by the MirrorSourceTask, in order to keep the same bound on the max.offset.lag. #13178 failed to change the logic for triggering offset syncs, and so too few offset syncs were emitted, causing the translated offsets to exceed the max.offset.lag.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
