### PR TITLE
MINOR: Debug EmbeddedConnect/KafkaCluster failures

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -181,7 +181,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         backupWorkerProps.putAll(mm2Config.workerConfig(new SourceAndTarget(PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS)));
         
         primary = new EmbeddedConnectCluster.Builder()
-                .name(PRIMARY_CLUSTER_ALIAS + "-connect-cluster")
+                .name(getClass().getSimpleName() + "-" + PRIMARY_CLUSTER_ALIAS + "-connect-cluster")
                 .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .brokerProps(primaryBrokerProps)
@@ -191,7 +191,7 @@ public class MirrorConnectorsIntegrationBaseTest {
                 .build();
 
         backup = new EmbeddedConnectCluster.Builder()
-                .name(BACKUP_CLUSTER_ALIAS + "-connect-cluster")
+                .name(getClass().getSimpleName() + "-" + BACKUP_CLUSTER_ALIAS + "-connect-cluster")
                 .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .brokerProps(backupBrokerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -119,7 +119,7 @@ public class BlockingConnectorTest {
     public void setup() throws Exception {
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .workerProps(new HashMap<>())

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -90,7 +90,7 @@ public class ConnectWorkerIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connectBuilder = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorClientPolicyIntegrationTest.java
@@ -112,7 +112,7 @@ public class ConnectorClientPolicyIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         EmbeddedConnectCluster connect = new EmbeddedConnectCluster.Builder()
-            .name("connect-cluster")
+            .name(getClass().getSimpleName() + "-cluster")
             .numWorkers(NUM_WORKERS)
             .numBrokers(1)
             .workerProps(workerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -102,7 +102,7 @@ public class ConnectorRestartApiIntegrationTest {
             brokerProps.put("auto.create.topics.enable", String.valueOf(false));
 
             EmbeddedConnectCluster.Builder connectBuilder = new EmbeddedConnectCluster.Builder()
-                    .name("connect-cluster")
+                    .name(getClass().getSimpleName() + "-cluster")
                     .numWorkers(numWorkers)
                     .workerProps(workerProps)
                     .brokerProps(brokerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
@@ -92,7 +92,7 @@ public class ConnectorTopicsIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connectBuilder = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -86,7 +86,7 @@ public class ExampleConnectIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .workerProps(exampleWorkerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -63,7 +63,7 @@ public class InternalTopicsIntegrationTest {
     public void testCreateInternalTopicsWithDefaultSettings() throws InterruptedException {
         int numWorkers = 1;
         int numBrokers = 3;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+        connect = new EmbeddedConnectCluster.Builder().name(getClass().getSimpleName() + "-cluster")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)
@@ -102,7 +102,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
         int numWorkers = 1;
         int numBrokers = 2;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+        connect = new EmbeddedConnectCluster.Builder().name(getClass().getSimpleName() + "-cluster")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)
@@ -128,7 +128,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
         int numWorkers = 1;
         int numBrokers = 1;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+        connect = new EmbeddedConnectCluster.Builder().name(getClass().getSimpleName() + "-cluster")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)
@@ -159,7 +159,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
         int numWorkers = 0;
         int numBrokers = 1;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+        connect = new EmbeddedConnectCluster.Builder().name(getClass().getSimpleName() + "-cluster")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)
@@ -233,7 +233,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
         int numWorkers = 0;
         int numBrokers = 1;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+        connect = new EmbeddedConnectCluster.Builder().name(getClass().getSimpleName() + "-cluster")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -76,7 +76,7 @@ public class OffsetsApiIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .workerProps(workerProps)
                 .build();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -91,7 +91,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .workerProps(workerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
@@ -68,7 +68,7 @@ public class RestExtensionIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-            .name("connect-cluster")
+            .name(getClass().getSimpleName() + "-cluster")
             .numWorkers(NUM_WORKERS)
             .numBrokers(1)
             .workerProps(workerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java
@@ -67,7 +67,7 @@ public class SessionedProtocolIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-            .name("connect-cluster")
+            .name(getClass().getSimpleName() + "-cluster")
             .numWorkers(2)
             .numBrokers(1)
             .workerProps(workerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
@@ -77,7 +77,7 @@ public class SinkConnectorsIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
@@ -82,7 +82,7 @@ public class SourceConnectorsIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connectBuilder = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -86,7 +86,7 @@ public class TransformationIntegrationTest {
 
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
+                .name(getClass().getSimpleName() + "-cluster")
                 .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .workerProps(workerProps)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -209,25 +209,29 @@ public class EmbeddedKafkaCluster {
         }
 
         for (KafkaServer broker : brokers) {
-            try {
-                broker.shutdown();
-            } catch (Throwable t) {
-                String msg = String.format("Could not shutdown broker at %s", address(broker));
-                log.error(msg, t);
-                throw new RuntimeException(msg, t);
+            if (broker != null) {
+                try {
+                    broker.shutdown();
+                } catch (Throwable t) {
+                    String msg = String.format("Could not shutdown broker at %s", address(broker));
+                    log.error(msg, t);
+                    throw new RuntimeException(msg, t);
+                }
             }
         }
 
         if (deleteLogDirs) {
             for (KafkaServer broker : brokers) {
-                try {
-                    log.info("Cleaning up kafka log dirs at {}", broker.config().logDirs());
-                    CoreUtils.delete(broker.config().logDirs());
-                } catch (Throwable t) {
-                    String msg = String.format("Could not clean up log dirs for broker at %s",
-                            address(broker));
-                    log.error(msg, t);
-                    throw new RuntimeException(msg, t);
+                if (broker != null) {
+                    try {
+                        log.info("Cleaning up kafka log dirs at {}", broker.config().logDirs());
+                        CoreUtils.delete(broker.config().logDirs());
+                    } catch (Throwable t) {
+                        String msg = String.format("Could not clean up log dirs for broker at %s",
+                                address(broker));
+                        log.error(msg, t);
+                        throw new RuntimeException(msg, t);
+                    }
                 }
             }
         }


### PR DESCRIPTION
It appears that very rarely the EmbeddedConnectCluster will not come up, possibly due to the underlying EmbeddedKafkaCluster being unhealthy. This PR is trying to improve the debug info for this failure when it occurs again in the future.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
