### PR TITLE
KAFKA-14800: Bump snappy-java version to 1.1.9.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -120,7 +120,7 @@ versions += [
   scalaJava8Compat : "1.0.2",
   scoverage: "1.4.11",
   slf4j: "1.7.36",
-  snappy: "1.1.8.4",
+  snappy: "1.1.9.1",
   spotbugs: "4.7.3",
   swaggerAnnotations: "2.2.0",
   swaggerJaxrs2: "2.2.0",


### PR DESCRIPTION
Extra Release Details: 
- https://github.com/google/snappy/releases/tag/1.1.9
- https://github.com/xerial/snappy-java/releases/tag/v1.1.9.1

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
