### PR TITLE
MINOR: fix flaky KRaft-related tests

### DIFF
--- a/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
+++ b/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
@@ -267,7 +267,7 @@ public class KafkaEventQueueTest {
         assertFalse(queue.isEmpty());
         queue.cancelDeferred("later");
         queue.cancelDeferred("soon");
-        assertTrue(queue.isEmpty());
+        TestUtils.waitForCondition(() -> queue.isEmpty(), "Failed to see the queue become empty.");
         queue.close();
         assertTrue(queue.isEmpty());
     }


### PR DESCRIPTION
In SharedServer, fix some cases where a volatile variable could change to null while we were using
it, during shutdown. This is mainly a junit test issue, although it could also cause ugly error
messages during shutdown when running the server in a production context.

Fix a race in KafkaEventQueueTest.testSize.