### PR TITLE
MINOR: Rename remote_controller_quorum to isolated_controller_quorum

### DIFF
--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -165,7 +165,7 @@ class SecurityTest(EndToEndTest):
         if quorum.for_test(self.test_context) == quorum.zk:
             self.kafka.zk.restart_cluster()
         else:
-            self.kafka.remote_controller_quorum.restart_cluster()
+            self.kafka.isolated_controller_quorum.restart_cluster()
 
         try:
             self.kafka.start_node(self.kafka.nodes[0], timeout_sec=30)


### PR DESCRIPTION
Similar to https://github.com/apache/kafka/pull/13439:

ddd652c standardized on "isolated" as the name for all the isolated modes, and renamed remote_controller_quorum to
kafkatest.services.kafka.quorum.remote_kraft to
isolated_controller_quorum. This broke
SecurityTest.test_quorum_ssl_endpoint_validation_failure, which should be fixed by this simple rename.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
