### PR TITLE
KAFKA-12446: update change encoding to use varint

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -52,7 +52,7 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
         // The format we need to deserialize is:
         // {BYTE_ARRAY oldValue}{BYTE encodingFlag=0}
         // {BYTE_ARRAY newValue}{BYTE encodingFlag=1}
-        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE newOlvencodingFlagdFlag=2}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE encodingFlag=2}
         // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE encodingFlag=3}
         // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE encodingFlag=4}
         // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE vencodingFlag=5}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
 
 public class ChangedDeserializer<T> implements Deserializer<Change<T>>, WrappingNullableDeserializer<Change<T>, Void, T> {
 
-    private static final int NEW_OLD_FLAG_SIZE = 1;
+    private static final int ENCODING_FLAG_SIZE = 1;
     private static final int IS_LATEST_FLAG_SIZE = 1;
 
     private Deserializer<T> inner;
@@ -50,63 +50,76 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
     @Override
     public Change<T> deserialize(final String topic, final Headers headers, final byte[] data) {
         // The format we need to deserialize is:
-        // {BYTE_ARRAY oldValue}{BYTE newOldFlag=0}
-        // {BYTE_ARRAY newValue}{BYTE newOldFlag=1}
-        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE newOldFlag=2}
-        // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=3}
-        // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE newOldFlag=4}
-        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=5}
+        // {BYTE_ARRAY oldValue}{BYTE encodingFlag=0}
+        // {BYTE_ARRAY newValue}{BYTE encodingFlag=1}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE newOlvencodingFlagdFlag=2}
+        // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE encodingFlag=3}
+        // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE encodingFlag=4}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE vencodingFlag=5}
         final ByteBuffer buffer = ByteBuffer.wrap(data);
-        final byte newOldFlag = buffer.get(data.length - NEW_OLD_FLAG_SIZE);
+        final byte encodingFlag = buffer.get(data.length - ENCODING_FLAG_SIZE);
 
         final byte[] newData;
         final byte[] oldData;
         final boolean isLatest;
-        if (newOldFlag == (byte) 0) {
-            newData = null;
-            final int oldDataLength = data.length - NEW_OLD_FLAG_SIZE;
-            oldData = new byte[oldDataLength];
-            buffer.get(oldData);
-            isLatest = true;
-        } else if (newOldFlag == (byte) 1) {
-            oldData = null;
-            final int newDataLength = data.length - NEW_OLD_FLAG_SIZE;
-            newData = new byte[newDataLength];
-            buffer.get(newData);
-            isLatest = true;
-        } else if (newOldFlag == (byte) 2) {
-            final int newDataLength = ByteUtils.readVarint(buffer);
-            newData = new byte[newDataLength];
-            buffer.get(newData);
+        switch (encodingFlag) {
+            case (byte) 0: {
+                newData = null;
+                final int oldDataLength = data.length - ENCODING_FLAG_SIZE;
+                oldData = new byte[oldDataLength];
+                buffer.get(oldData);
+                isLatest = true;
+                break;
+            }
+            case (byte) 1: {
+                oldData = null;
+                final int newDataLength = data.length - ENCODING_FLAG_SIZE;
+                newData = new byte[newDataLength];
+                buffer.get(newData);
+                isLatest = true;
+                break;
+            }
+            case (byte) 2: {
+                final int newDataLength = ByteUtils.readVarint(buffer);
+                newData = new byte[newDataLength];
+                buffer.get(newData);
 
-            final int oldDataLength = buffer.capacity() - buffer.position() - NEW_OLD_FLAG_SIZE;
-            oldData = new byte[oldDataLength];
-            buffer.get(oldData);
-            isLatest = true;
-        } else if (newOldFlag == (byte) 3) {
-            newData = null;
-            final int oldDataLength = data.length - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE;
-            oldData = new byte[oldDataLength];
-            buffer.get(oldData);
-            isLatest = readIsLatestFlag(buffer);
-        } else if (newOldFlag == (byte) 4) {
-            oldData = null;
-            final int newDataLength = data.length - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE;
-            newData = new byte[newDataLength];
-            buffer.get(newData);
-            isLatest = readIsLatestFlag(buffer);
-        } else if (newOldFlag == (byte) 5) {
-            final int newDataLength = ByteUtils.readVarint(buffer);
-            newData = new byte[newDataLength];
-            buffer.get(newData);
+                final int oldDataLength = buffer.capacity() - buffer.position() - ENCODING_FLAG_SIZE;
+                oldData = new byte[oldDataLength];
+                buffer.get(oldData);
+                isLatest = true;
+                break;
+            }
+            case (byte) 3: {
+                newData = null;
+                final int oldDataLength = data.length - IS_LATEST_FLAG_SIZE - ENCODING_FLAG_SIZE;
+                oldData = new byte[oldDataLength];
+                buffer.get(oldData);
+                isLatest = readIsLatestFlag(buffer);
+                break;
+            }
+            case (byte) 4: {
+                oldData = null;
+                final int newDataLength = data.length - IS_LATEST_FLAG_SIZE - ENCODING_FLAG_SIZE;
+                newData = new byte[newDataLength];
+                buffer.get(newData);
+                isLatest = readIsLatestFlag(buffer);
+                break;
+            }
+            case (byte) 5: {
+                final int newDataLength = ByteUtils.readVarint(buffer);
+                newData = new byte[newDataLength];
+                buffer.get(newData);
 
-            final int oldDataLength = buffer.capacity() - buffer.position() - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE;
-            oldData = new byte[oldDataLength];
-            buffer.get(oldData);
+                final int oldDataLength = buffer.capacity() - buffer.position() - IS_LATEST_FLAG_SIZE - ENCODING_FLAG_SIZE;
+                oldData = new byte[oldDataLength];
+                buffer.get(oldData);
 
-            isLatest = readIsLatestFlag(buffer);
-        } else {
-            throw new StreamsException("Encountered unknown byte value `" + newOldFlag + "` for oldNewFlag in ChangedDeserializer.");
+                isLatest = readIsLatestFlag(buffer);
+                break;
+            }
+            default:
+                throw new StreamsException("Encountered unknown byte value `" + encodingFlag + "` for encodingFlag in ChangedDeserializer.");
         }
 
         return new Change<>(
@@ -116,7 +129,7 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
     }
 
     private boolean readIsLatestFlag(final ByteBuffer buffer) {
-        final byte isLatestFlag = buffer.get(buffer.capacity() - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE);
+        final byte isLatestFlag = buffer.get(buffer.capacity() - IS_LATEST_FLAG_SIZE - ENCODING_FLAG_SIZE);
         if (isLatestFlag == (byte) 1) {
             return true;
         } else if (isLatestFlag == (byte) 0) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -55,7 +55,7 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
         // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE encodingFlag=2}
         // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE encodingFlag=3}
         // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE encodingFlag=4}
-        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE vencodingFlag=5}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE encodingFlag=5}
         final ByteBuffer buffer = ByteBuffer.wrap(data);
         final byte encodingFlag = buffer.get(data.length - ENCODING_FLAG_SIZE);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -75,13 +75,12 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
             buffer.get(newData);
             isLatest = true;
         } else if (newOldFlag == (byte) 2) {
-            final int newDataLength = Math.toIntExact(ByteUtils.readUnsignedInt(buffer));
+            final int newDataLength = ByteUtils.readVarint(buffer);
             newData = new byte[newDataLength];
-
-            final int oldDataLength = data.length - Integer.BYTES - newDataLength - NEW_OLD_FLAG_SIZE;
-            oldData = new byte[oldDataLength];
-
             buffer.get(newData);
+
+            final int oldDataLength = buffer.capacity() - buffer.position() - NEW_OLD_FLAG_SIZE;
+            oldData = new byte[oldDataLength];
             buffer.get(oldData);
             isLatest = true;
         } else if (newOldFlag == (byte) 3) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
@@ -106,7 +106,7 @@ public class ChangedSerializer<T> implements Serializer<Change<T>>, WrappingNull
         // The serialization format is:
         // {BYTE_ARRAY oldValue}{BYTE encodingFlag=0}
         // {BYTE_ARRAY newValue}{BYTE encodingFlag=1}
-        // {UINT32 newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE encodingFlag=2}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE encodingFlag=2}
         if (newValueIsNotNull && oldValueIsNotNull) {
             if (isUpgrade) {
                 throw new StreamsException("Both old and new values are not null (" + data.oldValue

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -543,6 +543,16 @@ public class NamedTopologyIntegrationTest {
 
     @Test
     public void shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing() throws Exception {
+        /*
+        Gradle Test Run :streams:unitTest > Gradle Test Executor 19 > NamedTopologyIntegrationTest > shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing() FAILED
+    java.lang.AssertionError:
+    Expected: <[KeyValue(B, 1), KeyValue(A, 2), KeyValue(C, 2)]>
+         but: was <[KeyValue(B, 1), KeyValue(A, 2), KeyValue(C, 1)]>
+        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
+        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
+        at org.apache.kafka.streams.integration.NamedTopologyIntegrationTest.shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing(NamedTopologyIntegrationTest.java:563)
+
+         */
         CLUSTER.createTopic(DELAYED_INPUT_STREAM_1, 2, 1);
         CLUSTER.createTopic(DELAYED_INPUT_STREAM_2, 2, 1);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -543,16 +543,6 @@ public class NamedTopologyIntegrationTest {
 
     @Test
     public void shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing() throws Exception {
-        /*
-        Gradle Test Run :streams:unitTest > Gradle Test Executor 19 > NamedTopologyIntegrationTest > shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing() FAILED
-    java.lang.AssertionError:
-    Expected: <[KeyValue(B, 1), KeyValue(A, 2), KeyValue(C, 2)]>
-         but: was <[KeyValue(B, 1), KeyValue(A, 2), KeyValue(C, 1)]>
-        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
-        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
-        at org.apache.kafka.streams.integration.NamedTopologyIntegrationTest.shouldRemoveOneNamedTopologyWhileAnotherContinuesProcessing(NamedTopologyIntegrationTest.java:563)
-
-         */
         CLUSTER.createTopic(DELAYED_INPUT_STREAM_1, 2, 1);
         CLUSTER.createTopic(DELAYED_INPUT_STREAM_2, 2, 1);
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
@@ -45,7 +45,7 @@ public class ChangedSerdeTest {
 
     private static final int NEW_OLD_FLAG_SIZE = 1;
     private static final int IS_LATEST_FLAG_SIZE = 1;
-    private static final int UINT32_SIZE = 4;
+    private static final int MAX_VARINT_LENGTH = 5;
 
     final String nonNullNewValue = "hello";
     final String nonNullOldValue = "world";
@@ -143,13 +143,13 @@ public class ChangedSerdeTest {
         // The serialization format is:
         // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=3}
         // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE newOldFlag=4}
-        // {UINT32 newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=5}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=5}
         final ByteBuffer buf;
         final byte isLatest = data.isLatest ? (byte) 1 : (byte) 0;
         if (newValueIsNotNull && oldValueIsNotNull) {
-            final int capacity = UINT32_SIZE + newDataLength + oldDataLength + IS_LATEST_FLAG_SIZE + NEW_OLD_FLAG_SIZE;
+            final int capacity = MAX_VARINT_LENGTH + newDataLength + oldDataLength + IS_LATEST_FLAG_SIZE + NEW_OLD_FLAG_SIZE;
             buf = ByteBuffer.allocate(capacity);
-            ByteUtils.writeUnsignedInt(buf, newDataLength);
+            ByteUtils.writeVarint(newDataLength, buf);
             buf.put(newData).put(oldData).put(isLatest).put((byte) 5);
         } else if (newValueIsNotNull) {
             final int capacity = newDataLength + IS_LATEST_FLAG_SIZE + NEW_OLD_FLAG_SIZE;
@@ -163,7 +163,11 @@ public class ChangedSerdeTest {
             throw new StreamsException("Both old and new values are null in ChangeSerializer, which is not allowed.");
         }
 
-        return buf.array();
+        final byte[] serialized = new byte[buf.position()];
+        buf.position(0);
+        buf.get(serialized);
+
+        return serialized;
     }
 
     private static void checkRoundTripForReservedVersion(final Change<String> data) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
@@ -43,7 +43,7 @@ public class ChangedSerdeTest {
     private static final ChangedDeserializer<String> CHANGED_STRING_DESERIALIZER =
             new ChangedDeserializer<>(Serdes.String().deserializer());
 
-    private static final int NEW_OLD_FLAG_SIZE = 1;
+    private static final int ENCODING_FLAG_SIZE = 1;
     private static final int IS_LATEST_FLAG_SIZE = 1;
     private static final int MAX_VARINT_LENGTH = 5;
 
@@ -147,16 +147,16 @@ public class ChangedSerdeTest {
         final ByteBuffer buf;
         final byte isLatest = data.isLatest ? (byte) 1 : (byte) 0;
         if (newValueIsNotNull && oldValueIsNotNull) {
-            final int capacity = MAX_VARINT_LENGTH + newDataLength + oldDataLength + IS_LATEST_FLAG_SIZE + NEW_OLD_FLAG_SIZE;
+            final int capacity = MAX_VARINT_LENGTH + newDataLength + oldDataLength + IS_LATEST_FLAG_SIZE + ENCODING_FLAG_SIZE;
             buf = ByteBuffer.allocate(capacity);
             ByteUtils.writeVarint(newDataLength, buf);
             buf.put(newData).put(oldData).put(isLatest).put((byte) 5);
         } else if (newValueIsNotNull) {
-            final int capacity = newDataLength + IS_LATEST_FLAG_SIZE + NEW_OLD_FLAG_SIZE;
+            final int capacity = newDataLength + IS_LATEST_FLAG_SIZE + ENCODING_FLAG_SIZE;
             buf = ByteBuffer.allocate(capacity);
             buf.put(newData).put(isLatest).put((byte) 4);
         } else if (oldValueIsNotNull) {
-            final int capacity = oldDataLength + IS_LATEST_FLAG_SIZE + NEW_OLD_FLAG_SIZE;
+            final int capacity = oldDataLength + IS_LATEST_FLAG_SIZE + ENCODING_FLAG_SIZE;
             buf = ByteBuffer.allocate(capacity);
             buf.put(oldData).put(isLatest).put((byte) 3);
         } else {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
@@ -141,9 +141,9 @@ public class ChangedSerdeTest {
         final int oldDataLength = oldValueIsNotNull ? oldData.length : 0;
 
         // The serialization format is:
-        // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=3}
-        // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE newOldFlag=4}
-        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=5}
+        // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE encodingFlag=3}
+        // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE encodingFlag=4}
+        // {VARINT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE encodingFlag=5}
         final ByteBuffer buf;
         final byte isLatest = data.isLatest ? (byte) 1 : (byte) 0;
         if (newValueIsNotNull && oldValueIsNotNull) {


### PR DESCRIPTION
Using UINT32 does not save us any bytes, compared to using INT32; both are 4 bytes. Also note, the value we encode is a byte-array size, and arrays in Java have a max size of `Integer.MAX_VALUE` anyway, so we could just encode as INT32 without risk. Using UINT32 does not provide any advantage as we don't need the "enlarged positive integer space" anyway, and we have weird cast/overflow stuff in the current code for no reason.

The original discussion on the KIP was about reducing serialized byte size, so using varint seems to be the right choice.

If we don't care about varint, I would at least like to simplify the code to use INT32. UNIT32 just seem not to be a good choices overall.