### PR TITLE
MINOR: fix BrokerMetadataPublisherTest.testExceptionInUpdateCoordinator

### DIFF
--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -254,6 +254,7 @@ class BrokerMetadataPublisherTest {
       val publisher = Mockito.spy(broker.brokerMetadataPublisher)
       doThrow(new RuntimeException("injected failure")).when(publisher).updateCoordinator(any(), any(), any(), any(), any())
       broker.sharedServer.loader.removeAndClosePublisher(broker.brokerMetadataPublisher).get(1, TimeUnit.MINUTES)
+      broker.metadataPublishers.remove(broker.brokerMetadataPublisher)
       broker.sharedServer.loader.installPublishers(List(publisher).asJava).get(1, TimeUnit.MINUTES)
       val admin = Admin.create(cluster.clientProperties())
       try {


### PR DESCRIPTION
Fix a case where we were getting an exception because we removed a publisher, but left it in BrokerServer.metadataPublishers (resulting in us trying to remove it during broker shutdown.)