### PR TITLE
KAFKA-14834: [10/N] Reserve repartition topic formats to include `isLatest`

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -1026,7 +1026,7 @@ KTable&lt;byte[], Long&gt; aggregatedTable = groupedTable.aggregate(
                                     <li>When the first non-<code class="docutils literal"><span class="pre">null</span></code> value is received for a key (e.g.,  INSERT), then only the adder is called.</li>
                                     <li>When subsequent non-<code class="docutils literal"><span class="pre">null</span></code> values are received for a key (e.g.,  UPDATE), then (1) the subtractor is
                                         called with the old value as stored in the table and (2) the adder is called with the new value of the
-                                        input record that was just received. The subtractor will be called before the adder if and only if the extracted grouping key of the old and new value is the same.
+                                        input record that was just received. The subtractor is guaranteed to be called before the adder if the extracted grouping key of the old and new value is the same.
                                         The detection of this case depends on the correct implementation of the equals() method of the extracted key type. Otherwise, the order of execution for the subtractor
                                         and adder is not defined.</li>
                                     <li>When a tombstone record &#8211; i.e. a record with a <code class="docutils literal"><span class="pre">null</span></code> value &#8211; is received for a key (e.g.,  DELETE),
@@ -1276,7 +1276,7 @@ KTable&lt;String, Long&gt; aggregatedTable = groupedTable.reduce(
                                     <li>When the first non-<code class="docutils literal"><span class="pre">null</span></code> value is received for a key (e.g.,  INSERT), then only the adder is called.</li>
                                     <li>When subsequent non-<code class="docutils literal"><span class="pre">null</span></code> values are received for a key (e.g.,  UPDATE), then (1) the subtractor is
                                         called with the old value as stored in the table and (2) the adder is called with the new value of the
-                                        input record that was just received. The subtractor will be called before the adder if and only if the extracted grouping key of the old and new value is the same.
+                                        input record that was just received. The subtractor is guaranteed be called before the adder if the extracted grouping key of the old and new value is the same.
                                         The detection of this case depends on the correct implementation of the equals() method of the extracted key type. Otherwise, the order of execution for the subtractor
                                         and adder is not defined.</li>
                                     <li>When a tombstone record &#8211; i.e. a record with a <code class="docutils literal"><span class="pre">null</span></code> value &#8211; is received for a key (e.g.,  DELETE),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 public class ChangedDeserializer<T> implements Deserializer<Change<T>>, WrappingNullableDeserializer<Change<T>, Void, T> {
 
     private static final int NEW_OLD_FLAG_SIZE = 1;
+    private static final int IS_LATEST_FLAG_SIZE = 1;
 
     private Deserializer<T> inner;
 
@@ -52,21 +53,27 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
         // {BYTE_ARRAY oldValue}{BYTE newOldFlag=0}
         // {BYTE_ARRAY newValue}{BYTE newOldFlag=1}
         // {UINT32 newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE newOldFlag=2}
+        // {BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=3}
+        // {BYTE_ARRAY newValue}{BYTE isLatest}{BYTE newOldFlag=4}
+        // {UINT32 newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE isLatest}{BYTE newOldFlag=5}
         final ByteBuffer buffer = ByteBuffer.wrap(data);
         final byte newOldFlag = buffer.get(data.length - NEW_OLD_FLAG_SIZE);
 
         final byte[] newData;
         final byte[] oldData;
+        final boolean isLatest;
         if (newOldFlag == (byte) 0) {
             newData = null;
             final int oldDataLength = data.length - NEW_OLD_FLAG_SIZE;
             oldData = new byte[oldDataLength];
             buffer.get(oldData);
+            isLatest = true;
         } else if (newOldFlag == (byte) 1) {
             oldData = null;
             final int newDataLength = data.length - NEW_OLD_FLAG_SIZE;
             newData = new byte[newDataLength];
             buffer.get(newData);
+            isLatest = true;
         } else if (newOldFlag == (byte) 2) {
             final int newDataLength = Math.toIntExact(ByteUtils.readUnsignedInt(buffer));
             newData = new byte[newDataLength];
@@ -76,13 +83,48 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
 
             buffer.get(newData);
             buffer.get(oldData);
+            isLatest = true;
+        } else if (newOldFlag == (byte) 3) {
+            newData = null;
+            final int oldDataLength = data.length - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE;
+            oldData = new byte[oldDataLength];
+            buffer.get(oldData);
+            isLatest = readIsLatestFlag(buffer);
+        } else if (newOldFlag == (byte) 4) {
+            oldData = null;
+            final int newDataLength = data.length - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE;
+            newData = new byte[newDataLength];
+            buffer.get(newData);
+            isLatest = readIsLatestFlag(buffer);
+        } else if (newOldFlag == (byte) 5) {
+            final int newDataLength = Math.toIntExact(ByteUtils.readUnsignedInt(buffer));
+            newData = new byte[newDataLength];
+
+            final int oldDataLength = data.length - Integer.BYTES - newDataLength - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE;
+            oldData = new byte[oldDataLength];
+
+            buffer.get(newData);
+            buffer.get(oldData);
+            isLatest = readIsLatestFlag(buffer);
         } else {
             throw new StreamsException("Encountered unknown byte value `" + newOldFlag + "` for oldNewFlag in ChangedDeserializer.");
         }
 
         return new Change<>(
-                inner.deserialize(topic, headers, newData),
-                inner.deserialize(topic, headers, oldData));
+            inner.deserialize(topic, headers, newData),
+            inner.deserialize(topic, headers, oldData),
+            isLatest);
+    }
+
+    private boolean readIsLatestFlag(final ByteBuffer buffer) {
+        final byte isLatestFlag = buffer.get(buffer.capacity() - IS_LATEST_FLAG_SIZE - NEW_OLD_FLAG_SIZE);
+        if (isLatestFlag == (byte) 1) {
+            return true;
+        } else if (isLatestFlag == (byte) 0) {
+            return false;
+        } else {
+            throw new StreamsException("Encountered unexpected byte value `" + isLatestFlag + "` for isLatestFlag in ChangedDeserializer.");
+        }
     }
 
     @Override


### PR DESCRIPTION
https://github.com/apache/kafka/pull/13564 introduced a new boolean `isLatest` into `Change` to indicate whether a change update represents the latest for the key. Even though `Change` is serialized into the table repartition topic, the new boolean does not need to be serialized in, because the table repartition map processor performs an optimization to drop records for which `isLatest = false`. If not for this optimization, the downstream table aggregate would have to drop such records instead, and `isLatest` would need to be serialized into the repartition topic. 

In light of the possibility that `isLatest` may need to be serialized into the repartition topic in the future, e.g., if other downstream processors are added which need to distinguish between records for which `isLatest = true` vs `isLatest = false`, this PR reserves repartition topic formats which include `isLatest`. Reserving these formats now comes at no additional cost to users since a rolling bounce is already required for the upcoming release due to https://github.com/apache/kafka/pull/10747. If we don't reserve them now and instead have to add them later, then another bounce would be required at that time. Reserving formats is cheap, so we choose to do it now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
