### PR TITLE
KAFKA-14809 Fix logging conditional on WorkerSourceTask

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -216,7 +216,7 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
             this.committableOffsets = CommittableOffsets.EMPTY;
         }
 
-        if (committableOffsets.isEmpty()) {
+        if (offsetsToCommit.isEmpty()) {
             log.debug("{} Either no records were produced by the task since the last offset commit, " 
                     + "or every record has been filtered out by a transformation " 
                     + "or dropped due to transformation or conversion errors.",

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -225,15 +225,15 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
             // We continue with the offset commit process here instead of simply returning immediately
             // in order to invoke SourceTask::commit and record metrics for a successful offset commit
         } else {
-            log.info("{} Committing offsets for {} acknowledged messages", this, committableOffsets.numCommittableMessages());
-            if (committableOffsets.hasPending()) {
+            log.info("{} Committing offsets for {} acknowledged messages", this, offsetsToCommit.numCommittableMessages());
+            if (offsetsToCommit.hasPending()) {
                 log.debug("{} There are currently {} pending messages spread across {} source partitions whose offsets will not be committed. "
                                 + "The source partition with the most pending messages is {}, with {} pending messages",
                         this,
-                        committableOffsets.numUncommittableMessages(),
-                        committableOffsets.numDeques(),
-                        committableOffsets.largestDequePartition(),
-                        committableOffsets.largestDequeSize()
+                        offsetsToCommit.numUncommittableMessages(),
+                        offsetsToCommit.numDeques(),
+                        offsetsToCommit.largestDequePartition(),
+                        offsetsToCommit.largestDequeSize()
                 );
             } else {
                 log.debug("{} There are currently no pending messages for this offset commit; "


### PR DESCRIPTION
This shouldn't be a controversial change: the `if` condition here is checking the wrong variable (`this.committableOffsets.isEmpty()` always evaluates to true because of L#216). I assume this bug went undetected because it's only used to log information around committable offsets.

Should I file a JIRA?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
