### PR TITLE
Revert "KAFKA-14318: KIP-878, Introduce partition autoscaling configs (#12962)"

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -625,18 +625,6 @@ public class StreamsConfig extends AbstractConfig {
     public static final String NUM_STREAM_THREADS_CONFIG = "num.stream.threads";
     private static final String NUM_STREAM_THREADS_DOC = "The number of threads to execute stream processing.";
 
-    /** {@code partition.autoscaling.enabled} */
-    @SuppressWarnings("WeakerAccess")
-    public static final String PARTITION_AUTOSCALING_ENABLED_CONFIG = "partition.autoscaling.enabled";
-    private static final String PARTITION_AUTOSCALING_ENABLED_DOC = "Enable autoscaling the partitions of internal topics which are managed by Streams."
-        + " If an internal topic's partition count depends on an upstream input topic (or topics), then expanding the number of partitions on the input "
-        + "topic(s) will result in the internal topic(s) automatically being expanded to match.";
-
-    /** {@code partition.autoscaling.timeout.ms} */
-    @SuppressWarnings("WeakerAccess")
-    public static final String PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG = "partition.autoscaling.timeout.ms";
-    private static final String PARTITION_AUTOSCALING_TIMEOUT_MS_DOC = "The maximum amount of time in milliseconds that Streams will attempt to retry autoscaling of internal topic partitions.";
-
     /** {@code poll.ms} */
     @SuppressWarnings("WeakerAccess")
     public static final String POLL_MS_CONFIG = "poll.ms";
@@ -1008,17 +996,6 @@ public class StreamsConfig extends AbstractConfig {
                     true,
                     Importance.LOW,
                     CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_DOC)
-            .define(PARTITION_AUTOSCALING_ENABLED_CONFIG,
-                    Type.BOOLEAN,
-                    false,
-                    Importance.LOW,
-                    PARTITION_AUTOSCALING_ENABLED_DOC)
-            .define(PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG,
-                    Type.LONG,
-                    15 * 60 * 1000L,
-                    atLeast(0),
-                    Importance.LOW,
-                    PARTITION_AUTOSCALING_TIMEOUT_MS_DOC)
             .define(POLL_MS_CONFIG,
                     Type.LONG,
                     100L,
@@ -1556,8 +1533,6 @@ public class StreamsConfig extends AbstractConfig {
         consumerProps.put(NUM_STANDBY_REPLICAS_CONFIG, getInt(NUM_STANDBY_REPLICAS_CONFIG));
         consumerProps.put(ACCEPTABLE_RECOVERY_LAG_CONFIG, getLong(ACCEPTABLE_RECOVERY_LAG_CONFIG));
         consumerProps.put(MAX_WARMUP_REPLICAS_CONFIG, getInt(MAX_WARMUP_REPLICAS_CONFIG));
-        consumerProps.put(PARTITION_AUTOSCALING_ENABLED_CONFIG, getBoolean(PARTITION_AUTOSCALING_ENABLED_CONFIG));
-        consumerProps.put(PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG, getLong(PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG));
         consumerProps.put(PROBING_REBALANCE_INTERVAL_MS_CONFIG, getLong(PROBING_REBALANCE_INTERVAL_MS_CONFIG));
         consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName());
         consumerProps.put(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, getLong(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -261,16 +261,10 @@ public final class AssignorConfiguration {
         void onAssignmentComplete(final boolean stable);
     }
 
-    /**
-     * NOTE: any StreamsConfig you add here MUST be passed in to the consumer via
-     * {@link StreamsConfig#getMainConsumerConfigs}
-     */
     public static class AssignmentConfigs {
         public final long acceptableRecoveryLag;
         public final int maxWarmupReplicas;
         public final int numStandbyReplicas;
-        public final boolean partitionAutoscalingEnabled;
-        public final long partitionAutoscalingTimeoutMs;
         public final long probingRebalanceIntervalMs;
         public final List<String> rackAwareAssignmentTags;
 
@@ -278,8 +272,6 @@ public final class AssignorConfiguration {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);
             maxWarmupReplicas = configs.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG);
             numStandbyReplicas = configs.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
-            partitionAutoscalingEnabled = configs.getBoolean(StreamsConfig.PARTITION_AUTOSCALING_ENABLED_CONFIG);
-            partitionAutoscalingTimeoutMs = configs.getLong(StreamsConfig.PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG);
             probingRebalanceIntervalMs = configs.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG);
             rackAwareAssignmentTags = configs.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
         }
@@ -287,15 +279,11 @@ public final class AssignorConfiguration {
         AssignmentConfigs(final Long acceptableRecoveryLag,
                           final Integer maxWarmupReplicas,
                           final Integer numStandbyReplicas,
-                          final boolean partitionAutoscalingEnabled,
-                          final long partitionAutoscalingTimeoutMs,
                           final Long probingRebalanceIntervalMs,
                           final List<String> rackAwareAssignmentTags) {
             this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
             this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
             this.numStandbyReplicas = validated(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
-            this.partitionAutoscalingEnabled = validated(StreamsConfig.PARTITION_AUTOSCALING_ENABLED_CONFIG, partitionAutoscalingEnabled);
-            this.partitionAutoscalingTimeoutMs = validated(StreamsConfig.PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG, partitionAutoscalingTimeoutMs);
             this.probingRebalanceIntervalMs = validated(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, probingRebalanceIntervalMs);
             this.rackAwareAssignmentTags = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rackAwareAssignmentTags);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -62,8 +62,6 @@ import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_BETA;
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_V2;
 import static org.apache.kafka.streams.StreamsConfig.MAX_RACK_AWARE_ASSIGNMENT_TAG_KEY_LENGTH;
 import static org.apache.kafka.streams.StreamsConfig.MAX_RACK_AWARE_ASSIGNMENT_TAG_VALUE_LENGTH;
-import static org.apache.kafka.streams.StreamsConfig.PARTITION_AUTOSCALING_ENABLED_CONFIG;
-import static org.apache.kafka.streams.StreamsConfig.PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.adminClientPrefix;
@@ -1369,20 +1367,6 @@ public class StreamsConfigTest {
     public void shouldNotEnableAnyOptimizationsWithNoOptimizationConfig() {
         final Set<String> configs = StreamsConfig.verifyTopologyOptimizationConfigs(StreamsConfig.NO_OPTIMIZATION);
         assertEquals(0, configs.size());
-    }
-
-    @Test
-    public void shouldEnablePartitionAutoscaling() {
-        props.put("partition.autoscaling.enabled", true);
-        final StreamsConfig config = new StreamsConfig(props);
-        assertTrue(config.getBoolean(PARTITION_AUTOSCALING_ENABLED_CONFIG));
-    }
-
-    @Test
-    public void shouldSetPartitionAutoscalingTimeout() {
-        props.put("partition.autoscaling.timeout.ms", 0L);
-        final StreamsConfig config = new StreamsConfig(props);
-        assertThat(config.getLong(PARTITION_AUTOSCALING_TIMEOUT_MS_CONFIG), is(0L));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
-import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -112,93 +111,6 @@ public final class AssignmentTestUtils {
     public static final Map<String, String> EMPTY_CLIENT_TAGS = Collections.emptyMap();
 
     private AssignmentTestUtils() {}
-
-    public static final long ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT = 100;
-
-    public static AssignmentConfigs getDefaultConfigsWithZeroStandbys() {
-        return new AssignmentConfigs(
-            ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT,
-            2,
-            0,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
-
-    public static AssignmentConfigs getDefaultConfigsWithOneStandbys() {
-        return new AssignmentConfigs(
-            ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT,
-            2,
-            1,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
-
-    public static AssignmentConfigs getConfigsWithZeroStandbysAndWarmups(final int maxWarmups) {
-        return new AssignmentConfigs(
-            ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT,
-            maxWarmups,
-            0,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
-
-    public static AssignmentConfigs getConfigsWithOneStandbysAndWarmups(final int maxWarmups) {
-        return new AssignmentConfigs(
-            ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT,
-            maxWarmups,
-            1,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
-
-    public static AssignmentConfigs getConfigsWithOneStandbysAndZeroLagAndWarmups(final int maxWarmups) {
-        return new AssignmentConfigs(
-            0L,
-            maxWarmups,
-            1,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
-
-    public static AssignmentConfigs getConfigsWithZeroStandbysAndZeroLagAndWarmups(final int maxWarmups) {
-        return new AssignmentConfigs(
-            0L,
-            maxWarmups,
-            0,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
-
-    public static AssignmentConfigs getConfigsWithOneStandbysAndLagAndWarmups(final long acceptableRecoveryLag,
-                                                                              final int maxWarmups) {
-        return new AssignmentConfigs(
-            acceptableRecoveryLag,
-            maxWarmups,
-            1,
-            false,
-            90_000L,
-            60_000L,
-            EMPTY_RACK_AWARE_ASSIGNMENT_TAGS
-        );
-    }
 
     static Map<UUID, ClientState> getClientStatesMap(final ClientState... states) {
         final Map<UUID, ClientState> clientStates = new HashMap<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfigurationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfigurationTest.java
@@ -30,7 +30,7 @@ public class AssignorConfigurationTest {
     public void configsShouldRejectZeroWarmups() {
         final ConfigException exception = assertThrows(
             ConfigException.class,
-            () -> new AssignorConfiguration.AssignmentConfigs(1L, 0, 1, false, 1L, 1L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
+            () -> new AssignorConfiguration.AssignmentConfigs(1L, 0, 1, 1L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
         );
 
         assertThat(exception.getMessage(), containsString("Invalid value 0 for configuration max.warmup.replicas"));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
@@ -656,8 +656,6 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         return new AssignmentConfigs(0L,
                                      1,
                                      numStandbyReplicas,
-                                     false,
-                                     1L,
                                      60000L,
                                      asList(rackAwareAssignmentTags));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/FallbackPriorTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/FallbackPriorTaskAssignorTest.java
@@ -54,7 +54,7 @@ public class FallbackPriorTaskAssignorTest {
             clients,
             new HashSet<>(taskIds),
             new HashSet<>(taskIds),
-            new AssignorConfiguration.AssignmentConfigs(0L, 1, 0, false, 1L, 60_000L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
+            new AssignorConfiguration.AssignmentConfigs(0L, 1, 0, 60_000L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
         );
         assertThat(probingRebalanceNeeded, is(true));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactoryTest.java
@@ -28,8 +28,6 @@ public class StandbyTaskAssignorFactoryTest {
     private static final long ACCEPTABLE_RECOVERY_LAG = 0L;
     private static final int MAX_WARMUP_REPLICAS = 1;
     private static final int NUMBER_OF_STANDBY_REPLICAS = 1;
-    private static final boolean PARTITION_AUTOSCALING_ENABLED = false;
-    private static final long PARTITION_AUTOSCALING_TIMEOUT_MS = 90000L;
     private static final long PROBING_REBALANCE_INTERVAL_MS = 60000L;
 
     @Test
@@ -48,8 +46,6 @@ public class StandbyTaskAssignorFactoryTest {
         return new AssignorConfiguration.AssignmentConfigs(ACCEPTABLE_RECOVERY_LAG,
                                                            MAX_WARMUP_REPLICAS,
                                                            NUMBER_OF_STANDBY_REPLICAS,
-                                                           PARTITION_AUTOSCALING_ENABLED,
-                                                           PARTITION_AUTOSCALING_TIMEOUT_MS,
                                                            PROBING_REBALANCE_INTERVAL_MS,
                                                            rackAwareAssignmentTags);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -677,7 +677,7 @@ public class StickyTaskAssignorTest {
             clients,
             new HashSet<>(taskIds),
             new HashSet<>(taskIds),
-            new AssignorConfiguration.AssignmentConfigs(0L, 1, 0, false, 90_000L, 60_000L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
+            new AssignorConfiguration.AssignmentConfigs(0L, 1, 0, 60_000L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
         );
         assertThat(probingRebalanceNeeded, is(false));
 
@@ -696,7 +696,7 @@ public class StickyTaskAssignorTest {
             clients,
             new HashSet<>(taskIds),
             new HashSet<>(taskIds),
-            new AssignorConfiguration.AssignmentConfigs(0L, 1, numStandbys, false, 90_000L, 60_000L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
+            new AssignorConfiguration.AssignmentConfigs(0L, 1, numStandbys, 60_000L, EMPTY_RACK_AWARE_ASSIGNMENT_TAGS)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
@@ -29,13 +29,11 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_RACK_AWARE_ASSIGNMENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.appendClientStates;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedActiveAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedStatefulAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertValidAssignment;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getDefaultConfigsWithZeroStandbys;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
 import static org.junit.Assert.fail;
 
@@ -231,7 +229,11 @@ public class TaskAssignorConvergenceTest {
 
     @Test
     public void staticAssignmentShouldConvergeWithTheFirstAssignment() {
-        final AssignmentConfigs configs = getDefaultConfigsWithZeroStandbys();
+        final AssignmentConfigs configs = new AssignmentConfigs(100L,
+                                                                2,
+                                                                0,
+                                                                60_000L,
+                                                                EMPTY_RACK_AWARE_ASSIGNMENT_TAGS);
 
         final Harness harness = Harness.initializeCluster(1, 1, 1, () -> 1);
 
@@ -247,7 +249,11 @@ public class TaskAssignorConvergenceTest {
         final int maxWarmupReplicas = 2;
         final int numStandbyReplicas = 0;
 
-        final AssignmentConfigs configs = getDefaultConfigsWithZeroStandbys();
+        final AssignmentConfigs configs = new AssignmentConfigs(100L,
+                                                                maxWarmupReplicas,
+                                                                numStandbyReplicas,
+                                                                60_000L,
+                                                                EMPTY_RACK_AWARE_ASSIGNMENT_TAGS);
 
         final Harness harness = Harness.initializeCluster(numStatelessTasks, numStatefulTasks, 1, () -> 5);
         testForConvergence(harness, configs, 1);
@@ -266,7 +272,11 @@ public class TaskAssignorConvergenceTest {
         final int maxWarmupReplicas = 2;
         final int numStandbyReplicas = 0;
 
-        final AssignmentConfigs configs = getDefaultConfigsWithZeroStandbys();
+        final AssignmentConfigs configs = new AssignmentConfigs(100L,
+                                                                maxWarmupReplicas,
+                                                                numStandbyReplicas,
+                                                                60_000L,
+                                                                EMPTY_RACK_AWARE_ASSIGNMENT_TAGS);
 
         final Harness harness = Harness.initializeCluster(numStatelessTasks, numStatefulTasks, 7, () -> 5);
         testForConvergence(harness, configs, 1);
@@ -304,11 +314,9 @@ public class TaskAssignorConvergenceTest {
 
             final int numberOfEvents = prng.nextInt(10) + 1;
 
-            final AssignmentConfigs configs = new AssignmentConfigs(ACCEPTABLE_RECOVERY_LAG_TEST_DEFAULT,
+            final AssignmentConfigs configs = new AssignmentConfigs(100L,
                                                                     maxWarmupReplicas,
                                                                     numStandbyReplicas,
-                                                                    false,
-                                                                    90_000L,
                                                                     60_000L,
                                                                     EMPTY_RACK_AWARE_ASSIGNMENT_TAGS);
 
@@ -418,5 +426,6 @@ public class TaskAssignorConvergenceTest {
             fail(message.toString());
         }
     }
+
 
 }


### PR DESCRIPTION
This reverts commit d9b139220ee253da673af44d58dc87bd184188f1.

KIP-878 implementation did not make any progress, so we need to revert the public API changes which are not functional right now.