### PR TITLE
MINOR: Fix base ConfigDef in AbstractHerder::connectorPluginConfig

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -841,7 +841,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             ConfigDef pluginConfigDefs;
             switch (pluginType) {
                 case SINK:
-                    baseConfigDefs = SourceConnectorConfig.configDef();
+                    baseConfigDefs = SinkConnectorConfig.configDef();
                     pluginConfigDefs = ((SinkConnector) plugin).config();
                     break;
                 case SOURCE:


### PR DESCRIPTION
Fixes a small error in https://github.com/apache/kafka/pull/13445.

This was not caught during testing because we only compare the number of properties defined by a `ConfigDef`, but not which properties--and it just so happens that, since 3.3, the `SourceConnectorConfig` and `SinkConnectorConfig` `ConfigDef` instances define the same number of properties.