### PR TITLE
MINOR: add equals and hashcode methods to KafkaProducer and ProducerMetadata

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -317,6 +317,74 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         this(Utils.propsToMap(properties), keySerializer, valueSerializer);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof KafkaProducer)) {
+            return false;
+        }
+        KafkaProducer other = (KafkaProducer) o;
+
+        if (!this.partitioner.equals(other.partitioner)) {
+            return false;
+        }
+        if (!this.accumulator.equals(other.accumulator)) {
+            return false;
+        }
+        if (this.maxRequestSize != other.maxRequestSize) {
+            return false;
+        }
+        if (this.totalMemorySize != other.totalMemorySize) {
+            return false;
+        }
+        if (!this.metadata.equals(other.metadata)) {
+            return false;
+        }
+        if (!this.sender.equals(other.sender)) {
+            return false;
+        }
+        if (!this.compressionType.equals(other.compressionType)) {
+            return false;
+        }
+        if (!this.time.equals(other.time)) {
+            return false;
+        }
+        if (!this.keySerializer.equals(other.keySerializer)) {
+            return false;
+        }
+        if (!this.valueSerializer.equals(other.valueSerializer)) {
+            return false;
+        }
+        if (!this.interceptors.equals(other.interceptors)) {
+            return false;
+        }
+        if (this.maxBlockTimeMs != other.maxBlockTimeMs) {
+            return false;
+        }
+        if (!this.apiVersions.equals(other.apiVersions)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int temp = 31 * this.partitioner.hashCode();
+        temp = 31 * temp + this.accumulator.hashCode();
+        temp = 31 * temp + this.maxRequestSize;
+        temp = 31 * temp + Long.hashCode(this.totalMemorySize);
+        temp = 31 * temp + this.metadata.hashCode();
+        temp = 31 * temp + this.sender.hashCode();
+        temp = 31 * temp + this.compressionType.hashCode();
+        temp = 31 * temp + this.time.hashCode();
+        temp = 31 * temp + this.keySerializer.hashCode();
+        temp = 31 * temp + this.valueSerializer.hashCode();
+        temp = 31 * temp + this.interceptors.hashCode();
+        temp = 31 * temp + Long.hashCode(this.maxBlockTimeMs);
+        temp = 31 * temp + this.apiVersions.hashCode();
+        return temp;
+    }
+
     /**
      * Check if partitioner is deprecated and log a warning if it is.
      */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -64,6 +64,38 @@ public class ProducerMetadata extends Metadata {
         return new MetadataRequest.Builder(new ArrayList<>(newTopics), true);
     }
 
+    @Override
+    public int hashCode() {
+        int temp = topics.hashCode();
+        temp = 31 * temp + newTopics.hashCode();
+        temp = 31 * temp + log.hashCode();
+        temp = 31 * temp + time.hashCode();
+        return temp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ProducerMetadata)) {
+            return false;
+        }
+        ProducerMetadata other = (ProducerMetadata) o;
+
+        if (!this.topics.equals(other.topics)) {
+            return false;
+        }
+        if (!this.newTopics.equals(other.newTopics)) {
+            return false;
+        }
+        if (!this.log.equals(other.log)) {
+            return false;
+        }
+        if (!this.time.equals(other.time)) {
+            return false;
+        }
+
+        return true;
+    }
+
     public synchronized void add(String topic, long nowMs) {
         Objects.requireNonNull(topic, "topic cannot be null");
         if (topics.put(topic, nowMs + metadataIdleMs) == null) {


### PR DESCRIPTION
Equals and hashcode methods are missing from KafkaProducer and ProducerMetadata classes.

Hashcode method is constructed by sequentially multiplying by a prime number and adding the components. 