### PR TITLE
KAFKA-14837, KAFKA-14842: Ignore groups that do not have offsets for filtered topics in MirrorCheckpointConnector

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -18,6 +18,8 @@ package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Utils;
@@ -30,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +49,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
 
     private Scheduler scheduler;
     private MirrorCheckpointConfig config;
+    private TopicFilter topicFilter;
     private GroupFilter groupFilter;
     private Admin sourceAdminClient;
     private Admin targetAdminClient;
@@ -70,6 +74,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
         }
         String connectorName = config.connectorName();
         sourceAndTarget = new SourceAndTarget(config.sourceClusterAlias(), config.targetClusterAlias());
+        topicFilter = config.topicFilter();
         groupFilter = config.groupFilter();
         sourceAdminClient = config.forwardingAdmin(config.sourceAdminConfig());
         targetAdminClient = config.forwardingAdmin(config.targetAdminConfig());
@@ -88,6 +93,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
             return;
         }
         Utils.closeQuietly(scheduler, "scheduler");
+        Utils.closeQuietly(topicFilter, "topic filter");
         Utils.closeQuietly(groupFilter, "group filter");
         Utils.closeQuietly(sourceAdminClient, "source admin client");
         Utils.closeQuietly(targetAdminClient, "target admin client");
@@ -150,10 +156,31 @@ public class MirrorCheckpointConnector extends SourceConnector {
 
     List<String> findConsumerGroups()
             throws InterruptedException, ExecutionException {
-        return listConsumerGroups().stream()
+        List<String> filteredGroups = listConsumerGroups().stream()
                 .map(ConsumerGroupListing::groupId)
-                .filter(this::shouldReplicate)
+                .filter(this::shouldReplicateByGroupFilter)
                 .collect(Collectors.toList());
+
+        List<String> checkpointGroups = new LinkedList<>();
+        List<String> irrelevantGroups = new LinkedList<>();
+
+        for (String group : filteredGroups) {
+            Set<String> consumedTopics = listConsumerGroupOffsets(group).keySet().stream()
+                    .map(TopicPartition::topic)
+                    .filter(this::shouldReplicateByTopicFilter)
+                    .collect(Collectors.toSet());
+            // Only perform checkpoints for groups that have offsets for at least one topic that's accepted
+            // by the topic filter.
+            if (consumedTopics.size() > 0) {
+                checkpointGroups.add(group);
+            } else {
+                irrelevantGroups.add(group);
+            }
+        }
+
+        log.debug("Ignoring the following groups which do not have any offsets for topics that are accepted by " +
+                        "the topic filter: {}", irrelevantGroups);
+        return checkpointGroups;
     }
 
     Collection<ConsumerGroupListing> listConsumerGroups()
@@ -167,9 +194,18 @@ public class MirrorCheckpointConnector extends SourceConnector {
                 config.checkpointsTopicReplicationFactor(),
                 targetAdminClient
         );
-    } 
+    }
 
-    boolean shouldReplicate(String group) {
+    Map<TopicPartition, OffsetAndMetadata> listConsumerGroupOffsets(String group)
+            throws InterruptedException, ExecutionException {
+        return sourceAdminClient.listConsumerGroupOffsets(group).partitionsToOffsetAndMetadata().get();
+    }
+
+    boolean shouldReplicateByGroupFilter(String group) {
         return groupFilter.shouldReplicateGroup(group);
+    }
+
+    boolean shouldReplicateByTopicFilter(String topic) {
+        return topicFilter.shouldReplicateTopic(topic);
     }
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -180,7 +180,7 @@ public class MirrorCheckpointTask extends SourceTask {
 
     private List<Checkpoint> checkpointsForGroup(String group) throws ExecutionException, InterruptedException {
         return listConsumerGroupOffsets(group).entrySet().stream()
-            .filter(x -> shouldCheckpointTopic(x.getKey().topic()))
+            .filter(x -> shouldCheckpointTopic(x.getKey().topic())) // Only perform relevant checkpoints filtered by "topic filter"
             .map(x -> checkpoint(group, x.getKey(), x.getValue()))
             .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty)) // do not emit checkpoints for partitions that don't have offset-syncs
             .filter(x -> x.downstreamOffset() >= 0)  // ignore offsets we cannot translate accurately


### PR DESCRIPTION
In practice, I found that when I configure a mirror checkpoint connector, because the source cluster has a large number of group or the number of group under a topic changes frequently, the connector will frequently rebalance between its tasks, although there is no change in the synchronized group list of the configuration. 
I don't think connector should rebalance frequently in this case to affect  group synchronization tasks without any group changes.
In this PR, MirrorCheckpointConnector avoids the rabalance interference caused by the addition and deletion of irrelevant groups ([KAFKA-14837](https://issues.apache.org/jira/browse/KAFKA-14837)), and reduces the rpc calls of "listConsumerGroupOffsets" in each task about irrelevant groups ([KAFKA-14842](https://issues.apache.org/jira/browse/KAFKA-14842)).