### PR TITLE
KAFKA-14908: Set setReuseAddress on the kafka server socket

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -723,6 +723,7 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
         new InetSocketAddress(host, port)
     val serverChannel = ServerSocketChannel.open()
     serverChannel.configureBlocking(false)
+    serverChannel.socket().setReuseAddress(true);
     if (recvBufferSize != Selectable.USE_DEFAULT_BUFFER_SIZE)
       serverChannel.socket().setReceiveBufferSize(recvBufferSize)
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -723,6 +723,9 @@ private[kafka] abstract class Acceptor(val socketServer: SocketServer,
         new InetSocketAddress(host, port)
     val serverChannel = ServerSocketChannel.open()
     serverChannel.configureBlocking(false)
+    // Configure the socket with setReuseAddress(true). This is done to aid use-cases where the kafka
+    // server is rapidly shut down and started up on the same port (e.g. application integration test suites
+    // that embed a kafka cluster).
     serverChannel.socket().setReuseAddress(true);
     if (recvBufferSize != Selectable.USE_DEFAULT_BUFFER_SIZE)
       serverChannel.socket().setReceiveBufferSize(recvBufferSize)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -20,7 +20,7 @@ package kafka.network
 import java.io._
 import java.net._
 import java.nio.ByteBuffer
-import java.nio.channels.{SelectionKey, SocketChannel}
+import java.nio.channels.{SelectionKey, ServerSocketChannel, SocketChannel}
 import java.nio.charset.StandardCharsets
 import java.util
 import java.util.concurrent.{CompletableFuture, ConcurrentLinkedQueue, ExecutionException, Executors, TimeUnit}
@@ -1891,6 +1891,33 @@ class SocketServerTest {
         assertTrue(connect(testableServer).isConnected)
       }
     }, false)
+  }
+
+  @Test
+  def testDataPlaneAcceptingSocketUsesReuseAddress(): Unit = {
+    val acceptor = server.dataPlaneAcceptor(listener)
+    val channel = acceptor.get.serverChannel
+    verifySocketUsesReuseAddress(channel)
+  }
+
+  @Test
+  def testControlPlaneAcceptingSocketUsesReuseAddress(): Unit = {
+    shutdownServerAndMetrics(server)
+    val testProps = new Properties
+    testProps ++= props
+    testProps.put("listeners", "PLAINTEXT://localhost:0,CONTROL_PLANE://localhost:0")
+    testProps.put("listener.security.protocol.map", "PLAINTEXT:PLAINTEXT,CONTROL_PLANE:PLAINTEXT")
+    testProps.put("control.plane.listener.name", "CONTROL_PLANE")
+    val config = KafkaConfig.fromProps(testProps)
+    val testServer = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager)
+    val channel = testServer.controlPlaneAcceptorOpt.get.serverChannel
+    verifySocketUsesReuseAddress(channel)
+    shutdownServerAndMetrics(testServer)
+  }
+
+  private def verifySocketUsesReuseAddress(channel: ServerSocketChannel): Unit = {
+    assertTrue(channel.socket().isBound, "Listening channel not bound")
+    assertTrue(channel.socket().getReuseAddress, "Listening socket reuseAddress in unexpected state")
   }
 
   /**


### PR DESCRIPTION
Changes `SocketServer` to set the `setReuseAddress(true)` socket option.

This aids use-cases where kafka is started/stopped on the same port in rapid succession. Examples are: where a kafka cluster is embedded in an integration test suite that starts/stops a cluster before/after each test.

I don't think this change brings any backward compatibility concerns, so I don't think it will need to be configurable.  However I can make it that way if necessary.

I have tested this change locally and confirmed that with the option the sporadic issue I see goes away.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
