### PR TITLE
MINOR: Fix regression in MM2 task forwarding introduced by KAFKA-14783

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2044,7 +2044,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                                 "because the URL of the leader's REST interface is empty!"), null);
                         return;
                     }
-                    String reconfigUrl = UriBuilder.fromUri(leaderUrl)
+                    String reconfigUrl = namespacedUrl(leaderUrl)
                             .path("connectors")
                             .path(connName)
                             .path("tasks")


### PR DESCRIPTION
The DistributedHerder was computing the forwarded URL for publishing task configs incorrectly leading to 404s in MM2 distributed mode.

This regression appears in #13424 and presently only exists on trunk. This manifests as a return to pre-KIP-710 behavior, and causes the DedicatedMirrorIntegrationTest to fail whenever forwarding happens, making the test flake in >50% of runs.

It appears to be just a typo and not an intended change, and was hidden by the github diff when this function was split into two parts.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
