### PR TITLE
KAFKA-14862: Outer stream-stream join does not output all results with multiple input partitions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.WindowedStreamProcessorNode;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSide;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -43,6 +44,7 @@ import org.apache.kafka.streams.state.internals.LeftOrRightValueSerde;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -56,6 +58,18 @@ class KStreamImplJoin {
     private final InternalStreamsBuilder builder;
     private final boolean leftOuter;
     private final boolean rightOuter;
+
+    static class TimeTrackerSupplier {
+        private final Map<TaskId, TimeTracker> tracker = new HashMap<>();
+
+        public TimeTracker get(final TaskId taskId) {
+            return tracker.computeIfAbsent(taskId, taskId1 -> new TimeTracker());
+        }
+
+        public void remove(final TaskId taskId) {
+            tracker.remove(taskId);
+        }
+    }
 
     static class TimeTracker {
         private long emitIntervalMs = 1000L;
@@ -159,7 +173,7 @@ class KStreamImplJoin {
         }
 
         // Time-shared between joins to keep track of the maximum stream time
-        final TimeTracker sharedTimeTracker = new TimeTracker();
+        final TimeTrackerSupplier sharedTimeTrackerSupplier = new TimeTrackerSupplier();
 
         final JoinWindowsInternal internalWindows = new JoinWindowsInternal(windows);
         final KStreamKStreamJoin<K, V1, V2, VOut> joinThis = new KStreamKStreamJoin<>(
@@ -169,7 +183,7 @@ class KStreamImplJoin {
             joiner,
             leftOuter,
             outerJoinWindowStore.map(StoreBuilder::name),
-            sharedTimeTracker
+            sharedTimeTrackerSupplier
         );
 
         final KStreamKStreamJoin<K, V2, V1, VOut> joinOther = new KStreamKStreamJoin<>(
@@ -179,14 +193,13 @@ class KStreamImplJoin {
             AbstractStream.reverseJoinerWithKey(joiner),
             rightOuter,
             outerJoinWindowStore.map(StoreBuilder::name),
-            sharedTimeTracker
+            sharedTimeTrackerSupplier
         );
 
         final KStreamKStreamSelfJoin<K, V1, V2, VOut> selfJoin = new KStreamKStreamSelfJoin<>(
             thisWindowStore.name(),
             internalWindows,
             joiner,
-            sharedTimeTracker,
             windows.size() + windows.gracePeriodMs()
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKStreamIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKStreamIntegrationTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+import kafka.utils.MockTime;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.asList;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@Timeout(600)
+@Tag("integration")
+public class KStreamKStreamIntegrationTest {
+    private final static int NUM_BROKERS = 1;
+
+    public final static EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    private final static MockTime MOCK_TIME = CLUSTER.time;
+    private final static String STREAM_1 = "stream1";
+    private final static String STREAM_2 = "stream2";
+    private final static String OUTPUT = "output-";
+    private Properties streamsConfig;
+    private KafkaStreams streams;
+    private final static Properties CONSUMER_CONFIG = new Properties();
+    private final static Properties PRODUCER_CONFIG = new Properties();
+
+    @BeforeAll
+    public static void startCluster() throws Exception {
+        CLUSTER.start();
+        //Use multiple partitions to ensure distribution of keys.
+
+        CLUSTER.createTopic(STREAM_1, 4, 1);
+        CLUSTER.createTopic(STREAM_2, 4, 1);
+        CLUSTER.createTopic(OUTPUT, 1, 1);
+
+        CONSUMER_CONFIG.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        CONSUMER_CONFIG.put(ConsumerConfig.GROUP_ID_CONFIG, "result-consumer");
+        CONSUMER_CONFIG.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        CONSUMER_CONFIG.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    }
+
+    @AfterAll
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    @BeforeEach
+    public void before(final TestInfo testInfo) throws IOException {
+        final String stateDirBasePath = TestUtils.tempDirectory().getPath();
+        final String safeTestName = safeUniqueTestName(getClass(), testInfo);
+        streamsConfig = getStreamsConfig(safeTestName);
+        streamsConfig.put(StreamsConfig.STATE_DIR_CONFIG, stateDirBasePath);
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        if (streams != null) {
+            streams.close();
+            streams = null;
+        }
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfig);
+    }
+
+    @Test
+    public void shouldOuterJoin() throws Exception {
+        final Set<KeyValue<String, String>> expectedOne = new HashSet<>();
+        expectedOne.add(new KeyValue<>("Key-1", "value1=left-1,value2=null"));
+        expectedOne.add(new KeyValue<>("Key-2", "value1=left-2,value2=null"));
+        expectedOne.add(new KeyValue<>("Key-3", "value1=left-3,value2=null"));
+        expectedOne.add(new KeyValue<>("Key-4", "value1=left-4,value2=null"));
+
+        verifyKStreamKStreamOuterJoin(expectedOne);
+    }
+
+    private void verifyKStreamKStreamOuterJoin(final Set<KeyValue<String, String>> expectedResult) throws Exception {
+        streams = prepareTopology(streamsConfig);
+
+        startApplicationAndWaitUntilRunning(Collections.singletonList(streams), ofSeconds(120));
+
+        PRODUCER_CONFIG.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        PRODUCER_CONFIG.put(ProducerConfig.ACKS_CONFIG, "all");
+        PRODUCER_CONFIG.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        PRODUCER_CONFIG.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        final List<KeyValue<String, String>> stream1 = asList(
+                new KeyValue<>("Key-1", "left-1"),
+                new KeyValue<>("Key-2", "left-2"),
+                new KeyValue<>("Key-3", "left-3"),
+                new KeyValue<>("Key-4", "left-4")
+        );
+
+        final List<KeyValue<String, String>> stream2 = asList(
+                new KeyValue<>("Key-1", "right-1"),
+                new KeyValue<>("Key-2", "right-2"),
+                new KeyValue<>("Key-3", "right-3"),
+                new KeyValue<>("Key-4", "right-4")
+        );
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(STREAM_1, stream1, PRODUCER_CONFIG, MOCK_TIME);
+        MOCK_TIME.sleep(11000);
+        Thread.sleep(11000);
+        IntegrationTestUtils.produceKeyValuesSynchronously(STREAM_1, stream2, PRODUCER_CONFIG, MOCK_TIME);
+
+        final Set<KeyValue<String, String>> result = new HashSet<>(waitUntilMinKeyValueRecordsReceived(
+            CONSUMER_CONFIG,
+            OUTPUT,
+            expectedResult.size()));
+
+        assertThat(expectedResult, equalTo(result));
+    }
+
+    private Properties getStreamsConfig(final String testName) {
+        final Properties streamsConfig = new Properties();
+        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "KStream-KStream-join" + testName);
+        streamsConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfig.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        streamsConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        streamsConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+
+        return streamsConfig;
+    }
+
+    private static KafkaStreams prepareTopology(final Properties streamsConfig) {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<String, String> stream1 = builder.stream(STREAM_1);
+        final KStream<String, String> stream2 = builder.stream(STREAM_2);
+
+        final ValueJoiner<String, String, String> joiner = (value1, value2) -> "value1=" + value1 + ",value2=" + value2;
+
+        stream1.outerJoin(stream2, joiner, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(10))).to(OUTPUT);
+
+        return new KafkaStreams(builder.build(streamsConfig), streamsConfig);
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKStreamIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKStreamIntegrationTest.java
@@ -65,9 +65,9 @@ public class KStreamKStreamIntegrationTest {
 
     public final static EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
     private final static MockTime MOCK_TIME = CLUSTER.time;
-    private final static String STREAM_1 = "stream1";
-    private final static String STREAM_2 = "stream2";
-    private final static String OUTPUT = "output-";
+    private final static String LEFT_STREAM = "leftStream";
+    private final static String RIGHT_STREAM = "rightStream";
+    private final static String OUTPUT = "output";
     private Properties streamsConfig;
     private KafkaStreams streams;
     private final static Properties CONSUMER_CONFIG = new Properties();
@@ -78,8 +78,8 @@ public class KStreamKStreamIntegrationTest {
         CLUSTER.start();
 
         //Use multiple partitions to ensure distribution of keys.
-        CLUSTER.createTopic(STREAM_1, 4, 1);
-        CLUSTER.createTopic(STREAM_2, 4, 1);
+        CLUSTER.createTopic(LEFT_STREAM, 4, 1);
+        CLUSTER.createTopic(RIGHT_STREAM, 4, 1);
         CLUSTER.createTopic(OUTPUT, 4, 1);
 
         CONSUMER_CONFIG.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
@@ -145,9 +145,9 @@ public class KStreamKStreamIntegrationTest {
                 new KeyValue<>("Key-4", "left-4b")
         );
 
-        IntegrationTestUtils.produceKeyValuesSynchronously(STREAM_1, left1, PRODUCER_CONFIG, MOCK_TIME);
+        IntegrationTestUtils.produceKeyValuesSynchronously(LEFT_STREAM, left1, PRODUCER_CONFIG, MOCK_TIME);
         MOCK_TIME.sleep(10000);
-        IntegrationTestUtils.produceKeyValuesSynchronously(STREAM_1, left2, PRODUCER_CONFIG, MOCK_TIME);
+        IntegrationTestUtils.produceKeyValuesSynchronously(LEFT_STREAM, left2, PRODUCER_CONFIG, MOCK_TIME);
 
         final Set<KeyValue<String, String>> result = new HashSet<>(waitUntilMinKeyValueRecordsReceived(
             CONSUMER_CONFIG,
@@ -172,8 +172,8 @@ public class KStreamKStreamIntegrationTest {
     private static KafkaStreams prepareTopology(final Properties streamsConfig) {
         final StreamsBuilder builder = new StreamsBuilder();
 
-        final KStream<String, String> stream1 = builder.stream(STREAM_1);
-        final KStream<String, String> stream2 = builder.stream(STREAM_2);
+        final KStream<String, String> stream1 = builder.stream(LEFT_STREAM);
+        final KStream<String, String> stream2 = builder.stream(RIGHT_STREAM);
 
         final ValueJoiner<String, String, String> joiner = (value1, value2) -> "value1=" + value1 + ",value2=" + value2;
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -362,7 +362,7 @@ public class KStreamKStreamJoinTest {
         /**
          * This test is testing something internal to [[KStreamKStreamJoin]], so we had to setup low-level api manually.
          */
-        final KStreamImplJoin.TimeTracker tracker = new KStreamImplJoin.TimeTracker();
+        final KStreamImplJoin.TimeTrackerSupplier tracker = new KStreamImplJoin.TimeTrackerSupplier();
         final KStreamKStreamJoin<String, String, String, String> join = new KStreamKStreamJoin<>(
                 false,
                 "other",


### PR DESCRIPTION
Stream-stream outer join, uses a "shared time tracker" to track stream-time progress for left and right input in a single place. This time tracker is incorrectly shared across tasks.

This PR introduces a supplier to create a "shared time tracker" object per task, to be shared between the left and right join processors.
