### PR TITLE
MINOR: fix KafkaTest#testIsKRaftCombinedMode

### DIFF
--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -133,6 +133,7 @@ class KafkaTest {
     propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller,broker")
     propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
     propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "1@localhost:9092")
+    setListenerProps(propertiesFile)
     val config = KafkaConfig.fromProps(propertiesFile)
     assertTrue(config.isKRaftCombinedMode)
   }


### PR DESCRIPTION
related to #13390

```
Gradle Test Run :core:test > Gradle Test Executor 25 > KafkaTest > testIsKRaftCombinedMode() FAILED
    java.lang.IllegalArgumentException: requirement failed: controller.listener.names must contain at least one value appearing in the 'listeners' configuration when running the KRaft controller role
        at scala.Predef$.require(Predef.scala:337)
        at kafka.server.KafkaConfig.validateControllerListenerExistsForKRaftController$1(KafkaConfig.scala:2227)
        at kafka.server.KafkaConfig.validateValues(KafkaConfig.scala:2289)
        at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:2160)
        at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:1569)
        at kafka.server.KafkaConfig$.fromProps(KafkaConfig.scala:1492)
        at kafka.KafkaTest.testIsKRaftCombinedMode(KafkaConfigTest.scala:136)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
