### PR TITLE
MINOR: Fix mock in BrokerMetadataPublisherTest

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -544,7 +544,7 @@ class BrokerServer(
       if (socketServer != null) {
         CoreUtils.swallow(socketServer.stopProcessingRequests(), this)
       }
-      metadataPublishers.forEach(p => CoreUtils.swallow(sharedServer.loader.removeAndClosePublisher(p).get(), this))
+      metadataPublishers.forEach(p => sharedServer.loader.removeAndClosePublisher(p).get())
       metadataPublishers.clear()
       if (dataPlaneRequestHandlerPool != null)
         CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), this)

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -376,7 +376,7 @@ class ControllerServer(
       // Ensure that we're not the Raft leader prior to shutting down our socket server, for a
       // smoother transition.
       sharedServer.ensureNotRaftLeader()
-      metadataPublishers.forEach(p => CoreUtils.swallow(sharedServer.loader.removeAndClosePublisher(p).get(), this))
+      metadataPublishers.forEach(p => sharedServer.loader.removeAndClosePublisher(p).get())
       metadataPublishers.clear()
       if (socketServer != null)
         CoreUtils.swallow(socketServer.stopProcessingRequests(), this)


### PR DESCRIPTION
https://github.com/apache/kafka/commit/09e59bc7761a6b9ec1437b3decdfcd7b5fff868e added a list of metadata publishers in BrokerServer.scala which broke the mock used in BrokerMetadataPublisherTest#testExceptionInUpdateCoordinator. @showuon suppressed the exception in #13486. This patch fixes the mock