### PR TITLE
KAFKA-14834: [1/N] Add timestamped get to KTableValueGetter

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -152,5 +152,15 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
         public ValueAndTimestamp<VAgg> get(final KIn key) {
             return store.get(key);
         }
+
+        @Override
+        public ValueAndTimestamp<VAgg> get(final KIn key, final long asOfTimestamp) {
+            return store.get(key, asOfTimestamp);
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return store.isVersionedStore();
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -147,6 +147,16 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K,
         public ValueAndTimestamp<V> get(final K key) {
             return store.get(key);
         }
+
+        @Override
+        public ValueAndTimestamp<V> get(final K key, final long asOfTimestamp) {
+            return store.get(key, asOfTimestamp);
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return store.isVersionedStore();
+        }
     }
 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -379,5 +379,10 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                 store.fetchSession(key.key(), key.window().start(), key.window().end()),
                 key.window().end());
         }
+
+        @Override
+        public boolean isVersioned() {
+            return false;
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -499,5 +499,10 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
 
         @Override
         public void close() {}
+
+        @Override
+        public boolean isVersioned() {
+            return false;
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -210,5 +210,10 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
             final W window = (W) windowedKey.window();
             return windowStore.fetch(key, window.start());
         }
+
+        @Override
+        public boolean isVersioned() {
+            return false;
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
@@ -178,6 +178,16 @@ class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn, KIn, V
         }
 
         @Override
+        public ValueAndTimestamp<VIn> get(final KIn key, final long asOfTimestamp) {
+            return computeValue(key, parentGetter.get(key, asOfTimestamp));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return parentGetter.isVersioned();
+        }
+
+        @Override
         public void close() {
             parentGetter.close();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.function.Function;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.ValueJoiner;
@@ -154,37 +153,12 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public ValueAndTimestamp<VOut> get(final K key) {
-            return computeJoin(key, valueGetter1::get, valueGetter2::get);
-        }
-
-        @Override
-        public ValueAndTimestamp<VOut> get(final K key, final long asOfTimestamp) {
-            return computeJoin(
-                key,
-                k -> valueGetter1.get(k, asOfTimestamp),
-                k -> valueGetter2.get(k, asOfTimestamp));
-        }
-
-        @Override
-        public boolean isVersioned() {
-            return valueGetter1.isVersioned() && valueGetter2.isVersioned();
-        }
-
-        @Override
-        public void close() {
-            valueGetter1.close();
-            valueGetter2.close();
-        }
-
-        private ValueAndTimestamp<VOut> computeJoin(final K key,
-                                                    final Function<K, ValueAndTimestamp<V1>> valueAndTimestamp1Supplier,
-                                                    final Function<K, ValueAndTimestamp<V2>> valueAndTimestamp2Supplier) {
-            final ValueAndTimestamp<V1> valueAndTimestamp1 = valueAndTimestamp1Supplier.apply(key);
+            final ValueAndTimestamp<V1> valueAndTimestamp1 = valueGetter1.get(key);
             final V1 value1 = getValueOrNull(valueAndTimestamp1);
 
             if (value1 != null) {
                 final ValueAndTimestamp<V2> valueAndTimestamp2
-                    = valueAndTimestamp2Supplier.apply(keyValueMapper.apply(key, value1));
+                    = valueGetter2.get(keyValueMapper.apply(key, value1));
                 final V2 value2 = getValueOrNull(valueAndTimestamp2);
 
                 if (value2 != null) {
@@ -197,6 +171,20 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
             } else {
                 return null;
             }
+        }
+
+        @Override
+        public boolean isVersioned() {
+            // even though we can derive a proper versioned result (assuming both parent value
+            // getters are versioned), we choose not to since the output of a join of two
+            // versioned tables today is not considered versioned (cf KIP-914)
+            return false;
+        }
+
+        @Override
+        public void close() {
+            valueGetter1.close();
+            valueGetter2.close();
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.function.Function;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
@@ -159,11 +160,36 @@ class KTableKTableLeftJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K, 
 
         @Override
         public ValueAndTimestamp<VOut> get(final K key) {
-            final ValueAndTimestamp<V1> valueAndTimestamp1 = valueGetter1.get(key);
+            return computeJoin(key, valueGetter1::get, valueGetter2::get);
+        }
+
+        @Override
+        public ValueAndTimestamp<VOut> get(final K key, final long asOfTimestamp) {
+            return computeJoin(
+                key,
+                k -> valueGetter1.get(k, asOfTimestamp),
+                k -> valueGetter2.get(k, asOfTimestamp));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return valueGetter1.isVersioned() && valueGetter2.isVersioned();
+        }
+
+        @Override
+        public void close() {
+            valueGetter1.close();
+            valueGetter2.close();
+        }
+
+        private ValueAndTimestamp<VOut> computeJoin(final K key,
+                                                    final Function<K, ValueAndTimestamp<V1>> valueAndTimestamp1Supplier,
+                                                    final Function<K, ValueAndTimestamp<V2>> valueAndTimestamp2Supplier) {
+            final ValueAndTimestamp<V1> valueAndTimestamp1 = valueAndTimestamp1Supplier.apply(key);
             final V1 value1 = getValueOrNull(valueAndTimestamp1);
 
             if (value1 != null) {
-                final ValueAndTimestamp<V2> valueAndTimestamp2 = valueGetter2.get(key);
+                final ValueAndTimestamp<V2> valueAndTimestamp2 = valueAndTimestamp2Supplier.apply(key);
                 final V2 value2 = getValueOrNull(valueAndTimestamp2);
                 final long resultTimestamp;
                 if (valueAndTimestamp2 == null) {
@@ -175,12 +201,6 @@ class KTableKTableLeftJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K, 
             } else {
                 return null;
             }
-        }
-
-        @Override
-        public void close() {
-            valueGetter1.close();
-            valueGetter2.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.function.Function;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
@@ -155,34 +154,9 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public ValueAndTimestamp<VOut> get(final K key) {
-            return computeJoin(key, valueGetter1::get, valueGetter2::get);
-        }
-
-        @Override
-        public ValueAndTimestamp<VOut> get(final K key, final long asOfTimestamp) {
-            return computeJoin(
-                key,
-                k -> valueGetter1.get(k, asOfTimestamp),
-                k -> valueGetter2.get(k, asOfTimestamp));
-        }
-
-        @Override
-        public boolean isVersioned() {
-            return valueGetter1.isVersioned() && valueGetter2.isVersioned();
-        }
-
-        @Override
-        public void close() {
-            valueGetter1.close();
-            valueGetter2.close();
-        }
-
-        private ValueAndTimestamp<VOut> computeJoin(final K key,
-                                                    final Function<K, ValueAndTimestamp<V1>> valueAndTimestamp1Supplier,
-                                                    final Function<K, ValueAndTimestamp<V2>> valueAndTimestamp2Supplier) {
             VOut newValue = null;
 
-            final ValueAndTimestamp<V1> valueAndTimestamp1 = valueAndTimestamp1Supplier.apply(key);
+            final ValueAndTimestamp<V1> valueAndTimestamp1 = valueGetter1.get(key);
             final V1 value1;
             final long timestamp1;
             if (valueAndTimestamp1 == null) {
@@ -193,7 +167,7 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 timestamp1 = valueAndTimestamp1.timestamp();
             }
 
-            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueAndTimestamp2Supplier.apply(key);
+            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueGetter2.get(key);
             final V2 value2;
             final long timestamp2;
             if (valueAndTimestamp2 == null) {
@@ -209,6 +183,20 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
             }
 
             return ValueAndTimestamp.make(newValue, Math.max(timestamp1, timestamp2));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            // even though we can derive a proper versioned result (assuming both parent value
+            // getters are versioned), we choose not to since the output of a join of two
+            // versioned tables today is not considered versioned (cf KIP-914)
+            return false;
+        }
+
+        @Override
+        public void close() {
+            valueGetter1.close();
+            valueGetter2.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.function.Function;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
@@ -150,11 +151,36 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public ValueAndTimestamp<VOut> get(final K key) {
-            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueGetter2.get(key);
+            return computeJoin(key, valueGetter1::get, valueGetter2::get);
+        }
+
+        @Override
+        public ValueAndTimestamp<VOut> get(final K key, final long asOfTimestamp) {
+            return computeJoin(
+                key,
+                k -> valueGetter1.get(k, asOfTimestamp),
+                k -> valueGetter2.get(k, asOfTimestamp));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return valueGetter1.isVersioned() && valueGetter2.isVersioned();
+        }
+
+        @Override
+        public void close() {
+            valueGetter1.close();
+            valueGetter2.close();
+        }
+
+        private ValueAndTimestamp<VOut> computeJoin(final K key,
+                                                    final Function<K, ValueAndTimestamp<V1>> valueAndTimestamp1Supplier,
+                                                    final Function<K, ValueAndTimestamp<V2>> valueAndTimestamp2Supplier) {
+            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueAndTimestamp2Supplier.apply(key);
             final V2 value2 = getValueOrNull(valueAndTimestamp2);
 
             if (value2 != null) {
-                final ValueAndTimestamp<V1> valueAndTimestamp1 = valueGetter1.get(key);
+                final ValueAndTimestamp<V1> valueAndTimestamp1 = valueAndTimestamp1Supplier.apply(key);
                 final V1 value1 = getValueOrNull(valueAndTimestamp1);
                 final long resultTimestamp;
                 if (valueAndTimestamp1 == null) {
@@ -166,12 +192,6 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
             } else {
                 return null;
             }
-        }
-
-        @Override
-        public void close() {
-            valueGetter1.close();
-            valueGetter2.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.function.Function;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
@@ -151,36 +150,11 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public ValueAndTimestamp<VOut> get(final K key) {
-            return computeJoin(key, valueGetter1::get, valueGetter2::get);
-        }
-
-        @Override
-        public ValueAndTimestamp<VOut> get(final K key, final long asOfTimestamp) {
-            return computeJoin(
-                key,
-                k -> valueGetter1.get(k, asOfTimestamp),
-                k -> valueGetter2.get(k, asOfTimestamp));
-        }
-
-        @Override
-        public boolean isVersioned() {
-            return valueGetter1.isVersioned() && valueGetter2.isVersioned();
-        }
-
-        @Override
-        public void close() {
-            valueGetter1.close();
-            valueGetter2.close();
-        }
-
-        private ValueAndTimestamp<VOut> computeJoin(final K key,
-                                                    final Function<K, ValueAndTimestamp<V1>> valueAndTimestamp1Supplier,
-                                                    final Function<K, ValueAndTimestamp<V2>> valueAndTimestamp2Supplier) {
-            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueAndTimestamp2Supplier.apply(key);
+            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueGetter2.get(key);
             final V2 value2 = getValueOrNull(valueAndTimestamp2);
 
             if (value2 != null) {
-                final ValueAndTimestamp<V1> valueAndTimestamp1 = valueAndTimestamp1Supplier.apply(key);
+                final ValueAndTimestamp<V1> valueAndTimestamp1 = valueGetter1.get(key);
                 final V1 value1 = getValueOrNull(valueAndTimestamp1);
                 final long resultTimestamp;
                 if (valueAndTimestamp1 == null) {
@@ -192,6 +166,20 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
             } else {
                 return null;
             }
+        }
+
+        @Override
+        public boolean isVersioned() {
+            // even though we can derive a proper versioned result (assuming both parent value
+            // getters are versioned), we choose not to since the output of a join of two
+            // versioned tables today is not considered versioned (cf KIP-914)
+            return false;
+        }
+
+        @Override
+        public void close() {
+            valueGetter1.close();
+            valueGetter2.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
@@ -165,6 +165,16 @@ class KTableMapValues<KIn, VIn, VOut> implements KTableProcessorSupplier<KIn, VI
         }
 
         @Override
+        public ValueAndTimestamp<VOut> get(final KIn key, final long asOfTimestamp) {
+            return computeValueAndTimestamp(key, parentGetter.get(key, asOfTimestamp));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return parentGetter.isVersioned();
+        }
+
+        @Override
         public void close() {
             parentGetter.close();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMaterializedValueGetterSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMaterializedValueGetterSupplier.java
@@ -48,5 +48,15 @@ public class KTableMaterializedValueGetterSupplier<K, V> implements KTableValueG
         public ValueAndTimestamp<V> get(final K key) {
             return store.get(key);
         }
+
+        @Override
+        public ValueAndTimestamp<V> get(final K key, final long asOfTimestamp) {
+            return store.get(key, asOfTimestamp);
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return store.isVersionedStore();
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
@@ -91,5 +91,14 @@ public class KTablePassThrough<KIn, VIn> implements KTableProcessorSupplier<KIn,
             return store.get(key);
         }
 
+        @Override
+        public ValueAndTimestamp<VIn> get(final KIn key, final long asOfTimestamp) {
+            return store.get(key, asOfTimestamp);
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return store.isVersionedStore();
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -121,16 +121,29 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
 
         @Override
         public ValueAndTimestamp<KeyValue<K1, V1>> get(final K key) {
-            final ValueAndTimestamp<V> valueAndTimestamp = parentGetter.get(key);
-            return ValueAndTimestamp.make(
-                mapper.apply(key, getValueOrNull(valueAndTimestamp)),
-                valueAndTimestamp == null ? context.timestamp() : valueAndTimestamp.timestamp()
-            );
+            return mapValue(key, parentGetter.get(key));
+        }
+
+        @Override
+        public ValueAndTimestamp<KeyValue<K1, V1>> get(final K key, final long asOfTimestamp) {
+            return mapValue(key, parentGetter.get(key, asOfTimestamp));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return parentGetter.isVersioned();
         }
 
         @Override
         public void close() {
             parentGetter.close();
+        }
+
+        private ValueAndTimestamp<KeyValue<K1, V1>> mapValue(final K key, final ValueAndTimestamp<V> valueAndTimestamp) {
+            return ValueAndTimestamp.make(
+                mapper.apply(key, getValueOrNull(valueAndTimestamp)),
+                valueAndTimestamp == null ? context.timestamp() : valueAndTimestamp.timestamp()
+            );
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSourceValueGetterSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSourceValueGetterSupplier.java
@@ -47,5 +47,15 @@ public class KTableSourceValueGetterSupplier<K, V> implements KTableValueGetterS
         public ValueAndTimestamp<V> get(final K key) {
             return store.get(key);
         }
+
+        @Override
+        public ValueAndTimestamp<V> get(final K key, final long asOfTimestamp) {
+            return store.get(key, asOfTimestamp);
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return store.isVersionedStore();
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
@@ -153,8 +153,26 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
 
         @Override
         public ValueAndTimestamp<VOut> get(final K key) {
-            final ValueAndTimestamp<V> valueAndTimestamp = parentGetter.get(key);
+            return transformValue(key, parentGetter.get(key));
+        }
 
+        @Override
+        public ValueAndTimestamp<VOut> get(final K key, final long asOfTimestamp) {
+            return transformValue(key, parentGetter.get(key, asOfTimestamp));
+        }
+
+        @Override
+        public boolean isVersioned() {
+            return parentGetter.isVersioned();
+        }
+
+        @Override
+        public void close() {
+            parentGetter.close();
+            valueTransformer.close();
+        }
+
+        private ValueAndTimestamp<VOut> transformValue(final K key, final ValueAndTimestamp<V> valueAndTimestamp) {
             final ProcessorRecordContext currentContext = internalProcessorContext.recordContext();
 
             internalProcessorContext.setRecordContext(new ProcessorRecordContext(
@@ -176,12 +194,6 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
             internalProcessorContext.setRecordContext(currentContext);
 
             return result;
-        }
-
-        @Override
-        public void close() {
-            parentGetter.close();
-            valueTransformer.close();
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableValueGetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableValueGetter.java
@@ -25,5 +25,21 @@ public interface KTableValueGetter<K, V> {
 
     ValueAndTimestamp<V> get(K key);
 
+    /**
+     * Returns the latest record version, associated with the provided key, with timestamp
+     * not exceeding the provided timestamp bound. This method may only be called if
+     * {@link #isVersioned()} is true.
+     */
+    default ValueAndTimestamp<V> get(K key, long asOfTimestamp) {
+        throw new UnsupportedOperationException("get(key, timestamp) is only supported for versioned stores");
+    }
+
+    /**
+     * @return whether this value getter supports multiple record versions for the same key.
+     *         If true, then {@link #get(Object, long)} must be implemented. If not, then
+     *         {@link #get(Object, long)} must not be called.
+     */
+    boolean isVersioned();
+
     default void close() {}
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
@@ -90,6 +90,11 @@ public class KTableSuppressProcessorSupplier<K, V> implements
                     }
 
                     @Override
+                    public boolean isVersioned() {
+                        return false;
+                    }
+
+                    @Override
                     public void close() {
                         // the main processor is responsible for the buffer's lifecycle
                         parentGetter.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapper.java
@@ -81,6 +81,14 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
         throw new IllegalStateException("KeyValueStoreWrapper must be initialized with either timestamped or versioned store");
     }
 
+    public ValueAndTimestamp<V> get(final K key, final long asOfTimestamp) {
+        if (!isVersionedStore()) {
+            throw new UnsupportedOperationException("get(key, timestamp) is only supported for versioned stores");
+        }
+        final VersionedRecord<V> versionedRecord = versionedStore.get(key, asOfTimestamp);
+        return versionedRecord == null ? null : ValueAndTimestamp.make(versionedRecord.value(), versionedRecord.timestamp());
+    }
+
     public void put(final K key, final V value, final long timestamp) {
         if (timestampedStore != null) {
             timestampedStore.put(key, ValueAndTimestamp.make(value, timestamp));
@@ -95,6 +103,10 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
 
     public StateStore getStore() {
         return store;
+    }
+
+    public boolean isVersionedStore() {
+        return versionedStore != null;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplierTest.java
@@ -352,6 +352,11 @@ public class ForeignJoinSubscriptionProcessorSupplierTest {
             public void init(final ProcessorContext context) {
 
             }
+
+            @Override
+            public boolean isVersioned() {
+                return false;
+            }
         };
         return new KTableValueGetterSupplier<String, String>() {
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResolverJoinProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResolverJoinProcessorSupplierTest.java
@@ -56,6 +56,11 @@ public class SubscriptionResolverJoinProcessorSupplierTest {
                 public ValueAndTimestamp<V> get(final K key) {
                     return ValueAndTimestamp.make(map.get(key), -1);
                 }
+
+                @Override
+                public boolean isVersioned() {
+                    return false;
+                }
             };
         }
 


### PR DESCRIPTION
In preparation for updating DSL processors to use versioned stores (cf [KIP-914](https://cwiki.apache.org/confluence/display/KAFKA/KIP-914%3A+Join+Processor+Semantics+for+Versioned+Stores)), this PR adds two new methods to KTableValueGetter: `isVersioned()` and `get(key, asOfTimestamp)` and updates all existing implementations accordingly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
