### PR TITLE
KAFKA-14900: Fix NPE in SharedServer causing flaky failure in AuthorizerTest

### DIFF
--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -248,12 +248,13 @@ class SharedServer(
         )
         raftManager.startup()
 
+        val client = raftManager.client
         val loaderBuilder = new MetadataLoader.Builder().
           setNodeId(metaProps.nodeId).
           setTime(time).
           setThreadNamePrefix(s"kafka-${sharedServerConfig.nodeId}-").
           setFaultHandler(metadataLoaderFaultHandler).
-          setHighWaterMarkAccessor(() => raftManager.client.highWatermark())
+          setHighWaterMarkAccessor(() => client.highWatermark())
         if (brokerMetrics != null) {
           loaderBuilder.setMetadataLoaderMetrics(brokerMetrics)
         }


### PR DESCRIPTION
It appears that raftManager can become null via ControllerServer.shutdown() -> ensureNotRaftLeader() and various call sites of stop(). Rather than emit an NPE, evaluate raftManager.client while it is known to be non-null, and pass the evaluated client into the setHighWaterMarkAccessor.

I unfortunately don't have much context here, and I'm not sure if once raftManager becomes null, if it is still reasonable to evaluate highWatermark(), or whether the HighWaterMarkAccessor should return empty.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
