### PR TITLE
KAFKA-14907:Add the traffic metric of the partition dimension in BrokerTopicStats

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1057,8 +1057,10 @@ class ReplicaManager(val config: KafkaConfig,
           // update stats for successfully appended bytes and messages as bytesInRate and messageInRate
           brokerTopicStats.topicStats(topicPartition.topic).bytesInRate.mark(records.sizeInBytes)
           brokerTopicStats.allTopicsStats.bytesInRate.mark(records.sizeInBytes)
+          brokerTopicStats.topicPartitionStats(topicPartition).partitionBytesInRate.mark(records.sizeInBytes)
           brokerTopicStats.topicStats(topicPartition.topic).messagesInRate.mark(numAppendedMessages)
           brokerTopicStats.allTopicsStats.messagesInRate.mark(numAppendedMessages)
+          brokerTopicStats.topicPartitionStats(topicPartition).partitionMessagesInRate.mark(numAppendedMessages)
 
           if (traceEnabled)
             trace(s"${records.sizeInBytes} written to log $topicPartition beginning at offset " +


### PR DESCRIPTION
Currently, there are two metrics for measuring the traffic in topic dimensions: MessagesInPerSec, BytesInPerSec, but there are two problems:
1. It is difficult to intuitively reflect the problem of topic partition traffic inclination through these indicators, and it is impossible to clearly see which partition has the largest traffic and the traffic situation of each partition. But the partition dimension can solve this.
2. For the sudden increase in topic traffic (for example, this will lead some followers to out of Isr, which can be avoided by appropriately increasing the number of partitions.), the metrics of the partition dimension can help to provide guidance on whether to expand the partition.

On the whole, I think it is very meaningful to add traffic metrics of partition dimension, especially the issue of traffic skew.

The added two partition dimension metrics have passed the unit test in MetricsTest.