### PR TITLE
KAFKA-12525: Ignoring stale status statuses when reading from Connect status topic

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -315,6 +315,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             this.generation = status.generation();
             if (safeWrite && !entry.canWriteSafely(status))
                 return;
+
             sequence = entry.increment();
         }
 
@@ -562,11 +563,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         synchronized (this) {
             log.trace("Received connector {} status update {}", connector, status);
             CacheEntry<ConnectorStatus> entry = getOrAdd(connector);
-            if (entry.canWriteSafely(status)) {
-                entry.put(status);
-            } else {
-                log.trace("Ignoring stale status update {} for connector {}", status, connector);
-            }
+            entry.put(status);
         }
     }
 
@@ -592,11 +589,20 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         synchronized (this) {
             log.trace("Received task {} status update {}", id, status);
             CacheEntry<TaskStatus> entry = getOrAdd(id);
-            if (entry.canWriteSafely(status)) {
-                entry.put(status);
-            } else {
-                log.trace("Ignoring stale status update {} for task {}", status, id);
+
+            // During frequent rebalances, there could be a race condition because of which
+            // an UNASSIGNED state of a prior generation can be sent by a worker despite a
+            // RUNNING status in a newer generation by another worker because the first worker
+            // couldn't read the newer RUNNING status. This can lead to an inaccurate status
+            // representation even though the task might be actually running.
+            if (status.state() == ConnectorStatus.State.UNASSIGNED
+                    && entry.get().state() == ConnectorStatus.State.RUNNING
+                    && entry.get().generation() > status.generation()) {
+                log.trace("Ignoring stale status {} in favour of more upto date status {}", status, entry.get());
+                return;
             }
+
+            entry.put(status);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -562,7 +562,11 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         synchronized (this) {
             log.trace("Received connector {} status update {}", connector, status);
             CacheEntry<ConnectorStatus> entry = getOrAdd(connector);
-            entry.put(status);
+            if (entry.canWriteSafely(status)) {
+                entry.put(status);
+            } else {
+                log.trace("Ignoring stale status update {} for connector {}", status, connector);
+            }
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -315,7 +315,6 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             this.generation = status.generation();
             if (safeWrite && !entry.canWriteSafely(status))
                 return;
-
             sequence = entry.increment();
         }
 
@@ -596,6 +595,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             // couldn't read the newer RUNNING status. This can lead to an inaccurate status
             // representation even though the task might be actually running.
             if (status.state() == ConnectorStatus.State.UNASSIGNED
+                    && entry.get() != null
                     && entry.get().state() == ConnectorStatus.State.RUNNING
                     && entry.get().generation() > status.generation()) {
                 log.trace("Ignoring stale status {} in favour of more upto date status {}", status, entry.get());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -594,6 +594,11 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             // RUNNING status by another worker because the first worker
             // couldn't read the latest RUNNING status. This can lead to an inaccurate status
             // representation even though the task might be actually running.
+            // Note that this could also mean that when a generation reset happens, and an
+            // UNASSIGNED status is sent, then it would be ignored if the current status is RUNNING
+            // at a higher generation. But since it will be followed by a RUNNING or a different
+            // status message(at a lower generation) soon after, the misrepresentation of the UNASSIGNED
+            // status would be short-lived in most cases.
             if (status.state() == TaskStatus.State.UNASSIGNED
                     && entry.get() != null
                     && entry.get().state() == TaskStatus.State.RUNNING

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -597,7 +597,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             // Note that this could also mean that when a generation reset happens, and an
             // UNASSIGNED status is sent, then it would be ignored if the current status is RUNNING
             // at a higher generation. But since it will be followed by a RUNNING or a different
-            // status message(at a lower generation) soon after, the misrepresentation of the UNASSIGNED
+            // status message(at the lower generation) soon after, the misrepresentation of the UNASSIGNED
             // status would be short-lived in most cases.
             if (status.state() == TaskStatus.State.UNASSIGNED
                     && entry.get() != null

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -588,7 +588,14 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         synchronized (this) {
             log.trace("Received task {} status update {}", id, status);
             CacheEntry<TaskStatus> entry = getOrAdd(id);
-            entry.put(status);
+            // We add the status only if it's safe to do so. This is applicable
+            // when there are race conditions during frequent rebalances leading to
+            // the RUNNING status record with the latest generation followed by a stale
+            // UNASSIGNED status record belonging to the same or a previous generation
+            // from a worker which couldn't read the RUNNING record of the latest generation.
+            if (entry.canWriteSafely(status)) {
+                entry.put(status);
+            }
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -594,9 +595,9 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             // RUNNING status in a newer generation by another worker because the first worker
             // couldn't read the newer RUNNING status. This can lead to an inaccurate status
             // representation even though the task might be actually running.
-            if (status.state() == ConnectorStatus.State.UNASSIGNED
+            if (status.state() == TaskStatus.State.UNASSIGNED
                     && entry.get() != null
-                    && entry.get().state() == ConnectorStatus.State.RUNNING
+                    && entry.get().state() == TaskStatus.State.RUNNING
                     && entry.get().generation() > status.generation()) {
                 log.trace("Ignoring stale status {} in favour of more upto date status {}", status, entry.get());
                 return;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -588,13 +588,10 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         synchronized (this) {
             log.trace("Received task {} status update {}", id, status);
             CacheEntry<TaskStatus> entry = getOrAdd(id);
-            // We add the status only if it's safe to do so. This is applicable
-            // when there are race conditions during frequent rebalances leading to
-            // the RUNNING status record with the latest generation followed by a stale
-            // UNASSIGNED status record belonging to the same or a previous generation
-            // from a worker which couldn't read the RUNNING record of the latest generation.
             if (entry.canWriteSafely(status)) {
                 entry.put(status);
+            } else {
+                log.trace("Ignoring stale status update {} for task {}", status, id);
             }
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
@@ -355,10 +355,10 @@ public class KafkaStatusBackingStoreTest {
         assertEquals(status, store.get(TASK));
 
         // This  status is from the another worker not necessarily belonging to the above group.
-        // In this case, the status should get update irrespective of whatever status info was present before.
-        TaskStatus staleStatus = new TaskStatus(TASK, ConnectorStatus.State.RUNNING, yetAnotherWorkerId, 1);
-        store.put(staleStatus);
-        assertEquals(staleStatus, store.get(TASK));
+        // In this case, the status should get updated irrespective of whatever status info was present before.
+        TaskStatus latestStatus = new TaskStatus(TASK, ConnectorStatus.State.RUNNING, yetAnotherWorkerId, 1);
+        store.put(latestStatus);
+        assertEquals(latestStatus, store.get(TASK));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.ConnectorStatus;
 import org.apache.kafka.connect.runtime.TaskStatus;
 import org.apache.kafka.connect.runtime.WorkerConfig;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
@@ -351,12 +351,12 @@ public class KafkaStatusBackingStoreTest {
         store.read(consumerRecord(1, "status-task-conn-0", value));
 
         // The latest task status should reflect RUNNING status from the newer generation
-        TaskStatus status = new TaskStatus(TASK, ConnectorStatus.State.RUNNING, otherWorkerId, 10);
+        TaskStatus status = new TaskStatus(TASK, TaskStatus.State.RUNNING, otherWorkerId, 10);
         assertEquals(status, store.get(TASK));
 
         // This  status is from the another worker not necessarily belonging to the above group.
         // In this case, the status should get updated irrespective of whatever status info was present before.
-        TaskStatus latestStatus = new TaskStatus(TASK, ConnectorStatus.State.RUNNING, yetAnotherWorkerId, 1);
+        TaskStatus latestStatus = new TaskStatus(TASK, TaskStatus.State.RUNNING, yetAnotherWorkerId, 1);
         store.put(latestStatus);
         assertEquals(latestStatus, store.get(TASK));
     }


### PR DESCRIPTION
During fast consecutive rebalances where a task is revoked from one worker and assigned to another one, it has been observed that there is a small time window and thus a race condition during which a RUNNING status record in the new generation is produced and is immediately followed by a delayed UNASSIGNED status record belonging to the same or a previous generation before the worker that sends this message reads the RUNNING status record that corresponds to the latest generation.
Although this doesn't inhibit the actual execution of tasks, it reports an incorrect status for those tasks(i.e UNASSIGNED). If the users have setup some kind of monitoring on tasks status then this could lead to false alarms for example.
This PR aims to solve this problem by checking if a status message is stale after reading it and updates it's status only when it is safe to. Note that it uses the same method `canWriteSafely` to check the staleness, so if needed, that method can be renamed (which I haven't done in this PR). Also, the original description of the ticket only talks about RUNNING/UNASSIGNED state but this PR should ideally help in filtering out all stale messages (which might still be infrequent but worth handling imo).