### PR TITLE
KAFKA-8713: Allow using null for field in JsonConverter (KIP-581)

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -46,6 +46,11 @@ public class JsonConverterConfig extends ConverterConfig {
         + " This value is case insensitive and can be either 'BASE64' (default) or 'NUMERIC'";
     private static final String DECIMAL_FORMAT_DISPLAY = "Decimal Format";
 
+    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+    public static final boolean REPLACE_NULL_WITH_DEFAULT_DEFAULT = true;
+    private static final String REPLACE_NULL_WITH_DEFAULT_DOC = "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.";
+    private static final String REPLACE_NULL_WITH_DEFAULT_DISPLAY = "Replace null with default";
+
     private final static ConfigDef CONFIG;
 
     static {
@@ -66,6 +71,10 @@ public class JsonConverterConfig extends ConverterConfig {
                 DecimalFormat.NUMERIC.name()),
             Importance.LOW, DECIMAL_FORMAT_DOC, group, orderInGroup++,
             Width.MEDIUM, DECIMAL_FORMAT_DISPLAY);
+        CONFIG.define(
+                REPLACE_NULL_WITH_DEFAULT_CONFIG, Type.BOOLEAN, REPLACE_NULL_WITH_DEFAULT_DEFAULT,
+                Importance.LOW, REPLACE_NULL_WITH_DEFAULT_DOC, group, orderInGroup++,
+                Width.MEDIUM, REPLACE_NULL_WITH_DEFAULT_DISPLAY);
     }
 
     public static ConfigDef configDef() {
@@ -76,12 +85,14 @@ public class JsonConverterConfig extends ConverterConfig {
     private final boolean schemasEnabled;
     private final int schemaCacheSize;
     private final DecimalFormat decimalFormat;
+    private final boolean replaceNullWithDefault;
 
     public JsonConverterConfig(Map<String, ?> props) {
         super(CONFIG, props);
         this.schemasEnabled = getBoolean(SCHEMAS_ENABLE_CONFIG);
         this.schemaCacheSize = getInt(SCHEMAS_CACHE_SIZE_CONFIG);
         this.decimalFormat = DecimalFormat.valueOf(getString(DECIMAL_FORMAT_CONFIG).toUpperCase(Locale.ROOT));
+        this.replaceNullWithDefault = getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     /**
@@ -109,6 +120,14 @@ public class JsonConverterConfig extends ConverterConfig {
      */
     public DecimalFormat decimalFormat() {
         return decimalFormat;
+    }
+
+    /**
+     * Whether to replace null values with the default value when serializing and deserializing fields
+     * @return true if we want to use the default value
+     */
+    public boolean replaceNullWithDefault() {
+        return replaceNullWithDefault;
     }
 
 }


### PR DESCRIPTION
Add a new configuration replace.null.with.default to allow using null instead of the default value.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
