### PR TITLE
MINOR: fix invalid usage in java docs

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/util/Scheduler.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/Scheduler.java
@@ -50,7 +50,7 @@ public interface Scheduler {
      * @param name The name of this task
      * @param task The task to run
      * @param delayMs The number of milliseconds to wait before the first execution
-     * @param periodMs The period in milliseconds with which to execute the task. If < 0 the task will execute only once.
+     * @param periodMs The period in milliseconds with which to execute the task. If &lt; 0 the task will execute only once.
      * @return A Future object to manage the task scheduled.
      */
     ScheduledFuture<?> schedule(String name, Runnable task, long delayMs, long periodMs);

--- a/streams/src/main/java/org/apache/kafka/streams/query/Position.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/Position.java
@@ -57,7 +57,7 @@ public class Position {
     }
 
     /**
-     * Create a new Position and populate it with a mapping of topic -> partition -> offset.
+     * Create a new Position and populate it with a mapping of topic -&gt; partition -&gt; offset.
      * <p>
      * Note, the resulting Position does not share any structure with the provided map, so
      * subsequent changes to the map or Position will not affect the other.
@@ -95,7 +95,7 @@ public class Position {
     /**
      * Merges the provided Position into the current instance.
      * <p>
-     * If both Positions contain the same topic -> partition -> offset mapping, the resulting
+     * If both Positions contain the same topic -&gt; partition -&gt; offset mapping, the resulting
      * Position will contain a mapping with the larger of the two offsets.
      */
     public Position merge(final Position other) {
@@ -127,7 +127,7 @@ public class Position {
     }
 
     /**
-     * Return the partition -> offset mapping for a specific topic.
+     * Return the partition -&gt; offset mapping for a specific topic.
      */
     public Map<Integer, Long> getPartitionPositions(final String topic) {
         final ConcurrentHashMap<Integer, Long> bound = position.get(topic);


### PR DESCRIPTION
noted this issue when testing javadoc command for #13454

the result is shown below.
<img width="1420" alt="截圖 2023-04-06 上午1 24 18" src="https://user-images.githubusercontent.com/6234750/230157066-e0b27487-4c28-43f8-996b-84ab54ea17cc.png">
<img width="1009" alt="截圖 2023-04-06 上午1 24 28" src="https://user-images.githubusercontent.com/6234750/230157086-f8e6a175-b6b1-4e26-a59d-0c9a791fa3b4.png">
<img width="593" alt="截圖 2023-04-06 上午1 24 32" src="https://user-images.githubusercontent.com/6234750/230157091-65d8fdea-9c63-4bcb-a0f9-095d60e450cf.png">




### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
