### PR TITLE
KAFKA-13884; Only voters flush on Fetch response

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -670,7 +670,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       interBrokerProtocolVersion = MetadataVersion.latest,
       validateAndAssignOffsets = false,
       leaderEpoch = -1,
-      None,
+      requestLocal = None,
       // disable to check the validation of record size since the record is already accepted by leader.
       ignoreRecordSize = true)
   }
@@ -686,7 +686,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    * @param interBrokerProtocolVersion Inter-broker message protocol version
    * @param validateAndAssignOffsets Should the log assign offsets to this message set or blindly apply what it is given
    * @param leaderEpoch The partition's leader epoch which will be applied to messages when offsets are assigned on the leader
-   * @param requestLocal The request local instance if assignOffsets is true
+   * @param requestLocal The request local instance if validateAndAssignOffsets is true
    * @param ignoreRecordSize true to skip validation of record size.
    * @throws KafkaStorageException If the append fails due to an I/O error.
    * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -216,10 +216,6 @@ final class KafkaMetadataLog private (
     log.flush(forceFlushActiveSegment)
   }
 
-  override def lastFlushedOffset(): Long = {
-    log.recoveryPoint
-  }
-
   /**
    * Return the topic partition associated with the log.
    */

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1141,7 +1141,11 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         Records records
     ) {
         LogAppendInfo info = log.appendAsFollower(records);
-        log.flush(false);
+        if (quorum.isVoter()) {
+            // the leader only requires that voters have flushed their log before sending
+            // a Fetch request
+            log.flush(false);
+        }
 
         OffsetAndEpoch endOffset = endOffset();
         kafkaRaftMetrics.updateFetchedRecords(info.lastOffset - info.firstOffset + 1);

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -195,11 +195,6 @@ public interface ReplicatedLog extends AutoCloseable {
     boolean maybeClean();
 
     /**
-     * Get the last offset which has been flushed to disk.
-     */
-    long lastFlushedOffset();
-
-    /**
      * Return the topic partition associated with the log.
      */
     TopicPartition topicPartition();

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -616,7 +616,7 @@ public class KafkaRaftClientTest {
 
         // Leader change record appended
         assertEquals(1L, context.log.endOffset().offset);
-        assertEquals(1L, context.log.lastFlushedOffset());
+        assertEquals(1L, context.log.firstUnflushedOffset());
 
         // Send BeginQuorumEpoch to voters
         context.client.poll();
@@ -656,7 +656,7 @@ public class KafkaRaftClientTest {
 
         // Leader change record appended
         assertEquals(1L, context.log.endOffset().offset);
-        assertEquals(1L, context.log.lastFlushedOffset());
+        assertEquals(1L, context.log.firstUnflushedOffset());
 
         // Send BeginQuorumEpoch to voters
         context.client.poll();
@@ -2156,7 +2156,7 @@ public class KafkaRaftClientTest {
 
         context.client.poll();
         assertEquals(2L, context.log.endOffset().offset);
-        assertEquals(2L, context.log.lastFlushedOffset());
+        assertEquals(2L, context.log.firstUnflushedOffset());
     }
 
     @Test
@@ -2339,6 +2339,7 @@ public class KafkaRaftClientTest {
         // Poll again to complete truncation
         context.client.poll();
         assertEquals(2L, context.log.endOffset().offset);
+        assertEquals(2L, context.log.firstUnflushedOffset());
 
         // Now we should be fetching
         context.client.poll();

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -66,6 +66,7 @@ public class MockLog implements ReplicatedLog {
     private long nextId = ID_GENERATOR.getAndIncrement();
     private LogOffsetMetadata highWatermark = new LogOffsetMetadata(0, Optional.empty());
     private long lastFlushedOffset = 0;
+    private boolean flushedSinceLastChecked = false;
 
     public MockLog(
         TopicPartition topicPartition,
@@ -329,6 +330,7 @@ public class MockLog implements ReplicatedLog {
 
     @Override
     public void flush(boolean forceFlushActiveSegment) {
+        flushedSinceLastChecked = true;
         lastFlushedOffset = endOffset().offset;
     }
 
@@ -340,6 +342,15 @@ public class MockLog implements ReplicatedLog {
     @Override
     public long lastFlushedOffset() {
         return lastFlushedOffset;
+    }
+
+    /**
+     * Returns true if the log was flushed since the last time this method was called.
+     */
+    public boolean flushedSinceLastChecked() {
+        boolean oldValue = flushedSinceLastChecked;
+        flushedSinceLastChecked = false;
+        return oldValue;
     }
 
     /**

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -988,11 +988,12 @@ public final class RaftClientTestContext {
 
         // Assert that voters have flushed up to the fetch offset
         if (localId.isPresent() && voters.contains(localId.getAsInt())) {
-            assertTrue(
-                log.lastFlushedOffset() + 1 >= fetchOffset,
+            assertEquals(
+                log.firstUnflushedOffset(),
+                fetchOffset,
                 String.format(
-                    "expected voter to flush (%s) up to the fetch offset (%s)",
-                    log.lastFlushedOffset(),
+                    "expected voters have the fetch offset (%s) be the same as the unflushed offset (%s)",
+                    log.firstUnflushedOffset(),
                     fetchOffset
                 )
             );

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -81,6 +81,7 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.raft.RaftUtil.hasValidTopicPartition;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class RaftClientTestContext {
@@ -189,6 +190,10 @@ public final class RaftClientTestContext {
             // because append operation was done in the Builder which represent the state of the
             // log before the replica starts.
             log.flush(false);
+
+            // Reset the value of this method since "flush" before the replica start should not
+            // count when checking for flushes by the KRaft client.
+            log.flushedSinceLastChecked();
             return this;
         }
 
@@ -991,6 +996,8 @@ public final class RaftClientTestContext {
                     fetchOffset
                 )
             );
+        } else {
+            assertFalse(log.flushedSinceLastChecked(), "KRaft client should not explicitly flush when it is an observer");
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -185,6 +185,10 @@ public final class RaftClientTestContext {
                 records
             );
             log.appendAsLeader(batch, epoch);
+            // Need to flush the log to update the last flushed offset. This is always correct
+            // because append operation was done in the Builder which represent the state of the
+            // log before the replica starts.
+            log.flush(false);
             return this;
         }
 
@@ -654,10 +658,9 @@ public final class RaftClientTestContext {
         List<RaftRequest.Outbound> sentMessages = channel.drainSendQueue();
         assertEquals(1, sentMessages.size());
 
-        // TODO: Use more specific type
-        RaftMessage raftMessage = sentMessages.get(0);
-        assertFetchRequestData(raftMessage, epoch, fetchOffset, lastFetchedEpoch);
-        return raftMessage.correlationId();
+        RaftRequest.Outbound raftRequest = sentMessages.get(0);
+        assertFetchRequestData(raftRequest, epoch, fetchOffset, lastFetchedEpoch);
+        return raftRequest.correlationId();
     }
 
     FetchResponseData.PartitionData assertSentFetchPartitionResponse() {
@@ -955,13 +958,15 @@ public final class RaftClientTestContext {
     }
 
     void assertFetchRequestData(
-        RaftMessage message,
+        RaftRequest.Outbound message,
         int epoch,
         long fetchOffset,
         int lastFetchedEpoch
     ) {
         assertTrue(
-            message.data() instanceof FetchRequestData, "Unexpected request type " + message.data());
+            message.data() instanceof FetchRequestData,
+            "unexpected request type " + message.data()
+        );
         FetchRequestData request = (FetchRequestData) message.data();
         assertEquals(KafkaRaftClient.MAX_FETCH_SIZE_BYTES, request.maxBytes());
         assertEquals(fetchMaxWaitMs, request.maxWaitMs());
@@ -975,6 +980,18 @@ public final class RaftClientTestContext {
         assertEquals(fetchOffset, fetchPartition.fetchOffset());
         assertEquals(lastFetchedEpoch, fetchPartition.lastFetchedEpoch());
         assertEquals(localId.orElse(-1), request.replicaId());
+
+        // Assert that voters have flushed up to the fetch offset
+        if (localId.isPresent() && voters.contains(localId.getAsInt())) {
+            assertTrue(
+                log.lastFlushedOffset() + 1 >= fetchOffset,
+                String.format(
+                    "expected voter to flush (%s) up to the fetch offset (%s)",
+                    log.lastFlushedOffset(),
+                    fetchOffset
+                )
+            );
+        }
     }
 
     FetchRequestData fetchRequest(


### PR DESCRIPTION
The leader only requires that voters have flushed their log up to the fetch offset before sending a fetch request.

This change only flushes the log when handling the fetch response, if the follower is a voter. This should improve the disk performance on observers (brokers).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
