### PR TITLE
MINOR: Add unclean field of PartitionReassignmentRevert to hashCode equals and toString

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentRevert.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentRevert.java
@@ -85,7 +85,7 @@ class PartitionReassignmentRevert {
 
     @Override
     public int hashCode() {
-        return Objects.hash(replicas, isr);
+        return Objects.hash(replicas, isr, unclean);
     }
 
     @Override
@@ -93,13 +93,15 @@ class PartitionReassignmentRevert {
         if (!(o instanceof PartitionReassignmentRevert)) return false;
         PartitionReassignmentRevert other = (PartitionReassignmentRevert) o;
         return replicas.equals(other.replicas) &&
-            isr.equals(other.isr);
+            isr.equals(other.isr) &&
+            unclean == other.unclean;
     }
 
     @Override
     public String toString() {
         return "PartitionReassignmentRevert(" +
             "replicas=" + replicas + ", " +
-            "isr=" + isr + ")";
+            "isr=" + isr + ", " +
+            "unclean=" + unclean + ")";
     }
 }


### PR DESCRIPTION
### Details
It looks like we forgot to add the `unclean` field of `PartitionReassignmentRevert` to a few methods. So adding it here. 

### Testing
`./gradlew jar`
`./gradlew metadata:test --tests org.apache.kafka.controller.PartitionReassignmentRevertTest`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
