### PR TITLE
KAFKA-14750: Check if topic exists in WorkerSinkTask when committing offsets.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1367,9 +1367,14 @@ public class Worker {
                     connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
+            Map<String, Object> adminOverrides = adminConfigs(id.connector(), "connector-worker-adminclient-" + id.connector(),
+                    config, connectorConfig, connectorClass, connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
+
+            TopicAdmin admin = new TopicAdmin(adminOverrides);
+
             return new WorkerSinkTask(id, (SinkTask) task, statusListener, initialState, config, configState, metrics, keyConverter,
                     valueConverter, errorHandlingMetrics, headerConverter, transformationChain, consumer, classLoader, time,
-                    retryWithToleranceOperator, workerErrantRecordReporter, herder.statusBackingStore());
+                    retryWithToleranceOperator, workerErrantRecordReporter, herder.statusBackingStore(), admin);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -152,8 +152,7 @@ class WorkerSinkTask extends WorkerTask {
         this.taskStopped = false;
         this.workerErrantRecordReporter = workerErrantRecordReporter;
         Map<String, Object> adminProps = new HashMap<>(workerConfig.originals());
-        String clientIdBase = "admin";
-        adminProps.put(CLIENT_ID_CONFIG, clientIdBase + "sink-task-admin");
+        adminProps.put(CLIENT_ID_CONFIG, id + "-admin");
         this.topicAdmin = new TopicAdmin(adminProps);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -708,7 +708,7 @@ class WorkerSinkTask extends WorkerTask {
             Set<String> deletedTopics = new HashSet<>();
             for (TopicPartition tp : partitions) {
                 if (deletedTopics.contains(tp.topic())) {
-                    log.debug("Not Committing offsets for topic-partition {} since the topic {} has been deleted", tp, tp.topic());
+                    log.debug("Not assigning offsets for topic-partition {} since the topic {} has been deleted", tp, tp.topic());
                     continue;
                 }
                 long pos;
@@ -719,7 +719,7 @@ class WorkerSinkTask extends WorkerTask {
                             "Checking if the topic {} exists", tp, tp.topic());
                     Map<String, TopicDescription> topic = topicAdmin.describeTopics(tp.topic());
                     if (topic.isEmpty()) {
-                        log.debug("Not Committing offsets for topic-partition {} since the topic {} has been deleted", tp, tp.topic());
+                        log.debug("Not assigning offsets for topic-partition {} since the topic {} has been deleted", tp, tp.topic());
                         deletedTopics.add(tp.topic());
                         continue;
                     } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -71,7 +70,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
-import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG;
 
 /**
@@ -125,7 +123,8 @@ class WorkerSinkTask extends WorkerTask {
                           Time time,
                           RetryWithToleranceOperator retryWithToleranceOperator,
                           WorkerErrantRecordReporter workerErrantRecordReporter,
-                          StatusBackingStore statusBackingStore) {
+                          StatusBackingStore statusBackingStore,
+                          TopicAdmin topicAdmin) {
         super(id, statusListener, initialState, loader, connectMetrics, errorMetrics,
                 retryWithToleranceOperator, time, statusBackingStore);
 
@@ -154,10 +153,7 @@ class WorkerSinkTask extends WorkerTask {
         this.isTopicTrackingEnabled = workerConfig.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG);
         this.taskStopped = false;
         this.workerErrantRecordReporter = workerErrantRecordReporter;
-        Map<String, Object> adminProps = new HashMap<>();
-        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, workerConfig.bootstrapServers());
-        adminProps.put(CLIENT_ID_CONFIG, id + "-admin");
-        this.topicAdmin = new TopicAdmin(adminProps);
+        this.topicAdmin = topicAdmin;
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
@@ -169,34 +169,6 @@ public class ConnectorTopicsIntegrationTest {
     }
 
     @Test
-    public void testSubscribedTopicDeletionDoesNotLeadToSinkTaskFailure() throws InterruptedException {
-        connect = connectBuilder.build();
-        // start the clusters
-        connect.start();
-
-        // create test topic
-        connect.kafka().createTopic(FOO_TOPIC, NUM_TOPIC_PARTITIONS);
-        connect.kafka().createTopic(BAR_TOPIC, NUM_TOPIC_PARTITIONS);
-
-        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
-
-        // start a sink connector
-        connect.configureConnector(SINK_CONNECTOR, defaultSinkConnectorProps(FOO_TOPIC, BAR_TOPIC));
-
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(SINK_CONNECTOR, NUM_TASKS,
-                "Connector tasks did not start in time.");
-
-        connect.assertions().assertConnectorActiveTopics(SINK_CONNECTOR, Arrays.asList(FOO_TOPIC, BAR_TOPIC),
-                "Active topic set is not: " + Arrays.asList(FOO_TOPIC, BAR_TOPIC) + " for connector: " + SINK_CONNECTOR);
-
-        // Delete one of the topics
-        connect.kafka().deleteTopic(FOO_TOPIC);
-
-        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(SINK_CONNECTOR, 1,
-                "Connector task failed because one of the subscribed topics " + FOO_TOPIC + " was deleted.");
-    }
-
-    @Test
     public void testTopicTrackingResetIsDisabled() throws InterruptedException {
         workerProps.put(TOPIC_TRACKING_ALLOW_RESET_CONFIG, "false");
         connect = connectBuilder.build();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -509,7 +509,7 @@ public class ErrorHandlingTaskTest {
             ClusterConfigState.EMPTY, metrics, converter, converter, errorHandlingMetrics,
             headerConverter, sinkTransforms, consumer, pluginLoader, time,
             retryWithToleranceOperator, workerErrantRecordReporter,
-                statusBackingStore);
+                statusBackingStore, admin);
     }
 
     private void createSourceTask(TargetState initialState, RetryWithToleranceOperator retryWithToleranceOperator) {


### PR DESCRIPTION
Currently, the WorkerSinkTask fails when a subscribed topic is deleted and the RebalanceListener tries to fetch the position of such a topic. Note that this doesn't happen whenever a topic is deleted but instead under extreme scenarios like mass deletion of topics. To get around this, Admin Client has been added to WorkerSinkTask. When RebalanceListener is invoked, and a TimeoutException is thrown upon fetching position, it is checked if the topic exists. If it doesn't, then the offset of that TopicPartition isn't committed and the deleted topic name is cached so that any future position fetch for other partitions of the deleted topic doesn't invoke AdminClient again. Note that there could be a case when the topic might get recreated and the caching might prohibit committing offsets. But it seems like an extreme scenario and AFAIK, it the topic gets assigned to the consumer again, then the RebalanceListener would be invoked again. If the topic exists, then the error is rethrown to fail the task.

The test scenario in the JIRA is the one where I could replicate the issue and I have tested locally to observe the connector/task doesn't fail.
