### PR TITLE
MINOR: Log consumer groups mirrored by checkpoint tasks

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -109,6 +109,8 @@ public class MirrorCheckpointTask extends SourceTask {
             scheduler.scheduleRepeatingDelayed(this::syncGroupOffset, config.syncGroupOffsetsInterval(),
                     "sync idle consumer group offset from source to target");
         }, "starting offset sync store");
+        log.info("{} checkpointing {} consumer groups {}->{}: {}.", Thread.currentThread().getName(),
+                consumerGroups.size(), sourceClusterAlias, config.targetClusterAlias(), consumerGroups);
     }
 
     @Override


### PR DESCRIPTION
While investigating an issue today, I found this log line https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java#L112-L113 particularly useful. So adding a matching line for MirrorCheckpointTask.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
