### PR TITLE
KAFKA-14491: [19/N] Combine versioned store RocksDB instances into one

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
@@ -16,14 +16,32 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 
+/**
+ * A {@link Segments} implementation which uses a single underlying RocksDB instance.
+ * Regular segments with {@code segmentId >= 0} expire according to the specified
+ * retention period. "Reserved" segments with {@code segmentId < 0} do not expire
+ * and are completely separate from regular segments in that methods such as
+ * {@link #getSegmentForTimestamp(long)}, {@link #getOrCreateSegment(long, ProcessorContext)},
+ * {@link #getOrCreateSegmentIfLive(long, ProcessorContext, long)},
+ * {@link #segments(long, long, boolean)}, and {@link #allSegments(boolean)}
+ * only return regular segments and not reserved segments. The methods {@link #flush()}
+ * and {@link #close()} flush and close both regular and reserved segments, due to
+ * the fact that both types of segments share the same physical RocksDB instance.
+ * To create a reserved segment, use {@link #createReservedSegment(long, String)} instead.
+ */
 public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSegment> {
 
     private final RocksDBMetricsRecorder metricsRecorder;
     private final RocksDBStore physicalStore;
+
+    // reserved segments do not expire, and are tracked here separately from regular segments
+    private final Map<Long, LogicalKeyValueSegment> reservedSegments = new HashMap<>();
 
     LogicalKeyValueSegments(final String name,
                             final String parentDir,
@@ -41,6 +59,12 @@ public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSeg
         if (segments.containsKey(segmentId)) {
             return segments.get(segmentId);
         } else {
+            if (segmentId < 0) {
+                throw new IllegalArgumentException(
+                    "Negative segment IDs are reserved for reserved segments, "
+                        + "and should be created through createReservedSegment() instead");
+            }
+
             final LogicalKeyValueSegment newSegment = new LogicalKeyValueSegment(segmentId, segmentName(segmentId), physicalStore);
 
             if (segments.put(segmentId, newSegment) != null) {
@@ -49,6 +73,26 @@ public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSeg
 
             return newSegment;
         }
+    }
+
+    LogicalKeyValueSegment createReservedSegment(final long segmentId,
+                                                 final String segmentName) {
+        if (segmentId >= 0) {
+            throw new IllegalArgumentException("segmentId for a reserved segment must be negative");
+        }
+
+        final LogicalKeyValueSegment newSegment = new LogicalKeyValueSegment(segmentId, segmentName, physicalStore);
+
+        if (reservedSegments.put(segmentId, newSegment) != null) {
+            throw new IllegalStateException("LogicalKeyValueSegment already exists.");
+        }
+
+        return newSegment;
+    }
+
+    // VisibleForTesting
+    LogicalKeyValueSegment getReservedSegment(final long segmentId) {
+        return reservedSegments.get(segmentId);
     }
 
     @Override
@@ -71,6 +115,24 @@ public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSeg
     public void close() {
         // close the logical segments first to close any open iterators
         super.close();
+
+        // same for reserved segments
+        for (final LogicalKeyValueSegment segment : reservedSegments.values()) {
+            segment.close();
+        }
+        reservedSegments.clear();
+
         physicalStore.close();
+    }
+
+    @Override
+    public String segmentName(final long segmentId) {
+        if (segmentId < 0) {
+            throw new IllegalArgumentException(
+                "Negative segment IDs are reserved for reserved segments, "
+                    + "which have custom names that should not be accessed from this method");
+        }
+
+        return super.segmentName(segmentId);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -236,7 +236,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
 
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final Bytes prefix) {
-            final Bytes to = Bytes.increment(prefix);
+            final Bytes to = incrementWithoutOverflow(prefix);
             return new RocksDBDualCFRangeIterator(
                 name,
                 db.newIterator(newColumnFamily),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
@@ -55,9 +55,10 @@ public class LogicalKeyValueSegmentTest {
 
     private RocksDBStore physicalStore;
 
+    private LogicalKeyValueSegment segment0;
     private LogicalKeyValueSegment segment1;
     private LogicalKeyValueSegment segment2;
-    private LogicalKeyValueSegment segment3;
+    private LogicalKeyValueSegment negativeIdSegment;
 
     @Before
     public void setUp() {
@@ -69,16 +70,19 @@ public class LogicalKeyValueSegmentTest {
             new StreamsConfig(StreamsTestUtils.getStreamsConfig())
         ), physicalStore);
 
+        segment0 = new LogicalKeyValueSegment(0, "segment-0", physicalStore);
         segment1 = new LogicalKeyValueSegment(1, "segment-1", physicalStore);
         segment2 = new LogicalKeyValueSegment(2, "segment-2", physicalStore);
-        segment3 = new LogicalKeyValueSegment(3, "segment-3", physicalStore);
+
+        // segments with negative IDs are supported as well for use in "reserved segments" (see LogicalKeyValueSegments.java)
+        negativeIdSegment = new LogicalKeyValueSegment(-1, "reserved-segment", physicalStore);
     }
 
     @After
     public void tearDown() {
+        segment0.close();
         segment1.close();
         segment2.close();
-        segment3.close();
         physicalStore.close();
     }
 
@@ -86,66 +90,100 @@ public class LogicalKeyValueSegmentTest {
     public void shouldPut() {
         final KeyValue<String, String> sharedKeyV1 = new KeyValue<>("shared", "v1");
         final KeyValue<String, String> sharedKeyV2 = new KeyValue<>("shared", "v2");
-        final KeyValue<String, String> segment1KeyOnly = new KeyValue<>("segment1_only", "v");
-        final KeyValue<String, String> segment2KeyOnly = new KeyValue<>("segment2_only", "other");
+        final KeyValue<String, String> sharedKeyV3 = new KeyValue<>("shared", "v3");
+        final KeyValue<String, String> segment0KeyOnly = new KeyValue<>("segment0_only", "foo");
+        final KeyValue<String, String> segment1KeyOnly = new KeyValue<>("segment1_only", "bar");
+        final KeyValue<String, String> negativeSegmentKeyOnly = new KeyValue<>("negative_segment_only", "baz");
 
-        segment1.put(new Bytes(serializeBytes(sharedKeyV1.key)), serializeBytes(sharedKeyV1.value));
+        segment0.put(new Bytes(serializeBytes(sharedKeyV1.key)), serializeBytes(sharedKeyV1.value));
+        segment0.put(new Bytes(serializeBytes(segment0KeyOnly.key)), serializeBytes(segment0KeyOnly.value));
+        segment1.put(new Bytes(serializeBytes(sharedKeyV2.key)), serializeBytes(sharedKeyV2.value));
         segment1.put(new Bytes(serializeBytes(segment1KeyOnly.key)), serializeBytes(segment1KeyOnly.value));
-        segment2.put(new Bytes(serializeBytes(sharedKeyV2.key)), serializeBytes(sharedKeyV2.value));
-        segment2.put(new Bytes(serializeBytes(segment2KeyOnly.key)), serializeBytes(segment2KeyOnly.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(sharedKeyV3.key)), serializeBytes(sharedKeyV3.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(negativeSegmentKeyOnly.key)), serializeBytes(negativeSegmentKeyOnly.value));
 
-        assertEquals("v1", getAndDeserialize(segment1, "shared"));
-        assertEquals("v2", getAndDeserialize(segment2, "shared"));
+        assertEquals("v1", getAndDeserialize(segment0, "shared"));
+        assertEquals("v2", getAndDeserialize(segment1, "shared"));
+        assertEquals("v3", getAndDeserialize(negativeIdSegment, "shared"));
 
-        assertEquals("v", getAndDeserialize(segment1, "segment1_only"));
-        assertNull(getAndDeserialize(segment2, "segment1_only"));
+        assertEquals("foo", getAndDeserialize(segment0, "segment0_only"));
+        assertNull(getAndDeserialize(segment1, "segment0_only"));
+        assertNull(getAndDeserialize(negativeIdSegment, "segment0_only"));
 
-        assertNull(getAndDeserialize(segment1, "segment2_only"));
-        assertEquals("other", getAndDeserialize(segment2, "segment2_only"));
+        assertNull(getAndDeserialize(segment0, "segment1_only"));
+        assertEquals("bar", getAndDeserialize(segment1, "segment1_only"));
+        assertNull(getAndDeserialize(negativeIdSegment, "segment1_only"));
+
+        assertNull(getAndDeserialize(segment0, "negative_segment_only"));
+        assertNull(getAndDeserialize(segment1, "negative_segment_only"));
+        assertEquals("baz", getAndDeserialize(negativeIdSegment, "negative_segment_only"));
     }
 
     @Test
     public void shouldPutAll() {
+        final List<KeyValue<Bytes, byte[]>> segment0Records = new ArrayList<>();
+        segment0Records.add(new KeyValue<>(
+            new Bytes(serializeBytes("shared")),
+            serializeBytes("v1")));
+        segment0Records.add(new KeyValue<>(
+            new Bytes(serializeBytes("segment0_only")),
+            serializeBytes("foo")));
+
         final List<KeyValue<Bytes, byte[]>> segment1Records = new ArrayList<>();
         segment1Records.add(new KeyValue<>(
             new Bytes(serializeBytes("shared")),
-            serializeBytes("v1")));
+            serializeBytes("v2")));
         segment1Records.add(new KeyValue<>(
             new Bytes(serializeBytes("segment1_only")),
-            serializeBytes("v")));
-        final List<KeyValue<Bytes, byte[]>> segment2Records = new ArrayList<>();
-        segment2Records.add(new KeyValue<>(
+            serializeBytes("bar")));
+
+        final List<KeyValue<Bytes, byte[]>> negativeSegmentRecords = new ArrayList<>();
+        negativeSegmentRecords.add(new KeyValue<>(
             new Bytes(serializeBytes("shared")),
-            serializeBytes("v2")));
-        segment2Records.add(new KeyValue<>(
-            new Bytes(serializeBytes("segment2_only")),
-            serializeBytes("other")));
+            serializeBytes("v3")));
+        negativeSegmentRecords.add(new KeyValue<>(
+            new Bytes(serializeBytes("negative_segment_only")),
+            serializeBytes("baz")));
 
+        segment0.putAll(segment0Records);
         segment1.putAll(segment1Records);
-        segment2.putAll(segment2Records);
+        negativeIdSegment.putAll(negativeSegmentRecords);
 
-        assertEquals("v1", getAndDeserialize(segment1, "shared"));
-        assertEquals("v2", getAndDeserialize(segment2, "shared"));
+        assertEquals("v1", getAndDeserialize(segment0, "shared"));
+        assertEquals("v2", getAndDeserialize(segment1, "shared"));
+        assertEquals("v3", getAndDeserialize(negativeIdSegment, "shared"));
 
-        assertEquals("v", getAndDeserialize(segment1, "segment1_only"));
-        assertNull(getAndDeserialize(segment2, "segment1_only"));
+        assertEquals("foo", getAndDeserialize(segment0, "segment0_only"));
+        assertNull(getAndDeserialize(segment1, "segment0_only"));
+        assertNull(getAndDeserialize(negativeIdSegment, "segment0_only"));
 
-        assertNull(getAndDeserialize(segment1, "segment2_only"));
-        assertEquals("other", getAndDeserialize(segment2, "segment2_only"));
+        assertNull(getAndDeserialize(segment0, "segment1_only"));
+        assertEquals("bar", getAndDeserialize(segment1, "segment1_only"));
+        assertNull(getAndDeserialize(negativeIdSegment, "segment1_only"));
+
+        assertNull(getAndDeserialize(segment0, "negative_segment_only"));
+        assertNull(getAndDeserialize(segment1, "negative_segment_only"));
+        assertEquals("baz", getAndDeserialize(negativeIdSegment, "negative_segment_only"));
     }
 
     @Test
     public void shouldPutIfAbsent() {
         final Bytes keyBytes = new Bytes(serializeBytes("one"));
-        final byte[] valueBytes = serializeBytes("A");
-        final byte[] valueBytesUpdate = serializeBytes("B");
+        final byte[] valueBytes1 = serializeBytes("A");
+        final byte[] valueBytes2 = serializeBytes("B");
+        final byte[] valueBytesUpdate = serializeBytes("C");
 
-        segment1.putIfAbsent(keyBytes, valueBytes);
-        segment1.putIfAbsent(keyBytes, valueBytesUpdate);
-        segment2.putIfAbsent(keyBytes, valueBytesUpdate);
+        segment0.putIfAbsent(keyBytes, valueBytes1);
+        negativeIdSegment.putIfAbsent(keyBytes, valueBytes2);
 
-        assertEquals("A", STRING_DESERIALIZER.deserialize(null, segment1.get(keyBytes)));
-        assertEquals("B", STRING_DESERIALIZER.deserialize(null, segment2.get(keyBytes)));
+        assertEquals("A", STRING_DESERIALIZER.deserialize(null, segment0.get(keyBytes)));
+        assertEquals("B", STRING_DESERIALIZER.deserialize(null, negativeIdSegment.get(keyBytes)));
+
+        segment0.putIfAbsent(keyBytes, valueBytesUpdate);
+        negativeIdSegment.putIfAbsent(keyBytes, valueBytesUpdate);
+
+        assertEquals("A", STRING_DESERIALIZER.deserialize(null, segment0.get(keyBytes)));
+        assertEquals("B", STRING_DESERIALIZER.deserialize(null, negativeIdSegment.get(keyBytes)));
     }
 
     @Test
@@ -153,14 +191,31 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv0 = new KeyValue<>("1", "a");
         final KeyValue<String, String> kv1 = new KeyValue<>("2", "b");
 
+        segment0.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment0.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
         segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
         segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        segment0.delete(new Bytes(serializeBytes(kv0.key)));
+
+        assertNull(getAndDeserialize(segment0, kv0.key));
+        assertEquals("b", getAndDeserialize(segment0, "2"));
+        assertEquals("a", getAndDeserialize(segment1, "1"));
+        assertEquals("b", getAndDeserialize(segment1, "2"));
+    }
+
+    @Test
+    public void shouldDeleteFromSegmentWithNegativeId() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("1", "a");
+        final KeyValue<String, String> kv1 = new KeyValue<>("2", "b");
+
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
         segment2.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
         segment2.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment1.delete(new Bytes(serializeBytes(kv0.key)));
+        negativeIdSegment.delete(new Bytes(serializeBytes(kv0.key)));
 
-        assertNull(getAndDeserialize(segment1, kv0.key));
-        assertEquals("b", getAndDeserialize(segment1, "2"));
+        assertNull(getAndDeserialize(negativeIdSegment, kv0.key));
+        assertEquals("b", getAndDeserialize(negativeIdSegment, "2"));
         assertEquals("a", getAndDeserialize(segment2, "1"));
         assertEquals("b", getAndDeserialize(segment2, "2"));
     }
@@ -172,14 +227,14 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
         final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
 
-        segment2.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
-        segment2.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment2.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
-        segment1.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
-        segment3.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        segment1.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment0.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment2.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
 
         // non-null bounds
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(new Bytes(serializeBytes("1")), new Bytes(serializeBytes("2")))) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("1")), new Bytes(serializeBytes("2")))) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv1);
             expectedContents.add(kv2);
@@ -187,7 +242,7 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null lower bound
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(null, new Bytes(serializeBytes("1")))) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(null, new Bytes(serializeBytes("1")))) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);
@@ -195,7 +250,7 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null upper bound
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("0")), null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);
@@ -204,7 +259,54 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null upper and lower bounds
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("0")), null)) {
+            final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+            expectedContents.add(kv0);
+            expectedContents.add(kv1);
+            expectedContents.add(kv2);
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnValuesOnRangeFromSegmentWithNegativeId() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+        final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
+        final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
+
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment0.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+
+        // non-null bounds
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(new Bytes(serializeBytes("1")), new Bytes(serializeBytes("2")))) {
+            final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+            expectedContents.add(kv1);
+            expectedContents.add(kv2);
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+
+        // null lower bound
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(null, new Bytes(serializeBytes("1")))) {
+            final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+            expectedContents.add(kv0);
+            expectedContents.add(kv1);
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+
+        // null upper bound
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(new Bytes(serializeBytes("0")), null)) {
+            final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+            expectedContents.add(kv0);
+            expectedContents.add(kv1);
+            expectedContents.add(kv2);
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+
+        // null upper and lower bounds
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(new Bytes(serializeBytes("0")), null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);
@@ -220,18 +322,41 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
         final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
 
-        segment2.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
-        segment2.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment2.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
-        segment1.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
-        segment3.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        segment1.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment0.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment2.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
 
         final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
         expectedContents.add(kv0);
         expectedContents.add(kv1);
         expectedContents.add(kv2);
 
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment2.all()) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.all()) {
+            assertEquals(expectedContents, getDeserializedList(iterator));
+        }
+    }
+
+    @Test
+    public void shouldReturnAllFromSegmentWithNegativeId() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+        final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
+        final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
+
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment0.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment1.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+
+        final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
+        expectedContents.add(kv0);
+        expectedContents.add(kv1);
+        expectedContents.add(kv2);
+
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.all()) {
             assertEquals(expectedContents, getDeserializedList(iterator));
         }
     }
@@ -243,16 +368,35 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
         final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
 
-        segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
-        segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment1.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
-        segment2.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
-        segment1.deleteRange(new Bytes(serializeBytes(kv0.key)), new Bytes(serializeBytes(kv1.key)));
+        segment0.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment0.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        segment0.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment1.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        segment0.deleteRange(new Bytes(serializeBytes(kv0.key)), new Bytes(serializeBytes(kv1.key)));
 
-        assertNull(getAndDeserialize(segment1, "0"));
-        assertNull(getAndDeserialize(segment1, "1"));
-        assertEquals("two", getAndDeserialize(segment1, "2"));
-        assertEquals("other", getAndDeserialize(segment2, "1"));
+        assertNull(getAndDeserialize(segment0, "0"));
+        assertNull(getAndDeserialize(segment0, "1"));
+        assertEquals("two", getAndDeserialize(segment0, "2"));
+        assertEquals("other", getAndDeserialize(segment1, "1"));
+    }
+
+    @Test
+    public void shouldDeleteRangeFromSegmentWithNegativeId() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+        final KeyValue<String, String> kv2 = new KeyValue<>("2", "two");
+        final KeyValue<String, String> kvOther = new KeyValue<>("1", "other");
+
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv2.key)), serializeBytes(kv2.value));
+        segment1.put(new Bytes(serializeBytes(kvOther.key)), serializeBytes(kvOther.value));
+        negativeIdSegment.deleteRange(new Bytes(serializeBytes(kv0.key)), new Bytes(serializeBytes(kv1.key)));
+
+        assertNull(getAndDeserialize(negativeIdSegment, "0"));
+        assertNull(getAndDeserialize(negativeIdSegment, "1"));
+        assertEquals("two", getAndDeserialize(negativeIdSegment, "2"));
+        assertEquals("other", getAndDeserialize(segment1, "1"));
     }
 
     @Test
@@ -260,20 +404,31 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv0 = new KeyValue<>("1", "a");
         final KeyValue<String, String> kv1 = new KeyValue<>("2", "b");
 
+        segment0.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment0.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
         segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
         segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment2.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
-        segment2.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
 
-        segment1.destroy();
+        segment0.destroy();
 
-        assertEquals("a", getAndDeserialize(segment2, "1"));
-        assertEquals("b", getAndDeserialize(segment2, "2"));
+        assertEquals("a", getAndDeserialize(segment1, "1"));
+        assertEquals("b", getAndDeserialize(segment1, "2"));
+        assertEquals("a", getAndDeserialize(negativeIdSegment, "1"));
+        assertEquals("b", getAndDeserialize(negativeIdSegment, "2"));
 
-        segment1 = new LogicalKeyValueSegment(1, "segment-1", physicalStore);
+        segment0 = new LogicalKeyValueSegment(0, "segment-0", physicalStore);
 
-        assertNull(getAndDeserialize(segment1, "1"));
-        assertNull(getAndDeserialize(segment1, "2"));
+        assertNull(getAndDeserialize(segment0, "1"));
+        assertNull(getAndDeserialize(segment0, "2"));
+    }
+
+    @Test
+    public void shouldNotDestroySegmentWithNegativeId() {
+        // reserved segments should not be destroyed. they are cleaned up only when
+        // an entire store is closed, via the close() method rather than destroy()
+        assertThrows(IllegalStateException.class, () -> negativeIdSegment.destroy());
     }
 
     @Test
@@ -281,24 +436,59 @@ public class LogicalKeyValueSegmentTest {
         final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
         final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
 
+        segment0.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment0.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
         segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
         segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
-        segment2.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
-        segment2.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
 
+        final KeyValueIterator<Bytes, byte[]> range0 = segment0.range(null, new Bytes(serializeBytes("1")));
+        final KeyValueIterator<Bytes, byte[]> all0 = segment0.all();
         final KeyValueIterator<Bytes, byte[]> range1 = segment1.range(null, new Bytes(serializeBytes("1")));
-        final KeyValueIterator<Bytes, byte[]> all1 = segment1.all();
-        final KeyValueIterator<Bytes, byte[]> range2 = segment2.range(null, new Bytes(serializeBytes("1")));
+        final KeyValueIterator<Bytes, byte[]> rangeNegative = negativeIdSegment.range(null, new Bytes(serializeBytes("1")));
 
+        assertTrue(range0.hasNext());
+        assertTrue(all0.hasNext());
         assertTrue(range1.hasNext());
-        assertTrue(all1.hasNext());
-        assertTrue(range2.hasNext());
+        assertTrue(rangeNegative.hasNext());
 
-        segment1.close();
+        segment0.close();
 
-        assertThrows(InvalidStateStoreException.class, range1::hasNext);
-        assertThrows(InvalidStateStoreException.class, all1::hasNext);
-        assertTrue(range2.hasNext());
+        assertThrows(InvalidStateStoreException.class, range0::hasNext);
+        assertThrows(InvalidStateStoreException.class, all0::hasNext);
+        assertTrue(range1.hasNext());
+        assertTrue(rangeNegative.hasNext());
+    }
+
+    @Test
+    public void shouldCloseOpenIteratorsWhenStoreWithNegativeIdClosed() {
+        final KeyValue<String, String> kv0 = new KeyValue<>("0", "zero");
+        final KeyValue<String, String> kv1 = new KeyValue<>("1", "one");
+
+        segment0.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment0.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        segment1.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        segment1.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv0.key)), serializeBytes(kv0.value));
+        negativeIdSegment.put(new Bytes(serializeBytes(kv1.key)), serializeBytes(kv1.value));
+
+        final KeyValueIterator<Bytes, byte[]> rangeNegative = negativeIdSegment.range(null, new Bytes(serializeBytes("1")));
+        final KeyValueIterator<Bytes, byte[]> allNegative = negativeIdSegment.all();
+        final KeyValueIterator<Bytes, byte[]> range0 = segment0.range(null, new Bytes(serializeBytes("1")));
+        final KeyValueIterator<Bytes, byte[]> range1 = segment1.range(null, new Bytes(serializeBytes("1")));
+
+        assertTrue(rangeNegative.hasNext());
+        assertTrue(allNegative.hasNext());
+        assertTrue(range0.hasNext());
+        assertTrue(range1.hasNext());
+
+        negativeIdSegment.close();
+
+        assertThrows(InvalidStateStoreException.class, rangeNegative::hasNext);
+        assertThrows(InvalidStateStoreException.class, allNegative::hasNext);
+        assertTrue(range0.hasNext());
+        assertTrue(range1.hasNext());
     }
 
     private static byte[] serializeBytes(final String s) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
@@ -250,16 +250,15 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null upper bound
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("1")), null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
-            expectedContents.add(kv0);
             expectedContents.add(kv1);
             expectedContents.add(kv2);
             assertEquals(expectedContents, getDeserializedList(iterator));
         }
 
         // null upper and lower bounds
-        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = segment1.range(null, null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);
@@ -297,16 +296,15 @@ public class LogicalKeyValueSegmentTest {
         }
 
         // null upper bound
-        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(new Bytes(serializeBytes("1")), null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
-            expectedContents.add(kv0);
             expectedContents.add(kv1);
             expectedContents.add(kv2);
             assertEquals(expectedContents, getDeserializedList(iterator));
         }
 
         // null upper and lower bounds
-        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(new Bytes(serializeBytes("0")), null)) {
+        try (final KeyValueIterator<Bytes, byte[]> iterator = negativeIdSegment.range(null, null)) {
             final LinkedList<KeyValue<String, String>> expectedContents = new LinkedList<>();
             expectedContents.add(kv0);
             expectedContents.add(kv1);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
@@ -21,14 +21,18 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.List;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
@@ -102,9 +106,33 @@ public class LogicalKeyValueSegmentsTest {
     }
 
     @Test
+    public void shouldCreateReservedSegments() {
+        final LogicalKeyValueSegment reservedSegment1 = segments.createReservedSegment(-1, "reserved-1");
+        final LogicalKeyValueSegment reservedSegment2 = segments.createReservedSegment(-2, "reserved-2");
+
+        final File rocksdbDir = new File(new File(context.stateDir(), DB_FILE_DIR), STORE_NAME);
+        assertTrue(rocksdbDir.isDirectory());
+
+        assertTrue(reservedSegment1.isOpen());
+        assertTrue(reservedSegment2.isOpen());
+    }
+
+    @Test
+    public void shouldNotCreateReservedSegmentWithNonNegativeId() {
+        assertThrows(IllegalArgumentException.class, () -> segments.createReservedSegment(0, "reserved"));
+        assertThrows(IllegalArgumentException.class, () -> segments.createReservedSegment(1, "reserved"));
+    }
+
+    @Test
+    public void shouldNotCreateReservedSegmentFromRegularMethod() {
+        assertThrows(IllegalArgumentException.class, () -> segments.getOrCreateSegmentIfLive(-1, context, 0));
+        assertThrows(IllegalArgumentException.class, () -> segments.getOrCreateSegment(-1, context));
+    }
+
+    @Test
     public void shouldCleanupSegmentsThatHaveExpired() {
         final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(0, context, 0);
-        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(0, context, SEGMENT_INTERVAL * 2L);
+        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(2, context, SEGMENT_INTERVAL * 2L);
         final LogicalKeyValueSegment segment3 = segments.getOrCreateSegmentIfLive(3, context, SEGMENT_INTERVAL * 3L);
         final LogicalKeyValueSegment segment4 = segments.getOrCreateSegmentIfLive(7, context, SEGMENT_INTERVAL * 7L);
 
@@ -114,6 +142,20 @@ public class LogicalKeyValueSegmentsTest {
         assertEquals(2, allSegments.size());
         assertEquals(segment3, allSegments.get(0));
         assertEquals(segment4, allSegments.get(1));
+    }
+
+    @Test
+    public void shouldNotCleanUpReservedSegments() {
+        final LogicalKeyValueSegment reservedSegment = segments.createReservedSegment(-1, "reserved");
+        final LogicalKeyValueSegment segment1 = segments.getOrCreateSegmentIfLive(1, context, SEGMENT_INTERVAL);
+        final LogicalKeyValueSegment segment2 = segments.getOrCreateSegmentIfLive(2, context, SEGMENT_INTERVAL * 2L);
+
+        segments.cleanupExpiredSegments(SEGMENT_INTERVAL * 6L);
+
+        final List<LogicalKeyValueSegment> allSegments = segments.allSegments(true);
+        assertEquals(1, allSegments.size());
+        assertEquals(segment2, allSegments.get(0));
+        assertEquals(reservedSegment, segments.getReservedSegment(-1));
     }
 
     @Test
@@ -129,6 +171,9 @@ public class LogicalKeyValueSegmentsTest {
 
     @Test
     public void shouldGetSegmentsWithinTimeRange() {
+        // presence of reserved segment changes nothing (reserved segments are not returned from segments())
+        segments.createReservedSegment(-1, "reserved");
+
         final long streamTime = updateStreamTimeAndCreateSegment(4);
         segments.getOrCreateSegmentIfLive(0, context, streamTime);
         segments.getOrCreateSegmentIfLive(2, context, streamTime);
@@ -145,6 +190,9 @@ public class LogicalKeyValueSegmentsTest {
 
     @Test
     public void shouldGetSegmentsWithinBackwardTimeRange() {
+        // presence of reserved segment changes nothing (reserved segments are not returned from segments())
+        segments.createReservedSegment(-1, "reserved");
+
         final long streamTime = updateStreamTimeAndCreateSegment(4);
         segments.getOrCreateSegmentIfLive(0, context, streamTime);
         segments.getOrCreateSegmentIfLive(2, context, streamTime);
@@ -161,9 +209,24 @@ public class LogicalKeyValueSegmentsTest {
 
     @Test
     public void shouldClearSegmentsOnClose() {
-        segments.getOrCreateSegmentIfLive(0, context, 0L);
+        final LogicalKeyValueSegment segment = segments.getOrCreateSegmentIfLive(0, context, 0L);
+        final LogicalKeyValueSegment reservedSegment = segments.createReservedSegment(-1, "reserved");
+
+        // add data and open some iterators to verify that they are properly closed later
+        segment.put(new Bytes("k".getBytes()), "v".getBytes());
+        reservedSegment.put(new Bytes("k".getBytes()), "v".getBytes());
+        final KeyValueIterator<Bytes, byte[]> all1 = segment.all();
+        final KeyValueIterator<Bytes, byte[]> all2 = reservedSegment.all();
+        assertTrue(all1.hasNext());
+        assertTrue(all2.hasNext());
+
         segments.close();
+
         assertThat(segments.getSegmentForTimestamp(0), is(nullValue()));
+        assertThat(segments.getReservedSegment(-1), is(nullValue()));
+        // verify iterators closed as well
+        assertThrows(InvalidStateStoreException.class, all1::hasNext);
+        assertThrows(InvalidStateStoreException.class, all2::hasNext);
     }
 
     private long updateStreamTimeAndCreateSegment(final int segment) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -95,6 +95,7 @@ import java.util.stream.Collectors;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.state.internals.RocksDBStore.DB_FILE_DIR;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -168,11 +169,11 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
     }
 
     private RocksDBStore getRocksDBStoreWithRocksDBMetricsRecorder() {
-        return new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);
+        return new RocksDBStore(DB_NAME, DB_FILE_DIR, metricsRecorder);
     }
 
     private RocksDBStore getRocksDBStoreWithCustomManagedIterators() {
-        return new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder, false);
+        return new RocksDBStore(DB_NAME, DB_FILE_DIR, metricsRecorder, false);
     }
 
     private InternalMockProcessorContext getProcessorContext(final Properties streamsProps) {


### PR DESCRIPTION
The RocksDB-based versioned store implementation introduced in https://github.com/apache/kafka/pull/13188 currently uses two physical RocksDB instances per store instance: one for the "latest value store" and another for the "segments store." This PR combines those two RocksDB instances into one by representing the latest value store as a special "reserved" segment within the segments store. This reserved segment has segment ID -1, is never expired, and is not included in the regular `Segments` methods for getting or creating segments, but is represented in the physical RocksDB instance the same way as any other segment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
