### PR TITLE
MINOR: correct the class name for delegation token script

### DIFF
--- a/bin/kafka-delegation-tokens.sh
+++ b/bin/kafka-delegation-tokens.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.DelegationTokenCommand "$@"
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.DelegationTokenCommand "$@"

--- a/bin/windows/kafka-delegation-tokens.bat
+++ b/bin/windows/kafka-delegation-tokens.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-"%~dp0kafka-run-class.bat" kafka.admin.DelegationTokenCommand %*
+"%~dp0kafka-run-class.bat" org.apache.kafka.tools.DelegationTokenCommand %*


### PR DESCRIPTION
#13172 rewrite `DelegationTokenCommand` by java and the package was changed from `kafka.admin` to `org.apache.kafka.tools`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
