### PR TITLE
MINOR: Standardize KRaft logging, thread names, and terminology

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -81,7 +81,6 @@ object Kafka extends Logging {
       new KafkaRaftServer(
         config,
         Time.SYSTEM,
-        threadNamePrefix = None
       )
     }
   }

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -143,7 +143,7 @@ class KafkaRaftManager[T](
   val apiVersions = new ApiVersions()
   private val raftConfig = new RaftConfig(config)
   private val threadNamePrefix = threadNamePrefixOpt.getOrElse("kafka-raft")
-  private val logContext = new LogContext(s"[RaftManager nodeId=${config.nodeId}] ")
+  private val logContext = new LogContext(s"[RaftManager id=${config.nodeId}] ")
   this.logIdent = logContext.logPrefix()
 
   private val scheduler = new KafkaScheduler(1, true, threadNamePrefix + "-scheduler")

--- a/core/src/main/scala/kafka/server/AlterPartitionManager.scala
+++ b/core/src/main/scala/kafka/server/AlterPartitionManager.scala
@@ -81,7 +81,7 @@ object AlterPartitionManager {
     controllerNodeProvider: ControllerNodeProvider,
     time: Time,
     metrics: Metrics,
-    threadNamePrefix: Option[String],
+    threadNamePrefix: String,
     brokerEpochSupplier: () => Long,
   ): AlterPartitionManager = {
     val channelManager = BrokerToControllerChannelManager(
@@ -89,7 +89,7 @@ object AlterPartitionManager {
       time = time,
       metrics = metrics,
       config = config,
-      channelName = "alterPartition",
+      channelName = "alter-partition",
       threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = Long.MaxValue
     )

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -54,11 +54,21 @@ import scala.jdk.CollectionConverters._
 class BrokerLifecycleManager(
   val config: KafkaConfig,
   val time: Time,
-  val threadNamePrefix: Option[String],
+  val threadNamePrefix: String,
   val isZkBroker: Boolean
 ) extends Logging {
 
-  val logContext = new LogContext(s"[BrokerLifecycleManager id=${config.nodeId}] ")
+  private def logPrefix(): String = {
+    val builder = new StringBuilder("[BrokerLifecycleManager")
+    builder.append(" id=").append(config.nodeId)
+    if (isZkBroker) {
+      builder.append(" isZkBroker=true")
+    }
+    builder.append("]")
+    builder.toString()
+  }
+
+  val logContext = new LogContext(logPrefix())
 
   this.logIdent = logContext.logPrefix()
 
@@ -182,7 +192,7 @@ class BrokerLifecycleManager(
    */
   private[server] val eventQueue = new KafkaEventQueue(time,
     logContext,
-    threadNamePrefix.getOrElse(""),
+    threadNamePrefix + "lifecycle-manager",
     new ShutdownEvent())
 
   /**

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -192,7 +192,7 @@ class BrokerLifecycleManager(
    */
   private[server] val eventQueue = new KafkaEventQueue(time,
     logContext,
-    threadNamePrefix + "lifecycle-manager",
+    threadNamePrefix + "lifecycle-manager-",
     new ShutdownEvent())
 
   /**

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -236,7 +236,7 @@ class BrokerToControllerChannelManagerImpl(
         logContext
       )
     }
-    val threadName = s"${threadNamePrefix}-to-controller-${channelName}-channel-manager"
+    val threadName = s"${threadNamePrefix}to-controller-${channelName}-channel-manager"
 
     val controllerInformation = controllerNodeProvider.getControllerInfo()
     new BrokerToControllerRequestThread(

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -136,7 +136,7 @@ object BrokerToControllerChannelManager {
     metrics: Metrics,
     config: KafkaConfig,
     channelName: String,
-    threadNamePrefix: Option[String],
+    threadNamePrefix: String,
     retryTimeoutMs: Long
   ): BrokerToControllerChannelManager = {
     new BrokerToControllerChannelManagerImpl(
@@ -174,10 +174,10 @@ class BrokerToControllerChannelManagerImpl(
   metrics: Metrics,
   config: KafkaConfig,
   channelName: String,
-  threadNamePrefix: Option[String],
+  threadNamePrefix: String,
   retryTimeoutMs: Long
 ) extends BrokerToControllerChannelManager with Logging {
-  private val logContext = new LogContext(s"[BrokerToControllerChannelManager broker=${config.brokerId} name=$channelName] ")
+  private val logContext = new LogContext(s"[BrokerToControllerChannelManager id=${config.brokerId} name=${channelName}] ")
   private val manualMetadataUpdater = new ManualMetadataUpdater()
   private val apiVersions = new ApiVersions()
   private val requestThread = newRequestThread
@@ -236,10 +236,7 @@ class BrokerToControllerChannelManagerImpl(
         logContext
       )
     }
-    val threadName = threadNamePrefix match {
-      case None => s"BrokerToControllerChannelManager broker=${config.brokerId} name=$channelName"
-      case Some(name) => s"$name:BrokerToControllerChannelManager broker=${config.brokerId} name=$channelName"
-    }
+    val threadName = s"${threadNamePrefix}-to-controller-${channelName}-channel-manager"
 
     val controllerInformation = controllerNodeProvider.getControllerInfo()
     new BrokerToControllerRequestThread(

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1718,7 +1718,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     distinctRoles
   }
 
-  def isKRaftCoResidentMode: Boolean = {
+  def isKRaftCombinedMode: Boolean = {
     processRoles == Set(BrokerRole, ControllerRole)
   }
 
@@ -2280,8 +2280,8 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       validateControllerQuorumVotersMustContainNodeIdForKRaftController()
       validateControllerListenerExistsForKRaftController()
       validateControllerListenerNamesMustAppearInListenersForKRaftController()
-    } else if (isKRaftCoResidentMode) {
-      // KRaft colocated broker and controller
+    } else if (isKRaftCombinedMode) {
+      // KRaft combined broker and controller
       validateNonEmptyQuorumVotersForKRaft()
       validateControlPlaneListenerEmptyForKRaft()
       validateAdvertisedListenersDoesNotContainControllerListenersForKRaftBroker()

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -48,7 +48,6 @@ import scala.jdk.CollectionConverters._
 class KafkaRaftServer(
   config: KafkaConfig,
   time: Time,
-  threadNamePrefix: Option[String]
 ) extends Server with Logging {
 
   this.logIdent = s"[KafkaRaftServer nodeId=${config.nodeId}] "
@@ -71,7 +70,6 @@ class KafkaRaftServer(
     metaProps,
     time,
     metrics,
-    threadNamePrefix,
     controllerQuorumVotersFuture,
     new StandardFaultHandlerFactory(),
   )

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -311,7 +311,7 @@ class KafkaServer(
           metrics = metrics,
           config = config,
           channelName = "forwarding",
-          threadNamePrefix = threadNamePrefix,
+          s"zk-broker-${config.nodeId}-",
           retryTimeoutMs = config.requestTimeoutMs.longValue
         )
         clientToControllerChannelManager.start()
@@ -348,7 +348,7 @@ class KafkaServer(
             controllerNodeProvider,
             time = time,
             metrics = metrics,
-            threadNamePrefix = threadNamePrefix,
+            s"zk-broker-${config.nodeId}-",
             brokerEpochSupplier = brokerEpochSupplier
           )
         } else {
@@ -379,7 +379,7 @@ class KafkaServer(
           logger.info("Starting up additional components for ZooKeeper migration")
           lifecycleManager = new BrokerLifecycleManager(config,
             time,
-            threadNamePrefix,
+            s"zk-broker-${config.nodeId}-",
             isZkBroker = true)
 
           // If the ZK broker is in migration mode, start up a RaftManager to learn about the new KRaft controller
@@ -406,7 +406,7 @@ class KafkaServer(
             metrics = metrics,
             config = config,
             channelName = "quorum",
-            threadNamePrefix = threadNamePrefix,
+            s"zk-broker-${config.nodeId}-",
             retryTimeoutMs = config.requestTimeoutMs.longValue
           )
 

--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -68,13 +68,13 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
     private final ClusterConfig clusterConfig;
     private final AtomicReference<KafkaClusterTestKit> clusterReference;
     private final AtomicReference<EmbeddedZookeeper> zkReference;
-    private final boolean isCoResident;
+    private final boolean isCombined;
 
-    public RaftClusterInvocationContext(ClusterConfig clusterConfig, boolean isCoResident) {
+    public RaftClusterInvocationContext(ClusterConfig clusterConfig, boolean isCombined) {
         this.clusterConfig = clusterConfig;
         this.clusterReference = new AtomicReference<>();
         this.zkReference = new AtomicReference<>();
-        this.isCoResident = isCoResident;
+        this.isCombined = isCombined;
     }
 
     @Override
@@ -82,7 +82,7 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
         String clusterDesc = clusterConfig.nameTags().entrySet().stream()
             .map(Object::toString)
             .collect(Collectors.joining(", "));
-        return String.format("[%d] Type=Raft-%s, %s", invocationIndex, isCoResident ? "CoReside" : "Distributed", clusterDesc);
+        return String.format("[%d] Type=Raft-%s, %s", invocationIndex, isCombined ? "Combined" : "Isolated", clusterDesc);
     }
 
     @Override
@@ -92,7 +92,7 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
             (BeforeTestExecutionCallback) context -> {
                 TestKitNodes nodes = new TestKitNodes.Builder().
                         setBootstrapMetadataVersion(clusterConfig.metadataVersion()).
-                        setCoResident(isCoResident).
+                        setCombined(isCombined).
                         setNumBrokerNodes(clusterConfig.numBrokers()).
                         setNumControllerNodes(clusterConfig.numControllers()).build();
                 nodes.brokerNodes().forEach((brokerId, brokerNode) -> {

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -218,7 +218,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 baseDirectory = TestUtils.tempDirectory();
                 nodes = nodes.copyWithAbsolutePaths(baseDirectory.getAbsolutePath());
                 executorService = Executors.newFixedThreadPool(numOfExecutorThreads,
-                    ThreadUtils.createThreadFactory("KafkaClusterTestKit%d", false));
+                    ThreadUtils.createThreadFactory("kafka-cluster-test-kit-executor-%d", false));
                 for (ControllerNode node : nodes.controllerNodes().values()) {
                     setupNodeDirectories(baseDirectory, node.metadataDirectory(), Collections.emptyList());
                     BootstrapMetadata bootstrapMetadata = BootstrapMetadata.

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -223,14 +223,10 @@ public class KafkaClusterTestKit implements AutoCloseable {
                     setupNodeDirectories(baseDirectory, node.metadataDirectory(), Collections.emptyList());
                     BootstrapMetadata bootstrapMetadata = BootstrapMetadata.
                         fromVersion(nodes.bootstrapMetadataVersion(), "testkit");
-                    String threadNamePrefix = (nodes.brokerNodes().containsKey(node.id())) ?
-                            String.format("colocated%d", node.id()) :
-                            String.format("controller%d", node.id());
                     SharedServer sharedServer = new SharedServer(createNodeConfig(node),
                             MetaProperties.apply(nodes.clusterId().toString(), node.id()),
                             Time.SYSTEM,
                             new Metrics(),
-                            Option.apply(threadNamePrefix),
                             connectFutureManager.future,
                             faultHandlerFactory);
                     ControllerServer controller = null;
@@ -261,7 +257,6 @@ public class KafkaClusterTestKit implements AutoCloseable {
                             MetaProperties.apply(nodes.clusterId().toString(), id),
                             Time.SYSTEM,
                             new Metrics(),
-                            Option.apply(String.format("broker%d_", id)),
                             connectFutureManager.future,
                             faultHandlerFactory));
                     BrokerServer broker = null;
@@ -304,7 +299,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
         }
 
         private String listeners(int node) {
-            if (nodes.isCoResidentNode(node)) {
+            if (nodes.isCombined(node)) {
                 return "EXTERNAL://localhost:0,CONTROLLER://localhost:0";
             }
             if (nodes.controllerNodes().containsKey(node)) {
@@ -314,7 +309,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
         }
 
         private String roles(int node) {
-            if (nodes.isCoResidentNode(node)) {
+            if (nodes.isCombined(node)) {
                 return "broker,controller";
             }
             if (nodes.controllerNodes().containsKey(node)) {

--- a/core/src/test/java/kafka/testkit/TestKitNodes.java
+++ b/core/src/test/java/kafka/testkit/TestKitNodes.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 
 public class TestKitNodes {
     public static class Builder {
-        private boolean coResident = false;
+        private boolean combined = false;
         private Uuid clusterId = null;
         private MetadataVersion bootstrapMetadataVersion = null;
         private final NavigableMap<Integer, ControllerNode> controllerNodes = new TreeMap<>();
@@ -49,8 +49,8 @@ public class TestKitNodes {
             return this;
         }
 
-        public Builder setCoResident(boolean coResident) {
-            this.coResident = coResident;
+        public Builder setCombined(boolean combined) {
+            this.combined = combined;
             return this;
         }
 
@@ -127,7 +127,7 @@ public class TestKitNodes {
         }
 
         private int startControllerId() {
-            if (coResident) {
+            if (combined) {
                 return startBrokerId();
             }
             return startBrokerId() + 3000;
@@ -139,7 +139,7 @@ public class TestKitNodes {
     private final NavigableMap<Integer, ControllerNode> controllerNodes;
     private final NavigableMap<Integer, BrokerNode> brokerNodes;
 
-    public boolean isCoResidentNode(int node) {
+    public boolean isCombined(int node) {
         return controllerNodes.containsKey(node) && brokerNodes.containsKey(node);
     }
 

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -980,7 +980,7 @@ class KRaftClusterTest {
     val cluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
         setNumBrokerNodes(1).
-        setCoResident(combinedController).
+        setCombined(combinedController).
         setNumControllerNodes(1).build()).
       setConfigProp("client.quota.callback.class", classOf[DummyClientQuotaCallback].getName).
       setConfigProp(DummyClientQuotaCallback.dummyClientQuotaCallbackValueConfigKey, "0").
@@ -1022,7 +1022,7 @@ class KRaftClusterTest {
     val cluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
         setNumBrokerNodes(1).
-        setCoResident(combinedMode).
+        setCombined(combinedMode).
         setNumControllerNodes(1).build()).
       setConfigProp("authorizer.class.name", classOf[FakeConfigurableAuthorizer].getName).
       build()

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -98,7 +98,6 @@ class KRaftQuorumImplementation(
       new MetaProperties(clusterId, config.nodeId),
       Time.SYSTEM,
       new Metrics(),
-      Option("Broker%02d_".format(config.nodeId)),
       controllerQuorumVotersFuture,
       faultHandlerFactory)
     var broker: BrokerServer = null
@@ -316,7 +315,6 @@ abstract class QuorumTestHarness extends Logging {
       metaProperties,
       Time.SYSTEM,
       new Metrics(),
-      Option("Controller_" + testInfo.getDisplayName),
       controllerQuorumVotersFuture,
       faultHandlerFactory)
     var controllerServer: ControllerServer = null

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -112,8 +112,8 @@ class KafkaTest {
   }
 
   @Test
-  def testColocatedRoleNodeIdValidation(): Unit = {
-    // Ensure that validation is happening at startup to check that colocated processes use their node.id as a voter in controller.quorum.voters 
+  def testCombinedRoleNodeIdValidation(): Unit = {
+    // Ensure that validation is happening at startup to check that combined processes use their node.id as a voter in controller.quorum.voters
     val propertiesFile = new Properties
     propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller,broker")
     propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
@@ -125,6 +125,16 @@ class KafkaTest {
     // Ensure that with a valid config no exception is thrown
     propertiesFile.setProperty(KafkaConfig.NodeIdProp, "2")
     KafkaConfig.fromProps(propertiesFile)
+  }
+
+  @Test
+  def testIsKRaftCombinedMode(): Unit = {
+    val propertiesFile = new Properties
+    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller,broker")
+    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
+    propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "1@localhost:9092")
+    val config = KafkaConfig.fromProps(propertiesFile)
+    assertTrue(config.isKRaftCombinedMode)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -98,14 +98,14 @@ class BrokerLifecycleManagerTest {
   @Test
   def testCreateAndClose(): Unit = {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
-    val manager = new BrokerLifecycleManager(context.config, context.time, None, isZkBroker = false)
+    val manager = new BrokerLifecycleManager(context.config, context.time, "create-and-close-", isZkBroker = false)
     manager.close()
   }
 
   @Test
   def testCreateStartAndClose(): Unit = {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
-    val manager = new BrokerLifecycleManager(context.config, context.time, None, isZkBroker = false)
+    val manager = new BrokerLifecycleManager(context.config, context.time, "create-start-and-close-", isZkBroker = false)
     assertEquals(BrokerState.NOT_RUNNING, manager.state)
     manager.start(() => context.highestMetadataOffset.get(),
       context.mockChannelManager, context.clusterId, context.advertisedListeners,
@@ -120,7 +120,7 @@ class BrokerLifecycleManagerTest {
   @Test
   def testSuccessfulRegistration(): Unit = {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
-    val manager = new BrokerLifecycleManager(context.config, context.time, None, isZkBroker = false)
+    val manager = new BrokerLifecycleManager(context.config, context.time, "successful-registration-", isZkBroker = false)
     val controllerNode = new Node(3000, "localhost", 8021)
     context.controllerNodeProvider.node.set(controllerNode)
     context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
@@ -140,7 +140,7 @@ class BrokerLifecycleManagerTest {
   def testRegistrationTimeout(): Unit = {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
     val controllerNode = new Node(3000, "localhost", 8021)
-    val manager = new BrokerLifecycleManager(context.config, context.time, None, isZkBroker = false)
+    val manager = new BrokerLifecycleManager(context.config, context.time, "registration-timeout-", isZkBroker = false)
     context.controllerNodeProvider.node.set(controllerNode)
     def newDuplicateRegistrationResponse(): Unit = {
       context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(
@@ -181,7 +181,7 @@ class BrokerLifecycleManagerTest {
   @Test
   def testControlledShutdown(): Unit = {
     val context = new BrokerLifecycleManagerTestContext(configProperties)
-    val manager = new BrokerLifecycleManager(context.config, context.time, None, isZkBroker = false)
+    val manager = new BrokerLifecycleManager(context.config, context.time, "controlled-shutdown-", isZkBroker = false)
     val controllerNode = new Node(3000, "localhost", 8021)
     context.controllerNodeProvider.node.set(controllerNode)
     context.mockClient.prepareResponseFrom(new BrokerRegistrationResponse(

--- a/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerRegistrationRequestTest.scala
@@ -69,7 +69,7 @@ class BrokerRegistrationRequestTest {
       new Metrics(),
       clusterInstance.anyControllerSocketServer().config,
       "heartbeat",
-      Some("heartbeat"),
+      "test-heartbeat-",
       10000
     )
   }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -316,10 +316,10 @@ public final class QuorumController implements Controller {
             }
 
             if (threadNamePrefix == null) {
-                threadNamePrefix = String.format("Node%d_", nodeId);
+                threadNamePrefix = String.format("quorum-controller-%d-", nodeId);
             }
             if (logContext == null) {
-                logContext = new LogContext(String.format("[Controller %d] ", nodeId));
+                logContext = new LogContext(String.format("[QuorumController id=%d] ", nodeId));
             }
             if (controllerMetrics == null) {
                 controllerMetrics = (ControllerMetrics) Class.forName(
@@ -328,7 +328,7 @@ public final class QuorumController implements Controller {
 
             KafkaEventQueue queue = null;
             try {
-                queue = new KafkaEventQueue(time, logContext, threadNamePrefix + "QuorumController");
+                queue = new KafkaEventQueue(time, logContext, threadNamePrefix);
                 return new QuorumController(
                     fatalFaultHandler,
                     logContext,

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -213,7 +213,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         this.publishers = new LinkedHashMap<>();
         this.image = MetadataImage.EMPTY;
         this.eventQueue = new KafkaEventQueue(time, logContext,
-                threadNamePrefix + "metadata-loader",
+                threadNamePrefix + "metadata-loader-",
                 new ShutdownEvent());
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -64,9 +64,9 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>, AutoCloseable {
     public static class Builder {
         private int nodeId = -1;
+        private String threadNamePrefix = "";
         private Time time = Time.SYSTEM;
         private LogContext logContext = null;
-        private String threadNamePrefix = "";
         private FaultHandler faultHandler = (m, e) -> new FaultHandlerException(m, e);
         private MetadataLoaderMetrics metrics = new MetadataLoaderMetrics() {
             private volatile long lastAppliedOffset = -1L;
@@ -97,13 +97,13 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
             return this;
         }
 
-        public Builder setTime(Time time) {
-            this.time = time;
+        public Builder setThreadNamePrefix(String threadNamePrefix) {
+            this.threadNamePrefix = threadNamePrefix;
             return this;
         }
 
-        public Builder setThreadNamePrefix(String threadNamePrefix) {
-            this.threadNamePrefix = threadNamePrefix;
+        public Builder setTime(Time time) {
+            this.time = time;
             return this;
         }
 
@@ -124,7 +124,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
 
         public MetadataLoader build() {
             if (logContext == null) {
-                logContext = new LogContext("[MetadataLoader " + nodeId + "] ");
+                logContext = new LogContext("[MetadataLoader id=" + nodeId + "] ");
             }
             if (highWaterMarkAccessor == null) {
                 throw new RuntimeException("You must set the high water mark accessor.");
@@ -132,6 +132,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
             return new MetadataLoader(
                 time,
                 logContext,
+                nodeId,
                 threadNamePrefix,
                 faultHandler,
                 metrics,
@@ -197,6 +198,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
     private MetadataLoader(
         Time time,
         LogContext logContext,
+        int nodeId,
         String threadNamePrefix,
         FaultHandler faultHandler,
         MetadataLoaderMetrics metrics,
@@ -210,7 +212,9 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         this.uninitializedPublishers = new LinkedHashMap<>();
         this.publishers = new LinkedHashMap<>();
         this.image = MetadataImage.EMPTY;
-        this.eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix, new ShutdownEvent());
+        this.eventQueue = new KafkaEventQueue(time, logContext,
+                threadNamePrefix + "metadata-loader",
+                new ShutdownEvent());
     }
 
     private boolean stillNeedToCatchUp(long offset) {

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
@@ -45,6 +45,7 @@ public class SnapshotGenerator implements MetadataPublisher {
         private long maxBytesSinceLastSnapshot = 100 * 1024L * 1024L;
         private long maxTimeSinceLastSnapshotNs = TimeUnit.DAYS.toNanos(1);
         private AtomicReference<String> disabledReason = null;
+        private String threadNamePrefix = "";
 
         public Builder(Emitter emitter) {
             this.emitter = emitter;
@@ -80,6 +81,11 @@ public class SnapshotGenerator implements MetadataPublisher {
             return this;
         }
 
+        public Builder setThreadNamePrefix(String threadNamePrefix) {
+            this.threadNamePrefix = threadNamePrefix;
+            return this;
+        }
+
         public SnapshotGenerator build() {
             if (disabledReason == null) {
                 disabledReason = new AtomicReference<>();
@@ -91,7 +97,8 @@ public class SnapshotGenerator implements MetadataPublisher {
                 faultHandler,
                 maxBytesSinceLastSnapshot,
                 maxTimeSinceLastSnapshotNs,
-                disabledReason
+                disabledReason,
+                threadNamePrefix
             );
         }
     }
@@ -174,7 +181,8 @@ public class SnapshotGenerator implements MetadataPublisher {
         FaultHandler faultHandler,
         long maxBytesSinceLastSnapshot,
         long maxTimeSinceLastSnapshotNs,
-        AtomicReference<String> disabledReason
+        AtomicReference<String> disabledReason,
+        String threadNamePrefix
     ) {
         this.nodeId = nodeId;
         this.time = time;
@@ -182,10 +190,10 @@ public class SnapshotGenerator implements MetadataPublisher {
         this.faultHandler = faultHandler;
         this.maxBytesSinceLastSnapshot = maxBytesSinceLastSnapshot;
         this.maxTimeSinceLastSnapshotNs = maxTimeSinceLastSnapshotNs;
-        LogContext logContext = new LogContext("[SnapshotGenerator " + nodeId + "] ");
+        LogContext logContext = new LogContext("[SnapshotGenerator id=" + nodeId + "] ");
         this.log = logContext.logger(SnapshotGenerator.class);
         this.disabledReason = disabledReason;
-        this.eventQueue = new KafkaEventQueue(time, logContext, "SnapshotGenerator" + nodeId);
+        this.eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix + "snapshot-generator-");
         resetSnapshotCounters();
         log.debug("Starting SnapshotGenerator.");
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -89,11 +89,11 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         this.zkMigrationClient = zkMigrationClient;
         this.propagator = propagator;
         this.time = Time.SYSTEM;
-        LogContext logContext = new LogContext(String.format("[KRaftMigrationDriver nodeId=%d] ", nodeId));
+        LogContext logContext = new LogContext("[KRaftMigrationDriver id=" + nodeId + "] ");
         this.log = logContext.logger(KRaftMigrationDriver.class);
         this.migrationState = MigrationDriverState.UNINITIALIZED;
         this.migrationLeadershipState = ZkMigrationLeadershipState.EMPTY;
-        this.eventQueue = new KafkaEventQueue(Time.SYSTEM, logContext, "kraft-migration");
+        this.eventQueue = new KafkaEventQueue(Time.SYSTEM, logContext, "controller-" + nodeId + "-migration-driver-");
         this.image = MetadataImage.EMPTY;
         this.leaderAndEpoch = LeaderAndEpoch.UNKNOWN;
         this.initialZkLoadHandler = initialZkLoadHandler;

--- a/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
@@ -453,7 +453,7 @@ public final class KafkaEventQueue implements EventQueue {
         this.lock = new ReentrantLock();
         this.log = logContext.logger(KafkaEventQueue.class);
         this.eventHandler = new EventHandler();
-        this.eventHandlerThread = new KafkaThread(threadNamePrefix + "EventHandler",
+        this.eventHandlerThread = new KafkaThread(threadNamePrefix + "event-handler",
             this.eventHandler, false);
         this.shuttingDown = false;
         this.interrupted = false;

--- a/tests/kafkatest/sanity_checks/test_bounce.py
+++ b/tests/kafkatest/sanity_checks/test_bounce.py
@@ -36,7 +36,7 @@ class TestBounce(Test):
             raise Exception("Illegal %s value provided for the test: %s" % (quorum_size_arg_name, quorum_size))
         self.topic = "topic"
         self.zk = ZookeeperService(test_context, num_nodes=quorum_size) if quorum.for_test(test_context) == quorum.zk else None
-        num_kafka_nodes = quorum_size if quorum.for_test(test_context) == quorum.colocated_kraft else 1
+        num_kafka_nodes = quorum_size if quorum.for_test(test_context) == quorum.combined_kraft else 1
         self.kafka = KafkaService(test_context, num_nodes=num_kafka_nodes, zk=self.zk,
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}},
                                   controller_num_nodes_override=quorum_size)
@@ -53,7 +53,7 @@ class TestBounce(Test):
     # ZooKeeper and KRaft, quorum size = 1
     @cluster(num_nodes=4)
     @matrix(metadata_quorum=quorum.all, quorum_size=[1])
-    # Remote and Co-located KRaft, quorum size = 3
+    # Isolated and Combined KRaft, quorum size = 3
     @cluster(num_nodes=6)
     @matrix(metadata_quorum=quorum.all_kraft, quorum_size=[3])
     def test_simple_run(self, metadata_quorum, quorum_size):
@@ -73,6 +73,6 @@ class TestBounce(Test):
             assert num_produced == self.num_messages, "num_produced: %d, num_messages: %d" % (num_produced, self.num_messages)
             if first_time:
                 self.producer.stop()
-                if self.kafka.quorum_info.using_kraft and self.kafka.remote_controller_quorum:
-                    self.kafka.remote_controller_quorum.restart_cluster()
+                if self.kafka.quorum_info.using_kraft and self.kafka.isolated_controller_quorum:
+                    self.kafka.isolated_controller_quorum.restart_cluster()
                 self.kafka.restart_cluster()

--- a/tests/kafkatest/services/kafka/quorum.py
+++ b/tests/kafkatest/services/kafka/quorum.py
@@ -15,20 +15,20 @@
 
 # the types of metadata quorums we support
 zk = 'ZK' # ZooKeeper, used before/during the KIP-500 bridge release(s)
-colocated_kraft = 'COLOCATED_KRAFT' # co-located Controllers in KRaft mode, used during/after the KIP-500 bridge release(s)
-remote_kraft = 'REMOTE_KRAFT' # separate Controllers in KRaft mode, used during/after the KIP-500 bridge release(s)
+combined_kraft = 'COMBINED_KRAFT' # combined Controllers in KRaft mode, used during/after the KIP-500 bridge release(s)
+isolated_kraft = 'ISOLATED_KRAFT' # isolated Controllers in KRaft mode, used during/after the KIP-500 bridge release(s)
 
 # How we will parameterize tests that exercise all quorum styles
-#   [“ZK”, “REMOTE_KRAFT”, "COLOCATED_KRAFT"] during the KIP-500 bridge release(s)
-#   [“REMOTE_KRAFT”, "COLOCATED_KRAFT”] after the KIP-500 bridge release(s)
-all = [zk, remote_kraft, colocated_kraft]
+#   [“ZK”, “ISOLATED_KRAFT”, "COMBINED_KRAFT"] during the KIP-500 bridge release(s)
+#   [“ISOLATED_KRAFT”, "COMBINED_KRAFT”] after the KIP-500 bridge release(s)
+all = [zk, isolated_kraft, combined_kraft]
 # How we will parameterize tests that exercise all KRaft quorum styles
-all_kraft = [remote_kraft, colocated_kraft]
+all_kraft = [isolated_kraft, combined_kraft]
 # How we will parameterize tests that are unrelated to upgrades:
 #   [“ZK”] before the KIP-500 bridge release(s)
-#   [“ZK”, “REMOTE_KRAFT”] during the KIP-500 bridge release(s) and in preview releases
-#   [“REMOTE_KRAFT”] after the KIP-500 bridge release(s)
-all_non_upgrade = [zk, remote_kraft]
+#   [“ZK”, “ISOLATED_KRAFT”] during the KIP-500 bridge release(s) and in preview releases
+#   [“ISOLATED_KRAFT”] after the KIP-500 bridge release(s)
+all_non_upgrade = [zk, isolated_kraft]
 
 def for_test(test_context):
     # A test uses ZooKeeper if it doesn't specify a metadata quorum or if it explicitly specifies ZooKeeper
@@ -44,13 +44,13 @@ class ServiceQuorumInfo:
     Exposes quorum-related information for a KafkaService
 
     Kafka can use either ZooKeeper or a KRaft (Kafka Raft) Controller quorum for
-    its metadata.  KRaft Controllers can either be co-located with Kafka in
-    the same JVM or remote in separate JVMs.  The choice is made via
+    its metadata.  KRaft Controllers can either be combined with Kafka in
+    the same JVM or isolated in separate JVMs.  The choice is made via
     the 'metadata_quorum' parameter defined for the system test: if it
     is not explicitly defined, or if it is set to 'ZK', then ZooKeeper
-    is used.  If it is explicitly set to 'COLOCATED_KRAFT' then KRaft
-    controllers will be co-located with the brokers; the value
-    `REMOTE_KRAFT` indicates remote controllers.
+    is used.  If it is explicitly set to 'COMBINED_KRAFT' then KRaft
+    controllers will be combined with the brokers; the value
+    `ISOLATED_KRAFT` indicates isolated controllers.
 
     Attributes
     ----------
@@ -59,7 +59,7 @@ class ServiceQuorumInfo:
         The service for which this instance exposes quorum-related
         information
     quorum_type : str
-        COLOCATED_KRAFT, REMOTE_KRAFT, or ZK
+        COMBINED_KRAFT, ISOLATED_KRAFT, or ZK
     using_zk : bool
         True iff quorum_type==ZK
     using_kraft : bool
@@ -67,22 +67,22 @@ class ServiceQuorumInfo:
     has_brokers : bool
         Whether there is at least one node with process.roles
         containing 'broker'.  True iff using_kraft and the Kafka
-        service doesn't itself have a remote Kafka service (meaning
-        it is not a remote controller quorum).
+        service doesn't itself have an isolated Kafka service (meaning
+        it is not an isolated controller quorum).
     has_controllers : bool
         Whether there is at least one node with process.roles
         containing 'controller'.  True iff quorum_type ==
-        COLOCATED_KRAFT or the Kafka service itself has a remote Kafka
-        service (meaning it is a remote controller quorum).
+        COMBINED_KRAFT or the Kafka service itself has an isolated Kafka
+        service (meaning it is an isolated controller quorum).
     has_brokers_and_controllers :
-        True iff quorum_type==COLOCATED_KRAFT
+        True iff quorum_type==COMBINED_KRAFT
     """
 
     def __init__(self, quorum_type, kafka):
         """
 
         :param quorum_type : str
-            The type of quorum being used. Either "ZK", "COLOCATED_KRAFT", or "REMOTE_KRAFT"
+            The type of quorum being used. Either "ZK", "COMBINED_KRAFT", or "ISOLATED_KRAFT"
         :param context : TestContext
             The test context within which the this instance and the
             given Kafka service is being instantiated
@@ -90,16 +90,16 @@ class ServiceQuorumInfo:
 
         if quorum_type != zk and kafka.zk and not kafka.allow_zk_with_kraft:
             raise Exception("Cannot use ZooKeeper while specifying a KRaft metadata quorum unless explicitly allowing it")
-        if kafka.remote_kafka and quorum_type != remote_kraft:
-            raise Exception("Cannot specify a remote Kafka service unless using a remote KRaft metadata quorum (should not happen)")
+        if kafka.isolated_kafka and quorum_type != isolated_kraft:
+            raise Exception("Cannot specify an isolated Kafka service unless using an isolated KRaft metadata quorum (should not happen)")
 
         self.kafka = kafka
         self.quorum_type = quorum_type
         self.using_zk = quorum_type == zk
         self.using_kraft = not self.using_zk
-        self.has_brokers = self.using_kraft and not kafka.remote_kafka
-        self.has_controllers = quorum_type == colocated_kraft or kafka.remote_kafka
-        self.has_brokers_and_controllers = quorum_type == colocated_kraft
+        self.has_brokers = self.using_kraft and not kafka.isolated_kafka
+        self.has_controllers = quorum_type == combined_kraft or kafka.isolated_kafka
+        self.has_brokers_and_controllers = quorum_type == combined_kraft
 
     @staticmethod
     def from_test_context(kafka, context):
@@ -127,12 +127,12 @@ class NodeQuorumInfo:
         belongs
     has_broker_role : bool
         True iff using_kraft and the Kafka service doesn't itself have
-        a remote Kafka service (meaning it is not a remote controller)
+        an isolated Kafka service (meaning it is not an isolated controller)
     has_controller_role : bool
-        True iff quorum_type==COLOCATED_KRAFT and the node is one of
+        True iff quorum_type==COMBINED_KRAFT and the node is one of
         the first N in the cluster where N is the number of nodes
-        that have a controller role; or the Kafka service itself has a
-        remote Kafka service (meaning it is a remote controller
+        that have a controller role; or the Kafka service itself has an
+        isolated Kafka service (meaning it is an isolated controller
         quorum).
     has_combined_broker_and_controller_roles :
         True iff has_broker_role==True and has_controller_role==true
@@ -145,7 +145,7 @@ class NodeQuorumInfo:
             belongs
         :param node : Node
             The particular node for which this information applies.
-            In the co-located case, whether or not a node's broker's
+            In the combined case, whether or not a node's broker's
             process.roles contains 'controller' may vary based on the
             particular node if the number of controller nodes is less
             than the number of nodes in the service.

--- a/tests/kafkatest/tests/core/kraft_upgrade_test.py
+++ b/tests/kafkatest/tests/core/kraft_upgrade_test.py
@@ -18,7 +18,7 @@ from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.kafka import KafkaService
-from kafkatest.services.kafka.quorum import remote_kraft, colocated_kraft
+from kafkatest.services.kafka.quorum import isolated_kraft, combined_kraft
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
@@ -109,14 +109,14 @@ class TestKRaftUpgrade(ProduceConsumeValidateTest):
         assert self.kafka.check_protocol_errors(self)
 
     @cluster(num_nodes=5)
-    @parametrize(from_kafka_version=str(LATEST_3_1), metadata_quorum=colocated_kraft)
-    @parametrize(from_kafka_version=str(LATEST_3_2), metadata_quorum=colocated_kraft)
-    def test_colocated_upgrade(self, from_kafka_version, metadata_quorum):
+    @parametrize(from_kafka_version=str(LATEST_3_1), metadata_quorum=combined_kraft)
+    @parametrize(from_kafka_version=str(LATEST_3_2), metadata_quorum=combined_kraft)
+    def test_combined_mode_upgrade(self, from_kafka_version, metadata_quorum):
         self.run_upgrade(from_kafka_version)
 
     @cluster(num_nodes=8)
-    @parametrize(from_kafka_version=str(LATEST_3_1), metadata_quorum=remote_kraft)
-    @parametrize(from_kafka_version=str(LATEST_3_2), metadata_quorum=remote_kraft)
-    def test_non_colocated_upgrade(self, from_kafka_version, metadata_quorum):
+    @parametrize(from_kafka_version=str(LATEST_3_1), metadata_quorum=isolated_kraft)
+    @parametrize(from_kafka_version=str(LATEST_3_2), metadata_quorum=isolated_kraft)
+    def test_isolated_mode_upgrade(self, from_kafka_version, metadata_quorum):
         self.run_upgrade(from_kafka_version)
 

--- a/tests/kafkatest/tests/core/snapshot_test.py
+++ b/tests/kafkatest/tests/core/snapshot_test.py
@@ -71,8 +71,8 @@ class TestSnapshots(ProduceConsumeValidateTest):
         topic_count = 10
         self.topics_created += self.create_n_topics(topic_count)
 
-        if self.kafka.remote_controller_quorum:
-            self.controller_nodes = self.kafka.remote_controller_quorum.nodes
+        if self.kafka.isolated_controller_quorum:
+            self.controller_nodes = self.kafka.isolated_controller_quorum.nodes
         else:
             self.controller_nodes = self.kafka.nodes[:self.kafka.num_nodes_controller_role]
 
@@ -145,7 +145,7 @@ class TestSnapshots(ProduceConsumeValidateTest):
 
     @cluster(num_nodes=9)
     @matrix(metadata_quorum=quorum.all_kraft)
-    def test_broker(self, metadata_quorum=quorum.colocated_kraft):
+    def test_broker(self, metadata_quorum=quorum.combined_kraft):
         """ Test the ability of a broker to consume metadata snapshots
         and to recover the cluster metadata state using them
 
@@ -205,7 +205,7 @@ class TestSnapshots(ProduceConsumeValidateTest):
 
     @cluster(num_nodes=9)
     @matrix(metadata_quorum=quorum.all_kraft)
-    def test_controller(self, metadata_quorum=quorum.colocated_kraft):
+    def test_controller(self, metadata_quorum=quorum.combined_kraft):
         """ Test the ability of controllers to consume metadata snapshots
         and to recover the cluster metadata state using them
 


### PR DESCRIPTION
Standardize KRaft thread names.

- Always use kebab case. That is, "my-thread-name".

- Thread prefixes are just strings, not Option[String] or Optional<String>.
  If you don't want a prefix, use the empty string.

- Thread prefixes end in a dash (except the empty prefix). Then you can
  calculate thread names as $prefix + "my-thread-name"

- Broker-only components get "broker-$id-" as a thread name prefix. For example, "broker-1-"

- Controller-only components get "controller-$id-" as a thread name prefix. For example, "controller-1-"

- Shared components get "kafka-$id-" as a thread name prefix. For example, "kafka-0-"

- Always pass a prefix to KafkaEventQueue, so that threads have names like
  "broker-0-metadata-loader-event-handler" rather than "event-handler". Prior to this PR, we had
  several threads just named "EventHandler" which was not helpful for debugging.

- QuorumController thread name is "quorum-controller-123-event-handler"

- Don't set a thread prefix for replication threads started by ReplicaManager. They run only on the
  broker, and already include the broker ID.

Standardize KRaft slf4j log prefixes.

- Names should be of the form "[ComponentName id=$id] ". So for a ControllerServer with ID 123, we
  will have "[ControllerServer id=123] "

- For the QuorumController class, use the prefix "[QuorumController id=$id] " rather than
  "[Controller <nodeId] ", to make it clearer that this is a KRaft controller.

- In BrokerLifecycleManager, add isZkBroker=true to the log prefix for the migration case.

Standardize KRaft terminology.

- All synonyms of combined mode (colocated, coresident, etc.) should be replaced by "combined"

- All synonyms of isolated mode (remote, non-colocated, distributed, etc.) should be replaced by
  "isolated".