### PR TITLE
MINOR: Rename remote_kraft to isolated_kraft in kafkatests

### DIFF
--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -101,11 +101,11 @@ class TestVerifiableProducer(Test):
         assert num_produced == self.num_messages, "num_produced: %d, num_messages: %d" % (num_produced, self.num_messages)
 
     @cluster(num_nodes=4)
-    @matrix(inter_broker_security_protocol=['PLAINTEXT', 'SSL'], metadata_quorum=[quorum.remote_kraft])
+    @matrix(inter_broker_security_protocol=['PLAINTEXT', 'SSL'], metadata_quorum=[quorum.isolated_kraft])
     @matrix(inter_broker_security_protocol=['SASL_SSL'], inter_broker_sasl_mechanism=['PLAIN', 'GSSAPI'],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     def test_multiple_kraft_security_protocols(
-            self, inter_broker_security_protocol, inter_broker_sasl_mechanism='GSSAPI', metadata_quorum=quorum.remote_kraft):
+            self, inter_broker_security_protocol, inter_broker_sasl_mechanism='GSSAPI', metadata_quorum=quorum.isolated_kraft):
         """
         Test for remote KRaft cases that we can start VerifiableProducer on the current branch snapshot version, and
         verify that we can produce a small number of messages.  The inter-controller and broker-to-controller
@@ -144,7 +144,7 @@ class TestVerifiableProducer(Test):
         assert num_produced == self.num_messages, "num_produced: %d, num_messages: %d" % (num_produced, self.num_messages)
 
     @cluster(num_nodes=4)
-    @parametrize(metadata_quorum=quorum.remote_kraft)
+    @parametrize(metadata_quorum=quorum.isolated_kraft)
     def test_multiple_kraft_sasl_mechanisms(self, metadata_quorum):
         """
         Test for remote KRaft cases that we can start VerifiableProducer on the current branch snapshot version, and

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -139,8 +139,8 @@ class ConnectStandaloneFileTest(Test):
 
     @cluster(num_nodes=5)
     @parametrize(error_tolerance=ErrorTolerance.ALL, metadata_quorum=quorum.zk)
-    @parametrize(error_tolerance=ErrorTolerance.NONE, metadata_quorum=quorum.remote_kraft)
-    @parametrize(error_tolerance=ErrorTolerance.ALL, metadata_quorum=quorum.remote_kraft)
+    @parametrize(error_tolerance=ErrorTolerance.NONE, metadata_quorum=quorum.isolated_kraft)
+    @parametrize(error_tolerance=ErrorTolerance.ALL, metadata_quorum=quorum.isolated_kraft)
     @parametrize(error_tolerance=ErrorTolerance.NONE, metadata_quorum=quorum.zk)
     def test_skip_and_log_to_dlq(self, error_tolerance, metadata_quorum):
         self.kafka = KafkaService(self.test_context, self.num_brokers, self.zk, topics=self.topics)

--- a/tests/kafkatest/tests/core/authorizer_test.py
+++ b/tests/kafkatest/tests/core/authorizer_test.py
@@ -43,8 +43,8 @@ class AuthorizerTest(Test):
         self.acls = ACLs(self.test_context)
 
     @cluster(num_nodes=4)
-    @parametrize(metadata_quorum=quorum.remote_kraft, authorizer_class=KafkaService.KRAFT_ACL_AUTHORIZER)
-    @parametrize(metadata_quorum=quorum.remote_kraft, authorizer_class=KafkaService.ZK_ACL_AUTHORIZER)
+    @parametrize(metadata_quorum=quorum.isolated_kraft, authorizer_class=KafkaService.KRAFT_ACL_AUTHORIZER)
+    @parametrize(metadata_quorum=quorum.isolated_kraft, authorizer_class=KafkaService.ZK_ACL_AUTHORIZER)
     @parametrize(metadata_quorum=quorum.zk, authorizer_class=KafkaService.ZK_ACL_AUTHORIZER)
     def test_authorizer(self, metadata_quorum, authorizer_class):
         topics = {"test_topic": {"partitions": 1, "replication-factor": 1}}
@@ -83,7 +83,7 @@ class AuthorizerTest(Test):
         node.account.ssh(alter_client_quotas_cmd)
 
         # set authorizer, restart with broker as super user
-        if (metadata_quorum == quorum.remote_kraft):
+        if (metadata_quorum == quorum.isolated_kraft):
             # we need to explicitly reconfigure/restart any remote controller quorum
             self.kafka.logger.info("Restarting Remote KRaft Controller with authorizer and broker principal as super user")
             controller_quorum = self.kafka.controller_quorum

--- a/tests/kafkatest/tests/core/round_trip_fault_test.py
+++ b/tests/kafkatest/tests/core/round_trip_fault_test.py
@@ -38,7 +38,7 @@ class RoundTripFaultTest(Test):
         self.workload_service = RoundTripWorkloadService(test_context, self.kafka)
         if quorum.for_test(test_context) == quorum.zk:
             trogdor_client_services = [self.zk, self.kafka, self.workload_service]
-        elif quorum.for_test(test_context) == quorum.remote_kraft:
+        elif quorum.for_test(test_context) == quorum.isolated_kraft:
             trogdor_client_services = [self.kafka.controller_quorum, self.kafka, self.workload_service]
         else: #co-located case, which we currently don't test but handle here for completeness in case we do test it
             trogdor_client_services = [self.kafka, self.workload_service]
@@ -70,7 +70,7 @@ class RoundTripFaultTest(Test):
     def remote_quorum_nodes(self):
         if quorum.for_test(self.test_context) == quorum.zk:
             return self.zk.nodes
-        elif quorum.for_test(self.test_context) == quorum.remote_kraft:
+        elif quorum.for_test(self.test_context) == quorum.isolated_kraft:
             return self.kafka.controller_quorum.nodes
         else: # co-located case, which we currently don't test but handle here for completeness in case we do test it
             return []

--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -132,7 +132,7 @@ class SecurityTest(EndToEndTest):
         self.consumer.start()
 
     @cluster(num_nodes=2)
-    @matrix(metadata_quorum=[quorum.zk, quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.zk, quorum.isolated_kraft])
     def test_quorum_ssl_endpoint_validation_failure(self, metadata_quorum=quorum.zk):
         """
         Test that invalid hostname in ZooKeeper or KRaft Controller results in broker inability to start.

--- a/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
@@ -216,7 +216,7 @@ class StreamsBrokerBounceTest(Test):
             broker_type=["leader"],
             num_threads=[1, 3],
             sleep_time_secs=[120],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
             broker_type=["leader", "controller"],
             num_threads=[1, 3],

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -45,7 +45,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
             self.zk.start()
 
     @cluster(num_nodes=7)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_streams_resilient_to_broker_down(self, metadata_quorum):
         self.kafka.start()
 
@@ -82,7 +82,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         self.kafka.stop()
 
     @cluster(num_nodes=7)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_streams_runs_with_broker_down_initially(self, metadata_quorum):
         self.kafka.start()
         node = self.kafka.leader(self.inputTopic)
@@ -150,7 +150,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         self.kafka.stop()
 
     @cluster(num_nodes=9)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_streams_should_scale_in_while_brokers_down(self, metadata_quorum):
         self.kafka.start()
 
@@ -229,7 +229,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         self.kafka.stop()
 
     @cluster(num_nodes=9)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_streams_should_failover_while_brokers_down(self, metadata_quorum):
         self.kafka.start()
 

--- a/tests/kafkatest/tests/streams/streams_eos_test.py
+++ b/tests/kafkatest/tests/streams/streams_eos_test.py
@@ -40,7 +40,7 @@ class StreamsEosTest(KafkaTest):
 
     @cluster(num_nodes=9)
     @matrix(processing_guarantee=["exactly_once", "exactly_once_v2"],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     def test_rebalance_simple(self, processing_guarantee, metadata_quorum):
         self.run_rebalance(StreamsEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
                            StreamsEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
@@ -49,7 +49,7 @@ class StreamsEosTest(KafkaTest):
 
     @cluster(num_nodes=9)
     @matrix(processing_guarantee=["exactly_once", "exactly_once_v2"],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     def test_rebalance_complex(self, processing_guarantee, metadata_quorum):
         self.run_rebalance(StreamsComplexEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
                            StreamsComplexEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
@@ -84,7 +84,7 @@ class StreamsEosTest(KafkaTest):
 
     @cluster(num_nodes=9)
     @matrix(processing_guarantee=["exactly_once", "exactly_once_v2"],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     def test_failure_and_recovery(self, processing_guarantee, metadata_quorum):
         self.run_failure_and_recovery(StreamsEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
                                       StreamsEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
@@ -93,7 +93,7 @@ class StreamsEosTest(KafkaTest):
 
     @cluster(num_nodes=9)
     @matrix(processing_guarantee=["exactly_once", "exactly_once_v2"],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     def test_failure_and_recovery_complex(self, processing_guarantee, metadata_quorum):
         self.run_failure_and_recovery(StreamsComplexEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),
                                       StreamsComplexEosTestJobRunnerService(self.test_context, self.kafka, processing_guarantee),

--- a/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
+++ b/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
@@ -57,7 +57,7 @@ class StreamsNamedRepartitionTopicTest(Test):
                                            acks=1)
 
     @cluster(num_nodes=8)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_upgrade_topology_with_named_repartition_topic(self, metadata_quorum):
         if self.zookeeper:
             self.zookeeper.start()

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -62,7 +62,7 @@ class StreamsOptimizedTest(Test):
                                            acks=1)
 
     @cluster(num_nodes=9)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_upgrade_optimized_topology(self, metadata_quorum):
         if self.zookeeper:
             self.zookeeper.start()

--- a/tests/kafkatest/tests/streams/streams_relational_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_relational_smoke_test.py
@@ -87,7 +87,7 @@ class StreamsRelationalSmokeTest(KafkaTest):
     @cluster(num_nodes=8)
     @matrix(crash=[False, True],
             processing_guarantee=['exactly_once', 'exactly_once_v2'],
-            metadata_quorum=[quorum.remote_kraft])
+            metadata_quorum=[quorum.isolated_kraft])
     def test_streams(self, crash, processing_guarantee, metadata_quorum):
         driver = StreamsRelationalSmokeTestService(self.test_context, self.kafka, "driver", "ignored", "ignored")
 

--- a/tests/kafkatest/tests/streams/streams_shutdown_deadlock_test.py
+++ b/tests/kafkatest/tests/streams/streams_shutdown_deadlock_test.py
@@ -33,7 +33,7 @@ class StreamsShutdownDeadlockTest(KafkaTest):
         self.driver = StreamsSmokeTestShutdownDeadlockService(test_context, self.kafka)
 
     @cluster(num_nodes=3)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_shutdown_wont_deadlock(self, metadata_quorum):
         """
         Start ShutdownDeadLockTest, wait for upt to 1 minute, and check that the process exited.

--- a/tests/kafkatest/tests/streams/streams_standby_replica_test.py
+++ b/tests/kafkatest/tests/streams/streams_standby_replica_test.py
@@ -47,7 +47,7 @@ class StreamsStandbyTask(BaseStreamsTest):
                                                  })
 
     @cluster(num_nodes=10)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_standby_tasks_rebalance(self, metadata_quorum):
         # TODO KIP-441: consider rewriting the test for HighAvailabilityTaskAssignor
         configs = self.get_configs(

--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -55,7 +55,7 @@ class StreamsStaticMembershipTest(Test):
                                            acks=1)
 
     @cluster(num_nodes=8)
-    @matrix(metadata_quorum=[quorum.remote_kraft])
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
     def test_rolling_bounces_will_not_trigger_rebalance_under_static_membership(self, metadata_quorum):
         if self.zookeeper:
             self.zookeeper.start()


### PR DESCRIPTION
 ddd652c6 standardized on "isolated" as the name for all the isolated
 modes, and renamed kafkatest.services.kafka.quorum.remote_kraft to
 isolated_kraft. However, the tests using remote_kraft weren't
 updated, and are broken as a result. This is a simple search and
 replace to fix those.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
