### PR TITLE
KAFKA-14617: Fill broker epochs to the AlterPartitionRequest

### DIFF
--- a/core/src/main/scala/kafka/api/LeaderAndIsr.scala
+++ b/core/src/main/scala/kafka/api/LeaderAndIsr.scala
@@ -18,10 +18,7 @@
 package kafka.api
 
 import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState
-import org.apache.kafka.common.requests.AlterPartitionRequest
 import org.apache.kafka.metadata.LeaderRecoveryState
-
-import scala.jdk.CollectionConverters._
 
 object LeaderAndIsr {
   val InitialLeaderEpoch: Int = 0
@@ -44,7 +41,7 @@ object LeaderAndIsr {
       leader,
       leaderEpoch,
       leaderRecoveryState,
-      AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(isr.map(Integer.valueOf).asJava).asScala.toList,
+      isr.map(brokerId => new BrokerState().setBrokerId(brokerId)),
       partitionEpoch)
   }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1719,11 +1719,11 @@ class Partition(val topicPartition: TopicPartition,
         brokerState.setBrokerEpoch(localBrokerEpochSupplier())
       } else if (!remoteReplicasMap.contains(brokerId) || !remoteReplicasMap.get(brokerId).stateSnapshot.brokerEpoch.isDefined) {
         // There are two cases where the broker epoch can be missing:
-        // 1. In ISR expansion. We already held lock for the partition and did the broker epoch check, so the new
-        //   ISR replica should have a valid broker epoch. Then, the missing broker epoch can only be the existing
-        //   ISR replicas whose fetch request has not been received by this leader. It is safe to set the epoch -1
-        //   for this replica because even if it crashed at the moment, the controller will remove it from ISR
-        //   later and bump the partition epoch to reject this AlterPartition request.
+        // 1. During ISR expansion, we already held lock for the partition and did the broker epoch check, so the new
+        //   ISR replica should have a valid broker epoch. Then, the missing broker epoch can only happens to the
+        //   existing ISR replicas whose fetch request has not been received by this leader. It is safe to set the epoch
+        //   -1 for this replica because even if it crashes at the moment, the controller will remove it from ISR
+        //   and bump the partition epoch to reject this AlterPartition request.
         // 2. In ISR shrinking. Similarly, if the existing ISR replicas does not have broker epoch, it is safe to
         //   set the broker epoch to -1 here.
         brokerState.setBrokerEpoch(-1)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -988,8 +988,8 @@ class Partition(val topicPartition: TopicPartition,
       // 3. Its metadata cached broker epoch matches its Fetch request broker epoch. Or the Fetch
       //    request broker epoch is -1 which bypass the epoch verification.
       case kRaftMetadataCache: KRaftMetadataCache =>
-        val cachedBrokerEpoch = kRaftMetadataCache.getAliveBrokerEpoch(followerReplicaId)
         val storedBrokerEpoch = remoteReplicasMap.get(followerReplicaId).stateSnapshot.brokerEpoch
+        val cachedBrokerEpoch = kRaftMetadataCache.getAliveBrokerEpoch(followerReplicaId)
         !kRaftMetadataCache.isBrokerFenced(followerReplicaId) &&
           !kRaftMetadataCache.isBrokerShuttingDown(followerReplicaId) &&
           isBrokerEpochIsrEligible(storedBrokerEpoch, cachedBrokerEpoch)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -17,7 +17,7 @@
 package kafka.cluster
 
 import java.util.concurrent.locks.ReentrantReadWriteLock
-import java.util.{Optional}
+import java.util.Optional
 import java.util.concurrent.{CompletableFuture, CopyOnWriteArrayList}
 import kafka.api.LeaderAndIsr
 import kafka.common.UnexpectedAppendOffsetException
@@ -982,11 +982,11 @@ class Partition(val topicPartition: TopicPartition,
 
   private def isReplicaIsrEligible(followerReplicaId: Int): Boolean = {
     metadataCache match {
-      // In KRaft mode, only replicas which meets all of the following requirements are allowed to join the ISR.
-      // 1. are not fenced.
-      // 2. are not in controlled shutdown.
-      // 3. have a cached brokerEpoch that matches with the brokerEpoch from the Fetch request, OR broker epoch
-      //    verification is not supported.
+      // In KRaft mode, only a replica which meets all of the following requirements is allowed to join the ISR.
+      // 1. It is not fenced.
+      // 2. It is not in controlled shutdown.
+      // 3. Its metadata cached broker epoch matches its Fetch request broker epoch. Or the Fetch
+      //    request broker epoch is -1 which bypass the epoch verification.
       case kRaftMetadataCache: KRaftMetadataCache =>
         val cachedBrokerEpoch = kRaftMetadataCache.getAliveBrokerEpoch(followerReplicaId)
         val storedBrokerEpoch = remoteReplicasMap.get(followerReplicaId).stateSnapshot.brokerEpoch

--- a/core/src/main/scala/kafka/server/AlterPartitionManager.scala
+++ b/core/src/main/scala/kafka/server/AlterPartitionManager.scala
@@ -28,7 +28,6 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.errors.OperationNotAttemptedException
 import org.apache.kafka.common.message.AlterPartitionRequestData
-import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.RequestHeader
@@ -281,12 +280,10 @@ class DefaultAlterPartitionManager(
       message.topics.add(topicData)
 
       items.foreach { item =>
-        val isrWithEpoch = new util.ArrayList[BrokerState](item.leaderAndIsr.isr.size)
-        item.leaderAndIsr.isr.foreach(brokerId => isrWithEpoch.add(new BrokerState().setBrokerId(brokerId)))
         val partitionData = new AlterPartitionRequestData.PartitionData()
           .setPartitionIndex(item.topicIdPartition.partition)
           .setLeaderEpoch(item.leaderAndIsr.leaderEpoch)
-          .setNewIsrWithEpochs(isrWithEpoch)
+          .setNewIsrWithEpochs(item.leaderAndIsr.isrWithBrokerEpoch.asJava)
           .setPartitionEpoch(item.leaderAndIsr.partitionEpoch)
 
         if (metadataVersion.isLeaderRecoverySupported) {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -194,7 +194,7 @@ class ReplicaManager(val config: KafkaConfig,
                      delayedDeleteRecordsPurgatoryParam: Option[DelayedOperationPurgatory[DelayedDeleteRecords]] = None,
                      delayedElectLeaderPurgatoryParam: Option[DelayedOperationPurgatory[DelayedElectLeader]] = None,
                      threadNamePrefix: Option[String] = None,
-                     brokerEpochSupplier: () => Long = () => -1
+                     val brokerEpochSupplier: () => Long = () => -1
                      ) extends Logging {
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -310,6 +310,11 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
     }
   }
 
+  def getAliveBrokerEpoch(brokerId: Int): Option[Long] = {
+    Option(_currentImage.cluster().broker(brokerId)).filterNot(_.fenced()).
+      map(brokerRegistration => brokerRegistration.epoch())
+  }
+
   override def getClusterMetadata(clusterId: String, listenerName: ListenerName): Cluster = {
     val image = _currentImage
     val nodes = new util.HashMap[Integer, Node]

--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -390,7 +390,7 @@ class ZkMigrationClient(
     controllerEpoch: Int
   ): (String, Array[Byte]) = {
     val path = TopicPartitionStateZNode.path(topicPartition)
-    val data = TopicPartitionStateZNode.encode(LeaderIsrAndControllerEpoch(new LeaderAndIsr(
+    val data = TopicPartitionStateZNode.encode(LeaderIsrAndControllerEpoch(LeaderAndIsr(
       partitionRegistration.leader,
       partitionRegistration.leaderEpoch,
       partitionRegistration.isr.toList,

--- a/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
+++ b/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test
 final class LeaderAndIsrTest {
   @Test
   def testRecoveringLeaderAndIsr(): Unit = {
-    val leaderAndIsr = LeaderAndIsr(1,  List(1, 2))
+    val leaderAndIsr = LeaderAndIsr(1, List(1, 2))
     val recoveringLeaderAndIsr = leaderAndIsr.newRecoveringLeaderAndIsr(3, List(3))
 
     assertEquals(3, recoveringLeaderAndIsr.leader)

--- a/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
+++ b/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test
 final class LeaderAndIsrTest {
   @Test
   def testRecoveringLeaderAndIsr(): Unit = {
-    val leaderAndIsr = LeaderAndIsr(1, List(1, 2))
+    val leaderAndIsr = LeaderAndIsr(1,  List(1, 2))
     val recoveringLeaderAndIsr = leaderAndIsr.newRecoveringLeaderAndIsr(3, List(3))
 
     assertEquals(3, recoveringLeaderAndIsr.leader)

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -82,6 +82,7 @@ class AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = interBrokerProtocolVersion,
       localBrokerId = brokerId,
+      () => getDefaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -145,5 +146,9 @@ class AbstractPartitionTest {
     }
 
     partition
+  }
+
+  def getDefaultBrokerEpoch(brokerId: Int): Long = {
+    brokerId + 1000L
   }
 }

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -82,7 +82,7 @@ class AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = interBrokerProtocolVersion,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -148,7 +148,7 @@ class AbstractPartitionTest {
     partition
   }
 
-  def getDefaultBrokerEpoch(brokerId: Int): Long = {
+  def defaultBrokerEpoch(brokerId: Int): Long = {
     brokerId + 1000L
   }
 }

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -271,6 +271,7 @@ class PartitionLockTest extends Logging {
       replicaLagTimeMaxMs = kafka.server.Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
+      () => 1L,
       mockTime,
       isrChangeListener,
       delayedOperations,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -417,7 +417,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -1478,7 +1478,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -1586,7 +1586,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -1610,7 +1610,7 @@ class PartitionTest extends AbstractPartitionTest {
     assertEquals(isr, partition.partitionState.maximalIsr)
 
     // Fetch to let the follower catch up to the log end offset, but using a wrong broker epoch. The expansion should fail.
-    val wrongReplicaEpoch = getDefaultBrokerEpoch(remoteBrokerId1) + 1
+    val wrongReplicaEpoch = defaultBrokerEpoch(remoteBrokerId1) + 1
     fetchFollower(partition,
       replicaId = remoteBrokerId1,
       fetchOffset = log.logEndOffset,
@@ -1635,7 +1635,7 @@ class PartitionTest extends AbstractPartitionTest {
       fetchOffset = log.logEndOffset
     )
 
-    // Follower fetches and catches up to the log end offset.
+    // Follower should still catch up to the log end offset.
     assertReplicaState(partition, remoteBrokerId1,
       lastCaughtUpTimeMs = time.milliseconds(),
       logStartOffset = 0L,
@@ -1648,11 +1648,11 @@ class PartitionTest extends AbstractPartitionTest {
     assertEquals(1, alterPartitionManager.isrUpdates.size)
     val isrUpdate = alterPartitionManager.isrUpdates.head
     isrUpdate.leaderAndIsr.isrWithBrokerEpoch.foreach(brokerState => {
-      if (brokerState.brokerId() != remoteBrokerId2) {
-        assertEquals(getDefaultBrokerEpoch(brokerState.brokerId()), brokerState.brokerEpoch())
-      } else {
+      if (brokerState.brokerId() == remoteBrokerId2) {
         // remoteBrokerId2 has not received any fetch request yet, it does not have broker epoch.
         assertEquals(-1, brokerState.brokerEpoch())
+      } else {
+        assertEquals(defaultBrokerEpoch(brokerState.brokerId()), brokerState.brokerEpoch())
       }
     })
   }
@@ -1676,7 +1676,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -1832,7 +1832,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -1876,7 +1876,7 @@ class PartitionTest extends AbstractPartitionTest {
     assertEquals(alterPartitionManager.isrUpdates.head.leaderAndIsr.isr, List(brokerId, remoteBrokerId1))
     val isrUpdate = alterPartitionManager.isrUpdates.head
     isrUpdate.leaderAndIsr.isrWithBrokerEpoch.foreach(brokerState => {
-      assertEquals(getDefaultBrokerEpoch(brokerState.brokerId()), brokerState.brokerEpoch())
+      assertEquals(defaultBrokerEpoch(brokerState.brokerId()), brokerState.brokerEpoch())
     })
     assertEquals(Set(brokerId, remoteBrokerId1, remoteBrokerId2), partition.partitionState.isr)
     assertEquals(Set(brokerId, remoteBrokerId1, remoteBrokerId2), partition.partitionState.maximalIsr)
@@ -2232,7 +2232,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = interBrokerProtocolVersion,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -2352,7 +2352,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = IBP_2_6_IV0, // shouldn't matter, but set this to a ZK isr version
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -2444,7 +2444,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -2489,7 +2489,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -2570,7 +2570,7 @@ class PartitionTest extends AbstractPartitionTest {
   def testUpdateAssignmentAndIsr(): Unit = {
     val topicPartition = new TopicPartition("test", 1)
     val partition = new Partition(
-      topicPartition, 1000, MetadataVersion.latest, 0, () => getDefaultBrokerEpoch(0),
+      topicPartition, 1000, MetadataVersion.latest, 0, () => defaultBrokerEpoch(0),
       new SystemTime(), mock(classOf[AlterPartitionListener]), mock(classOf[DelayedOperations]),
       mock(classOf[MetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterPartitionManager]))
 
@@ -2647,7 +2647,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -2686,7 +2686,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -2728,7 +2728,7 @@ class PartitionTest extends AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
-      () => getDefaultBrokerEpoch(brokerId),
+      () => defaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -3380,7 +3380,7 @@ class PartitionTest extends AbstractPartitionTest {
     val fetchParams = followerFetchParams(
       replicaId,
       maxBytes = maxBytes,
-      replicaEpoch = if (replicaEpoch == -2) getDefaultBrokerEpoch(replicaId) else replicaEpoch
+      replicaEpoch = if (replicaEpoch == -2) defaultBrokerEpoch(replicaId) else replicaEpoch
     )
 
     val fetchPartitionData = new FetchRequest.PartitionData(
@@ -3404,7 +3404,7 @@ class PartitionTest extends AbstractPartitionTest {
 
   private def addBrokerEpochToMockMetadataCache(kRaftMetadataCache: KRaftMetadataCache, brokers: List[Int]): Unit = {
     brokers.foreach(broker => {
-      when(kRaftMetadataCache.getAliveBrokerEpoch(broker)).thenReturn(Option(getDefaultBrokerEpoch(broker)))
+      when(kRaftMetadataCache.getAliveBrokerEpoch(broker)).thenReturn(Option(defaultBrokerEpoch(broker)))
     })
   }
 }

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1614,14 +1614,14 @@ class PartitionTest extends AbstractPartitionTest {
     fetchFollower(partition,
       replicaId = remoteBrokerId1,
       fetchOffset = log.logEndOffset,
-      replicaEpoch = wrongReplicaEpoch
+      replicaEpoch = Some(wrongReplicaEpoch)
     )
 
     assertReplicaState(partition, remoteBrokerId1,
       lastCaughtUpTimeMs = time.milliseconds(),
       logStartOffset = 0L,
       logEndOffset = log.logEndOffset,
-      brokerEpoch = Option[Long](wrongReplicaEpoch)
+      brokerEpoch = Some(wrongReplicaEpoch)
     )
 
     // Expansion is not triggered.
@@ -3375,12 +3375,12 @@ class PartitionTest extends AbstractPartitionTest {
     lastFetchedEpoch: Option[Int] = None,
     fetchTimeMs: Long = time.milliseconds(),
     topicId: Uuid = Uuid.ZERO_UUID,
-    replicaEpoch: Long = -2
+    replicaEpoch: Option[Long] = Option.empty
   ): LogReadInfo = {
     val fetchParams = followerFetchParams(
       replicaId,
       maxBytes = maxBytes,
-      replicaEpoch = if (replicaEpoch == -2) defaultBrokerEpoch(replicaId) else replicaEpoch
+      replicaEpoch = if (!replicaEpoch.isDefined) defaultBrokerEpoch(replicaId) else replicaEpoch.get
     )
 
     val fetchPartitionData = new FetchRequest.PartitionData(

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -23,8 +23,6 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
-import java.util.OptionalLong
-
 object ReplicaTest {
   val BrokerId: Int = 0
   val Partition: TopicPartition = new TopicPartition("foo", 0)
@@ -47,7 +45,8 @@ class ReplicaTest {
     logEndOffset: Long,
     lastCaughtUpTimeMs: Long,
     lastFetchLeaderLogEndOffset: Long,
-    lastFetchTimeMs: Long
+    lastFetchTimeMs: Long,
+    brokerEpoch: Option[Long] = Option[Long](1L)
   ): Unit = {
     val replicaState = replica.stateSnapshot
     assertEquals(logStartOffset, replicaState.logStartOffset,
@@ -60,7 +59,7 @@ class ReplicaTest {
       "Unexpected Last Fetch Leader Log End Offset")
     assertEquals(lastFetchTimeMs, replicaState.lastFetchTimeMs,
       "Unexpected Last Fetch Time")
-    assertEquals(OptionalLong.of(1L), replicaState.brokerEpoch,
+    assertEquals(brokerEpoch, replicaState.brokerEpoch,
       "Unexpected Last Fetch Time")
   }
 
@@ -128,7 +127,8 @@ class ReplicaTest {
       logEndOffset = UnifiedLog.UnknownOffset,
       lastCaughtUpTimeMs = 0L,
       lastFetchLeaderLogEndOffset = 0L,
-      lastFetchTimeMs = 0L
+      lastFetchTimeMs = 0L,
+      brokerEpoch = Option.empty
     )
   }
 
@@ -242,7 +242,8 @@ class ReplicaTest {
       logEndOffset = UnifiedLog.UnknownOffset,
       lastCaughtUpTimeMs = resetTimeMs1,
       lastFetchLeaderLogEndOffset = UnifiedLog.UnknownOffset,
-      lastFetchTimeMs = 0L
+      lastFetchTimeMs = 0L,
+      brokerEpoch = Option.empty
     )
   }
 
@@ -265,7 +266,8 @@ class ReplicaTest {
       logEndOffset = UnifiedLog.UnknownOffset,
       lastCaughtUpTimeMs = 0L,
       lastFetchLeaderLogEndOffset = UnifiedLog.UnknownOffset,
-      lastFetchTimeMs = 0L
+      lastFetchTimeMs = 0L,
+      brokerEpoch = Option.empty
     )
   }
 

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -23,6 +23,8 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
+import java.util.OptionalLong
+
 object ReplicaTest {
   val BrokerId: Int = 0
   val Partition: TopicPartition = new TopicPartition("foo", 0)
@@ -58,6 +60,8 @@ class ReplicaTest {
       "Unexpected Last Fetch Leader Log End Offset")
     assertEquals(lastFetchTimeMs, replicaState.lastFetchTimeMs,
       "Unexpected Last Fetch Time")
+    assertEquals(OptionalLong.of(1L), replicaState.brokerEpoch,
+      "Unexpected Last Fetch Time")
   }
 
   def assertReplicaStateDoesNotChange(
@@ -86,7 +90,8 @@ class ReplicaTest {
       followerFetchOffsetMetadata = new LogOffsetMetadata(followerFetchOffset),
       followerStartOffset = followerStartOffset,
       followerFetchTimeMs = currentTimeMs,
-      leaderEndOffset = leaderEndOffset
+      leaderEndOffset = leaderEndOffset,
+      brokerEpoch = 1L
     )
     currentTimeMs
   }

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -60,7 +60,7 @@ class ReplicaTest {
     assertEquals(lastFetchTimeMs, replicaState.lastFetchTimeMs,
       "Unexpected Last Fetch Time")
     assertEquals(brokerEpoch, replicaState.brokerEpoch,
-      "Unexpected Last Fetch Time")
+      "Broker Epoch Mismatch")
   }
 
   def assertReplicaStateDoesNotChange(

--- a/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
@@ -95,7 +95,7 @@ class AlterPartitionManagerTest {
     }
     alterPartitionManager.submit(tp0, LeaderAndIsr(1, 1, LeaderRecoveryState.RECOVERED, isrWithBrokerEpoch.toList, 10), 0)
 
-    val message = new AlterPartitionRequestData()
+    val expectedAlterPartitionData = new AlterPartitionRequestData()
       .setBrokerId(brokerId)
       .setBrokerEpoch(101)
     val topicData = new AlterPartitionRequestData.TopicData()
@@ -120,12 +120,12 @@ class AlterPartitionManagerTest {
         .setNewIsr(List(1, 2, 3).map(Integer.valueOf).asJava))
     }
 
-    message.topics.add(topicData)
+    expectedAlterPartitionData.topics.add(topicData)
 
     verify(brokerToController).start()
     val captor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
     verify(brokerToController).sendRequest(captor.capture(), any())
-    assertEquals(message, captor.getValue.asInstanceOf[AlterPartitionRequest.Builder].build().data())
+    assertEquals(expectedAlterPartitionData, captor.getValue.asInstanceOf[AlterPartitionRequest.Builder].build().data())
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
@@ -125,7 +125,7 @@ class AlterPartitionManagerTest {
     verify(brokerToController).start()
     val captor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
     verify(brokerToController).sendRequest(captor.capture(), any())
-    assertEquals(message.toString, captor.getValue.asInstanceOf[AlterPartitionRequest.Builder].build().toString)
+    assertEquals(message, captor.getValue.asInstanceOf[AlterPartitionRequest.Builder].build().data())
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -101,7 +101,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset - 1),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
     var partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
 
@@ -150,7 +151,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset - 2),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
 
     // Simulate 2 fetch requests spanning more than 100 ms which do not read to the end of the log.
     // The replicas will no longer be in ISR. We do 2 fetches because we want to simulate the case where the replica is lagging but is not stuck
@@ -164,7 +166,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset - 1),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
     }
     partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -181,7 +184,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
     }
     partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -205,7 +209,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
 
     var partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -241,7 +246,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(0L),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = 0L)
+        leaderEndOffset = 0L,
+        brokerEpoch = 1L)
 
     // set the leader and its hw and the hw update time
     partition.leaderReplicaIdOpt = Some(leaderId)

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -703,7 +703,7 @@ class MetadataCacheTest {
 
     metadataCache.setImage(delta.apply(MetadataProvenance.EMPTY))
 
-    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1))
+    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1L))
     assertEquals(-1L, metadataCache.getAliveBrokerEpoch(1).getOrElse(-1L))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -685,4 +685,25 @@ class MetadataCacheTest {
 
     assertTrue(metadataCache.isBrokerShuttingDown(0))
   }
+
+  @Test
+  def testGetLiveBrokerEpoch(): Unit = {
+    val metadataCache = MetadataCache.kRaftMetadataCache(0)
+
+    val delta = new MetadataDelta.Builder().build()
+    delta.replay(new RegisterBrokerRecord()
+      .setBrokerId(0)
+      .setBrokerEpoch(100)
+      .setFenced(false))
+
+    delta.replay(new RegisterBrokerRecord()
+      .setBrokerId(1)
+      .setBrokerEpoch(101)
+      .setFenced(true))
+
+    metadataCache.setImage(delta.apply(MetadataProvenance.EMPTY))
+
+    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1))
+    assertEquals(-1L, metadataCache.getAliveBrokerEpoch(1).getOrElse(-1L))
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -231,7 +231,7 @@ class ReplicaManagerConcurrencyTest {
       val fetchParams = new FetchParams(
         ApiKeys.FETCH.latestVersion,
         replicaId,
-        1,
+        getDefaultBrokerEpoch(replicaId),
         random.nextInt(100),
         1,
         1024 * 1024,
@@ -356,6 +356,7 @@ class ReplicaManagerConcurrencyTest {
             delta.replay(new RegisterBrokerRecord()
               .setBrokerId(brokerId)
               .setFenced(false)
+              .setBrokerEpoch(getDefaultBrokerEpoch(brokerId))
             )
           }
           topic.initialize(delta)
@@ -473,6 +474,10 @@ class ReplicaManagerConcurrencyTest {
       leaderEpoch,
       partitionEpoch
     )
+  }
+
+  private def getDefaultBrokerEpoch(brokerId: Int): Long = {
+    brokerId + 100L
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -231,7 +231,7 @@ class ReplicaManagerConcurrencyTest {
       val fetchParams = new FetchParams(
         ApiKeys.FETCH.latestVersion,
         replicaId,
-        getDefaultBrokerEpoch(replicaId),
+        defaultBrokerEpoch(replicaId),
         random.nextInt(100),
         1,
         1024 * 1024,
@@ -356,7 +356,7 @@ class ReplicaManagerConcurrencyTest {
             delta.replay(new RegisterBrokerRecord()
               .setBrokerId(brokerId)
               .setFenced(false)
-              .setBrokerEpoch(getDefaultBrokerEpoch(brokerId))
+              .setBrokerEpoch(defaultBrokerEpoch(brokerId))
             )
           }
           topic.initialize(delta)
@@ -476,8 +476,7 @@ class ReplicaManagerConcurrencyTest {
     )
   }
 
-  private def getDefaultBrokerEpoch(brokerId: Int): Long = {
+  private def defaultBrokerEpoch(brokerId: Int): Long = {
     brokerId + 100L
   }
-
 }

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -144,9 +144,9 @@ class ZkMigrationClientTest extends QuorumTestHarness {
 
     val leaderAndIsrs = Map(
       new TopicPartition("test", 0) -> LeaderIsrAndControllerEpoch(
-        new LeaderAndIsr(0, 5, List(0, 1, 2), LeaderRecoveryState.RECOVERED, -1), 1),
+        LeaderAndIsr(0, 5, List(0, 1, 2), LeaderRecoveryState.RECOVERED, -1), 1),
       new TopicPartition("test", 1) -> LeaderIsrAndControllerEpoch(
-        new LeaderAndIsr(1, 5, List(1, 2, 3), LeaderRecoveryState.RECOVERED, -1), 1)
+        LeaderAndIsr(1, 5, List(1, 2, 3), LeaderRecoveryState.RECOVERED, -1), 1)
     )
     zkClient.createTopicPartitionStatesRaw(leaderAndIsrs, 0)
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -178,7 +178,7 @@ public class ReplicaFetcherThreadBenchmark {
             Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
             AlterPartitionManager isrChannelManager = Mockito.mock(AlterPartitionManager.class);
             Partition partition = new Partition(tp, 100, MetadataVersion.latest(),
-                    0, Time.SYSTEM, alterPartitionListener, new DelayedOperationsMock(tp),
+                    0, () -> -1, Time.SYSTEM, alterPartitionListener, new DelayedOperationsMock(tp),
                     Mockito.mock(MetadataCache.class), logManager, isrChannelManager);
 
             partition.makeFollower(partitionState, offsetCheckpoints, topicId);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -122,7 +122,7 @@ public class PartitionMakeFollowerBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(tp, 100,
-            MetadataVersion.latest(), 0, Time.SYSTEM,
+            MetadataVersion.latest(), 0, () -> -1, Time.SYSTEM,
             alterPartitionListener, delayedOperations,
             Mockito.mock(MetadataCache.class), logManager, alterPartitionManager);
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -160,9 +160,9 @@ public class UpdateFollowerFetchStateBenchmark {
     public void updateFollowerFetchStateBench() {
         // measure the impact of two follower fetches on the leader
         partition.updateFollowerFetchState(replica1, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, nextOffset);
+                0, 1, nextOffset, -1);
         partition.updateFollowerFetchState(replica2, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, nextOffset);
+                0, 1, nextOffset, -1);
         nextOffset++;
     }
 
@@ -172,8 +172,8 @@ public class UpdateFollowerFetchStateBenchmark {
         // measure the impact of two follower fetches on the leader when the follower didn't
         // end up fetching anything
         partition.updateFollowerFetchState(replica1, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, 100);
+                0, 1, 100, -1);
         partition.updateFollowerFetchState(replica2, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, 100);
+                0, 1, 100, -1);
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -125,7 +125,7 @@ public class UpdateFollowerFetchStateBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(topicPartition, 100,
-                MetadataVersion.latest(), 0, Time.SYSTEM,
+                MetadataVersion.latest(), 0, () -> -1,Time.SYSTEM,
                 alterPartitionListener, delayedOperations,
                 Mockito.mock(MetadataCache.class), logManager, alterPartitionManager);
         partition.makeLeader(partitionState, offsetCheckpoints, topicId);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -125,7 +125,7 @@ public class UpdateFollowerFetchStateBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(topicPartition, 100,
-                MetadataVersion.latest(), 0, () -> -1,Time.SYSTEM,
+                MetadataVersion.latest(), 0, () -> -1, Time.SYSTEM,
                 alterPartitionListener, delayedOperations,
                 Mockito.mock(MetadataCache.class), logManager, alterPartitionManager);
         partition.makeLeader(partitionState, offsetCheckpoints, topicId);


### PR DESCRIPTION
As the third part of the [KIP-903](https://cwiki.apache.org/confluence/display/KAFKA/KIP-903%3A+Replicas+with+stale+broker+epoch+should+not+be+allowed+to+join+the+ISR), it fills the broker epochs from the Fetch request into the AlterPartitionRequest. Also, before generating the alterPartitionRequest, the partition will check whether the broker epoch from the FetchRequest matches with the broker epoch recorded in the metadata cache. If not, the ISR change will be delayed. 

https://issues.apache.org/jira/browse/KAFKA-14617
