### PR TITLE
KAFKA-14834: [6/N] Add tracking of versioned tables into graph nodes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 
 public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> implements CogroupedKStream<K, VOut> {
 
@@ -136,6 +137,8 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,
                                         final NamedInternal named,
                                         final MaterializedInternal<K, VOut, KeyValueStore<Bytes, byte[]>> materializedInternal) {
+        final boolean isOutputVersioned = materializedInternal != null
+            && materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier;
         return aggregateBuilder.build(
             groupPatterns,
             initializer,
@@ -143,6 +146,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             new KeyValueStoreMaterializer<>(materializedInternal).materialize(),
             materializedInternal.keySerde(),
             materializedInternal.valueSerde(),
-            materializedInternal.queryableStoreName());
+            materializedInternal.queryableStoreName(),
+            isOutputVersioned);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -137,8 +137,6 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,
                                         final NamedInternal named,
                                         final MaterializedInternal<K, VOut, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-        final boolean isOutputVersioned = materializedInternal != null
-            && materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier;
         return aggregateBuilder.build(
             groupPatterns,
             initializer,
@@ -147,6 +145,6 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             materializedInternal.keySerde(),
             materializedInternal.valueSerde(),
             materializedInternal.queryableStoreName(),
-            isOutputVersioned);
+            materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -55,7 +55,8 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final StoreBuilder<?> storeBuilder,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
-                                final String queryableName) {
+                                final String queryableName,
+                                final boolean isOutputVersioned) {
         processRepartitions(groupPatterns, storeBuilder);
         final Collection<GraphNode> processors = new ArrayList<>();
         final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
@@ -73,6 +74,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                 stateCreated,
                 storeBuilder,
                 parentProcessor);
+            statefulProcessorNode.setOutputVersioned(isOutputVersioned);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -71,7 +71,8 @@ class GroupedStreamAggregateBuilder<K, V> {
                                   final KStreamAggProcessorSupplier<K, V, KR, VR> aggregateSupplier,
                                   final String queryableStoreName,
                                   final Serde<KR> keySerde,
-                                  final Serde<VR> valueSerde) {
+                                  final Serde<VR> valueSerde,
+                                  final boolean isOutputVersioned) {
         assert queryableStoreName == null || queryableStoreName.equals(storeBuilder.name());
 
         final String aggFunctionName = functionName.name();
@@ -102,6 +103,7 @@ class GroupedStreamAggregateBuilder<K, V> {
                 new ProcessorParameters<>(aggregateSupplier, aggFunctionName),
                 storeBuilder
             );
+        statefulProcessorNode.setOutputVersioned(isOutputVersioned);
 
         builder.addGraphNode(parentNode, statefulProcessorNode);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -36,10 +36,12 @@ import org.apache.kafka.streams.kstream.internals.graph.StreamSourceNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode;
+import org.apache.kafka.streams.kstream.internals.graph.VersionedSemanticsGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.WindowedStreamProcessorNode;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +73,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     private final LinkedHashMap<GraphNode, LinkedHashSet<OptimizableRepartitionNode<?, ?>>> keyChangingOperationsToOptimizableRepartitionNodes = new LinkedHashMap<>();
     private final LinkedHashSet<GraphNode> mergeNodes = new LinkedHashSet<>();
     private final LinkedHashSet<GraphNode> tableSourceNodes = new LinkedHashSet<>();
+    private final LinkedHashSet<GraphNode> versionedSemanticsNodes = new LinkedHashSet<>();
 
     private static final String TOPOLOGY_ROOT = "root";
     private static final Logger LOG = LoggerFactory.getLogger(InternalStreamsBuilder.class);
@@ -142,6 +145,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
             .withMaterializedInternal(materialized)
             .withProcessorParameters(processorParameters)
             .build();
+        tableSourceNode.setOutputVersioned(materialized.storeSupplier() instanceof VersionedBytesStoreSupplier);
 
         addGraphNode(root, tableSourceNode);
 
@@ -234,6 +238,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         Objects.requireNonNull(child, "child node can't be null");
         parent.addChild(child);
         maybeAddNodeForOptimizationMetadata(child);
+        maybeAddNodeForVersionedSemanticsMetadata(child);
     }
 
     void addGraphNode(final Collection<GraphNode> parents,
@@ -273,6 +278,12 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         }
     }
 
+    private void maybeAddNodeForVersionedSemanticsMetadata(final GraphNode node) {
+        if (node instanceof VersionedSemanticsGraphNode) {
+            versionedSemanticsNodes.add(node);
+        }
+    }
+
     // use this method for testing only
     public void buildAndOptimizeTopology() {
         buildAndOptimizeTopology(null);
@@ -281,6 +292,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     public void buildAndOptimizeTopology(final Properties props) {
         mergeDuplicateSourceNodes();
         optimizeTopology(props);
+        enableVersionedSemantics();
 
         final PriorityQueue<GraphNode> graphNodePriorityQueue = new PriorityQueue<>(5, Comparator.comparing(GraphNode::buildPriority));
 
@@ -595,6 +607,39 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         }
 
         return new GroupedInternal<>(Grouped.with(keySerde, valueSerde));
+    }
+
+    private void enableVersionedSemantics() {
+        versionedSemanticsNodes.forEach(node -> ((VersionedSemanticsGraphNode) node).enableVersionedSemantics(isVersionedUpstream(node)));
+    }
+
+    /**
+     * Seeks up the parent chain to determine whether the input to this node is versioned,
+     * i.e., whether the output of its parent(s) is versioned or not
+     */
+    private boolean isVersionedUpstream(final GraphNode startSeekingNode) {
+        if (root.equals(startSeekingNode)) {
+            return false;
+        }
+
+        for (final GraphNode parentNode : startSeekingNode.parentNodes()) {
+            // in order for this node to be versioned, all parents must be versioned
+            if (!isVersionedOrVersionedUpstream(parentNode)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Seeks up the parent chain to determine whether the output of this node is versioned.
+     */
+    private boolean isVersionedOrVersionedUpstream(final GraphNode startSeekingNode) {
+        if (startSeekingNode.isOutputVersioned().isPresent()) {
+            return startSeekingNode.isOutputVersioned().get();
+        }
+
+        return isVersionedUpstream(startSeekingNode);
     }
 
     private GraphNode findParentNodeMatching(final GraphNode startSeekingNode,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.Objects;
 import java.util.Set;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 
 class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedStream<K, V> {
 
@@ -236,13 +237,16 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
     private <T> KTable<K, T> doAggregate(final KStreamAggProcessorSupplier<K, V, K, T> aggregateSupplier,
                                          final String functionName,
                                          final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materializedInternal) {
+        final boolean isOutputVersioned = materializedInternal != null
+            && materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier;
         return aggregateBuilder.build(
             new NamedInternal(functionName),
             new KeyValueStoreMaterializer<>(materializedInternal).materialize(),
             aggregateSupplier,
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde(),
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            isOutputVersioned);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -237,8 +237,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
     private <T> KTable<K, T> doAggregate(final KStreamAggProcessorSupplier<K, V, K, T> aggregateSupplier,
                                          final String functionName,
                                          final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-        final boolean isOutputVersioned = materializedInternal != null
-            && materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier;
         return aggregateBuilder.build(
             new NamedInternal(functionName),
             new KeyValueStoreMaterializer<>(materializedInternal).materialize(),
@@ -246,7 +244,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde(),
             materializedInternal.valueSerde(),
-            isOutputVersioned);
+            materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -29,12 +29,14 @@ import org.apache.kafka.streams.kstream.internals.graph.GroupedTableOperationRep
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableAggregateNode;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 
 /**
  * The implementation class of {@link KGroupedTable}.
@@ -92,6 +94,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K, V> implements KGr
             new ProcessorParameters<>(aggregateSupplier, funcName),
             new KeyValueStoreMaterializer<>(materialized).materialize()
         );
+        statefulProcessorNode.setOutputVersioned(materialized.storeSupplier() instanceof VersionedBytesStoreSupplier);
 
         // now the repartition node must be the parent of the StateProcessorNode
         builder.addGraphNode(repartitionGraphNode, statefulProcessorNode);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.kstream.internals.graph.GroupedTableOperationRep
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
-import org.apache.kafka.streams.kstream.internals.graph.TableAggregateNode;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -73,6 +73,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 
 import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.optimizableRepartitionNodeBuilder;
 
@@ -763,6 +764,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             processorParameters,
             materializedInternal
         );
+        tableNode.setOutputVersioned(materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier);
 
         builder.addGraphNode(tableParentNode, tableNode);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
@@ -25,12 +25,13 @@ import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
-class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn, KIn, VIn> {
+public class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn, KIn, VIn> {
     private final KTableImpl<KIn, ?, VIn> parent;
     private final Predicate<? super KIn, ? super VIn> predicate;
     private final boolean filterNot;
     private final String queryableName;
     private boolean sendOldValues;
+    private boolean useVersionedSemantics = false;
 
     KTableFilter(final KTableImpl<KIn, ?, VIn> parent,
                  final Predicate<? super KIn, ? super VIn> predicate,
@@ -42,6 +43,10 @@ class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn, KIn, V
         this.queryableName = queryableName;
         // If upstream is already materialized, enable sending old values to avoid sending unnecessary tombstones:
         this.sendOldValues = parent.enableSendingOldValues(false);
+    }
+
+    public void setUseVersionedSemantics(final boolean useVersionedSemantics) {
+        this.useVersionedSemantics = useVersionedSemantics;
     }
 
     @Override
@@ -112,8 +117,10 @@ class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn, KIn, V
             final VIn newValue = computeValue(key, change.newValue);
             final VIn oldValue = computeOldValue(key, change);
 
-            if (sendOldValues && oldValue == null && newValue == null) {
-                return; // unnecessary to forward here.
+            if (!useVersionedSemantics) {
+                if (sendOldValues && oldValue == null && newValue == null) {
+                    return; // unnecessary to forward here.
+                }
             }
 
             if (queryableName != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
@@ -49,6 +49,11 @@ public class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn,
         this.useVersionedSemantics = useVersionedSemantics;
     }
 
+    // VisibleForTesting
+    boolean isUseVersionedSemantics() {
+        return useVersionedSemantics;
+    }
+
     @Override
     public Processor<KIn, Change<VIn>, KIn, Change<VIn>> get() {
         return new KTableFilterProcessor();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -54,7 +54,9 @@ import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSinkNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSourceNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableFilterNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableProcessorNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableRepartitionMapNode;
 import org.apache.kafka.streams.kstream.internals.suppress.FinalResultsSuppressionBuilder;
 import org.apache.kafka.streams.kstream.internals.suppress.KTableSuppressProcessorSupplier;
 import org.apache.kafka.streams.kstream.internals.suppress.NamedSuppressed;
@@ -68,6 +70,7 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -206,11 +209,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             new ProcessorParameters<>(processorSupplier, name)
         );
 
-        final GraphNode tableNode = new TableProcessorNode<>(
+        final GraphNode tableNode = new TableFilterNode<>(
             name,
             processorParameters,
             storeBuilder
         );
+        maybeSetOutputVersioned(tableNode, materializedInternal);
 
         builder.addGraphNode(this.graphNode, tableNode);
 
@@ -324,6 +328,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             processorParameters,
             storeBuilder
         );
+        maybeSetOutputVersioned(tableNode, materializedInternal);
 
         builder.addGraphNode(this.graphNode, tableNode);
 
@@ -480,6 +485,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             storeBuilder,
             stateStoreNames
         );
+        maybeSetOutputVersioned(tableNode, materializedInternal);
 
         builder.addGraphNode(this.graphNode, tableNode);
 
@@ -574,6 +580,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             new ProcessorParameters<>(suppressionSupplier, name),
             storeBuilder
         );
+        node.setOutputVersioned(false);
 
         builder.addGraphNode(graphNode, node);
 
@@ -781,6 +788,11 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 .withQueryableStoreName(queryableStoreName)
                 .withStoreBuilder(storeBuilder)
                 .build();
+
+        final boolean isOutputVersioned = materializedInternal != null
+            && materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier;
+        kTableKTableJoinNode.setOutputVersioned(isOutputVersioned);
+
         builder.addGraphNode(this.graphNode, kTableKTableJoinNode);
 
         // we can inherit parent key serde if user do not provide specific overrides
@@ -813,7 +825,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorParameters<K, Change<V>, ?, ?> processorParameters = new ProcessorParameters<>(selectSupplier, selectName);
 
         // select the aggregate key and values (old and new), it would require parent to send old values
-        final ProcessorGraphNode<K, Change<V>> groupByMapNode = new ProcessorGraphNode<>(selectName, processorParameters);
+        final TableRepartitionMapNode<K, Change<V>> groupByMapNode = new TableRepartitionMapNode<>(selectName, processorParameters);
 
         builder.addGraphNode(this.graphNode, groupByMapNode);
 
@@ -1281,6 +1293,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             ),
             resultStore
         );
+        resultNode.setOutputVersioned(materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier);
         builder.addGraphNode(resolverNode, resultNode);
 
         return new KTableImpl<K, V, VR>(
@@ -1293,5 +1306,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             resultNode,
             builder
         );
+    }
+
+    private static void maybeSetOutputVersioned(final GraphNode tableNode,
+                                                final MaterializedInternal<?, ?, KeyValueStore<Bytes, byte[]>> materializedInternal) {
+        if (materializedInternal != null) {
+            tableNode.setOutputVersioned(materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier);
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -40,10 +40,15 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
 
     private final KTableImpl<K, ?, V> parent;
     private final KeyValueMapper<? super K, ? super V, KeyValue<K1, V1>> mapper;
+    private boolean useVersionedSemantics = false;
 
     KTableRepartitionMap(final KTableImpl<K, ?, V> parent, final KeyValueMapper<? super K, ? super V, KeyValue<K1, V1>> mapper) {
         this.parent = parent;
         this.mapper = mapper;
+    }
+
+    public void setUseVersionedSemantics(final boolean useVersionedSemantics) {
+        this.useVersionedSemantics = useVersionedSemantics;
     }
 
     @Override
@@ -131,6 +136,13 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
                 throw new StreamsException("Record key for the grouping KTable should not be null.");
             }
 
+            if (useVersionedSemantics && isOutOfOrder(record.value())) {
+                // skip out-of-order records when aggregating a versioned table, since the
+                // aggregate should include latest-by-timestamp records only. as an optimization,
+                // do not forward the out-of-order record downstream to the repartition topic either.
+                return;
+            }
+
             // if the value is null, we do not need to forward its selected key-value further
             final KeyValue<? extends K1, ? extends V1> newPair = record.value().newValue == null ? null :
                 mapper.apply(record.key(), record.value().newValue);
@@ -153,6 +165,10 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
                 }
             }
 
+        }
+
+        private boolean isOutOfOrder(final Change<V> change) {
+            return false; // TODO: this will be updated in a follow-up PR
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -47,6 +47,11 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
         this.mapper = mapper;
     }
 
+    // VisibleForTesting
+    boolean isUseVersionedSemantics() {
+        return useVersionedSemantics;
+    }
+
     public void setUseVersionedSemantics(final boolean useVersionedSemantics) {
         this.useVersionedSemantics = useVersionedSemantics;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -125,7 +125,8 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                 countMerger),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new WindowedSerdes.SessionWindowedSerde<>(materializedInternal.keySerde()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            false);
     }
 
     @Override
@@ -175,7 +176,8 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             ),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new WindowedSerdes.SessionWindowedSerde<>(materializedInternal.keySerde()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            false);
     }
 
     @Override
@@ -232,7 +234,8 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                 sessionMerger),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new WindowedSerdes.SessionWindowedSerde<>(materializedInternal.keySerde()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            false);
     }
 
     private <VR> StoreBuilder<SessionStore<K, VR>> materialize(final MaterializedInternal<K, VR, SessionStore<Bytes, byte[]>> materialized) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
@@ -104,7 +104,8 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                 new KStreamSlidingWindowAggregate<>(windows, materializedInternal.storeName(), emitStrategy, aggregateBuilder.countInitializer, aggregateBuilder.countAggregator),
                 materializedInternal.queryableStoreName(),
                 materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.timeDifferenceMs()) : null,
-                materializedInternal.valueSerde());
+                materializedInternal.valueSerde(),
+                false);
     }
 
     @Override
@@ -148,7 +149,8 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                 new KStreamSlidingWindowAggregate<>(windows, materializedInternal.storeName(), emitStrategy, initializer, aggregator),
                 materializedInternal.queryableStoreName(),
                 materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.timeDifferenceMs()) : null,
-                materializedInternal.valueSerde());
+                materializedInternal.valueSerde(),
+                false);
     }
 
     @Override
@@ -193,7 +195,8 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                 new KStreamSlidingWindowAggregate<>(windows, materializedInternal.storeName(), emitStrategy, aggregateBuilder.reduceInitializer, aggregatorForReducer(reducer)),
                 materializedInternal.queryableStoreName(),
                 materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.timeDifferenceMs()) : null,
-                materializedInternal.valueSerde());
+                materializedInternal.valueSerde(),
+                false);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -120,7 +120,8 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
                 aggregateBuilder.countAggregator),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.size()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            false);
     }
 
     @Override
@@ -171,7 +172,8 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
                 aggregator),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.size()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            false);
     }
 
     @Override
@@ -221,7 +223,8 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
                 aggregatorForReducer(reducer)),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.size()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            false);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.streams.kstream.internals.graph;
 
 
+import java.util.Optional;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
 import java.util.Arrays;
@@ -34,6 +35,10 @@ public abstract class GraphNode {
     private boolean mergeNode;
     private Integer buildPriority;
     private boolean hasWrittenToTopology = false;
+    // whether the output of this node is versioned. if empty, the output of this node is not
+    // explicitly materialized (as either a versioned or an unversioned store) and therefore
+    // whether the output is to be considered versioned or not depends on its parent(s)
+    private Optional<Boolean> outputVersioned = Optional.empty();
 
     public GraphNode(final String nodeName) {
         this.nodeName = nodeName;
@@ -125,6 +130,14 @@ public abstract class GraphNode {
 
     public void setHasWrittenToTopology(final boolean hasWrittenToTopology) {
         this.hasWrittenToTopology = hasWrittenToTopology;
+    }
+
+    public Optional<Boolean> isOutputVersioned() {
+        return outputVersioned;
+    }
+
+    public void setOutputVersioned(final boolean outputVersioned) {
+        this.outputVersioned = Optional.of(outputVersioned);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import org.apache.kafka.streams.kstream.internals.KTableFilter;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class TableFilterNode<K, V> extends TableProcessorNode<K, V> implements VersionedSemanticsGraphNode {
+
+    public TableFilterNode(final String nodeName,
+                           final ProcessorParameters<K, V, ?, ?> processorParameters,
+                           final StoreBuilder<?> storeBuilder) {
+        super(nodeName, processorParameters, storeBuilder);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void enableVersionedSemantics(final boolean useVersionedSemantics) {
+        final ProcessorSupplier<K, V, ?, ?> processorSupplier = processorParameters().processorSupplier();
+        if (!(processorSupplier instanceof KTableFilter)) {
+            throw new IllegalStateException("Unexpected processor type for table filter: " + processorSupplier.getClass().getName());
+        }
+
+        final KTableFilter<K, V> tableFilter = (KTableFilter<K, V>) processorSupplier;
+        tableFilter.setUseVersionedSemantics(useVersionedSemantics);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -46,6 +46,10 @@ public class TableProcessorNode<K, V> extends GraphNode {
         this.storeNames = storeNames != null ? storeNames : new String[] {};
     }
 
+    public ProcessorParameters<K, V, ?, ?> processorParameters() {
+        return processorParameters;
+    }
+
     @Override
     public String toString() {
         return "TableProcessorNode{" +

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableRepartitionMapNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableRepartitionMapNode.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import org.apache.kafka.streams.kstream.internals.KTableRepartitionMap;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+
+public class TableRepartitionMapNode<K, V> extends ProcessorGraphNode<K, V> implements VersionedSemanticsGraphNode {
+
+    public TableRepartitionMapNode(final String nodeName,
+                                   final ProcessorParameters<K, V, ?, ?> processorParameters) {
+        super(nodeName, processorParameters);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void enableVersionedSemantics(final boolean useVersionedSemantics) {
+        final ProcessorSupplier<K, V, ?, ?> processorSupplier = processorParameters().processorSupplier();
+        if (!(processorSupplier instanceof KTableRepartitionMap)) {
+            throw new IllegalStateException("Unexpected processor type for table repartition map: " + processorSupplier.getClass().getName());
+        }
+
+        final KTableRepartitionMap<K, V, ?, ?> tableRepartitionMap = (KTableRepartitionMap<K, V, ?, ?>) processorSupplier;
+        tableRepartitionMap.setUseVersionedSemantics(useVersionedSemantics);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/VersionedSemanticsGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/VersionedSemanticsGraphNode.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.graph;
+
+/**
+ * Indicates a table processor node that behaves differently depending on whether the upstream
+ * table is versioned or unversioned. Versioned semantics are disabled by default, and enabled
+ * as part of {@code InternalStreamsBuilder#buildAndOptimizeTopology()} if an upstream table
+ * is identified to be versioned.
+ */
+public interface VersionedSemanticsGraphNode {
+
+    /**
+     * @param useVersionedSemantics whether versioned semantics should be enabled
+     */
+    void enableVersionedSemantics(final boolean useVersionedSemantics);
+
+}


### PR DESCRIPTION
This PR adds a method into GraphNode to assist in tracking whether tables are materialized as versioned or unversioned stores. This is needed in order to allow processors which have different behavior on versioned vs unversioned tables to use the correct semantics. For the full definition of when a table is considered "versioned" and which processors behave differently on versioned tables, see [KIP-914](https://cwiki.apache.org/confluence/display/KAFKA/KIP-914%3A+DSL+Processor+Semantics+for+Versioned+Stores). 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
