### PR TITLE
KAFKA-14852: Propagate Topic Ids to the Group Coordinator for Offset Fetch

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1062,8 +1062,8 @@ private[group] class GroupCoordinator(
   def handleFetchOffsets(
     groupId: String,
     requireStable: Boolean,
-    partitions: Option[Seq[TopicPartition]] = None
-  ): (Errors, Map[TopicPartition, OffsetFetchResponse.PartitionData]) = {
+    partitions: Option[Seq[TopicIdPartition]] = None
+  ): (Errors, Map[TopicIdPartition, OffsetFetchResponse.PartitionData]) = {
 
     validateGroupStatus(groupId, ApiKeys.OFFSET_FETCH) match {
       case Some(error) => error -> Map.empty

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -291,24 +291,24 @@ private[group] class GroupCoordinatorAdapter(
     topics: util.List[OffsetFetchRequestData.OffsetFetchRequestTopics],
     requireStable: Boolean
   ): CompletableFuture[util.List[OffsetFetchResponseData.OffsetFetchResponseTopics]] = {
-    val topicPartitions = new mutable.ArrayBuffer[TopicPartition]()
+    val topicIdPartitions = new mutable.ArrayBuffer[TopicIdPartition]()
     topics.forEach { topic =>
       topic.partitionIndexes.forEach { partition =>
-        topicPartitions += new TopicPartition(topic.name, partition)
+        topicIdPartitions += new TopicIdPartition(Uuid.ZERO_UUID, partition, topic.name)
       }
     }
 
     handleFetchOffset(
       groupId,
       requireStable,
-      Some(topicPartitions.toSeq)
+      Some(topicIdPartitions.toSeq)
     )
   }
 
   private def handleFetchOffset(
     groupId: String,
     requireStable: Boolean,
-    partitions: Option[Seq[TopicPartition]]
+    partitions: Option[Seq[TopicIdPartition]]
   ): CompletableFuture[util.List[OffsetFetchResponseData.OffsetFetchResponseTopics]] = {
     val (error, results) = coordinator.handleFetchOffsets(
       groupId,

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -19,6 +19,7 @@ package kafka.coordinator.group
 import java.nio.ByteBuffer
 import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
+
 import kafka.common.OffsetAndMetadata
 import kafka.utils.{CoreUtils, Logging, nonthreadsafe}
 import kafka.utils.Implicits._
@@ -823,8 +824,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     expiredOffsets
   }
 
-  def allOffsets: Map[TopicIdPartition, OffsetAndMetadata] = offsets.map { case (topicPartition, commitRecordMetadataAndOffset) =>
-    (new TopicIdPartition(Uuid.ZERO_UUID, topicPartition), commitRecordMetadataAndOffset.offsetAndMetadata)
+  def allOffsets: Map[TopicPartition, OffsetAndMetadata] = offsets.map { case (topicPartition, commitRecordMetadataAndOffset) =>
+    (topicPartition, commitRecordMetadataAndOffset.offsetAndMetadata)
   }.toMap
 
   def offset(topicIdPartition: TopicIdPartition): Option[OffsetAndMetadata] = offsets.get(topicIdPartition.topicPartition).map(_.offsetAndMetadata)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -464,9 +464,9 @@ class GroupCoordinatorAdapterTest {
 
   @Test
   def testFetchAllOffsets(): Unit = {
-    val foo0 = new TopicPartition("foo", 0)
-    val foo1 = new TopicPartition("foo", 1)
-    val bar1 = new TopicPartition("bar", 1)
+    val foo0 = new TopicIdPartition(Uuid.randomUuid(), 0, "foo")
+    val foo1 = new TopicIdPartition(Uuid.randomUuid(), 1, "foo")
+    val bar1 = new TopicIdPartition(Uuid.randomUuid(), 1, "bar")
 
     val groupCoordinator = mock(classOf[GroupCoordinator])
     val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
@@ -545,9 +545,9 @@ class GroupCoordinatorAdapterTest {
 
   @Test
   def testFetchOffsets(): Unit = {
-    val foo0 = new TopicPartition("foo", 0)
-    val foo1 = new TopicPartition("foo", 1)
-    val bar1 = new TopicPartition("bar", 1)
+    val foo0 = new TopicIdPartition(Uuid.ZERO_UUID, 0, "foo")
+    val foo1 = new TopicIdPartition(Uuid.ZERO_UUID, 1, "foo")
+    val bar1 = new TopicIdPartition(Uuid.ZERO_UUID, 1, "bar")
 
     val groupCoordinator = mock(classOf[GroupCoordinator])
     val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -370,8 +370,8 @@ object GroupCoordinatorConcurrencyTest {
   type SyncGroupCallback = SyncGroupResult => Unit
   type HeartbeatCallbackParams = Errors
   type HeartbeatCallback = Errors => Unit
-  type OffsetFetchCallbackParams = (Errors, Map[TopicPartition, OffsetFetchResponse.PartitionData])
-  type OffsetFetchCallback = (Errors, Map[TopicPartition, OffsetFetchResponse.PartitionData]) => Unit
+  type OffsetFetchCallbackParams = (Errors, Map[TopicIdPartition, OffsetFetchResponse.PartitionData])
+  type OffsetFetchCallback = (Errors, Map[TopicIdPartition, OffsetFetchResponse.PartitionData]) => Unit
   type CommitOffsetCallbackParams = Map[TopicIdPartition, Errors]
   type CommitOffsetCallback = Map[TopicIdPartition, Errors] => Unit
   type LeaveGroupCallbackParams = LeaveGroupResult

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -2564,9 +2564,9 @@ class GroupCoordinatorTest {
       OffsetCommitRequest.DEFAULT_GENERATION_ID, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(0), partitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(0), partitionData.get(tip).map(_.offset))
   }
 
   @Test
@@ -2581,10 +2581,10 @@ class GroupCoordinatorTest {
       OffsetCommitRequest.DEFAULT_GENERATION_ID, Map(tip -> offsetAndMetadata))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, error)
 
-    val maybePartitionData = partitionData.get(tip.topicPartition)
+    val maybePartitionData = partitionData.get(tip)
     assertTrue(maybePartitionData.isDefined)
     assertEquals(offset, maybePartitionData.get.offset)
     assertEquals(metadata, maybePartitionData.get.metadata)
@@ -2604,9 +2604,9 @@ class GroupCoordinatorTest {
       OffsetCommitRequest.DEFAULT_GENERATION_ID, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (fetchError, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (fetchError, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, fetchError)
-    assertEquals(Some(0), partitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(0), partitionData.get(tip).map(_.offset))
 
     val (describeError, summary) = groupCoordinator.handleDescribeGroup(groupId)
     assertEquals(Errors.NONE, describeError)
@@ -2622,9 +2622,9 @@ class GroupCoordinatorTest {
     val deleteErrors = groupCoordinator.handleDeleteGroups(Set(groupId))
     assertEquals(Errors.NONE, deleteErrors(groupId))
 
-    val (err, data) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (err, data) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, err)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), data.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), data.get(tip).map(_.offset))
   }
 
   @Test
@@ -2637,11 +2637,11 @@ class GroupCoordinatorTest {
     val commitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
 
     // Validate that the offset isn't materialjzed yet.
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip).map(_.offset))
 
     val offsetsTopic = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId)
 
@@ -2649,9 +2649,9 @@ class GroupCoordinatorTest {
     handleTxnCompletion(producerId, List(offsetsTopic), TransactionResult.COMMIT)
 
     // Validate that committed offset is materialized.
-    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, secondReqError)
-    assertEquals(Some(0), secondReqPartitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(0), secondReqPartitionData.get(tip).map(_.offset))
   }
 
   @Test
@@ -2664,18 +2664,18 @@ class GroupCoordinatorTest {
     val commitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip).map(_.offset))
 
     val offsetsTopic = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId)
 
     // Validate that the pending commit is discarded.
     handleTxnCompletion(producerId, List(offsetsTopic), TransactionResult.ABORT)
 
-    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, secondReqError)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), secondReqPartitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), secondReqPartitionData.get(tip).map(_.offset))
   }
 
   @Test
@@ -2688,11 +2688,11 @@ class GroupCoordinatorTest {
     val commitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val nonExistTp = new TopicPartition("non-exist-topic", 0)
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition, nonExistTp)))
+    val nonExistTp = new TopicIdPartition(Uuid.randomUuid(), 0, "non-exist-topic")
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip, nonExistTp)))
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip.topicPartition).map(_.offset))
-    assertEquals(Some(Errors.UNSTABLE_OFFSET_COMMIT), partitionData.get(tip.topicPartition).map(_.error))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip).map(_.offset))
+    assertEquals(Some(Errors.UNSTABLE_OFFSET_COMMIT), partitionData.get(tip).map(_.error))
     assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(nonExistTp).map(_.offset))
     assertEquals(Some(Errors.NONE), partitionData.get(nonExistTp).map(_.error))
 
@@ -2701,10 +2701,10 @@ class GroupCoordinatorTest {
     // Validate that the pending commit is discarded.
     handleTxnCompletion(producerId, List(offsetsTopic), TransactionResult.ABORT)
 
-    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, secondReqError)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), secondReqPartitionData.get(tip.topicPartition).map(_.offset))
-    assertEquals(Some(Errors.NONE), secondReqPartitionData.get(tip.topicPartition).map(_.error))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), secondReqPartitionData.get(tip).map(_.offset))
+    assertEquals(Some(Errors.NONE), secondReqPartitionData.get(tip).map(_.error))
   }
 
   @Test
@@ -2717,20 +2717,20 @@ class GroupCoordinatorTest {
     val commitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip.topicPartition).map(_.offset))
-    assertEquals(Some(Errors.UNSTABLE_OFFSET_COMMIT), partitionData.get(tip.topicPartition).map(_.error))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip).map(_.offset))
+    assertEquals(Some(Errors.UNSTABLE_OFFSET_COMMIT), partitionData.get(tip).map(_.error))
 
     val offsetsTopic = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId)
 
     // Validate that the pending commit is committed
     handleTxnCompletion(producerId, List(offsetsTopic), TransactionResult.COMMIT)
 
-    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, secondReqError)
-    assertEquals(Some(25), secondReqPartitionData.get(tip.topicPartition).map(_.offset))
-    assertEquals(Some(Errors.NONE), secondReqPartitionData.get(tip.topicPartition).map(_.error))
+    assertEquals(Some(25), secondReqPartitionData.get(tip).map(_.offset))
+    assertEquals(Some(Errors.NONE), secondReqPartitionData.get(tip).map(_.error))
   }
 
   @Test
@@ -2743,23 +2743,23 @@ class GroupCoordinatorTest {
     val commitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch, Map(tip -> offset))
     assertEquals(Map(tip -> Errors.NONE), commitOffsetResult)
 
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip).map(_.offset))
 
     val offsetsTopic = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId)
     handleTxnCompletion(producerId, List(offsetsTopic), TransactionResult.ABORT)
 
-    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (secondReqError, secondReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, secondReqError)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), secondReqPartitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), secondReqPartitionData.get(tip).map(_.offset))
 
     // Ignore spurious commit.
     handleTxnCompletion(producerId, List(offsetsTopic), TransactionResult.COMMIT)
 
-    val (thirdReqError, thirdReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip.topicPartition)))
+    val (thirdReqError, thirdReqPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, thirdReqError)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), thirdReqPartitionData.get(tip.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), thirdReqPartitionData.get(tip).map(_.offset))
   }
 
   @Test
@@ -2782,7 +2782,7 @@ class GroupCoordinatorTest {
 
     groupCoordinator.groupManager.addOwnedPartition(offsetTopicPartitions(1).partition)
     val errors = mutable.ArrayBuffer[Errors]()
-    val partitionData = mutable.ArrayBuffer[scala.collection.Map[TopicPartition, OffsetFetchResponse.PartitionData]]()
+    val partitionData = mutable.ArrayBuffer[scala.collection.Map[TopicIdPartition, OffsetFetchResponse.PartitionData]]()
 
     val commitOffsetResults = mutable.ArrayBuffer[CommitOffsetCallbackParams]()
 
@@ -2795,16 +2795,15 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, commitOffsetResults(1)(topicIdPartitions(1)))
 
     // We got a commit for only one __consumer_offsets partition. We should only materialize it's group offsets.
-    val topicPartitions = topicIdPartitions.map(_.topicPartition)
     handleTxnCompletion(producerId, List(offsetTopicPartitions(0)), TransactionResult.COMMIT)
-    groupCoordinator.handleFetchOffsets(groupIds(0), requireStable, Some(topicPartitions)) match {
+    groupCoordinator.handleFetchOffsets(groupIds(0), requireStable, Some(topicIdPartitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)
       case _ =>
     }
 
-    groupCoordinator.handleFetchOffsets(groupIds(1), requireStable, Some(topicPartitions)) match {
+    groupCoordinator.handleFetchOffsets(groupIds(1), requireStable, Some(topicIdPartitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)
@@ -2816,33 +2815,33 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, errors(1))
 
     // Exactly one offset commit should have been materialized.
-    assertEquals(Some(offsets(0).offset), partitionData(0).get(topicPartitions(0)).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(0).get(topicPartitions(1)).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(1).get(topicPartitions(0)).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(1).get(topicPartitions(1)).map(_.offset))
+    assertEquals(Some(offsets(0).offset), partitionData(0).get(topicIdPartitions(0)).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(0).get(topicIdPartitions(1)).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(1).get(topicIdPartitions(0)).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(1).get(topicIdPartitions(1)).map(_.offset))
 
     // Now we receive the other marker.
     handleTxnCompletion(producerId, List(offsetTopicPartitions(1)), TransactionResult.COMMIT)
     errors.clear()
     partitionData.clear()
-    groupCoordinator.handleFetchOffsets(groupIds(0), requireStable, Some(topicPartitions)) match {
+    groupCoordinator.handleFetchOffsets(groupIds(0), requireStable, Some(topicIdPartitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)
       case _ =>
     }
 
-     groupCoordinator.handleFetchOffsets(groupIds(1), requireStable, Some(topicPartitions)) match {
+     groupCoordinator.handleFetchOffsets(groupIds(1), requireStable, Some(topicIdPartitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)
       case _ =>
     }
     // Two offsets should have been materialized
-    assertEquals(Some(offsets(0).offset), partitionData(0).get(topicPartitions(0)).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(0).get(topicPartitions(1)).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(1).get(topicPartitions(0)).map(_.offset))
-    assertEquals(Some(offsets(1).offset), partitionData(1).get(topicPartitions(1)).map(_.offset))
+    assertEquals(Some(offsets(0).offset), partitionData(0).get(topicIdPartitions(0)).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(0).get(topicIdPartitions(1)).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(1).get(topicIdPartitions(0)).map(_.offset))
+    assertEquals(Some(offsets(1).offset), partitionData(1).get(topicIdPartitions(1)).map(_.offset))
   }
 
   @Test
@@ -2862,7 +2861,7 @@ class GroupCoordinatorTest {
     val offsetTopicPartition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupCoordinator.partitionFor(groupId))
 
     val errors = mutable.ArrayBuffer[Errors]()
-    val partitionData = mutable.ArrayBuffer[scala.collection.Map[TopicPartition, OffsetFetchResponse.PartitionData]]()
+    val partitionData = mutable.ArrayBuffer[scala.collection.Map[TopicIdPartition, OffsetFetchResponse.PartitionData]]()
 
     val commitOffsetResults = mutable.ArrayBuffer[CommitOffsetCallbackParams]()
 
@@ -2875,9 +2874,8 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, commitOffsetResults(1)(topicIdPartitions(1)))
 
     // producer0 commits its transaction.
-    val topicPartitions = topicIdPartitions.map(_.topicPartition)
     handleTxnCompletion(producerIds(0), List(offsetTopicPartition), TransactionResult.COMMIT)
-    groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(topicPartitions)) match {
+    groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(topicIdPartitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)
@@ -2887,13 +2885,13 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, errors(0))
 
     // We should only see the offset commit for producer0
-    assertEquals(Some(offsets(0).offset), partitionData(0).get(topicPartitions(0)).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(0).get(topicPartitions(1)).map(_.offset))
+    assertEquals(Some(offsets(0).offset), partitionData(0).get(topicIdPartitions(0)).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData(0).get(topicIdPartitions(1)).map(_.offset))
 
     // producer1 now commits its transaction.
     handleTxnCompletion(producerIds(1), List(offsetTopicPartition), TransactionResult.COMMIT)
 
-    groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(topicPartitions)) match {
+    groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(topicIdPartitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)
@@ -2903,31 +2901,31 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, errors(1))
 
     // We should now see the offset commits for both producers.
-    assertEquals(Some(offsets(0).offset), partitionData(1).get(topicPartitions(0)).map(_.offset))
-    assertEquals(Some(offsets(1).offset), partitionData(1).get(topicPartitions(1)).map(_.offset))
+    assertEquals(Some(offsets(0).offset), partitionData(1).get(topicIdPartitions(0)).map(_.offset))
+    assertEquals(Some(offsets(1).offset), partitionData(1).get(topicIdPartitions(1)).map(_.offset))
   }
 
   @Test
   def testFetchOffsetForUnknownPartition(): Unit = {
-    val tp = new TopicPartition("topic", 0)
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tp)))
+    val tip = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NONE, error)
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tp).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), partitionData.get(tip).map(_.offset))
   }
 
   @Test
   def testFetchOffsetNotCoordinatorForGroup(): Unit = {
-    val tp = new TopicPartition("topic", 0)
-    val (error, partitionData) = groupCoordinator.handleFetchOffsets(otherGroupId, requireStable, Some(Seq(tp)))
+    val tip = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
+    val (error, partitionData) = groupCoordinator.handleFetchOffsets(otherGroupId, requireStable, Some(Seq(tip)))
     assertEquals(Errors.NOT_COORDINATOR, error)
     assertTrue(partitionData.isEmpty)
   }
 
   @Test
   def testFetchAllOffsets(): Unit = {
-    val tip1 = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
-    val tip2 = new TopicIdPartition(tip1.topicId, 1, "topic")
-    val tip3 = new TopicIdPartition(Uuid.randomUuid(), 0, "other-topic")
+    val tip1 = new TopicIdPartition(Uuid.ZERO_UUID, 0, "topic")
+    val tip2 = new TopicIdPartition(Uuid.ZERO_UUID, 1, "topic")
+    val tip3 = new TopicIdPartition(Uuid.ZERO_UUID, 0, "other-topic")
     val offset1 = offsetAndMetadata(15)
     val offset2 = offsetAndMetadata(16)
     val offset3 = offsetAndMetadata(17)
@@ -2942,9 +2940,9 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, error)
     assertEquals(3, partitionData.size)
     assertTrue(partitionData.forall(_._2.error == Errors.NONE))
-    assertEquals(Some(offset1.offset), partitionData.get(tip1.topicPartition).map(_.offset))
-    assertEquals(Some(offset2.offset), partitionData.get(tip2.topicPartition).map(_.offset))
-    assertEquals(Some(offset3.offset), partitionData.get(tip3.topicPartition).map(_.offset))
+    assertEquals(Some(offset1.offset), partitionData.get(tip1).map(_.offset))
+    assertEquals(Some(offset2.offset), partitionData.get(tip2).map(_.offset))
+    assertEquals(Some(offset3.offset), partitionData.get(tip3).map(_.offset))
   }
 
   @Test
@@ -3568,10 +3566,10 @@ class GroupCoordinatorTest {
     assertEquals(1, topics.size)
     assertEquals(Some(Errors.NONE), topics.get(ti1p0.topicPartition))
 
-    val cachedOffsets = groupCoordinator.groupManager.getOffsets(groupId, requireStable, Some(Seq(ti1p0.topicPartition, ti2p0.topicPartition)))
+    val cachedOffsets = groupCoordinator.groupManager.getOffsets(groupId, requireStable, Some(Seq(ti1p0, ti2p0)))
 
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(ti1p0.topicPartition).map(_.offset))
-    assertEquals(Some(offset.offset), cachedOffsets.get(ti2p0.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(ti1p0).map(_.offset))
+    assertEquals(Some(offset.offset), cachedOffsets.get(ti2p0).map(_.offset))
   }
 
   @Test
@@ -3649,10 +3647,10 @@ class GroupCoordinatorTest {
     assertEquals(1, topics.size)
     assertEquals(Some(Errors.NONE), topics.get(ti1p0.topicPartition))
 
-    val cachedOffsets = groupCoordinator.groupManager.getOffsets(groupId, requireStable, Some(Seq(ti1p0.topicPartition, ti2p0.topicPartition)))
+    val cachedOffsets = groupCoordinator.groupManager.getOffsets(groupId, requireStable, Some(Seq(ti1p0, ti2p0)))
 
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(ti1p0.topicPartition).map(_.offset))
-    assertEquals(Some(offset.offset), cachedOffsets.get(ti2p0.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(ti1p0).map(_.offset))
+    assertEquals(Some(offset.offset), cachedOffsets.get(ti2p0).map(_.offset))
   }
 
   @Test
@@ -3693,10 +3691,10 @@ class GroupCoordinatorTest {
     assertEquals(Some(Errors.NONE), topics.get(ti1p0.topicPartition))
     assertEquals(Some(Errors.GROUP_SUBSCRIBED_TO_TOPIC), topics.get(ti2p0.topicPartition))
 
-    val cachedOffsets = groupCoordinator.groupManager.getOffsets(groupId, requireStable, Some(Seq(ti1p0.topicPartition, ti2p0.topicPartition)))
+    val cachedOffsets = groupCoordinator.groupManager.getOffsets(groupId, requireStable, Some(Seq(ti1p0, ti2p0)))
 
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(ti1p0.topicPartition).map(_.offset))
-    assertEquals(Some(offset.offset), cachedOffsets.get(ti2p0.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(ti1p0).map(_.offset))
+    assertEquals(Some(offset.offset), cachedOffsets.get(ti2p0).map(_.offset))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -139,9 +139,9 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)
@@ -154,8 +154,8 @@ class GroupMetadataManagerTest {
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(committedOffsets.size, group.allOffsets.size)
-    committedOffsets.foreach { case (topicPartition, offset) =>
-      assertEquals(Some(offset), group.offset(topicPartition).map(_.offset))
+    committedOffsets.foreach { case (topicIdPartition, offset) =>
+      assertEquals(Some(offset), group.offset(topicIdPartition).map(_.offset))
     }
   }
 
@@ -167,9 +167,9 @@ class GroupMetadataManagerTest {
     val startOffset = 15L
     val groupEpoch = 2
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)
@@ -201,9 +201,9 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -234,9 +234,9 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val abortedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -262,9 +262,9 @@ class GroupMetadataManagerTest {
     val producerEpoch: Short = 2
     val groupEpoch = 2
 
-    val foo0 = new TopicPartition("foo", 0)
-    val foo1 = new TopicPartition("foo", 1)
-    val bar0 = new TopicPartition("bar", 0)
+    val foo0 = new TopicIdPartition(Uuid.randomUuid(), 0, "foo")
+    val foo1 = new TopicIdPartition(Uuid.randomUuid(), 1, "foo")
+    val bar0 = new TopicIdPartition(Uuid.randomUuid(), 0, "bar")
     val pendingOffsets = Map(
       foo0 -> 23L,
       foo1 -> 455L,
@@ -303,15 +303,15 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val abortedOffsets = Map(
-      new TopicPartition("foo", 2) -> 231L,
-      new TopicPartition("foo", 3) -> 4551L,
-      new TopicPartition("bar", 1) -> 89921L
+      new TopicIdPartition(Uuid.randomUuid(), 2, "foo") -> 231L,
+      new TopicIdPartition(Uuid.randomUuid(), 3, "foo") -> 4551L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "bar") -> 89921L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -347,23 +347,23 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
-    val foo3 = new TopicPartition("foo", 3)
+    val foo3 = new TopicIdPartition(Uuid.randomUuid(), 3, "foo")
 
     val abortedOffsets = Map(
-      new TopicPartition("foo", 2) -> 231L,
+      new TopicIdPartition(Uuid.randomUuid(), 2, "foo") -> 231L,
       foo3 -> 4551L,
-      new TopicPartition("bar", 1) -> 89921L
+      new TopicIdPartition(Uuid.randomUuid(), 1, "bar") -> 89921L
     )
 
     val pendingOffsets = Map(
       foo3 -> 2312L,
-      new TopicPartition("foo", 4) -> 45512L,
-      new TopicPartition("bar", 2) -> 899212L
+      new TopicIdPartition(Uuid.randomUuid(), 4, "foo") -> 45512L,
+      new TopicIdPartition(Uuid.randomUuid(), 2, "bar") -> 899212L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -388,9 +388,9 @@ class GroupMetadataManagerTest {
     // Ensure that only the committed offsets are materialized, and that there are no pending commits for the producer.
     // This allows us to be certain that the aborted offset commits are truly discarded.
     assertEquals(committedOffsets.size, group.allOffsets.size)
-    committedOffsets.foreach { case (topicPartition, offset) =>
-      assertEquals(Some(offset), group.offset(topicPartition).map(_.offset))
-      assertEquals(Some(commitOffsetsLogPosition), group.offsetWithRecordMetadata(topicPartition).head.appendedBatchOffset)
+    committedOffsets.foreach { case (topicIdPartition, offset) =>
+      assertEquals(Some(offset), group.offset(topicIdPartition).map(_.offset))
+      assertEquals(Some(commitOffsetsLogPosition), group.offsetWithRecordMetadata(topicIdPartition).head.appendedBatchOffset)
     }
 
     // We should have pending commits.
@@ -415,15 +415,15 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsetsFirstProducer = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val committedOffsetsSecondProducer = Map(
-      new TopicPartition("foo", 2) -> 231L,
-      new TopicPartition("foo", 3) -> 4551L,
-      new TopicPartition("bar", 1) -> 89921L
+      new TopicIdPartition(Uuid.randomUuid(), 2, "foo") -> 231L,
+      new TopicIdPartition(Uuid.randomUuid(), 3, "foo") -> 4551L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "bar") -> 89921L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -450,13 +450,13 @@ class GroupMetadataManagerTest {
     // Ensure that only the committed offsets are materialized, and that there are no pending commits for the producer.
     // This allows us to be certain that the aborted offset commits are truly discarded.
     assertEquals(committedOffsetsFirstProducer.size + committedOffsetsSecondProducer.size, group.allOffsets.size)
-    committedOffsetsFirstProducer.foreach { case (topicPartition, offset) =>
-      assertEquals(Some(offset), group.offset(topicPartition).map(_.offset))
-      assertEquals(Some(firstProduceRecordOffset), group.offsetWithRecordMetadata(topicPartition).head.appendedBatchOffset)
+    committedOffsetsFirstProducer.foreach { case (topicIdPartition, offset) =>
+      assertEquals(Some(offset), group.offset(topicIdPartition).map(_.offset))
+      assertEquals(Some(firstProduceRecordOffset), group.offsetWithRecordMetadata(topicIdPartition).head.appendedBatchOffset)
     }
-    committedOffsetsSecondProducer.foreach { case (topicPartition, offset) =>
-      assertEquals(Some(offset), group.offset(topicPartition).map(_.offset))
-      assertEquals(Some(secondProducerRecordOffset), group.offsetWithRecordMetadata(topicPartition).head.appendedBatchOffset)
+    committedOffsetsSecondProducer.foreach { case (topicIdPartition, offset) =>
+      assertEquals(Some(offset), group.offset(topicIdPartition).map(_.offset))
+      assertEquals(Some(secondProducerRecordOffset), group.offsetWithRecordMetadata(topicIdPartition).head.appendedBatchOffset)
     }
   }
 
@@ -468,11 +468,11 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val transactionalOffsetCommits = Map(
-      new TopicPartition("foo", 0) -> 23L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L
     )
 
     val consumerOffsetCommits = Map(
-      new TopicPartition("foo", 0) -> 24L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 24L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -510,11 +510,11 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val transactionalOffsetCommits = Map(
-      new TopicPartition("foo", 0) -> 23L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L
     )
 
     val consumerOffsetCommits = Map(
-      new TopicPartition("foo", 0) -> 24L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 24L
     )
 
     val buffer = ByteBuffer.allocate(1024)
@@ -562,7 +562,7 @@ class GroupMetadataManagerTest {
     assertTrue(groupMetadataManager.groupNotExists(groupId))
   }
 
-  private def appendConsumerOffsetCommit(buffer: ByteBuffer, baseOffset: Long, offsets: Map[TopicPartition, Long]) = {
+  private def appendConsumerOffsetCommit(buffer: ByteBuffer, baseOffset: Long, offsets: Map[TopicIdPartition, Long]) = {
     val builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.LOG_APPEND_TIME, baseOffset)
     val commitRecords = createCommittedOffsetRecords(offsets)
     commitRecords.foreach(builder.append)
@@ -571,7 +571,7 @@ class GroupMetadataManagerTest {
   }
 
   private def appendTransactionalOffsetCommits(buffer: ByteBuffer, producerId: Long, producerEpoch: Short,
-                                               baseOffset: Long, offsets: Map[TopicPartition, Long]): Int = {
+                                               baseOffset: Long, offsets: Map[TopicIdPartition, Long]): Int = {
     val builder = MemoryRecords.builder(buffer, CompressionType.NONE, baseOffset, producerId, producerEpoch, 0, true)
     val commitRecords = createCommittedOffsetRecords(offsets)
     commitRecords.foreach(builder.append)
@@ -596,15 +596,15 @@ class GroupMetadataManagerTest {
     val startOffset = 15L
     val groupEpoch = 2
 
-    val tombstonePartition = new TopicPartition("foo", 1)
+    val tombstonePartition = new TopicIdPartition(Uuid.randomUuid(), 1, "foo")
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
       tombstonePartition -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)
-    val tombstone = new SimpleRecord(GroupMetadataManager.offsetCommitKey(groupId, tombstonePartition), null)
+    val tombstone = new SimpleRecord(GroupMetadataManager.offsetCommitKey(groupId, tombstonePartition.topicPartition), null)
     val records = MemoryRecords.withRecords(startOffset, CompressionType.NONE,
       (offsetCommitRecords ++ Seq(tombstone)).toArray: _*)
 
@@ -635,9 +635,9 @@ class GroupMetadataManagerTest {
     val protocol = "range"
     val startOffset = 15L
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)
@@ -769,9 +769,9 @@ class GroupMetadataManagerTest {
     val startOffset = 15L
     val groupEpoch = 2
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     // create a GroupMetadata record larger then offsets.load.buffer.size (here at least 16 bytes larger)
@@ -834,9 +834,9 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)
     val memberId = "98098230493"
@@ -853,8 +853,8 @@ class GroupMetadataManagerTest {
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(committedOffsets.size, group.allOffsets.size)
-    committedOffsets.foreach { case (topicPartition, offset) =>
-      assertEquals(Some(offset), group.offset(topicPartition).map(_.offset))
+    committedOffsets.foreach { case (topicIdPartition, offset) =>
+      assertEquals(Some(offset), group.offset(topicIdPartition).map(_.offset))
     }
   }
 
@@ -865,10 +865,10 @@ class GroupMetadataManagerTest {
     val protocol = "range"
     val startOffset = 15L
     val groupEpoch = 2
-    val tp0 = new TopicPartition("foo", 0)
-    val tp1 = new TopicPartition("foo", 1)
-    val tp2 = new TopicPartition("bar", 0)
-    val tp3 = new TopicPartition("xxx", 0)
+    val tp0 = new TopicIdPartition(Uuid.randomUuid(), 0, "foo")
+    val tp1 = new TopicIdPartition(Uuid.randomUuid(), 1, "foo")
+    val tp2 = new TopicIdPartition(Uuid.randomUuid(), 0, "bar")
+    val tp3 = new TopicIdPartition(Uuid.randomUuid(), 0, "xxx")
 
     val fileRecordsMock: FileRecords = mock(classOf[FileRecords])
     val logMock: UnifiedLog = mock(classOf[UnifiedLog])
@@ -1281,8 +1281,8 @@ class GroupMetadataManagerTest {
     assertEquals(Some(Errors.NONE), maybeError)
     assertTrue(group.hasOffsets)
 
-    val cachedOffsets = groupMetadataManager.getOffsets(groupId, defaultRequireStable, Some(Seq(topicIdPartition.topicPartition)))
-    val maybePartitionResponse = cachedOffsets.get(topicIdPartition.topicPartition)
+    val cachedOffsets = groupMetadataManager.getOffsets(groupId, defaultRequireStable, Some(Seq(topicIdPartition)))
+    val maybePartitionResponse = cachedOffsets.get(topicIdPartition)
     assertFalse(maybePartitionResponse.isEmpty)
 
     val partitionResponse = maybePartitionResponse.get
@@ -1352,7 +1352,7 @@ class GroupMetadataManagerTest {
     group.completePendingTxnOffsetCommit(producerId, isCommit = true)
     assertTrue(group.hasOffsets)
     assertFalse(group.allOffsets.isEmpty)
-    assertEquals(Some(offsetAndMetadata), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(offsetAndMetadata), group.offset(topicIdPartition))
   }
 
   @Test
@@ -1530,11 +1530,11 @@ class GroupMetadataManagerTest {
     val cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition.topicPartition))
+      Some(Seq(topicIdPartition))
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition).map(_.offset)
     )
 
     verify(replicaManager).getMagic(any())
@@ -1582,15 +1582,15 @@ class GroupMetadataManagerTest {
     val cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition.topicPartition, topicIdPartitionFailed.topicPartition))
+      Some(Seq(topicIdPartition, topicIdPartitionFailed))
     )
     assertEquals(
       Some(offset),
-      cachedOffsets.get(topicIdPartition.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition).map(_.offset)
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartitionFailed.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartitionFailed).map(_.offset)
     )
 
     verify(replicaManager).appendRecords(anyLong(),
@@ -1639,11 +1639,11 @@ class GroupMetadataManagerTest {
     val cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition.topicPartition))
+      Some(Seq(topicIdPartition))
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition).map(_.offset)
     )
 
     assertEquals(0, TestUtils.totalMetricValue(metrics, "offset-commit-count"))
@@ -1689,16 +1689,16 @@ class GroupMetadataManagerTest {
     groupMetadataManager.cleanupGroupMetadata()
 
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
-    assertEquals(None, group.offset(topicIdPartition1.topicPartition))
-    assertEquals(Some(offset), group.offset(topicIdPartition2.topicPartition).map(_.offset))
+    assertEquals(None, group.offset(topicIdPartition1))
+    assertEquals(Some(offset), group.offset(topicIdPartition2).map(_.offset))
 
     val cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2))
     )
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition2).map(_.offset))
 
     verify(replicaManager).appendRecords(anyLong(),
       anyShort(),
@@ -1716,8 +1716,8 @@ class GroupMetadataManagerTest {
 
   @Test
   def testGroupMetadataRemoval(): Unit = {
-    val topicPartition1 = new TopicPartition("foo", 0)
-    val topicPartition2 = new TopicPartition("foo", 1)
+    val topicIdPartition1 = new TopicIdPartition(Uuid.randomUuid(), 0, "foo")
+    val topicIdPartition2 = new TopicIdPartition(Uuid.randomUuid(), 1, "foo")
 
     groupMetadataManager.addOwnedPartition(groupPartitionId)
 
@@ -1752,15 +1752,15 @@ class GroupMetadataManagerTest {
 
     // the full group should be gone since all offsets were removed
     assertEquals(None, groupMetadataManager.getGroup(groupId))
-    val cachedOffsets = groupMetadataManager.getOffsets(groupId, defaultRequireStable, Some(Seq(topicPartition1, topicPartition2)))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicPartition1).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicPartition2).map(_.offset))
+    val cachedOffsets = groupMetadataManager.getOffsets(groupId, defaultRequireStable, Some(Seq(topicIdPartition1, topicIdPartition2)))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition2).map(_.offset))
   }
 
   @Test
   def testGroupMetadataRemovalWithLogAppendTime(): Unit = {
-    val topicPartition1 = new TopicPartition("foo", 0)
-    val topicPartition2 = new TopicPartition("foo", 1)
+    val topicIdPartition1 = new TopicIdPartition(Uuid.randomUuid(), 0, "foo")
+    val topicIdPartition2 = new TopicIdPartition(Uuid.randomUuid(), 1, "foo")
 
     groupMetadataManager.addOwnedPartition(groupPartitionId)
 
@@ -1796,9 +1796,9 @@ class GroupMetadataManagerTest {
 
     // the full group should be gone since all offsets were removed
     assertEquals(None, groupMetadataManager.getGroup(groupId))
-    val cachedOffsets = groupMetadataManager.getOffsets(groupId, defaultRequireStable, Some(Seq(topicPartition1, topicPartition2)))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicPartition1).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicPartition2).map(_.offset))
+    val cachedOffsets = groupMetadataManager.getOffsets(groupId, defaultRequireStable, Some(Seq(topicIdPartition1, topicIdPartition2)))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition2).map(_.offset))
   }
 
   @Test
@@ -1862,15 +1862,15 @@ class GroupMetadataManagerTest {
     val cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2))
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition1).map(_.offset)
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition2).map(_.offset)
     )
 
     verify(replicaManager).onlinePartition(groupTopicPartition)
@@ -1930,18 +1930,18 @@ class GroupMetadataManagerTest {
 
     // group and offsets should still be there
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
-    assertEquals(Some(tp1OffsetAndMetadata), group.offset(topicIdPartition1.topicPartition))
-    assertEquals(Some(tp2OffsetAndMetadata), group.offset(topicIdPartition2.topicPartition))
-    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3.topicPartition))
+    assertEquals(Some(tp1OffsetAndMetadata), group.offset(topicIdPartition1))
+    assertEquals(Some(tp2OffsetAndMetadata), group.offset(topicIdPartition2))
+    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3))
 
     var cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition, topicIdPartition3.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2, topicIdPartition3))
     )
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition3.topicPartition).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition1).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition2).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition3).map(_.offset))
 
     verify(replicaManager).onlinePartition(groupTopicPartition)
 
@@ -1956,18 +1956,18 @@ class GroupMetadataManagerTest {
 
     // group is empty now, only one offset should expire
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
-    assertEquals(None, group.offset(topicIdPartition1.topicPartition))
-    assertEquals(Some(tp2OffsetAndMetadata), group.offset(topicIdPartition2.topicPartition))
-    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition1))
+    assertEquals(Some(tp2OffsetAndMetadata), group.offset(topicIdPartition2))
+    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3))
 
     cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition, topicIdPartition3.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2, topicIdPartition3))
     )
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition3.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition2).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition3).map(_.offset))
 
     verify(replicaManager, times(2)).onlinePartition(groupTopicPartition)
 
@@ -1981,18 +1981,18 @@ class GroupMetadataManagerTest {
 
     // one more offset should expire
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
-    assertEquals(None, group.offset(topicIdPartition1.topicPartition))
-    assertEquals(None, group.offset(topicIdPartition2.topicPartition))
-    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition1))
+    assertEquals(None, group.offset(topicIdPartition2))
+    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3))
 
     cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition, topicIdPartition3.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2, topicIdPartition3))
     )
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset))
-    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition3.topicPartition).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition1).map(_.offset))
+    assertEquals(Some(OffsetFetchResponse.INVALID_OFFSET), cachedOffsets.get(topicIdPartition2).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition3).map(_.offset))
 
     verify(replicaManager, times(3)).onlinePartition(groupTopicPartition)
 
@@ -2003,26 +2003,26 @@ class GroupMetadataManagerTest {
 
     // one more offset should expire
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
-    assertEquals(None, group.offset(topicIdPartition1.topicPartition))
-    assertEquals(None, group.offset(topicIdPartition2.topicPartition))
-    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition1))
+    assertEquals(None, group.offset(topicIdPartition2))
+    assertEquals(Some(tp3OffsetAndMetadata), group.offset(topicIdPartition3))
 
     cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition, topicIdPartition3.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2, topicIdPartition3))
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition1).map(_.offset)
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition2).map(_.offset)
     )
     assertEquals(
       Some(offset),
-      cachedOffsets.get(topicIdPartition3.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition3).map(_.offset)
     )
 
     verify(replicaManager, times(4)).onlinePartition(groupTopicPartition)
@@ -2038,26 +2038,26 @@ class GroupMetadataManagerTest {
 
     // group and all its offsets should be gone now
     assertEquals(None, groupMetadataManager.getGroup(groupId))
-    assertEquals(None, group.offset(topicIdPartition1.topicPartition))
-    assertEquals(None, group.offset(topicIdPartition2.topicPartition))
-    assertEquals(None, group.offset(topicIdPartition3.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition1))
+    assertEquals(None, group.offset(topicIdPartition2))
+    assertEquals(None, group.offset(topicIdPartition3))
 
     cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition, topicIdPartition2.topicPartition, topicIdPartition3.topicPartition))
+      Some(Seq(topicIdPartition1, topicIdPartition2, topicIdPartition3))
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition1).map(_.offset)
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition2.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition2).map(_.offset)
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition3.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition3).map(_.offset)
     )
 
     verify(replicaManager, times(5)).onlinePartition(groupTopicPartition)
@@ -2106,14 +2106,14 @@ class GroupMetadataManagerTest {
 
     // group and offsets should still be there
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
-    assertEquals(Some(tp1OffsetAndMetadata), group.offset(topicIdPartition1.topicPartition))
+    assertEquals(Some(tp1OffsetAndMetadata), group.offset(topicIdPartition1))
 
     var cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition))
+      Some(Seq(topicIdPartition1))
     )
-    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topicIdPartition1).map(_.offset))
 
     verify(replicaManager).onlinePartition(groupTopicPartition)
 
@@ -2128,16 +2128,16 @@ class GroupMetadataManagerTest {
 
     // group and all its offsets should be gone now
     assertEquals(None, groupMetadataManager.getGroup(groupId))
-    assertEquals(None, group.offset(topicIdPartition1.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition1))
 
     cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
-      Some(Seq(topicIdPartition1.topicPartition))
+      Some(Seq(topicIdPartition1))
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topicIdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topicIdPartition1).map(_.offset)
     )
 
     verify(replicaManager, times(2)).onlinePartition(groupTopicPartition)
@@ -2221,37 +2221,37 @@ class GroupMetadataManagerTest {
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
     assert(group.is(Stable))
 
-    assertEquals(Some(t1p0OffsetAndMetadata), group.offset(topic1IdPartition0.topicPartition))
-    assertEquals(Some(t1p1OffsetAndMetadata), group.offset(topic1IdPartition1.topicPartition))
-    assertEquals(Some(t2p0OffsetAndMetadata), group.offset(topic2IdPartition0.topicPartition))
-    assertEquals(Some(t2p1OffsetAndMetadata), group.offset(topic2IdPartition1.topicPartition))
+    assertEquals(Some(t1p0OffsetAndMetadata), group.offset(topic1IdPartition0))
+    assertEquals(Some(t1p1OffsetAndMetadata), group.offset(topic1IdPartition1))
+    assertEquals(Some(t2p0OffsetAndMetadata), group.offset(topic2IdPartition0))
+    assertEquals(Some(t2p1OffsetAndMetadata), group.offset(topic2IdPartition1))
 
     var cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
       Some(Seq(
-        topic1IdPartition0.topicPartition,
-        topic1IdPartition1.topicPartition,
-        topic2IdPartition0.topicPartition,
-        topic2IdPartition1.topicPartition)
+        topic1IdPartition0,
+        topic1IdPartition1,
+        topic2IdPartition0,
+        topic2IdPartition1)
       )
     )
 
     assertEquals(
       Some(offset),
-      cachedOffsets.get(topic1IdPartition0.topicPartition).map(_.offset)
+      cachedOffsets.get(topic1IdPartition0).map(_.offset)
     )
     assertEquals(
       Some(offset),
-      cachedOffsets.get(topic1IdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topic1IdPartition1).map(_.offset)
     )
     assertEquals(
       Some(offset),
-      cachedOffsets.get(topic2IdPartition0.topicPartition).map(_.offset)
+      cachedOffsets.get(topic2IdPartition0).map(_.offset)
     )
     assertEquals(
       Some(offset),
-      cachedOffsets.get(topic2IdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topic2IdPartition1).map(_.offset)
     )
 
     verify(replicaManager).onlinePartition(groupTopicPartition)
@@ -2287,31 +2287,31 @@ class GroupMetadataManagerTest {
     assertEquals(Some(group), groupMetadataManager.getGroup(groupId))
     assert(group.is(Stable))
 
-    assertEquals(Some(t1p0OffsetAndMetadata), group.offset(topic1IdPartition0.topicPartition))
-    assertEquals(Some(t1p1OffsetAndMetadata), group.offset(topic1IdPartition1.topicPartition))
-    assertEquals(None, group.offset(topic2IdPartition0.topicPartition))
-    assertEquals(None, group.offset(topic2IdPartition1.topicPartition))
+    assertEquals(Some(t1p0OffsetAndMetadata), group.offset(topic1IdPartition0))
+    assertEquals(Some(t1p1OffsetAndMetadata), group.offset(topic1IdPartition1))
+    assertEquals(None, group.offset(topic2IdPartition0))
+    assertEquals(None, group.offset(topic2IdPartition1))
 
     cachedOffsets = groupMetadataManager.getOffsets(
       groupId,
       defaultRequireStable,
       Some(Seq(
-        topic1IdPartition0.topicPartition,
-        topic1IdPartition1.topicPartition,
-        topic2IdPartition0.topicPartition,
-        topic2IdPartition1.topicPartition)
+        topic1IdPartition0,
+        topic1IdPartition1,
+        topic2IdPartition0,
+        topic2IdPartition1)
       )
     )
 
-    assertEquals(Some(offset), cachedOffsets.get(topic1IdPartition0.topicPartition).map(_.offset))
-    assertEquals(Some(offset), cachedOffsets.get(topic1IdPartition1.topicPartition).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topic1IdPartition0).map(_.offset))
+    assertEquals(Some(offset), cachedOffsets.get(topic1IdPartition1).map(_.offset))
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topic2IdPartition0.topicPartition).map(_.offset)
+      cachedOffsets.get(topic2IdPartition0).map(_.offset)
     )
     assertEquals(
       Some(OffsetFetchResponse.INVALID_OFFSET),
-      cachedOffsets.get(topic2IdPartition1.topicPartition).map(_.offset)
+      cachedOffsets.get(topic2IdPartition1).map(_.offset)
     )
   }
 
@@ -2324,9 +2324,9 @@ class GroupMetadataManagerTest {
     val startOffset = 15L
     val groupEpoch = 2
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val metadataVersion = IBP_1_1_IV0
@@ -2364,9 +2364,9 @@ class GroupMetadataManagerTest {
     val startOffset = 15L
     val groupEpoch = 2
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, retentionTimeOpt = Some(100))
@@ -2705,9 +2705,9 @@ class GroupMetadataManagerTest {
     val groupEpoch = 2
 
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0, "foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)
@@ -2905,11 +2905,11 @@ class GroupMetadataManagerTest {
     endOffset
   }
 
-  private def createCommittedOffsetRecords(committedOffsets: Map[TopicPartition, Long],
+  private def createCommittedOffsetRecords(committedOffsets: Map[TopicIdPartition, Long],
                                            groupId: String = groupId,
                                            metadataVersion: MetadataVersion = MetadataVersion.latest,
                                            retentionTimeOpt: Option[Long] = None): Seq[SimpleRecord] = {
-    committedOffsets.map { case (topicPartition, offset) =>
+    committedOffsets.map { case (topicIdPartition, offset) =>
       val commitTimestamp = time.milliseconds()
       val offsetAndMetadata = retentionTimeOpt match {
         case Some(retentionTimeMs) =>
@@ -2918,7 +2918,7 @@ class GroupMetadataManagerTest {
         case None =>
           OffsetAndMetadata(offset, "", commitTimestamp)
       }
-      val offsetCommitKey = GroupMetadataManager.offsetCommitKey(groupId, topicPartition)
+      val offsetCommitKey = GroupMetadataManager.offsetCommitKey(groupId, topicIdPartition.topicPartition)
       val offsetCommitValue = GroupMetadataManager.offsetCommitValue(offsetAndMetadata, metadataVersion)
       new SimpleRecord(offsetCommitKey, offsetCommitValue)
     }.toSeq
@@ -2977,9 +2977,9 @@ class GroupMetadataManagerTest {
     val startOffset = 15L
     val memberId = "98098230493"
     val committedOffsets = Map(
-      new TopicPartition("foo", 0) -> 23L,
-      new TopicPartition("foo", 1) -> 455L,
-      new TopicPartition("bar", 0) -> 8992L
+      new TopicIdPartition(Uuid.randomUuid(), 0,"foo") -> 23L,
+      new TopicIdPartition(Uuid.randomUuid(), 1, "foo") -> 455L,
+      new TopicIdPartition(Uuid.randomUuid(), 0, "bar") -> 8992L
     )
 
     val offsetCommitRecords = createCommittedOffsetRecords(committedOffsets)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -20,7 +20,7 @@ package kafka.coordinator.group
 import kafka.common.OffsetAndMetadata
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
-import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.common.{TopicIdPartition, Uuid}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.utils.{MockTime, Time}
 import org.junit.jupiter.api.Assertions._
@@ -280,7 +280,7 @@ class GroupMetadataTest {
 
     group.prepareOffsetCommit(Map(topicIdPartition -> offset))
     assertTrue(group.hasOffsets)
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
     group.onOffsetCommitAppend(topicIdPartition, CommitRecordMetadataAndOffset(Some(commitRecordOffset), offset))
 
     val offsetRetentionMs = 50000L
@@ -393,11 +393,11 @@ class GroupMetadataTest {
 
     group.prepareOffsetCommit(Map(partition -> offset))
     assertTrue(group.hasOffsets)
-    assertEquals(None, group.offset(partition.topicPartition))
+    assertEquals(None, group.offset(partition))
 
     group.onOffsetCommitAppend(partition, CommitRecordMetadataAndOffset(Some(commitRecordOffset), offset))
     assertTrue(group.hasOffsets)
-    assertEquals(Some(offset), group.offset(partition.topicPartition))
+    assertEquals(Some(offset), group.offset(partition))
   }
 
   @Test
@@ -408,12 +408,12 @@ class GroupMetadataTest {
     group.prepareOffsetCommit(Map(topicIdPartition -> offset))
     assertTrue(group.hasOffsets)
     assertEquals(Some(offset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.failPendingOffsetWrite(topicIdPartition, offset)
     assertFalse(group.hasOffsets)
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
   }
 
   @Test
@@ -425,22 +425,22 @@ class GroupMetadataTest {
     group.prepareOffsetCommit(Map(topicIdPartition -> firstOffset))
     assertTrue(group.hasOffsets)
     assertEquals(Some(firstOffset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.prepareOffsetCommit(Map(topicIdPartition -> secondOffset))
     assertTrue(group.hasOffsets)
     assertEquals(Some(secondOffset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.failPendingOffsetWrite(topicIdPartition, firstOffset)
     assertTrue(group.hasOffsets)
     assertEquals(Some(secondOffset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.onOffsetCommitAppend(topicIdPartition, CommitRecordMetadataAndOffset(Some(3L), secondOffset))
     assertTrue(group.hasOffsets)
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(Some(secondOffset), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(secondOffset), group.offset(topicIdPartition))
   }
 
   @Test
@@ -452,22 +452,22 @@ class GroupMetadataTest {
     group.prepareOffsetCommit(Map(topicIdPartition -> firstOffset))
     assertTrue(group.hasOffsets)
     assertEquals(Some(firstOffset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.prepareOffsetCommit(Map(topicIdPartition -> secondOffset))
     assertTrue(group.hasOffsets)
     assertEquals(Some(secondOffset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.onOffsetCommitAppend(topicIdPartition, CommitRecordMetadataAndOffset(Some(4L), firstOffset))
     assertTrue(group.hasOffsets)
     assertEquals(Some(secondOffset), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(Some(firstOffset), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(firstOffset), group.offset(topicIdPartition))
 
     group.onOffsetCommitAppend(topicIdPartition, CommitRecordMetadataAndOffset(Some(5L), secondOffset))
     assertTrue(group.hasOffsets)
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(Some(secondOffset), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(secondOffset), group.offset(topicIdPartition))
   }
 
   @Test
@@ -480,26 +480,26 @@ class GroupMetadataTest {
     group.prepareTxnOffsetCommit(producerId, Map(topicIdPartition -> txnOffsetCommit))
     assertTrue(group.hasOffsets)
     assertEquals(Some(CommitRecordMetadataAndOffset(None, txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.prepareOffsetCommit(Map(topicIdPartition -> consumerOffsetCommit))
     assertTrue(group.hasOffsets)
     assertEquals(Some(consumerOffsetCommit), group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.onTxnOffsetCommitAppend(producerId, topicIdPartition, CommitRecordMetadataAndOffset(Some(3L), txnOffsetCommit))
     group.onOffsetCommitAppend(topicIdPartition, CommitRecordMetadataAndOffset(Some(4L), consumerOffsetCommit))
     assertTrue(group.hasOffsets)
     assertEquals(Some(CommitRecordMetadataAndOffset(Some(3), txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition))
 
     group.completePendingTxnOffsetCommit(producerId, isCommit = true)
     assertTrue(group.hasOffsets)
     assertEquals(None, group.pendingTxnOffsetCommit(producerId, topicIdPartition))
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
     // This is the crucial assertion which validates that we materialize offsets in offset order, not transactional order.
-    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition))
   }
 
   @Test
@@ -512,7 +512,7 @@ class GroupMetadataTest {
     group.prepareTxnOffsetCommit(producerId, Map(topicIdPartition -> txnOffsetCommit))
     assertTrue(group.hasOffsets)
     assertEquals(Some(CommitRecordMetadataAndOffset(None, txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
 
     group.prepareOffsetCommit(Map(topicIdPartition -> consumerOffsetCommit))
     assertTrue(group.hasOffsets)
@@ -524,7 +524,7 @@ class GroupMetadataTest {
     assertEquals(Some(CommitRecordMetadataAndOffset(Some(4), txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
     // The transactional offset commit hasn't been committed yet, so we should materialize the consumer offset commit.
-    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition))
 
     group.completePendingTxnOffsetCommit(producerId, isCommit = true)
     assertTrue(group.hasOffsets)
@@ -532,7 +532,7 @@ class GroupMetadataTest {
     // so it should be materialized.
     assertEquals(None, group.pendingTxnOffsetCommit(producerId, topicIdPartition))
     assertEquals(None, group.pendingOffsetCommit(topicIdPartition))
-    assertEquals(Some(txnOffsetCommit), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(txnOffsetCommit), group.offset(topicIdPartition))
   }
 
   @Test
@@ -544,12 +544,12 @@ class GroupMetadataTest {
 
     group.prepareTxnOffsetCommit(producerId, Map(topicIdPartition -> txnOffsetCommit))
     assertTrue(group.hasOffsets)
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
     assertEquals(Some(CommitRecordMetadataAndOffset(None, txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
 
     group.prepareOffsetCommit(Map(topicIdPartition -> consumerOffsetCommit))
     assertTrue(group.hasOffsets)
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
     assertEquals(Some(CommitRecordMetadataAndOffset(None, txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
     assertEquals(Some(consumerOffsetCommit), group.pendingOffsetCommit(topicIdPartition))
 
@@ -558,7 +558,7 @@ class GroupMetadataTest {
     assertTrue(group.hasOffsets)
     assertEquals(Some(CommitRecordMetadataAndOffset(Some(4L), txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
     // The transactional offset commit hasn't been committed yet, so we should materialize the consumer offset commit.
-    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition))
 
     group.completePendingTxnOffsetCommit(producerId, isCommit = false)
     assertTrue(group.hasOffsets)
@@ -566,7 +566,7 @@ class GroupMetadataTest {
     // materialized.
     assertFalse(group.hasPendingOffsetCommitsFromProducer(producerId))
     assertEquals(None, group.pendingTxnOffsetCommit(producerId, topicIdPartition))
-    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition.topicPartition))
+    assertEquals(Some(consumerOffsetCommit), group.offset(topicIdPartition))
   }
 
   @Test
@@ -579,7 +579,7 @@ class GroupMetadataTest {
     assertTrue(group.hasPendingOffsetCommitsFromProducer(producerId))
     assertTrue(group.hasOffsets)
     assertEquals(Some(CommitRecordMetadataAndOffset(None, txnOffsetCommit)), group.pendingTxnOffsetCommit(producerId, topicIdPartition))
-    assertEquals(None, group.offset(topicIdPartition.topicPartition))
+    assertEquals(None, group.offset(topicIdPartition))
     group.failPendingTxnOffsetCommit(producerId, topicIdPartition)
     assertFalse(group.hasOffsets)
     assertFalse(group.hasPendingOffsetCommitsFromProducer(producerId))
@@ -744,7 +744,7 @@ class GroupMetadataTest {
     val offset = offsetAndMetadata(37)
 
     group.prepareOffsetCommit(Map(partition -> offset))
-    assertTrue(group.hasPendingOffsetCommitsForTopicPartition(partition.topicPartition))
+    assertTrue(group.hasPendingOffsetCommitsForTopicPartition(partition))
   }
 
   @Test
@@ -754,9 +754,9 @@ class GroupMetadataTest {
     val producerId = 5
 
     group.prepareTxnOffsetCommit(producerId, Map(txnPartition -> offset))
-    assertTrue(group.hasPendingOffsetCommitsForTopicPartition(txnPartition.topicPartition))
+    assertTrue(group.hasPendingOffsetCommitsForTopicPartition(txnPartition))
 
-    assertFalse(group.hasPendingOffsetCommitsForTopicPartition(new TopicPartition("non-exist", 0)))
+    assertFalse(group.hasPendingOffsetCommitsForTopicPartition(new TopicIdPartition(Uuid.randomUuid(), 0, "non-exist")))
   }
 
   @Test


### PR DESCRIPTION
This task is the sibling of [PR-13378](https://github.com/apache/kafka/pull/13378) which propagates topic ids in the group coordinator on the offset commit (write) path. The purpose of this PR is to change the interfaces of the group coordinator and its adapter to propagate topic ids in a similar way on the offset fetch path.

[KAFKA-14691](https://issues.apache.org/jira/browse/KAFKA-14691) will add the topic ids to the OffsetFetch API itself so that topic ids are propagated from clients to the coordinator on the offset fetch path. 

Changes to the persisted data model (group metadata and keys) are out of scope.
There is no functional change in this PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
