### PR TITLE
KAFKA-14904: Pending state blocked verification of transactions

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -344,9 +344,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 Left(Errors.INVALID_PRODUCER_ID_MAPPING)
               } else if (txnMetadata.producerEpoch != producerEpoch) {
                 Left(Errors.PRODUCER_FENCED)
-              } else if (txnMetadata.pendingTransitionInProgress && !(txnMetadata.pendingState == Some(Ongoing) && txnMetadata.state == Ongoing)) {
-                // return a retriable exception to let the client backoff and retry
-                Left(Errors.CONCURRENT_TRANSACTIONS)
               } else if (txnMetadata.state == PrepareCommit || txnMetadata.state == PrepareAbort) {
                 Left(Errors.CONCURRENT_TRANSACTIONS)
               } else {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.common.requests.{AddPartitionsToTxnResponse, Transaction
 import org.apache.kafka.common.utils.{LogContext, ProducerIdAndEpoch, Time}
 import org.apache.kafka.server.util.Scheduler
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 object TransactionCoordinator {
@@ -332,24 +331,45 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
       debug(s"Returning ${Errors.INVALID_REQUEST} error code to client for $transactionalId's AddPartitions request for verification")
       responseCallback(AddPartitionsToTxnResponse.resultForTransaction(transactionalId, partitions.map(_ -> Errors.INVALID_REQUEST).toMap.asJava))
     } else {
-      val result: ApiResult[(Int, TransactionMetadata)] = getTransactionMetadata(transactionalId, producerId, producerEpoch, partitions, true)
-      
+      val result: ApiResult[Map[TopicPartition, Errors]] =
+        txnManager.getTransactionState(transactionalId).flatMap {
+          case None => Left(Errors.INVALID_PRODUCER_ID_MAPPING)
+
+          case Some(epochAndMetadata) =>
+            val txnMetadata = epochAndMetadata.transactionMetadata
+
+            // generate the new transaction metadata with added partitions
+            txnMetadata.inLock {
+              if (txnMetadata.producerId != producerId) {
+                Left(Errors.INVALID_PRODUCER_ID_MAPPING)
+              } else if (txnMetadata.producerEpoch != producerEpoch) {
+                Left(Errors.PRODUCER_FENCED)
+              } else if (txnMetadata.pendingTransitionInProgress && !(txnMetadata.pendingState == Some(Ongoing) && txnMetadata.state == Ongoing)) {
+                // return a retriable exception to let the client backoff and retry
+                Left(Errors.CONCURRENT_TRANSACTIONS)
+              } else if (txnMetadata.state == PrepareCommit || txnMetadata.state == PrepareAbort) {
+                Left(Errors.CONCURRENT_TRANSACTIONS)
+              } else {
+                Right(partitions.map(part => 
+                  if (txnMetadata.topicPartitions.contains(part))
+                    (part, Errors.NONE)
+                  else
+                    (part, Errors.INVALID_TXN_STATE)
+                ).toMap)
+              }
+            }
+        }
+
       result match {
         case Left(err) =>
           debug(s"Returning $err error code to client for $transactionalId's AddPartitions request for verification")
           responseCallback(AddPartitionsToTxnResponse.resultForTransaction(transactionalId, partitions.map(_ -> err).toMap.asJava))
-
-        case Right((_, txnMetadata)) =>
-          val errors = mutable.Map[TopicPartition, Errors]()
-          partitions.foreach { tp => 
-            if (txnMetadata.topicPartitions.contains(tp))
-              errors.put(tp, Errors.NONE)
-            else
-              errors.put(tp, Errors.INVALID_TXN_STATE)  
-          }
+          
+        case Right(errors) =>
           responseCallback(AddPartitionsToTxnResponse.resultForTransaction(transactionalId, errors.asJava))
       }
     }
+    
   }
 
   def handleAddPartitionsToTransaction(transactionalId: String,
@@ -364,56 +384,42 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     } else {
       // try to update the transaction metadata and append the updated metadata to txn log;
       // if there is no such metadata treat it as invalid producerId mapping error.
-      val result: ApiResult[(Int, TransactionMetadata)] = getTransactionMetadata(transactionalId, producerId, producerEpoch, partitions, false)
+      val result: ApiResult[(Int, TxnTransitMetadata)] = txnManager.getTransactionState(transactionalId).flatMap {
+        case None => Left(Errors.INVALID_PRODUCER_ID_MAPPING)
+
+        case Some(epochAndMetadata) =>
+          val coordinatorEpoch = epochAndMetadata.coordinatorEpoch
+          val txnMetadata = epochAndMetadata.transactionMetadata
+
+          // generate the new transaction metadata with added partitions
+          txnMetadata.inLock {
+            if (txnMetadata.producerId != producerId) {
+              Left(Errors.INVALID_PRODUCER_ID_MAPPING)
+            } else if (txnMetadata.producerEpoch != producerEpoch) {
+              Left(Errors.PRODUCER_FENCED)
+            } else if (txnMetadata.pendingTransitionInProgress) {
+              // return a retriable exception to let the client backoff and retry
+              Left(Errors.CONCURRENT_TRANSACTIONS)
+            } else if (txnMetadata.state == PrepareCommit || txnMetadata.state == PrepareAbort) {
+              Left(Errors.CONCURRENT_TRANSACTIONS)
+            } else if (txnMetadata.state == Ongoing && partitions.subsetOf(txnMetadata.topicPartitions)) {
+              // this is an optimization: if the partitions are already in the metadata reply OK immediately
+              Left(Errors.NONE)
+            } else {
+              Right(coordinatorEpoch, txnMetadata.prepareAddPartitions(partitions.toSet, time.milliseconds()))
+            }
+          }
+      }
 
       result match {
         case Left(err) =>
           debug(s"Returning $err error code to client for $transactionalId's AddPartitions request")
           responseCallback(err)
 
-        case Right((coordinatorEpoch, txnMetadata)) =>
-          txnManager.appendTransactionToLog(transactionalId, coordinatorEpoch, txnMetadata.prepareAddPartitions(partitions.toSet, time.milliseconds()),
+        case Right((coordinatorEpoch, newMetadata)) =>
+          txnManager.appendTransactionToLog(transactionalId, coordinatorEpoch, newMetadata,
             responseCallback, requestLocal = requestLocal)
       }
-    }
-  }
-  
-  private def getTransactionMetadata(transactionalId: String,
-                                     producerId: Long,
-                                     producerEpoch: Short,
-                                     partitions: collection.Set[TopicPartition],
-                                     verifyOnly: Boolean): ApiResult[(Int, TransactionMetadata)] = {
-    txnManager.getTransactionState(transactionalId).flatMap {
-      case None => Left(Errors.INVALID_PRODUCER_ID_MAPPING)
-
-      case Some(epochAndMetadata) =>
-        val coordinatorEpoch = epochAndMetadata.coordinatorEpoch
-        val txnMetadata = epochAndMetadata.transactionMetadata
-
-        // generate the new transaction metadata with added partitions
-        txnMetadata.inLock {
-          if (txnMetadata.producerId != producerId) {
-            Left(Errors.INVALID_PRODUCER_ID_MAPPING)
-          } else if (txnMetadata.producerEpoch != producerEpoch) {
-            Left(Errors.PRODUCER_FENCED)
-          } else if (txnMetadata.pendingTransitionInProgress) {
-            // If we are in the produce path, we want to avoid OutOfOrderSequence errors if the added partition is pending.
-            // Part 2 of KIP-890 will always start transactions with sequence 0, so we enforce that and avoid this workaround.
-            if (verifyOnly && txnMetadata.pendingState == Some(Ongoing) && partitions.subsetOf(txnMetadata.topicPartitions)) {
-              Left(Errors.NONE)
-            } else {
-              // return a retriable exception to let the client backoff and retry
-              Left(Errors.CONCURRENT_TRANSACTIONS)
-            }
-          } else if (txnMetadata.state == PrepareCommit || txnMetadata.state == PrepareAbort) {
-            Left(Errors.CONCURRENT_TRANSACTIONS)
-          } else if (txnMetadata.state == Ongoing && partitions.subsetOf(txnMetadata.topicPartitions)) {
-            // this is an optimization: if the partitions are already in the metadata reply OK immediately
-            Left(Errors.NONE)
-          } else {
-            Right(coordinatorEpoch, txnMetadata)
-          }
-        }
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -398,7 +398,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
             Left(Errors.PRODUCER_FENCED)
           } else if (txnMetadata.pendingTransitionInProgress) {
             // If we are in the produce path, we want to avoid OutOfOrderSequence errors if the added partition is pending.
-            // TODO: Part 2 of KIP-890 will always start transactions with sequence 0, so we enforce that and avoid this workaround.
+            // Part 2 of KIP-890 will always start transactions with sequence 0, so we enforce that and avoid this workaround.
             if (verifyOnly && txnMetadata.pendingState == Some(Ongoing) && partitions.subsetOf(txnMetadata.topicPartitions)) {
               Left(Errors.NONE)
             } else {


### PR DESCRIPTION
[KAFKA-14561](https://github.com/apache/kafka/commit/56dcb837a2f1c1d8c016cfccf8268a910bb77a36) added verification to transactional produce requests to confirm an ongoing transaction.

There is an edge case where the transaction is added, but the coordinator is writing to the log for another partition. In this case, when verifying, we return CONCURRENT_TRANSACTIONS and retry. However, the next inflight batch is often successful because the write completes. 

When a partition has no entry in the PSM, it will allow any sequence number. This means if we retry the first write to the partition (or first write in a while) we will never be able to write it and get OutOfOrderSequence exceptions. This is a known issue. Since the verification makes this more common, I propose allowing verification on pending ongoing state since the pending state doesn't prevent us from checking the already added partitions.

The good news is part 2 of KIP-890 will allow us to enforce that the first write for a transaction is sequence 0 and this issue will go away entirely.  

This PR also adds the locking back into the addPartitions/verify path that was incorrectly removed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
