### PR TITLE
KAFKA-14883: Expose `observer` state in KRaft metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1834,7 +1834,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Current State</td>
-    <td>The current state of this member; possible values are leader, candidate, voted, follower, unattached.</td>
+    <td>The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer.</td>
     <td>kafka.server:type=raft-metrics,name=current-state</td>
   </tr>
   <tr>

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
@@ -65,17 +65,19 @@ public class KafkaRaftMetrics implements AutoCloseable {
 
         this.currentStateMetricName = metrics.metricName("current-state", metricGroupName, "The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer");
         Gauge<String> stateProvider = (mConfig, currentTimeMs) -> {
-            // a broker, as not being a voter, is always an observer
-            if (state.isObserver()) {
-                return "observer";
-            } else if (state.isLeader()) {
+            if (state.isLeader()) {
                 return "leader";
             } else if (state.isCandidate()) {
                 return "candidate";
             } else if (state.isVoted()) {
                 return "voted";
             } else if (state.isFollower()) {
-                return "follower";
+                // a broker is special kind of follower, as not being a voter, it's an observer
+                if (state.isObserver()) {
+                    return "observer";
+                } else {
+                    return "follower";
+                }
             } else {
                 return "unattached";
             }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
@@ -63,7 +63,7 @@ public class KafkaRaftMetrics implements AutoCloseable {
         this.numUnknownVoterConnections = 0;
         this.logEndOffset = new OffsetAndEpoch(0L, 0);
 
-        this.currentStateMetricName = metrics.metricName("current-state", metricGroupName, "The current state of this member; possible values are leader, candidate, voted, follower, unattached");
+        this.currentStateMetricName = metrics.metricName("current-state", metricGroupName, "The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer");
         Gauge<String> stateProvider = (mConfig, currentTimeMs) -> {
             // a broker, as not being a voter, is always an observer
             if (state.isObserver()) {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
@@ -71,6 +71,8 @@ public class KafkaRaftMetrics implements AutoCloseable {
                 return "candidate";
             } else if (state.isVoted()) {
                 return "voted";
+            } else if (state.isObserver()) {
+                return "observer";
             } else if (state.isFollower()) {
                 return "follower";
             } else {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java
@@ -65,14 +65,15 @@ public class KafkaRaftMetrics implements AutoCloseable {
 
         this.currentStateMetricName = metrics.metricName("current-state", metricGroupName, "The current state of this member; possible values are leader, candidate, voted, follower, unattached");
         Gauge<String> stateProvider = (mConfig, currentTimeMs) -> {
-            if (state.isLeader()) {
+            // a broker, as not being a voter, is always an observer
+            if (state.isObserver()) {
+                return "observer";
+            } else if (state.isLeader()) {
                 return "leader";
             } else if (state.isCandidate()) {
                 return "candidate";
             } else if (state.isVoted()) {
                 return "voted";
-            } else if (state.isObserver()) {
-                return "observer";
             } else if (state.isFollower()) {
                 return "follower";
             } else {

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -137,14 +137,14 @@ public class KafkaRaftMetricsTest {
         state.initialize(new OffsetAndEpoch(0L, 0));
         raftMetrics = new KafkaRaftMetrics(metrics, "raft", state);
 
-        assertEquals("unattached", getMetric(metrics, "current-state").metricValue());
+        assertEquals("observer", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) -1L, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) -1L, getMetric(metrics, "current-vote").metricValue());
         assertEquals((double) 0, getMetric(metrics, "current-epoch").metricValue());
         assertEquals((double) -1L, getMetric(metrics, "high-watermark").metricValue());
 
         state.transitionToFollower(2, 1);
-        assertEquals("follower", getMetric(metrics, "current-state").metricValue());
+        assertEquals("observer", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) 1, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) -1, getMetric(metrics, "current-vote").metricValue());
         assertEquals((double) 2, getMetric(metrics, "current-epoch").metricValue());
@@ -154,7 +154,7 @@ public class KafkaRaftMetricsTest {
         assertEquals((double) 10L, getMetric(metrics, "high-watermark").metricValue());
 
         state.transitionToUnattached(4);
-        assertEquals("unattached", getMetric(metrics, "current-state").metricValue());
+        assertEquals("observer", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) -1, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) -1, getMetric(metrics, "current-vote").metricValue());
         assertEquals((double) 4, getMetric(metrics, "current-epoch").metricValue());

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -137,7 +137,7 @@ public class KafkaRaftMetricsTest {
         state.initialize(new OffsetAndEpoch(0L, 0));
         raftMetrics = new KafkaRaftMetrics(metrics, "raft", state);
 
-        assertEquals("observer", getMetric(metrics, "current-state").metricValue());
+        assertEquals("unattached", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) -1L, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) -1L, getMetric(metrics, "current-vote").metricValue());
         assertEquals((double) 0, getMetric(metrics, "current-epoch").metricValue());
@@ -154,7 +154,7 @@ public class KafkaRaftMetricsTest {
         assertEquals((double) 10L, getMetric(metrics, "high-watermark").metricValue());
 
         state.transitionToUnattached(4);
-        assertEquals("observer", getMetric(metrics, "current-state").metricValue());
+        assertEquals("unattached", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) -1, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) -1, getMetric(metrics, "current-vote").metricValue());
         assertEquals((double) 4, getMetric(metrics, "current-epoch").metricValue());


### PR DESCRIPTION
Currently, the `current-state` KRaft related metric reports `follower` state for a broker while technically it should be reported as an `observer`  as the `kafka-metadata-quorum` tool does.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
