### PR TITLE
MINOR: Correct type of record batch CRC field

### DIFF
--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -36,7 +36,7 @@
 batchLength: int32
 partitionLeaderEpoch: int32
 magic: int8 (current magic value is 2)
-crc: int32
+crc: uint32
 attributes: int16
     bit 0~2:
         0: no compression


### PR DESCRIPTION
The CRC field of Record Batch was incorrectly documented as int32 while in reality it's an [unsigned uint32 field](https://github.com/apache/kafka/blob/9c12e462106343fbc6af5873074d48f98687af39/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java#L52).
<!--
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
-->
### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
