### PR TITLE
KAFKA-14808: fix leaderless partition issue when controller removes u…

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1894,10 +1894,16 @@ class KafkaController(val config: KafkaConfig,
       val currentAssignment = controllerContext.partitionFullReplicaAssignment(topicPartition)
       val newAssignment = currentAssignment.reassignTo(replicas)
       val areNewReplicasAlive = newAssignment.addingReplicas.toSet.subsetOf(controllerContext.liveBrokerIds)
+      val currentLeader = controllerContext.partitionLeadershipInfo(topicPartition).get.leaderAndIsr.leader
+      val unneededAddingReplicas = currentAssignment.replicas.diff(newAssignment.replicas)
       if (!areNewReplicasAlive)
         Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
           s"Replica assignment has brokers that are not alive. Replica list: " +
             s"${newAssignment.addingReplicas}, live broker list: ${controllerContext.liveBrokerIds}"))
+      else if (unneededAddingReplicas.contains(currentLeader))
+        Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+          s"Current leader is inside unneeded adding replicas. Current leader: " +
+            s"${currentLeader}, unneeded adding replica list: ${unneededAddingReplicas}"))
       else None
     }
   }

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -573,6 +573,48 @@ class ControllerIntegrationTest extends QuorumTestHarness {
   }
 
   @Test
+  def testAutoPreferredReplicaLeaderElectionFollowedByAnotherNewReassignment(): Unit = {
+    servers = makeServers(5, autoLeaderRebalanceEnable = true)
+    val controller = getController().kafkaController
+    val tp = new TopicPartition("t", 0)
+    val assignment = Map(tp.partition -> Seq(0, 2, 4))
+    TestUtils.createTopic(zkClient, tp.topic, partitionReplicaAssignment = assignment, servers = servers)
+
+    // Shutdown broker 2 and reassign partition tp from [0, 2, 4] to [1, 0, 2] to create a stuck reassignment.
+    servers(2).shutdown()
+    servers(2).awaitShutdown()
+    val reassignment = Map(tp -> Some(Seq(1, 0, 2)))
+    controller.eventManager.put(ApiPartitionReassignment(reassignment, _ => ()))
+
+    // Make sure broker 1 is elected as leader (preferred) of partition tp automatically
+    // even though the reassignment is still ongoing.
+    waitForPartitionState(tp, firstControllerEpoch, 1, LeaderAndIsr.InitialLeaderEpoch + 3,
+      "failed to get expected partition state after auto preferred replica leader election")
+
+    // Submit another reassignment to replace the current leader 1 with broker 3 which
+    // should be rejected.
+    val reassignment_update = Map(tp -> Some(Seq(3, 0, 2)))
+    controller.eventManager.put(ApiPartitionReassignment(reassignment_update, _ => ()))
+
+    // Start broker 2 and make sure the reassignment which was stuck can be fulfilled.
+    servers(2).startup()
+    waitForPartitionState(tp, firstControllerEpoch, 1, LeaderAndIsr.InitialLeaderEpoch + 4,
+      "failed to get expected partition state after broker startup")
+
+    TestUtils.waitUntilTrue(() => {
+      val leaderIsrAndControllerEpochMap = zkClient.getTopicPartitionStates(Seq(tp))
+      leaderIsrAndControllerEpochMap.contains(tp) &&
+        isExpectedPartitionState(leaderIsrAndControllerEpochMap(tp), firstControllerEpoch, 1, LeaderAndIsr.InitialLeaderEpoch + 6) &&
+        leaderIsrAndControllerEpochMap(tp).leaderAndIsr.isr.toSet == Set(1, 0, 2)
+    }, "failed to get expected partition state for assignment")
+
+    controller.eventManager.put(ListPartitionReassignments(None, {
+      case Left(results) => assert(results.isEmpty)
+      case Right(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
+    }))
+  }
+
+  @Test
   def testLeaderAndIsrWhenEntireIsrOfflineAndUncleanLeaderElectionDisabled(): Unit = {
     servers = makeServers(2)
     val controllerId = TestUtils.waitUntilControllerElected(zkClient)


### PR DESCRIPTION
…nneeded replicas

If there is ongoing partition reassignment and any adding replica has been elected as leader (due to preferred leader election or other reason), the partition will immediately becomes leaderless when controller removes unneeded replicas on receiving a new partition reassignment which removes that adding replica.

Reject the new reassignment in such scenario to avoid leaderless partitions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
