### PR TITLE
KAFKA-14906:Extract the coordinator service log from server log

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -57,6 +57,12 @@ log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
+log4j.appender.coordinatorAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.coordinatorAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.coordinatorAppender.File=${kafka.logs.dir}/coordinator.log
+log4j.appender.coordinatorAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.coordinatorAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
 # Change the line below to adjust ZK client logging
 log4j.logger.org.apache.zookeeper=INFO
 
@@ -83,6 +89,9 @@ log4j.additivity.org.apache.kafka.controller=false
 # Change the line below to adjust ZK mode controller logging
 log4j.logger.kafka.controller=TRACE, controllerAppender
 log4j.additivity.kafka.controller=false
+
+log4j.logger.kafka.coordinator=INFO, coordinatorAppender
+log4j.additivity.kafka.coordinator=false
 
 log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
 log4j.additivity.kafka.log.LogCleaner=false


### PR DESCRIPTION
Currently, the coordinator service log and server log are mixed together. When troubleshooting the coordinator problem, it is necessary to filter from the server log, which is not very convenient. Therefore, the coordinator log is separated like the controller log.