### PR TITLE
KAFKA-14888: Added remote log segments retention functionality based on time and size.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -336,9 +336,9 @@
 
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"
-              files="(LogValidator|RemoteLogManagerConfig).java"/>
+              files="(LogValidator|RemoteLogManagerConfig|RemoteLogManager).java"/>
     <suppress checks="NPathComplexity"
-              files="(LogValidator|RemoteIndexCache).java"/>
+              files="(LogValidator|RemoteLogManager|RemoteIndexCache).java"/>
     <suppress checks="ParameterNumber"
               files="(LogAppendInfo|RemoteLogManagerConfig).java"/>
 

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -866,7 +866,7 @@ public class RemoteLogManager implements Closeable {
                     // Publish delete segment started event.
                     remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
                             new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
-                                    RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId)).get();
+                                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId)).get();
 
                     // Delete the segment in remote storage.
                     remoteLogStorageManager.deleteLogSegmentData(segmentMetadata);
@@ -874,7 +874,7 @@ public class RemoteLogManager implements Closeable {
                     // Publish delete segment finished event.
                     remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
                             new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
-                                    RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId)).get();
+                                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId)).get();
                     logger.info("Deleted remote log segment {}", segmentMetadata.remoteLogSegmentId());
                     return true;
                 }

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -814,10 +814,8 @@ public class RemoteLogManager implements Closeable {
                 return isSegmentDeleted;
             }
 
-            // There are two cases:
-            // 1) When there are offline partitions and a new replica with empty disk is brought as leader, then the
-            //    leader-epoch gets bumped but the log-start-offset gets truncated back to 0.
-            // 2) To remove the unreferenced segments.
+            // It removes the segments beyond the current leader's earliest epoch. Those segments are considered as
+            // unreferenced because they are not part of the current leader epoch lineage.
             private boolean deleteLogSegmentsDueToLeaderEpochCacheTruncation(EpochEntry earliestEpochEntry, RemoteLogSegmentMetadata metadata) throws RemoteStorageException, ExecutionException, InterruptedException {
                 boolean isSegmentDeleted = deleteRemoteLogSegment(metadata, x ->
                         x.segmentLeaderEpochs().keySet().stream().allMatch(epoch -> epoch < earliestEpochEntry.epoch));

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -170,6 +170,7 @@ public class RemoteLogManager implements Closeable {
      * @param clusterId The cluster id.
      * @param fetchLog  function to get UnifiedLog instance for a given topic.
      * @param updateRemoteLogStartOffset function to update the log-start-offset for a given topic partition.
+     * @param brokerTopicStats BrokerTopicStats instance to update the respective metrics.
      */
     public RemoteLogManager(RemoteLogManagerConfig rlmConfig,
                             int brokerId,
@@ -954,7 +955,9 @@ public class RemoteLogManager implements Closeable {
             }
 
             // Remove the remote log segments whose segment-leader-epochs are less than the earliest-epoch known
-            // to the leader. This will remove the unreferenced segments in the remote storage.
+            // to the leader. This will remove the unreferenced segments in the remote storage. This is needed for
+            // unclean leader election scenarios as the remote storage can have epochs earlier to the current leader's
+            // earliest leader epoch.
             if (earliestEpochEntryOptional.isPresent()) {
                 EpochEntry earliestEpochEntry = earliestEpochEntryOptional.get();
                 Iterator<Integer> epochsToClean = remoteLeaderEpochs.stream().filter(x -> x < earliestEpochEntry.epoch).iterator();

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1521,9 +1521,8 @@ public class RemoteLogManager implements Closeable {
             if (retentionMs < 0)
                 throw new IllegalArgumentException("retentionMs should be non negative, but it is " + retentionMs);
 
-            if (retentionMs < cleanupUntilMs) {
-                throw new IllegalArgumentException("retentionMs [" + retentionMs + "] must be greater than cleanupUntilMs [" + cleanupUntilMs + "]");
-            }
+            if (cleanupUntilMs < 0)
+                throw new IllegalArgumentException("cleanupUntilMs should be non negative, but it is " + cleanupUntilMs);
 
             this.retentionMs = retentionMs;
             this.cleanupUntilMs = cleanupUntilMs;

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -796,7 +796,7 @@ public class RemoteLogManager implements Closeable {
 
                 boolean isSegmentDeleted = deleteRemoteLogSegment(metadata, x -> {
                     // Assumption that segments contain size >= 0
-                    if (retentionSizeData.get().remainingBreachedSize > 0) {
+                    if (remainingBreachedSize > 0) {
                         remainingBreachedSize -= x.segmentSizeInBytes();
                         return remainingBreachedSize >= 0;
                     } else return false;
@@ -914,11 +914,12 @@ public class RemoteLogManager implements Closeable {
             // leaks. We can have a followup to improve it by maintaining these values through both copying and deletion.
             final Set<Integer> epochsSet = new HashSet<>();
             long totalSizeEarlierToLocalLogStartOffset = 0L;
+            long localLogStartOffset = log.localLogStartOffset();
             while (segmentMetadataIter.hasNext()) {
                 RemoteLogSegmentMetadata segmentMetadata = segmentMetadataIter.next();
                 epochsSet.addAll(segmentMetadata.segmentLeaderEpochs().keySet());
 
-                if (checkSizeRetention && segmentMetadata.endOffset() < log.localLogStartOffset()) {
+                if (checkSizeRetention && segmentMetadata.endOffset() < localLogStartOffset) {
                     totalSizeEarlierToLocalLogStartOffset += segmentMetadata.segmentSizeInBytes();
                 }
             }

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -168,6 +168,7 @@ public class RemoteLogManager implements Closeable {
      * @param time      Time instance.
      * @param clusterId The cluster id.
      * @param fetchLog  function to get UnifiedLog instance for a given topic.
+     * @param updateRemoteLogStartOffset function to update the log-start-offset for a given topic partition.
      */
     public RemoteLogManager(RemoteLogManagerConfig rlmConfig,
                             int brokerId,

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1129,18 +1129,24 @@ public class RemoteLogManager implements Closeable {
      */
     // Visible for testing
     public static NavigableMap<Integer, Long> buildFilteredLeaderEpochMap(NavigableMap<Integer, Long> leaderEpochs) {
-        NavigableMap<Integer, Long> refinedLeaderEpochs = new TreeMap<>();
+        List<Integer> duplicatedEpochs = new ArrayList<>();
         Map.Entry<Integer, Long> previousEntry = null;
         for (Map.Entry<Integer, Long> entry : leaderEpochs.entrySet()) {
-            refinedLeaderEpochs.put(entry.getKey(), entry.getValue());
-
             if (previousEntry != null && previousEntry.getValue().equals(entry.getValue())) {
-                refinedLeaderEpochs.remove(previousEntry.getKey());
+                duplicatedEpochs.add(previousEntry.getKey());
             }
             previousEntry = entry;
         }
 
-        return refinedLeaderEpochs;
+        if (duplicatedEpochs.isEmpty()) {
+            return leaderEpochs;
+        }
+
+        TreeMap<Integer, Long> filteredLeaderEpochs = new TreeMap<>(leaderEpochs);
+        for (Integer duplicatedEpoch : duplicatedEpochs) {
+            filteredLeaderEpochs.remove(duplicatedEpoch);
+        }
+        return filteredLeaderEpochs;
     }
 
     public FetchDataInfo read(RemoteStorageFetchInfo remoteStorageFetchInfo) throws RemoteStorageException, IOException {

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -739,6 +739,8 @@ public class RemoteLogManager implements Closeable {
                 .remoteCopyBytesRate().mark(copySegmentStartedRlsm.segmentSizeInBytes());
             brokerTopicStats.allTopicsStats().remoteCopyBytesRate().mark(copySegmentStartedRlsm.segmentSizeInBytes());
             copiedOffsetOption = OptionalLong.of(endOffset);
+            // Update the highest offset in remote storage for this partition's log so that the local log segments
+            // are not deleted before they are copied to remote storage.
             log.updateHighestOffsetInRemoteStorage(endOffset);
             logger.info("Copied {} to remote storage with segment-id: {}", logFileName, copySegmentFinishedRlsm.remoteLogSegmentId());
         }
@@ -766,6 +768,8 @@ public class RemoteLogManager implements Closeable {
                     cleanupExpiredRemoteLogSegments();
                 } else {
                     long offset = findHighestRemoteOffset(topicIdPartition, log);
+                    // Update the highest offset in remote storage for this partition's log so that the local log segments
+                    // are not deleted before they are copied to remote storage.
                     log.updateHighestOffsetInRemoteStorage(offset);
                 }
             } catch (InterruptedException ex) {

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1334,7 +1334,6 @@ public class RemoteLogManager implements Closeable {
             this.retentionSize = retentionSize;
             this.remainingBreachedSize = remainingBreachedSize;
         }
-
     }
 
     private static class RetentionTimeData {

--- a/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
+++ b/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
@@ -230,7 +230,7 @@ public class ReplicaFetcherTierStateMachine implements TierStateMachine {
                 partition.truncateFullyAndStartAt(nextOffset, false);
 
                 // Build leader epoch cache.
-                unifiedLog.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented);
+                unifiedLog.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented, false);
                 List<EpochEntry> epochs = readLeaderEpochCheckpoint(rlm, remoteLogSegmentMetadata);
                 if (unifiedLog.leaderEpochCache().isDefined()) {
                     unifiedLog.leaderEpochCache().get().assign(epochs);

--- a/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
+++ b/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
@@ -230,7 +230,7 @@ public class ReplicaFetcherTierStateMachine implements TierStateMachine {
                 partition.truncateFullyAndStartAt(nextOffset, false);
 
                 // Build leader epoch cache.
-                unifiedLog.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented, false);
+                unifiedLog.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented);
                 List<EpochEntry> epochs = readLeaderEpochCheckpoint(rlm, remoteLogSegmentMetadata);
                 if (unifiedLog.leaderEpochCache().isDefined()) {
                     unifiedLog.leaderEpochCache().get().assign(epochs);

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -430,7 +430,8 @@ class LogManager(logDirs: Seq[File],
               val remainingLogs = decNumRemainingLogs(numRemainingLogs, dir.getAbsolutePath)
               val currentNumLoaded = logsToLoad.length - remainingLogs
               log match {
-                case Some(loadedLog) => info(s"Completed load of $loadedLog with ${loadedLog.numberOfSegments} segments in ${logLoadDurationMs}ms " +
+                case Some(loadedLog) => info(s"Completed load of $loadedLog with ${loadedLog.numberOfSegments} segments, " +
+                  s"local-log-start-offset ${loadedLog.localLogStartOffset()} and log-end-offset ${loadedLog.logEndOffset} in ${logLoadDurationMs}ms " +
                   s"($currentNumLoaded/${logsToLoad.length} completed in $logDirAbsolutePath)")
                 case None => info(s"Error while loading logs in $logDir in ${logLoadDurationMs}ms ($currentNumLoaded/${logsToLoad.length} completed in $logDirAbsolutePath)")
               }

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -182,7 +182,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   def updateLogStartOffsetFromRemoteTier(remoteLogStartOffset: Long): Unit = {
     if (!remoteLogEnabled()) {
-      warn("Ignoring the call as the remote log storage is disabled")
+      info("Ignoring the call as the remote log storage is disabled")
       return;
     }
     maybeIncrementLogStartOffset(remoteLogStartOffset, LogStartOffsetIncrementReason.SegmentDeletion)

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1500,7 +1500,6 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     deleteOldSegments(shouldDelete, RetentionMsBreach(this))
   }
 
-
   private def deleteRetentionSizeBreachedSegments(): Int = {
     val retentionSize: Long = localRetentionSize(config)
     if (retentionSize < 0 || size < retentionSize) return 0

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1530,10 +1530,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   def size: Long = localLog.segments.sizeInBytes
 
   /**
-   * The size of the log in bytes for segments with offsets >= localLogStartOffset. Any segment with
-   * offset < localLogStartOffset is considered invalid since it should not be in the local log.
+   * The log size in bytes for all segments that are only in local log but not yet in remote log.
    */
-  def validLocalLogSegmentsSize: Long = UnifiedLog.sizeInBytes(logSegments.filter(_.baseOffset >= localLogStartOffset()))
+  def onlyLocalLogSegmentsSize: Long = UnifiedLog.sizeInBytes(logSegments.filter(_.baseOffset >= highestOffsetInRemoteStorage))
 
   /**
    * The offset of the next message that will be appended to the log

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1012,6 +1012,11 @@ class UnifiedLog(@volatile var logStartOffset: Long,
           throw new OffsetOutOfRangeException(s"Cannot increment the log start offset to $newLogStartOffset of partition $topicPartition " +
             s"since it is larger than the high watermark $highWatermark")
 
+        if (remoteLogEnabled()) {
+          // This should be set log-start-offset is set more than the current local-log-start-offset
+          _localLogStartOffset = math.max(newLogStartOffset, localLogStartOffset())
+        }
+
         localLog.checkIfMemoryMappedBufferClosed()
         if (newLogStartOffset > logStartOffset) {
           updatedLogStartOffset = true

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -183,6 +183,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   def updateLogStartOffsetFromRemoteTier(remoteLogStartOffset: Long): Unit = {
     if (!remoteLogEnabled()) {
       warn("Ignoring the call as the remote log storage is disabled")
+      return;
     }
     maybeIncrementLogStartOffset(remoteLogStartOffset, LogStartOffsetIncrementReason.SegmentDeletion)
   }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -574,9 +574,9 @@ class BrokerServer(
       Some(new RemoteLogManager(config.remoteLogManagerConfig, config.brokerId, config.logDirs.head, clusterId, time,
         (tp: TopicPartition) => logManager.getLog(tp).asJava,
         (tp: TopicPartition, remoteLogStartOffset: java.lang.Long) => {
-          logManager.getLog(tp).foreach(log => {
+          logManager.getLog(tp).foreach { log =>
             log.updateLogStartOffsetFromRemoteTier(remoteLogStartOffset)
-          })
+          }
         },
         brokerTopicStats))
     } else {

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -572,7 +572,13 @@ class BrokerServer(
       }
 
       Some(new RemoteLogManager(config.remoteLogManagerConfig, config.brokerId, config.logDirs.head, clusterId, time,
-        (tp: TopicPartition) => logManager.getLog(tp).asJava, brokerTopicStats));
+        (tp: TopicPartition) => logManager.getLog(tp).asJava,
+        (tp: TopicPartition, remoteLogStartOffset: java.lang.Long) => {
+          logManager.getLog(tp).foreach(log => {
+            log.updateLogStartOffsetFromRemoteTier(remoteLogStartOffset)
+          })
+        },
+        brokerTopicStats));
     } else {
       None
     }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -578,7 +578,7 @@ class BrokerServer(
             log.updateLogStartOffsetFromRemoteTier(remoteLogStartOffset)
           })
         },
-        brokerTopicStats));
+        brokerTopicStats))
     } else {
       None
     }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -616,9 +616,9 @@ class KafkaServer(
       Some(new RemoteLogManager(config.remoteLogManagerConfig, config.brokerId, config.logDirs.head, clusterId, time,
         (tp: TopicPartition) => logManager.getLog(tp).asJava,
         (tp: TopicPartition, remoteLogStartOffset: java.lang.Long) => {
-          logManager.getLog(tp).foreach(log => {
+          logManager.getLog(tp).foreach { log =>
             log.updateLogStartOffsetFromRemoteTier(remoteLogStartOffset)
-          })
+          }
       },
         brokerTopicStats));
     } else {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -614,7 +614,13 @@ class KafkaServer(
       }
 
       Some(new RemoteLogManager(config.remoteLogManagerConfig, config.brokerId, config.logDirs.head, clusterId, time,
-        (tp: TopicPartition) => logManager.getLog(tp).asJava, brokerTopicStats));
+        (tp: TopicPartition) => logManager.getLog(tp).asJava,
+        (tp: TopicPartition, remoteLogStartOffset: java.lang.Long) => {
+          logManager.getLog(tp).foreach(log => {
+            log.updateLogStartOffsetFromRemoteTier(remoteLogStartOffset)
+          })
+      },
+        brokerTopicStats));
     } else {
       None
     }

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -276,7 +276,15 @@ public class RemoteLogManagerTest {
         Properties props = new Properties();
         // override common security.protocol by adding "RLMM prefix" and "remote log metadata common client prefix"
         props.put(DEFAULT_REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX + REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + "security.protocol", "SSL");
-        try (RemoteLogManager remoteLogManager = new RemoteLogManager(createRLMConfig(props), brokerId, logDir, clusterId, time, tp -> Optional.of(mockLog), brokerTopicStats) {
+        try (RemoteLogManager remoteLogManager = new RemoteLogManager(
+                createRLMConfig(props),
+                brokerId,
+                logDir,
+                clusterId,
+                time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> { },
+                brokerTopicStats) {
             public RemoteStorageManager createRemoteStorageManager() {
                 return remoteStorageManager;
             }

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1286,7 +1286,7 @@ public class RemoteLogManagerTest {
         Supplier<RemoteLogManager.RetentionTimeData>[] invalidRetentionTimeData =
             new Supplier[] {
                 () -> new RemoteLogManager.RetentionTimeData(-1, 10),
-                () -> new RemoteLogManager.RetentionTimeData(10, 1000),
+                () -> new RemoteLogManager.RetentionTimeData(10, -1),
             };
 
         for (Supplier<RemoteLogManager.RetentionTimeData> invalidRetentionTimeDataEntry : invalidRetentionTimeData) {

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1034,6 +1034,33 @@ public class RemoteLogManagerTest {
     }
 
     @Test
+    public void testBuildRefinedLeaderEpochMap() {
+        TreeMap<Integer, Long> leaderEpochToStartOffset = new TreeMap<Integer, Long>() {{
+                put(0, 0L);
+                put(1, 10L);
+                put(2, 20L);
+                put(3, 30L);
+                put(4, 40L);
+                put(5, 60L);
+                put(6, 60L);
+                put(7, 70L);
+            }};
+
+        TreeMap<Integer, Long> expectedLeaderEpochs = new TreeMap<Integer, Long>() {{
+                put(0, 0L);
+                put(1, 10L);
+                put(2, 20L);
+                put(3, 30L);
+                put(4, 40L);
+                put(6, 60L);
+                put(7, 70L);
+            }};
+
+        NavigableMap<Integer, Long> refinedLeaderEpochMap = RemoteLogManager.buildFilteredLeaderEpochMap(leaderEpochToStartOffset);
+        assertEquals(expectedLeaderEpochs, refinedLeaderEpochMap);
+    }
+
+    @Test
     public void testRemoteSegmentWithinLeaderEpochs() {
         // Test whether a remote segment is within the leader epochs
         final long logEndOffset = 90L;

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1020,6 +1020,7 @@ public class RemoteLogManagerTest {
                 1,
                 100000L,
                 1000,
+                Optional.empty(),
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED, segmentEpochs);
     }
 

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -128,38 +128,38 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class RemoteLogManagerTest {
-    Time time = new MockTime();
-    int brokerId = 0;
-    String logDir = TestUtils.tempDirectory("kafka-").toString();
-    String clusterId = "dummyId";
-    String remoteLogStorageTestProp = "remote.log.storage.test";
-    String remoteLogStorageTestVal = "storage.test";
-    String remoteLogMetadataTestProp = "remote.log.metadata.test";
-    String remoteLogMetadataTestVal = "metadata.test";
-    String remoteLogMetadataCommonClientTestProp = REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + "common.client.test";
-    String remoteLogMetadataCommonClientTestVal = "common.test";
-    String remoteLogMetadataProducerTestProp = REMOTE_LOG_METADATA_PRODUCER_PREFIX + "producer.test";
-    String remoteLogMetadataProducerTestVal = "producer.test";
-    String remoteLogMetadataConsumerTestProp = REMOTE_LOG_METADATA_CONSUMER_PREFIX + "consumer.test";
-    String remoteLogMetadataConsumerTestVal = "consumer.test";
-    String remoteLogMetadataTopicPartitionsNum = "1";
+    private final Time time = new MockTime();
+    private final int brokerId = 0;
+    private final String logDir = TestUtils.tempDirectory("kafka-").toString();
+    private final String clusterId = "dummyId";
+    private final String remoteLogStorageTestProp = "remote.log.storage.test";
+    private final String remoteLogStorageTestVal = "storage.test";
+    private final String remoteLogMetadataTestProp = "remote.log.metadata.test";
+    private final String remoteLogMetadataTestVal = "metadata.test";
+    private final String remoteLogMetadataCommonClientTestProp = REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + "common.client.test";
+    private final String remoteLogMetadataCommonClientTestVal = "common.test";
+    private final String remoteLogMetadataProducerTestProp = REMOTE_LOG_METADATA_PRODUCER_PREFIX + "producer.test";
+    private final String remoteLogMetadataProducerTestVal = "producer.test";
+    private final String remoteLogMetadataConsumerTestProp = REMOTE_LOG_METADATA_CONSUMER_PREFIX + "consumer.test";
+    private final String remoteLogMetadataConsumerTestVal = "consumer.test";
+    private final String remoteLogMetadataTopicPartitionsNum = "1";
 
-    RemoteStorageManager remoteStorageManager = mock(RemoteStorageManager.class);
-    RemoteLogMetadataManager remoteLogMetadataManager = mock(RemoteLogMetadataManager.class);
-    RemoteLogManagerConfig remoteLogManagerConfig = null;
+    private final RemoteStorageManager remoteStorageManager = mock(RemoteStorageManager.class);
+    private final RemoteLogMetadataManager remoteLogMetadataManager = mock(RemoteLogMetadataManager.class);
+    private RemoteLogManagerConfig remoteLogManagerConfig = null;
 
-    BrokerTopicStats brokerTopicStats = null;
-    RemoteLogManager remoteLogManager = null;
+    private BrokerTopicStats brokerTopicStats = null;
+    private RemoteLogManager remoteLogManager = null;
 
-    TopicIdPartition leaderTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("Leader", 0));
-    TopicIdPartition followerTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("Follower", 0));
-    Map<String, Uuid> topicIds = new HashMap<>();
-    TopicPartition tp = new TopicPartition("TestTopic", 5);
-    EpochEntry epochEntry0 = new EpochEntry(0, 0);
-    EpochEntry epochEntry1 = new EpochEntry(1, 100);
-    EpochEntry epochEntry2 = new EpochEntry(2, 200);
-    List<EpochEntry> totalEpochEntries = Arrays.asList(epochEntry0, epochEntry1, epochEntry2);
-    LeaderEpochCheckpoint checkpoint = new LeaderEpochCheckpoint() {
+    private final TopicIdPartition leaderTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("Leader", 0));
+    private final TopicIdPartition followerTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("Follower", 0));
+    private final Map<String, Uuid> topicIds = new HashMap<>();
+    private final TopicPartition tp = new TopicPartition("TestTopic", 5);
+    private final EpochEntry epochEntry0 = new EpochEntry(0, 0);
+    private final EpochEntry epochEntry1 = new EpochEntry(1, 100);
+    private final EpochEntry epochEntry2 = new EpochEntry(2, 200);
+    private final List<EpochEntry> totalEpochEntries = Arrays.asList(epochEntry0, epochEntry1, epochEntry2);
+    private final LeaderEpochCheckpoint checkpoint = new LeaderEpochCheckpoint() {
         List<EpochEntry> epochs = Collections.emptyList();
 
         @Override
@@ -173,7 +173,7 @@ public class RemoteLogManagerTest {
         }
     };
 
-    UnifiedLog mockLog = mock(UnifiedLog.class);
+    private final UnifiedLog mockLog = mock(UnifiedLog.class);
 
     @BeforeEach
     void setUp() throws Exception {
@@ -1034,25 +1034,24 @@ public class RemoteLogManagerTest {
     }
 
     @Test
-    public void testBuildRefinedLeaderEpochMap() {
+    public void testBuildFilteredLeaderEpochMap() {
         TreeMap<Integer, Long> leaderEpochToStartOffset = new TreeMap<>();
         leaderEpochToStartOffset.put(0, 0L);
-        leaderEpochToStartOffset.put(1, 10L);
-        leaderEpochToStartOffset.put(2, 20L);
+        leaderEpochToStartOffset.put(1, 0L);
+        leaderEpochToStartOffset.put(2, 0L);
         leaderEpochToStartOffset.put(3, 30L);
         leaderEpochToStartOffset.put(4, 40L);
         leaderEpochToStartOffset.put(5, 60L);
         leaderEpochToStartOffset.put(6, 60L);
         leaderEpochToStartOffset.put(7, 70L);
+        leaderEpochToStartOffset.put(8, 70L);
 
         TreeMap<Integer, Long> expectedLeaderEpochs = new TreeMap<>();
-        expectedLeaderEpochs.put(0, 0L);
-        expectedLeaderEpochs.put(1, 10L);
-        expectedLeaderEpochs.put(2, 20L);
+        expectedLeaderEpochs.put(2, 0L);
         expectedLeaderEpochs.put(3, 30L);
         expectedLeaderEpochs.put(4, 40L);
         expectedLeaderEpochs.put(6, 60L);
-        expectedLeaderEpochs.put(7, 70L);
+        expectedLeaderEpochs.put(8, 70L);
 
         NavigableMap<Integer, Long> refinedLeaderEpochMap = RemoteLogManager.buildFilteredLeaderEpochMap(leaderEpochToStartOffset);
         assertEquals(expectedLeaderEpochs, refinedLeaderEpochMap);
@@ -1241,7 +1240,7 @@ public class RemoteLogManagerTest {
         Supplier<RemoteLogManager.RetentionTimeData>[] invalidRetentionTimeData =
             new Supplier[] {
                 () -> new RemoteLogManager.RetentionTimeData(-1, 10),
-                () -> new RemoteLogManager.RetentionTimeData(1000, 10),
+                () -> new RemoteLogManager.RetentionTimeData(10, 1000),
             };
 
         for (Supplier<RemoteLogManager.RetentionTimeData> invalidRetentionTimeDataEntry : invalidRetentionTimeData) {

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -183,8 +183,10 @@ public class RemoteLogManagerTest {
         brokerTopicStats = new BrokerTopicStats(Optional.of(KafkaConfig.fromProps(props)));
 
         kafka.utils.TestUtils.clearYammerMetrics();
-
-        remoteLogManager = new RemoteLogManager(remoteLogManagerConfig, brokerId, logDir, clusterId, time, tp -> Optional.of(mockLog), brokerTopicStats) {
+        remoteLogManager = new RemoteLogManager(remoteLogManagerConfig, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> { },
+                brokerTopicStats) {
             public RemoteStorageManager createRemoteStorageManager() {
                 return remoteStorageManager;
             }
@@ -790,7 +792,10 @@ public class RemoteLogManagerTest {
     void testGetClassLoaderAwareRemoteStorageManager() throws Exception {
         ClassLoaderAwareRemoteStorageManager rsmManager = mock(ClassLoaderAwareRemoteStorageManager.class);
         try (RemoteLogManager remoteLogManager =
-            new RemoteLogManager(remoteLogManagerConfig, brokerId, logDir, clusterId, time, t -> Optional.empty(), brokerTopicStats) {
+            new RemoteLogManager(remoteLogManagerConfig, brokerId, logDir, clusterId, time,
+                    t -> Optional.empty(),
+                    (topicPartition, offset) -> { },
+                    brokerTopicStats) {
                 public RemoteStorageManager createRemoteStorageManager() {
                     return rsmManager;
                 }
@@ -974,7 +979,7 @@ public class RemoteLogManagerTest {
         MockedConstruction<KafkaMetricsGroup> mockMetricsGroupCtor = mockConstruction(KafkaMetricsGroup.class);
         try {
             RemoteLogManager remoteLogManager = new RemoteLogManager(remoteLogManagerConfig, brokerId, logDir, clusterId,
-                time, tp -> Optional.of(mockLog), brokerTopicStats) {
+                time, tp -> Optional.of(mockLog), (topicPartition, offset) -> { }, brokerTopicStats) {
                 public RemoteStorageManager createRemoteStorageManager() {
                     return remoteStorageManager;
                 }

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1038,23 +1038,48 @@ public class RemoteLogManagerTest {
                 put(7, 70L);
             }};
 
-        // Test whether a remote segment's epochs/offsets are within the range of leader epochs
+        // Test whether a remote segment's epochs/offsets(multiple) are within the range of leader epochs
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
-                25,
+                35,
                 new TreeMap<Integer, Long>() {{
                     put(1, 15L);
                     put(2, 20L);
+                    put(3, 30L);
+                }}), logEndOffset, leaderEpochToStartOffset));
+
+        // Test whether a remote segment's epochs/offsets(single) are within the range of leader epochs
+        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+                15,
+                19,
+                new TreeMap<Integer, Long>() {{
+                    put(1, 15L);
+                }}), logEndOffset, leaderEpochToStartOffset));
+
+        // Test whether a remote segment's epochs/offsets(single) are within the range of leader epochs
+        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+                15,
+                19,
+                new TreeMap<Integer, Long>() {{
+                    put(1, 15L);
                 }}), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether a remote segment's start offset is same as the offset of the respective leader epoch entry.
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
-                15,
-                25,
+                0,
+                5,
                 new TreeMap<Integer, Long>() {{
-                    put(1, 10L); // same as leader epoch's start offset
-                    put(2, 20L);
+                    put(0, 0L); // same as leader epoch's start offset
                 }}), logEndOffset, leaderEpochToStartOffset));
+
+        // Test whether a remote segment's start offset is same as the offset of the respective leader epoch entry.
+        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+                70,
+                75,
+                new TreeMap<Integer, Long>() {{
+                    put(7, 70L); // same as leader epoch's start offset
+                }}), logEndOffset, leaderEpochToStartOffset));
+
 
         // Test whether a remote segment's end offset is same as the end offset of the respective leader epoch entry.
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1035,26 +1035,24 @@ public class RemoteLogManagerTest {
 
     @Test
     public void testBuildRefinedLeaderEpochMap() {
-        TreeMap<Integer, Long> leaderEpochToStartOffset = new TreeMap<Integer, Long>() {{
-                put(0, 0L);
-                put(1, 10L);
-                put(2, 20L);
-                put(3, 30L);
-                put(4, 40L);
-                put(5, 60L);
-                put(6, 60L);
-                put(7, 70L);
-            }};
+        TreeMap<Integer, Long> leaderEpochToStartOffset = new TreeMap<>();
+        leaderEpochToStartOffset.put(0, 0L);
+        leaderEpochToStartOffset.put(1, 10L);
+        leaderEpochToStartOffset.put(2, 20L);
+        leaderEpochToStartOffset.put(3, 30L);
+        leaderEpochToStartOffset.put(4, 40L);
+        leaderEpochToStartOffset.put(5, 60L);
+        leaderEpochToStartOffset.put(6, 60L);
+        leaderEpochToStartOffset.put(7, 70L);
 
-        TreeMap<Integer, Long> expectedLeaderEpochs = new TreeMap<Integer, Long>() {{
-                put(0, 0L);
-                put(1, 10L);
-                put(2, 20L);
-                put(3, 30L);
-                put(4, 40L);
-                put(6, 60L);
-                put(7, 70L);
-            }};
+        TreeMap<Integer, Long> expectedLeaderEpochs = new TreeMap<>();
+        expectedLeaderEpochs.put(0, 0L);
+        expectedLeaderEpochs.put(1, 10L);
+        expectedLeaderEpochs.put(2, 20L);
+        expectedLeaderEpochs.put(3, 30L);
+        expectedLeaderEpochs.put(4, 40L);
+        expectedLeaderEpochs.put(6, 60L);
+        expectedLeaderEpochs.put(7, 70L);
 
         NavigableMap<Integer, Long> refinedLeaderEpochMap = RemoteLogManager.buildFilteredLeaderEpochMap(leaderEpochToStartOffset);
         assertEquals(expectedLeaderEpochs, refinedLeaderEpochMap);
@@ -1065,106 +1063,111 @@ public class RemoteLogManagerTest {
         // Test whether a remote segment is within the leader epochs
         final long logEndOffset = 90L;
 
-        TreeMap<Integer, Long> leaderEpochToStartOffset = new TreeMap<Integer, Long>() {{
-                put(0, 0L);
-                put(1, 10L);
-                put(2, 20L);
-                put(3, 30L);
-                put(4, 40L);
-                put(5, 50L);
-                put(7, 70L);
-            }};
+        TreeMap<Integer, Long> leaderEpochToStartOffset = new TreeMap<>();
+        leaderEpochToStartOffset.put(0, 0L);
+        leaderEpochToStartOffset.put(1, 10L);
+        leaderEpochToStartOffset.put(2, 20L);
+        leaderEpochToStartOffset.put(3, 30L);
+        leaderEpochToStartOffset.put(4, 40L);
+        leaderEpochToStartOffset.put(5, 50L);
+        leaderEpochToStartOffset.put(7, 70L);
 
         // Test whether a remote segment's epochs/offsets(multiple) are within the range of leader epochs
+        TreeMap<Integer, Long> segmentEpochs1 = new TreeMap<>();
+        segmentEpochs1.put(1, 15L);
+        segmentEpochs1.put(2, 20L);
+        segmentEpochs1.put(3, 30L);
+
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 35,
-                new TreeMap<Integer, Long>() {{
-                    put(1, 15L);
-                    put(2, 20L);
-                    put(3, 30L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs1), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether a remote segment's epochs/offsets(single) are within the range of leader epochs
+        TreeMap<Integer, Long> segmentEpochs2 = new TreeMap<>();
+        segmentEpochs2.put(1, 15L);
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 19,
-                new TreeMap<Integer, Long>() {{
-                    put(1, 15L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs2), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether a remote segment's start offset is same as the offset of the respective leader epoch entry.
+        TreeMap<Integer, Long> segmentEpochs3 = new TreeMap<>();
+        segmentEpochs3.put(0, 0L); // same as leader epoch's start offset
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 0,
                 5,
-                new TreeMap<Integer, Long>() {{
-                    put(0, 0L); // same as leader epoch's start offset
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs3), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether a remote segment's start offset is same as the offset of the respective leader epoch entry.
+        TreeMap<Integer, Long> segmentEpochs4 = new TreeMap<>();
+        segmentEpochs4.put(7, 70L); // same as leader epoch's start offset
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 70,
                 75,
-                new TreeMap<Integer, Long>() {{
-                    put(7, 70L); // same as leader epoch's start offset
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs4), logEndOffset, leaderEpochToStartOffset));
 
 
         // Test whether a remote segment's end offset is same as the end offset of the respective leader epoch entry.
+        TreeMap<Integer, Long> segmentEpochs5 = new TreeMap<>();
+        segmentEpochs5.put(1, 15L);
+        segmentEpochs5.put(2, 20L);
+
         assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 29, // same as end offset for epoch 2 in leaderEpochToStartOffset
-                new TreeMap<Integer, Long>() {{
-                    put(1, 15L);
-                    put(2, 20L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs5), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether any of the epoch's is not with in the leader epoch chain.
+        TreeMap<Integer, Long> segmentEpochs6 = new TreeMap<Integer, Long>();
+        segmentEpochs6.put(5, 55L);
+        segmentEpochs6.put(6, 60L); // epoch 6 exists here but it is missing in leaderEpochToStartOffset
+        segmentEpochs6.put(7, 70L);
+
         assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 55,
                 85,
-                new TreeMap<Integer, Long>() {{
-                    put(5, 55L);
-                    put(6, 60L); // epoch 6 exists here but it is missing in leaderEpochToStartOffset
-                    put(7, 70L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs6), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether an epoch existing in remote segment does not exist in leader epoch chain.
+        TreeMap<Integer, Long> segmentEpochs7 = new TreeMap<>();
+        segmentEpochs7.put(1, 15L);
+        segmentEpochs7.put(2, 20L); // epoch 3 is missing here which exists in leaderEpochToStartOffset
+        segmentEpochs7.put(4, 40L);
+
         assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 45,
-                new TreeMap<Integer, Long>() {{
-                    put(1, 15L);
-                    put(2, 20L); // epoch 3 is missing here which exists in leaderEpochToStartOffset
-                    put(4, 40L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs7), logEndOffset, leaderEpochToStartOffset));
 
         // Test a remote segment having larger end offset than the log end offset
+        TreeMap<Integer, Long> segmentEpochs8 = new TreeMap<>();
+        segmentEpochs8.put(1, 15L);
+        segmentEpochs8.put(2, 20L);
+
         assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 95, // larger than log end offset
-                new TreeMap<Integer, Long>() {{
-                    put(1, 15L);
-                    put(2, 20L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs8), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether a segment's first offset is earlier to the respective epoch's start offset
+        TreeMap<Integer, Long> segmentEpochs9 = new TreeMap<>();
+        segmentEpochs9.put(1, 5L);
+        segmentEpochs9.put(2, 20L);
+
         assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 5, // earlier to epoch 1's start offset
                 25,
-                new TreeMap<Integer, Long>() {{
-                    put(1, 5L);
-                    put(2, 20L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs9), logEndOffset, leaderEpochToStartOffset));
 
         // Test whether a segment's last offset is more than the respective epoch's end offset
+        TreeMap<Integer, Long> segmentEpochs10 = new TreeMap<>();
+        segmentEpochs10.put(1, 15L);
+        segmentEpochs10.put(2, 20L);
         assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 35, // more than epoch 2's end offset
-                new TreeMap<Integer, Long>() {{
-                    put(1, 15L);
-                    put(2, 20L);
-                }}), logEndOffset, leaderEpochToStartOffset));
+                segmentEpochs10), logEndOffset, leaderEpochToStartOffset));
     }
 
     @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -3631,6 +3631,7 @@ class ReplicaManagerTest {
       "clusterId",
       time,
       _ => Optional.of(mockLog),
+      (TopicPartition, Long) => {},
       brokerTopicStats)
     val spyRLM = spy(remoteLogManager)
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.TreeMap;
@@ -402,6 +403,19 @@ public class LeaderEpochFileCache {
         lock.readLock().lock();
         try {
             return new ArrayList<>(epochs.values());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public NavigableMap<Integer, Long> epochWithOffsets() {
+        lock.readLock().lock();
+        try {
+            NavigableMap<Integer, Long> epochWithOffsets = new TreeMap<>();
+            for (EpochEntry epochEntry : epochs.values()) {
+                epochWithOffsets.put(epochEntry.epoch, epochEntry.startOffset);
+            }
+            return epochWithOffsets;
         } finally {
             lock.readLock().unlock();
         }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
@@ -398,7 +398,6 @@ public class LeaderEpochFileCache {
         }
     }
 
-    // Visible for testing
     public List<EpochEntry> epochEntries() {
         lock.readLock().lock();
         try {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -102,9 +102,9 @@ public class LogConfig extends AbstractConfig {
 
     public static class RemoteLogConfig {
 
-        private final boolean remoteStorageEnable;
-        private final long localRetentionMs;
-        private final long localRetentionBytes;
+        public final boolean remoteStorageEnable;
+        public final long localRetentionMs;
+        public final long localRetentionBytes;
 
         private RemoteLogConfig(LogConfig config) {
             this.remoteStorageEnable = config.getBoolean(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG);


### PR DESCRIPTION
This change introduces a remote log segment segment retention cleanup mechanism.

RemoteLogManager runs retention cleanup activity tasks on each leader replica. It assesses factors such as overall size and retention duration, subsequently removing qualified segments from remote storage. This process also involves adjusting the log-start-offset within the UnifiedLog accordingly. It also cleans up the segments which have epochs earlier to the earliest leader epoch in the current leader. 

PS: This functionality is pulled out from internal branches with other functionalities related to the feature in 2.8.x. The reason for not pulling all the changes as it makes the PR huge and burdensome to review and it also needs other metrics and minor enhancements(including perf) and minor changes done for tests. So, we will try to have followup PRs to cover all those.

Co-authored-by: Kamal Chandraprakash <kamal.chandraprakash@gmail.com>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
