### PR TITLE
KAFKA-14902: KafkaStatusBackingStore retries on a dedicated backgroun…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ThreadUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ThreadUtils.java
@@ -17,7 +17,9 @@
 
 package org.apache.kafka.common.utils;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -51,5 +53,23 @@ public class ThreadUtils {
                 return thread;
             }
         };
+    }
+
+    /**
+     * Shuts down an executor service with a timeout. After the timeout/on interrupt, the service is forcefully closed.
+     * @param executorService The service to shut down.
+     * @param timeout The timeout of the shutdown.
+     * @param timeUnit The time unit of the shutdown timeout.
+     */
+    public static void shutdownExecutorServiceQuietly(ExecutorService executorService,
+                                                      long timeout, TimeUnit timeUnit) {
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(timeout, timeUnit)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+        }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema;
@@ -63,6 +64,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -138,6 +142,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
     private KafkaBasedLog<String, byte[]> kafkaLog;
     private int generation;
     private SharedTopicAdmin ownTopicAdmin;
+    private ExecutorService sendRetryExecutor;
 
     @Deprecated
     public KafkaStatusBackingStore(Time time, Converter converter) {
@@ -159,6 +164,8 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         this(time, converter);
         this.kafkaLog = kafkaLog;
         this.statusTopic = statusTopic;
+        sendRetryExecutor = Executors.newSingleThreadExecutor(
+                ThreadUtils.createThreadFactory("status-store-retry-" + statusTopic, true));
     }
 
     @Override
@@ -166,6 +173,9 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         this.statusTopic = config.getString(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG);
         if (this.statusTopic == null || this.statusTopic.trim().length() == 0)
             throw new ConfigException("Must specify topic for connector status.");
+
+        sendRetryExecutor = Executors.newSingleThreadExecutor(
+                ThreadUtils.createThreadFactory("status-store-retry-" + statusTopic, true));
 
         String clusterId = config.kafkaClusterId();
         Map<String, Object> originals = config.originals();
@@ -246,6 +256,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         try {
             kafkaLog.stop();
         } finally {
+            ThreadUtils.shutdownExecutorServiceQuietly(sendRetryExecutor, 10, TimeUnit.SECONDS);
             if (ownTopicAdmin != null) {
                 ownTopicAdmin.close();
             }
@@ -307,7 +318,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
                 if (exception == null) return;
                 // TODO: retry more gracefully and not forever
                 if (exception instanceof RetriableException) {
-                    kafkaLog.send(key, value, this);
+                    sendRetryExecutor.submit((Runnable) () -> kafkaLog.send(key, value, this));
                 } else {
                     log.error("Failed to write status update", exception);
                 }
@@ -340,7 +351,8 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
                             || (safeWrite && !entry.canWriteSafely(status, sequence)))
                             return;
                     }
-                    kafkaLog.send(key, value, this);
+
+                    sendRetryExecutor.submit((Runnable) () -> kafkaLog.send(key, value, this));
                 } else {
                     log.error("Failed to write status update", exception);
                 }


### PR DESCRIPTION
…d thread to avoid stack overflows

KafkaStatusBackingStore uses an infinite retry logic on producer send, which can lead to a stack overflow. To avoid the problem, a background thread was added, and the callback submits the retry onto the background thread.

Change-Id: Ia2e4eb0a39e370df139a23b9c816ccaff14eb166

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
