### PR TITLE
KAFKA-14740: Add source tag to MirrorSourceMetrics - KIP-911

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -90,6 +90,12 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
     private static final String OFFSET_LAG_MAX_DOC = "How out-of-sync a remote partition can be before it is resynced.";
     public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
 
+    public static final String ADD_SOURCE_ALIAS_TO_METRICS = "add.source.alias.to.metrics";
+    private static final String ADD_SOURCE_ALIAS_TO_METRICS_DOC = "Deprecated. Whether to tag metrics with the source cluster alias. "
+        + "Metrics have the target, topic and partition tags. When this setting is enabled, it adds the source tag. "
+        + "This configuration will be removed in Kafka 4.0 and the default behavior will be to always have the source tag.";
+    public static final boolean ADD_SOURCE_ALIAS_TO_METRICS_DEFAULT = false;
+
     public MirrorSourceConfig(Map<String, String> props) {
         super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{
                 {TOPICS_EXCLUDE, TOPICS_EXCLUDE_ALIAS},
@@ -189,6 +195,10 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
 
     Duration consumerPollTimeout() {
         return Duration.ofMillis(getLong(CONSUMER_POLL_TIMEOUT_MILLIS));
+    }
+
+    boolean addSourceAliasToMetrics() {
+        return getBoolean(ADD_SOURCE_ALIAS_TO_METRICS);
     }
 
     protected static final ConfigDef CONNECTOR_CONFIG_DEF = new ConfigDef(BASE_CONNECTOR_CONFIG_DEF)
@@ -300,7 +310,13 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
                     OFFSET_SYNCS_TOPIC_LOCATION_DEFAULT,
                     ConfigDef.ValidString.in(SOURCE_CLUSTER_ALIAS_DEFAULT, TARGET_CLUSTER_ALIAS_DEFAULT),
                     ConfigDef.Importance.LOW,
-                    OFFSET_SYNCS_TOPIC_LOCATION_DOC);
+                    OFFSET_SYNCS_TOPIC_LOCATION_DOC)
+            .define(
+                    ADD_SOURCE_ALIAS_TO_METRICS,
+                    ConfigDef.Type.BOOLEAN,
+                    ADD_SOURCE_ALIAS_TO_METRICS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    ADD_SOURCE_ALIAS_TO_METRICS_DOC);
 
     public static void main(String[] args) {
         System.out.println(CONNECTOR_CONFIG_DEF.toHtml(4, config -> "mirror_source_" + config));

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceMetricsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceMetricsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MirrorSourceMetricsTest {
+
+    private final static String SOURCE = "source";
+    private final static String TARGET = "target";
+    private final static TopicPartition TP = new TopicPartition("topic", 0);
+    private final static TopicPartition SOURCE_TP = new TopicPartition(SOURCE + "." + TP.topic(), TP.partition());
+
+    private final Map<String, String> configs = new HashMap<>();
+    private TestReporter reporter;
+
+    @BeforeEach
+    public void setUp() {
+        configs.put(ConnectorConfig.NAME_CONFIG, "name");
+        configs.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, MirrorSourceConnector.class.getName());
+        configs.put(MirrorConnectorConfig.SOURCE_CLUSTER_ALIAS, SOURCE);
+        configs.put(MirrorConnectorConfig.TARGET_CLUSTER_ALIAS, TARGET);
+        configs.put(MirrorSourceTaskConfig.TASK_TOPIC_PARTITIONS, TP.toString());
+        reporter = new TestReporter();
+    }
+
+    @Test
+    public void testTags() {
+        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(configs);
+        MirrorSourceMetrics metrics = new MirrorSourceMetrics(taskConfig);
+        metrics.addReporter(reporter);
+
+        metrics.countRecord(SOURCE_TP);
+        assertEquals(13, reporter.metrics.size());
+        Map<String, String> tags = reporter.metrics.get(0).metricName().tags();
+        assertEquals(TARGET, tags.get("target"));
+        assertEquals(SOURCE_TP.topic(), tags.get("topic"));
+        assertEquals(String.valueOf(SOURCE_TP.partition()), tags.get("partition"));
+        assertNull(tags.get("source"));
+    }
+
+    @Test
+    public void testTagsWithSourceAlias() {
+        configs.put(MirrorSourceConfig.ADD_SOURCE_ALIAS_TO_METRICS, "true");
+        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(configs);
+        MirrorSourceMetrics metrics = new MirrorSourceMetrics(taskConfig);
+        metrics.addReporter(reporter);
+
+        metrics.countRecord(SOURCE_TP);
+        assertEquals(13, reporter.metrics.size());
+        Map<String, String> tags = reporter.metrics.get(0).metricName().tags();
+        assertEquals(SOURCE, tags.get("source"));
+        assertEquals(TARGET, tags.get("target"));
+        assertEquals(SOURCE_TP.topic(), tags.get("topic"));
+        assertEquals(String.valueOf(SOURCE_TP.partition()), tags.get("partition"));
+    }
+
+    static class TestReporter implements MetricsReporter {
+
+        List<KafkaMetric> metrics = new ArrayList<>();
+
+        @Override
+        public void init(List<KafkaMetric> metrics) {
+            for (KafkaMetric metric : metrics) {
+                metricChange(metric);
+            }
+        }
+
+        @Override
+        public void metricChange(KafkaMetric metric) {
+            metrics.add(metric);
+        }
+
+        @Override
+        public void metricRemoval(KafkaMetric metric) {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void configure(Map<String, ?> configs) {}
+    }
+}


### PR DESCRIPTION
New add.source.alias.to.metrics setting to add the source cluster alias to the MirrorSourceConnector metrics


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
