### PR TITLE
KAFKA-14834: [8/N] Propagate `isLatest` as part of `Change`

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/Change.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/Change.java
@@ -22,10 +22,16 @@ public class Change<T> {
 
     public final T newValue;
     public final T oldValue;
+    public final boolean isLatest;
 
     public Change(final T newValue, final T oldValue) {
+        this(newValue, oldValue, true);
+    }
+
+    public Change(final T newValue, final T oldValue, final boolean isLatest) {
         this.newValue = newValue;
         this.oldValue = oldValue;
+        this.isLatest = isLatest;
     }
 
     @Override
@@ -42,12 +48,13 @@ public class Change<T> {
             return false;
         }
         final Change<?> change = (Change<?>) o;
-        return Objects.equals(newValue, change.newValue) &&
-                Objects.equals(oldValue, change.oldValue);
+        return Objects.equals(newValue, change.newValue)
+            && Objects.equals(oldValue, change.oldValue)
+            && isLatest == change.isLatest;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(newValue, oldValue);
+        return Objects.hash(newValue, oldValue, isLatest);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupplier<KIn, VIn, KIn, VAgg> {
 
@@ -118,10 +120,13 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
 
             newAgg = aggregator.apply(record.key(), record.value(), oldAgg);
 
-            store.put(record.key(), newAgg, newTimestamp);
-            tupleForwarder.maybeForward(
-                record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null))
-                    .withTimestamp(newTimestamp));
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp);
+            // if not put to store, do not forward downstream either
+            if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                tupleForwarder.maybeForward(
+                    record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null, putReturnCode == PUT_RETURN_CODE_IS_LATEST))
+                        .withTimestamp(newTimestamp));
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K, V> {
 
@@ -112,10 +114,13 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K,
                 newTimestamp = Math.max(record.timestamp(), oldAggAndTimestamp.timestamp());
             }
 
-            store.put(record.key(), newAgg, newTimestamp);
-            tupleForwarder.maybeForward(
-                record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null))
-                    .withTimestamp(newTimestamp));
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp);
+            // if not put to store, do not forward downstream either
+            if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                tupleForwarder.maybeForward(
+                    record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null, putReturnCode == PUT_RETURN_CODE_IS_LATEST))
+                        .withTimestamp(newTimestamp));
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableAggregate.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 public class KTableAggregate<KIn, VIn, VAgg> implements
     KTableProcessorSupplier<KIn, VIn, KIn, VAgg> {
@@ -116,10 +118,13 @@ public class KTableAggregate<KIn, VIn, VAgg> implements
             }
 
             // update the store with the new value
-            store.put(record.key(), newAgg, newTimestamp);
-            tupleForwarder.maybeForward(
-                record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null))
-                    .withTimestamp(newTimestamp));
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp);
+            // if not put to store, do not forward downstream either
+            if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                tupleForwarder.maybeForward(
+                    record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null, putReturnCode == PUT_RETURN_CODE_IS_LATEST))
+                        .withTimestamp(newTimestamp));
+            }
         }
 
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
@@ -24,6 +24,8 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 public class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn, KIn, VIn> {
     private final KTableImpl<KIn, ?, VIn> parent;
@@ -129,10 +131,13 @@ public class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn,
             }
 
             if (queryableName != null) {
-                store.put(key, newValue, record.timestamp());
-                tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue)));
+                final long putReturnCode = store.put(key, newValue, record.timestamp());
+                // if not put to store, do not forward downstream either
+                if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                    tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));
+                }
             } else {
-                context.forward(record.withValue(new Change<>(newValue, oldValue)));
+                context.forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)));
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
@@ -139,7 +139,7 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 oldValue = joiner.apply(record.value().oldValue, valueRight);
             }
 
-            context().forward(record.withValue(new Change<>(newValue, oldValue)).withTimestamp(resultTimestamp));
+            context().forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)).withTimestamp(resultTimestamp));
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
@@ -145,7 +145,7 @@ class KTableKTableLeftJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K, 
                 oldValue = joiner.apply(record.value().oldValue, value2);
             }
 
-            context().forward(record.withValue(new Change<>(newValue, oldValue)).withTimestamp(resultTimestamp));
+            context().forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)).withTimestamp(resultTimestamp));
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -140,7 +140,7 @@ class KTableKTableOuterJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 oldValue = joiner.apply(record.value().oldValue, value2);
             }
 
-            context().forward(record.withValue(new Change<>(newValue, oldValue)).withTimestamp(resultTimestamp));
+            context().forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)).withTimestamp(resultTimestamp));
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -136,7 +136,7 @@ class KTableKTableRightJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 oldValue = joiner.apply(record.value().oldValue, valueLeft);
             }
 
-            context().forward(record.withValue(new Change<>(newValue, oldValue)).withTimestamp(resultTimestamp));
+            context().forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)).withTimestamp(resultTimestamp));
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
@@ -24,6 +24,8 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 
 class KTableMapValues<KIn, VIn, VOut> implements KTableProcessorSupplier<KIn, VIn, KIn, VOut> {
@@ -128,10 +130,13 @@ class KTableMapValues<KIn, VIn, VOut> implements KTableProcessorSupplier<KIn, VI
             final VOut oldValue = computeOldValue(record.key(), record.value());
 
             if (queryableName != null) {
-                store.put(record.key(), newValue, record.timestamp());
-                tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue)));
+                final long putReturnCode = store.put(record.key(), newValue, record.timestamp());
+                // if not put to store, do not forward downstream either
+                if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                    tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));
+                }
             } else {
-                context.forward(record.withValue(new Change<>(newValue, oldValue)));
+                context.forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)));
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
@@ -25,6 +25,8 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 public class KTableReduce<K, V> implements KTableProcessorSupplier<K, V, K, V> {
 
@@ -106,10 +108,13 @@ public class KTableReduce<K, V> implements KTableProcessorSupplier<K, V, K, V> {
             }
 
             // update the store with the new value
-            store.put(record.key(), newAgg, newTimestamp);
-            tupleForwarder.maybeForward(
-                record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null))
-                    .withTimestamp(newTimestamp));
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp);
+            // if not put to store, do not forward downstream either
+            if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                tupleForwarder.maybeForward(
+                    record.withValue(new Change<>(newAgg, sendOldValues ? oldAgg : null, putReturnCode == PUT_RETURN_CODE_IS_LATEST))
+                        .withTimestamp(newTimestamp));
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -141,7 +141,7 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
                 throw new StreamsException("Record key for the grouping KTable should not be null.");
             }
 
-            if (useVersionedSemantics && isOutOfOrder(record.value())) {
+            if (useVersionedSemantics && !record.value().isLatest) {
                 // skip out-of-order records when aggregating a versioned table, since the
                 // aggregate should include latest-by-timestamp records only. as an optimization,
                 // do not forward the out-of-order record downstream to the repartition topic either.
@@ -172,10 +172,6 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
                 }
             }
 
-        }
-
-        private boolean isOutOfOrder(final Change<V> change) {
-            return false; // TODO: this will be updated in a follow-up PR
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -154,19 +154,21 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
             final KeyValue<? extends K1, ? extends V1> oldPair = record.value().oldValue == null ? null :
                 mapper.apply(record.key(), record.value().oldValue);
 
+            final boolean isLatest = record.value().isLatest;
+
             // if the selected repartition key or value is null, skip
             // forward oldPair first, to be consistent with reduce and aggregate
             final boolean oldPairNotNull = oldPair != null && oldPair.key != null && oldPair.value != null;
             final boolean newPairNotNull = newPair != null && newPair.key != null && newPair.value != null;
             if (isNotUpgrade && oldPairNotNull && newPairNotNull && oldPair.key.equals(newPair.key)) {
-                context().forward(record.withKey(oldPair.key).withValue(new Change<>(newPair.value, oldPair.value)));
+                context().forward(record.withKey(oldPair.key).withValue(new Change<>(newPair.value, oldPair.value, isLatest)));
             } else {
                 if (oldPairNotNull) {
-                    context().forward(record.withKey(oldPair.key).withValue(new Change<>(null, oldPair.value)));
+                    context().forward(record.withKey(oldPair.key).withValue(new Change<>(null, oldPair.value, isLatest)));
                 }
 
                 if (newPairNotNull) {
-                    context().forward(record.withKey(newPair.key).withValue(new Change<>(newPair.value, null)));
+                    context().forward(record.withKey(newPair.key).withValue(new Change<>(newPair.value, null, isLatest)));
                 }
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
@@ -33,6 +33,8 @@ import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
 import static org.apache.kafka.streams.processor.internals.RecordQueue.UNKNOWN;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
+import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 
 class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V, K, VOut> {
     private final KTableImpl<K, ?, V> parent;
@@ -118,11 +120,14 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
 
             if (queryableName == null) {
                 final VOut oldValue = sendOldValues ? valueTransformer.transform(record.key(), record.value().oldValue) : null;
-                context().forward(record.withValue(new Change<>(newValue, oldValue)));
+                context().forward(record.withValue(new Change<>(newValue, oldValue, record.value().isLatest)));
             } else {
                 final VOut oldValue = sendOldValues ? getValueOrNull(store.get(record.key())) : null;
-                store.put(record.key(), newValue, record.timestamp());
-                tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue)));
+                final long putReturnCode = store.put(record.key(), newValue, record.timestamp());
+                // if not put to store, do not forward downstream either
+                if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
+                    tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));
+                }
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedCacheFlushListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedCacheFlushListener.java
@@ -47,7 +47,8 @@ class TimestampedCacheFlushListener<KOut, VOut> implements CacheFlushListener<KO
                     .withValue(
                         new Change<>(
                             getValueOrNull(record.value().newValue),
-                            getValueOrNull(record.value().oldValue)))
+                            getValueOrNull(record.value().oldValue),
+                            record.value().isLatest))
                     .withTimestamp(
                         record.value().newValue != null ? record.value().newValue.timestamp()
                             : record.timestamp())

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedTupleForwarder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedTupleForwarder.java
@@ -58,7 +58,7 @@ class TimestampedTupleForwarder<K, V> {
             if (sendOldValues) {
                 context.forward(record);
             } else {
-                context.forward(record.withValue(new Change<>(record.value().newValue, null)));
+                context.forward(record.withValue(new Change<>(record.value().newValue, null, record.value().isLatest)));
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -200,7 +200,8 @@ public class MeteredKeyValueStore<K, V>
                     record.withKey(serdes.keyFrom(record.key()))
                         .withValue(new Change<>(
                             record.value().newValue != null ? serdes.valueFrom(record.value().newValue) : null,
-                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null
+                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null,
+                            record.value().isLatest
                         ))
                 ),
                 sendOldValues);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -165,7 +165,8 @@ public class MeteredSessionStore<K, V>
                     record.withKey(SessionKeySchema.from(record.key(), serdes.keyDeserializer(), serdes.topic()))
                         .withValue(new Change<>(
                             record.value().newValue != null ? serdes.valueFrom(record.value().newValue) : null,
-                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null
+                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null,
+                            record.value().isLatest
                         ))
                 ),
                 sendOldValues);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -182,7 +182,8 @@ public class MeteredWindowStore<K, V>
                     record.withKey(WindowKeySchema.fromStoreKey(record.key(), windowSizeMs, serdes.keyDeserializer(), serdes.topic()))
                         .withValue(new Change<>(
                             record.value().newValue != null ? serdes.valueFrom(record.value().newValue) : null,
-                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null
+                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null,
+                            record.value().isLatest
                         ))
                 ),
                 sendOldValues);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimestampedTupleForwarderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimestampedTupleForwarderTest.java
@@ -66,11 +66,11 @@ public class TimestampedTupleForwarderTest {
 
         expect(store.setFlushListener(null, sendOldValues)).andReturn(false);
         if (sendOldValues) {
-            context.forward(new Record<>("key1", new Change<>("newValue1",  "oldValue1"), 0L));
-            context.forward(new Record<>("key2", new Change<>("newValue2",  "oldValue2"), 42L));
+            context.forward(new Record<>("key1", new Change<>("newValue1",  "oldValue1", true), 0L));
+            context.forward(new Record<>("key2", new Change<>("newValue2",  "oldValue2", false), 42L));
         } else {
-            context.forward(new Record<>("key1", new Change<>("newValue1", null), 0L));
-            context.forward(new Record<>("key2", new Change<>("newValue2", null), 42L));
+            context.forward(new Record<>("key1", new Change<>("newValue1", null, true), 0L));
+            context.forward(new Record<>("key2", new Change<>("newValue2", null, false), 42L));
         }
         expectLastCall();
         replay(store, context);
@@ -82,8 +82,8 @@ public class TimestampedTupleForwarderTest {
                 null,
                 sendOldValues
             );
-        forwarder.maybeForward(new Record<>("key1", new Change<>("newValue1", "oldValue1"), 0L));
-        forwarder.maybeForward(new Record<>("key2", new Change<>("newValue2", "oldValue2"), 42L));
+        forwarder.maybeForward(new Record<>("key1", new Change<>("newValue1", "oldValue1", true), 0L));
+        forwarder.maybeForward(new Record<>("key2", new Change<>("newValue2", "oldValue2", false), 42L));
 
         verify(store, context);
     }
@@ -103,8 +103,8 @@ public class TimestampedTupleForwarderTest {
                 null,
                 false
             );
-        forwarder.maybeForward(new Record<>("key", new Change<>("newValue", "oldValue"), 0L));
-        forwarder.maybeForward(new Record<>("key", new Change<>("newValue", "oldValue"), 42L));
+        forwarder.maybeForward(new Record<>("key", new Change<>("newValue", "oldValue", true), 0L));
+        forwarder.maybeForward(new Record<>("key", new Change<>("newValue", "oldValue", true), 42L));
 
         verify(store, context);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CacheFlushListenerStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CacheFlushListenerStub.java
@@ -40,7 +40,8 @@ public class CacheFlushListenerStub<K, V> implements CacheFlushListener<byte[], 
             keyDeserializer.deserialize(null, record.key()),
             new Change<>(
                 valueDeserializer.deserialize(null, record.value().newValue),
-                valueDeserializer.deserialize(null, record.value().oldValue)
+                valueDeserializer.deserialize(null, record.value().oldValue),
+                record.value().isLatest
             )
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapperTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapperTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -116,36 +117,40 @@ public class KeyValueStoreWrapperTest {
     public void shouldPutToTimestampedStore() {
         givenWrapperWithTimestampedStore();
 
-        wrapper.put(KEY, VALUE_AND_TIMESTAMP.value(), VALUE_AND_TIMESTAMP.timestamp());
+        final long putReturnCode = wrapper.put(KEY, VALUE_AND_TIMESTAMP.value(), VALUE_AND_TIMESTAMP.timestamp());
 
+        assertThat(putReturnCode, equalTo(PUT_RETURN_CODE_IS_LATEST));
         verify(timestampedStore).put(KEY, VALUE_AND_TIMESTAMP);
     }
 
     @Test
     public void shouldPutToVersionedStore() {
         givenWrapperWithVersionedStore();
+        when(versionedStore.put(KEY, VALUE_AND_TIMESTAMP.value(), VALUE_AND_TIMESTAMP.timestamp())).thenReturn(12L);
 
-        wrapper.put(KEY, VALUE_AND_TIMESTAMP.value(), VALUE_AND_TIMESTAMP.timestamp());
+        final long putReturnCode = wrapper.put(KEY, VALUE_AND_TIMESTAMP.value(), VALUE_AND_TIMESTAMP.timestamp());
 
-        verify(versionedStore).put(KEY, VALUE_AND_TIMESTAMP.value(), VALUE_AND_TIMESTAMP.timestamp());
+        assertThat(putReturnCode, equalTo(12L));
     }
 
     @Test
     public void shouldPutNullToTimestampedStore() {
         givenWrapperWithTimestampedStore();
 
-        wrapper.put(KEY, null, VALUE_AND_TIMESTAMP.timestamp());
+        final long putReturnCode = wrapper.put(KEY, null, VALUE_AND_TIMESTAMP.timestamp());
 
+        assertThat(putReturnCode, equalTo(PUT_RETURN_CODE_IS_LATEST));
         verify(timestampedStore).put(KEY, null);
     }
 
     @Test
     public void shouldPutNullToVersionedStore() {
         givenWrapperWithVersionedStore();
+        when(versionedStore.put(KEY, null, VALUE_AND_TIMESTAMP.timestamp())).thenReturn(12L);
 
-        wrapper.put(KEY, null, VALUE_AND_TIMESTAMP.timestamp());
+        final long putReturnCode = wrapper.put(KEY, null, VALUE_AND_TIMESTAMP.timestamp());
 
-        verify(versionedStore).put(KEY, null, VALUE_AND_TIMESTAMP.timestamp());
+        assertThat(putReturnCode, equalTo(12L));
     }
 
     @Test


### PR DESCRIPTION
This PR adds an additional boolean `isLatest` into `Change` which specifies whether the new value is the latest for its key. For un-versioned stores, `isLatest` is always true. For versioned stores, `isLatest` is true if the value has the latest timestamp seen for the key, else false. This boolean will be used by processors such as the table repartition map processor to determine when a record is out-of-order and should be dropped (when processing a versioned table). See [KIP-914](https://cwiki.apache.org/confluence/display/KAFKA/KIP-914%3A+DSL+Processor+Semantics+for+Versioned+Stores) for details. 

This PR updates the table repartition map processor accordingly, and also adds test coverage for table filter. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
