### PR TITLE
MINOR:Remove unused metric variable in ReplicaManager

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -249,8 +249,7 @@ class ReplicaManager(val config: KafkaConfig,
   private[server] val replicaSelectorOpt: Option[ReplicaSelector] = createReplicaSelector()
 
   metricsGroup.newGauge("LeaderCount", () => leaderPartitionsIterator.size)
-  // Visible for testing
-  private[kafka] val partitionCount = metricsGroup.newGauge("PartitionCount", () => allPartitions.size)
+  metricsGroup.newGauge("PartitionCount", () => allPartitions.size)
   metricsGroup.newGauge("OfflineReplicaCount", () => offlinePartitionCount)
   metricsGroup.newGauge("UnderReplicatedPartitions", () => underReplicatedPartitionCount)
   metricsGroup.newGauge("UnderMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isUnderMinIsr))


### PR DESCRIPTION
This metric variable has never been used and has not been used for testing. Should it be deleted?