### PR TITLE
KAFKA-14864: Close iterator in KStream windowed aggregation emit on window close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.HashSet;
@@ -122,9 +123,11 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
 
             if (reverseIteratorPossible == null) {
                 try {
-                    windowStore.backwardFetch(record.key(), 0L, 0L);
-                    reverseIteratorPossible = true;
-                    log.debug("Sliding Windows aggregate using a reverse iterator");
+                    try (final WindowStoreIterator<ValueAndTimestamp<VAgg>> iterator
+                             = windowStore.backwardFetch(record.key(), 0L, 0L)) {
+                        reverseIteratorPossible = true;
+                        log.debug("Sliding Windows aggregate using a reverse iterator");
+                    }
                 } catch (final UnsupportedOperationException e)  {
                     reverseIteratorPossible = false;
                     log.debug("Sliding Windows aggregate using a forward iterator");


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/KAFKA-14864, there is currently a memory leak in KStream windowed aggregations when using the ON_WINDOW_CLOSE emit strategy, due to an iterator not being properly cleaned up. This PR fixes the bug, and also updates one other location where a windowed iterator was being created and not closed either. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
