### PR TITLE
KAFKA-14172: Should clear cache when active recycled from standby

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -226,7 +226,7 @@ class ActiveTaskCreator {
         }
 
         standbyTask.prepareRecycle();
-        standbyTask.stateMgr.transitionTaskType(Task.TaskType.ACTIVE);
+        standbyTask.stateMgr.transitionTaskType(Task.TaskType.ACTIVE, getLogContext(standbyTask.id));
 
         final RecordCollector recordCollector = createRecordCollector(standbyTask.id, getLogContext(standbyTask.id), standbyTask.topology);
         final StreamTask task = new StreamTask(
@@ -324,7 +324,7 @@ class ActiveTaskCreator {
 
     private LogContext getLogContext(final TaskId taskId) {
         final String threadIdPrefix = String.format("stream-thread [%s] ", Thread.currentThread().getName());
-        final String logPrefix = threadIdPrefix + String.format("%s [%s] ", "task", taskId);
+        final String logPrefix = threadIdPrefix + String.format("%s [%s] ", "stream-task", taskId);
         return new LogContext(logPrefix);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -590,12 +590,13 @@ public class ProcessorStateManager implements StateManager {
         }
     }
 
-    void transitionTaskType(final TaskType newType) {
+    void transitionTaskType(final TaskType newType, final LogContext logContext) {
         if (taskType.equals(newType)) {
             throw new IllegalStateException("Tried to recycle state for task type conversion but new type was the same.");
         }
 
         taskType = newType;
+        log = logContext.logger(ProcessorStateManager.class);
     }
 
     @Override
@@ -639,7 +640,7 @@ public class ProcessorStateManager implements StateManager {
             }
         }
 
-        log.debug("Writing checkpoint: {}", checkpointingOffsets);
+        log.warn("Writing checkpoint: {} for task {}", checkpointingOffsets, taskId);
         try {
             checkpointFile.write(checkpointingOffsets);
         } catch (final IOException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -123,7 +123,7 @@ class StandbyTaskCreator {
         }
 
         streamTask.prepareRecycle();
-        streamTask.stateMgr.transitionTaskType(Task.TaskType.STANDBY);
+        streamTask.stateMgr.transitionTaskType(Task.TaskType.STANDBY, getLogContext(streamTask.id));
 
         final StandbyTask task = new StandbyTask(
             streamTask.id,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -846,7 +846,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
                 changelogMetadata.restoreEndOffset = Math.min(endOffset, committedOffset);
 
-                log.debug("End offset for changelog {} initialized as {}.", partition, changelogMetadata.restoreEndOffset);
+                log.info("End offset for changelog {} initialized as {}.", partition, changelogMetadata.restoreEndOffset);
             } else {
                 if (!newPartitionsToRestore.remove(changelogMetadata)) {
                     throw new IllegalStateException("New changelogs to restore " + newPartitionsToRestore +

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachedStateStore.java
@@ -32,4 +32,12 @@ public interface CachedStateStore<K, V> {
      * TODO: this is a hacky workaround for now, should be removed when we decouple caching with emitting
      */
     void flushCache();
+
+    /**
+     * Clear the cache; this is used if the underlying store could be updated directly
+     * and hence making the cache out of date.
+     *
+     * TODO: this is a hacky workaround for now, should be removed when we decouple caching with emitting
+     */
+    void clearCache();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachedStateStore.java
@@ -36,6 +36,8 @@ public interface CachedStateStore<K, V> {
     /**
      * Clear the cache; this is used if the underlying store could be updated directly
      * and hence making the cache out of date.
+     * Please note this call does not try to flush the cache, instead if assumes the cache
+     * itself has been flushed completely
      *
      * TODO: this is a hacky workaround for now, should be removed when we decouple caching with emitting
      */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -477,6 +477,17 @@ public class CachingKeyValueStore
         try {
             validateStoreOpen();
             context.cache().flush(cacheName);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void clearCache() {
+        validateStoreOpen();
+        lock.writeLock().lock();
+        try {
+            validateStoreOpen();
             context.cache().clear(cacheName);
         } finally {
             lock.writeLock().unlock();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -477,6 +477,7 @@ public class CachingKeyValueStore
         try {
             validateStoreOpen();
             context.cache().flush(cacheName);
+            context.cache().clear(cacheName);
         } finally {
             lock.writeLock().unlock();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -334,6 +334,11 @@ class CachingSessionStore
         context.cache().flush(cacheName);
     }
 
+    @Override
+    public void clearCache() {
+        context.cache().clear(cacheName);
+    }
+
     public void close() {
         final LinkedList<RuntimeException> suppressed = executeAll(
             () -> context.cache().flush(cacheName),

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -426,6 +426,11 @@ class CachingWindowStore
     }
 
     @Override
+    public void clearCache() {
+        context.cache().clear(cacheName);
+    }
+
+    @Override
     public synchronized void close() {
         final LinkedList<RuntimeException> suppressed = executeAll(
             () -> context.cache().flush(cacheName),

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -361,6 +361,13 @@ class NamedCache {
         streamsMetrics.removeAllCacheLevelSensors(Thread.currentThread().getName(), taskName, storeName);
     }
 
+    synchronized void clear() {
+        head = tail = null;
+        currentSizeBytes = 0;
+        dirtyKeys.clear();
+        cache.clear();
+    }
+
     /**
      * A simple wrapper class to implement a doubly-linked list around MemoryLRUCacheBytesEntry
      */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -280,6 +280,13 @@ public class ThreadCache {
         }
     }
 
+    synchronized void clear(final String namespace) {
+        final NamedCache cleared = caches.get(namespace);
+        if (cleared != null) {
+            cleared.clear();
+        }
+    }
+
     private void maybeEvict(final String namespace, final NamedCache cache) {
         int numEvicted = 0;
         while (sizeInBytes.get() > maxCacheSizeBytes) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -283,6 +283,7 @@ public class ThreadCache {
     synchronized void clear(final String namespace) {
         final NamedCache cleared = caches.get(namespace);
         if (cleared != null) {
+            sizeInBytes.getAndAdd(-cleared.sizeInBytes());
             cleared.clear();
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
@@ -521,6 +521,11 @@ class TimeOrderedCachingWindowStore
     }
 
     @Override
+    public void clearCache() {
+        context.cache().clear(cacheName);
+    }
+
+    @Override
     public synchronized void close() {
         final LinkedList<RuntimeException> suppressed = executeAll(
             () -> context.cache().flush(cacheName),

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -89,6 +89,14 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
     }
 
     @Override
+    public void clearCache() {
+        if (wrapped instanceof CachedStateStore) {
+            ((CachedStateStore) wrapped).clearCache();
+        }
+    }
+
+
+    @Override
     public String name() {
         return wrapped.name();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSCachingAndAcceptableLagIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSCachingAndAcceptableLagIntegrationTest.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * An integration test to verify EOS properties when using Caching and Standby replicas
+ * while tasks are being redistributed after re-balancing event.
+ * The intent is not that this test should be merged into the repo but only provided for evidence on how to reproduce.
+ * One test fail and two test pass reliably on an i7-8750H CPU @ 2.20GHz × 12 with 32 GiB Memory
+ */
+@RunWith(Parameterized.class)
+@Category(IntegrationTest.class)
+public class StandbyTaskEOSCachingAndAcceptableLagIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StandbyTaskEOSCachingAndAcceptableLagIntegrationTest.class);
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<ConfigSetup[]> data() {
+        return asList(new ConfigSetup[][]{
+                // The default config produces errors.
+                {ConfigSetup.DEFAULT_CONFIG},
+                // Caching disabled and no lag acceptable both works as expected
+                {ConfigSetup.CACHING_DISABLED}, {ConfigSetup.NO_LAG_ACCEPTABLE}
+        });
+    }
+
+    public enum ConfigSetup {
+        DEFAULT_CONFIG,
+        CACHING_DISABLED,
+        NO_LAG_ACCEPTABLE
+    }
+
+    @Parameterized.Parameter
+    public ConfigSetup configSetup;
+
+    private final static long TWO_MINUTE_TIMEOUT = Duration.ofMinutes(2L).toMillis();
+
+    private String appId;
+    private String inputTopic;
+    private String storeName;
+    private String counterName;
+
+    private String outputTopic;
+
+    private KafkaStreams streamInstanceOne;
+    private KafkaStreams streamInstanceTwo;
+    private KafkaStreams streamInstanceThree;
+
+
+    private static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
+
+    @BeforeClass
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterClass
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    @Before
+    public void createTopics() throws Exception {
+        final String safeTestName = UUID.randomUUID().toString();
+        appId = "app-" + safeTestName;
+        inputTopic = "input-" + safeTestName;
+        outputTopic = "output-" + safeTestName;
+        storeName = "store-" + safeTestName;
+        counterName = "counter-" + safeTestName;
+
+        CLUSTER.deleteTopicsAndWait(inputTopic, outputTopic);
+        CLUSTER.createTopic(inputTopic, partitionCount, 3);
+        CLUSTER.createTopic(outputTopic, partitionCount, 3);
+    }
+
+    private final int partitionCount = 12;
+
+    @After
+    public void cleanUp() {
+        if (streamInstanceOne != null) {
+            streamInstanceOne.close();
+        }
+        if (streamInstanceTwo != null) {
+            streamInstanceTwo.close();
+        }
+        if (streamInstanceThree != null) {
+            streamInstanceThree.close();
+        }
+    }
+
+    // The test produces a duplicate fee range of integers from 0 (inclusive) to initialBulk + secondBulk (exclusive) as input to the stream.
+    // The stream is responsible for assigning a unique id to each of the integers.
+    // The output topic must thus contain 63000 message:
+    //      The Key is unique and from the range of input values
+    //      The Values produced are unique.
+    @Test
+    public void shouldHonorEOSWhenUsingCachingAndStandbyReplicas() throws Exception {
+        final Properties readCommitted = new Properties();
+        readCommitted.setProperty("isolation.level", "read_committed");
+        final long time = System.currentTimeMillis();
+        final String base = TestUtils.tempDirectory(appId).getPath();
+
+        final int initialBulk = 3000;
+        final int secondBulk = 60000;
+
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+                inputTopic,
+                IntStream.range(0, initialBulk).boxed().map(i -> new KeyValue<>(i, i)).collect(Collectors.toList()),
+                TestUtils.producerConfig(
+                        CLUSTER.bootstrapServers(),
+                        IntegerSerializer.class,
+                        IntegerSerializer.class,
+                        new Properties()
+                ),
+                10L + time
+        );
+
+        streamInstanceOne = buildWithUniqueIdAssignmentTopology(base + "-1");
+        streamInstanceTwo = buildWithUniqueIdAssignmentTopology(base + "-2");
+        streamInstanceThree = buildWithUniqueIdAssignmentTopology(base + "-3");
+
+        LOG.info("start first instance and wait for completed processing");
+        startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceOne), Duration.ofSeconds(30));
+        IntegrationTestUtils.waitUntilMinRecordsReceived(
+                TestUtils.consumerConfig(
+                        CLUSTER.bootstrapServers(),
+                        UUID.randomUUID().toString(),
+                        IntegerDeserializer.class,
+                        IntegerDeserializer.class,
+                        readCommitted
+                ),
+                outputTopic,
+                initialBulk
+        );
+        LOG.info("Finished reading the initial bulk");
+
+        LOG.info("start second instance and wait for standby replication");
+        startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceTwo), Duration.ofSeconds(30));
+        waitForCondition(
+                () -> streamInstanceTwo.store(
+                        StoreQueryParameters.fromNameAndType(
+                                storeName,
+                                QueryableStoreTypes.<Integer, Integer>keyValueStore()
+                        ).enableStaleStores()
+                ).get(0) != null,
+                TWO_MINUTE_TIMEOUT,
+                "Could not get key from standby store"
+        );
+        LOG.info("Second stream have some data in the state store");
+
+
+        LOG.info("Produce the second bulk");
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+                inputTopic,
+                IntStream.range(initialBulk, initialBulk + secondBulk).boxed().map(i -> new KeyValue<>(i, i)).collect(Collectors.toList()),
+                TestUtils.producerConfig(
+                        CLUSTER.bootstrapServers(),
+                        IntegerSerializer.class,
+                        IntegerSerializer.class,
+                        new Properties()
+                ),
+                1000L + time
+        );
+
+        LOG.info("Allow for some processing of messages by stream one and two and some catching up of standby tasks");
+        Thread.sleep(5000);
+
+        LOG.info("Start stream three which will introduce a re-balancing event and hopefully some redistribution of tasks.");
+        startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceThree), Duration.ofSeconds(90));
+
+        LOG.info("Wait for the processing to be completed");
+        final List<ConsumerRecord<Integer, Integer>> outputRecords = IntegrationTestUtils.waitUntilMinRecordsReceived(
+                TestUtils.consumerConfig(
+                        CLUSTER.bootstrapServers(),
+                        UUID.randomUUID().toString(),
+                        IntegerDeserializer.class,
+                        IntegerDeserializer.class,
+                        readCommitted
+                ),
+                outputTopic,
+                initialBulk + secondBulk,
+                TWO_MINUTE_TIMEOUT
+        );
+        LOG.info("Processing completed");
+
+        outputRecords.stream().collect(Collectors.groupingBy(ConsumerRecord::value)).forEach(this::logIfDuplicate);
+
+        assertThat("Each output should correspond to one distinct value", outputRecords.stream().map(ConsumerRecord::value).distinct().count(), is(Matchers.equalTo((long) outputRecords.size())));
+    }
+
+    private void logIfDuplicate(final Integer id, final List<ConsumerRecord<Integer, Integer>> record) {
+        assertThat("The id and the value in the records must match", record.stream().allMatch(r -> id.equals(r.value())));
+        if (record.size() > 1) {
+            LOG.debug("Id : " + id + " is assigned to the following " + record.stream().map(ConsumerRecord::key).collect(Collectors.toList()));
+        }
+    }
+
+    private KafkaStreams buildWithUniqueIdAssignmentTopology(final String stateDirPath) {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        builder.addStateStore(Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(storeName),
+                Serdes.Integer(),
+                Serdes.Integer())
+        );
+        builder.addStateStore(Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(counterName),
+                Serdes.Integer(),
+                Serdes.Integer()).withCachingEnabled()
+        );
+        builder.<Integer, Integer>stream(inputTopic)
+                .transform(
+                        () -> new Transformer<Integer, Integer, KeyValue<Integer, Integer>>() {
+                            private KeyValueStore<Integer, Integer> store;
+                            private KeyValueStore<Integer, Integer> counter;
+                            private ProcessorContext context;
+
+                            @Override
+                            public void init(final ProcessorContext context) {
+                                this.context = context;
+                                store = context.getStateStore(storeName);
+                                counter = context.getStateStore(counterName);
+                            }
+
+                            @Override
+                            public KeyValue<Integer, Integer> transform(final Integer key, final Integer unused) {
+                                assertThat("Key and value mus be equal", key.equals(unused));
+                                // Introduce a small delay
+                                if (key > 10000) {
+                                    try {
+                                        Thread.sleep(10);
+                                    } catch (final InterruptedException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                }
+                                Integer id = store.get(key);
+                                // Only assign a new id if the value have not been observed before
+                                if (id == null) {
+                                    final int counterKey = 0;
+                                    final Integer lastCounter = counter.get(counterKey);
+                                    final int newCounter = lastCounter == null ? 0 : lastCounter + 1;
+                                    counter.put(counterKey, newCounter);
+                                    // Partitions assign ids from their own id space
+                                    id = newCounter * partitionCount + context.partition();
+                                    store.put(key, id);
+                                }
+                                return KeyValue.pair(key, id);
+                            }
+
+                            @Override
+                            public void close() {
+                            }
+                        },
+                        storeName, counterName
+                )
+                .to(outputTopic);
+        return new KafkaStreams(builder.build(), props(stateDirPath));
+    }
+
+
+    private Properties props(final String stateDirPath) {
+        final Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDirPath);
+        streamsConfiguration.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4);
+
+        streamsConfiguration.put(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, 1);
+        streamsConfiguration.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        //PRODUCES DUPLICATES
+        switch (configSetup) {
+            case DEFAULT_CONFIG:
+                streamsConfiguration.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, 100000); // DEFAULT
+                streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 10 * 1024 * 1024L); //DEFAULT
+                break;
+            case CACHING_DISABLED:
+                streamsConfiguration.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, 100000); //DEFAULT
+                streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0); // Caching disabled
+                break;
+            case NO_LAG_ACCEPTABLE:
+                streamsConfiguration.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, 0); // No lag accepted
+                streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 10 * 1024 * 1024L); // DEFAULT
+                break;
+        }
+
+        return streamsConfiguration;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSMultiRebalanceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSMultiRebalanceIntegrationTest.java
@@ -59,12 +59,6 @@ import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-/**
- * An integration test to verify EOS properties when using Caching and Standby replicas
- * while tasks are being redistributed after re-balancing event.
- * The intent is not that this test should be merged into the repo but only provided for evidence on how to reproduce.
- * One test fail and two test pass reliably on an i7-8750H CPU @ 2.20GHz × 12 with 32 GiB Memory
- */
 @Category(IntegrationTest.class)
 @SuppressWarnings("deprecation")
 public class StandbyTaskEOSMultiRebalanceIntegrationTest {


### PR DESCRIPTION
This fix is inspired by https://github.com/apache/kafka/pull/12540.

1. Added a `clearCache` function for CachedStateStore, which would be triggered upon recycling a state manager.
2. Added the integration test inherited from #12540 .
3. Improved some log4j entries.
4. Found and fixed a minor issue with log4j prefix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
