### PR TITLE
MINOR: fix broker testExceptionInUpdateCoordinator test

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -544,7 +544,7 @@ class BrokerServer(
       if (socketServer != null) {
         CoreUtils.swallow(socketServer.stopProcessingRequests(), this)
       }
-      metadataPublishers.forEach(p => sharedServer.loader.removeAndClosePublisher(p).get())
+      metadataPublishers.forEach(p => CoreUtils.swallow(sharedServer.loader.removeAndClosePublisher(p).get(), this))
       metadataPublishers.clear()
       if (dataPlaneRequestHandlerPool != null)
         CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), this)

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -376,7 +376,7 @@ class ControllerServer(
       // Ensure that we're not the Raft leader prior to shutting down our socket server, for a
       // smoother transition.
       sharedServer.ensureNotRaftLeader()
-      metadataPublishers.forEach(p => sharedServer.loader.removeAndClosePublisher(p).get())
+      metadataPublishers.forEach(p => CoreUtils.swallow(sharedServer.loader.removeAndClosePublisher(p).get(), this))
       metadataPublishers.clear()
       if (socketServer != null)
         CoreUtils.swallow(socketServer.stopProcessingRequests(), this)


### PR DESCRIPTION
After this change: https://github.com/apache/kafka/pull/13462 , the `testExceptionInUpdateCoordinator` failed with 
```
java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: org.apache.kafka.server.fault.FaultHandlerException: nonFatalFaultHandler: Error updating group coordinator with local changes in MetadataDelta up to 9: injected failure
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at kafka.testkit.KafkaClusterTestKit.waitForAllFutures(KafkaClusterTestKit.java:569)
	at kafka.testkit.KafkaClusterTestKit.close(KafkaClusterTestKit.java:541)
	at kafka.server.metadata.BrokerMetadataPublisherTest.testExceptionInUpdateCoordinator(BrokerMetadataPublisherTest.scala:270)
Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.server.fault.FaultHandlerException: nonFatalFaultHandler: Error updating group coordinator with local changes in MetadataDelta up to 9: injected failure
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at kafka.server.BrokerServer.$anonfun$shutdown$6(BrokerServer.scala:547)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at kafka.server.BrokerServer.shutdown(BrokerServer.scala:547)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.apache.kafka.server.fault.FaultHandlerException: nonFatalFaultHandler: Error updating group coordinator with local changes in MetadataDelta up to 9: injected failure
	at app//kafka.server.metadata.BrokerMetadataPublisher.$anonfun$onMetadataUpdate$7(BrokerMetadataPublisher.scala:188)
	at app//scala.Option.foreach(Option.scala:407)
	at app//kafka.server.metadata.BrokerMetadataPublisher.onMetadataUpdate(BrokerMetadataPublisher.scala:174)
	at app//org.apache.kafka.image.loader.MetadataLoader.initializeNewPublishers(MetadataLoader.java:298)
	at app//org.apache.kafka.image.loader.MetadataLoader.lambda$scheduleInitializeNewPublishers$0(MetadataLoader.java:258)
	at app//org.apache.kafka.queue.KafkaEventQueue$EventContext.run(KafkaEventQueue.java:127)
	at app//org.apache.kafka.queue.KafkaEventQueue$EventHandler.handleEvents(KafkaEventQueue.java:210)
	at app//org.apache.kafka.queue.KafkaEventQueue$EventHandler.run(KafkaEventQueue.java:181)
	... 1 more
Caused by: java.lang.RuntimeException: injected failure
	at kafka.server.metadata.BrokerMetadataPublisher.$anonfun$onMetadataUpdate$7(BrokerMetadataPublisher.scala:200)
	at scala.Option.foreach(Option.scala:407)
	at kafka.server.metadata.BrokerMetadataPublisher.onMetadataUpdate(BrokerMetadataPublisher.scala:174)
	at org.apache.kafka.image.loader.MetadataLoader.lambda$handleCommit$1(MetadataLoader.java:341)
	... 4 more
```


So, it failed when we tried to remove and close the `brokerMetadataPublisher`, because the `uninitializedPublishers` has no this publisher when we removing it (deleted [here](https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java#L291-L298)). We should, anyway, not failed when shutdown the broker/controller, so swallow the exceptions.  


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
