### PR TITLE
[MINOR]: Fixing gradle build during compileScala and compileTestScala

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -454,7 +454,7 @@ public class RemoteLogManager implements Closeable {
                 // This is found by traversing from the latest leader epoch from leader epoch history and find the highest offset
                 // of a segment with that epoch copied into remote storage. If it can not find an entry then it checks for the
                 // previous leader epoch till it finds an entry, If there are no entries till the earliest leader epoch in leader
-                // epoch cache then it starts copying the segments from the earliest epoch entry’s offset.
+                // epoch cache then it starts copying the segments from the earliest epoch entry's offset.
                 copiedOffsetOption = OptionalLong.of(findHighestRemoteOffset(topicIdPartition));
             }
         }

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -202,7 +202,7 @@ public class RemoteLogManagerTest {
     }
 
     // This test creates 2 log segments, 1st one has start offset of 0, 2nd one (and active one) has start offset of 150.
-    // The leader epochs are [0->0, 1->100, 2->200]. We are verifying：
+    // The leader epochs are [0->0, 1->100, 2->200]. We are verifying:
     // 1. There's only 1 segment copied to remote storage
     // 2. The segment got copied to remote storage is the old segment, not the active one
     // 3. The log segment metadata stored into remoteLogMetadataManager is what we expected, both before and after copying the log segments


### PR DESCRIPTION
@satishd , I am getting a gradle build failure (using Intellij gradle plugin) during compileScala and compileTestScala because of what seems to be a non-ASCII character in RemoteLogManager.java and RemoteLogManagerTest.java. The errors that I get are :

```
[Error] /Users/sagarrao/gitprojects/kafka/core/src/test/java/kafka/log/remote/RemoteLogManager.java:457:  error: unmappable character for encoding ASCII
```

and 

```
[Error] /Users/sagarrao/gitprojects/kafka/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java:205:  error: unmappable character for encoding ASCII
```

With these changes, the build seems to be working. Let me know if this PR makes sense. 