### PR TITLE
KAFKA-14876: Document the new 'GET /connectors/{name}/offsets' REST API for Connect

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -312,6 +312,7 @@ listeners=http://localhost:8080,https://localhost:8443</pre>
         <li><code>DELETE /connectors/{name}</code> - delete a connector, halting all tasks and deleting its configuration</li>
         <li><code>GET /connectors/{name}/topics</code> - get the set of topics that a specific connector is using since the connector was created or since a request to reset its set of active topics was issued</li>
         <li><code>PUT /connectors/{name}/topics/reset</code> - send a request to empty the set of active topics of a connector</li>
+        <li><code>GET /connectors/{name}/offsets</code> - get the current offsets for a connector (see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect">KIP-875</a> for more details)</li>
     </ul>
 
     <p>Kafka Connect also provides a REST API for getting information about connector plugins:</p>


### PR DESCRIPTION
- Adds documentation for the new `GET /connectors/{name}/offsets` REST API for Connect (see [KIP-875](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect))
- https://github.com/apache/kafka/pull/13434

<img width="1728" alt="Screenshot 2023-04-17 at 9 40 48 PM" src="https://user-images.githubusercontent.com/23502577/232546534-b42fa9e7-4051-453d-a860-65f3014698c3.png">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
