### PR TITLE
KAFKA-14462; [4/N] Add GroupMetadataManager: ConsumerGroups Management, Members Management and Reconciliation Logic

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -345,11 +345,18 @@
   <subpackage name="coordinator">
     <subpackage name="group">
       <allow pkg="org.apache.kafka.common.annotation" />
+      <allow pkg="org.apache.kafka.common.config" />
       <allow pkg="org.apache.kafka.common.message" />
+      <allow pkg="org.apache.kafka.common.metadata" />
+      <allow pkg="org.apache.kafka.common.network" />
       <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.requests" />
+      <allow pkg="org.apache.kafka.coordinator.group" />
       <allow pkg="org.apache.kafka.image"/>
+      <allow pkg="org.apache.kafka.server.common"/>
+      <allow pkg="org.apache.kafka.server.record"/>
       <allow pkg="org.apache.kafka.server.util"/>
+      <allow pkg="org.apache.kafka.timeline"/>
     </subpackage>
   </subpackage>
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -318,6 +318,16 @@
     <suppress checks="AvoidStarImport"
               files="MetadataVersionTest.java"/>
 
+    <!-- group coordinator -->
+    <suppress checks="CyclomaticComplexity"
+              files="(GroupMetadataManager|ConsumerGroupMember).java"/>
+    <suppress checks="MethodLength"
+              files="(GroupMetadataManager|GroupMetadataManagerTest).java"/>
+    <suppress checks="NPathComplexity"
+              files="(GroupMetadataManager|ConsumerGroupMember).java"/>
+    <suppress checks="ParameterNumber"
+              files="(ConsumerGroupMember).java"/>
+
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"
               files="(LogValidator|RemoteLogManagerConfig).java"/>

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+public interface Group {
+    enum GroupType {
+        CONSUMER("consumer"),
+        GENERIC("generic");
+
+        private final String name;
+
+        GroupType(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    GroupType type();
+
+    String stateAsString();
+
+    String groupId();
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1,0 +1,873 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.FencedMemberEpochException;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
+import org.apache.kafka.common.errors.GroupMaxSizeReachedException;
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnsupportedAssignorException;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.MemberAssignment;
+import org.apache.kafka.coordinator.group.consumer.CurrentAssignmentBuilder;
+import org.apache.kafka.coordinator.group.consumer.TargetAssignmentBuilder;
+import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.timeline.SnapshotRegistry;
+import org.apache.kafka.timeline.TimelineHashMap;
+import org.apache.kafka.timeline.TimelineHashSet;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupEpochRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupSubscriptionMetadataRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newMemberSubscriptionRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newMemberSubscriptionTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentTombstoneRecord;
+
+/**
+ * The GroupMetadataManager manages the metadata of all generic and consumer groups. It holds
+ * the hard and the soft state of the groups. This class has two kinds of methods:
+ * 1) The request handlers which handle the requests and generate a response and records to
+ *    mutate the hard state. Those records will be written by the runtime and applied to the
+ *    hard state via the replay methods.
+ * 2) The replay methods which apply records to the hard state. Those are used in the request
+ *    handling as well as during the initial loading of the records from the partitions.
+ */
+public class GroupMetadataManager {
+
+    public static class Builder {
+        private LogContext logContext = null;
+        private SnapshotRegistry snapshotRegistry = null;
+        private List<PartitionAssignor> assignors = null;
+        private TopicsImage topicsImage = null;
+        private int consumerGroupMaxSize = Integer.MAX_VALUE;
+        private int consumerGroupHeartbeatIntervalMs = 5000;
+
+        Builder withLogContext(LogContext logContext) {
+            this.logContext = logContext;
+            return this;
+        }
+
+        Builder withSnapshotRegistry(SnapshotRegistry snapshotRegistry) {
+            this.snapshotRegistry = snapshotRegistry;
+            return this;
+        }
+
+        Builder withAssignors(List<PartitionAssignor> assignors) {
+            this.assignors = assignors;
+            return this;
+        }
+
+        Builder withConsumerGroupMaxSize(int consumerGroupMaxSize) {
+            this.consumerGroupMaxSize = consumerGroupMaxSize;
+            return this;
+        }
+
+        Builder withConsumerGroupHeartbeatInterval(int consumerGroupHeartbeatIntervalMs) {
+            this.consumerGroupHeartbeatIntervalMs = consumerGroupHeartbeatIntervalMs;
+            return this;
+        }
+
+        Builder withTopicsImage(TopicsImage topicsImage) {
+            this.topicsImage = topicsImage;
+            return this;
+        }
+
+        GroupMetadataManager build() {
+            if (logContext == null) logContext = new LogContext();
+            if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
+            if (topicsImage == null) topicsImage = TopicsImage.EMPTY;
+
+            if (assignors == null || assignors.isEmpty()) {
+                throw new IllegalStateException("Assignors must be set before building.");
+            }
+
+            return new GroupMetadataManager(
+                snapshotRegistry,
+                logContext,
+                assignors,
+                topicsImage,
+                consumerGroupMaxSize,
+                consumerGroupHeartbeatIntervalMs
+            );
+        }
+    }
+
+    /**
+     * The logger.
+     */
+    private final Logger log;
+
+    /**
+     * The snapshot registry.
+     */
+    private final SnapshotRegistry snapshotRegistry;
+
+    /**
+     * The list of supported assignors.
+     */
+    private final Map<String, PartitionAssignor> assignors;
+
+    /**
+     * The default assignor used.
+     */
+    private final PartitionAssignor defaultAssignor;
+
+    /**
+     * The generic and consumer groups keyed by their name.
+     */
+    private final TimelineHashMap<String, Group> groups;
+
+    /**
+     * The generic and consumer groups keyed by their subscribed topics.
+     */
+    private final TimelineHashMap<String, TimelineHashSet<Group>> groupsByTopicName;
+
+    /**
+     * The maximum number of members allowed in a single consumer group.
+     */
+    private final int consumerGroupMaxSize;
+
+    /**
+     * The heartbeat interval for consumer groups.
+     */
+    private final int consumerGroupHeartbeatIntervalMs;
+
+    /**
+     * The topics metadata (or image).
+     */
+    private TopicsImage topicsImage;
+
+    private GroupMetadataManager(
+        SnapshotRegistry snapshotRegistry,
+        LogContext logContext,
+        List<PartitionAssignor> assignors,
+        TopicsImage topicsImage,
+        int consumerGroupMaxSize,
+        int consumerGroupHeartbeatIntervalMs
+    ) {
+        this.log = logContext.logger(GroupMetadataManager.class);
+        this.snapshotRegistry = snapshotRegistry;
+        this.topicsImage = topicsImage;
+        this.assignors = assignors.stream().collect(Collectors.toMap(PartitionAssignor::name, Function.identity()));
+        this.defaultAssignor = assignors.get(0);
+        this.groups = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.groupsByTopicName = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.consumerGroupMaxSize = consumerGroupMaxSize;
+        this.consumerGroupHeartbeatIntervalMs = consumerGroupHeartbeatIntervalMs;
+    }
+
+    /**
+     * Gets or maybe creates a consumer group.
+     *
+     * @param groupId           The group id.
+     * @param createIfNotExists A boolean indicating whether the group should be
+     *                          created if it does not exist.
+     *
+     * @return A ConsumerGroup.
+     * @throws GroupIdNotFoundException if the group does not exist and createIfNotExists is false or
+     *                                  if the group is not a consumer group.
+     */
+    // Package private for testing.
+    ConsumerGroup getOrMaybeCreateConsumerGroup(
+        String groupId,
+        boolean createIfNotExists
+    ) throws GroupIdNotFoundException {
+        Group group = groups.get(groupId);
+
+        if (group == null && !createIfNotExists) {
+            throw new GroupIdNotFoundException(String.format("Consumer group %s not found.", groupId));
+        }
+
+        if (group == null) {
+            ConsumerGroup consumerGroup = new ConsumerGroup(snapshotRegistry, groupId);
+            groups.put(groupId, consumerGroup);
+            return consumerGroup;
+        } else {
+            if (group.type() == Group.GroupType.CONSUMER) {
+                return (ConsumerGroup) group;
+            } else {
+                // We don't support upgrading/downgrading between protocols at the moment so
+                // we throw an exception if a group exists with the wrong type.
+                throw new GroupIdNotFoundException(String.format("Group %s is not a consumer group.", groupId));
+            }
+        }
+    }
+
+    /**
+     * Removes the group.
+     *
+     * @param groupId The group id.
+     */
+    private void removeGroup(
+        String groupId
+    ) {
+        groups.remove(groupId);
+    }
+
+    /**
+     * Validates the request.
+     *
+     * @param request The request to validate.
+     *
+     * @throws InvalidRequestException if the request is not valid.
+     * @throws UnsupportedAssignorException if the assignor is not supported.
+     */
+    private void throwIfConsumerGroupHeartbeatRequestIsInvalid(
+        ConsumerGroupHeartbeatRequestData request
+    ) throws InvalidRequestException, UnsupportedAssignorException {
+        if (request.groupId().isEmpty()) {
+            throw new InvalidRequestException("GroupId can't be empty.");
+        }
+
+        if (request.memberEpoch() > 0 || request.memberEpoch() == -1) {
+            if (request.memberId().isEmpty()) {
+                throw new InvalidRequestException("MemberId can't be empty.");
+            }
+            if (request.instanceId() != null) {
+                throw new InvalidRequestException("InstanceId should only be provided in first request.");
+            }
+            if (request.rackId() != null) {
+                throw new InvalidRequestException("RackId should only be provided in first request.");
+            }
+        } else if (request.memberEpoch() == 0) {
+            if (request.rebalanceTimeoutMs() == -1) {
+                throw new InvalidRequestException("RebalanceTimeoutMs must be provided in first request.");
+            }
+            if (request.topicPartitions() == null || !request.topicPartitions().isEmpty()) {
+                throw new InvalidRequestException("TopicPartitions must be empty when (re-)joining.");
+            }
+            if (request.subscribedTopicNames() == null || request.subscribedTopicNames().isEmpty()) {
+                throw new InvalidRequestException("SubscribedTopicNames must be set in first request.");
+            }
+            if (request.serverAssignor() != null && !assignors.containsKey(request.serverAssignor())) {
+                throw new UnsupportedAssignorException("ServerAssignor " + request.serverAssignor()
+                    + " is not supported. Supported assignors: " + String.join(", ", assignors.keySet())
+                    + ".");
+            }
+        } else {
+            throw new InvalidRequestException("MemberEpoch is invalid.");
+        }
+
+        if (request.subscribedTopicRegex() != null) {
+            throw new InvalidRequestException("SubscribedTopicRegex is not supported yet.");
+        }
+
+        if (request.clientAssignors() != null) {
+            // TODO We need to remove them from the request.
+            throw new InvalidRequestException("Client side assignors are not supported yet.");
+        }
+    }
+
+    /**
+     * Verifies that the partitions currently owned by the member (the ones set in the
+     * request) matches the ones that the member should own. It matches if the client
+     * has a least of subset of them.
+     *
+     * @param ownedTopicPartitions  The partitions provided by the client in the request.
+     * @param target                The partitions that they client should have.
+     *
+     * @return A boolean indicating whether the owned partitions are a subset or not.
+     */
+    private boolean isSubset(
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> ownedTopicPartitions,
+        Map<Uuid, Set<Integer>> target
+    ) {
+        if (ownedTopicPartitions == null) return false;
+
+        for (ConsumerGroupHeartbeatRequestData.TopicPartitions topicPartitions : ownedTopicPartitions) {
+            Set<Integer> partitions = target.get(topicPartitions.topicId());
+            if (partitions == null) return false;
+            for (Integer partitionId : topicPartitions.partitions()) {
+                if (!partitions.contains(partitionId)) return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks whether the consumer group can accept a new member or not based on the
+     * max group side defined.
+     *
+     * @param group     The consumer group.
+     * @param memberId  The member id.
+     *
+     * @throws GroupMaxSizeReachedException if the maximum capacity has been reached.
+     */
+    private void throwIfConsumerGroupIsFull(
+        ConsumerGroup group,
+        String memberId
+    ) throws GroupMaxSizeReachedException {
+        // If the consumer group has reached its maximum capacity, the member is rejected if it is not
+        // already a member of the consumer group.
+        if (group.numMembers() >= consumerGroupMaxSize && (memberId.isEmpty() || !group.hasMember(memberId))) {
+            throw new GroupMaxSizeReachedException("The consumer group has reached its maximum capacity of "
+                + consumerGroupMaxSize + " members.");
+        }
+    }
+
+    /**
+     * Validates the member epoch provided in the heartbeat request.
+     *
+     * @param member                The consumer group member.
+     * @param memberEpoch           The member epoch.
+     * @param ownedTopicPartitions  The owned partitions.
+     *
+     * @throws NotCoordinatorException if the provided epoch is ahead of the epoch known
+     *                                 by this coordinator. This suggests that the member
+     *                                 got a higher epoch from another coordinator.
+     * @throws FencedMemberEpochException if the provided epoch is behind the epoch known
+     *                                    by this coordinator.
+     */
+    private void throwIfMemberEpochIsInvalid(
+        ConsumerGroupMember member,
+        int memberEpoch,
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> ownedTopicPartitions
+    ) {
+        if (memberEpoch > member.memberEpoch()) {
+            // The member has likely got a bump from another coordinator and this coordinator
+            // is stale. Return NOT_COORDINATOR to force the member to refresh its coordinator.
+            throw new NotCoordinatorException("The consumer group member has got a larger member "
+                + "epoch (" + memberEpoch + ") than the one known by this group coordinator ("
+                + member.memberEpoch() + ").");
+        } else if (memberEpoch < member.memberEpoch()) {
+            // If the member comes with the previous epoch and has a subset of the current assignment partitions,
+            // we accept it because the response with the bumped epoch may have been lost.
+            if (memberEpoch != member.previousMemberEpoch() || !isSubset(ownedTopicPartitions, member.assigned())) {
+                throw new FencedMemberEpochException("The consumer group member has an old member "
+                    + "epoch. The member must abandon all its partitions and rejoin.");
+            }
+        }
+    }
+
+    private ConsumerGroupHeartbeatResponseData.Assignment createResponseAssignment(
+        ConsumerGroupMember member
+    ) {
+        ConsumerGroupHeartbeatResponseData.Assignment assignment = new ConsumerGroupHeartbeatResponseData.Assignment()
+            .setAssignedTopicPartitions(fromAssignmentMap(member.assigned()));
+
+        if (member.state() == ConsumerGroupMember.MemberState.ASSIGNING) {
+            assignment.setPendingTopicPartitions(fromAssignmentMap(member.assigning()));
+        }
+
+        return assignment;
+    }
+
+    private List<ConsumerGroupHeartbeatResponseData.TopicPartitions> fromAssignmentMap(
+        Map<Uuid, Set<Integer>> assignment
+    ) {
+        return assignment.entrySet().stream()
+            .map(keyValue -> new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                .setTopicId(keyValue.getKey())
+                .setPartitions(new ArrayList<>(keyValue.getValue())))
+            .collect(Collectors.toList());
+    }
+
+    private OptionalInt ofSentinel(int value) {
+        return value != -1 ? OptionalInt.of(value) : OptionalInt.empty();
+    }
+
+    /**
+     * Handles a regular heartbeat from a consumer group member.
+     *
+     * @param groupId               The group id from the request.
+     * @param memberId              The member id from the request.
+     * @param memberEpoch           The member epoch from the request.
+     * @param instanceId            The instance id from the request or null.
+     * @param rackId                The rack id from the request or null.
+     * @param rebalanceTimeoutMs    The rebalance timeout from the request or -1.
+     * @param clientId              The client id.
+     * @param clientHost            The client host.
+     * @param subscribedTopicNames  The list of subscribed topic names from the request
+     *                              of null.
+     * @param subscribedTopicRegex  The regular expression based subscription from the
+     *                              request or null.
+     * @param assignorName          The assignor name from the request or null.
+     * @param ownedTopicPartitions  The list of owned partitions from the request or null.
+     *
+     * @return A Result containing the ConsumerGroupHeartbeat response and
+     *         a list of records to update the state machine.
+     */
+    private Result<ConsumerGroupHeartbeatResponseData> consumerGroupHeartbeat(
+        String groupId,
+        String memberId,
+        int memberEpoch,
+        String instanceId,
+        String rackId,
+        int rebalanceTimeoutMs,
+        String clientId,
+        String clientHost,
+        List<String> subscribedTopicNames,
+        String subscribedTopicRegex,
+        String assignorName,
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> ownedTopicPartitions
+    ) throws ApiException {
+        List<Record> records = new ArrayList<>();
+        boolean createIfNotExists = memberEpoch == 0;
+
+        ConsumerGroup group = getOrMaybeCreateConsumerGroup(groupId, createIfNotExists);
+        throwIfConsumerGroupIsFull(group, memberId);
+
+        if (memberId.isEmpty()) memberId = Uuid.randomUuid().toString();
+        ConsumerGroupMember member = group.getOrMaybeCreateMember(memberId, createIfNotExists);
+        throwIfMemberEpochIsInvalid(member, memberEpoch, ownedTopicPartitions);
+
+        if (memberEpoch == 0) {
+            log.info("[GroupId " + groupId + "] Member " + memberId + " re-joins the consumer group.");
+        }
+
+        // Update the subscription part of the member if we received new values. If the member has
+        // changed, we write it to the log. If the subscribed topics have changed, we also recompute
+        // the subscription metadata.
+        int groupEpoch = group.groupEpoch();
+        Map<String, TopicMetadata> subscriptionMetadata = group.subscriptionMetadata();
+        ConsumerGroupMember updatedMember = new ConsumerGroupMember.Builder(member)
+            .maybeUpdateInstanceId(Optional.ofNullable(instanceId))
+            .maybeUpdateRackId(Optional.ofNullable(rackId))
+            .maybeUpdateRebalanceTimeoutMs(ofSentinel(rebalanceTimeoutMs))
+            .maybeUpdateServerAssignorName(Optional.ofNullable(assignorName))
+            .maybeUpdateSubscribedTopicNames(Optional.ofNullable(subscribedTopicNames))
+            .maybeUpdateSubscribedTopicRegex(Optional.ofNullable(subscribedTopicRegex))
+            .setClientId(clientId)
+            .setClientHost(clientHost)
+            .build();
+
+        if (!updatedMember.equals(member)) {
+            records.add(newMemberSubscriptionRecord(groupId, updatedMember));
+
+            if (!updatedMember.subscribedTopicNames().equals(member.subscribedTopicNames())) {
+                log.info("[GroupId " + groupId + "] Member " + memberId + " updated its subscribed topics to: " +
+                    updatedMember.subscribedTopicNames());
+
+                subscriptionMetadata = group.computeSubscriptionMetadata(
+                    updatedMember.memberId(),
+                    updatedMember.subscribedTopicNames(),
+                    topicsImage
+                );
+
+                if (!subscriptionMetadata.equals(group.subscriptionMetadata())) {
+                    log.info("[GroupId " + groupId + "] Computed new subscription metadata: "
+                        + subscriptionMetadata + ".");
+                    records.add(newGroupSubscriptionMetadataRecord(groupId, subscriptionMetadata));
+                }
+
+                groupEpoch += 1;
+                records.add(newGroupEpochRecord(groupId, groupEpoch));
+
+                log.info("[GroupId " + groupId + "] Bumped group epoch to " + groupEpoch + ".");
+            }
+
+            member = updatedMember;
+        }
+
+        // Update target assignment if needed. If the new target has any changes, we write the
+        // changes to the log.
+        int targetAssignmentEpoch = group.assignmentEpoch();
+        MemberAssignment targetAssignment = group.targetAssignment(memberId);
+        if (groupEpoch > targetAssignmentEpoch) {
+            String preferredServerAssignor = group.preferredServerAssignor(
+                member.memberId(),
+                member.serverAssignorName()
+            ).orElse(defaultAssignor.name());
+
+            try {
+                TargetAssignmentBuilder.TargetAssignmentResult assignmentResult =
+                    new TargetAssignmentBuilder(groupId, groupEpoch, assignors.get(preferredServerAssignor))
+                        .withMembers(group.members())
+                        .withSubscriptionMetadata(subscriptionMetadata)
+                        .withTargetAssignments(group.targetAssignments())
+                        .withUpdatedMember(member.memberId(), member)
+                        .build();
+
+                log.info("[GroupId " + groupId + "] Computed a new target assignment for epoch " + groupEpoch + ": "
+                    + assignmentResult.assignments() + ".");
+
+                records.addAll(assignmentResult.records());
+                targetAssignment = assignmentResult.assignments().get(member.memberId());
+                targetAssignmentEpoch = groupEpoch;
+            } catch (PartitionAssignorException ex) {
+                String msg = "Failed to compute a new target assignment for epoch " + groupEpoch + ": " + ex + ".";
+                log.error("[GroupId " + groupId + "] " + msg);
+                throw new UnknownServerException(msg, ex);
+            }
+        }
+
+        // If the member is stable and its next epoch matches the current target epoch
+        // of the assignment, we can skip this reconciliation.
+        boolean assignmentUpdated = false;
+        if (member.state() != ConsumerGroupMember.MemberState.STABLE
+            || member.nextMemberEpoch() != targetAssignmentEpoch) {
+            updatedMember = new CurrentAssignmentBuilder(member)
+                .withTargetAssignment(targetAssignmentEpoch, targetAssignment)
+                .withCurrentPartitionEpoch(group::currentPartitionEpoch)
+                .withOwnedTopicPartitions(ownedTopicPartitions)
+                .build();
+
+            // Checking the reference is enough here because a new instance
+            // is created only when the state has changed.
+            if (updatedMember != member) {
+                assignmentUpdated = true;
+                records.add(newCurrentAssignmentRecord(groupId, updatedMember));
+
+                log.info("[GroupId " + groupId + "] Member " + memberId + " transitioned from " +
+                    member.currentAssignmentSummary() + " to " + updatedMember.currentAssignmentSummary() + ".");
+
+                // TODO(dajac) Starts or restarts the timer for the revocation timeout.
+
+                member = updatedMember;
+            }
+        }
+
+        // TODO(dajac) Starts or restarts the timer for the session timeout.
+
+        ConsumerGroupHeartbeatResponseData response = new ConsumerGroupHeartbeatResponseData()
+            .setMemberId(member.memberId())
+            .setMemberEpoch(member.memberEpoch())
+            .setHeartbeatIntervalMs(consumerGroupHeartbeatIntervalMs);
+
+        if (ownedTopicPartitions != null || memberEpoch == 0 || assignmentUpdated) {
+            response.setAssignment(createResponseAssignment(member));
+        }
+
+        return new Result<>(records, response);
+    }
+
+    /**
+     * Handles leave request from a consumer group member.
+     * @param groupId       The group id from the request.
+     * @param memberId      The member id from the request.
+     *
+     * @return A Result containing the ConsumerGroupHeartbeat response and
+     *         a list of records to update the state machine.
+     */
+    private Result<ConsumerGroupHeartbeatResponseData> consumerGroupLeave(
+        String groupId,
+        String memberId
+    ) throws ApiException {
+        List<Record> records = new ArrayList<>();
+
+        ConsumerGroup group = getOrMaybeCreateConsumerGroup(groupId, false);
+        ConsumerGroupMember member = group.getOrMaybeCreateMember(memberId, false);
+
+        log.info("[GroupId " + groupId + "] Member " + memberId + " left the consumer group.");
+
+        // Write tombstones for the member. The order matters here.
+        records.add(newCurrentAssignmentTombstoneRecord(groupId, memberId));
+        records.add(newTargetAssignmentTombstoneRecord(groupId, memberId));
+        records.add(newMemberSubscriptionTombstoneRecord(groupId, memberId));
+
+        // We update the subscription metadata without the leaving member.
+        Map<String, TopicMetadata> subscriptionMetadata = group.computeSubscriptionMetadata(
+            memberId,
+            null,
+            topicsImage
+        );
+
+        if (!subscriptionMetadata.equals(group.subscriptionMetadata())) {
+            log.info("[GroupId " + groupId + "] Computed new subscription metadata: "
+                + subscriptionMetadata + ".");
+            records.add(newGroupSubscriptionMetadataRecord(groupId, subscriptionMetadata));
+        }
+
+        // We bump the group epoch.
+        int groupEpoch = group.groupEpoch() + 1;
+        records.add(newGroupEpochRecord(groupId, groupEpoch));
+
+        // We update the target assignment for the group and write it to
+        // the log.
+        String assignorName = group.preferredServerAssignor(
+            member.memberId(),
+            Optional.empty()
+        ).orElse(defaultAssignor.name());
+
+        try {
+            TargetAssignmentBuilder.TargetAssignmentResult assignmentResult =
+                new TargetAssignmentBuilder(groupId, groupEpoch, assignors.get(assignorName))
+                    .withMembers(group.members())
+                    .withSubscriptionMetadata(subscriptionMetadata)
+                    .withRemoveMembers(member.memberId())
+                    .build();
+
+            log.info("[GroupId " + groupId + "] Computed a new target assignment for epoch " + groupEpoch + ": "
+                + assignmentResult.assignments() + ".");
+
+            records.addAll(assignmentResult.records());
+        } catch (PartitionAssignorException ex) {
+            String msg = "Failed to compute a new target assignment for epoch " + groupEpoch + ": " + ex + ".";
+            log.error("[GroupId " + groupId + "] " + msg);
+            throw new UnknownServerException(msg, ex);
+        }
+
+        return new Result<>(records, new ConsumerGroupHeartbeatResponseData()
+            .setMemberId(memberId)
+            .setMemberEpoch(-1)
+        );
+    }
+
+    /**
+     * Handles a ConsumerGroupHeartbeat request.
+     *
+     * @param context The request context.
+     * @param request The actual ConsumerGroupHeartbeat request.
+     *
+     * @return A Result containing the ConsumerGroupHeartbeat response and
+     *         a list of records to update the state machine.
+     */
+    public Result<ConsumerGroupHeartbeatResponseData> consumerGroupHeartbeat(
+        RequestContext context,
+        ConsumerGroupHeartbeatRequestData request
+    ) throws ApiException {
+        throwIfConsumerGroupHeartbeatRequestIsInvalid(request);
+
+        if (request.memberEpoch() == -1) {
+            // -1 means that the member wants to leave the group.
+            return consumerGroupLeave(
+                request.groupId(),
+                request.memberId()
+            );
+        } else {
+            // Otherwise, it is a regular heartbeat.
+            return consumerGroupHeartbeat(
+                request.groupId(),
+                request.memberId(),
+                request.memberEpoch(),
+                request.instanceId(),
+                request.rackId(),
+                request.rebalanceTimeoutMs(),
+                context.clientId(),
+                context.clientAddress.toString(),
+                request.subscribedTopicNames(),
+                request.subscribedTopicRegex(),
+                request.serverAssignor(),
+                request.topicPartitions()
+            );
+        }
+    }
+
+    /**
+     * Replays ConsumerGroupMemberMetadataKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupMemberMetadataKey key.
+     * @param value A ConsumerGroupMemberMetadataValue record.
+     */
+    public void replay(
+        ConsumerGroupMemberMetadataKey key,
+        ConsumerGroupMemberMetadataValue value
+    ) {
+        String groupId = key.groupId();
+        String memberId = key.memberId();
+
+        if (value != null) {
+            ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, true);
+            ConsumerGroupMember oldMember = consumerGroup.getOrMaybeCreateMember(memberId, true);
+            consumerGroup.updateMember(new ConsumerGroupMember.Builder(oldMember)
+                .mergeWith(value)
+                .build());
+        } else {
+            ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, false);
+            ConsumerGroupMember oldMember = consumerGroup.getOrMaybeCreateMember(memberId, false);
+            if (oldMember.memberEpoch() != -1) {
+                throw new IllegalStateException("Received a tombstone record to delete member " + memberId
+                    + " but did not receive ConsumerGroupCurrentMemberAssignmentValue tombstone.");
+            }
+            if (consumerGroup.targetAssignments().containsKey(memberId)) {
+                throw new IllegalStateException("Received a tombstone record to delete member " + memberId
+                    + " but did not receive ConsumerGroupTargetAssignmentMetadataValue tombstone.");
+            }
+            consumerGroup.removeMember(memberId);
+        }
+    }
+
+    /**
+     * Replays ConsumerGroupMetadataKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupMetadataKey key.
+     * @param value A ConsumerGroupMetadataValue record.
+     */
+    public void replay(
+        ConsumerGroupMetadataKey key,
+        ConsumerGroupMetadataValue value
+    ) {
+        String groupId = key.groupId();
+
+        if (value != null) {
+            ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, true);
+            consumerGroup.setGroupEpoch(value.epoch());
+        } else {
+            ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, false);
+            if (!consumerGroup.members().isEmpty()) {
+                throw new IllegalStateException("Received a tombstone record to delete group " + groupId
+                    + " but the group still has " + consumerGroup.members().size() + " members.");
+            }
+            if (!consumerGroup.targetAssignments().isEmpty()) {
+                throw new IllegalStateException("Received a tombstone record to delete group " + groupId
+                    + " but the group still has " + consumerGroup.targetAssignments().size() + " members.");
+            }
+            if (consumerGroup.assignmentEpoch() != -1) {
+                throw new IllegalStateException("Received a tombstone record to delete group " + groupId
+                    + " but did not receive ConsumerGroupTargetAssignmentMetadataValue tombstone.");
+            }
+            removeGroup(groupId);
+        }
+
+    }
+
+    /**
+     * Replays ConsumerGroupPartitionMetadataKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupPartitionMetadataKey key.
+     * @param value A ConsumerGroupPartitionMetadataValue record.
+     */
+    public void replay(
+        ConsumerGroupPartitionMetadataKey key,
+        ConsumerGroupPartitionMetadataValue value
+    ) {
+        String groupId = key.groupId();
+        ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, false);
+
+        if (value != null) {
+            Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
+            value.topics().forEach(topicMetadata -> {
+                subscriptionMetadata.put(topicMetadata.topicName(), TopicMetadata.fromRecord(topicMetadata));
+            });
+            consumerGroup.setSubscriptionMetadata(subscriptionMetadata);
+        } else {
+            consumerGroup.setSubscriptionMetadata(Collections.emptyMap());
+        }
+    }
+
+    /**
+     * Replays ConsumerGroupTargetAssignmentMemberKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupTargetAssignmentMemberKey key.
+     * @param value A ConsumerGroupTargetAssignmentMemberValue record.
+     */
+    public void replay(
+        ConsumerGroupTargetAssignmentMemberKey key,
+        ConsumerGroupTargetAssignmentMemberValue value
+    ) {
+        String groupId = key.groupId();
+        String memberId = key.memberId();
+        ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, false);
+
+        if (value != null) {
+            consumerGroup.updateTargetAssignment(memberId, MemberAssignment.fromRecord(value));
+        } else {
+            consumerGroup.removeTargetAssignment(memberId);
+        }
+    }
+
+    /**
+     * Replays ConsumerGroupTargetAssignmentMetadataKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupTargetAssignmentMetadataKey key.
+     * @param value A ConsumerGroupTargetAssignmentMetadataValue record.
+     */
+    public void replay(
+        ConsumerGroupTargetAssignmentMetadataKey key,
+        ConsumerGroupTargetAssignmentMetadataValue value
+    ) {
+        String groupId = key.groupId();
+        ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, false);
+
+        if (value != null) {
+            consumerGroup.setAssignmentEpoch(value.assignmentEpoch());
+        } else {
+            if (!consumerGroup.targetAssignments().isEmpty()) {
+                throw new IllegalStateException("Received a tombstone record to delete target assignment of " + groupId
+                    + " but the assignment still has " + consumerGroup.targetAssignments().size() + " members.");
+            }
+            consumerGroup.setAssignmentEpoch(-1);
+        }
+    }
+
+    /**
+     * Replays ConsumerGroupCurrentMemberAssignmentKey/Value to update the hard state of
+     * the consumer group.
+     *
+     * @param key   A ConsumerGroupCurrentMemberAssignmentKey key.
+     * @param value A ConsumerGroupCurrentMemberAssignmentValue record.
+     */
+    public void replay(
+        ConsumerGroupCurrentMemberAssignmentKey key,
+        ConsumerGroupCurrentMemberAssignmentValue value
+    ) {
+        String groupId = key.groupId();
+        String memberId = key.memberId();
+        ConsumerGroup consumerGroup = getOrMaybeCreateConsumerGroup(groupId, false);
+        ConsumerGroupMember oldMember = consumerGroup.getOrMaybeCreateMember(memberId, false);
+
+        if (value != null) {
+            ConsumerGroupMember newMember = new ConsumerGroupMember.Builder(oldMember)
+                .mergeWith(value)
+                .build();
+            consumerGroup.updateMember(newMember);
+        } else {
+            ConsumerGroupMember newMember = new ConsumerGroupMember.Builder(oldMember)
+                .setMemberEpoch(-1)
+                .setPreviousMemberEpoch(-1)
+                .setNextMemberEpoch(-1)
+                .setAssigning(Collections.emptyMap())
+                .setRevoking(Collections.emptyMap())
+                .setAssigning(Collections.emptyMap())
+                .build();
+            consumerGroup.updateMember(newMember);
+        }
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Record.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Record.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.util.Objects;
+
+public class Record {
+    private final ApiMessageAndVersion key;
+    private final ApiMessageAndVersion value;
+
+    public Record(
+        ApiMessageAndVersion key,
+        ApiMessageAndVersion value
+    ) {
+        this.key = Objects.requireNonNull(key);
+        this.value = value;
+    }
+
+    public ApiMessageAndVersion key() {
+        return this.key;
+    }
+
+    public ApiMessageAndVersion value() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Record record = (Record) o;
+
+        if (!Objects.equals(key, record.key)) return false;
+        return Objects.equals(value, record.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Record(key=" + key + ", value=" + value + ")";
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RecordHelpers {
+    private RecordHelpers() {}
+
+    public static Record newMemberSubscriptionRecord(
+        String groupId,
+        ConsumerGroupMember member
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMemberMetadataKey()
+                    .setGroupId(groupId)
+                    .setMemberId(member.memberId()),
+                (short) 5
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupMemberMetadataValue()
+                    .setRackId(member.rackId())
+                    .setInstanceId(member.instanceId())
+                    .setClientId(member.clientId())
+                    .setClientHost(member.clientHost())
+                    .setSubscribedTopicNames(member.subscribedTopicNames())
+                    .setSubscribedTopicRegex(member.subscribedTopicRegex())
+                    .setServerAssignor(member.serverAssignorName().orElse(null))
+                    .setRebalanceTimeoutMs(member.rebalanceTimeoutMs())
+                    .setAssignors(member.clientAssignors().stream().map(assignorState ->
+                        new ConsumerGroupMemberMetadataValue.Assignor()
+                            .setName(assignorState.name())
+                            .setReason(assignorState.reason())
+                            .setMinimumVersion(assignorState.minimumVersion())
+                            .setMaximumVersion(assignorState.maximumVersion())
+                            .setVersion(assignorState.metadataVersion())
+                            .setMetadata(assignorState.metadataBytes().array())
+                    ).collect(Collectors.toList())),
+                (short) 0
+            )
+        );
+    }
+
+    public static Record newMemberSubscriptionTombstoneRecord(
+        String groupId,
+        String memberId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMemberMetadataKey()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId),
+                (short) 5
+            ),
+            null // Tombstone.
+        );
+    }
+
+    public static Record newGroupSubscriptionMetadataRecord(
+        String groupId,
+        Map<String, TopicMetadata> newSubscriptionMetadata
+    ) {
+        ConsumerGroupPartitionMetadataValue value = new ConsumerGroupPartitionMetadataValue();
+        newSubscriptionMetadata.forEach((topicName, topicMetadata) ->
+            value.topics().add(new ConsumerGroupPartitionMetadataValue.TopicMetadata()
+                .setTopicId(topicMetadata.id())
+                .setTopicName(topicMetadata.name())
+                .setNumPartitions(topicMetadata.numPartitions())
+            )
+        );
+
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupPartitionMetadataKey()
+                    .setGroupId(groupId),
+                (short) 4
+            ),
+            new ApiMessageAndVersion(
+                value,
+                (short) 0
+            )
+        );
+    }
+
+    public static Record newGroupSubscriptionMetadataTombstoneRecord(
+        String groupId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupPartitionMetadataKey()
+                    .setGroupId(groupId),
+                (short) 4
+            ),
+            null // Tombstone.
+        );
+    }
+
+    public static Record newGroupEpochRecord(
+        String groupId,
+        int newGroupEpoch
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMetadataKey()
+                    .setGroupId(groupId),
+                (short) 3
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupMetadataValue()
+                    .setEpoch(newGroupEpoch),
+                (short) 0
+            )
+        );
+    }
+
+    public static Record newGroupEpochTombstoneRecord(
+        String groupId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMetadataKey()
+                    .setGroupId(groupId),
+                (short) 3
+            ),
+            null // Tombstone.
+        );
+    }
+
+    public static Record newTargetAssignmentRecord(
+        String groupId,
+        String memberId,
+        Map<Uuid, Set<Integer>> partitions
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMemberKey()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId),
+                (short) 7
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMemberValue()
+                    .setTopicPartitions(partitions.entrySet().stream()
+                        .map(keyValue -> new ConsumerGroupTargetAssignmentMemberValue.TopicPartition()
+                            .setTopicId(keyValue.getKey())
+                            .setPartitions(new ArrayList<>(keyValue.getValue())))
+                        .collect(Collectors.toList())),
+                (short) 0
+            )
+        );
+    }
+
+    public static Record newTargetAssignmentTombstoneRecord(
+        String groupId,
+        String memberId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMemberKey()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId),
+                (short) 7
+            ),
+            null // Tombstone.
+        );
+    }
+
+    public static Record newTargetAssignmentEpochRecord(
+        String groupId,
+        int groupEpoch
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMetadataKey()
+                    .setGroupId(groupId),
+                (short) 6
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMetadataValue()
+                    .setAssignmentEpoch(groupEpoch),
+                (short) 0
+            )
+        );
+    }
+
+    public static Record newTargetAssignmentEpochTombstoneRecord(
+        String groupId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMetadataKey()
+                    .setGroupId(groupId),
+                (short) 6
+            ),
+            null // Tombstone.
+        );
+    }
+
+    public static Record newCurrentAssignmentRecord(
+        String groupId,
+        ConsumerGroupMember member
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupCurrentMemberAssignmentKey()
+                    .setGroupId(groupId)
+                    .setMemberId(member.memberId()),
+                (short) 8
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupCurrentMemberAssignmentValue()
+                    .setMemberEpoch(member.memberEpoch())
+                    .setPreviousMemberEpoch(member.previousMemberEpoch())
+                    .setTargetMemberEpoch(member.nextMemberEpoch())
+                    .setAssigned(topicPartitions(member.assigned()))
+                    .setRevoking(topicPartitions(member.revoking()))
+                    .setAssigning(topicPartitions(member.assigning())),
+                (short) 0
+            )
+        );
+    }
+
+    private static List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> topicPartitions(
+        Map<Uuid, Set<Integer>> topicPartitions
+    ) {
+        return topicPartitions.entrySet().stream()
+            .map(keyValue -> new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                .setTopicId(keyValue.getKey())
+                .setPartitions(new ArrayList<>(keyValue.getValue())))
+            .collect(Collectors.toList());
+    }
+
+    public static Record newCurrentAssignmentTombstoneRecord(
+        String groupId,
+        String memberId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupCurrentMemberAssignmentKey()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId),
+                (short) 8
+            ),
+            null // Tombstone
+        );
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Result.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Result.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import java.util.List;
+import java.util.Objects;
+
+class Result<T> {
+    private final List<Record> records;
+    private final T response;
+
+    public Result(
+        List<Record> records,
+        T response
+    ) {
+        this.records = Objects.requireNonNull(records);
+        this.response = Objects.requireNonNull(response);
+    }
+
+    public List<Record> records() {
+        return records;
+    }
+
+    public T response() {
+        return response;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Result<?> result = (Result<?>) o;
+
+        if (!records.equals(result.records)) return false;
+        return response.equals(result.response);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = records.hashCode();
+        result = 31 * result + response.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Result(records=" + records +
+            ", response=" + response +
+            ")";
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentMemberSpec.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentMemberSpec.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.coordinator.group.assignor;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The assignment specification for a consumer group member.
@@ -39,18 +41,18 @@ public class AssignmentMemberSpec {
     /**
      * The topics that the member is subscribed to.
      */
-    final Collection<String> subscribedTopics;
+    final Collection<Uuid> subscribedTopics;
 
     /**
      * The current target partitions of the member.
      */
-    final Collection<TopicPartition> targetPartitions;
+    final Map<Uuid, Set<Integer>> targetPartitions;
 
     public AssignmentMemberSpec(
         Optional<String> instanceId,
         Optional<String> rackId,
-        Collection<String> subscribedTopics,
-        Collection<TopicPartition> targetPartitions
+        Collection<Uuid> subscribedTopics,
+        Map<Uuid, Set<Integer>> targetPartitions
     ) {
         Objects.requireNonNull(instanceId);
         Objects.requireNonNull(rackId);
@@ -60,6 +62,22 @@ public class AssignmentMemberSpec {
         this.rackId = rackId;
         this.subscribedTopics = subscribedTopics;
         this.targetPartitions = targetPartitions;
+    }
+
+    public Optional<String> instanceId() {
+        return instanceId;
+    }
+
+    public Optional<String> rackId() {
+        return rackId;
+    }
+
+    public Collection<Uuid> subscribedTopics() {
+        return subscribedTopics;
+    }
+
+    public Map<Uuid, Set<Integer>> targetPartitions() {
+        return targetPartitions;
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentTopicMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AssignmentTopicMetadata.java
@@ -16,29 +16,23 @@
  */
 package org.apache.kafka.coordinator.group.assignor;
 
-import java.util.Objects;
-
 /**
  * Metadata of a topic.
  */
 public class AssignmentTopicMetadata {
-    /**
-     * The topic name.
-     */
-    final String topicName;
-
     /**
      * The number of partitions.
      */
     final int numPartitions;
 
     public AssignmentTopicMetadata(
-        String topicName,
         int numPartitions
     ) {
-        Objects.requireNonNull(topicName);
-        this.topicName = topicName;
         this.numPartitions = numPartitions;
+    }
+
+    public int numPartitions() {
+        return numPartitions;
     }
 
     @Override
@@ -48,21 +42,16 @@ public class AssignmentTopicMetadata {
 
         AssignmentTopicMetadata that = (AssignmentTopicMetadata) o;
 
-        if (numPartitions != that.numPartitions) return false;
-        return topicName.equals(that.topicName);
+        return numPartitions == that.numPartitions;
     }
 
     @Override
     public int hashCode() {
-        int result = topicName.hashCode();
-        result = 31 * result + numPartitions;
-        return result;
+        return numPartitions;
     }
 
     @Override
     public String toString() {
-        return "AssignmentTopicMetadata(topicName=" + topicName +
-            ", numPartitions=" + numPartitions +
-            ')';
+        return "AssignmentTopicMetadata(numPartitions=" + numPartitions + ')';
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/GroupAssignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/GroupAssignment.java
@@ -26,13 +26,17 @@ public class GroupAssignment {
     /**
      * The member assignments keyed by member id.
      */
-    final Map<String, MemberAssignment> members;
+    private final Map<String, MemberAssignment> members;
 
     public GroupAssignment(
         Map<String, MemberAssignment> members
     ) {
         Objects.requireNonNull(members);
         this.members = members;
+    }
+
+    public Map<String, MemberAssignment> members() {
+        return members;
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/MemberAssignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/MemberAssignment.java
@@ -16,10 +16,11 @@
  */
 package org.apache.kafka.coordinator.group.assignor;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 
-import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * The partition assignment for a consumer group member.
@@ -28,13 +29,17 @@ public class MemberAssignment {
     /**
      * The target partitions assigned to this member.
      */
-    final Collection<TopicPartition> targetPartitions;
+    private final Map<Uuid, Set<Integer>> targetPartitions;
 
     public MemberAssignment(
-        Collection<TopicPartition> targetPartitions
+        Map<Uuid, Set<Integer>> targetPartitions
     ) {
         Objects.requireNonNull(targetPartitions);
         this.targetPartitions = targetPartitions;
+    }
+
+    public Map<Uuid, Set<Integer>> targetPartitions() {
+        return targetPartitions;
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ClientAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ClientAssignor.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * An immutable representation of an assignor within a consumer group member.
+ */
+public class ClientAssignor {
+    /**
+     * The name of the assignor.
+     */
+    private final String name;
+
+    /**
+     * The reason reported by the assignor.
+     */
+    private final byte reason;
+
+    /**
+     * The minimum metadata version supported by the assignor.
+     */
+    private final short minimumVersion;
+
+    /**
+     * The maximum metadata version supported by the assignor.
+     */
+    private final short maximumVersion;
+
+    /**
+     * The metadata version reported by the assignor.
+     */
+    private final short metadataVersion;
+
+    /**
+     * The metadata raw bytes reported by the assignor.
+     */
+    private final ByteBuffer metadataBytes;
+
+    public ClientAssignor(
+        String name,
+        byte reason,
+        short minimumVersion,
+        short maximumVersion,
+        short metadataVersion,
+        ByteBuffer metadataBytes
+    ) {
+        this.name = Objects.requireNonNull(name);
+        this.reason = reason;
+        this.minimumVersion = minimumVersion;
+        this.maximumVersion = maximumVersion;
+        this.metadataVersion = metadataVersion;
+        this.metadataBytes = Objects.requireNonNull(metadataBytes);
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public byte reason() {
+        return this.reason;
+    }
+
+    public short minimumVersion() {
+        return this.minimumVersion;
+    }
+
+    public short maximumVersion() {
+        return this.maximumVersion;
+    }
+
+    public short metadataVersion() {
+        return this.metadataVersion;
+    }
+
+    public ByteBuffer metadataBytes() {
+        return this.metadataBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClientAssignor that = (ClientAssignor) o;
+
+        if (reason != that.reason) return false;
+        if (minimumVersion != that.minimumVersion) return false;
+        if (maximumVersion != that.maximumVersion) return false;
+        if (metadataVersion != that.metadataVersion) return false;
+        if (!name.equals(that.name)) return false;
+        return metadataBytes.equals(that.metadataBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (int) reason;
+        result = 31 * result + (int) minimumVersion;
+        result = 31 * result + (int) maximumVersion;
+        result = 31 * result + (int) metadataVersion;
+        result = 31 * result + metadataBytes.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientAssignor(name=" + name +
+            ", reason=" + reason +
+            ", minimumVersion=" + minimumVersion +
+            ", maximumVersion=" + maximumVersion +
+            ", metadataVersion=" + metadataVersion +
+            ", metadataBytes=" + metadataBytes +
+            ')';
+    }
+
+    public static ClientAssignor fromRecord(
+        ConsumerGroupMemberMetadataValue.Assignor record
+    ) {
+        return new ClientAssignor(
+            record.name(),
+            record.reason(),
+            record.minimumVersion(),
+            record.maximumVersion(),
+            record.version(),
+            ByteBuffer.wrap(record.metadata())
+        );
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -1,0 +1,535 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.coordinator.group.Group;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.timeline.SnapshotRegistry;
+import org.apache.kafka.timeline.TimelineHashMap;
+import org.apache.kafka.timeline.TimelineInteger;
+import org.apache.kafka.timeline.TimelineObject;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A Consumer Group. All the metadata in this class are backed by
+ * records in the __consumer_offsets partitions.
+ */
+public class ConsumerGroup implements Group {
+
+    public enum ConsumerGroupState {
+        EMPTY("empty"),
+        ASSIGNING("assigning"),
+        RECONCILING("reconciling"),
+        STABLE("stable"),
+        DEAD("dead");
+
+        private final String name;
+
+        ConsumerGroupState(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    /**
+     * The snapshot registry.
+     */
+    private final SnapshotRegistry snapshotRegistry;
+
+    /**
+     * The group id.
+     */
+    private final String groupId;
+
+    /**
+     * The group state.
+     */
+    private final TimelineObject<ConsumerGroupState> state;
+
+    /**
+     * The group epoch. The epoch is incremented whenever the subscriptions
+     * are updated and it will trigger the computation of a new assignment
+     * for the group.
+     */
+    private final TimelineInteger groupEpoch;
+
+    /**
+     * The group members.
+     */
+    private final TimelineHashMap<String, ConsumerGroupMember> members;
+
+    /**
+     * The metadata of the subscribed topics.
+     */
+    private final TimelineHashMap<String, TopicMetadata> subscribedTopicMetadata;
+
+    /**
+     * The assignment epoch. An assignment epoch smaller than the group epoch means
+     * that a new assignment is required. The assignment epoch is updated when a new
+     * assignment is installed.
+     */
+    private final TimelineInteger assignmentEpoch;
+
+    /**
+     * The target assignment.
+     */
+    private final TimelineHashMap<String, MemberAssignment> assignments;
+
+    /**
+     * The current partition epoch maps each topic-partitions to their current epoch where
+     * the epoch is the epoch of their owners. When a member revokes a partition, it removes
+     * itself from this map. When a member gets a partition, it adds itself to this map.
+     */
+    private final TimelineHashMap<Uuid, TimelineHashMap<Integer, Integer>> currentPartitionEpoch;
+
+    public ConsumerGroup(
+        SnapshotRegistry snapshotRegistry,
+        String groupId
+    ) {
+        this.snapshotRegistry = Objects.requireNonNull(snapshotRegistry);
+        this.groupId = Objects.requireNonNull(groupId);
+        this.state = new TimelineObject<>(snapshotRegistry, ConsumerGroupState.EMPTY);
+        this.groupEpoch = new TimelineInteger(snapshotRegistry);
+        this.members = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.subscribedTopicMetadata = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.assignmentEpoch = new TimelineInteger(snapshotRegistry);
+        this.assignments = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.currentPartitionEpoch = new TimelineHashMap<>(snapshotRegistry, 0);
+    }
+
+    /**
+     * The type of this group.
+     *
+     * @return The group type (Consumer).
+     */
+    @Override
+    public GroupType type() {
+        return GroupType.CONSUMER;
+    }
+
+    /**
+     * The state of this group.
+     *
+     * @return The current state as a String.
+     */
+    @Override
+    public String stateAsString() {
+        return state.get().toString();
+    }
+
+    /**
+     * The group id.
+     *
+     * @return The group id.
+     */
+    @Override
+    public String groupId() {
+        return groupId;
+    }
+
+    /**
+     * The state of this group.
+     *
+     * @return The current state.
+     */
+    public ConsumerGroupState state() {
+        return state.get();
+    }
+
+    /**
+     * Returns the current group epoch.
+     *
+     * @return The group epoch.
+     */
+    public int groupEpoch() {
+        return groupEpoch.get();
+    }
+
+    /**
+     * Sets the group epoch.
+     *
+     * @param groupEpoch The new group epoch.
+     */
+    public void setGroupEpoch(int groupEpoch) {
+        this.groupEpoch.set(groupEpoch);
+        maybeUpdateGroupState();
+    }
+
+    /**
+     * Returns the current assignment epoch.
+     *
+     * @return The current assignment epoch.
+     */
+    public int assignmentEpoch() {
+        return assignmentEpoch.get();
+    }
+
+    /**
+     * Sets the assignment epoch.
+     *
+     * @param assignmentEpoch The new assignment epoch.
+     */
+    public void setAssignmentEpoch(int assignmentEpoch) {
+        this.assignmentEpoch.set(assignmentEpoch);
+        maybeUpdateGroupState();
+    }
+
+    /**
+     * Gets or creates a member.
+     *
+     * @param memberId          The member id.
+     * @param createIfNotExists Booleans indicating whether the member must be
+     *                          created if it does not exist.
+     *
+     * @return A ConsumerGroupMember.
+     */
+    public ConsumerGroupMember getOrMaybeCreateMember(
+        String memberId,
+        boolean createIfNotExists
+    ) {
+        ConsumerGroupMember member = members.get(memberId);
+        if (member == null) {
+            if (!createIfNotExists) {
+                throw new UnknownMemberIdException(String.format("Member %s is not a member of group %s.",
+                    memberId, groupId));
+            }
+            member = new ConsumerGroupMember.Builder(memberId).build();
+            members.put(memberId, member);
+        }
+
+        return member;
+    }
+
+    /**
+     * Updates the member.
+     *
+     * @param newMember The new member state.
+     */
+    public void updateMember(ConsumerGroupMember newMember) {
+        ConsumerGroupMember oldMember = members.put(newMember.memberId(), newMember);
+        maybeUpdatePartitionEpoch(oldMember, newMember);
+        maybeUpdateGroupState();
+    }
+
+    /**
+     * Remove the member from the group.
+     *
+     * @param memberId The member id to remove.
+     */
+    public void removeMember(String memberId) {
+        ConsumerGroupMember member = members.remove(memberId);
+        maybeRemovePartitionEpoch(member);
+        maybeUpdateGroupState();
+    }
+
+    /**
+     * Returns true if the member exists.
+     *
+     * @param memberId The member id.
+     *
+     * @return A boolean indicating whether the member exists or not.
+     */
+    public boolean hasMember(String memberId) {
+        return members.containsKey(memberId);
+    }
+
+    /**
+     * Returns the number of members in the group.
+     *
+     * @return The number of members.
+     */
+    public int numMembers() {
+        return members.size();
+    }
+
+    /**
+     * Returns the members keyed by their id.
+     *
+     * @return A immutable Map containing all the members.
+     */
+    public Map<String, ConsumerGroupMember> members() {
+        return Collections.unmodifiableMap(members);
+    }
+
+    /**
+     * Returns the current target assignment of the member.
+     *
+     * @return The ConsumerGroupMemberAssignment or an EMPTY one if it does not
+     *         exist.
+     */
+    public MemberAssignment targetAssignment(String memberId) {
+        return assignments.getOrDefault(memberId, MemberAssignment.EMPTY);
+    }
+
+    /**
+     * Updates target assignment of a member.
+     *
+     * @param memberId              The member id.
+     * @param newTargetAssignment   The new target assignment.
+     */
+    public void updateTargetAssignment(String memberId, MemberAssignment newTargetAssignment) {
+        assignments.put(memberId, newTargetAssignment);
+    }
+
+    /**
+     * Removes the target assignment of a member.
+     *
+     * @param memberId The member id.
+     */
+    public void removeTargetAssignment(String memberId) {
+        assignments.remove(memberId);
+    }
+
+    /**
+     * Returns the target assignments for the entire group.
+     *
+     * @return A immutable Map containing all the target assignments.
+     */
+    public Map<String, MemberAssignment> targetAssignments() {
+        return Collections.unmodifiableMap(assignments);
+    }
+
+    /**
+     * Returns the current epoch of a partition or -1 if the partition
+     * does not have one.
+     *
+     * @param topicId       The topic id.
+     * @param partitionId   The partition id.
+     *
+     * @return The epoch or -1.
+     */
+    public int currentPartitionEpoch(
+        Uuid topicId, int partitionId
+    ) {
+        Map<Integer, Integer> partitions = currentPartitionEpoch.get(topicId);
+        if (partitions == null) {
+            return -1;
+        } else {
+            return partitions.getOrDefault(partitionId, -1);
+        }
+    }
+
+    /**
+     * Compute the preferred (server side) assignor for the group while
+     * using the provided assignor for the member.
+     *
+     * @param updatedMemberId       The member id.
+     * @param serverAssignorNameOpt The assignor name.
+     *
+     * @return An Optional containing the preferred assignor.
+     */
+    public Optional<String> preferredServerAssignor(
+        String updatedMemberId,
+        Optional<String> serverAssignorNameOpt
+    ) {
+        Map<String, Integer> counts = new HashMap<>();
+
+        serverAssignorNameOpt.ifPresent(serverAssignorName ->
+            counts.put(serverAssignorName, 1)
+        );
+
+        members.forEach((memberId, member) -> {
+            if (!memberId.equals(updatedMemberId) && member.serverAssignorName().isPresent()) {
+                counts.compute(member.serverAssignorName().get(), (k, v) -> v == null ? 1 : v + 1);
+            }
+        });
+
+        return counts.entrySet().stream()
+            .max(Map.Entry.comparingByValue())
+            .map(Map.Entry::getKey);
+    }
+
+    /**
+     * Returns the subscription metadata for all the topics whose
+     * members are subscribed to.
+     *
+     * @return An immutable Map containing the subscription metadata.
+     */
+    public Map<String, TopicMetadata> subscriptionMetadata() {
+        return Collections.unmodifiableMap(subscribedTopicMetadata);
+    }
+
+    /**
+     * Updates the subscription metadata. This replace the previous one.
+     *
+     * @param subscriptionMetadata The new subscription metadata.
+     */
+    public void setSubscriptionMetadata(
+        Map<String, TopicMetadata> subscriptionMetadata
+    ) {
+        this.subscribedTopicMetadata.clear();
+        this.subscribedTopicMetadata.putAll(subscriptionMetadata);
+    }
+
+    /**
+     * Computes new subscription metadata but with specific information for
+     * a member.
+     *
+     * @param updatedMemberId               The member id.
+     * @param updatedMemberSubscriptions    The member's updated topic subscriptions.
+     * @param topicsImage                   The topics metadata.
+     *
+     * @return The new subscription metadata as an immutable Map.
+     */
+    public Map<String, TopicMetadata> computeSubscriptionMetadata(
+        String updatedMemberId,
+        List<String> updatedMemberSubscriptions,
+        TopicsImage topicsImage
+    ) {
+        Map<String, TopicMetadata> newSubscriptionMetadata = new HashMap<>(subscriptionMetadata().size());
+
+        Consumer<List<String>> updateSubscription = subscribedTopicNames -> {
+            subscribedTopicNames.forEach(topicName ->
+                newSubscriptionMetadata.computeIfAbsent(topicName, __ -> {
+                    TopicImage topicImage = topicsImage.getTopic(topicName);
+                    if (topicImage == null) {
+                        return null;
+                    } else {
+                        return new TopicMetadata(
+                            topicImage.id(),
+                            topicImage.name(),
+                            topicImage.partitions().size()
+                        );
+                    }
+                })
+            );
+        };
+
+        if (updatedMemberSubscriptions != null) {
+            updateSubscription.accept(updatedMemberSubscriptions);
+        }
+
+        members.forEach((memberId, member) -> {
+            if (!memberId.equals(updatedMemberId)) {
+                updateSubscription.accept(member.subscribedTopicNames());
+            }
+        });
+
+        return Collections.unmodifiableMap(newSubscriptionMetadata);
+    }
+
+    /**
+     * Updates the current state of the group.
+     */
+    private void maybeUpdateGroupState() {
+        if (members.isEmpty()) {
+            state.set(ConsumerGroupState.EMPTY);
+        } else if (groupEpoch.get() > assignmentEpoch.get()) {
+            state.set(ConsumerGroupState.ASSIGNING);
+        } else {
+            for (Map.Entry<String, ConsumerGroupMember> keyValue : members.entrySet()) {
+                ConsumerGroupMember member = keyValue.getValue();
+                if (member.nextMemberEpoch() != assignmentEpoch.get() || member.state() != ConsumerGroupMember.MemberState.STABLE) {
+                    state.set(ConsumerGroupState.RECONCILING);
+                    return;
+                }
+            }
+
+            state.set(ConsumerGroupState.STABLE);
+        }
+    }
+
+    /**
+     * Updates the partition epochs based on the old and the new member.
+     */
+    private void maybeUpdatePartitionEpoch(
+        ConsumerGroupMember oldMember,
+        ConsumerGroupMember newMember
+    ) {
+        if (oldMember == null) {
+            addPartitionEpochs(newMember.assigned(), newMember.memberEpoch());
+            addPartitionEpochs(newMember.revoking(), newMember.memberEpoch());
+        } else {
+            if (!oldMember.assigned().equals(newMember.assigned())) {
+                removePartitionEpochs(oldMember.assigned());
+                addPartitionEpochs(newMember.assigned(), newMember.memberEpoch());
+            }
+            if (!oldMember.revoking().equals(newMember.revoking())) {
+                removePartitionEpochs(oldMember.revoking());
+                addPartitionEpochs(newMember.revoking(), newMember.memberEpoch());
+            }
+        }
+    }
+
+    /**
+     * Removes the partition epochs for the provided member.
+     */
+    private void maybeRemovePartitionEpoch(
+        ConsumerGroupMember oldMember
+    ) {
+        if (oldMember != null) {
+            removePartitionEpochs(oldMember.assigned());
+            removePartitionEpochs(oldMember.revoking());
+        }
+    }
+
+    /**
+     * Removes the partition epochs based on the provided assignment.
+     */
+    private void removePartitionEpochs(
+        Map<Uuid, Set<Integer>> assignment
+    ) {
+        assignment.forEach((topicId, assignedPartitions) -> {
+            currentPartitionEpoch.compute(topicId, (__, partitionsOrNull) -> {
+                if (partitionsOrNull != null) {
+                    assignedPartitions.forEach(partitionsOrNull::remove);
+                    if (partitionsOrNull.isEmpty()) {
+                        return null;
+                    } else {
+                        return partitionsOrNull;
+                    }
+                } else {
+                    return null;
+                }
+            });
+        });
+    }
+
+    /**
+     * Adds the partitions epoch based on the provided assignment.
+     */
+    private void addPartitionEpochs(
+        Map<Uuid, Set<Integer>> assignment,
+        int epoch
+    ) {
+        assignment.forEach((topicId, assignedPartitions) -> {
+            currentPartitionEpoch.compute(topicId, (__, partitionsOrNull) -> {
+                if (partitionsOrNull == null) partitionsOrNull = new TimelineHashMap<>(snapshotRegistry, 1);
+                for (Integer partitionId : assignedPartitions) {
+                    partitionsOrNull.put(partitionId, epoch);
+                }
+                return partitionsOrNull;
+            });
+        });
+    }
+
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * ConsumerGroupMember contains all the information related to a member
+ * within a consumer group. This class is immutable.
+ */
+public class ConsumerGroupMember {
+    /**
+     * A builder allowing to create a new member or update an
+     * existing one.
+     */
+    public static class Builder {
+        private final String memberId;
+        private int memberEpoch = 0;
+        private int previousMemberEpoch = -1;
+        private int nextMemberEpoch = 0;
+        private String instanceId = null;
+        private String rackId = null;
+        private int rebalanceTimeoutMs = -1;
+        private String clientId = "";
+        private String clientHost = "";
+        private List<String> subscribedTopicNames = Collections.emptyList();
+        private String subscribedTopicRegex = "";
+        private String serverAssignorName = null;
+        private List<ClientAssignor> clientAssignors = Collections.emptyList();
+        private Map<Uuid, Set<Integer>> assigned = Collections.emptyMap();
+        private Map<Uuid, Set<Integer>> revoking = Collections.emptyMap();
+        private Map<Uuid, Set<Integer>> assigning = Collections.emptyMap();
+
+        public Builder(String memberId) {
+            this.memberId = Objects.requireNonNull(memberId);
+        }
+
+        public Builder(ConsumerGroupMember member) {
+            Objects.requireNonNull(member);
+
+            this.memberId = member.memberId;
+            this.memberEpoch = member.memberEpoch;
+            this.previousMemberEpoch = member.previousMemberEpoch;
+            this.nextMemberEpoch = member.nextMemberEpoch;
+            this.instanceId = member.instanceId;
+            this.rackId = member.rackId;
+            this.rebalanceTimeoutMs = member.rebalanceTimeoutMs;
+            this.clientId = member.clientId;
+            this.clientHost = member.clientHost;
+            this.subscribedTopicNames = member.subscribedTopicNames;
+            this.subscribedTopicRegex = member.subscribedTopicRegex;
+            this.serverAssignorName = member.serverAssignorName;
+            this.clientAssignors = member.clientAssignors;
+            this.assigned = member.assigned;
+            this.revoking = member.revoking;
+            this.assigning = member.assigning;
+        }
+
+        public Builder setMemberEpoch(int memberEpoch) {
+            this.memberEpoch = memberEpoch;
+            return this;
+        }
+
+        public Builder setPreviousMemberEpoch(int previousMemberEpoch) {
+            this.previousMemberEpoch = previousMemberEpoch;
+            return this;
+        }
+
+        public Builder setNextMemberEpoch(int nextMemberEpoch) {
+            this.nextMemberEpoch = nextMemberEpoch;
+            return this;
+        }
+
+        public Builder setInstanceId(String instanceId) {
+            this.instanceId = instanceId;
+            return this;
+        }
+
+        public Builder maybeUpdateInstanceId(Optional<String> instanceId) {
+            this.instanceId = instanceId.orElse(this.instanceId);
+            return this;
+        }
+
+        public Builder setRackId(String rackId) {
+            this.rackId = rackId;
+            return this;
+        }
+
+        public Builder maybeUpdateRackId(Optional<String> rackId) {
+            this.rackId = rackId.orElse(this.rackId);
+            return this;
+        }
+
+        public Builder setRebalanceTimeoutMs(int rebalanceTimeoutMs) {
+            this.rebalanceTimeoutMs = rebalanceTimeoutMs;
+            return this;
+        }
+
+        public Builder maybeUpdateRebalanceTimeoutMs(OptionalInt rebalanceTimeoutMs) {
+            this.rebalanceTimeoutMs = rebalanceTimeoutMs.orElse(this.rebalanceTimeoutMs);
+            return this;
+        }
+
+        public Builder setClientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder setClientHost(String clientHost) {
+            this.clientHost = clientHost;
+            return this;
+        }
+
+        public Builder setSubscribedTopicNames(List<String> subscribedTopicNames) {
+            this.subscribedTopicNames = subscribedTopicNames;
+            this.subscribedTopicNames.sort(Comparator.naturalOrder());
+            return this;
+        }
+
+        public Builder maybeUpdateSubscribedTopicNames(Optional<List<String>> subscribedTopicNames) {
+            this.subscribedTopicNames = subscribedTopicNames.orElse(this.subscribedTopicNames);
+            this.subscribedTopicNames.sort(Comparator.naturalOrder());
+            return this;
+        }
+
+        public Builder setSubscribedTopicRegex(String subscribedTopicRegex) {
+            this.subscribedTopicRegex = subscribedTopicRegex;
+            return this;
+        }
+
+        public Builder maybeUpdateSubscribedTopicRegex(Optional<String> subscribedTopicRegex) {
+            this.subscribedTopicRegex = subscribedTopicRegex.orElse(this.subscribedTopicRegex);
+            return this;
+        }
+
+        public Builder setServerAssignorName(String serverAssignorName) {
+            this.serverAssignorName = serverAssignorName;
+            return this;
+        }
+
+        public Builder maybeUpdateServerAssignorName(Optional<String> serverAssignorName) {
+            this.serverAssignorName = serverAssignorName.orElse(this.serverAssignorName);
+            return this;
+        }
+
+        public Builder setClientAssignors(List<ClientAssignor> clientAssignors) {
+            this.clientAssignors = clientAssignors;
+            return this;
+        }
+
+        public Builder maybeUpdateClientAssignors(Optional<List<ClientAssignor>> clientAssignors) {
+            this.clientAssignors = clientAssignors.orElse(this.clientAssignors);
+            return this;
+        }
+
+        public Builder setAssigned(Map<Uuid, Set<Integer>> assigned) {
+            this.assigned = assigned;
+            return this;
+        }
+
+        public Builder setRevoking(Map<Uuid, Set<Integer>> revoking) {
+            this.revoking = revoking;
+            return this;
+        }
+
+        public Builder setAssigning(Map<Uuid, Set<Integer>> assigning) {
+            this.assigning = assigning;
+            return this;
+        }
+
+        public Builder mergeWith(ConsumerGroupMemberMetadataValue record) {
+            setInstanceId(record.instanceId());
+            setRackId(record.rackId());
+            setClientId(record.clientId());
+            setClientHost(record.clientHost());
+            setSubscribedTopicNames(record.subscribedTopicNames());
+            setSubscribedTopicRegex(record.subscribedTopicRegex());
+            setRebalanceTimeoutMs(record.rebalanceTimeoutMs());
+            setServerAssignorName(record.serverAssignor());
+            setClientAssignors(record.assignors().stream()
+                .map(ClientAssignor::fromRecord)
+                .collect(Collectors.toList()));
+            return this;
+        }
+
+        public Builder mergeWith(ConsumerGroupCurrentMemberAssignmentValue record) {
+            setMemberEpoch(record.memberEpoch());
+            setPreviousMemberEpoch(record.previousMemberEpoch());
+            setNextMemberEpoch(record.targetMemberEpoch());
+            setAssigned(assignmentFromTopicPartitions(record.assigned()));
+            setRevoking(assignmentFromTopicPartitions(record.revoking()));
+            setAssigning(assignmentFromTopicPartitions(record.assigning()));
+            return this;
+        }
+
+        private Map<Uuid, Set<Integer>> assignmentFromTopicPartitions(
+            List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> topicPartitionsList
+        ) {
+            return topicPartitionsList.stream().collect(Collectors.toMap(
+                ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId,
+                topicPartitions -> Collections.unmodifiableSet(new HashSet<>(topicPartitions.partitions()))));
+        }
+
+        public ConsumerGroupMember build() {
+            MemberState state;
+            if (!revoking.isEmpty()) {
+                state = MemberState.REVOKING;
+            } else if (!assigning.isEmpty()) {
+                state = MemberState.ASSIGNING;
+            } else {
+                state = MemberState.STABLE;
+            }
+
+            return new ConsumerGroupMember(
+                memberId,
+                memberEpoch,
+                previousMemberEpoch,
+                nextMemberEpoch,
+                instanceId,
+                rackId,
+                rebalanceTimeoutMs,
+                clientId,
+                clientHost,
+                subscribedTopicNames,
+                subscribedTopicRegex,
+                serverAssignorName,
+                clientAssignors,
+                state,
+                assigned,
+                revoking,
+                assigning
+            );
+        }
+    }
+
+    public enum MemberState {
+        REVOKING("revoking"),
+        ASSIGNING("assigning"),
+        STABLE("stable");
+
+        private final String name;
+
+        MemberState(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    /**
+     * The member id.
+     */
+    private final String memberId;
+
+    /**
+     * The current member epoch.
+     */
+    private final int memberEpoch;
+
+    /**
+     * The previous member epoch.
+     */
+    private final int previousMemberEpoch;
+
+    /**
+     * The next member epoch. This corresponds to the target
+     * assignment epoch used to compute the current assigned,
+     * revoking and assigning partitions.
+     */
+    private final int nextMemberEpoch;
+
+    /**
+     * The instance id provided by the member.
+     */
+    private final String instanceId;
+
+    /**
+     * The rack id provided by the member.
+     */
+    private final String rackId;
+
+    /**
+     * The rebalance timeout provided by the member.
+     */
+    private final int rebalanceTimeoutMs;
+
+    /**
+     * The client id reported by the member.
+     */
+    private final String clientId;
+
+    /**
+     * The host reported by the member.
+     */
+    private final String clientHost;
+
+    /**
+     * The list of subscriptions (topic names) configured by the member.
+     */
+    private final List<String> subscribedTopicNames;
+
+    /**
+     * The subscription pattern configured by the member,
+     */
+    private final String subscribedTopicRegex;
+
+    /**
+     * The server side assignor selected by the member.
+     */
+    private final String serverAssignorName;
+
+    /**
+     * The states of the client side assignors of the member.
+     */
+    private final List<ClientAssignor> clientAssignors;
+
+    /**
+     * The member state.
+     */
+    private final MemberState state;
+
+    /**
+     * The partitions assigned to this member.
+     */
+    private final Map<Uuid, Set<Integer>> assigned;
+
+    /**
+     * The partitions being revoked by this member.
+     */
+    private final Map<Uuid, Set<Integer>> revoking;
+
+    /**
+     * The partitions waiting to be assigned to this
+     * member. They will be assigned when they are
+     * released by their previous owners.
+     */
+    private final Map<Uuid, Set<Integer>> assigning;
+
+    private ConsumerGroupMember(
+        String memberId,
+        int memberEpoch,
+        int previousMemberEpoch,
+        int nextMemberEpoch,
+        String instanceId,
+        String rackId,
+        int rebalanceTimeoutMs,
+        String clientId,
+        String clientHost,
+        List<String> subscribedTopicNames,
+        String subscribedTopicRegex,
+        String serverAssignorName,
+        List<ClientAssignor> clientAssignors,
+        MemberState state,
+        Map<Uuid, Set<Integer>> assigned,
+        Map<Uuid, Set<Integer>> revoking,
+        Map<Uuid, Set<Integer>> assigning
+    ) {
+        this.memberId = memberId;
+        this.memberEpoch = memberEpoch;
+        this.previousMemberEpoch = previousMemberEpoch;
+        this.nextMemberEpoch = nextMemberEpoch;
+        this.instanceId = instanceId;
+        this.rackId = rackId;
+        this.rebalanceTimeoutMs = rebalanceTimeoutMs;
+        this.clientId = clientId;
+        this.clientHost = clientHost;
+        this.subscribedTopicNames = subscribedTopicNames;
+        this.subscribedTopicRegex = subscribedTopicRegex;
+        this.serverAssignorName = serverAssignorName;
+        this.clientAssignors = clientAssignors;
+        this.state = state;
+        this.assigned = assigned;
+        this.revoking = revoking;
+        this.assigning = assigning;
+    }
+
+    public String memberId() {
+        return memberId;
+    }
+
+    public int memberEpoch() {
+        return memberEpoch;
+    }
+
+    public int previousMemberEpoch() {
+        return previousMemberEpoch;
+    }
+
+    public int nextMemberEpoch() {
+        return nextMemberEpoch;
+    }
+
+    public String instanceId() {
+        return instanceId;
+    }
+
+    public String rackId() {
+        return rackId;
+    }
+
+    public int rebalanceTimeoutMs() {
+        return rebalanceTimeoutMs;
+    }
+
+    public String clientId() {
+        return clientId;
+    }
+
+    public String clientHost() {
+        return clientHost;
+    }
+
+    public List<String> subscribedTopicNames() {
+        return subscribedTopicNames;
+    }
+
+    public String subscribedTopicRegex() {
+        return subscribedTopicRegex;
+    }
+
+    public Optional<String> serverAssignorName() {
+        return Optional.ofNullable(serverAssignorName);
+    }
+
+    public List<ClientAssignor> clientAssignors() {
+        return clientAssignors;
+    }
+
+    public MemberState state() {
+        return state;
+    }
+
+    public Map<Uuid, Set<Integer>> assigned() {
+        return assigned;
+    }
+
+    public Map<Uuid, Set<Integer>> revoking() {
+        return revoking;
+    }
+
+    public Map<Uuid, Set<Integer>> assigning() {
+        return assigning;
+    }
+
+    public String currentAssignmentSummary() {
+        return "CurrentAssignment(" +
+            ", memberEpoch=" + memberEpoch +
+            ", previousMemberEpoch=" + previousMemberEpoch +
+            ", nextMemberEpoch=" + nextMemberEpoch +
+            ", state=" + state +
+            ", assigned=" + assigned +
+            ", revoking=" + revoking +
+            ", assigning=" + assigning +
+            ')';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConsumerGroupMember that = (ConsumerGroupMember) o;
+
+        if (memberEpoch != that.memberEpoch) return false;
+        if (previousMemberEpoch != that.previousMemberEpoch) return false;
+        if (nextMemberEpoch != that.nextMemberEpoch) return false;
+        if (rebalanceTimeoutMs != that.rebalanceTimeoutMs) return false;
+        if (!Objects.equals(memberId, that.memberId)) return false;
+        if (!Objects.equals(instanceId, that.instanceId)) return false;
+        if (!Objects.equals(rackId, that.rackId)) return false;
+        if (!Objects.equals(clientId, that.clientId)) return false;
+        if (!Objects.equals(clientHost, that.clientHost)) return false;
+        if (!Objects.equals(subscribedTopicNames, that.subscribedTopicNames)) return false;
+        if (!Objects.equals(subscribedTopicRegex, that.subscribedTopicRegex)) return false;
+        if (!Objects.equals(serverAssignorName, that.serverAssignorName)) return false;
+        if (!Objects.equals(clientAssignors, that.clientAssignors)) return false;
+        if (!Objects.equals(assigned, that.assigned)) return false;
+        if (!Objects.equals(revoking, that.revoking)) return false;
+        return Objects.equals(assigning, that.assigning);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memberId != null ? memberId.hashCode() : 0;
+        result = 31 * result + memberEpoch;
+        result = 31 * result + previousMemberEpoch;
+        result = 31 * result + nextMemberEpoch;
+        result = 31 * result + (instanceId != null ? instanceId.hashCode() : 0);
+        result = 31 * result + (rackId != null ? rackId.hashCode() : 0);
+        result = 31 * result + rebalanceTimeoutMs;
+        result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
+        result = 31 * result + (clientHost != null ? clientHost.hashCode() : 0);
+        result = 31 * result + (subscribedTopicNames != null ? subscribedTopicNames.hashCode() : 0);
+        result = 31 * result + (subscribedTopicRegex != null ? subscribedTopicRegex.hashCode() : 0);
+        result = 31 * result + (serverAssignorName != null ? serverAssignorName.hashCode() : 0);
+        result = 31 * result + (clientAssignors != null ? clientAssignors.hashCode() : 0);
+        result = 31 * result + (assigned != null ? assigned.hashCode() : 0);
+        result = 31 * result + (revoking != null ? revoking.hashCode() : 0);
+        result = 31 * result + (assigning != null ? assigning.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerGroupMember(" +
+            "memberId='" + memberId + '\'' +
+            ", memberEpoch=" + memberEpoch +
+            ", previousMemberEpoch=" + previousMemberEpoch +
+            ", nextMemberEpoch=" + nextMemberEpoch +
+            ", instanceId='" + instanceId + '\'' +
+            ", rackId='" + rackId + '\'' +
+            ", rebalanceTimeoutMs=" + rebalanceTimeoutMs +
+            ", clientId='" + clientId + '\'' +
+            ", clientHost='" + clientHost + '\'' +
+            ", subscribedTopicNames=" + subscribedTopicNames +
+            ", subscribedTopicRegex='" + subscribedTopicRegex + '\'' +
+            ", serverAssignorName='" + serverAssignorName + '\'' +
+            ", clientAssignors=" + clientAssignors +
+            ", state=" + state +
+            ", assigned=" + assigned +
+            ", revoking=" + revoking +
+            ", assigning=" + assigning +
+            ')';
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/CurrentAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/CurrentAssignmentBuilder.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * This CurrentAssignmentBuilder class encapsulates the reconciliation engine of the
+ * consumer group protocol. Given the current state of a member and a desired or target
+ * assignment state, the state machine takes the necessary steps to converge them.
+ *
+ * The member state has the following properties:
+ * - Current Epoch  - The current epoch of the member.
+ * - Next Epoch     - The desired epoch of the member. It corresponds to the epoch of
+ *                    the target/desired assignment. The member transition to this epoch
+ *                    when it has revoked the partitions that it does not owned or if it
+ *                    does not have to revoke any.
+ * - Previous Epoch - The previous epoch of the member when the state was updated.
+ * - Assigned Set   - The set of partitions currently assigned to the member. This represents what
+ *                    the member should have.
+ * - Revoking Set   - The set of partitions that the member should revoke before it could transition
+ *                    to the next state.
+ * - Assigning Set  - The set of partitions that the member will eventually receive. The partitions
+ *                    in this set are still owned by other members in the group.
+ *
+ * The state machine has four states:
+ * - NEW_TARGET_ASSIGNMENT - This is the initial state of the state machine. The state machine starts
+ *                           here when the next epoch does not match the target epoch. It means that
+ *                           a new target assignment has been installed so the reconciliation process
+ *                           must restart. In this state, the Assigned, Revoking and Assigning sets
+ *                           are computed. If Revoking is not empty, the state machine transitions
+ *                           to REVOKE; if Assigning is not empty, it transitions to ASSIGNING;
+ *                           otherwise it transitions to STABLE.
+ * - REVOKE                - This state means that the member must revoke partitions before it can
+ *                           transition to the next epoch and thus start receiving new partitions.
+ *                           The member transitions to the next state only when it has acknowledged
+ *                           the revocation.
+ * - ASSIGNING             - This state means that the member waits on partitions which are still
+ *                           owned by other members in the group. It remains in this state until
+ *                           they are all freed up.
+ * - STABLE                - This state means that the member has received all its assigned partitions.
+ */
+public class CurrentAssignmentBuilder {
+    private final ConsumerGroupMember member;
+    private int targetAssignmentEpoch;
+    private MemberAssignment targetAssignment;
+    private BiFunction<Uuid, Integer, Integer> currentPartitionEpoch;
+    private List<ConsumerGroupHeartbeatRequestData.TopicPartitions> ownedTopicPartitions;
+
+    /**
+     * Constructs the CurrentAssignmentBuilder based on the current state of the
+     * provided consumer group member.
+     *
+     * @param member The consumer group member that must be reconciled.
+     */
+    public CurrentAssignmentBuilder(ConsumerGroupMember member) {
+        this.member = Objects.requireNonNull(member);
+    }
+
+    /**
+     * Sets the target assignment epoch and the target assignment that the
+     * consumer group member must be reconciled to.
+     *
+     * @param targetAssignmentEpoch The target assignment epoch.
+     * @param targetAssignment      The target assignment.
+     *
+     * @return This object.
+     */
+    public CurrentAssignmentBuilder withTargetAssignment(
+        int targetAssignmentEpoch,
+        MemberAssignment targetAssignment
+    ) {
+        this.targetAssignmentEpoch = targetAssignmentEpoch;
+        this.targetAssignment = Objects.requireNonNull(targetAssignment);
+        return this;
+    }
+
+    /**
+     * Sets a BiFunction which allows to retrieve the current epoch of a
+     * partition. This is used by the state machine to determine if a
+     * partition is free or still used by another member.
+     *
+     * @param currentPartitionEpoch A BiFunction which gets the epoch of a
+     *                              topic id / partitions id pair.
+     *
+     * @return This object.
+     */
+    public CurrentAssignmentBuilder withCurrentPartitionEpoch(
+        BiFunction<Uuid, Integer, Integer> currentPartitionEpoch
+    ) {
+        this.currentPartitionEpoch = Objects.requireNonNull(currentPartitionEpoch);
+        return this;
+    }
+
+    /**
+     * Sets the partitions currently owned by the member. This comes directly
+     * from the last ConsumerGroupHeartbeat request. This is used to determine
+     * if the member has revoked the necessary partitions.
+     *
+     * @param ownedTopicPartitions A list of topic-partitions.
+     *
+     * @return This object.
+     */
+    public CurrentAssignmentBuilder withOwnedTopicPartitions(
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> ownedTopicPartitions
+    ) {
+        this.ownedTopicPartitions = ownedTopicPartitions;
+        return this;
+    }
+
+    /**
+     * Builds the next state for the member or keep the current one if it
+     * is not possible to move forward with the current state.
+     *
+     * @return A new ConsumerGroupMember or the current one.
+     */
+    public ConsumerGroupMember build() {
+        // A new target assignment has been installed, we need to restart
+        // the reconciliation loop from the beginning.
+        if (targetAssignmentEpoch != member.nextMemberEpoch()) {
+            return transitionToInitialState();
+        }
+
+        switch (member.state()) {
+            // Check if the partitions have been revoked by the member.
+            case REVOKING:
+                return maybeTransitionFromRevokingToAssigningOrStable();
+
+            // Check if pending partitions have been freed up.
+            case ASSIGNING:
+                return maybeTransitionFromAssigningToAssigningOrStable();
+
+            // Nothing to do.
+            case STABLE:
+                return member;
+        }
+
+        return member;
+    }
+
+    /**
+     * Transitions to the initial state. Here we compute the Assigned,
+     * Revoking and Assigning sets.
+     *
+     * TODO Add details here.
+     *
+     * @return A new ConsumerGroupMember.
+     */
+    private ConsumerGroupMember transitionToInitialState() {
+        Map<Uuid, Set<Integer>> newAssignedSet = new HashMap<>();
+        Map<Uuid, Set<Integer>> newRevokingSet = new HashMap<>();
+        Map<Uuid, Set<Integer>> newAssigningSet = new HashMap<>();
+
+        // Compute the combined set of topics.
+        Set<Uuid> allTopicIds = new HashSet<>(targetAssignment.partitions().keySet());
+        allTopicIds.addAll(member.assigned().keySet());
+        allTopicIds.addAll(member.revoking().keySet());
+        allTopicIds.addAll(member.assigning().keySet());
+
+        for (Uuid topicId : allTopicIds) {
+            Set<Integer> target = targetAssignment.partitions().getOrDefault(topicId, Collections.emptySet());
+            Set<Integer> currentAssignedPartitions = member.assigned().getOrDefault(topicId, Collections.emptySet());
+            Set<Integer> currentRevokingPartitions = member.revoking().getOrDefault(topicId, Collections.emptySet());
+
+            // Assigned_1 = (Assigned_0 + Revoking_0) /\ Target
+            Set<Integer> newAssignedPartitions = new HashSet<>(currentAssignedPartitions);
+            newAssignedPartitions.addAll(currentRevokingPartitions);
+            newAssignedPartitions.retainAll(target);
+
+            // Revoking_1 = (Assigned_0 + Revoking_0) - Assigned_1
+            Set<Integer> newRevokingPartitions = new HashSet<>(currentAssignedPartitions);
+            newRevokingPartitions.addAll(currentRevokingPartitions);
+            newRevokingPartitions.removeAll(newAssignedPartitions);
+
+            // Assigning_1 = Target - Assigned_1
+            Set<Integer> newAssigningPartitions = new HashSet<>(target);
+            newAssigningPartitions.removeAll(newAssignedPartitions);
+
+            if (!newAssignedPartitions.isEmpty()) {
+                newAssignedSet.put(topicId, newAssignedPartitions);
+            }
+
+            if (!newRevokingPartitions.isEmpty()) {
+                newRevokingSet.put(topicId, newRevokingPartitions);
+            }
+
+            if (!newAssigningPartitions.isEmpty()) {
+                newAssigningSet.put(topicId, newAssigningPartitions);
+            }
+        }
+
+        if (!newRevokingSet.isEmpty()) {
+            // If the revoking set is not empty, we transition to Revoking and we
+            // stay in the current epoch.
+            return new ConsumerGroupMember.Builder(member)
+                .setAssigned(newAssignedSet)
+                .setRevoking(newRevokingSet)
+                .setAssigning(newAssigningSet)
+                .setNextMemberEpoch(targetAssignmentEpoch)
+                .build();
+        } else {
+            if (!newAssigningSet.isEmpty()) {
+                // If the assigning set is not empty, we check if some or all
+                // partitions are free to use. If they are, we move them to
+                // the assigned set.
+                maybeAssignPendingPartitions(newAssignedSet, newAssigningSet);
+            }
+
+            // We transition to the target epoch. If the assigning set is empty,
+            // the member transition to stable, otherwise to assigning.
+            return new ConsumerGroupMember.Builder(member)
+                .setAssigned(newAssignedSet)
+                .setRevoking(Collections.emptyMap())
+                .setAssigning(newAssigningSet)
+                .setPreviousMemberEpoch(member.memberEpoch())
+                .setMemberEpoch(targetAssignmentEpoch)
+                .setNextMemberEpoch(targetAssignmentEpoch)
+                .build();
+        }
+    }
+
+    /**
+     * Tries to transition from Revoke to Assigning or Stable. This is only
+     * possible when the member acknowledges that it only owns the partition
+     * in the Assigned set.
+     *
+     * @return A new ConsumerGroupMember with the new state or the current one
+     *         if the member stays in the current state.
+     */
+    private ConsumerGroupMember maybeTransitionFromRevokingToAssigningOrStable() {
+        if (member.revoking().isEmpty() || hasRevokedAllPartitions(ownedTopicPartitions)) {
+            Map<Uuid, Set<Integer>> newAssignedSet = deepCopy(member.assigned());
+            Map<Uuid, Set<Integer>> newAssigningSet = deepCopy(member.assigning());
+
+            if (!newAssigningSet.isEmpty()) {
+                // If the assigning set is not empty, we check if some or all
+                // partitions are free to use. If they are, we move them to
+                // the assigned set.
+                maybeAssignPendingPartitions(newAssignedSet, newAssigningSet);
+            }
+
+            // We transition to the target epoch. If the assigning set is empty,
+            // the member transition to stable, otherwise to assigning.
+            return new ConsumerGroupMember.Builder(member)
+                .setAssigned(newAssignedSet)
+                .setRevoking(Collections.emptyMap())
+                .setAssigning(newAssigningSet)
+                .setPreviousMemberEpoch(member.memberEpoch())
+                .setMemberEpoch(targetAssignmentEpoch)
+                .setNextMemberEpoch(targetAssignmentEpoch)
+                .build();
+        } else {
+            return member;
+        }
+    }
+
+    /**
+     * Tries to transition from Assigning to Assigning or Stable. This is only
+     * possible when one or more partitions in the Assigning set have been freed
+     * up by other members in the group.
+     *
+     * @return A new ConsumerGroupMember with the new state or the current one
+     *         if the member stays in the current state.
+     */
+    private ConsumerGroupMember maybeTransitionFromAssigningToAssigningOrStable() {
+        Map<Uuid, Set<Integer>> newAssignedSet = deepCopy(member.assigned());
+        Map<Uuid, Set<Integer>> newAssigningSet = deepCopy(member.assigning());
+
+        // If any partition can transition from assigning to assigned, we update
+        // the member. Otherwise, we return the current one.
+        if (maybeAssignPendingPartitions(newAssignedSet, newAssigningSet)) {
+            return new ConsumerGroupMember.Builder(member)
+                .setAssigned(newAssignedSet)
+                .setRevoking(Collections.emptyMap())
+                .setAssigning(newAssigningSet)
+                .setPreviousMemberEpoch(member.memberEpoch())
+                .setMemberEpoch(targetAssignmentEpoch)
+                .setNextMemberEpoch(targetAssignmentEpoch)
+                .build();
+        } else {
+            return member;
+        }
+    }
+
+    /**
+     * Makes a deep copy of an assignment map.
+     *
+     * @param map The Map to copy.
+     *
+     * @return The copy.
+     */
+    private Map<Uuid, Set<Integer>> deepCopy(Map<Uuid, Set<Integer>> map) {
+        Map<Uuid, Set<Integer>> copy = new HashMap<>();
+        map.forEach((topicId, partitions) -> {
+            copy.put(topicId, new HashSet<>(partitions));
+        });
+        return copy;
+    }
+
+    /**
+     * Tries to move partitions from the Assigning set to the Assigned set
+     * if they are no longer owned.
+     *
+     * @param newAssignedSet  The Assigned set.
+     * @param newAssigningSet The Assigning set.
+     *
+     * @return A boolean indicating if any partitions were moved.
+     */
+    private boolean maybeAssignPendingPartitions(
+        Map<Uuid, Set<Integer>> newAssignedSet,
+        Map<Uuid, Set<Integer>> newAssigningSet
+    ) {
+        boolean changed = false;
+
+        Iterator<Map.Entry<Uuid, Set<Integer>>> assigningSetIterator = newAssigningSet.entrySet().iterator();
+        while (assigningSetIterator.hasNext()) {
+            Map.Entry<Uuid, Set<Integer>> pair = assigningSetIterator.next();
+            Uuid topicId = pair.getKey();
+            Set<Integer> assigning = pair.getValue();
+            Iterator<Integer> assigningIterator = assigning.iterator();
+            while (assigningIterator.hasNext()) {
+                Integer partitionId = assigningIterator.next();
+                Integer partitionEpoch = currentPartitionEpoch.apply(topicId, partitionId);
+                if (partitionEpoch == -1) {
+                    assigningIterator.remove();
+                    put(newAssignedSet, topicId, partitionId);
+                    changed = true;
+                }
+            }
+            if (assigning.isEmpty()) {
+                assigningSetIterator.remove();
+            }
+        }
+
+        return changed;
+    }
+
+    /**
+     * Checks whether the owned topic partitions passed by the member to the state
+     * machine via the ConsumerGroupHeartbeat request corresponds to the Assigned
+     * set.
+     *
+     * @param ownedTopicPartitions The topic partitions owned by the remove client.
+     *
+     * @return A boolean indicating if the owned partitions matches the Assigned set.
+     */
+    private boolean hasRevokedAllPartitions(
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> ownedTopicPartitions
+    ) {
+        if (ownedTopicPartitions == null) return false;
+        if (ownedTopicPartitions.size() != member.assigned().size()) return false;
+
+        for (ConsumerGroupHeartbeatRequestData.TopicPartitions topicPartitions : ownedTopicPartitions) {
+            Set<Integer> partitions = member.assigned().get(topicPartitions.topicId());
+            if (partitions == null) return false;
+            for (Integer partitionId : topicPartitions.partitions()) {
+                if (!partitions.contains(partitionId)) return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Puts the given TopicId and Partitions to the given map.
+     */
+    private void put(Map<Uuid, Set<Integer>> map, Uuid topicId, Integer partitionId) {
+        map.compute(topicId, (__, partitionsOrNull) -> {
+            if (partitionsOrNull == null) partitionsOrNull = new HashSet<>();
+            partitionsOrNull.add(partitionId);
+            return partitionsOrNull;
+        });
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/MemberAssignment.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/MemberAssignment.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MemberAssignment {
+    public static final MemberAssignment EMPTY = new MemberAssignment(
+        (byte) 0,
+        Collections.emptyMap(),
+        VersionedMetadata.EMPTY
+    );
+
+    private final byte error;
+
+    private final Map<Uuid, Set<Integer>> partitions;
+
+    private final VersionedMetadata metadata;
+
+    public MemberAssignment(
+        Map<Uuid, Set<Integer>> partitions
+    ) {
+        this(
+            (byte) 0,
+            partitions,
+            VersionedMetadata.EMPTY
+        );
+    }
+
+    public MemberAssignment(
+        byte error,
+        Map<Uuid, Set<Integer>> partitions,
+        VersionedMetadata metadata
+    ) {
+        this.error = error;
+        this.partitions = Collections.unmodifiableMap(Objects.requireNonNull(partitions));
+        this.metadata = Objects.requireNonNull(metadata);
+    }
+
+    public byte error() {
+        return error;
+    }
+
+    public Map<Uuid, Set<Integer>> partitions() {
+        return partitions;
+    }
+
+    public VersionedMetadata metadata() {
+        return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MemberAssignment that = (MemberAssignment) o;
+
+        if (error != that.error) return false;
+        if (!partitions.equals(that.partitions)) return false;
+        return metadata.equals(that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = error;
+        result = 31 * result + partitions.hashCode();
+        result = 31 * result + metadata.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MemberAssignment(" +
+            "error=" + error +
+            ", partitions=" + partitions +
+            ", metadata=" + metadata +
+            ')';
+    }
+
+    public static MemberAssignment fromRecord(
+        ConsumerGroupTargetAssignmentMemberValue record
+    ) {
+        return new MemberAssignment(
+            record.error(),
+            record.topicPartitions().stream().collect(Collectors.toMap(
+                ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId,
+                topicPartitions -> new HashSet<>(topicPartitions.partitions()))),
+            new VersionedMetadata(
+                record.metadataVersion(),
+                ByteBuffer.wrap(record.metadataBytes()))
+        );
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.assignor.AssignmentMemberSpec;
+import org.apache.kafka.coordinator.group.assignor.AssignmentSpec;
+import org.apache.kafka.coordinator.group.assignor.AssignmentTopicMetadata;
+import org.apache.kafka.coordinator.group.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentRecord;
+
+/**
+ * Build a new Target Assignment based on the provided parameters. As a result,
+ * it yields the records that must be persisted to the log and the new member
+ * assignments as a map.
+ *
+ * Records are only created for members which have a new target assignment. If
+ * their assignment did not change, no new record is needed.
+ *
+ * When a member is deleted, it is assumed that its target assignment record
+ * is deleted as part of the member deletion process. In other words, this class
+ * does not yield a tombstone for remove members.
+ */
+public class TargetAssignmentBuilder {
+    public static class TargetAssignmentResult {
+        private final List<org.apache.kafka.coordinator.group.Record> records;
+        private final Map<String, MemberAssignment> assignments;
+
+        TargetAssignmentResult(
+            List<org.apache.kafka.coordinator.group.Record> records,
+            Map<String, MemberAssignment> assignments
+        ) {
+            Objects.requireNonNull(records);
+            Objects.requireNonNull(assignments);
+            this.records = records;
+            this.assignments = assignments;
+        }
+
+        public List<org.apache.kafka.coordinator.group.Record> records() {
+            return records;
+        }
+
+        public Map<String, MemberAssignment> assignments() {
+            return assignments;
+        }
+    }
+
+    private final String groupId;
+    private final int groupEpoch;
+    private final PartitionAssignor assignor;
+    private Map<String, ConsumerGroupMember> members = Collections.emptyMap();
+    private Map<String, TopicMetadata> subscriptionMetadata = Collections.emptyMap();
+    private Map<String, MemberAssignment> assignments = Collections.emptyMap();
+    private Map<String, ConsumerGroupMember> updatedMembers = new HashMap<>();
+
+    /**
+     * Instanciates the object.
+     *
+     * @param groupId       The group id.
+     * @param groupEpoch    The group epoch to compute a target assignment for.
+     * @param assignor      The assignor to use to compute the target assignment.
+     */
+    public TargetAssignmentBuilder(
+        String groupId,
+        int groupEpoch,
+        PartitionAssignor assignor
+    ) {
+        this.groupId = Objects.requireNonNull(groupId);
+        this.groupEpoch = groupEpoch;
+        this.assignor = Objects.requireNonNull(assignor);
+    }
+
+    /**
+     * Adds all the current members.
+     *
+     * @param members   The current members in the consumer groups.
+     *
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withMembers(
+        Map<String, ConsumerGroupMember> members
+    ) {
+        this.members = members;
+        return this;
+    }
+
+    /**
+     * Adds the subscription metadata to use.
+     *
+     * @param subscriptionMetadata  The subscription metadata.
+     *
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withSubscriptionMetadata(
+        Map<String, TopicMetadata> subscriptionMetadata
+    ) {
+        this.subscriptionMetadata = subscriptionMetadata;
+        return this;
+    }
+
+    /**
+     * Adds the current target assignments.
+     *
+     * @param assignments   The current assignments.
+     *
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withTargetAssignments(
+        Map<String, MemberAssignment> assignments
+    ) {
+        this.assignments = assignments;
+        return this;
+    }
+
+    /**
+     * Updates a member. This is useful when the updated member is
+     * not yet materialized in memory.
+     *
+     * @param memberId      The member id.
+     * @param updatedMember The updated member.
+     *
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withUpdatedMember(
+        String memberId,
+        ConsumerGroupMember updatedMember
+    ) {
+        this.updatedMembers.put(memberId, updatedMember);
+        return this;
+    }
+
+    /**
+     * Removes a member. This is useful when the removed member
+     * is not yet materialized in memory.
+     *
+     * @param memberId The member id.
+     *
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withRemoveMembers(
+        String memberId
+    ) {
+        return withUpdatedMember(memberId, null);
+    }
+
+    /**
+     * Builds the new target assignment.
+     *
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the current target assignment.
+     * @throws PartitionAssignorException
+     */
+    public TargetAssignmentResult build() throws PartitionAssignorException {
+        Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
+        members.forEach((memberId, member) -> addMemberSpec(
+            memberSpecs,
+            member,
+            assignments.getOrDefault(memberId, MemberAssignment.EMPTY)
+        ));
+
+        updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+            if (updatedMemberOrNull == null) {
+                memberSpecs.remove(memberId);
+            } else {
+                addMemberSpec(
+                    memberSpecs,
+                    updatedMemberOrNull,
+                    assignments.getOrDefault(memberId, MemberAssignment.EMPTY)
+                );
+            }
+        });
+
+        Map<Uuid, AssignmentTopicMetadata> topics = new HashMap<>();
+        subscriptionMetadata.forEach((topicName, topicMetadata) ->
+            topics.put(topicMetadata.id(), new AssignmentTopicMetadata(topicMetadata.numPartitions()))
+        );
+
+        // Compute the assignment.
+        GroupAssignment newGroupAssignment = assignor.assign(new AssignmentSpec(
+            Collections.unmodifiableMap(memberSpecs),
+            Collections.unmodifiableMap(topics)
+        ));
+
+        List<org.apache.kafka.coordinator.group.Record> records = new ArrayList<>();
+        Map<String, MemberAssignment> newTargetAssignment = new HashMap<>();
+
+        // Compute delta from previous to new assignment and create the
+        // relevant records.
+        memberSpecs.keySet().forEach(memberId -> {
+            MemberAssignment oldMemberAssignment = assignments.get(memberId);
+            MemberAssignment newMemberAssignment = newMemberAssignment(newGroupAssignment, memberId);
+
+            newTargetAssignment.put(memberId, newMemberAssignment);
+
+            if (oldMemberAssignment == null) {
+                // If the member had no assignment, we always create a record for him.
+                records.add(newTargetAssignmentRecord(
+                    groupId,
+                    memberId,
+                    newMemberAssignment.partitions()
+                ));
+            } else {
+                // If the member had an assignment, we only create a record if the
+                // new assignment is different.
+                if (!newMemberAssignment.equals(oldMemberAssignment)) {
+                    records.add(newTargetAssignmentRecord(
+                        groupId,
+                        memberId,
+                        newMemberAssignment.partitions()
+                    ));
+                }
+            }
+        });
+
+        // Bump the assignment epoch.
+        records.add(newTargetAssignmentEpochRecord(groupId, groupEpoch));
+
+        return new TargetAssignmentResult(records, newTargetAssignment);
+    }
+
+    private MemberAssignment newMemberAssignment(
+        GroupAssignment newGroupAssignment,
+        String memberId
+    ) {
+        org.apache.kafka.coordinator.group.assignor.MemberAssignment newMemberAssignment = newGroupAssignment.members().get(memberId);
+        if (newMemberAssignment != null) {
+            return new MemberAssignment(newMemberAssignment.targetPartitions());
+        } else {
+            return MemberAssignment.EMPTY;
+        }
+    }
+
+    private void addMemberSpec(
+        Map<String, AssignmentMemberSpec> members,
+        ConsumerGroupMember member,
+        MemberAssignment targetAssignment
+    ) {
+        Set<Uuid> subscribedTopics = new HashSet<>();
+        member.subscribedTopicNames().forEach(topicName -> {
+            TopicMetadata topicMetadata = subscriptionMetadata.get(topicName);
+            if (topicMetadata != null) {
+                subscribedTopics.add(topicMetadata.id());
+            }
+        });
+
+        members.put(member.memberId(), new AssignmentMemberSpec(
+            Optional.ofNullable(member.instanceId()),
+            Optional.ofNullable(member.rackId()),
+            subscribedTopics,
+            targetAssignment.partitions()
+        ));
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TopicMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TopicMetadata.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+
+import java.util.Objects;
+
+public class TopicMetadata {
+
+    private final Uuid id;
+
+    private final String name;
+
+    private final int numPartitions;
+
+    public TopicMetadata(
+        Uuid id,
+        String name,
+        int numPartitions
+    ) {
+        this.id = Objects.requireNonNull(id);
+        this.name = Objects.requireNonNull(name);
+        this.numPartitions = numPartitions;
+    }
+
+    public Uuid id() {
+        return this.id;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public int numPartitions() {
+        return this.numPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TopicMetadata that = (TopicMetadata) o;
+
+        if (!id.equals(that.id)) return false;
+        if (!name.equals(that.name)) return false;
+        return numPartitions == that.numPartitions;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 31 * result + name.hashCode();
+        result = 31 * result + numPartitions;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopicMetadata(" +
+            "id=" + id +
+            ", name=" + name +
+            ", numPartitions=" + numPartitions +
+            ')';
+    }
+
+    public static TopicMetadata fromRecord(
+        ConsumerGroupPartitionMetadataValue.TopicMetadata record
+    ) {
+        return new TopicMetadata(
+            record.topicId(),
+            record.topicName(),
+            record.numPartitions()
+        );
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/VersionedMetadata.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/VersionedMetadata.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Immutable versioned metadata.
+ */
+public class VersionedMetadata {
+    public static final VersionedMetadata EMPTY = new VersionedMetadata((short) 0, ByteBuffer.allocate(0));
+
+    private final short version;
+    private final ByteBuffer metadata;
+
+    public VersionedMetadata(
+        short version,
+        ByteBuffer metadata
+    ) {
+        this.version = version;
+        this.metadata = Objects.requireNonNull(metadata);
+    }
+
+    public short version() {
+        return this.version;
+    }
+
+    public ByteBuffer metadata() {
+        return this.metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        VersionedMetadata that = (VersionedMetadata) o;
+
+        if (version != that.version) return false;
+        return metadata.equals(that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = version;
+        result = 31 * result + metadata.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "VersionedMetadata(" +
+            "version=" + version +
+            ", metadata=" + metadata +
+            ')';
+    }
+}

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupCurrentMemberAssignmentValue.json
@@ -22,16 +22,29 @@
   "fields": [
     { "name": "MemberEpoch", "versions": "0+", "type": "int32",
       "about": "The member epoch." },
+    { "name": "PreviousMemberEpoch", "versions": "0+", "type": "int32",
+      "about": "The previous member epoch." },
+    { "name": "TargetMemberEpoch", "versions": "0+", "type": "int32",
+      "about": "The target member epoch." },
+    { "name": "Assigned", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions assigned to this member." },
+    { "name": "Revoking", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions being revoked by this member." },
+    { "name": "Assigning", "versions": "0+", "type": "[]TopicPartitions",
+      "about": "The partitions being assigned to this member." },
     { "name": "Error", "versions": "0+", "type": "int8",
       "about": "The error reported by the assignor." },
-    { "name": "TopicPartitions", "versions": "0+", "type": "[]TopicPartition",
-      "about": "The partitions assigned to this member.", "fields": [
-      { "name": "TopicId", "versions": "0+", "type": "uuid" },
-      { "name": "Partitions", "versions": "0+", "type": "[]int32" }
-    ]},
     { "name": "MetadataVersion", "versions": "0+", "type": "int16",
       "about": "The version of the metadata bytes." },
     { "name": "MetadataBytes", "versions": "0+", "type": "bytes",
       "about": "The metadata bytes." }
+  ],
+  "commonStructs": [
+    { "name": "TopicPartitions", "versions": "0+", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic ID." },
+      { "name": "Partitions", "type": "[]int32", "versions": "0+",
+        "about": "The partitions." }
+    ]}
   ]
 }

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMemberMetadataValue.json
@@ -20,8 +20,6 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "GroupEpoch", "versions": "0+", "type": "int32",
-      "about": "The group epoch." },
     { "name": "InstanceId", "versions": "0+", "nullableVersions": "0+", "type": "string",
       "about": "The (optional) instance id." },
     { "name": "RackId", "versions": "0+", "nullableVersions": "0+", "type": "string",
@@ -34,6 +32,10 @@
       "about": "The list of subscribed topic names." },
     { "name": "SubscribedTopicRegex", "versions": "0+", "nullableVersions": "0+", "type": "string",
       "about": "The subscribed topic regular expression." },
+    { "name": "RebalanceTimeoutMs", "type": "int32", "versions": "0+", "default": -1,
+      "about": "The rebalance timeout" },
+    { "name": "ServerAssignor", "versions": "0+", "nullableVersions": "0+", "type": "string",
+      "about": "The server assignor to use; or null if not used." },
     { "name": "Assignors", "versions": "0+", "type": "[]Assignor",
       "about": "The list of assignors.", "fields": [
       { "name": "Name", "versions": "0+", "type": "string",

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataValue.json
@@ -26,6 +26,8 @@
       "about": "The list of topic metadata.", "fields": [
       { "name": "TopicId", "versions": "0+", "type": "uuid",
         "about": "The topic id." },
+      { "name": "TopicName", "versions": "0+", "type": "string",
+        "about": "The topic name." },
       { "name": "NumPartitions", "versions": "0+", "type": "int32",
         "about": "The number of partitions of the topic." }
     ]}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1,0 +1,2068 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.FencedMemberEpochException;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
+import org.apache.kafka.common.errors.GroupMaxSizeReachedException;
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnsupportedAssignorException;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.common.metadata.TopicRecord;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.assignor.AssignmentSpec;
+import org.apache.kafka.coordinator.group.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.MemberAssignment;
+import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsDelta;
+import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.timeline.SnapshotRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GroupMetadataManagerTest {
+    static class MockPartitionAssignor implements PartitionAssignor {
+        private final String name;
+        private AssignmentSpec lastSpecReceived = null;
+        private GroupAssignment prepareGroupAssignment = null;
+
+        MockPartitionAssignor(String name) {
+            this.name = name;
+        }
+
+        public AssignmentSpec lastSpecReceived() {
+            return lastSpecReceived;
+        }
+
+        public void prepareGroupAssignment(GroupAssignment prepareGroupAssignment) {
+            this.prepareGroupAssignment = prepareGroupAssignment;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public GroupAssignment assign(AssignmentSpec assignmentSpec) throws PartitionAssignorException {
+            lastSpecReceived = assignmentSpec;
+            return prepareGroupAssignment;
+        }
+    }
+
+    public static class TopicsImageBuilder {
+        private TopicsDelta delta = new TopicsDelta(TopicsImage.EMPTY);
+
+        public TopicsImageBuilder addTopic(
+            Uuid topicId,
+            String topicName,
+            int numPartitions
+        ) {
+            delta.replay(new TopicRecord().setTopicId(topicId).setName(topicName));
+            for (int i = 0; i < numPartitions; i++) {
+                delta.replay(new PartitionRecord()
+                    .setTopicId(topicId)
+                    .setPartitionId(i));
+            }
+            return this;
+        }
+
+        public TopicsImage build() {
+            return delta.apply();
+        }
+    }
+
+    static class ConsumerGroupBuilder {
+        private final String groupId;
+        private final int groupEpoch;
+        private int assignmentEpoch;
+        private final Map<String, ConsumerGroupMember> members = new HashMap<>();
+        private final Map<String, MemberAssignment> assignments = new HashMap<>();
+
+        public ConsumerGroupBuilder(String groupId, int groupEpoch) {
+            this.groupId = groupId;
+            this.groupEpoch = groupEpoch;
+            this.assignmentEpoch = 0;
+        }
+
+        public ConsumerGroupBuilder withMember(ConsumerGroupMember member) {
+            this.members.put(member.memberId(), member);
+            return this;
+        }
+
+        public ConsumerGroupBuilder withAssignment(String memberId, Map<Uuid, Set<Integer>> assignment) {
+            this.assignments.put(memberId, new MemberAssignment(assignment));
+            return this;
+        }
+
+        public ConsumerGroupBuilder withAssignment(String memberId, MemberAssignment assignment) {
+            this.assignments.put(memberId, assignment);
+            return this;
+        }
+
+        public ConsumerGroupBuilder withAssignmentEpoch(int assignmentEpoch) {
+            this.assignmentEpoch = assignmentEpoch;
+            return this;
+        }
+
+        public List<Record> build(TopicsImage topicsImage) {
+            List<Record> records = new ArrayList<>();
+
+            // Add subscription records for members.
+            members.forEach((memberId, member) -> {
+                records.add(RecordHelpers.newMemberSubscriptionRecord(groupId, member));
+            });
+
+            // Add subscription metadata.
+            Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
+            members.forEach((memberId, member) -> {
+                member.subscribedTopicNames().forEach(topicName ->
+                    subscriptionMetadata.computeIfAbsent(topicName, __ -> {
+                        TopicImage topicImage = topicsImage.getTopic(topicName);
+                        if (topicImage == null) {
+                            return null;
+                        } else {
+                            return new TopicMetadata(
+                                topicImage.id(),
+                                topicImage.name(),
+                                topicImage.partitions().size()
+                            );
+                        }
+                    })
+                );
+            });
+            if (!subscriptionMetadata.isEmpty()) {
+                records.add(RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, subscriptionMetadata));
+            }
+
+            // Add group epoch record.
+            records.add(RecordHelpers.newGroupEpochRecord(groupId, groupEpoch));
+
+            // Add target assignment records.
+            assignments.forEach((memberId, assignment) -> {
+                records.add(RecordHelpers.newTargetAssignmentRecord(groupId, memberId, assignment.partitions()));
+            });
+
+            // Add target assignment epoch.
+            records.add(RecordHelpers.newTargetAssignmentEpochRecord(groupId, assignmentEpoch));
+
+            // Add current assignment records for members.
+            members.forEach((memberId, member) -> {
+                records.add(RecordHelpers.newCurrentAssignmentRecord(groupId, member));
+            });
+
+            return records;
+        }
+    }
+
+    static class GroupMetadataManagerTestContext {
+        static class Builder {
+            private LogContext logContext;
+            private SnapshotRegistry snapshotRegistry;
+            private TopicsImage topicsImage;
+            private List<PartitionAssignor> assignors;
+            private List<ConsumerGroupBuilder> consumerGroupBuilders = new ArrayList<>();
+            private int consumerGroupMaxSize = Integer.MAX_VALUE;
+
+            public Builder withLogContext(LogContext logContext) {
+                this.logContext = logContext;
+                return this;
+            }
+
+            public Builder withSnapshotRegistry(SnapshotRegistry snapshotRegistry) {
+                this.snapshotRegistry = snapshotRegistry;
+                return this;
+            }
+
+            public Builder withTopicsImage(TopicsImage topicsImage) {
+                this.topicsImage = topicsImage;
+                return this;
+            }
+
+            public Builder withAssignors(List<PartitionAssignor> assignors) {
+                this.assignors = assignors;
+                return this;
+            }
+
+            public Builder withConsumerGroup(ConsumerGroupBuilder builder) {
+                this.consumerGroupBuilders.add(builder);
+                return this;
+            }
+
+            public Builder withConsumerGroupMaxSize(int consumerGroupMaxSize) {
+                this.consumerGroupMaxSize = consumerGroupMaxSize;
+                return this;
+            }
+
+            public GroupMetadataManagerTestContext build() {
+                if (logContext == null) logContext = new LogContext();
+                if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
+                if (topicsImage == null) topicsImage = TopicsImage.EMPTY;
+                if (assignors == null) assignors = Collections.emptyList();
+
+                GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext(
+                    snapshotRegistry,
+                    new GroupMetadataManager.Builder()
+                        .withSnapshotRegistry(snapshotRegistry)
+                        .withLogContext(logContext)
+                        .withTopicsImage(topicsImage)
+                        .withConsumerGroupHeartbeatInterval(5000)
+                        .withConsumerGroupMaxSize(consumerGroupMaxSize)
+                        .withAssignors(assignors)
+                        .build()
+                );
+
+                consumerGroupBuilders.forEach(builder -> {
+                    builder.build(topicsImage).forEach(context::replay);
+                });
+
+                context.commit();
+
+                return context;
+            }
+        }
+
+        final SnapshotRegistry snapshotRegistry;
+        final GroupMetadataManager groupMetadataManager;
+
+        long lastCommittedOffset = 0L;
+        long lastWrittenOffset = 0L;
+
+        public GroupMetadataManagerTestContext(
+            SnapshotRegistry snapshotRegistry,
+            GroupMetadataManager groupMetadataManager
+        ) {
+            this.snapshotRegistry = snapshotRegistry;
+            this.groupMetadataManager = groupMetadataManager;
+        }
+
+        public void commit() {
+            long lastCommittedOffset = this.lastCommittedOffset;
+            this.lastCommittedOffset = lastWrittenOffset;
+            snapshotRegistry.deleteSnapshotsUpTo(lastCommittedOffset);
+        }
+
+        public void rollback() {
+            lastWrittenOffset = lastCommittedOffset;
+            snapshotRegistry.revertToSnapshot(lastCommittedOffset);
+        }
+
+        public ConsumerGroup.ConsumerGroupState consumerGroupState(
+            String groupId
+        ) {
+            return groupMetadataManager
+                .getOrMaybeCreateConsumerGroup(groupId, false)
+                .state();
+        }
+
+        public ConsumerGroupMember.MemberState consumerGroupMemberState(
+            String groupId,
+            String memberId
+        ) {
+            return groupMetadataManager
+                .getOrMaybeCreateConsumerGroup(groupId, false)
+                .getOrMaybeCreateMember(memberId, false)
+                .state();
+        }
+
+        public Result<ConsumerGroupHeartbeatResponseData> consumerGroupHeartbeat(
+            ConsumerGroupHeartbeatRequestData request
+        ) {
+            snapshotRegistry.getOrCreateSnapshot(lastCommittedOffset);
+
+            RequestContext context = new RequestContext(
+                new RequestHeader(
+                    ApiKeys.CONSUMER_GROUP_HEARTBEAT,
+                    ApiKeys.CONSUMER_GROUP_HEARTBEAT.latestVersion(),
+                    "client",
+                    0
+                ),
+                "1",
+                InetAddress.getLoopbackAddress(),
+                KafkaPrincipal.ANONYMOUS,
+                ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+                SecurityProtocol.PLAINTEXT,
+                ClientInformation.EMPTY,
+                false
+            );
+
+            Result<ConsumerGroupHeartbeatResponseData> result = groupMetadataManager.consumerGroupHeartbeat(
+                context,
+                request
+            );
+
+            result.records().forEach(this::replay);
+            return result;
+        }
+
+        private ApiMessage messageOrNull(ApiMessageAndVersion apiMessageAndVersion) {
+            if (apiMessageAndVersion == null) {
+                return null;
+            } else {
+                return apiMessageAndVersion.message();
+            }
+        }
+
+        private void replay(
+            Record record
+        ) {
+            ApiMessageAndVersion key = record.key();
+            ApiMessageAndVersion value = record.value();
+
+            if (key == null) {
+                throw new IllegalStateException("Received a null key in " + record);
+            }
+
+            switch (key.version()) {
+                case ConsumerGroupMemberMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                    groupMetadataManager.replay(
+                        (ConsumerGroupMemberMetadataKey) key.message(),
+                        (ConsumerGroupMemberMetadataValue) messageOrNull(value)
+                    );
+                    break;
+
+                case ConsumerGroupMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                    groupMetadataManager.replay(
+                        (ConsumerGroupMetadataKey) key.message(),
+                        (ConsumerGroupMetadataValue) messageOrNull(value)
+                    );
+                    break;
+
+                case ConsumerGroupPartitionMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                    groupMetadataManager.replay(
+                        (ConsumerGroupPartitionMetadataKey) key.message(),
+                        (ConsumerGroupPartitionMetadataValue) messageOrNull(value)
+                    );
+                    break;
+
+                case ConsumerGroupTargetAssignmentMemberKey.HIGHEST_SUPPORTED_VERSION:
+                    groupMetadataManager.replay(
+                        (ConsumerGroupTargetAssignmentMemberKey) key.message(),
+                        (ConsumerGroupTargetAssignmentMemberValue) messageOrNull(value)
+                    );
+                    break;
+
+                case ConsumerGroupTargetAssignmentMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                    groupMetadataManager.replay(
+                        (ConsumerGroupTargetAssignmentMetadataKey) key.message(),
+                        (ConsumerGroupTargetAssignmentMetadataValue) messageOrNull(value)
+                    );
+                    break;
+
+                case ConsumerGroupCurrentMemberAssignmentKey.HIGHEST_SUPPORTED_VERSION:
+                    groupMetadataManager.replay(
+                        (ConsumerGroupCurrentMemberAssignmentKey) key.message(),
+                        (ConsumerGroupCurrentMemberAssignmentValue) messageOrNull(value)
+                    );
+                    break;
+
+                default:
+                    throw new IllegalStateException("Received an unknown record type " + key.version()
+                        + " in " + record);
+            }
+
+            lastWrittenOffset++;
+        }
+    }
+
+    @Test
+    public void testConsumerHeartbeatRequestValidation() {
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .build();
+        Exception ex;
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()));
+        assertEquals("GroupId can't be empty.", ex.getMessage());
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberEpoch(0)));
+        assertEquals("RebalanceTimeoutMs must be provided in first request.", ex.getMessage());
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)));
+        assertEquals("TopicPartitions must be empty when (re-)joining.", ex.getMessage());
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setTopicPartitions(Collections.emptyList())));
+        assertEquals("SubscribedTopicNames must be set in first request.", ex.getMessage());
+
+        ex = assertThrows(UnsupportedAssignorException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setTopicPartitions(Collections.emptyList())
+                .setSubscribedTopicNames(Collections.singletonList("foo"))
+                .setServerAssignor("bar")));
+        assertEquals("ServerAssignor bar is not supported. Supported assignors: range.", ex.getMessage());
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberEpoch(1)));
+        assertEquals("MemberId can't be empty.", ex.getMessage());
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberId(Uuid.randomUuid().toString())
+                .setMemberEpoch(1)
+                .setInstanceId("instance-id")));
+        assertEquals("InstanceId should only be provided in first request.", ex.getMessage());
+
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("foo")
+                .setMemberId(Uuid.randomUuid().toString())
+                .setMemberEpoch(1)
+                .setRackId("rack-id")));
+        assertEquals("RackId should only be provided in first request.", ex.getMessage());
+    }
+
+    @Test
+    public void testMemberIdGeneration() {
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(TopicsImage.EMPTY)
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Collections.emptyMap()
+        ));
+
+        Result<ConsumerGroupHeartbeatResponseData> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("group-foo")
+                .setMemberEpoch(0)
+                .setServerAssignor("range")
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
+
+        // Verify that a member id was generated for the new member.
+        String memberId = result.response().memberId();
+        assertNotNull(memberId);
+        assertNotEquals("", memberId);
+
+        // The response should get a bumped epoch and should not
+        // contain any assignment because we did not provide
+        // topics metadata.
+        assertEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(1)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()),
+            result.response()
+        );
+    }
+
+    @Test
+    public void testUnknownGroupId() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .build();
+
+        assertThrows(GroupIdNotFoundException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setMemberEpoch(100) // Epoch must be > 0.
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testUnknownMemberIdJoinsConsumerGroup() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(Collections.emptyMap()));
+
+        // A first member joins to create the group.
+        context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setServerAssignor("range")
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
+
+        // The second member is rejected because the member id is unknown and
+        // the member epoch is not zero.
+        assertThrows(UnknownMemberIdException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(Uuid.randomUuid().toString())
+                    .setMemberEpoch(1)
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testConsumerGroupMemberEpochValidation() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+        Uuid fooTopicId = Uuid.randomUuid();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .build();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder(memberId)
+            .setMemberEpoch(100)
+            .setPreviousMemberEpoch(99)
+            .setNextMemberEpoch(100)
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssigned(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2, 3)))
+            .build();
+
+        context.replay(RecordHelpers.newMemberSubscriptionRecord(groupId, member));
+
+        context.replay(RecordHelpers.newGroupEpochRecord(groupId, 100));
+
+        context.replay(RecordHelpers.newTargetAssignmentRecord(groupId, memberId, mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3)
+        )));
+
+        context.replay(RecordHelpers.newTargetAssignmentEpochRecord(groupId, 100));
+
+        context.replay(RecordHelpers.newCurrentAssignmentRecord(groupId, member));
+
+        // Member epoch is greater than the expected epoch.
+        assertThrows(NotCoordinatorException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setMemberEpoch(200)
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))));
+
+        // Member epoch is smaller than the expected epoch.
+        assertThrows(FencedMemberEpochException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setMemberEpoch(50)
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))));
+
+        // Member joins with previous epoch but without providing partitions.
+        assertThrows(FencedMemberEpochException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setMemberEpoch(99)
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))));
+
+        // Member joins with previous epoch and has a subset of the owned partitions. This
+        // is accepted as the response with the bumped epoch may have been lost. In this
+        // case, we provide back the correct epoch to the member.
+        Result<ConsumerGroupHeartbeatResponseData> result = context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setMemberEpoch(99)
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setTopicPartitions(Collections.singletonList(new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                        .setTopicId(fooTopicId)
+                        .setPartitions(Arrays.asList(1, 2)))));
+        assertEquals(100, result.response().memberEpoch());
+    }
+
+    @Test
+    public void testMemberJoinsEmptyConsumerGroup() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Collections.singletonMap(memberId, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )))
+        ));
+
+        assertThrows(GroupIdNotFoundException.class, () ->
+            context.groupMetadataManager.getOrMaybeCreateConsumerGroup(groupId, false));
+
+        Result<ConsumerGroupHeartbeatResponseData> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setServerAssignor("range")
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(1)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(0, 1, 2, 3, 4, 5)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(0, 1, 2))
+                    ))),
+            result.response()
+        );
+
+        ConsumerGroupMember expectedMember = new ConsumerGroupMember.Builder(memberId)
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setNextMemberEpoch(1)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setRebalanceTimeoutMs(5000)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)))
+            .build();
+
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newMemberSubscriptionRecord(groupId, expectedMember),
+            RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {{
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3));
+                }}),
+            RecordHelpers.newGroupEpochRecord(groupId, 1),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId, mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )),
+            RecordHelpers.newTargetAssignmentEpochRecord(groupId, 1),
+            RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember)
+        );
+
+        assertEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testUpdatingSubscriptionTriggersNewTargetAssignment() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)))
+                    .build())
+                .withAssignment(memberId, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Collections.singletonMap(memberId, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )))
+        ));
+
+        Result<ConsumerGroupHeartbeatResponseData> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(10)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar")));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(0, 1, 2, 3, 4, 5)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(0, 1, 2))
+                    ))),
+            result.response()
+        );
+
+        ConsumerGroupMember expectedMember = new ConsumerGroupMember.Builder(memberId)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)))
+            .build();
+
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newMemberSubscriptionRecord(groupId, expectedMember),
+            RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {{
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3));
+                }}),
+            RecordHelpers.newGroupEpochRecord(groupId, 11),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId, mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )),
+            RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11),
+            RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember)
+        );
+
+        assertEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testNewJoiningMemberTriggersNewTargetAssignment() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String memberId3 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            new HashMap<String, org.apache.kafka.coordinator.group.assignor.MemberAssignment>() {{
+                    put(memberId1, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1),
+                        mkTopicAssignment(barTopicId, 0)
+                    )));
+                    put(memberId2, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2, 3),
+                        mkTopicAssignment(barTopicId, 1)
+                    )));
+                    put(memberId3, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)
+                    )));
+                }}
+        ));
+
+        // Member 3 joins the consumer group.
+        Result<ConsumerGroupHeartbeatResponseData> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId3)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setServerAssignor("range")
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setPendingTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(4, 5)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(2))
+                    ))),
+            result.response()
+        );
+
+        ConsumerGroupMember expectedMember3 = new ConsumerGroupMember.Builder(memberId3)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(0)
+            .setNextMemberEpoch(11)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setRebalanceTimeoutMs(5000)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5),
+                mkTopicAssignment(barTopicId, 2)))
+            .build();
+
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newMemberSubscriptionRecord(groupId, expectedMember3),
+            RecordHelpers.newGroupEpochRecord(groupId, 11),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId1, mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1),
+                mkTopicAssignment(barTopicId, 0)
+            )),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId2, mkAssignment(
+                mkTopicAssignment(fooTopicId, 2, 3),
+                mkTopicAssignment(barTopicId, 1)
+            )),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId3, mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5),
+                mkTopicAssignment(barTopicId, 2)
+            )),
+            RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11),
+            RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember3)
+        );
+
+        assertEquals(expectedRecords.subList(0, 2), result.records().subList(0, 2));
+        assertUnorderedListEquals(expectedRecords.subList(2, 5), result.records().subList(2, 5));
+        assertEquals(expectedRecords.subList(5, 7), result.records().subList(5, 7));
+    }
+
+    @Test
+    public void testLeavingMemberTriggersNewTargetAssignment() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+        Uuid zarTopicId = Uuid.randomUuid();
+        String zarTopicName = "zar";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        // Consumer group with two members.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addTopic(zarTopicId, zarTopicName, 1)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    // Use zar only here to ensure that metadata needs to be recomputed.
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Collections.singletonMap(memberId1, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )))
+        ));
+
+        // Member 3 leaves the consumer group.
+        Result<ConsumerGroupHeartbeatResponseData> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setMemberEpoch(-1)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(-1),
+            result.response()
+        );
+
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newCurrentAssignmentTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newTargetAssignmentTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newMemberSubscriptionTombstoneRecord(groupId, memberId2),
+            // Subscription metadata is recomputed because zar is no longer there.
+            RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {{
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3));
+                }}),
+            RecordHelpers.newGroupEpochRecord(groupId, 11),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId1, mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )),
+            RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11)
+        );
+
+        assertEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testReconciliationProcess() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String memberId3 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        // Create a context with one consumer group containing two members.
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        // Prepare new assignment for the group.
+        assignor.prepareGroupAssignment(new GroupAssignment(
+                new HashMap<String, org.apache.kafka.coordinator.group.assignor.MemberAssignment>() {{
+                    put(memberId1, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1),
+                        mkTopicAssignment(barTopicId, 0)
+                    )));
+                    put(memberId2, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2, 3),
+                        mkTopicAssignment(barTopicId, 2)
+                    )));
+                    put(memberId3, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 4, 5),
+                        mkTopicAssignment(barTopicId, 1)
+                    )));
+                }}
+        ));
+
+        Result<ConsumerGroupHeartbeatResponseData> result;
+
+        // Members in the group are in Stable state.
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, context.consumerGroupMemberState(groupId, memberId1));
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, context.consumerGroupMemberState(groupId, memberId2));
+        assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, context.consumerGroupState(groupId));
+
+        // Member 3 joins the group. This triggers the computation of a new target assignment
+        // for the group. Member 3 does not get any assigned partitions yet because they are
+        // all owned by other members. However, it transitions to epoch 11 / Assigning state.
+        result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId3)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setServerAssignor("range")
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setPendingTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(4, 5)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(1))
+                    ))),
+            result.response()
+        );
+
+        // We only check the last record as the subscription/target assignment updates are
+        // already covered by other tests.
+        assertEquals(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
+                .setMemberEpoch(11)
+                .setPreviousMemberEpoch(0)
+                .setNextMemberEpoch(11)
+                .setAssigning(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 4, 5),
+                    mkTopicAssignment(barTopicId, 1)))
+                .build()),
+            result.records().get(result.records().size() - 1)
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId3));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 1 heartbeats. It remains at epoch 10 but transitions to Revoking state until
+        // it acknowledges the revocation of its partitions. The response contains the new
+        // assignment without the partitions that must be revoked.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId1)
+            .setMemberEpoch(10));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(0, 1)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(0))
+                    ))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+                .setMemberEpoch(10)
+                .setPreviousMemberEpoch(9)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1),
+                    mkTopicAssignment(barTopicId, 0)))
+                .setRevoking(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2),
+                    mkTopicAssignment(barTopicId, 1)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, context.consumerGroupMemberState(groupId, memberId1));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 2 heartbeats. It remains at epoch 10 but transitions to Revoking state until
+        // it acknowledges the revocation of its partitions. The response contains the new
+        // assignment without the partitions that must be revoked.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId2)
+            .setMemberEpoch(10));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(3)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(2))
+                    ))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
+                .setMemberEpoch(10)
+                .setPreviousMemberEpoch(9)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3),
+                    mkTopicAssignment(barTopicId, 2)))
+                .setRevoking(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 4, 5)))
+                .setAssigning(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, context.consumerGroupMemberState(groupId, memberId2));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 3 heartbeats. The response does not contain any assignment
+        // because the member is still waiting on other members to revoke partitions.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId3)
+            .setMemberEpoch(11));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000),
+            result.response()
+        );
+
+        assertEquals(Collections.emptyList(), result.records());
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId3));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 1 acknowledges the revocation of the partitions. It does so by providing the
+        // partitions that it still owns in the request. This allows him to transition to epoch 11
+        // and to the Stable state.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId1)
+            .setMemberEpoch(10)
+            .setTopicPartitions(Arrays.asList(
+                new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                    .setTopicId(fooTopicId)
+                    .setPartitions(Arrays.asList(0, 1)),
+                new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                    .setTopicId(barTopicId)
+                    .setPartitions(Arrays.asList(0))
+            )));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(0, 1)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(0))
+                    ))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+                .setMemberEpoch(11)
+                .setPreviousMemberEpoch(10)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1),
+                    mkTopicAssignment(barTopicId, 0)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, context.consumerGroupMemberState(groupId, memberId1));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 2 heartbeats but without acknowledging the revocation yet. This is basically a no-op.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId2)
+            .setMemberEpoch(10));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000),
+            result.response()
+        );
+
+        assertEquals(Collections.emptyList(), result.records());
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, context.consumerGroupMemberState(groupId, memberId2));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 3 heartbeats. It receives the partitions revoked by member 1 but remains
+        // in Assigning state because it still waits on other partitions.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId3)
+            .setMemberEpoch(11));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(1))))
+                    .setPendingTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(4, 5))))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
+                .setMemberEpoch(11)
+                .setPreviousMemberEpoch(11)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(barTopicId, 1)))
+                .setAssigning(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 4, 5)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId3));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 3 heartbeats but without acknowledging the revocation yet. This is basically a no-op.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId3)
+            .setMemberEpoch(11));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000),
+            result.response()
+        );
+
+        assertEquals(Collections.emptyList(), result.records());
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId3));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 2 acknowledges the revocation of the partitions. It does so by providing the
+        // partitions that it still owns in the request. This allows him to transition to epoch 11
+        // and to the Stable state.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId2)
+            .setMemberEpoch(10)
+            .setTopicPartitions(Arrays.asList(
+                new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                    .setTopicId(fooTopicId)
+                    .setPartitions(Arrays.asList(3)),
+                new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                    .setTopicId(barTopicId)
+                    .setPartitions(Arrays.asList(2))
+            )));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(2, 3)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(2))
+                    ))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
+                .setMemberEpoch(11)
+                .setPreviousMemberEpoch(10)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2, 3),
+                    mkTopicAssignment(barTopicId, 2)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, context.consumerGroupMemberState(groupId, memberId2));
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        // Member 3 heartbeats. It receives all its partitions and transitions to Stable.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId3)
+            .setMemberEpoch(11));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Arrays.asList(1)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(4, 5))))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
+                .setMemberEpoch(11)
+                .setPreviousMemberEpoch(11)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(barTopicId, 1),
+                    mkTopicAssignment(fooTopicId, 4, 5)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, context.consumerGroupMemberState(groupId, memberId3));
+        assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, context.consumerGroupState(groupId));
+    }
+
+    @Test
+    public void testReconciliationRestartsWhenNewTargetAssignmentIsInstalled() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String memberId3 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        // Create a context with one consumer group containing one member.
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        Result<ConsumerGroupHeartbeatResponseData> result;
+
+        // Prepare new assignment for the group.
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            new HashMap<String, org.apache.kafka.coordinator.group.assignor.MemberAssignment>() {{
+                    put(memberId1, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1)
+                    )));
+                    put(memberId2, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2)
+                    )));
+                }}
+        ));
+
+        // Member 2 joins.
+        result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setServerAssignor("range")
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setPendingTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(2))
+                    ))),
+            result.response()
+        );
+
+        assertEquals(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
+                .setMemberEpoch(11)
+                .setPreviousMemberEpoch(0)
+                .setNextMemberEpoch(11)
+                .setAssigning(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2)))
+                .build()),
+            result.records().get(result.records().size() - 1)
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId2));
+
+        // Member 1 heartbeats and transitions to Revoking.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId1)
+            .setMemberEpoch(10));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(0, 1))))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+                .setMemberEpoch(10)
+                .setPreviousMemberEpoch(9)
+                .setNextMemberEpoch(11)
+                .setAssigned(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1)))
+                .setRevoking(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, context.consumerGroupMemberState(groupId, memberId1));
+
+        // Prepare new assignment for the group.
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            new HashMap<String, org.apache.kafka.coordinator.group.assignor.MemberAssignment>() {{
+                    put(memberId1, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0)
+                    )));
+                    put(memberId2, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2)
+                    )));
+                    put(memberId3, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 1)
+                    )));
+                }}
+        ));
+
+        // Member 3 joins.
+        result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId3)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setServerAssignor("range")
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(12)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setPendingTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(1))
+                    ))),
+            result.response()
+        );
+
+        assertEquals(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
+                .setMemberEpoch(12)
+                .setPreviousMemberEpoch(0)
+                .setNextMemberEpoch(12)
+                .setAssigning(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 1)))
+                .build()),
+            result.records().get(result.records().size() - 1)
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId3));
+
+        // When member 1 heartbeats, it transitions to Revoke again but an updated state.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId1)
+            .setMemberEpoch(10));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setAssignedTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(0))))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+                RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(12)
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0)))
+                    .setRevoking(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 1, 2)))
+                    .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, context.consumerGroupMemberState(groupId, memberId1));
+
+        // When member 2 heartbeats, it transitions to Assign again but with an updated state.
+        result = context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId2)
+            .setMemberEpoch(11));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(12)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setPendingTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(2))))),
+            result.response()
+        );
+
+        assertEquals(Collections.singletonList(
+            RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
+                .setMemberEpoch(12)
+                .setPreviousMemberEpoch(11)
+                .setNextMemberEpoch(12)
+                .setAssigning(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2)))
+                .build())),
+            result.records()
+        );
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, context.consumerGroupMemberState(groupId, memberId2));
+    }
+
+    @Test
+    public void testNewMemberIsRejectedWithMaximumMembersIsReached() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String memberId3 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        // Create a context with one consumer group containing two members.
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .withConsumerGroupMaxSize(2)
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        assertThrows(GroupMaxSizeReachedException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId3)
+                    .setMemberEpoch(0)
+                    .setServerAssignor("range")
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testConsumerGroupStates() {
+        String groupId = "fooup";
+        String memberId1 = Uuid.randomUuid().toString();
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10))
+            .build();
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, context.consumerGroupState(groupId));
+
+        context.replay(RecordHelpers.newMemberSubscriptionRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+            .setSubscribedTopicNames(Collections.singletonList(fooTopicName))
+            .build()));
+        context.replay(RecordHelpers.newGroupEpochRecord(groupId, 11));
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, context.consumerGroupState(groupId));
+
+        context.replay(RecordHelpers.newTargetAssignmentRecord(groupId, memberId1, mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3))));
+        context.replay(RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11));
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        context.replay(RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigning(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2)))
+            .setAssigning(mkAssignment(mkTopicAssignment(fooTopicId, 3)))
+            .build()));
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, context.consumerGroupState(groupId));
+
+        context.replay(RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2, 3)))
+            .build()));
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, context.consumerGroupState(groupId));
+    }
+
+    @Test
+    public void testPartitionAssignorExceptionOnRegularHeartbeat() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        PartitionAssignor assignor = mock(PartitionAssignor.class);
+        when(assignor.name()).thenReturn("range");
+        when(assignor.assign(any())).thenThrow(new PartitionAssignorException("Assignment failed."));
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .build();
+
+        // Member 1 joins the consumer group. The request fails because the
+        // target assignment computation failed.
+        assertThrows(UnknownServerException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId1)
+                    .setMemberEpoch(0)
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignor("range")
+                    .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testPartitionAssignorExceptionOnLeaveHeatbeat() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        PartitionAssignor assignor = mock(PartitionAssignor.class);
+        when(assignor.assign(any())).thenThrow(new PartitionAssignorException("Assignment failed."));
+
+        // Consumer group with two members.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withTopicsImage(new TopicsImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setNextMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssigned(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        // Member 3 leaves the consumer group.
+        assertThrows(UnknownServerException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId1)
+                    .setMemberEpoch(-1)
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setTopicPartitions(Collections.emptyList())));
+    }
+
+    private <T> void assertUnorderedListEquals(
+        List<T> expected,
+        List<T> actual
+    ) {
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    private void assertResponseEquals(
+        ConsumerGroupHeartbeatResponseData expected,
+        ConsumerGroupHeartbeatResponseData actual
+    ) {
+        if (!responseEquals(expected, actual)) {
+            assertionFailure()
+                .expected(expected)
+                .actual(actual)
+                .buildAndThrow();
+        }
+    }
+
+    private boolean responseEquals(
+        ConsumerGroupHeartbeatResponseData expected,
+        ConsumerGroupHeartbeatResponseData actual
+    ) {
+        if (expected.throttleTimeMs() != actual.throttleTimeMs()) return false;
+        if (expected.errorCode() != actual.errorCode()) return false;
+        if (!Objects.equals(expected.errorMessage(), actual.errorMessage())) return false;
+        if (!Objects.equals(expected.memberId(), actual.memberId())) return false;
+        if (expected.memberEpoch() != actual.memberEpoch()) return false;
+        if (expected.shouldComputeAssignment() != actual.shouldComputeAssignment()) return false;
+        if (expected.heartbeatIntervalMs() != actual.heartbeatIntervalMs()) return false;
+        // Unordered comparison of the assignments.
+        return responseAssignmentEquals(expected.assignment(), actual.assignment());
+    }
+
+    private boolean responseAssignmentEquals(
+        ConsumerGroupHeartbeatResponseData.Assignment expected,
+        ConsumerGroupHeartbeatResponseData.Assignment actual
+    ) {
+        if (expected == actual) return true;
+        if (expected == null) return false;
+        if (actual == null) return false;
+
+        if (!Objects.equals(fromAssignment(expected.pendingTopicPartitions()), fromAssignment(actual.pendingTopicPartitions())))
+            return false;
+
+        return Objects.equals(fromAssignment(expected.assignedTopicPartitions()), fromAssignment(actual.assignedTopicPartitions()));
+    }
+
+    private Map<Uuid, Set<Integer>> fromAssignment(
+        List<ConsumerGroupHeartbeatResponseData.TopicPartitions> assignment
+    ) {
+        if (assignment == null) return null;
+
+        Map<Uuid, Set<Integer>> assigmentMap = new HashMap<>();
+        assignment.forEach(topicPartitions -> {
+            assigmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
+        });
+        return assigmentMap;
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.consumer.ClientAssignor;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkSortedAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkSortedTopicAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupEpochRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupEpochTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupSubscriptionMetadataRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupSubscriptionMetadataTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newMemberSubscriptionRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newMemberSubscriptionTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochTombstoneRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentTombstoneRecord;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecordHelpersTest {
+
+    @Test
+    public void testNewMemberSubscriptionRecord() {
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member-id")
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client-id")
+            .setClientHost("client-host")
+            .setSubscribedTopicNames(Arrays.asList("foo", "zar", "bar"))
+            .setSubscribedTopicRegex("regex")
+            .setServerAssignorName("range")
+            .setClientAssignors(Collections.singletonList(new ClientAssignor(
+                "assignor",
+                (byte) 0,
+                (byte) 1,
+                (byte) 10,
+                (byte) 5,
+                ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)))))
+            .build();
+
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMemberMetadataKey()
+                    .setGroupId("group-id")
+                    .setMemberId("member-id"),
+                (short) 5),
+            new ApiMessageAndVersion(
+                new ConsumerGroupMemberMetadataValue()
+                    .setInstanceId("instance-id")
+                    .setRackId("rack-id")
+                    .setRebalanceTimeoutMs(5000)
+                    .setClientId("client-id")
+                    .setClientHost("client-host")
+                    .setSubscribedTopicNames(Arrays.asList("bar", "foo", "zar"))
+                    .setSubscribedTopicRegex("regex")
+                    .setServerAssignor("range")
+                    .setAssignors(Collections.singletonList(new ConsumerGroupMemberMetadataValue.Assignor()
+                        .setName("assignor")
+                        .setMinimumVersion((short) 1)
+                        .setMaximumVersion((short) 10)
+                        .setVersion((short) 5)
+                        .setMetadata("hello".getBytes(StandardCharsets.UTF_8)))),
+                (short) 0));
+
+        assertEquals(expectedRecord, newMemberSubscriptionRecord(
+            "group-id",
+            member
+        ));
+    }
+
+    @Test
+    public void testNewMemberSubscriptionTombstoneRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMemberMetadataKey()
+                    .setGroupId("group-id")
+                    .setMemberId("member-id"),
+                (short) 5
+            ),
+            null);
+
+        assertEquals(expectedRecord, newMemberSubscriptionTombstoneRecord(
+            "group-id",
+            "member-id"
+        ));
+    }
+
+    @Test
+    public void testNewGroupSubscriptionMetadataRecord() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+        Map<String, TopicMetadata> subscriptionMetadata = new LinkedHashMap<>();
+        subscriptionMetadata.put("foo", new TopicMetadata(
+            fooTopicId,
+            "foo",
+            10
+        ));
+        subscriptionMetadata.put("bar", new TopicMetadata(
+            barTopicId,
+            "bar",
+            20
+        ));
+
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupPartitionMetadataKey()
+                    .setGroupId("group-id"),
+                (short) 4
+            ),
+            new ApiMessageAndVersion(
+                new ConsumerGroupPartitionMetadataValue()
+                    .setTopics(Arrays.asList(
+                        new ConsumerGroupPartitionMetadataValue.TopicMetadata()
+                            .setTopicId(fooTopicId)
+                            .setTopicName("foo")
+                            .setNumPartitions(10),
+                        new ConsumerGroupPartitionMetadataValue.TopicMetadata()
+                            .setTopicId(barTopicId)
+                            .setTopicName("bar")
+                            .setNumPartitions(20))),
+                (short) 0));
+
+        assertEquals(expectedRecord, newGroupSubscriptionMetadataRecord(
+            "group-id",
+            subscriptionMetadata
+        ));
+    }
+
+    @Test
+    public void testNewGroupSubscriptionMetadataTombstoneRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupPartitionMetadataKey()
+                    .setGroupId("group-id"),
+                (short) 4
+            ),
+            null);
+
+        assertEquals(expectedRecord, newGroupSubscriptionMetadataTombstoneRecord(
+            "group-id"
+        ));
+    }
+
+    @Test
+    public void testNewGroupEpochRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMetadataKey()
+                    .setGroupId("group-id"),
+                (short) 3),
+            new ApiMessageAndVersion(
+                new ConsumerGroupMetadataValue()
+                    .setEpoch(10),
+                (short) 0));
+
+        assertEquals(expectedRecord, newGroupEpochRecord(
+            "group-id",
+            10
+        ));
+    }
+
+    @Test
+    public void testNewGroupEpochTombstoneRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupMetadataKey()
+                    .setGroupId("group-id"),
+                (short) 3),
+            null);
+
+        assertEquals(expectedRecord, newGroupEpochTombstoneRecord(
+            "group-id"
+        ));
+    }
+
+    @Test
+    public void testNewTargetAssignmentRecord() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        Map<Uuid, Set<Integer>> partitions = mkSortedAssignment(
+            mkTopicAssignment(topicId1, 11, 12, 13),
+            mkTopicAssignment(topicId2, 21, 22, 23)
+        );
+
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMemberKey()
+                    .setGroupId("group-id")
+                    .setMemberId("member-id"),
+                (short) 7),
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMemberValue()
+                    .setTopicPartitions(Arrays.asList(
+                        new ConsumerGroupTargetAssignmentMemberValue.TopicPartition()
+                            .setTopicId(topicId1)
+                            .setPartitions(Arrays.asList(11, 12, 13)),
+                        new ConsumerGroupTargetAssignmentMemberValue.TopicPartition()
+                            .setTopicId(topicId2)
+                            .setPartitions(Arrays.asList(21, 22, 23)))),
+                (short) 0));
+
+        assertEquals(expectedRecord, newTargetAssignmentRecord(
+            "group-id",
+            "member-id",
+            partitions
+        ));
+    }
+
+    @Test
+    public void testNewTargetAssignmentTombstoneRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMemberKey()
+                    .setGroupId("group-id")
+                    .setMemberId("member-id"),
+                (short) 7),
+            null);
+
+        assertEquals(expectedRecord, newTargetAssignmentTombstoneRecord(
+            "group-id",
+            "member-id"
+        ));
+    }
+
+    @Test
+    public void testNewTargetAssignmentEpochRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMetadataKey()
+                    .setGroupId("group-id"),
+                (short) 6),
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMetadataValue()
+                    .setAssignmentEpoch(10),
+                (short) 0));
+
+        assertEquals(expectedRecord, newTargetAssignmentEpochRecord(
+            "group-id",
+            10
+        ));
+    }
+
+    @Test
+    public void testNewTargetAssignmentEpochTombstoneRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupTargetAssignmentMetadataKey()
+                    .setGroupId("group-id"),
+                (short) 6),
+            null);
+
+        assertEquals(expectedRecord, newTargetAssignmentEpochTombstoneRecord(
+            "group-id"
+        ));
+    }
+
+    @Test
+    public void testNewCurrentAssignmentRecord() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        Map<Uuid, Set<Integer>> assigned = mkSortedAssignment(
+            mkSortedTopicAssignment(topicId1, 11, 12, 13),
+            mkSortedTopicAssignment(topicId2, 21, 22, 23)
+        );
+
+        Map<Uuid, Set<Integer>> revoking = mkSortedAssignment(
+            mkSortedTopicAssignment(topicId1, 14, 15, 16),
+            mkSortedTopicAssignment(topicId2, 24, 25, 26)
+        );
+
+        Map<Uuid, Set<Integer>> assigning = mkSortedAssignment(
+            mkSortedTopicAssignment(topicId1, 17, 18, 19),
+            mkSortedTopicAssignment(topicId2, 27, 28, 29)
+        );
+
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupCurrentMemberAssignmentKey()
+                    .setGroupId("group-id")
+                    .setMemberId("member-id"),
+                (short) 8),
+            new ApiMessageAndVersion(
+                new ConsumerGroupCurrentMemberAssignmentValue()
+                    .setMemberEpoch(22)
+                    .setPreviousMemberEpoch(21)
+                    .setTargetMemberEpoch(23)
+                    .setAssigned(Arrays.asList(
+                        new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                            .setTopicId(topicId1)
+                            .setPartitions(Arrays.asList(11, 12, 13)),
+                        new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                            .setTopicId(topicId2)
+                            .setPartitions(Arrays.asList(21, 22, 23))))
+                    .setRevoking(Arrays.asList(
+                        new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                            .setTopicId(topicId1)
+                            .setPartitions(Arrays.asList(14, 15, 16)),
+                        new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                            .setTopicId(topicId2)
+                            .setPartitions(Arrays.asList(24, 25, 26))))
+                    .setAssigning(Arrays.asList(
+                        new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                            .setTopicId(topicId1)
+                            .setPartitions(Arrays.asList(17, 18, 19)),
+                        new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                            .setTopicId(topicId2)
+                            .setPartitions(Arrays.asList(27, 28, 29)))),
+                (short) 0));
+
+        assertEquals(expectedRecord, newCurrentAssignmentRecord(
+            "group-id",
+            new ConsumerGroupMember.Builder("member-id")
+                .setMemberEpoch(22)
+                .setPreviousMemberEpoch(21)
+                .setNextMemberEpoch(23)
+                .setAssigned(assigned)
+                .setRevoking(revoking)
+                .setAssigning(assigning)
+                .build()
+        ));
+    }
+
+    @Test
+    public void testNewCurrentAssignmentTombstoneRecord() {
+        Record expectedRecord = new Record(
+            new ApiMessageAndVersion(
+                new ConsumerGroupCurrentMemberAssignmentKey()
+                    .setGroupId("group-id")
+                    .setMemberId("member-id"),
+                (short) 8),
+            null);
+
+        assertEquals(expectedRecord, newCurrentAssignmentTombstoneRecord(
+            "group-id",
+            "member-id"
+        ));
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/AssignmentTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/AssignmentTestUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class AssignmentTestUtil {
+    public static Map.Entry<Uuid, Set<Integer>> mkTopicAssignment(
+        Uuid topicId,
+        Integer... partitions
+    ) {
+        return new AbstractMap.SimpleEntry<>(
+            topicId,
+            new HashSet<>(Arrays.asList(partitions))
+        );
+    }
+
+    public static Map.Entry<Uuid, Set<Integer>> mkSortedTopicAssignment(
+        Uuid topicId,
+        Integer... partitions
+    ) {
+        return new AbstractMap.SimpleEntry<>(
+            topicId,
+            new TreeSet<>(Arrays.asList(partitions))
+        );
+    }
+
+    @SafeVarargs
+    public static Map<Uuid, Set<Integer>> mkAssignment(Map.Entry<Uuid, Set<Integer>>... entries) {
+        Map<Uuid, Set<Integer>> assignment = new HashMap<>();
+        for (Map.Entry<Uuid, Set<Integer>> entry : entries) {
+            assignment.put(entry.getKey(), entry.getValue());
+        }
+        return assignment;
+    }
+
+    @SafeVarargs
+    public static Map<Uuid, Set<Integer>> mkSortedAssignment(Map.Entry<Uuid, Set<Integer>>... entries) {
+        Map<Uuid, Set<Integer>> assignment = new LinkedHashMap<>();
+        for (Map.Entry<Uuid, Set<Integer>> entry : entries) {
+            assignment.put(entry.getKey(), entry.getValue());
+        }
+        return assignment;
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ClientAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ClientAssignorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ClientAssignorTest {
+
+    @Test
+    public void testConstructor() {
+        ClientAssignor clientAssignor = new ClientAssignor(
+            "range",
+            (byte) 2,
+            (short) 5,
+            (short) 10,
+            (short) 8,
+            ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertEquals("range", clientAssignor.name());
+        assertEquals((byte) 2, clientAssignor.reason());
+        assertEquals((short) 5, clientAssignor.minimumVersion());
+        assertEquals((short) 10, clientAssignor.maximumVersion());
+        assertEquals((short) 8, clientAssignor.metadataVersion());
+        assertEquals(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), clientAssignor.metadataBytes());
+    }
+
+    @Test
+    public void testFromRecord() {
+        ConsumerGroupMemberMetadataValue.Assignor record = new ConsumerGroupMemberMetadataValue.Assignor()
+            .setName("range")
+            .setReason((byte) 2)
+            .setMinimumVersion((byte) 5)
+            .setMaximumVersion((byte) 10)
+            .setVersion((byte) 8)
+            .setMetadata("hello".getBytes(StandardCharsets.UTF_8));
+
+        ClientAssignor clientAssignor = ClientAssignor.fromRecord(record);
+
+        assertEquals("range", clientAssignor.name());
+        assertEquals((byte) 2, clientAssignor.reason());
+        assertEquals((short) 5, clientAssignor.minimumVersion());
+        assertEquals((short) 10, clientAssignor.maximumVersion());
+        assertEquals((short) 8, clientAssignor.metadataVersion());
+        assertEquals(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), clientAssignor.metadataBytes());
+    }
+
+    @Test
+    public void testEquals() {
+        ClientAssignor clientAssignor1 = new ClientAssignor(
+            "range",
+            (byte) 2,
+            (short) 5,
+            (short) 10,
+            (short) 8,
+            ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8))
+        );
+
+        ClientAssignor clientAssignor2 = new ClientAssignor(
+            "range",
+            (byte) 2,
+            (short) 5,
+            (short) 10,
+            (short) 8,
+            ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertEquals(clientAssignor1, clientAssignor2);
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.consumer.ClientAssignor;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConsumerGroupMemberTest {
+
+    @Test
+    public void testNewMember() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+        Uuid topicId3 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member-id")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setNextMemberEpoch(11)
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client-id")
+            .setClientHost("hostname")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setSubscribedTopicRegex("regex")
+            .setServerAssignorName("range")
+            .setClientAssignors(Collections.singletonList(
+                new ClientAssignor(
+                    "assignor",
+                    (byte) 0,
+                    (byte) 0,
+                    (byte) 1,
+                    (byte) 1,
+                    ByteBuffer.allocate(0))))
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId3, 7, 8, 9)))
+            .build();
+
+        assertEquals("member-id", member.memberId());
+        assertEquals(10, member.memberEpoch());
+        assertEquals(9, member.previousMemberEpoch());
+        assertEquals(11, member.nextMemberEpoch());
+        assertEquals("instance-id", member.instanceId());
+        assertEquals("rack-id", member.rackId());
+        assertEquals("client-id", member.clientId());
+        assertEquals("hostname", member.clientHost());
+        // Names are sorted.
+        assertEquals(Arrays.asList("bar", "foo"), member.subscribedTopicNames());
+        assertEquals("regex", member.subscribedTopicRegex());
+        assertEquals("range", member.serverAssignorName().get());
+        assertEquals(
+            Collections.singletonList(
+                new ClientAssignor(
+                    "assignor",
+                    (byte) 0,
+                    (byte) 0,
+                    (byte) 1,
+                    (byte) 1,
+                    ByteBuffer.allocate(0))),
+            member.clientAssignors());
+        assertEquals(mkAssignment(mkTopicAssignment(topicId1, 1, 2, 3)), member.assigned());
+        assertEquals(mkAssignment(mkTopicAssignment(topicId2, 4, 5, 6)), member.revoking());
+        assertEquals(mkAssignment(mkTopicAssignment(topicId3, 7, 8, 9)), member.assigning());
+    }
+
+    @Test
+    public void testEquals() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+        Uuid topicId3 = Uuid.randomUuid();
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder("member-id")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setNextMemberEpoch(11)
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client-id")
+            .setClientHost("hostname")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setSubscribedTopicRegex("regex")
+            .setServerAssignorName("range")
+            .setClientAssignors(Collections.singletonList(
+                new ClientAssignor(
+                    "assignor",
+                    (byte) 0,
+                    (byte) 0,
+                    (byte) 1,
+                    (byte) 1,
+                    ByteBuffer.allocate(0))))
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId3, 7, 8, 9)))
+            .build();
+
+        ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member-id")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setNextMemberEpoch(11)
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client-id")
+            .setClientHost("hostname")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setSubscribedTopicRegex("regex")
+            .setServerAssignorName("range")
+            .setClientAssignors(Collections.singletonList(
+                new ClientAssignor(
+                    "assignor",
+                    (byte) 0,
+                    (byte) 0,
+                    (byte) 1,
+                    (byte) 1,
+                    ByteBuffer.allocate(0))))
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId3, 7, 8, 9)))
+            .build();
+
+        assertEquals(member1, member2);
+    }
+
+    @Test
+    public void testUpdateMember() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+        Uuid topicId3 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member-id")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setNextMemberEpoch(11)
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client-id")
+            .setClientHost("hostname")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setSubscribedTopicRegex("regex")
+            .setServerAssignorName("range")
+            .setClientAssignors(Collections.singletonList(
+                new ClientAssignor(
+                    "assignor",
+                    (byte) 0,
+                    (byte) 0,
+                    (byte) 1,
+                    (byte) 1,
+                    ByteBuffer.allocate(0))))
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId3, 7, 8, 9)))
+            .build();
+
+        // This is a no-op.
+        ConsumerGroupMember updatedMember = new ConsumerGroupMember.Builder(member)
+            .maybeUpdateRackId(Optional.empty())
+            .maybeUpdateInstanceId(Optional.empty())
+            .maybeUpdateServerAssignorName(Optional.empty())
+            .maybeUpdateSubscribedTopicNames(Optional.empty())
+            .maybeUpdateSubscribedTopicRegex(Optional.empty())
+            .maybeUpdateRebalanceTimeoutMs(OptionalInt.empty())
+            .maybeUpdateClientAssignors(Optional.empty())
+            .build();
+
+        assertEquals(member, updatedMember);
+
+        updatedMember = new ConsumerGroupMember.Builder(member)
+            .maybeUpdateRackId(Optional.of("new-rack-id"))
+            .maybeUpdateInstanceId(Optional.of("new-instance-id"))
+            .maybeUpdateServerAssignorName(Optional.of("new-assignor"))
+            .maybeUpdateSubscribedTopicNames(Optional.of(Arrays.asList("zar")))
+            .maybeUpdateSubscribedTopicRegex(Optional.of("new-regex"))
+            .maybeUpdateRebalanceTimeoutMs(OptionalInt.of(6000))
+            .maybeUpdateClientAssignors(Optional.of(Collections.emptyList()))
+            .build();
+
+        assertEquals("new-instance-id", updatedMember.instanceId());
+        assertEquals("new-rack-id", updatedMember.rackId());
+        // Names are sorted.
+        assertEquals(Arrays.asList("zar"), updatedMember.subscribedTopicNames());
+        assertEquals("new-regex", updatedMember.subscribedTopicRegex());
+        assertEquals("new-assignor", updatedMember.serverAssignorName().get());
+        assertEquals(Collections.emptyList(), updatedMember.clientAssignors());
+    }
+
+    @Test
+    public void testMergeWithConsumerGroupMemberMetadataValue() {
+        ConsumerGroupMemberMetadataValue record = new ConsumerGroupMemberMetadataValue()
+            .setAssignors(Collections.singletonList(new ConsumerGroupMemberMetadataValue.Assignor()
+                .setName("client")
+                .setMinimumVersion((short) 0)
+                .setMaximumVersion((short) 2)
+                .setVersion((short) 1)
+                .setMetadata(new byte[0])))
+            .setServerAssignor("range")
+            .setClientId("client-id")
+            .setClientHost("host-id")
+            .setInstanceId("instance-id")
+            .setRackId("rack-id")
+            .setRebalanceTimeoutMs(1000)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setSubscribedTopicRegex("regex");
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member-id")
+            .mergeWith(record)
+            .build();
+
+        assertEquals("instance-id", member.instanceId());
+        assertEquals("rack-id", member.rackId());
+        assertEquals("client-id", member.clientId());
+        assertEquals("host-id", member.clientHost());
+        // Names are sorted.
+        assertEquals(Arrays.asList("bar", "foo"), member.subscribedTopicNames());
+        assertEquals("regex", member.subscribedTopicRegex());
+        assertEquals("range", member.serverAssignorName().get());
+        assertEquals(
+            Collections.singletonList(
+                new ClientAssignor(
+                    "client",
+                    (byte) 0,
+                    (byte) 0,
+                    (byte) 2,
+                    (byte) 1,
+                    ByteBuffer.allocate(0))),
+            member.clientAssignors());
+    }
+
+    @Test
+    public void testMergeWithConsumerGroupCurrentMemberAssignmentValue() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+        Uuid topicId3 = Uuid.randomUuid();
+
+        ConsumerGroupCurrentMemberAssignmentValue record = new ConsumerGroupCurrentMemberAssignmentValue()
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setTargetMemberEpoch(11)
+            .setAssigned(Collections.singletonList(new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                .setTopicId(topicId1)
+                .setPartitions(Arrays.asList(0, 1, 2))))
+            .setRevoking(Collections.singletonList(new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                .setTopicId(topicId2)
+                .setPartitions(Arrays.asList(3, 4, 5))))
+            .setAssigning(Collections.singletonList(new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                .setTopicId(topicId3)
+                .setPartitions(Arrays.asList(6, 7, 8))));
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member-id")
+            .mergeWith(record)
+            .build();
+
+        assertEquals(10, member.memberEpoch());
+        assertEquals(9, member.previousMemberEpoch());
+        assertEquals(11, member.nextMemberEpoch());
+        assertEquals(mkAssignment(mkTopicAssignment(topicId1, 0, 1, 2)), member.assigned());
+        assertEquals(mkAssignment(mkTopicAssignment(topicId2, 3, 4, 5)), member.revoking());
+        assertEquals(mkAssignment(mkTopicAssignment(topicId3, 6, 7, 8)), member.assigning());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.GroupMetadataManagerTest;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.timeline.SnapshotRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConsumerGroupTest {
+
+    private ConsumerGroup createConsumerGroup(String groupId) {
+        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
+        return new ConsumerGroup(snapshotRegistry, groupId);
+    }
+
+    @Test
+    public void testGetOrCreateMember() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        ConsumerGroupMember member;
+
+        // Create a group.
+        member = consumerGroup.getOrMaybeCreateMember("member-id", true);
+        assertEquals("member-id", member.memberId());
+
+        // Get that group back.
+        member = consumerGroup.getOrMaybeCreateMember("member-id", false);
+        assertEquals("member-id", member.memberId());
+
+        assertThrows(UnknownMemberIdException.class, () ->
+            consumerGroup.getOrMaybeCreateMember("does-not-exist", false));
+    }
+
+    @Test
+    public void testUpdateMember() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        ConsumerGroupMember member;
+
+        member = consumerGroup.getOrMaybeCreateMember("member", true);
+
+        member = new ConsumerGroupMember.Builder(member)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .build();
+
+        consumerGroup.updateMember(member);
+
+        assertEquals(member, consumerGroup.getOrMaybeCreateMember("member", false));
+    }
+
+    @Test
+    public void testRemoveMember() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        consumerGroup.getOrMaybeCreateMember("member", true);
+        assertTrue(consumerGroup.hasMember("member"));
+
+        consumerGroup.removeMember("member");
+        assertFalse(consumerGroup.hasMember("member"));
+
+    }
+
+    @Test
+    public void testUpdatingMemberUpdatesPartitionEpoch() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+        Uuid zarTopicId = Uuid.randomUuid();
+
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        ConsumerGroupMember member;
+
+        member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(barTopicId, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(zarTopicId, 7, 8, 9)))
+            .build();
+
+        consumerGroup.updateMember(member);
+
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 2));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 3));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 4));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 5));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 6));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 7));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 8));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 9));
+
+        member = new ConsumerGroupMember.Builder(member)
+            .setMemberEpoch(10)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(barTopicId, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(zarTopicId, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(fooTopicId, 7, 8, 9)))
+            .build();
+
+        consumerGroup.updateMember(member);
+
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 1));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 2));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 3));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(zarTopicId, 4));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(zarTopicId, 5));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(zarTopicId, 6));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(fooTopicId, 7));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(fooTopicId, 8));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(fooTopicId, 9));
+    }
+
+    @Test
+    public void testDeletingMemberRemovesPartitionEpoch() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+        Uuid zarTopicId = Uuid.randomUuid();
+
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        ConsumerGroupMember member;
+
+        member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2, 3)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(barTopicId, 4, 5, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(zarTopicId, 7, 8, 9)))
+            .build();
+
+        consumerGroup.updateMember(member);
+
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 2));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 3));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 4));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 5));
+        assertEquals(10, consumerGroup.currentPartitionEpoch(barTopicId, 6));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 7));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 8));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 9));
+
+        consumerGroup.removeMember(member.memberId());
+
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(barTopicId, 1));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(barTopicId, 2));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(barTopicId, 3));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 4));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 5));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(zarTopicId, 6));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(fooTopicId, 7));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(fooTopicId, 8));
+        assertEquals(-1, consumerGroup.currentPartitionEpoch(fooTopicId, 9));
+    }
+
+    @Test
+    public void testGroupState() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder("member1")
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setNextMemberEpoch(1)
+            .build();
+
+        consumerGroup.updateMember(member1);
+        consumerGroup.setGroupEpoch(1);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, consumerGroup.state());
+
+        ConsumerGroupMember member2 = new ConsumerGroupMember.Builder("member2")
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setNextMemberEpoch(1)
+            .build();
+
+        consumerGroup.updateMember(member2);
+        consumerGroup.setGroupEpoch(2);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, consumerGroup.state());
+
+        consumerGroup.setAssignmentEpoch(2);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, consumerGroup.state());
+
+        member1 = new ConsumerGroupMember.Builder(member1)
+            .setMemberEpoch(2)
+            .setPreviousMemberEpoch(1)
+            .setNextMemberEpoch(2)
+            .build();
+        consumerGroup.updateMember(member1);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, consumerGroup.state());
+
+        member2 = new ConsumerGroupMember.Builder(member2)
+            .setMemberEpoch(2)
+            .setPreviousMemberEpoch(1)
+            .setNextMemberEpoch(2)
+            .build();
+        consumerGroup.updateMember(member2);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, consumerGroup.state());
+
+        consumerGroup.removeMember("member1");
+        consumerGroup.removeMember("member2");
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
+    }
+
+    @Test
+    public void testPreferredServerAssignor() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member1")
+            .setServerAssignorName("range")
+            .build());
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member2")
+            .setServerAssignorName("range")
+            .build());
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member3")
+            .setServerAssignorName("uniform")
+            .build());
+
+        assertEquals(Optional.of("range"), consumerGroup.preferredServerAssignor(
+            null,
+            Optional.empty())
+        );
+
+        assertEquals(Optional.of("uniform"), consumerGroup.preferredServerAssignor(
+            "member2",
+            Optional.of("uniform"))
+        );
+
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member1")
+            .setServerAssignorName(null)
+            .build());
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member2")
+            .setServerAssignorName(null)
+            .build());
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member3")
+            .setServerAssignorName(null)
+            .build());
+
+        assertEquals(Optional.empty(), consumerGroup.preferredServerAssignor(
+            null,
+            Optional.empty())
+        );
+    }
+
+    @Test
+    public void testUpdateSubscriptionMetadata() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+        Uuid zarTopicId = Uuid.randomUuid();
+
+        TopicsImage image = new GroupMetadataManagerTest.TopicsImageBuilder()
+            .addTopic(fooTopicId, "foo", 1)
+            .addTopic(barTopicId, "bar", 2)
+            .addTopic(zarTopicId, "zar", 3)
+            .build();
+
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .build());
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member2")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .build());
+        consumerGroup.updateMember(new ConsumerGroupMember.Builder("member3")
+            .setSubscribedTopicNames(Arrays.asList("bar", "zar"))
+            .build());
+
+        Map<String, TopicMetadata> expectedSubscriptionMetadata = new HashMap<>();
+        expectedSubscriptionMetadata.put("foo", new TopicMetadata(fooTopicId, "foo", 1));
+        expectedSubscriptionMetadata.put("bar", new TopicMetadata(barTopicId, "bar", 2));
+        expectedSubscriptionMetadata.put("zar", new TopicMetadata(zarTopicId, "zar", 3));
+        assertEquals(expectedSubscriptionMetadata, consumerGroup.computeSubscriptionMetadata(
+            null,
+            Collections.emptyList(),
+            image
+        ));
+
+        expectedSubscriptionMetadata.remove("zar");
+        assertEquals(expectedSubscriptionMetadata, consumerGroup.computeSubscriptionMetadata(
+            "member3",
+            Collections.emptyList(),
+            image
+        ));
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/CurrentAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/CurrentAssignmentBuilderTest.java
@@ -1,0 +1,551 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.MemberAssignment;
+import org.apache.kafka.coordinator.group.consumer.CurrentAssignmentBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CurrentAssignmentBuilderTest {
+
+    @Test
+    public void testTransitionFromNewTargetToRevoke() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(10)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3),
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> 10)
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(10, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3),
+            mkTopicAssignment(topicId2, 6)
+        ), updatedMember.assigned());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2),
+            mkTopicAssignment(topicId2, 4, 5)
+        ), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 4, 5),
+            mkTopicAssignment(topicId2, 7, 8)
+        ), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromNewTargetToAssigning() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(10)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3),
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2, 3, 4, 5),
+            mkTopicAssignment(topicId2, 4, 5, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> 10)
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(11, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2, 3),
+            mkTopicAssignment(topicId2, 4, 5, 6)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 4, 5),
+            mkTopicAssignment(topicId2, 7, 8)
+        ), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromNewTargetToStable() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(10)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2, 3),
+                mkTopicAssignment(topicId2, 4, 5, 6)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2, 3),
+            mkTopicAssignment(topicId2, 4, 5, 6)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(10, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> 10)
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(10, updatedMember.memberEpoch());
+        assertEquals(10, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2, 3),
+            mkTopicAssignment(topicId2, 4, 5, 6)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(Collections.emptyMap(), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromRevokeToRevokeWithNull() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2),
+                mkTopicAssignment(topicId2, 4, 5)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
+            .withOwnedTopicPartitions(null) // The client has not revoked yet.
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(10, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3),
+            mkTopicAssignment(topicId2, 6)
+        ), updatedMember.assigned());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2),
+            mkTopicAssignment(topicId2, 4, 5)
+        ), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 4, 5),
+            mkTopicAssignment(topicId2, 7, 8)
+        ), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromRevokeToRevokeWithEmptyList() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2),
+                mkTopicAssignment(topicId2, 4, 5)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
+            .withOwnedTopicPartitions(Collections.emptyList()) // The client has not revoked yet.
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(10, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3),
+            mkTopicAssignment(topicId2, 6)
+        ), updatedMember.assigned());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2),
+            mkTopicAssignment(topicId2, 4, 5)
+        ), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 4, 5),
+            mkTopicAssignment(topicId2, 7, 8)
+        ), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromRevokeToAssigning() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2),
+                mkTopicAssignment(topicId2, 4, 5)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> 10)
+            .withOwnedTopicPartitions(requestFromAssignment(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6))))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(11, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3),
+            mkTopicAssignment(topicId2, 6)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 4, 5),
+            mkTopicAssignment(topicId2, 7, 8)
+        ), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromRevokeToStable() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2),
+                mkTopicAssignment(topicId2, 4, 5)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
+            .withOwnedTopicPartitions(requestFromAssignment(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6))))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(11, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(Collections.emptyMap(), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromAssigningToAssigning() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(11)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> {
+                if (topicId.equals(topicId1))
+                    return -1;
+                else
+                    return 10;
+            })
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(11, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId2, 7, 8)
+        ), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromAssigningToStable() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(11)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(11, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(Collections.emptyMap(), updatedMember.assigning());
+    }
+
+    @Test
+    public void testTransitionFromStableToStable() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(11)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.ASSIGNING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(11, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.STABLE, updatedMember.state());
+        assertEquals(11, updatedMember.previousMemberEpoch());
+        assertEquals(11, updatedMember.memberEpoch());
+        assertEquals(11, updatedMember.nextMemberEpoch());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 3, 4, 5),
+            mkTopicAssignment(topicId2, 6, 7, 8)
+        ), updatedMember.assigned());
+        assertEquals(Collections.emptyMap(), updatedMember.revoking());
+        assertEquals(Collections.emptyMap(), updatedMember.assigning());
+    }
+
+    @Test
+    public void testNewTargetRestartReconciliation() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setNextMemberEpoch(11)
+            .setAssigned(mkAssignment(
+                mkTopicAssignment(topicId1, 3),
+                mkTopicAssignment(topicId2, 6)))
+            .setRevoking(mkAssignment(
+                mkTopicAssignment(topicId1, 1, 2),
+                mkTopicAssignment(topicId2, 4, 5)))
+            .setAssigning(mkAssignment(
+                mkTopicAssignment(topicId1, 4, 5),
+                mkTopicAssignment(topicId2, 7, 8)))
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, member.state());
+
+        MemberAssignment targetAssignment = new MemberAssignment(mkAssignment(
+            mkTopicAssignment(topicId1, 6, 7, 8),
+            mkTopicAssignment(topicId2, 9, 10, 11)
+        ));
+
+        ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(12, targetAssignment)
+            .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
+            .build();
+
+        assertEquals(ConsumerGroupMember.MemberState.REVOKING, updatedMember.state());
+        assertEquals(10, updatedMember.previousMemberEpoch());
+        assertEquals(10, updatedMember.memberEpoch());
+        assertEquals(12, updatedMember.nextMemberEpoch());
+        assertEquals(Collections.emptyMap(), updatedMember.assigned());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2, 3),
+            mkTopicAssignment(topicId2, 4, 5, 6)
+        ), updatedMember.revoking());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 6, 7, 8),
+            mkTopicAssignment(topicId2, 9, 10, 11)
+        ), updatedMember.assigning());
+    }
+
+    private static List<ConsumerGroupHeartbeatRequestData.TopicPartitions> requestFromAssignment(
+        Map<Uuid, Set<Integer>> assignment
+    ) {
+        List<ConsumerGroupHeartbeatRequestData.TopicPartitions> topicPartitions = new ArrayList<>();
+
+        assignment.forEach((topicId, partitions) -> {
+            ConsumerGroupHeartbeatRequestData.TopicPartitions topic = new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                .setTopicId(topicId)
+                .setPartitions(new ArrayList<>(partitions));
+            topicPartitions.add(topic);
+        });
+
+        return topicPartitions;
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/MemberAssignmentTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/MemberAssignmentTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MemberAssignmentTest {
+
+    @Test
+    public void testConstructor() {
+        Map<Uuid, Set<Integer>> partitions = mkAssignment(
+            mkTopicAssignment(Uuid.randomUuid(), 1, 2, 3)
+        );
+
+        VersionedMetadata metadata = new VersionedMetadata(
+            (short) 1,
+            ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8))
+        );
+
+        MemberAssignment assignment = new MemberAssignment(
+            (byte) 1,
+            partitions,
+            metadata
+        );
+
+        assertEquals((byte) 1, assignment.error());
+        assertEquals(partitions, assignment.partitions());
+        assertEquals(metadata, assignment.metadata());
+    }
+
+    @Test
+    public void testFromTargetAssignmentRecord() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        List<ConsumerGroupTargetAssignmentMemberValue.TopicPartition> partitions = new ArrayList<>();
+        partitions.add(new ConsumerGroupTargetAssignmentMemberValue.TopicPartition()
+            .setTopicId(topicId1)
+            .setPartitions(Arrays.asList(1, 2, 3)));
+        partitions.add(new ConsumerGroupTargetAssignmentMemberValue.TopicPartition()
+            .setTopicId(topicId2)
+            .setPartitions(Arrays.asList(4, 5, 6)));
+
+        ConsumerGroupTargetAssignmentMemberValue record = new ConsumerGroupTargetAssignmentMemberValue()
+            .setError((byte) 1)
+            .setTopicPartitions(partitions)
+            .setMetadataVersion((short) 2)
+            .setMetadataBytes("foo".getBytes(StandardCharsets.UTF_8));
+
+        MemberAssignment assignment = MemberAssignment.fromRecord(record);
+
+        assertEquals((short) 1, assignment.error());
+        assertEquals(mkAssignment(
+            mkTopicAssignment(topicId1, 1, 2, 3),
+            mkTopicAssignment(topicId2, 4, 5, 6)
+        ), assignment.partitions());
+        assertEquals(new VersionedMetadata(
+            (short) 2,
+            ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))
+        ), assignment.metadata());
+    }
+
+    @Test
+    public void testEquals() {
+        Map<Uuid, Set<Integer>> partitions = mkAssignment(
+            mkTopicAssignment(Uuid.randomUuid(), 1, 2, 3)
+        );
+
+        VersionedMetadata metadata = new VersionedMetadata(
+            (short) 1,
+            ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8))
+        );
+
+        MemberAssignment assignment1 = new MemberAssignment(
+            (byte) 1,
+            partitions,
+            metadata
+        );
+
+        MemberAssignment assignment2 = new MemberAssignment(
+            (byte) 1,
+            partitions,
+            metadata
+        );
+
+        assertEquals(assignment1, assignment2);
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -1,0 +1,682 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.coordinator.group.assignor.AssignmentMemberSpec;
+import org.apache.kafka.coordinator.group.assignor.AssignmentSpec;
+import org.apache.kafka.coordinator.group.assignor.AssignmentTopicMetadata;
+import org.apache.kafka.coordinator.group.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.apache.kafka.timeline.SnapshotRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentRecord;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TargetAssignmentBuilderTest {
+
+    public static class TargetAssignmentBuilderTestContext {
+        private final SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
+        private final String groupId;
+        private final int groupEpoch;
+        private final PartitionAssignor assignor = mock(PartitionAssignor.class);
+        private final Map<String, ConsumerGroupMember> members = new HashMap<>();
+        private final Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
+        private final Map<String, ConsumerGroupMember> updatedMembers = new HashMap<>();
+        private final Map<String, MemberAssignment> targetAssignments = new HashMap<>();
+        private final Map<String, org.apache.kafka.coordinator.group.assignor.MemberAssignment> assignments = new HashMap<>();
+
+        public TargetAssignmentBuilderTestContext(
+            String groupId,
+            int groupEpoch
+        ) {
+            this.groupId = groupId;
+            this.groupEpoch = groupEpoch;
+        }
+
+        public TargetAssignmentBuilderTestContext addGroupMember(
+            String memberId,
+            List<String> subscriptions,
+            Map<Uuid, Set<Integer>> targetPartitions
+        ) {
+            members.put(memberId, new ConsumerGroupMember.Builder(memberId)
+                .setSubscribedTopicNames(subscriptions)
+                .setRebalanceTimeoutMs(5000)
+                .build());
+
+            targetAssignments.put(memberId, new MemberAssignment(
+                (byte) 0,
+                targetPartitions,
+                VersionedMetadata.EMPTY
+            ));
+
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext addTopicMetadata(
+            Uuid topicId,
+            String topicName,
+            int numPartitions
+        ) {
+            subscriptionMetadata.put(topicName, new TopicMetadata(
+                topicId,
+                topicName,
+                numPartitions
+            ));
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext updateMemberSubscription(
+            String memberId,
+            List<String> subscriptions
+        ) {
+            return updateMemberSubscription(
+                memberId,
+                subscriptions,
+                Optional.empty(),
+                Optional.empty()
+            );
+        }
+
+        public TargetAssignmentBuilderTestContext updateMemberSubscription(
+            String memberId,
+            List<String> subscriptions,
+            Optional<String> instanceId,
+            Optional<String> rackId
+        ) {
+            ConsumerGroupMember existingMember = members.get(memberId);
+            ConsumerGroupMember.Builder builder;
+            if (existingMember != null) {
+                builder = new ConsumerGroupMember.Builder(existingMember);
+            } else {
+                builder = new ConsumerGroupMember.Builder(memberId);
+            }
+            updatedMembers.put(memberId, builder
+                .setSubscribedTopicNames(subscriptions)
+                .maybeUpdateInstanceId(instanceId)
+                .maybeUpdateRackId(rackId)
+                .build());
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext removeMemberSubscription(
+            String memberId
+        ) {
+            this.updatedMembers.put(memberId, null);
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext prepareMemberAssignment(
+            String memberId,
+            Map<Uuid, Set<Integer>> assignment
+        ) {
+            assignments.put(memberId, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(assignment));
+            return this;
+        }
+
+        private AssignmentMemberSpec assignmentMemberSpec(
+            ConsumerGroupMember member,
+            MemberAssignment targetAssignment
+        ) {
+            Set<Uuid> subscribedTopics = new HashSet<>();
+            member.subscribedTopicNames().forEach(topicName -> {
+                TopicMetadata topicMetadata = subscriptionMetadata.get(topicName);
+                if (topicMetadata != null) {
+                    subscribedTopics.add(topicMetadata.id());
+                }
+            });
+
+            return new AssignmentMemberSpec(
+                Optional.ofNullable(member.instanceId()),
+                Optional.ofNullable(member.rackId()),
+                subscribedTopics,
+                targetAssignment.partitions()
+            );
+        }
+
+        public TargetAssignmentBuilder.TargetAssignmentResult build() {
+            // Prepare expected member specs.
+            Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
+            members.forEach((memberId, member) -> {
+                memberSpecs.put(memberId, assignmentMemberSpec(
+                    member,
+                    targetAssignments.getOrDefault(memberId, MemberAssignment.EMPTY)
+                ));
+            });
+
+            updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+                if (updatedMemberOrNull == null) {
+                    memberSpecs.remove(memberId);
+                } else {
+                    memberSpecs.put(memberId, assignmentMemberSpec(
+                        updatedMemberOrNull,
+                        targetAssignments.getOrDefault(memberId, MemberAssignment.EMPTY)
+                    ));
+                }
+            });
+
+            Map<Uuid, AssignmentTopicMetadata> topicMetadata = new HashMap<>();
+            subscriptionMetadata.forEach((topicName, metadata) -> {
+                topicMetadata.put(metadata.id(), new AssignmentTopicMetadata(metadata.numPartitions()));
+            });
+
+            AssignmentSpec assignmentSpec = new AssignmentSpec(
+                memberSpecs,
+                topicMetadata
+            );
+
+            // We use `any` here to always return an assignment but use `verify` later on
+            // to ensure that the input was correct.
+            when(assignor.assign(any())).thenReturn(new GroupAssignment(assignments));
+
+            // Create and populate the assignment builder.
+            TargetAssignmentBuilder builder = new TargetAssignmentBuilder(groupId, groupEpoch, assignor)
+                .withMembers(members)
+                .withSubscriptionMetadata(subscriptionMetadata)
+                .withTargetAssignments(targetAssignments);
+
+            updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+                if (updatedMemberOrNull != null) {
+                    builder.withUpdatedMember(memberId, updatedMemberOrNull);
+                } else {
+                    builder.withRemoveMembers(memberId);
+                }
+            });
+
+            TargetAssignmentBuilder.TargetAssignmentResult result = builder.build();
+
+            verify(assignor, times(1)).assign(assignmentSpec);
+
+            return result;
+        }
+    }
+
+    @Test
+    public void testEmpty() {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+        assertEquals(Collections.emptyMap(), result.assignments());
+    }
+
+    @Test
+    public void testAssignmentIsNotChanged() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(Collections.singletonList(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        )), result.records());
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testAssignmentSwapped() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5, 6),
+                mkTopicAssignment(barTopicId, 4, 5, 6)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2, 3),
+                mkTopicAssignment(barTopicId, 1, 2, 3)
+            ))
+        ), result.records().subList(0, 2));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-2", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        )));
+        expectedAssignment.put("member-1", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testNewMember() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        context.updateMemberSubscription("member-3", Arrays.asList("foo", "bar", "zar"));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2),
+                mkTopicAssignment(barTopicId, 1, 2)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4),
+                mkTopicAssignment(barTopicId, 3, 4)
+            )),
+            newTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(fooTopicId, 5, 6),
+                mkTopicAssignment(barTopicId, 5, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        )));
+        expectedAssignment.put("member-3", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testUpdateMember() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", Arrays.asList("bar", "zar"), mkAssignment(
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.updateMemberSubscription(
+            "member-3",
+            Arrays.asList("foo", "bar", "zar"),
+            Optional.of("instance-id-3"),
+            Optional.of("rack-0")
+        );
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2),
+                mkTopicAssignment(barTopicId, 1, 2)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4),
+                mkTopicAssignment(barTopicId, 3, 4)
+            )),
+            newTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(fooTopicId, 5, 6),
+                mkTopicAssignment(barTopicId, 5, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        )));
+        expectedAssignment.put("member-3", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testPartialAssignmentUpdate() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", Arrays.asList("bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4, 5),
+            mkTopicAssignment(barTopicId, 3, 4, 5)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 6),
+            mkTopicAssignment(barTopicId, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        // Member 1 has not record because its assignment did not change.
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 3, 4, 5)
+            )),
+            newTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(fooTopicId, 6),
+                mkTopicAssignment(barTopicId, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4, 5),
+            mkTopicAssignment(barTopicId, 3, 4, 5)
+        )));
+        expectedAssignment.put("member-3", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 6),
+            mkTopicAssignment(barTopicId, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testDeleteMember() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.removeMemberSubscription("member-3");
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2, 3),
+                mkTopicAssignment(barTopicId, 1, 2, 3)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5, 6),
+                mkTopicAssignment(barTopicId, 4, 5, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    public static <T> void assertUnorderedList(
+        List<T> expected,
+        List<T> actual
+    ) {
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+}


### PR DESCRIPTION
This PR adds the GroupMetadataManager to the group-coordinator module. This manager is responsible for handling the groups management, the members management and the entire reconciliation process. At this point, only the new consumer group type/protocol is implemented.

As you will see, the new manager is based on an architecture inspired from the quorum controller. A request can access/read the state but can't mutate it directly. Instead, a list of records is generated together with the response and those records will be applied to the state by the runtime framework. We use timeline data structures. Note that the runtime framework is not part of this PR. It will come in a following one.

For the reviewers, I suggest starting from the GroupMetadataManager.consumerGroupHeartbeat method. From there, you will how the consumer group heartbeat is handled and how all the classes fit together. Then, it is possible to review the classes independently, I suppose.

Note that I have diverged from the KIP in a few places. Firstly, I have adapted to assignor interface to be more convenient with the internals. This is something that we could still change. Secondly, I have adapted a few records. Especially, I have changed how the current state of the member is persisted. The way that we had in the KIP was a but naive and not practical at all for the implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
