### PR TITLE
KAFKA-14834: [9/N] Disable versioned-stores for unsupported operations

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -369,6 +369,8 @@ public class StreamsBuilder {
      * <p>
      * Note that {@link GlobalKTable} always applies {@code "auto.offset.reset"} strategy {@code "earliest"}
      * regardless of the specified value in {@link StreamsConfig} or {@link Consumed}.
+     * Furthermore, {@link GlobalKTable} cannot be a {@link org.apache.kafka.streams.state.VersionedBytesStoreSupplier
+     * versioned state store}.
      *
      * @param topic the topic name; cannot be {@code null}
      * @param consumed  the instance of {@link Consumed} used to define optional parameters
@@ -400,6 +402,8 @@ public class StreamsBuilder {
      * <p>
      * Note that {@link GlobalKTable} always applies {@code "auto.offset.reset"} strategy {@code "earliest"}
      * regardless of the specified value in {@link StreamsConfig}.
+     * Furthermore, {@link GlobalKTable} cannot be a {@link org.apache.kafka.streams.state.VersionedBytesStoreSupplier
+     * versioned state store}.
      *
      * @param topic the topic name; cannot be {@code null}
      * @return a {@link GlobalKTable} for the specified topic
@@ -434,6 +438,8 @@ public class StreamsBuilder {
      * }</pre>
      * Note that {@link GlobalKTable} always applies {@code "auto.offset.reset"} strategy {@code "earliest"}
      * regardless of the specified value in {@link StreamsConfig} or {@link Consumed}.
+     * Furthermore, {@link GlobalKTable} cannot be a {@link org.apache.kafka.streams.state.VersionedBytesStoreSupplier
+     * versioned state store}.
      *
      * @param topic         the topic name; cannot be {@code null}
      * @param consumed      the instance of {@link Consumed} used to define optional parameters; can't be {@code null}
@@ -476,6 +482,8 @@ public class StreamsBuilder {
      * }</pre>
      * Note that {@link GlobalKTable} always applies {@code "auto.offset.reset"} strategy {@code "earliest"}
      * regardless of the specified value in {@link StreamsConfig}.
+     * Furthermore, {@link GlobalKTable} cannot be a {@link org.apache.kafka.streams.state.VersionedBytesStoreSupplier
+     * versioned state store}.
      *
      * @param topic         the topic name; cannot be {@code null}
      * @param materialized   the instance of {@link Materialized} used to materialize a state store; cannot be {@code null}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -715,8 +715,10 @@ public interface KTable<K, V> {
 
     /**
      * Suppress some updates from this changelog stream, determined by the supplied {@link Suppressed} configuration.
-     *
      * This controls what updates downstream table and stream operations will receive.
+     * <p>
+     * Note that {@code suppress()} cannot be applied to
+     * {@link org.apache.kafka.streams.state.VersionedBytesStoreSupplier versioned KTables}.
      *
      * @param suppressed Configuration object determining what, if any, updates to suppress
      * @return A new KTable with the desired suppression characteristics.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.kstream.internals.graph.StateStoreNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSourceNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
-import org.apache.kafka.streams.kstream.internals.graph.SuppressNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableSuppressNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode;
 import org.apache.kafka.streams.kstream.internals.graph.VersionedSemanticsGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.WindowedStreamProcessorNode;
@@ -75,7 +75,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     private final LinkedHashSet<GraphNode> mergeNodes = new LinkedHashSet<>();
     private final LinkedHashSet<GraphNode> tableSourceNodes = new LinkedHashSet<>();
     private final LinkedHashSet<GraphNode> versionedSemanticsNodes = new LinkedHashSet<>();
-    private final LinkedHashSet<SuppressNode> suppressNodesNodes = new LinkedHashSet<>();
+    private final LinkedHashSet<TableSuppressNode> tableSuppressNodesNodes = new LinkedHashSet<>();
 
     private static final String TOPOLOGY_ROOT = "root";
     private static final Logger LOG = LoggerFactory.getLogger(InternalStreamsBuilder.class);
@@ -168,7 +168,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         Objects.requireNonNull(materialized, "materialized can't be null");
 
         if (materialized.storeSupplier() instanceof VersionedBytesStoreSupplier) {
-            throw new IllegalArgumentException("GlobalTables cannot be versioned.");
+            throw new TopologyException("GlobalTables cannot be versioned.");
         }
 
         // explicitly disable logging for global stores
@@ -289,8 +289,8 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         if (node instanceof VersionedSemanticsGraphNode) {
             versionedSemanticsNodes.add(node);
         }
-        if (node instanceof SuppressNode) {
-            suppressNodesNodes.add((SuppressNode<?, ?>) node);
+        if (node instanceof TableSuppressNode) {
+            tableSuppressNodesNodes.add((TableSuppressNode<?, ?>) node);
         }
     }
 
@@ -621,9 +621,10 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     private void enableVersionedSemantics() {
         versionedSemanticsNodes.forEach(node -> ((VersionedSemanticsGraphNode) node).enableVersionedSemantics(isVersionedUpstream(node)));
-        suppressNodesNodes.forEach(node -> {
+        tableSuppressNodesNodes.forEach(node -> {
             if (isVersionedUpstream(node)) {
-                throw new UnsupportedOperationException("suppress() is only supported for non-versioned KTables");
+                throw new TopologyException("suppress() is only supported for non-versioned KTables " +
+                        "(note that version semantics might be inherited from upstream)");
             }
         });
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KGroupedTable;
@@ -54,7 +55,7 @@ import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSinkNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSourceNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
-import org.apache.kafka.streams.kstream.internals.graph.SuppressNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableSuppressNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableFilterNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableRepartitionMapNode;
@@ -540,8 +541,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
     @Override
     public KTable<K, V> suppress(final Suppressed<? super K> suppressed) {
+        // this is an eager, but insufficient check
+        // the check only works if the direct parent is materialized
+        // the actual check for "version inheritance" can only be done in the build-phase later
+        // we keep this check to get a better stack trace if possible
         if (graphNode.isOutputVersioned().isPresent() && graphNode.isOutputVersioned().get()) {
-            throw new UnsupportedOperationException("suppress() is only supported for non-versioned KTables");
+            throw new TopologyException("suppress() is only supported for non-versioned KTables");
         }
 
         final String name;
@@ -580,7 +585,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 .withLoggingDisabled();
         }
 
-        final ProcessorGraphNode<K, Change<V>> node = new SuppressNode<>(
+        final ProcessorGraphNode<K, Change<V>> node = new TableSuppressNode<>(
             name,
             new ProcessorParameters<>(suppressionSupplier, name),
             storeBuilder

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SuppressNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SuppressNode.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class SuppressNode<K, V> extends StatefulProcessorNode<K, V> {
+    public SuppressNode(final String nodeName,
+                        final ProcessorParameters<K, V, ?, ?> processorParameters,
+                        final StoreBuilder<?> materializedKTableStoreBuilder) {
+        super(nodeName, processorParameters, materializedKTableStoreBuilder);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSuppressNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSuppressNode.java
@@ -18,10 +18,10 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import org.apache.kafka.streams.state.StoreBuilder;
 
-public class SuppressNode<K, V> extends StatefulProcessorNode<K, V> {
-    public SuppressNode(final String nodeName,
-                        final ProcessorParameters<K, V, ?, ?> processorParameters,
-                        final StoreBuilder<?> materializedKTableStoreBuilder) {
+public class TableSuppressNode<K, V> extends StatefulProcessorNode<K, V> {
+    public TableSuppressNode(final String nodeName,
+                             final ProcessorParameters<K, V, ?, ?> processorParameters,
+                             final StoreBuilder<?> materializedKTableStoreBuilder) {
         super(nodeName, processorParameters, materializedKTableStoreBuilder);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -434,6 +434,21 @@ public class StreamsBuilderTest {
     }
 
     @Test
+    public void shouldThrowOnVersionedStoreSupplierForGlobalTable() {
+        final String topic = "topic";
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> builder.globalTable(
+                topic,
+                Materialized.<Long, String>as(Stores.persistentVersionedKeyValueStore("store", Duration.ZERO))
+                    .withKeySerde(Serdes.Long())
+                    .withValueSerde(Serdes.String()
+                )
+            )
+        );
+    }
+
+    @Test
     public void shouldNotMaterializeStoresIfNotRequired() {
         final String topic = "topic";
         builder.table(topic, Materialized.with(Serdes.Long(), Serdes.String()));

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -437,7 +437,7 @@ public class StreamsBuilderTest {
     public void shouldThrowOnVersionedStoreSupplierForGlobalTable() {
         final String topic = "topic";
         assertThrows(
-            IllegalArgumentException.class,
+            TopologyException.class,
             () -> builder.globalTable(
                 topic,
                 Materialized.<Long, String>as(Stores.persistentVersionedKeyValueStore("store", Duration.ZERO))

--- a/streams/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
@@ -321,52 +321,6 @@ public class VersionedKeyValueStoreIntegrationTest {
     }
 
     @Test
-    public void shouldCreateGlobalTable() throws Exception {
-        // produce data to global store topic and track in-memory for processor to verify
-        final DataTracker data = new DataTracker();
-        produceDataToTopic(globalTableTopic, data, baseTimestamp, KeyValue.pair(1, "a0"), KeyValue.pair(2, "b0"), KeyValue.pair(3, null));
-        produceDataToTopic(globalTableTopic, data, baseTimestamp + 5, KeyValue.pair(1, "a5"), KeyValue.pair(2, null), KeyValue.pair(3, "c5"));
-        produceDataToTopic(globalTableTopic, data, baseTimestamp + 2, KeyValue.pair(1, "a2"), KeyValue.pair(2, "b2"), KeyValue.pair(3, null)); // out-of-order data
-
-        // build topology and start app
-        final StreamsBuilder streamsBuilder = new StreamsBuilder();
-
-        streamsBuilder
-            .globalTable(
-                globalTableTopic,
-                Consumed.with(Serdes.Integer(), Serdes.String()),
-                Materialized
-                    .<Integer, String>as(Stores.persistentVersionedKeyValueStore(STORE_NAME, Duration.ofMillis(HISTORY_RETENTION)))
-                    .withKeySerde(Serdes.Integer())
-                    .withValueSerde(Serdes.String()));
-        streamsBuilder
-            .stream(inputStream, Consumed.with(Serdes.Integer(), Serdes.String()))
-            .process(() -> new VersionedStoreContentCheckerProcessor(false, data))
-            .to(outputStream, Produced.with(Serdes.Integer(), Serdes.Integer()));
-
-        final Properties props = props();
-        kafkaStreams = new KafkaStreams(streamsBuilder.build(), props);
-        kafkaStreams.start();
-
-        // produce source data to trigger store verifications in processor
-        final int numRecordsProduced = produceDataToTopic(inputStream, baseTimestamp + 8, KeyValue.pair(1, "a8"), KeyValue.pair(2, "b8"), KeyValue.pair(3, "c8"));
-
-        // wait for output and verify
-        final List<KeyValue<Integer, Integer>> receivedRecords = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
-            TestUtils.consumerConfig(
-                CLUSTER.bootstrapServers(),
-                IntegerDeserializer.class,
-                IntegerDeserializer.class),
-            outputStream,
-            numRecordsProduced);
-
-        for (final KeyValue<Integer, Integer> receivedRecord : receivedRecords) {
-            // verify zero failed checks for each record
-            assertThat(receivedRecord.value, equalTo(0));
-        }
-    }
-
-    @Test
     public void shouldManualUpgradeFromNonVersionedTimestampedToVersioned() throws Exception {
         // build non-versioned (timestamped) topology
         final StreamsBuilder streamsBuilder = new StreamsBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
@@ -45,7 +45,6 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -190,7 +190,7 @@ public class InternalStreamsBuilderTest {
         assertThrows(
             IllegalArgumentException.class,
             () -> builder.globalTable(
-            "table",
+                "table",
                 consumed,
                 materializedInternal)
         );

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.JoinWindows;
@@ -188,7 +189,7 @@ public class InternalStreamsBuilderTest {
                 );
 
         assertThrows(
-            IllegalArgumentException.class,
+            TopologyException.class,
             () -> builder.globalTable(
                 "table",
                 consumed,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -66,6 +66,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class InternalStreamsBuilderTest {
@@ -175,6 +176,24 @@ public class InternalStreamsBuilderTest {
 
         assertEquals(1, stateStores.size());
         assertEquals("globalTable", stateStores.get(0).name());
+    }
+
+    @Test
+    public void shouldThrowOnVersionedStoreSupplierForGlobalTable() {
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materializedInternal =
+                new MaterializedInternal<>(
+                        Materialized.as(Stores.persistentVersionedKeyValueStore("store", Duration.ZERO)),
+                        builder,
+                        storePrefix
+                );
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> builder.globalTable(
+            "table",
+                consumed,
+                materializedInternal)
+        );
     }
 
     private void doBuildGlobalTopologyWithAllGlobalTables() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoinTest.java
@@ -262,30 +262,4 @@ public class KStreamGlobalKTableJoinTest {
         processor.checkAndClearProcessResult(new KeyValueTimestamp<>(null, "X0,FKey0+Y0", 0),
                 new KeyValueTimestamp<>(1, "X1,FKey1+Y1", 1));
     }
-
-    @Test
-    public void shouldPerformTimestampedGet() {
-        initWithVersionedStore(1000);
-
-        // do not auto-advance stream timestamps for this test
-        inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
-
-        // produce out-of-order records including nulls to table
-        inputTableTopic.pipeInput("FKey1", "ValueT10", 10);
-        inputTableTopic.pipeInput("FKey1", "ValueT5", 5);
-        inputTableTopic.pipeInput("FKey1", null, 7);
-        inputTableTopic.pipeInput("FKey1", "ValueT12", 12);
-
-        // produce records to stream side
-        inputStreamTopic.pipeInput(1, "ValueS8,FKey1", 8);
-        inputStreamTopic.pipeInput(2, "ValueS12,FKey1", 12);
-        inputStreamTopic.pipeInput(3, "ValueS6,FKey1", 6);
-        inputStreamTopic.pipeInput(4, "ValueS10,FKey1", 10);
-        inputStreamTopic.pipeInput(5, "ValueS2,FKey1", 2);
-
-        processor.checkAndClearProcessResult(
-            new KeyValueTimestamp<>(2, "ValueS12,FKey1+ValueT12", 12),
-            new KeyValueTimestamp<>(3, "ValueS6,FKey1+ValueT5", 6),
-            new KeyValueTimestamp<>(4, "ValueS10,FKey1+ValueT10", 10));
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableLeftJoinTest.java
@@ -272,33 +272,4 @@ public class KStreamGlobalKTableLeftJoinTest {
                 new KeyValueTimestamp<>(2, "X2,FKey2+Y2", 2),
                 new KeyValueTimestamp<>(3, "X3,FKey3+Y3", 3));
     }
-
-    @Test
-    public void shouldPerformTimestampedGet() {
-        initWithVersionedStore(1000);
-
-        // do not auto-advance timestamps for this test
-        inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
-        inputTableTopic = driver.createInputTopic(globalTableTopic, new StringSerializer(), new StringSerializer());
-
-        // produce out-of-order records including nulls to table
-        inputTableTopic.pipeInput("FKey1", "ValueT10", 10);
-        inputTableTopic.pipeInput("FKey1", "ValueT5", 5);
-        inputTableTopic.pipeInput("FKey1", null, 7);
-        inputTableTopic.pipeInput("FKey1", "ValueT12", 12);
-
-        // produce records to stream side
-        inputStreamTopic.pipeInput(1, "ValueS8,FKey1", 8);
-        inputStreamTopic.pipeInput(2, "ValueS12,FKey1", 12);
-        inputStreamTopic.pipeInput(3, "ValueS6,FKey1", 6);
-        inputStreamTopic.pipeInput(4, "ValueS10,FKey1", 10);
-        inputStreamTopic.pipeInput(5, "ValueS2,FKey1", 2);
-
-        processor.checkAndClearProcessResult(
-            new KeyValueTimestamp<>(1, "ValueS8,FKey1+null", 8),
-            new KeyValueTimestamp<>(2, "ValueS12,FKey1+ValueT12", 12),
-            new KeyValueTimestamp<>(3, "ValueS6,FKey1+ValueT5", 6),
-            new KeyValueTimestamp<>(4, "ValueS10,FKey1+ValueT10", 10),
-            new KeyValueTimestamp<>(5, "ValueS2,FKey1+null", 2));
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
@@ -23,11 +23,14 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.Suppressed;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.Stores;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -38,6 +41,7 @@ import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
 import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("deprecation")
 public class SuppressTopologyTest {
@@ -208,5 +212,34 @@ public class SuppressTopologyTest {
 
         // without the name, the suppression node does not increment the topology index
         assertThat(namedNodeTopology, is(NAMED_INTERMEDIATE_TOPOLOGY));
+    }
+
+    @Test
+    public void shouldThrowOnSuppressForMaterializedVersionedTable() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<Object, Object> versionedTable = builder.table(
+            "input",
+            Materialized.as(Stores.persistentVersionedKeyValueStore("store", Duration.ZERO))
+        );
+
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> versionedTable.suppress(Suppressed.untilTimeLimit(Duration.ZERO, Suppressed.BufferConfig.unbounded()))
+        );
+    }
+
+    @Test
+    public void shouldThrowOnSuppressForNonMaterializedVersionedTable() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+                "input",
+                Materialized.as(Stores.persistentVersionedKeyValueStore("store", Duration.ZERO))
+        ).filter((k, v) -> true)
+        .suppress(Suppressed.untilTimeLimit(Duration.ZERO, Suppressed.BufferConfig.unbounded()));
+
+        assertThrows(
+            UnsupportedOperationException.class,
+            builder::build
+        );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KTable;
@@ -223,7 +224,7 @@ public class SuppressTopologyTest {
         );
 
         assertThrows(
-            UnsupportedOperationException.class,
+            TopologyException.class,
             () -> versionedTable.suppress(Suppressed.untilTimeLimit(Duration.ZERO, Suppressed.BufferConfig.unbounded()))
         );
     }
@@ -238,7 +239,7 @@ public class SuppressTopologyTest {
         .suppress(Suppressed.untilTimeLimit(Duration.ZERO, Suppressed.BufferConfig.unbounded()));
 
         assertThrows(
-            UnsupportedOperationException.class,
+            TopologyException.class,
             builder::build
         );
     }


### PR DESCRIPTION
Using versioned-stores for global-KTables is not allowed, because a global-table is bootstrapped on startup, and a stream-globalTable join does not support temporal semantics.

Furthermore, `suppress()` does not support temporal semantics and thus cannot be applied to an versioned-KTable.

This PR disallows both use-cases explicitely.

Part of KIP-914.