### PR TITLE
MINOR: Align swagger dependencies with gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
   id 'java-library'
   id 'org.owasp.dependencycheck' version '8.1.2'
   id 'org.nosphere.apache.rat' version "0.8.0"
-  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.0"
+  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.8"
 
   id "com.github.spotbugs" version '5.0.13' apply false
   id 'org.gradle.test-retry' version '1.5.2' apply false

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -122,8 +122,8 @@ versions += [
   slf4j: "1.7.36",
   snappy: "1.1.8.4",
   spotbugs: "4.7.3",
-  swaggerAnnotations: "2.2.0",
-  swaggerJaxrs2: "2.2.0",
+  swaggerAnnotations: "2.2.8",
+  swaggerJaxrs2: "2.2.8",
   zinc: "1.8.0",
   zookeeper: "3.6.4",
   zstd: "1.5.2-1"


### PR DESCRIPTION
Otherwise the build fails with
Caused by: java.lang.NoSuchMethodException: io.swagger.v3.jaxrs2.integration.SwaggerLoader.setOpenAPI31(java.lang.Boolean)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
