### PR TITLE
MINOR: Follow-up on failing streams test, and fix StoreChangelogReader

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -748,7 +748,7 @@ public class DefaultStateUpdater implements StateUpdater {
     @Override
     public boolean restoresActiveTasks() {
         return !executeWithQueuesLocked(
-            () -> getStreamOfNonPausedTasks().filter(Task::isActive).collect(Collectors.toSet())
+            () -> getStreamOfTasks().filter(Task::isActive).collect(Collectors.toSet())
         ).isEmpty();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
@@ -190,7 +190,7 @@ public class ReadOnlyTask implements Task {
     }
 
     @Override
-    public void maybeRecordRestored(final Time time, final long numRecords) {
+    public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
         throw new UnsupportedOperationException("This task is read-only");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -98,7 +98,7 @@ public class StandbyTask extends AbstractTask implements Task {
     @Override
     public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
         if (initRemaining) {
-            throw new IllegalStateException("Stanby task would not record remaining records to restore");
+            throw new IllegalStateException("Standby task would not record remaining records to restore");
         }
 
         maybeRecordSensor(numRecords, time, updateSensor);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -97,7 +97,7 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
-        if (initRemaining)
+        if (initRemaining) {
             throw new IllegalStateException("Stanby task would not record remaining records to restore");
 
         maybeRecordSensor(numRecords, time, updateSensor);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -96,7 +96,10 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void maybeRecordRestored(final Time time, final long numRecords) {
+    public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
+        if (initRemaining)
+            throw new IllegalStateException("Stanby task would not record remaining records to restore");
+
         maybeRecordSensor(numRecords, time, updateSensor);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -99,6 +99,7 @@ public class StandbyTask extends AbstractTask implements Task {
     public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
         if (initRemaining) {
             throw new IllegalStateException("Stanby task would not record remaining records to restore");
+        }
 
         maybeRecordSensor(numRecords, time, updateSensor);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -180,7 +180,7 @@ public interface StateUpdater {
      * Returns if the state updater restores active tasks.
      *
      * The state updater restores active tasks if at least one active task was added with {@link StateUpdater#add(Task)},
-     * the task is not paused, and the task was not removed from the state updater with one of the following methods:
+     * and the task was not removed from the state updater with one of the following methods:
      * <ul>
      *   <li>{@link StateUpdater#drainRestoredActiveTasks(Duration)}</li>
      *   <li>{@link StateUpdater#drainRemovedTasks()}</li>
@@ -189,6 +189,10 @@ public interface StateUpdater {
      *
      * @return {@code true} if the state updater restores active tasks, {@code false} otherwise
      */
+    // TODO: We would still return true if all active tasks to be restored
+    //       are paused, in order to keep consistent behavior compared with
+    //       state updater disabled. In the future we would modify this criterion
+    //       with state updater always enabled to allow mixed processing / restoration.
     boolean restoresActiveTasks();
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -920,7 +920,7 @@ public class StoreChangelogReader implements ChangelogReader {
     }
 
     private void removeChangelogsFromRestoreConsumer(final Collection<TopicPartition> partitions) {
-        if (partitions.isEmpty())
+        if (partitions.isEmpty()) {
             return;
 
         final Set<TopicPartition> assignment = new HashSet<>(restoreConsumer.assignment());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -458,19 +458,14 @@ public class StoreChangelogReader implements ChangelogReader {
                 final TaskId taskId = changelogs.get(partition).stateManager.taskId();
                 final Task task = tasks.get(taskId);
 
-                // if a task is null, it means the task is paused and hence not included
-                // in the parameter set of the restore call; in this case we would not restore
-                // that task
-                if (task != null) {
-                    try {
-                        final ChangelogMetadata changelogMetadata = changelogs.get(partition);
-                        totalRestored += restoreChangelog(task, changelogMetadata);
-                    } catch (final TimeoutException timeoutException) {
-                        tasks.get(taskId).maybeInitTaskTimeoutOrThrow(
-                            time.milliseconds(),
-                            timeoutException
-                        );
-                    }
+                try {
+                    final ChangelogMetadata changelogMetadata = changelogs.get(partition);
+                    totalRestored += restoreChangelog(task, changelogMetadata);
+                } catch (final TimeoutException timeoutException) {
+                    tasks.get(taskId).maybeInitTaskTimeoutOrThrow(
+                        time.milliseconds(),
+                        timeoutException
+                    );
                 }
             }
 
@@ -869,8 +864,7 @@ public class StoreChangelogReader implements ChangelogReader {
                         " does not contain the one looking for end offset: " + partition + ", this should not happen.");
                 }
 
-                log.info("End offset for changelog {} cannot be found or the corresponding task is paused and hence " +
-                    "not need to be retrieved yet; will retry in the next time.", partition);
+                log.info("End offset for changelog {} cannot be found; will retry in the next time.", partition);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -644,20 +644,19 @@ public class StoreChangelogReader implements ChangelogReader {
         final int numRecords = changelogMetadata.bufferedLimitIndex;
 
         if (numRecords != 0) {
-            final List<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>(changelogMetadata.bufferedRecords.subList(0, numRecords));
+            final List<ConsumerRecord<byte[], byte[]>> records = changelogMetadata.bufferedRecords.subList(0, numRecords);
             stateManager.restore(storeMetadata, records);
 
             // NOTE here we use removeRange of ArrayList in order to achieve efficiency with range shifting,
             // otherwise one-at-a-time removal or addition would be very costly; if all records are restored
             // then we can further optimize to save the array-shift but just set array elements to null
             if (numRecords < changelogMetadata.bufferedRecords.size()) {
-                // TODO: should optimize this
-                changelogMetadata.bufferedRecords.removeAll(records);
+                records.clear();
             } else {
                 changelogMetadata.bufferedRecords.clear();
             }
 
-            task.maybeRecordRestored(time, records.size());
+            task.recordRestoration(time, numRecords, false);
 
             final Long currentOffset = storeMetadata.offset();
             log.trace("Restored {} records from changelog {} to store {}, end offset is {}, current offset is {}",
@@ -691,7 +690,7 @@ public class StoreChangelogReader implements ChangelogReader {
             }
         }
 
-        if (task != null && (numRecords > 0 || changelogMetadata.state().equals(ChangelogState.COMPLETED))) {
+        if (numRecords > 0 || changelogMetadata.state().equals(ChangelogState.COMPLETED)) {
             task.clearTaskTimeout();
         }
 
@@ -988,6 +987,14 @@ public class StoreChangelogReader implements ChangelogReader {
                 } catch (final Exception e) {
                     throw new StreamsException("State restore listener failed on batch restored", e);
                 }
+
+                final TaskId taskId = changelogMetadata.stateManager.taskId();
+                final Task task = tasks.get(taskId);
+                // if the log is truncated between when we get the log end offset and when we get the
+                // consumer position, then it's possible that the difference become negative and there's actually
+                // no records to restore; in this case we just initialize the sensor to zero
+                final long recordsToRestore = Math.max(changelogMetadata.restoreEndOffset - startOffset, 0L);
+                task.recordRestoration(time, recordsToRestore, true);
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -922,6 +922,7 @@ public class StoreChangelogReader implements ChangelogReader {
     private void removeChangelogsFromRestoreConsumer(final Collection<TopicPartition> partitions) {
         if (partitions.isEmpty()) {
             return;
+        }
 
         final Set<TopicPartition> assignment = new HashSet<>(restoreConsumer.assignment());
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -219,13 +219,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     }
 
     @Override
-    public void maybeRecordRestored(final Time time, final long numRecords) {
-        maybeRecordSensor(numRecords, time, restoreSensor);
-        maybeRecordSensor(-1 * numRecords, time, restoreRemainingSensor);
-    }
-
-    public void initRemainingRecordsToRestore(final Time time, final long numRecords) {
-        maybeRecordSensor(numRecords, time, restoreRemainingSensor);
+    public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
+        if (initRemaining) {
+            maybeRecordSensor(numRecords, time, restoreRemainingSensor);
+        } else {
+            maybeRecordSensor(numRecords, time, restoreSensor);
+            maybeRecordSensor(-1 * numRecords, time, restoreRemainingSensor);
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -203,7 +203,7 @@ public interface Task {
 
     void clearTaskTimeout();
 
-    void maybeRecordRestored(final Time time, final long numRecords);
+    void recordRestoration(final Time time, final long numRecords, final boolean initRemaining);
 
     // task status inquiry
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
@@ -193,6 +193,8 @@ public class PauseResumeIntegrationTest {
 
         produceToInputTopics(INPUT_STREAM_1, STANDARD_INPUT_DATA);
 
+        waitUntilStreamsHasPolled(kafkaStreams, 2);
+
         assertTopicSize(OUTPUT_STREAM_1, 0);
 
         kafkaStreams.resume();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
@@ -188,12 +188,11 @@ public class PauseResumeIntegrationTest {
         kafkaStreams = buildKafkaStreams(OUTPUT_STREAM_1, stateUpdaterEnabled);
         kafkaStreams.pause();
         kafkaStreams.start();
-        waitForApplicationState(singletonList(kafkaStreams), State.RUNNING, STARTUP_TIMEOUT);
+        waitForApplicationState(singletonList(kafkaStreams), State.REBALANCING, STARTUP_TIMEOUT);
         assertTrue(kafkaStreams.isPaused());
 
         produceToInputTopics(INPUT_STREAM_1, STANDARD_INPUT_DATA);
 
-        waitUntilStreamsHasPolled(kafkaStreams, 2);
         assertTopicSize(OUTPUT_STREAM_1, 0);
 
         kafkaStreams.resume();
@@ -282,7 +281,7 @@ public class PauseResumeIntegrationTest {
 
         streamsNamedTopologyWrapper.pauseNamedTopology(TOPOLOGY1);
         streamsNamedTopologyWrapper.start(asList(builder1.build(), builder2.build()));
-        waitForApplicationState(singletonList(streamsNamedTopologyWrapper), State.RUNNING, STARTUP_TIMEOUT);
+        waitForApplicationState(singletonList(streamsNamedTopologyWrapper), State.REBALANCING, STARTUP_TIMEOUT);
 
         assertFalse(streamsNamedTopologyWrapper.isPaused());
         assertTrue(streamsNamedTopologyWrapper.isNamedTopologyPaused(TOPOLOGY1));
@@ -291,29 +290,16 @@ public class PauseResumeIntegrationTest {
         produceToInputTopics(INPUT_STREAM_1, STANDARD_INPUT_DATA);
         produceToInputTopics(INPUT_STREAM_2, STANDARD_INPUT_DATA);
 
-        awaitOutput(OUTPUT_STREAM_2, 5, COUNT_OUTPUT_DATA);
         assertTopicSize(OUTPUT_STREAM_1, 0);
-
-        streamsNamedTopologyWrapper.pause();
-        assertTrue(streamsNamedTopologyWrapper.isPaused());
-        assertTrue(streamsNamedTopologyWrapper.isNamedTopologyPaused(TOPOLOGY1));
-        assertTrue(streamsNamedTopologyWrapper.isNamedTopologyPaused(TOPOLOGY2));
-
-        produceToInputTopics(INPUT_STREAM_1, STANDARD_INPUT_DATA);
-        produceToInputTopics(INPUT_STREAM_2, STANDARD_INPUT_DATA);
-
-        waitUntilStreamsHasPolled(streamsNamedTopologyWrapper, 2);
-        assertTopicSize(OUTPUT_STREAM_1, 0);
-        assertTopicSize(OUTPUT_STREAM_2, 5);
+        assertTopicSize(OUTPUT_STREAM_2, 0);
 
         streamsNamedTopologyWrapper.resumeNamedTopology(TOPOLOGY1);
         assertFalse(streamsNamedTopologyWrapper.isPaused());
         assertFalse(streamsNamedTopologyWrapper.isNamedTopologyPaused(TOPOLOGY1));
-        assertTrue(streamsNamedTopologyWrapper.isNamedTopologyPaused(TOPOLOGY2));
+        assertFalse(streamsNamedTopologyWrapper.isNamedTopologyPaused(TOPOLOGY2));
 
-        awaitOutput(OUTPUT_STREAM_1, 10, COUNT_OUTPUT_DATA_ALL);
-        assertTopicSize(OUTPUT_STREAM_1, 10);
-        assertTopicSize(OUTPUT_STREAM_2, 5);
+        awaitOutput(OUTPUT_STREAM_1, 5, COUNT_OUTPUT_DATA);
+        awaitOutput(OUTPUT_STREAM_2, 5, COUNT_OUTPUT_DATA);
     }
 
     @ParameterizedTest
@@ -325,17 +311,15 @@ public class PauseResumeIntegrationTest {
         kafkaStreams.pause();
         kafkaStreams.start();
 
-        waitForApplicationState(singletonList(kafkaStreams), State.RUNNING, STARTUP_TIMEOUT);
+        waitForApplicationState(singletonList(kafkaStreams), State.REBALANCING, STARTUP_TIMEOUT);
         assertTrue(kafkaStreams.isPaused());
 
         kafkaStreams2 = buildKafkaStreams(OUTPUT_STREAM_2, stateUpdaterEnabled);
         kafkaStreams2.pause();
         kafkaStreams2.start();
-        waitForApplicationState(singletonList(kafkaStreams2), State.RUNNING, STARTUP_TIMEOUT);
+        waitForApplicationState(singletonList(kafkaStreams2), State.REBALANCING, STARTUP_TIMEOUT);
         assertTrue(kafkaStreams2.isPaused());
 
-        waitUntilStreamsHasPolled(kafkaStreams, 2);
-        waitUntilStreamsHasPolled(kafkaStreams2, 2);
         assertTopicSize(OUTPUT_STREAM_1, 0);
 
         kafkaStreams2.close();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -465,7 +465,7 @@ class DefaultStateUpdaterTest {
     }
 
     @Test
-    public void shouldReturnFalseForRestoreActiveTasksIfTaskPaused() throws Exception {
+    public void shouldReturnTrueForRestoreActiveTasksIfTaskPaused() throws Exception {
         final StreamTask task = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0))
             .inState(State.RESTORING).build();
         when(changelogReader.completedChangelogs())
@@ -482,7 +482,7 @@ class DefaultStateUpdaterTest {
         verifyRemovedTasks();
         verifyPausedTasks(task);
 
-        assertFalse(stateUpdater.restoresActiveTasks());
+        assertTrue(stateUpdater.restoresActiveTasks());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -657,12 +657,12 @@ public class StandbyTaskTest {
         assertThat(totalMetric.metricValue(), equalTo(0.0));
         assertThat(rateMetric.metricValue(), equalTo(0.0));
 
-        task.maybeRecordRestored(time, 25L);
+        task.recordRestoration(time, 25L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(25.0));
         assertThat(rateMetric.metricValue(), not(0.0));
 
-        task.maybeRecordRestored(time, 50L);
+        task.recordRestoration(time, 50L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(75.0));
         assertThat(rateMetric.metricValue(), not(0.0));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -74,6 +74,7 @@ import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_BATCH;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_SUSPENDED;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
+import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expectLastCall;
@@ -389,7 +390,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
         EasyMock.expect(storeMetadata.offset()).andReturn(null).andReturn(9L).anyTimes();
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(singletonMap(tp, 5L));
-        EasyMock.expect(stateManager.taskId()).andReturn(taskId);
+        EasyMock.expect(stateManager.taskId()).andReturn(taskId).anyTimes();
         EasyMock.replay(stateManager, storeMetadata, store);
 
         consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
@@ -419,7 +420,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
         EasyMock.expect(storeMetadata.offset()).andReturn(null).andReturn(9L).anyTimes();
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(singletonMap(tp, 5L));
-        EasyMock.expect(stateManager.taskId()).andReturn(taskId);
+        EasyMock.expect(stateManager.taskId()).andReturn(taskId).anyTimes();
         EasyMock.replay(stateManager, storeMetadata, store);
 
         consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
@@ -621,6 +622,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         mockTask.clearTaskTimeout();
         mockTask.maybeInitTaskTimeoutOrThrow(anyLong(), anyObject());
         EasyMock.expectLastCall();
+        mockTask.recordRestoration(anyObject(), anyLong(), anyBoolean());
+        EasyMock.expectLastCall();
         EasyMock.expect(storeMetadata.offset()).andReturn(10L).anyTimes();
         EasyMock.expect(activeStateManager.changelogOffsets()).andReturn(singletonMap(tp, 10L));
         EasyMock.expect(activeStateManager.taskId()).andReturn(taskId).anyTimes();
@@ -697,7 +700,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldRequestEndOffsetsAndHandleTimeoutException() {
         final TaskId taskId = new TaskId(0, 0);
 
-        final Task mockTask = mock(Task.class);
+        final Task mockTask = niceMock(Task.class);
         mockTask.maybeInitTaskTimeoutOrThrow(anyLong(), anyObject());
         EasyMock.expectLastCall();
 
@@ -742,6 +745,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
         EasyMock.resetToDefault(mockTask);
         mockTask.clearTaskTimeout();
+        mockTask.recordRestoration(anyObject(), anyLong(), anyBoolean());
+        EasyMock.expectLastCall();
         EasyMock.replay(mockTask);
 
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
@@ -835,6 +840,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         if (type == ACTIVE) {
             mockTask.clearTaskTimeout();
             mockTask.clearTaskTimeout();
+            expectLastCall();
+            mockTask.recordRestoration(anyObject(), anyLong(), anyBoolean());
             expectLastCall();
         }
         replay(mockTask);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -232,6 +232,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldSupportUnregisterChangelogBeforeCompletion() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(storeMetadata.offset()).andReturn(9L).anyTimes();
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(singletonMap(tp, 10L));
         EasyMock.replay(mockTasks, stateManager, storeMetadata, store);
@@ -275,6 +276,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldSupportUnregisterChangelogAfterCompletion() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(storeMetadata.offset()).andReturn(9L).anyTimes();
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(singletonMap(tp, 10L));
         EasyMock.replay(mockTasks, stateManager, storeMetadata, store);
@@ -321,6 +323,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldInitializeChangelogAndCheckForCompletion() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(storeMetadata.offset()).andReturn(9L).anyTimes();
         EasyMock.replay(mockTasks, stateManager, storeMetadata, store);
 
@@ -361,6 +364,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         if (type == ACTIVE) {
             final Map<TaskId, Task> mockTasks = mock(Map.class);
             EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+            EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
             EasyMock.expect(stateManager.changelogOffsets()).andReturn(singletonMap(tp, 5L));
             EasyMock.replay(mockTasks, stateManager, storeMetadata, store);
 
@@ -591,6 +595,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldCheckCompletionIfPositionLargerThanEndOffset() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(storeMetadata.offset()).andReturn(5L).anyTimes();
         EasyMock.replay(mockTasks, activeStateManager, storeMetadata, store);
 
@@ -759,7 +764,10 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
     @Test
     public void shouldThrowIfEndOffsetsFail() {
+        final TaskId taskId = new TaskId(0, 0);
+
         EasyMock.expect(storeMetadata.offset()).andReturn(10L).anyTimes();
+        EasyMock.expect(activeStateManager.taskId()).andReturn(taskId).anyTimes();
         EasyMock.replay(activeStateManager, storeMetadata, store);
 
         final MockAdminClient adminClient = new MockAdminClient() {
@@ -778,7 +786,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
         final StreamsException thrown = assertThrows(
             StreamsException.class,
-            () -> changelogReader.restore(Collections.emptyMap())
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -904,6 +912,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldOnlyRestoreStandbyChangelogInUpdateStandbyState() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.replay(mockTasks, standbyStateManager, storeMetadata, store);
 
         consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
@@ -942,6 +951,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldNotUpdateLimitForNonSourceStandbyChangelog() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(standbyStateManager.changelogAsSource(tp)).andReturn(false).anyTimes();
         EasyMock.replay(mockTasks, standbyStateManager, storeMetadata, store);
 
@@ -995,6 +1005,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldRestoreToLimitInStandbyState() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(standbyStateManager.changelogAsSource(tp)).andReturn(true).anyTimes();
         EasyMock.replay(mockTasks, standbyStateManager, storeMetadata, store);
 
@@ -1107,6 +1118,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldRestoreMultipleChangelogs() {
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         EasyMock.expect(mockTasks.get(null)).andReturn(mock(Task.class)).anyTimes();
+        EasyMock.expect(mockTasks.containsKey(null)).andReturn(true).anyTimes();
         EasyMock.expect(storeMetadataOne.changelogPartition()).andReturn(tp1).anyTimes();
         EasyMock.expect(storeMetadataOne.store()).andReturn(store).anyTimes();
         EasyMock.expect(storeMetadataTwo.changelogPartition()).andReturn(tp2).anyTimes();
@@ -1165,6 +1177,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         EasyMock.expect(standbyStateManager.storeMetadata(tp2)).andReturn(storeMetadataTwo).anyTimes();
         EasyMock.expect(activeStateManager.changelogOffsets()).andReturn(singletonMap(tp, 5L));
         EasyMock.expect(activeStateManager.taskId()).andReturn(taskId).anyTimes();
+        EasyMock.expect(standbyStateManager.taskId()).andReturn(taskId).anyTimes();
         EasyMock.replay(activeStateManager, standbyStateManager, storeMetadata, store, storeMetadataOne, storeMetadataTwo);
 
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -781,17 +781,17 @@ public class StreamTaskTest {
         assertThat(rateMetric.metricValue(), equalTo(0.0));
         assertThat(remainMetric.metricValue(), equalTo(0.0));
 
-        task.initRemainingRecordsToRestore(time, 100L);
+        task.recordRestoration(time, 100L, true);
 
         assertThat(remainMetric.metricValue(), equalTo(100.0));
 
-        task.maybeRecordRestored(time, 25L);
+        task.recordRestoration(time, 25L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(25.0));
         assertThat(rateMetric.metricValue(), not(0.0));
         assertThat(remainMetric.metricValue(), equalTo(75.0));
 
-        task.maybeRecordRestored(time, 50L);
+        task.recordRestoration(time, 50L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(75.0));
         assertThat(rateMetric.metricValue(), not(0.0));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -4866,7 +4866,7 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void maybeRecordRestored(final Time time, final long numRecords) {
+        public void recordRestoration(final Time time, final long numRecords, final boolean initRemaining) {
             // do nothing
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetricsTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals.metrics;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
@@ -255,7 +254,6 @@ public class TaskMetricsTest {
     }
 
     @Test
-    @Ignore
     public void shouldGetDroppedRecordsSensor() {
         final String operation = "dropped-records";
         final String totalDescription = "The total number of dropped records";
@@ -266,12 +264,21 @@ public class TaskMetricsTest {
         try (final MockedStatic<StreamsMetricsImpl> streamsMetricsStaticMock = mockStatic(StreamsMetricsImpl.class)) {
             final Sensor sensor = TaskMetrics.droppedRecordsSensor(THREAD_ID, TASK_ID, streamsMetrics);
             streamsMetricsStaticMock.verify(
-                () -> StreamsMetricsImpl.addInvocationRateAndCountToSensor(
+                () -> StreamsMetricsImpl.addInvocationRateToSensor(
                     expectedSensor,
                     TASK_LEVEL_GROUP,
                     tagMap,
                     operation,
-                    rateDescription,
+                    rateDescription
+                )
+            );
+            streamsMetricsStaticMock.verify(
+                () -> StreamsMetricsImpl.addSumMetricToSensor(
+                    expectedSensor,
+                    TASK_LEVEL_GROUP,
+                    tagMap,
+                    operation,
+                    true,
                     totalDescription
                 )
             );


### PR DESCRIPTION
1) I've verified and made sure the only case that `task` would be null and not stream task would be in testing code only, with pausing / resuming topologies; I've revamped the restoration recording func, mainly to make just one method on the Task interface, to make sure we would never get `task == null` and do not need to cast to `StreamTask`.
2) Use `numRecords` directly to avoid calling `records.size()` that triggers concurrent modifications.
3) Rewrite the TaskMetricsTest to not use the removed impl functions.
4) Found an issue while fixing 1) above, turns out it's related to pausing tasks: if the tasks are paused due to instance / named-topologies are paused while they need restoration, the restoration would never finish, and hence the instance's state would not transit to RUNNING. Similarly, if user paused just one of the named-topology right at the beginning, since the state would not transit to RUNNING, every tasks across all named-topologies would not make progress. We keep the behavior as is to be consistent with and without state-updater.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
