### PR TITLE
MINOR: Fix error check in zombie fencing for exactly-once source connectors

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -709,7 +709,7 @@ public class Worker {
                     FenceProducersOptions fencingOptions = new FenceProducersOptions()
                             .timeoutMs((int) ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
                     return admin.fenceProducers(transactionalIds, fencingOptions).all().whenComplete((ignored, error) -> {
-                        if (error != null)
+                        if (error == null)
                             log.debug("Finished fencing out {} task producers for source connector {}", numTasks, connName);
                         Utils.closeQuietly(admin, "Zombie fencing admin for connector " + connName);
                     });


### PR DESCRIPTION
- If the error is non-null, it is already handled appropriately here -https://github.com/apache/kafka/blob/df86228aaffb315f22ca3f19511b344b0e0bb4b1/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java#L2602-L2607
- This patch just fixes the check for the success log message that should be emitted only when there is no error arising from the admin client request to fence producers.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
