### PR TITLE
MINOR: Update zstd-jni to 1.5.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -126,7 +126,7 @@ versions += [
   swaggerJaxrs2: "2.2.8",
   zinc: "1.8.0",
   zookeeper: "3.6.4",
-  zstd: "1.5.2-1"
+  zstd: "1.5.5-1"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
1.5.4 is a large release that offers significant performance improvements across
multiple scenarios, as well as new features.

1.5.5 is a smaller release that corrects a rare corruption bug and improves performance
in some scenarios.

It looks like 1.5.3 was retracted or never released.

Zstandard release notes:
* 1.5.4: https://github.com/facebook/zstd/releases/tag/v1.5.4
* 1.5.5: https://github.com/facebook/zstd/releases/tag/v1.5.5

zstd-jni diff: https://github.com/luben/zstd-jni/compare/v1.5.2-1...v1.5.5-1

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
