### PR TITLE
MINOR: don't disconnect stale controller if the network client is res…

### DIFF
--- a/core/src/test/scala/kafka/server/BrokerToControllerChannelManagerImplTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerChannelManagerImplTest.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+import org.apache.kafka.clients.{ClientResponse, ManualMetadataUpdater, NetworkClient}
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.AbstractResponse
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.utils.Time
+import org.junit.jupiter.api.{Assertions, Test}
+import org.mockito.Mockito
+
+import java.util.Collections
+
+class BrokerToControllerChannelManagerImplTest {
+
+  @Test
+  def testInflightRequestsAreKeptWhenResetNetworkClient(): Unit = {
+    val node = new Node(
+      1,
+      "127.0.0.1",
+      22,
+    )
+    val client = Mockito.mock(classOf[NetworkClient])
+    val thread = new BrokerToControllerRequestThread(
+      client,
+      true,
+      _ => client,
+      new ManualMetadataUpdater(),
+      () => ControllerInformation(Some(node), ListenerName.normalised("PLAINTEXT"),
+        SecurityProtocol.PLAINTEXT, "", true),
+      Mockito.mock(classOf[KafkaConfig]),
+      Time.SYSTEM,
+      "test",
+      1000
+    )
+    val response = Mockito.mock(classOf[ClientResponse])
+    val body = Mockito.mock(classOf[AbstractResponse])
+    Mockito.when(body.errorCounts()).thenReturn(Collections.singletonMap(Errors.NOT_CONTROLLER, 1))
+    Mockito.when(response.responseBody()).thenReturn(body)
+    // change the controller node
+    thread.updateControllerAddress(new Node(300, "h", 22))
+    // the previous controller node is NOT existent so it should NOT reset current controller
+    thread.handleResponse(node, Mockito.mock(classOf[BrokerToControllerQueueItem]))(response)
+    Assertions.assertNotEquals(Option.empty, thread.activeControllerAddress())
+  }
+}


### PR DESCRIPTION
the unsent request stored by `InterBrokerSendThread` uses stale controller even though the `NetworkClient` is reset already. The request will get error `NOT_CONTROLLER`, and then the error handle will try to disconnect the "new" controller. The new controller is not connected so the call `networkClient.disconnect(controllerAddress.idString)` will cause following error.
```
java.lang.IllegalStateException: No entry found for connection 1000
	at org.apache.kafka.clients.ClusterConnectionStates.nodeState(ClusterConnectionStates.java:411)
	at org.apache.kafka.clients.ClusterConnectionStates.disconnected(ClusterConnectionStates.java:182)
	at org.apache.kafka.clients.NetworkClient.disconnect(NetworkClient.java:328)
	at kafka.server.BrokerToControllerRequestThread.$anonfun$handleResponse$9(BrokerToControllerChannelManager.scala:405)
	at kafka.server.BrokerToControllerRequestThread.$anonfun$handleResponse$9$adapted(BrokerToControllerChannelManager.scala:402)
	at scala.Option.foreach(Option.scala:437)
	at kafka.server.BrokerToControllerRequestThread.handleResponse(BrokerToControllerChannelManager.scala:402)
	at kafka.server.BrokerToControllerRequestThread.$anonfun$generateRequests$1(BrokerToControllerChannelManager.scala:377)
	at org.apache.kafka.clients.ClientResponse.onComplete(ClientResponse.java:154)
	at org.apache.kafka.clients.NetworkClient.completeResponses(NetworkClient.java:594)
	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:586)
	at kafka.common.InterBrokerSendThread.pollOnce(InterBrokerSendThread.scala:78)
	at kafka.server.BrokerToControllerRequestThread.doWork(BrokerToControllerChannelManager.scala:422)
	at org.apache.kafka.server.util.ShutdownableThread.run(ShutdownableThread.java:127)
```

This is not a critical bug since we swallow the exception, but the error is a bit scare to me when testing zk migration :) 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
