### PR TITLE
KAFKA-14652: Add the flow to the log context and the Connect-managed …

### DIFF
--- a/config/connect-mirror-maker.properties
+++ b/config/connect-mirror-maker.properties
@@ -57,3 +57,6 @@ config.storage.replication.factor=1
 # replication.policy.separator = _
 # sync.topic.acls.enabled = false
 # emit.heartbeats.interval.seconds = 5
+
+# enable flow in the logs for improved diagnostics
+add.flow.context = true

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -262,7 +262,10 @@ public class MirrorMaker {
         String workerId = sourceAndTarget.toString();
         Plugins plugins = new Plugins(workerProps);
         plugins.compareAndSwapWithDelegatingLoader();
-        DistributedConfig distributedConfig = new DistributedConfig(workerProps);
+        DistributedConfig distributedConfig = new MirrorMakerWorkerConfig(
+                workerProps,
+                config.addFlowToContext() ? sourceAndTarget.toString() : null
+        );
         String kafkaClusterId = distributedConfig.kafkaClusterId();
         String clientIdBase = ConnectUtils.clientIdBase(distributedConfig);
         // Create the admin client to be shared by all backing stores for this herder

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -86,6 +86,10 @@ public class MirrorMakerConfig extends AbstractConfig {
     private static final String ENABLE_INTERNAL_REST_DOC =
             "Whether to bring up an internal-only REST server that allows multi-node clusters to operate correctly.";
 
+    public static final String ADD_FLOW_CONTEXT_CONFIG = "add.flow.context";
+    private static final String ADD_FLOW_CONTEXT_DOC =
+            "Whether to add the flow (A->B) to the Connect-managed client.ids and the Connector log context.";
+
     private final Plugins plugins;
 
     private final Map<String, String> rawProperties;
@@ -174,6 +178,10 @@ public class MirrorMakerConfig extends AbstractConfig {
         }
  
         return props;
+    }
+
+    boolean addFlowToContext() {
+        return getBoolean(ADD_FLOW_CONTEXT_CONFIG);
     }
 
     // loads worker configs based on properties of the form x.y.z and cluster.x.y.z 
@@ -296,6 +304,7 @@ public class MirrorMakerConfig extends AbstractConfig {
                         in(Utils.enumOptions(SecurityProtocol.class)),
                         Importance.MEDIUM,
                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
+                .define(ADD_FLOW_CONTEXT_CONFIG, Type.BOOLEAN, false, Importance.MEDIUM, ADD_FLOW_CONTEXT_DOC)
                 .withClientSslSupport()
                 .withClientSaslSupport();
         RestServerConfig.addInternalConfig(result);

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerWorkerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerWorkerConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+
+import java.util.Map;
+
+public class MirrorMakerWorkerConfig extends DistributedConfig {
+    private final String contextPrefix;
+
+    public MirrorMakerWorkerConfig(Map<String, String> props, String contextPrefix) {
+        super(props);
+        this.contextPrefix = contextPrefix;
+    }
+
+    @Override
+    public String contextPrefix() {
+        return contextPrefix;
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -227,7 +227,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
                                        Executor closeExecutor) {
 
         super(id, statusListener, initialState, loader, connectMetrics, errorMetrics,
-                retryWithToleranceOperator, time, statusBackingStore);
+                retryWithToleranceOperator, time, statusBackingStore, workerConfig.contextPrefix());
 
         this.workerConfig = workerConfig;
         this.task = task;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -364,6 +364,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
     public String toString() {
         return "ExactlyOnceWorkerSourceTask{" +
             "id=" + id +
+            (workerConfig.contextPrefix() == null ? "" : ", context=" + workerConfig.contextPrefix()) +
             '}';
     }
 
@@ -404,7 +405,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
 
         private void maybeCommitTransaction(boolean shouldCommit) {
             if (shouldCommit) {
-                try (LoggingContext loggingContext = LoggingContext.forOffsets(id)) {
+                try (LoggingContext loggingContext = LoggingContext.forOffsets(id, workerConfig.contextPrefix())) {
                     commitTransaction();
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
@@ -81,7 +81,7 @@ class SourceTaskOffsetCommitter {
     public void schedule(final ConnectorTaskId id, final WorkerSourceTask workerTask) {
         long commitIntervalMs = config.getLong(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG);
         ScheduledFuture<?> commitFuture = commitExecutorService.scheduleWithFixedDelay(() -> {
-            try (LoggingContext loggingContext = LoggingContext.forOffsets(id)) {
+            try (LoggingContext loggingContext = LoggingContext.forOffsets(id, config.contextPrefix())) {
                 commit(workerTask);
             }
         }, commitIntervalMs, commitIntervalMs, TimeUnit.MILLISECONDS);
@@ -93,7 +93,7 @@ class SourceTaskOffsetCommitter {
         if (task == null)
             return;
 
-        try (LoggingContext loggingContext = LoggingContext.forTask(id)) {
+        try (LoggingContext loggingContext = LoggingContext.forTask(id, config.contextPrefix())) {
             task.cancel(false);
             if (!task.isDone())
                 task.get();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -395,6 +395,10 @@ public class WorkerConfig extends AbstractConfig {
         return kafkaClusterId;
     }
 
+    public String contextPrefix() {
+        return null;
+    }
+
     @Override
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -78,6 +78,7 @@ public class WorkerConnector implements Runnable {
     private State state;
     private final CloseableOffsetStorageReader offsetStorageReader;
     private final ConnectorOffsetBackingStore offsetStore;
+    private final String contextPrefix;
 
     public WorkerConnector(String connName,
                            Connector connector,
@@ -87,7 +88,8 @@ public class WorkerConnector implements Runnable {
                            ConnectorStatus.Listener statusListener,
                            CloseableOffsetStorageReader offsetStorageReader,
                            ConnectorOffsetBackingStore offsetStore,
-                           ClassLoader loader) {
+                           ClassLoader loader,
+                           String contextPrefix) {
         this.connName = connName;
         this.config = connectorConfig.originalsStrings();
         this.loader = loader;
@@ -103,6 +105,7 @@ public class WorkerConnector implements Runnable {
         this.shutdownLatch = new CountDownLatch(1);
         this.stopping = false;
         this.cancelled = false;
+        this.contextPrefix = contextPrefix;
     }
 
     public ClassLoader loader() {
@@ -114,7 +117,7 @@ public class WorkerConnector implements Runnable {
         // Clear all MDC parameters, in case this thread is being reused
         LoggingContext.clear();
 
-        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+        try (LoggingContext loggingContext = LoggingContext.forConnector(connName, contextPrefix)) {
             String savedName = Thread.currentThread().getName();
             try {
                 Thread.currentThread().setName(THREAD_NAME_PREFIX + connName);
@@ -393,6 +396,7 @@ public class WorkerConnector implements Runnable {
     public String toString() {
         return "WorkerConnector{" +
                        "id=" + connName +
+                        (contextPrefix == null ? "" : ", context=" + contextPrefix) +
                        '}';
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -118,7 +118,7 @@ class WorkerSinkTask extends WorkerTask {
                           WorkerErrantRecordReporter workerErrantRecordReporter,
                           StatusBackingStore statusBackingStore) {
         super(id, statusListener, initialState, loader, connectMetrics, errorMetrics,
-                retryWithToleranceOperator, time, statusBackingStore);
+                retryWithToleranceOperator, time, statusBackingStore, workerConfig.contextPrefix());
 
         this.workerConfig = workerConfig;
         this.task = task;
@@ -472,6 +472,7 @@ class WorkerSinkTask extends WorkerTask {
     public String toString() {
         return "WorkerSinkTask{" +
                 "id=" + id +
+                (workerConfig.contextPrefix() == null ? "" : ", context=" + workerConfig.contextPrefix()) +
                 '}';
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -340,6 +340,7 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
     public String toString() {
         return "WorkerSourceTask{" +
                 "id=" + id +
+                (workerConfig.contextPrefix() == null ? "" : ", context=" + workerConfig.contextPrefix()) +
                 '}';
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -68,6 +68,7 @@ abstract class WorkerTask implements Runnable {
     private final ErrorHandlingMetrics errorMetrics;
 
     protected final RetryWithToleranceOperator retryWithToleranceOperator;
+    private final String contextPrefix;
 
     public WorkerTask(ConnectorTaskId id,
                       TaskStatus.Listener statusListener,
@@ -77,7 +78,8 @@ abstract class WorkerTask implements Runnable {
                       ErrorHandlingMetrics errorMetrics,
                       RetryWithToleranceOperator retryWithToleranceOperator,
                       Time time,
-                      StatusBackingStore statusBackingStore) {
+                      StatusBackingStore statusBackingStore,
+                      String contextPrefix) {
         this.id = id;
         this.taskMetricsGroup = new TaskMetricsGroup(this.id, connectMetrics, statusListener);
         this.errorMetrics = errorMetrics;
@@ -91,6 +93,7 @@ abstract class WorkerTask implements Runnable {
         this.retryWithToleranceOperator = retryWithToleranceOperator;
         this.time = time;
         this.statusBackingStore = statusBackingStore;
+        this.contextPrefix = contextPrefix;
     }
 
     public ConnectorTaskId id() {
@@ -250,7 +253,7 @@ abstract class WorkerTask implements Runnable {
         // Clear all MDC parameters, in case this thread is being reused
         LoggingContext.clear();
 
-        try (LoggingContext loggingContext = LoggingContext.forTask(id())) {
+        try (LoggingContext loggingContext = LoggingContext.forTask(id(), contextPrefix)) {
             String savedName = Thread.currentThread().getName();
             try {
                 Thread.currentThread().setName(THREAD_NAME_PREFIX + id);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
@@ -97,7 +97,8 @@ public class WorkerConnectorTest {
         when(connector.version()).thenReturn(VERSION);
         doThrow(exception).when(connector).initialize(any());
 
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
         assertFailedMetric(workerConnector);
@@ -119,7 +120,8 @@ public class WorkerConnectorTest {
         doThrow(exception).when(connector).initialize(any());
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, null, null, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, null, null, classLoader, null);
 
         workerConnector.initialize();
         assertFailedMetric(workerConnector);
@@ -145,7 +147,8 @@ public class WorkerConnectorTest {
         when(connector.version()).thenReturn(VERSION);
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSourceMetric(workerConnector);
@@ -170,7 +173,8 @@ public class WorkerConnectorTest {
         when(connector.version()).thenReturn(VERSION);
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, null, null, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, null, null, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSinkMetric(workerConnector);
@@ -203,7 +207,8 @@ public class WorkerConnectorTest {
 
         Callback<TargetState> onStateChange = mockCallback();
 
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSourceMetric(workerConnector);
@@ -233,7 +238,8 @@ public class WorkerConnectorTest {
         when(connector.version()).thenReturn(VERSION);
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, null, null, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, null, null, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSinkMetric(workerConnector);
@@ -261,7 +267,8 @@ public class WorkerConnectorTest {
         doThrow(exception).when(connector).start(CONFIG);
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, null, null, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, null, null, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSinkMetric(workerConnector);
@@ -290,7 +297,8 @@ public class WorkerConnectorTest {
         doThrow(exception).when(connector).stop();
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSourceMetric(workerConnector);
@@ -317,7 +325,8 @@ public class WorkerConnectorTest {
 
         Callback<TargetState> onStateChange = mockCallback();
 
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSourceMetric(workerConnector);
@@ -344,7 +353,8 @@ public class WorkerConnectorTest {
         when(connector.version()).thenReturn(VERSION);
 
         Callback<TargetState> onStateChange = mockCallback();
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
         assertInitializedSourceMetric(workerConnector);
@@ -374,7 +384,8 @@ public class WorkerConnectorTest {
     public void testFailConnectorThatIsNeitherSourceNorSink() {
         connector = mock(Connector.class);
         when(connector.version()).thenReturn(VERSION);
-        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, connectorConfig, ctx, metrics,
+                listener, offsetStorageReader, offsetStore, classLoader, null);
 
         workerConnector.initialize();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
@@ -228,7 +228,8 @@ public class WorkerTaskTest {
         public TestWorkerTask(ConnectorTaskId id, Listener statusListener, TargetState initialState, ClassLoader loader,
                               ConnectMetrics connectMetrics, ErrorHandlingMetrics errorHandlingMetrics, RetryWithToleranceOperator retryWithToleranceOperator, Time time,
                               StatusBackingStore statusBackingStore) {
-            super(id, statusListener, initialState, loader, connectMetrics, errorHandlingMetrics,  retryWithToleranceOperator, time, statusBackingStore);
+            super(id, statusListener, initialState, loader, connectMetrics, errorHandlingMetrics,
+                    retryWithToleranceOperator, time, statusBackingStore, null);
         }
 
         @Override


### PR DESCRIPTION
…client.ids in MM2 dedicated mode

MM2 runs multiple Connect workers in a single process, and the Connectors inside each worker have identical names. This means that the current logging generates a lot of conflicts, and the logs of the different Connector instances are mixed. The Connect WorkerConfig is now extended with a contextPrefix method, which provides an optional label for the log context and the client ids. In Connect, it is always null, but in the dedicated MM2 mode, it is set to the flow (source->target).

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
