### PR TITLE
KAFKA-14903 MM2 GroupListener and TopicListener plugins

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultGroupListener.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultGroupListener.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.mirror;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * NOP implementation of {@link GroupListener}.
+ */
+public class DefaultGroupListener implements GroupListener {
+    @Override
+    public void groupsChanged(List<String> checkpointedGroups) {
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultTopicListener.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultTopicListener.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.mirror;
+
+import java.util.Map;
+
+/**
+ * NOP implementation of {@link TopicListener}.
+ */
+public class DefaultTopicListener implements TopicListener {
+    @Override
+    public void topicsChanged(Map<String, String> upstreamToDownstreamTopics) {
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/GroupListener.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/GroupListener.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.Configurable;
+
+import java.util.List;
+
+/**
+ * Listens to changes of checkpointed groups.
+ */
+public interface GroupListener extends Configurable, AutoCloseable {
+    /**
+     * Invoked with the latest checkpointed groups.
+     * @param checkpointedGroups The groups which are being checkpointed.
+     */
+    void groupsChanged(List<String> checkpointedGroups);
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
@@ -77,6 +77,10 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
     public static final String OFFSET_SYNCS_TARGET_CONSUMER_ROLE = "offset-syncs-target-consumer";
     public static final String OFFSET_SYNCS_SOURCE_ADMIN_ROLE = "offset-syncs-source-admin";
     public static final String OFFSET_SYNCS_TARGET_ADMIN_ROLE = "offset-syncs-target-admin";
+    public static final String GROUP_LISTENER_CLASS_CONFIG = "group.listener.class";
+    public static final Class<? extends GroupListener> GROUP_LISTENER_CLASS_DEFAULT = DefaultGroupListener.class;
+    public static final String GROUP_LISTENER_CLASS_DOC =
+            "Class listening to changes in the list of checkpointed groups.";
 
     public MirrorCheckpointConfig(Map<String, String> props) {
         super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{
@@ -165,6 +169,10 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
         return Duration.ofMillis(getLong(CONSUMER_POLL_TIMEOUT_MILLIS));
     }
 
+    GroupListener groupListener() {
+        return getConfiguredInstance(GROUP_LISTENER_CLASS_CONFIG, GroupListener.class);
+    }
+
     protected static final ConfigDef CONNECTOR_CONFIG_DEF = new ConfigDef(BASE_CONNECTOR_CONFIG_DEF)
             .define(
                     CONSUMER_POLL_TIMEOUT_MILLIS,
@@ -250,7 +258,13 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
                     ConfigDef.Type.CLASS,
                     TOPIC_FILTER_CLASS_DEFAULT,
                     ConfigDef.Importance.LOW,
-                    TOPIC_FILTER_CLASS_DOC);
+                    TOPIC_FILTER_CLASS_DOC)
+            .define(
+                    GROUP_LISTENER_CLASS_CONFIG,
+                    ConfigDef.Type.CLASS,
+                    GROUP_LISTENER_CLASS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    GROUP_LISTENER_CLASS_DOC);
 
     public static void main(String[] args) {
         System.out.println(CONNECTOR_CONFIG_DEF.toHtml(4, config -> "mirror_checkpoint_" + config));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -114,6 +114,10 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
     public static final String OFFSET_SYNCS_TARGET_PRODUCER_ROLE = "offset-syncs-target-producer";
     public static final String OFFSET_SYNCS_SOURCE_ADMIN_ROLE = "offset-syncs-source-admin";
     public static final String OFFSET_SYNCS_TARGET_ADMIN_ROLE = "offset-syncs-target-admin";
+    public static final String TOPIC_LISTENER_CLASS_CONFIG = "topic.listener.class";
+    public static final Class<? extends TopicListener> TOPIC_LISTENER_CLASS_DEFAULT = DefaultTopicListener.class;
+    public static final String TOPIC_LISTENER_CLASS_DOC =
+            "Class listening to changes in the list of replicated topics.";
 
     public MirrorSourceConfig(Map<String, String> props) {
         super(CONNECTOR_CONFIG_DEF, ConfigUtils.translateDeprecatedConfigs(props, new String[][]{
@@ -223,6 +227,10 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
 
     boolean addSourceAliasToMetrics() {
         return getBoolean(ADD_SOURCE_ALIAS_TO_METRICS);
+    }
+
+    TopicListener topicListener() {
+        return getConfiguredInstance(TOPIC_LISTENER_CLASS_CONFIG, TopicListener.class);
     }
 
     protected static final ConfigDef CONNECTOR_CONFIG_DEF = new ConfigDef(BASE_CONNECTOR_CONFIG_DEF)
@@ -347,7 +355,13 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
                     ConfigDef.Type.BOOLEAN,
                     ADD_SOURCE_ALIAS_TO_METRICS_DEFAULT,
                     ConfigDef.Importance.LOW,
-                    ADD_SOURCE_ALIAS_TO_METRICS_DOC);
+                    ADD_SOURCE_ALIAS_TO_METRICS_DOC)
+            .define(
+                    TOPIC_LISTENER_CLASS_CONFIG,
+                    ConfigDef.Type.CLASS,
+                    TOPIC_LISTENER_CLASS_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    TOPIC_LISTENER_CLASS_DOC);
 
     public static void main(String[] args) {
         System.out.println(CONNECTOR_CONFIG_DEF.toHtml(4, config -> "mirror_source_" + config));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicListener.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicListener.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Map;
+
+/**
+ * Listens to changes of replicated topics.
+ */
+@InterfaceStability.Evolving
+public interface TopicListener extends Configurable, AutoCloseable {
+    /**
+     * Invoked with the latest replicated topics.
+     * @param upstreamToDownstreamTopics Replicated topics, key is the upstream, value is the downstream topic.
+     */
+    void topicsChanged(Map<String, String> upstreamToDownstreamTopics);
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -98,7 +98,8 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testReplicatesHeartbeatsByDefault() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+            new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter(),
+            new DefaultTopicListener());
         assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
         assertTrue(connector.shouldReplicateTopic("us-west.heartbeats"), "should replicate upstream heartbeats");
     }
@@ -106,7 +107,7 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testReplicatesHeartbeatsDespiteFilter() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), x -> false, new DefaultConfigPropertyFilter());
+            new DefaultReplicationPolicy(), x -> false, new DefaultConfigPropertyFilter(), new DefaultTopicListener());
         assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
         assertTrue(connector.shouldReplicateTopic("us-west.heartbeats"), "should replicate upstream heartbeats");
     }
@@ -114,7 +115,7 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testNoCycles() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), x -> true, getConfigPropertyFilter());
+            new DefaultReplicationPolicy(), x -> true, getConfigPropertyFilter(), new DefaultTopicListener());
         assertFalse(connector.shouldReplicateTopic("target.topic1"), "should not allow cycles");
         assertFalse(connector.shouldReplicateTopic("target.source.topic1"), "should not allow cycles");
         assertFalse(connector.shouldReplicateTopic("source.target.topic1"), "should not allow cycles");
@@ -127,7 +128,7 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testIdentityReplication() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new IdentityReplicationPolicy(), x -> true, getConfigPropertyFilter());
+            new IdentityReplicationPolicy(), x -> true, getConfigPropertyFilter(), new DefaultTopicListener());
         assertTrue(connector.shouldReplicateTopic("target.topic1"), "should allow cycles");
         assertTrue(connector.shouldReplicateTopic("target.source.topic1"), "should allow cycles");
         assertTrue(connector.shouldReplicateTopic("source.target.topic1"), "should allow cycles");
@@ -147,7 +148,7 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testAclFiltering() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), x -> true, getConfigPropertyFilter());
+            new DefaultReplicationPolicy(), x -> true, getConfigPropertyFilter(), new DefaultTopicListener());
         assertFalse(connector.shouldReplicateAcl(
             new AclBinding(new ResourcePattern(ResourceType.TOPIC, "test_topic", PatternType.LITERAL),
             new AccessControlEntry("kafka", "", AclOperation.WRITE, AclPermissionType.ALLOW))), "should not replicate ALLOW WRITE");
@@ -159,7 +160,7 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testAclTransformation() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), x -> true, getConfigPropertyFilter());
+            new DefaultReplicationPolicy(), x -> true, getConfigPropertyFilter(), new DefaultTopicListener());
         AclBinding allowAllAclBinding = new AclBinding(
             new ResourcePattern(ResourceType.TOPIC, "test_topic", PatternType.LITERAL),
             new AccessControlEntry("kafka", "", AclOperation.ALL, AclPermissionType.ALLOW));
@@ -226,7 +227,7 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testConfigPropertyFiltering() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-            new DefaultReplicationPolicy(), x -> true, new DefaultConfigPropertyFilter());
+            new DefaultReplicationPolicy(), x -> true, new DefaultConfigPropertyFilter(), new DefaultTopicListener());
         ArrayList<ConfigEntry> entries = new ArrayList<>();
         entries.add(new ConfigEntry("name-1", "value-1"));
         entries.add(new ConfigEntry("name-2", "value-2", ConfigEntry.ConfigSource.DEFAULT_CONFIG, false, false, Collections.emptyList(), ConfigEntry.ConfigType.STRING, ""));
@@ -245,7 +246,8 @@ public class MirrorSourceConnectorTest {
     @Deprecated
     public void testConfigPropertyFilteringWithAlterConfigs() {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(), x -> true, new DefaultConfigPropertyFilter());
+                new DefaultReplicationPolicy(), x -> true, new DefaultConfigPropertyFilter(),
+                new DefaultTopicListener());
         List<ConfigEntry> entries = new ArrayList<>();
         entries.add(new ConfigEntry("name-1", "value-1"));
         // When "use.defaults.from" set to "target" by default, the config with default value should be excluded
@@ -269,7 +271,7 @@ public class MirrorSourceConnectorTest {
         filter.configure(filterConfig);
 
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(),  x -> true, filter);
+                new DefaultReplicationPolicy(),  x -> true, filter, new DefaultTopicListener());
         List<ConfigEntry> entries = new ArrayList<>();
         entries.add(new ConfigEntry("name-1", "value-1"));
         // When "use.defaults.from" explicitly set to "source", the config with default value should be replicated
@@ -299,7 +301,7 @@ public class MirrorSourceConnectorTest {
         filter.configure(filterConfig);
 
         MirrorSourceConnector connector = spy(new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(), x -> true, filter));
+                new DefaultReplicationPolicy(), x -> true, filter, new DefaultTopicListener()));
 
         final String topic = "testtopic";
         List<ConfigEntry> entries = new ArrayList<>();
@@ -484,8 +486,10 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testRefreshTopicPartitions() throws Exception {
+        TopicListener mockTopicListener = mock(TopicListener.class);
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter(),
+                mockTopicListener);
         connector.initialize(mock(ConnectorContext.class));
         connector = spy(connector);
 
@@ -500,9 +504,15 @@ public class MirrorSourceConnectorTest {
         doReturn(configs).when(connector).describeTopicConfigs(Collections.singleton("topic"));
         doNothing().when(connector).createNewTopics(any());
 
+        Map<String, String> expectedTopicsForListener = new HashMap<>();
+        expectedTopicsForListener.put("topic", "source.topic");
+
         connector.refreshTopicPartitions();
+        verify(mockTopicListener, times(1)).topicsChanged(expectedTopicsForListener);
+
         // if target topic is not created, refreshTopicPartitions() will call createTopicPartitions() again
         connector.refreshTopicPartitions();
+        verify(mockTopicListener, times(2)).topicsChanged(expectedTopicsForListener);
 
         Map<String, Long> expectedPartitionCounts = new HashMap<>();
         expectedPartitionCounts.put("source.topic", 1L);
@@ -522,12 +532,14 @@ public class MirrorSourceConnectorTest {
 
         // once target topic is created, refreshTopicPartitions() will NOT call computeAndCreateTopicPartitions() again
         verify(connector, times(2)).computeAndCreateTopicPartitions();
+        verify(mockTopicListener, times(3)).topicsChanged(expectedTopicsForListener);
     }
 
     @Test
     public void testRefreshTopicPartitionsTopicOnTargetFirst() throws Exception {
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter(),
+                new DefaultTopicListener());
         connector.initialize(mock(ConnectorContext.class));
         connector = spy(connector);
 
@@ -567,7 +579,8 @@ public class MirrorSourceConnectorTest {
             }
         }
         MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new CustomReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+                new CustomReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter(),
+                new DefaultTopicListener());
         assertDoesNotThrow(() -> connector.isCycle(".b"));
     }
 


### PR DESCRIPTION
Implements KIP-918.

The new listener plugins allow capturing the actively replicated topics and groups for monitoring purposes.

Change-Id: Ibc51660d7baec20d82b2dbb4f4f526042f551e0f

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
