### PR TITLE
KAFKA-14834: [4/N] Drop out-of-order records from table-table join with versioned tables

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -194,7 +194,7 @@
               files="StreamsMetricsImpl.java"/>
 
     <suppress checks="NPathComplexity"
-              files="(KafkaStreams|StreamsPartitionAssignor|StreamThread|TaskManager|GlobalStateManagerImpl|KStreamImplJoin|TopologyConfig).java"/>
+              files="(KafkaStreams|StreamsPartitionAssignor|StreamThread|TaskManager|GlobalStateManagerImpl|KStreamImplJoin|TopologyConfig|KTableKTableOuterJoin).java"/>
 
     <suppress checks="(FinalLocalVariable|UnnecessaryParentheses|BooleanExpressionComplexity|CyclomaticComplexity|WhitespaceAfter|LocalVariableName)"
               files="Murmur3.java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableAbstractJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableAbstractJoin.java
@@ -25,6 +25,8 @@ abstract class KTableKTableAbstractJoin<K, V1, V2, VOut> implements
     private final KTableImpl<K, ?, V2> table2;
     final KTableValueGetterSupplier<K, V1> valueGetterSupplier1;
     final KTableValueGetterSupplier<K, V2> valueGetterSupplier2;
+    final KTableValueGetter<K, V1> valueGetter1;
+    final KTableValueGetter<K, V2> valueGetter2;
     final ValueJoiner<? super V1, ? super V2, ? extends VOut> joiner;
 
     boolean sendOldValues = false;
@@ -36,6 +38,8 @@ abstract class KTableKTableAbstractJoin<K, V1, V2, VOut> implements
         this.table2 = table2;
         this.valueGetterSupplier1 = table1.valueGetterSupplier();
         this.valueGetterSupplier2 = table2.valueGetterSupplier();
+        this.valueGetter1 = valueGetterSupplier1.get();
+        this.valueGetter2 = valueGetterSupplier2.get();
         this.joiner = joiner;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -43,7 +43,7 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
     @Override
     public Processor<K, Change<V1>, K, Change<VOut>> get() {
-        return new KTableKTableOuterJoinProcessor(valueGetterSupplier2.get());
+        return new KTableKTableOuterJoinProcessor(valueGetter1, valueGetter2);
     }
 
     @Override
@@ -65,11 +65,14 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
     private class KTableKTableOuterJoinProcessor extends ContextualProcessor<K, Change<V1>, K, Change<VOut>> {
 
-        private final KTableValueGetter<K, V2> valueGetter;
+        private final KTableValueGetter<K, V2> otherValueGetter;
+        private final KTableValueGetter<K, V1> thisValueGetter;
         private Sensor droppedRecordsSensor;
 
-        KTableKTableOuterJoinProcessor(final KTableValueGetter<K, V2> valueGetter) {
-            this.valueGetter = valueGetter;
+        KTableKTableOuterJoinProcessor(final KTableValueGetter<K, V1> thisValueGetter,
+                                       final KTableValueGetter<K, V2> otherValueGetter) {
+            this.thisValueGetter = thisValueGetter;
+            this.otherValueGetter = otherValueGetter;
         }
 
         @Override
@@ -80,7 +83,8 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()
             );
-            valueGetter.init(context);
+            thisValueGetter.init(context);
+            otherValueGetter.init(context);
         }
 
         @Override
@@ -103,11 +107,21 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 return;
             }
 
+            // drop out-of-order records from versioned tables (cf. KIP-914)
+            if (thisValueGetter.isVersioned()) {
+                final ValueAndTimestamp<V1> valueAndTimestamp1 = thisValueGetter.get(record.key());
+                if (valueAndTimestamp1 != null && valueAndTimestamp1.timestamp() > record.timestamp()) {
+                    LOG.info("Skipping out-of-order record from versioned table while performing table-table join.");
+                    droppedRecordsSensor.record();
+                    return;
+                }
+            }
+
             VOut newValue = null;
             final long resultTimestamp;
             VOut oldValue = null;
 
-            final ValueAndTimestamp<V2> valueAndTimestamp2 = valueGetter.get(record.key());
+            final ValueAndTimestamp<V2> valueAndTimestamp2 = otherValueGetter.get(record.key());
             final V2 value2 = getValueOrNull(valueAndTimestamp2);
             if (value2 == null) {
                 if (record.value().newValue == null && record.value().oldValue == null) {
@@ -131,7 +145,8 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public void close() {
-            valueGetter.close();
+            thisValueGetter.close();
+            otherValueGetter.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -42,7 +42,7 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
     @Override
     public Processor<K, Change<V1>, K, Change<VOut>> get() {
-        return new KTableKTableRightJoinProcessor(valueGetterSupplier2.get());
+        return new KTableKTableRightJoinProcessor(valueGetter1, valueGetter2);
     }
 
     @Override
@@ -64,11 +64,14 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
     private class KTableKTableRightJoinProcessor extends ContextualProcessor<K, Change<V1>, K, Change<VOut>> {
 
-        private final KTableValueGetter<K, V2> valueGetter;
+        private final KTableValueGetter<K, V1> thisValueGetter;
+        private final KTableValueGetter<K, V2> otherValueGetter;
         private Sensor droppedRecordsSensor;
 
-        KTableKTableRightJoinProcessor(final KTableValueGetter<K, V2> valueGetter) {
-            this.valueGetter = valueGetter;
+        KTableKTableRightJoinProcessor(final KTableValueGetter<K, V1> thisValueGetter,
+                                       final KTableValueGetter<K, V2> otherValueGetter) {
+            this.thisValueGetter = thisValueGetter;
+            this.otherValueGetter = otherValueGetter;
         }
 
         @Override
@@ -79,7 +82,8 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()
             );
-            valueGetter.init(context);
+            thisValueGetter.init(context);
+            otherValueGetter.init(context);
         }
 
         @Override
@@ -102,11 +106,21 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 return;
             }
 
+            // drop out-of-order records from versioned tables (cf. KIP-914)
+            if (thisValueGetter.isVersioned()) {
+                final ValueAndTimestamp<V1> valueAndTimestampRight = thisValueGetter.get(record.key());
+                if (valueAndTimestampRight != null && valueAndTimestampRight.timestamp() > record.timestamp()) {
+                    LOG.info("Skipping out-of-order record from versioned table while performing table-table join.");
+                    droppedRecordsSensor.record();
+                    return;
+                }
+            }
+
             final VOut newValue;
             final long resultTimestamp;
             VOut oldValue = null;
 
-            final ValueAndTimestamp<V2> valueAndTimestampLeft = valueGetter.get(record.key());
+            final ValueAndTimestamp<V2> valueAndTimestampLeft = otherValueGetter.get(record.key());
             final V2 valueLeft = getValueOrNull(valueAndTimestampLeft);
             if (valueLeft == null) {
                 return;
@@ -127,7 +141,8 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public void close() {
-            valueGetter.close();
+            thisValueGetter.close();
+            otherValueGetter.close();
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -3254,10 +3254,10 @@ public class KStreamImplTest {
                 "    Processor: KSTREAM-TOTABLE-0000000004 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005])\n" +
                 "      --> KTABLE-JOINOTHER-0000000008\n" +
                 "      <-- KSTREAM-SOURCE-0000000003\n" +
-                "    Processor: KTABLE-JOINOTHER-0000000008 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
+                "    Processor: KTABLE-JOINOTHER-0000000008 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005, KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
                 "      --> KTABLE-MERGE-0000000006\n" +
                 "      <-- KSTREAM-TOTABLE-0000000004\n" +
-                "    Processor: KTABLE-JOINTHIS-0000000007 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005])\n" +
+                "    Processor: KTABLE-JOINTHIS-0000000007 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005, KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
                 "      --> KTABLE-MERGE-0000000006\n" +
                 "      <-- KSTREAM-TOTABLE-0000000001\n" +
                 "    Processor: KTABLE-MERGE-0000000006 (stores: [])\n" +


### PR DESCRIPTION
This PR updates primary-key table-table join processors to ignore out-of-order records from versioned tables, as specified in [KIP-914](https://cwiki.apache.org/confluence/display/KAFKA/KIP-914%3A+Join+Processor+Semantics+for+Versioned+Stores). Foreign-key table-table joins will be updated in a subsequent PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
