### PR TITLE
KAFKA-14894: MetadataLoader must call finishSnapshot after loading a snapshot

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -484,6 +484,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                 snapshotIndex++;
             }
         }
+        delta.finishSnapshot();
         MetadataProvenance provenance = new MetadataProvenance(reader.lastContainedLogOffset(),
                 reader.lastContainedLogEpoch(), reader.lastContainedLogTimestamp());
         return new SnapshotManifest(provenance,

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -278,13 +278,16 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         log.debug("InitializeNewPublishers: setting up snapshot image for new publisher(s): {}",
                 uninitializedPublisherNames());
         long startNs = time.nanoseconds();
+        // We base this delta off of the empty image, reflecting the fact that these publishers
+        // haven't seen anything previously.
         MetadataDelta delta = new MetadataDelta.Builder().
-                setImage(image).
+                setImage(MetadataImage.EMPTY).
                 build();
         ImageReWriter writer = new ImageReWriter(delta);
         image.write(writer, new ImageWriterOptions.Builder().
                 setMetadataVersion(image.features().metadataVersion()).
                 build());
+        // ImageReWriter#close invokes finishSnapshot, so we don't need to invoke it here.
         SnapshotManifest manifest = new SnapshotManifest(
                 image.provenance(),
                 time.nanoseconds() - startNs);

--- a/metadata/src/main/java/org/apache/kafka/image/writer/ImageReWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/writer/ImageReWriter.java
@@ -49,6 +49,7 @@ public class ImageReWriter implements ImageWriter {
         if (closed) return;
         closed = true;
         if (complete) {
+            delta.finishSnapshot();
             image = delta.apply(delta.image().provenance());
         }
     }

--- a/metadata/src/test/java/org/apache/kafka/image/writer/ImageReWriterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/writer/ImageReWriterTest.java
@@ -18,11 +18,17 @@
 package org.apache.kafka.image.writer;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.image.MetadataDelta;
+import org.apache.kafka.image.MetadataImage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.Collections;
+
+import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
 import static org.apache.kafka.metadata.RecordTestUtils.testRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -59,5 +65,29 @@ public class ImageReWriterTest {
                 writer.write(0, new TopicRecord().
                         setName("foo").
                         setTopicId(Uuid.fromString("3B134hrsQgKtz8Sp6QBIfg"))));
+    }
+
+    @Test
+    public void testCloseInvokesFinishSnapshot() {
+        MetadataDelta delta = new MetadataDelta.Builder().build();
+        ImageReWriter writer = new ImageReWriter(delta);
+        writer.write(0, new TopicRecord().
+                setName("foo").
+                setTopicId(Uuid.fromString("3B134hrsQgKtz8Sp6QBIfg")));
+        writer.close(true);
+
+        MetadataDelta delta2 = new MetadataDelta.Builder().setImage(writer.image()).build();
+        ImageReWriter writer2 = new ImageReWriter(delta2);
+        writer2.write(0, new ConfigRecord().
+                setResourceName("").
+                setResourceType(BROKER.id()).
+                setName("num.io.threads").
+                setValue("12"));
+        writer2.close(true);
+        MetadataImage newImage = writer2.image();
+
+        assertEquals(Collections.emptyMap(), newImage.topics().topicsById());
+        assertEquals(Collections.singletonMap("num.io.threads", "12"),
+            newImage.configs().configMapForResource(new ConfigResource(BROKER, "")));
     }
 }


### PR DESCRIPTION
The MetadataLoader must call finishSnapshot after loading a snapshot. This function removes
whatever was in the old snapshot that is not in the new snapshot that was just loaded. While this
is not significant when the old snapshot was the empty snapshot, it is important to do when we are
loading a snapshot on top of an existing non-empty image.

In initializeNewPublishers, the newly installed publishers should be given a MetadataDelta based on
MetadataImage.EMPTY, reflecting the fact that they are seeing everything for the first time.