### PR TITLE
MINOR: Add Exactly-once support for connectors to the docs table of contents

### DIFF
--- a/docs/toc.html
+++ b/docs/toc.html
@@ -197,6 +197,7 @@
                     <li><a href="#connect_transforms">Transformations</a></li>
                     <li><a href="#connect_rest">REST API</a></li>
                     <li><a href="#connect_errorreporting">Error Reporting in Connect</a></li>
+                    <li><a href="#connect_exactlyonce">Exactly-once support</a></li>
                 </ul>
                 <li><a href="#connect_development">8.3 Connector Development Guide</a></li>
             </ul>


### PR DESCRIPTION
- Documentation for exactly-once support for connectors was recently added in https://github.com/apache/kafka/pull/12941
- Although it's a top level header under `KAFKA CONNECT -> User Guide`, adding an entry to the docs table of contents was missed.

Before:
<img width="2560" alt="Screenshot 2023-03-22 at 8 01 35 PM" src="https://user-images.githubusercontent.com/23502577/226939201-031e0785-f8e0-4b90-8b1b-e2e947be188b.png">


After:
<img width="2560" alt="Screenshot 2023-03-22 at 8 02 22 PM" src="https://user-images.githubusercontent.com/23502577/226939231-d6ec00bf-dd66-4af5-906a-30bdd286dffc.png">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
