### PR TITLE
KAFKA-14799: Ignore source task requests to abort empty transactions

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/TransactionContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/TransactionContext.java
@@ -31,6 +31,11 @@ public interface TransactionContext {
     /**
      * Request a transaction commit after a source record is processed. The source record will be the
      * last record in the committed transaction.
+     * <p>
+     * If a task requests that the last record in a batch that it returns from {@link SourceTask#poll()}
+     * be committed by invoking this method, and also requests that that same batch be aborted by
+     * invoking {@link #abortTransaction()}, the record-based operation (in this case, committing
+     * the transaction) will take precedence.
      * @param record the record to commit the transaction after; may not be null.
      */
     void commitTransaction(SourceRecord record);
@@ -50,6 +55,11 @@ public interface TransactionContext {
      * and will not appear in a committed transaction. However, offsets for that transaction will still
      * be committed so that the records in that transaction are not reprocessed. If the data should be
      * reprocessed, the task should not invoke this method and should instead throw an exception.
+     * <p>
+     * If a task requests that the last record in a batch that it returns from {@link SourceTask#poll()}
+     * be aborted by invoking this method, and also requests that that same batch be committed by
+     * invoking {@link #commitTransaction()}, the record-based operation (in this case, aborting
+     * the transaction) will take precedence.
      * @param record the record to abort the transaction after; may not be null.
      */
     void abortTransaction(SourceRecord record);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -358,9 +358,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
                     continue;
                 }
                 log.trace("{} About to send {} records to Kafka", this, toSend.size());
-                if (sendRecords()) {
-                    batchDispatched();
-                } else {
+                if (!sendRecords()) {
                     stopRequestedLatch.await(SEND_FAILED_BACKOFF_MS, TimeUnit.MILLISECONDS);
                 }
             }
@@ -455,6 +453,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
             recordDispatched(preTransformRecord);
         }
         toSend = null;
+        batchDispatched();
         return true;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -470,7 +470,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                     protected boolean shouldCommitTransactionForBatch(long currentTimeMs) {
                         if (transactionContext.shouldAbortBatch()) {
                             log.info("Aborting transaction for batch as requested by connector");
-                            abortTransaction();
+                            maybeAbortTransaction();
                             // We abort the transaction, which causes all the records up to this point to be dropped, but we still want to
                             // commit offsets so that the task doesn't see the same records all over again
                             return true;
@@ -483,7 +483,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                         if (transactionContext.shouldAbortOn(record)) {
                             log.info("Aborting transaction for record on topic {} as requested by connector", record.topic());
                             log.trace("Last record in aborted transaction: {}", record);
-                            abortTransaction();
+                            maybeAbortTransaction();
                             // We abort the transaction, which causes all the records up to this point to be dropped, but we still want to
                             // commit offsets so that the task doesn't see the same records all over again
                             return true;
@@ -491,7 +491,11 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                         return transactionContext.shouldCommitOn(record);
                     }
 
-                    private void abortTransaction() {
+                    private void maybeAbortTransaction() {
+                        if (!transactionOpen) {
+                            log.warn("Ignoring request by task to abort transaction as the current transaction is empty");
+                            return;
+                        }
                         producer.abortTransaction();
                         transactionMetrics.abortTransaction();
                         transactionOpen = false;


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14799)

Since invoking `KafkaProducer::abortTransaction` when no transaction is currently open (via `KafkaProducer::beginTransaction`) causes an `IllegalStateException`, requests by source tasks to abort the current transaction when they have not returned any records from `SourceTask::poll` will currently cause the task to fail.

This patch gracefully handles that scenario by skipping the call to `KafkaProducer::abortTransaction` but emitting a `WARN`-level log message.

A basic unit test is added to ensure that we do not attempt to abort empty transactions.

A small bug in the internal API we use in `ExactlyOnceWorkerSourceTaskTest` for manipulating and awaiting source task poll contents is also fixed (two lines to change, two hours to figure out 😄).

As a follow-up item, we may want to consider using the `MockProducer` class in these and other unit tests since it may involve less work than manually mocking the `Producer` interface and should more-closely resemble the behavior of the `KafkaProducer` class (for example, it will automatically check for transaction state during calls to `beginTransaction`, `abortTransaction`, and `commitTransaction`).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
