### PR TITLE
MINOR: Assure no streamsProducer send after handling the serialization error.

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -1434,6 +1434,7 @@ public class RecordCollectorTest {
             final RecordCollector collector = newRecordCollector(new AlwaysContinueProductionExceptionHandler());
             collector.initialize();
 
+            assertThat(mockProducer.history().isEmpty(), equalTo(true));
             final StreamsException error = assertThrows(
                 StreamsException.class,
                 () -> collector.send(topic, true, "val", null, 0, null, (Serializer) errorSerializer, stringSerializer, sinkNodeName, context)


### PR DESCRIPTION
We want to make sure the streamsProducer doesn't send upon handling the error per comment here: https://github.com/apache/kafka/pull/13477/commits/510f2aaf0808d3c543720dec8a6dd6b455b41460