### PR TITLE
MINOR: fix failing ReadOnlyTaskTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ReadOnlyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ReadOnlyTaskTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.jupiter.api.Test;
 
@@ -183,6 +184,9 @@ class ReadOnlyTaskTest {
                     break;
                 case "java.lang.Iterable":
                     parameters[i] = Collections.emptySet();
+                    break;
+                case "org.apache.kafka.common.utils.Time":
+                    parameters[i] = Time.SYSTEM;
                     break;
                 default:
                     parameters[i] = parameterTypes[i].getConstructor().newInstance();


### PR DESCRIPTION
After https://github.com/apache/kafka/pull/13300, there are a bunch of failing tests. 
Some were fixed in https://github.com/apache/kafka/pull/13512, this is the final test that is failing.
