### PR TITLE
KAFKA-14617: Fill brokerEpoch in AlterPartitionRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -91,6 +92,7 @@ public class AlterPartitionRequest extends AbstractRequest {
                             newIsr.add(brokerState.brokerId());
                         });
                         partitionData.setNewIsr(newIsr);
+                        partitionData.setNewIsrWithEpochs(Collections.emptyList());
                     });
                 });
             }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
 
 public class AlterPartitionRequest extends AbstractRequest {
 
@@ -75,8 +77,23 @@ public class AlterPartitionRequest extends AbstractRequest {
             this.data = data;
         }
 
+        public AlterPartitionRequestData data() {
+            return this.data;
+        }
+
         @Override
         public AlterPartitionRequest build(short version) {
+            if (version < 3) {
+                data.topics().forEach(topicData -> {
+                    topicData.partitions().forEach(partitionData -> {
+                        List<Integer> newIsr = new LinkedList<>();
+                        partitionData.newIsrWithEpochs().forEach(brokerState -> {
+                            newIsr.add(brokerState.brokerId());
+                        });
+                        partitionData.setNewIsr(newIsr);
+                    });
+                });
+            }
             return new AlterPartitionRequest(data, version);
         }
 

--- a/clients/src/main/resources/common/message/AlterPartitionRequest.json
+++ b/clients/src/main/resources/common/message/AlterPartitionRequest.json
@@ -21,7 +21,9 @@
   // Version 1 adds LeaderRecoveryState field (KIP-704).
   //
   // Version 2 adds TopicId field to replace TopicName field (KIP-841).
-  "validVersions": "0-2",
+  //
+  // Version 3 adds the NewIsrEpochs field and deprecates the NewIsr field (KIP-903).
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
@@ -39,7 +41,13 @@
         { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
           "about": "The leader epoch of this partition" },
         { "name": "NewIsr", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
-          "about": "The ISR for this partition" },
+          "about": "The ISR for this partition. Deprecated since version 3." },
+        { "name": "NewIsrWithEpochs", "type": "[]BrokerState", "versions": "3+", "fields": [
+          { "name": "BrokerId", "type": "int32", "versions": "3+", "entityType": "brokerId",
+            "about": "The ID of the broker." },
+          { "name": "BrokerEpoch", "type": "int64", "versions": "3+", "default": "-1",
+            "about": "The epoch of the broker. It will be -1 if the epoch check is not supported." }
+        ]},
         { "name": "LeaderRecoveryState", "type": "int8", "versions": "1+", "default": "0",
           "about": "1 if the partition is recovering from an unclean leader election; 0 otherwise." },
         { "name": "PartitionEpoch", "type": "int32", "versions": "0+",

--- a/clients/src/main/resources/common/message/AlterPartitionResponse.json
+++ b/clients/src/main/resources/common/message/AlterPartitionResponse.json
@@ -21,7 +21,9 @@
   //
   // Version 2 adds TopicId field to replace TopicName field, can return the following new errors:
   // INELIGIBLE_REPLICA, NEW_LEADER_ELECTED and UNKNOWN_TOPIC_ID (KIP-841).
-  "validVersions": "0-2",
+  //
+  // Version 3 is the same as vesion 2 (KIP-903).
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/common/requests/AlterPartitionRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AlterPartitionRequestTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AlterPartitionRequestData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState;
+import org.apache.kafka.common.message.AlterPartitionRequestData.PartitionData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.TopicData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
+import org.apache.kafka.common.Uuid;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AlterPartitionRequestTest {
+    String topic = "test-topic";
+    Uuid topicId = Uuid.randomUuid();
+
+    @ParameterizedTest
+    @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
+    public void testBuildAlterPartitionRequest(short version) {
+        AlterPartitionRequestData request = new AlterPartitionRequestData()
+            .setBrokerId(1)
+            .setBrokerEpoch(1);
+
+        TopicData topicData = new TopicData()
+            .setTopicId(topicId)
+            .setTopicName(topic);
+
+        List<BrokerState> newIsrWithBrokerEpoch = new LinkedList<>();
+        newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(1).setBrokerEpoch(1001));
+        newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(2).setBrokerEpoch(1002));
+        newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(3).setBrokerEpoch(1003));
+
+        topicData.setPartitions(new LinkedList<>());
+        topicData.partitions().add(new PartitionData()
+            .setPartitionIndex(0)
+            .setLeaderEpoch(1)
+            .setPartitionEpoch(10)
+            .setNewIsrWithEpochs(newIsrWithBrokerEpoch));
+
+        request.topics().add(topicData);
+
+        AlterPartitionRequest.Builder builder = new AlterPartitionRequest.Builder(request, version >= 2);
+        AlterPartitionRequest alterPartitionRequest = builder.build(version);
+        assertEquals(1, alterPartitionRequest.data().topics().size());
+        assertEquals(1, alterPartitionRequest.data().topics().get(0).partitions().size());
+        PartitionData partitionData = alterPartitionRequest.data().topics().get(0).partitions().get(0);
+        assertEquals(version >= 3, partitionData.newIsr().isEmpty());
+        assertEquals(version < 3, partitionData.newIsrWithEpochs().isEmpty());
+        if (version < 3) {
+            assertEquals(Arrays.asList(1, 2, 3), partitionData.newIsr());
+        } else {
+            assertEquals(newIsrWithBrokerEpoch, partitionData.newIsrWithEpochs());
+        }
+    }
+}

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1048,6 +1048,10 @@ class ReplicaManager(val config: KafkaConfig,
     var hasPreferredReadReplica = false
     val logReadResultMap = new mutable.HashMap[TopicIdPartition, LogReadResult]
 
+    if (params.isFromFollower && params.replicaId != localBrokerId) {
+      alterPartitionManager.updateBrokerEpoch(params.replicaId, params.replicaEpoch)
+    }
+
     logReadResults.foreach { case (topicIdPartition, logReadResult) =>
       brokerTopicStats.topicStats(topicIdPartition.topicPartition.topic).totalFetchRequestRate.mark()
       brokerTopicStats.allTopicsStats.totalFetchRequestRate.mark()

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -310,6 +310,11 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
     }
   }
 
+  def getAliveBrokerEpoch(brokerId: Int): Option[Long] = {
+    Option(_currentImage.cluster().broker(brokerId)).filterNot(_.fenced()).
+      map(brokerRegistration => brokerRegistration.epoch())
+  }
+
   override def getClusterMetadata(clusterId: String, listenerName: ListenerName): Cluster = {
     val image = _currentImage
     val nodes = new util.HashMap[Integer, Node]

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -2091,6 +2091,7 @@ class PartitionTest extends AbstractPartitionTest {
       scheduler = mock(classOf[KafkaScheduler]),
       time = time,
       brokerId = brokerId,
+      metadataCache,
       brokerEpochSupplier = () => 0,
       metadataVersionSupplier = () => MetadataVersion.IBP_3_0_IV0
     )

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -685,4 +685,25 @@ class MetadataCacheTest {
 
     assertTrue(metadataCache.isBrokerShuttingDown(0))
   }
+
+  @Test
+  def testGetLiveBrokerEpoch(): Unit = {
+    val metadataCache = MetadataCache.kRaftMetadataCache(0)
+
+    val delta = new MetadataDelta.Builder().build()
+    delta.replay(new RegisterBrokerRecord()
+      .setBrokerId(0)
+      .setBrokerEpoch(100)
+      .setFenced(false))
+
+    delta.replay(new RegisterBrokerRecord()
+      .setBrokerId(1)
+      .setBrokerEpoch(101)
+      .setFenced(true))
+
+    metadataCache.setImage(delta.apply(MetadataProvenance.EMPTY))
+
+    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1))
+    assertEquals(-1L, metadataCache.getAliveBrokerEpoch(1).getOrElse(-1L))
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2433,10 +2433,10 @@ class ReplicaManagerTest {
       responseCallback
     )
 
-    if (replicaId != -1) {
-      verify(replicaManager.alterPartitionManager, atLeast(1)).updateBrokerEpoch(replicaId, 1)
+    if (replicaId == -1) {
+      verify(replicaManager.alterPartitionManager, never()).updateBrokerEpoch(ArgumentMatchers.eq(replicaId), any())
     } else {
-      verify(replicaManager.alterPartitionManager, never()).updateBrokerEpoch(replicaId, 1)
+      verify(replicaManager.alterPartitionManager, atLeast(1)).updateBrokerEpoch(replicaId, 1)
     }
   }
 


### PR DESCRIPTION
As the second part of the [KIP-903](https://cwiki.apache.org/confluence/display/KAFKA/KIP-903%3A+Replicas+with+stale+broker+epoch+should+not+be+allowed+to+join+the+ISR), it updates the AlterPartitionRequest:

- Deprecate the NewIsr field
- Create a new field BrokerState with BrokerId and BrokerEpoch
- Bump the AlterPartition version to 3

Also in this change, alterPartitionManager will start to manage the current broker epochs which come from FetchRequests.

https://issues.apache.org/jira/browse/KAFKA-14617