### PR TITLE
MINOR: Remove addOne to fix build

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -433,7 +433,7 @@ class ZkMigrationClientTest extends QuorumTestHarness {
   def migrateAclsAndVerify(authorizer: AclAuthorizer, acls: Seq[AclBinding]): Unit = {
     authorizer.createAcls(null, acls.asJava)
     val batches = new ArrayBuffer[mutable.Buffer[ApiMessageAndVersion]]()
-    migrationClient.migrateAcls(batch => batches.addOne(batch.asScala))
+    migrationClient.migrateAcls(batch => batches ++ batch.asScala)
     val records = batches.flatten.map(_.message().asInstanceOf[AccessControlEntryRecord])
     assertEquals(acls.size, records.size, "Expected one record for each ACLBinding")
   }

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -433,7 +433,7 @@ class ZkMigrationClientTest extends QuorumTestHarness {
   def migrateAclsAndVerify(authorizer: AclAuthorizer, acls: Seq[AclBinding]): Unit = {
     authorizer.createAcls(null, acls.asJava)
     val batches = new ArrayBuffer[mutable.Buffer[ApiMessageAndVersion]]()
-    migrationClient.migrateAcls(batch => batches ++ batch.asScala)
+    migrationClient.migrateAcls(batch => batches.append(batch.asScala))
     val records = batches.flatten.map(_.message().asInstanceOf[AccessControlEntryRecord])
     assertEquals(acls.size, records.size, "Expected one record for each ACLBinding")
   }


### PR DESCRIPTION
https://github.com/apache/kafka/commit/f1b3732fa64372327377834954561d2e63e7d2ce broke the build

[2023-03-28T17:49:54.909Z] [Error] /home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-13463/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala:436:50: value addOne is not a member of scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Buffer[org.apache.kafka.server.common.ApiMessageAndVersion]]

Removed the offending method

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
