### PR TITLE
KAFKA-14885: fix kafka client connect to the broker that offline from…

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -30,6 +30,7 @@ import kafka.raft.KafkaRaftManager
 import kafka.server.metadata.{OffsetTrackingListener, ZkConfigRepository, ZkMetadataCache}
 import kafka.utils._
 import kafka.zk.{AdminZkClient, BrokerInfo, KafkaZkClient}
+import kafka.zookeeper.StateChangeHandler
 import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, NetworkClient, NetworkClientUtils}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.internals.Topic
@@ -205,6 +206,26 @@ class KafkaServer(
   @volatile var brokerEpochManager: ZkBrokerEpochManager = _
 
   def brokerEpochSupplier(): Long = Option(brokerEpochManager).map(_.get()).getOrElse(-1)
+
+    private class BrokerInfoCheckHandler(info: BrokerInfo, id: Int) extends StateChangeHandler {
+     var brokerInfo: BrokerInfo = info
+     var brokerId: Int = id
+
+    override val name: String = brokerInfo.path
+
+    override def afterInitializingSession(): Unit = {
+      zkClient.getBroker(brokerId) match {
+        case Some(newBroker) =>
+          if (newBroker.endPoints != brokerInfo.broker.endPoints) {
+            fatal("endpoint from zookeeper: " + newBroker.endPoints + " is different from endpoint from local disk: " + brokerInfo.broker.endPoints)
+          }
+        case None =>
+          error("failed to get broker info for broker: " + brokerId)
+      }
+
+    }
+
+  }
 
   /**
    * Start up API for bringing up a single instance of the Kafka server.
@@ -405,6 +426,7 @@ class KafkaServer(
 
         val brokerInfo = createBrokerInfo
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
+        zkClient.registerStateChangeHandler(new BrokerInfoCheckHandler(brokerInfo, config.brokerId))
 
         /* start token manager */
         tokenManager = new DelegationTokenManagerZk(config, tokenCache, time , zkClient)


### PR DESCRIPTION


When a broker has some issues about network, the broker can not connect to zookeeper and controller.At this time, we replace this broker with a new broker that has a same `broker.id` with fault broker, and we can not  stop the Kafka process on fault broker because of network issue. So the client can still connect this broker and can produce and consume messages normally.  But the data on fault broker maybe be lost because there are some leader for partitions on the fault broker. 

In my opinion, we can check  broker configuration (for example: broker ip)  when broker reconnects to zookeeper and broker can exist if broker's configuration is not same with zookeeper. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
